### PR TITLE
samples/bookinfo: migrate `apiVersion` of deployments to `apps/v1`

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-add-serviceaccount.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-add-serviceaccount.yaml
@@ -3,12 +3,19 @@ kind: ServiceAccount
 metadata:
   name: bookinfo-productpage
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productpage-v1
+  labels:
+    app: productpage
+    version: v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
   template:
     metadata:
       labels:
@@ -28,12 +35,19 @@ kind: ServiceAccount
 metadata:
   name: bookinfo-reviews
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v2
+  labels:
+    app: reviews
+    version: v2
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
   template:
     metadata:
       labels:
@@ -48,12 +62,19 @@ spec:
         ports:
         - containerPort: 9080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v3
+  labels:
+    app: reviews
+    version: v3
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v3
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -25,12 +25,19 @@ spec:
   selector:
     app: mongodb
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mongodb-v1
+  labels:
+    app: mongodb
+    version: v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb
+      version: v1
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -15,12 +15,19 @@
 ##################################################################################################
 # Details service v2
 ##################################################################################################
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: details-v2
+  labels:
+    app: details
+    version: v2
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: details
+      version: v2
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -28,12 +28,19 @@ spec:
   selector:
     app: details
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: details-v1
+  labels:
+    app: details
+    version: v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: details
+      version: v1
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -37,12 +37,19 @@ spec:
   selector:
     app: mysqldb
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysqldb-v1
+  labels:
+    app: mysqldb
+    version: v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: mysqldb
+      version: v1
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -12,12 +12,19 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v2-mysql-vm
+  labels:
+    app: ratings
+    version: v2-mysql-vm
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v2-mysql-vm
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -12,12 +12,19 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v2-mysql
+  labels:
+    app: ratings
+    version: v2-mysql
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v2-mysql
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -12,12 +12,19 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v2
+  labels:
+    app: ratings
+    version: v2
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v2
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -28,12 +28,19 @@ spec:
   selector:
     app: ratings
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v1
+  labels:
+    app: ratings
+    version: v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -15,12 +15,19 @@
 ##################################################################################################
 # Reviews service v2
 ##################################################################################################
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v2
+  labels:
+    app: reviews
+    version: v2
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -29,7 +29,7 @@ spec:
   selector:
     app: details
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: details-v1
@@ -38,6 +38,10 @@ metadata:
     version: v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: details
+      version: v1
   template:
     metadata:
       labels:
@@ -68,7 +72,7 @@ spec:
   selector:
     app: ratings
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v1
@@ -77,6 +81,10 @@ metadata:
     version: v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
   template:
     metadata:
       labels:
@@ -107,7 +115,7 @@ spec:
   selector:
     app: reviews
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v1
@@ -116,6 +124,10 @@ metadata:
     version: v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v1
   template:
     metadata:
       labels:
@@ -129,7 +141,7 @@ spec:
         ports:
         - containerPort: 9080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v2
@@ -138,6 +150,10 @@ metadata:
     version: v2
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
   template:
     metadata:
       labels:
@@ -151,7 +167,7 @@ spec:
         ports:
         - containerPort: 9080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v3
@@ -160,6 +176,10 @@ metadata:
     version: v3
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v3
   template:
     metadata:
       labels:
@@ -190,7 +210,7 @@ spec:
   selector:
     app: productpage
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productpage-v1
@@ -199,6 +219,10 @@ metadata:
     version: v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
   template:
     metadata:
       labels:

--- a/samples/bookinfo/platform/kube/rbac/ratings-v2-add-serviceaccount.yaml
+++ b/samples/bookinfo/platform/kube/rbac/ratings-v2-add-serviceaccount.yaml
@@ -3,12 +3,19 @@ kind: ServiceAccount
 metadata:
   name: bookinfo-ratings-v2
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v2
+  labels:
+    app: ratings
+    version: v2
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v2
   template:
     metadata:
       labels:


### PR DESCRIPTION
Migrate `apiVersion` of deployments from `extensions/v1beta1` to `apps/v1` in folder `samples/bookinfo`.

Because these resources have been deprecated since k8s v1.9 and are planned to no longer be served starting in k8s v1.16 (c.f. kubernetes/kubernetes#43214).

Related issue: #12211.