### PR TITLE
[Test Framework]: Galley support for deleting config

### DIFF
--- a/pkg/test/framework/components/galley/galley.go
+++ b/pkg/test/framework/components/galley/galley.go
@@ -29,11 +29,17 @@ type Instance interface {
 	// Address of the Galley MCP Server.
 	Address() string
 
-	// ApplyConfig applies the given config yaml file via Galley.
+	// ApplyConfig applies the given config yaml text via Galley.
 	ApplyConfig(ns namespace.Instance, yamlText ...string) error
 
-	// ApplyConfigOrFail applies the given config yaml file via Galley.
+	// ApplyConfigOrFail applies the given config yaml text via Galley.
 	ApplyConfigOrFail(t *testing.T, ns namespace.Instance, yamlText ...string)
+
+	// DeleteConfig deletes the given config yaml text via Galley.
+	DeleteConfig(ns namespace.Instance, yamlText ...string) error
+
+	// DeleteConfigOrFail deletes the given config yaml text via Galley.
+	DeleteConfigOrFail(t *testing.T, ns namespace.Instance, yamlText ...string)
 
 	// ApplyConfigDir recursively applies all the config files in the specified directory
 	ApplyConfigDir(ns namespace.Instance, configDir string) error

--- a/pkg/test/framework/components/galley/kube.go
+++ b/pkg/test/framework/components/galley/kube.go
@@ -111,6 +111,20 @@ func (c *kubeComponent) ApplyConfigOrFail(t *testing.T, ns namespace.Instance, y
 	}
 }
 
+// DeleteConfig implements Galley.DeleteConfig.
+func (c *kubeComponent) DeleteConfig(ns namespace.Instance, yamlText ...string) (err error) {
+	panic("NYI: DeleteConfig")
+}
+
+// DeleteConfigOrFail implements Galley.DeleteConfigOrFail.
+func (c *kubeComponent) DeleteConfigOrFail(t *testing.T, ns namespace.Instance, yamlText ...string) {
+	t.Helper()
+	err := c.DeleteConfig(ns, yamlText...)
+	if err != nil {
+		t.Fatalf("Galley.DeleteConfigOrFail: %v", err)
+	}
+}
+
 // ApplyConfigDir implements Galley.ApplyConfigDir.
 func (c *kubeComponent) ApplyConfigDir(ns namespace.Instance, sourceDir string) (err error) {
 	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {

--- a/pkg/test/framework/components/galley/native.go
+++ b/pkg/test/framework/components/galley/native.go
@@ -116,25 +116,72 @@ func (c *nativeComponent) ClearConfig() (err error) {
 }
 
 // ApplyConfig implements Galley.ApplyConfig.
-func (c *nativeComponent) ApplyConfig(ns namespace.Instance, yamlText ...string) (err error) {
+func (c *nativeComponent) ApplyConfig(ns namespace.Instance, yamlText ...string) error {
 	defer appsignals.Notify("galley.native.ApplyConfig", syscall.SIGUSR1)
+
+	// Read information for all files in configDir
+	fileInfos, err := readFileInfos(c.configDir)
+	if err != nil {
+		return err
+	}
+
+	// Create a map of the resource descriptors to file resources.
+	// We'll use this map for handling updates.
+	fileResourceMap := newFileResourceMap(fileInfos)
+
 	for _, y := range yamlText {
-		if ns != nil {
-			y, err = yml.ApplyNamespace(y, ns.Name())
-			if err != nil {
-				return
+		y, err = applyNamespace(ns, y)
+		if err != nil {
+			return err
+		}
+
+		// Parse the file to obtain all resources and their descriptors.
+		resources, err := parseResources(y)
+		if err != nil {
+			return err
+		}
+
+		// Look in the existing files for the resources. If found, overwrite the original.
+		for i, r := range resources {
+			if fileResource := fileResourceMap[r.descriptor]; fileResource != nil {
+				// Update the file resource.
+				fileResource.update(r.content)
+
+				// Mark this resource as applied so that we don't write it to a new file.
+				resources[i] = nil
 			}
 		}
 
-		fn := fmt.Sprintf("cfg-%d.yaml", time.Now().UnixNano())
-		fn = path.Join(c.configDir, fn)
+		// Generate the new content, if any.
+		newFileContent := ""
+		for _, r := range resources {
+			if r != nil {
+				newFileContent = yml.JoinString(newFileContent, r.content)
+			}
+		}
 
-		scopes.Framework.Debugf("Galley.ApplyConfig: %q\n%s\n----\n", fn, y)
-		if err = ioutil.WriteFile(fn, []byte(y), os.ModePerm); err != nil {
-			return err
+		// If there were new resources, write their content to a new file.
+		if len(newFileContent) > 0 {
+			fn := fmt.Sprintf("cfg-%d.yaml", time.Now().UnixNano())
+			fn = path.Join(c.configDir, fn)
+
+			scopes.Framework.Debugf("Galley.ApplyConfig: %q\n%s\n----\n", fn, newFileContent)
+			if err = ioutil.WriteFile(fn, []byte(newFileContent), os.ModePerm); err != nil {
+				return err
+			}
 		}
 	}
-	return
+
+	// If any existing files were modified, write their contents back to configDir.
+	for _, fi := range fileInfos {
+		if fi.isUpdated() {
+			if err := fi.writeFile(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // ApplyConfigOrFail applies the given config yaml file via Galley.
@@ -143,6 +190,62 @@ func (c *nativeComponent) ApplyConfigOrFail(t *testing.T, ns namespace.Instance,
 	err := c.ApplyConfig(ns, yamlText...)
 	if err != nil {
 		t.Fatalf("Galley.ApplyConfigOrFail: %v", err)
+	}
+}
+
+// DeleteConfig implements Galley.DeleteConfig.
+func (c *nativeComponent) DeleteConfig(ns namespace.Instance, yamlText ...string) error {
+	defer appsignals.Notify("galley.native.DeleteConfig", syscall.SIGUSR1)
+
+	// Read information for all files in configDir
+	fileInfos, err := readFileInfos(c.configDir)
+	if err != nil {
+		return err
+	}
+
+	// Create a map of the resource descriptors to file resources.
+	// We'll use this map for handling updates.
+	fileResourceMap := newFileResourceMap(fileInfos)
+
+	for _, y := range yamlText {
+		y, err = applyNamespace(ns, y)
+		if err != nil {
+			return err
+		}
+
+		// Parse the file to obtain all resources and their descriptors.
+		resources, err := parseResources(y)
+		if err != nil {
+			return err
+		}
+
+		// Look in the existing files for the resources. If found, delete it.
+		for _, r := range resources {
+			if fileResource := fileResourceMap[r.descriptor]; fileResource != nil {
+				// Delete it.
+				fileResource.update("")
+			}
+		}
+	}
+
+	// If any existing files were modified, write their contents back to configDir.
+	for _, fi := range fileInfos {
+		if fi.isUpdated() {
+			if err := fi.writeFile(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// DeleteConfigOrFail implements Galley.DeleteConfigOrFail.
+func (c *nativeComponent) DeleteConfigOrFail(t *testing.T, ns namespace.Instance, yamlText ...string) {
+	t.Helper()
+	err := c.DeleteConfig(ns, yamlText...)
+	if err != nil {
+		t.Fatalf("Galley.DeleteConfigOrFail: %v", err)
 	}
 }
 
@@ -282,4 +385,115 @@ func (c *nativeComponent) applyAttributeManifest() error {
 	}
 
 	return c.ApplyConfig(nil, m)
+}
+
+func applyNamespace(ns namespace.Instance, yamlText string) (out string, err error) {
+	out = yamlText
+	if ns != nil {
+		out, err = yml.ApplyNamespace(yamlText, ns.Name())
+	}
+	return
+}
+
+type resourceInfo struct {
+	content    string
+	descriptor yml.Descriptor
+	updated    bool
+}
+
+func (ri *resourceInfo) update(content string) {
+	ri.content = content
+	ri.updated = true
+}
+
+type fileInfo struct {
+	name      string
+	resources []*resourceInfo
+}
+
+func (fi *fileInfo) isUpdated() bool {
+	for _, r := range fi.resources {
+		if r.updated {
+			return true
+		}
+	}
+	return false
+}
+
+func (fi *fileInfo) writeFile() error {
+	// Merge all the resources into a single document.
+	resourceContent := make([]string, 0, len(fi.resources))
+	for _, r := range fi.resources {
+		if len(r.content) > 0 {
+			resourceContent = append(resourceContent, r.content)
+		}
+	}
+
+	if len(resourceContent) > 0 {
+		// Update the file
+		newContent := yml.JoinString(resourceContent...)
+		return ioutil.WriteFile(fi.name, []byte(newContent), os.ModePerm)
+	}
+
+	// The file is now empty - remove it.
+	return os.Remove(fi.name)
+}
+
+func readFileInfos(configDir string) ([]*fileInfo, error) {
+	infos, err := ioutil.ReadDir(configDir)
+	if err != nil {
+		return nil, err
+	}
+
+	fileInfos := make([]*fileInfo, 0)
+	for _, i := range infos {
+		filename := filepath.Join(configDir, i.Name())
+		content, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return nil, err
+		}
+
+		resources, err := parseResources(string(content))
+		if err != nil {
+			return nil, err
+		}
+
+		fileInfos = append(fileInfos, &fileInfo{
+			name:      filename,
+			resources: resources,
+		})
+	}
+
+	return fileInfos, nil
+}
+
+func newFileResourceMap(fileInfos []*fileInfo) map[yml.Descriptor]*resourceInfo {
+	// Create a map of the resource descriptors to file resources.
+	// We'll use this map for handling updates.
+	fileResourceMap := make(map[yml.Descriptor]*resourceInfo)
+	for _, fi := range fileInfos {
+		for _, ri := range fi.resources {
+			fileResourceMap[ri.descriptor] = ri
+		}
+	}
+	return fileResourceMap
+}
+
+func parseResources(yamlText string) ([]*resourceInfo, error) {
+	splitContent := yml.SplitString(yamlText)
+	resources := make([]*resourceInfo, 0, len(splitContent))
+	for _, part := range splitContent {
+		if len(part) > 0 {
+			descriptor, err := yml.ParseDescriptor(part)
+			if err != nil {
+				return nil, err
+			}
+
+			resources = append(resources, &resourceInfo{
+				content:    part,
+				descriptor: descriptor,
+			})
+		}
+	}
+	return resources, nil
 }

--- a/pkg/test/framework/components/galley/native_test.go
+++ b/pkg/test/framework/components/galley/native_test.go
@@ -1,0 +1,155 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package galley
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/yml"
+)
+
+func TestResourceLifecycle(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ctx := framework.NewContext(t)
+
+	ns := namespace.NewOrFail(t, ctx, "fake", false)
+
+	c := NewOrFail(t, ctx, Config{}).(*nativeComponent)
+
+	gateway := `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: some-ingress
+spec:
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: http
+    hosts:
+    - "*.example.com"
+`
+
+	virtualService := `
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: route-for-myapp
+spec:
+  hosts:
+  - some.example.com
+  gateways:
+  - some-ingress
+  http:
+  - route:
+    - destination:
+        host: some.example.internal
+`
+
+	// Create resources.
+	c.ApplyConfigOrFail(t, ns, yml.JoinString(gateway, virtualService))
+	fileInfos, err := readFileInfos(c.configDir)
+	g.Expect(err).To(BeNil())
+	g.Expect(len(fileInfos)).To(Equal(2))
+	g.Expect(len(fileInfos[0].resources)).To(Equal(1))
+	g.Expect(len(fileInfos[1].resources)).To(Equal(2))
+	g.Expect(fileInfos[0].resources[0].descriptor).To(Equal(yml.Descriptor{
+		Kind:       "attributemanifest",
+		APIVersion: "config.istio.io/v1alpha2",
+		Metadata: yml.Metadata{
+			Name:      "istioproxy",
+			Namespace: "istio-system",
+		},
+	}))
+	g.Expect(fileInfos[1].resources[0].descriptor).To(Equal(yml.Descriptor{
+		Kind:       "Gateway",
+		APIVersion: "networking.istio.io/v1alpha3",
+		Metadata: yml.Metadata{
+			Name:      "some-ingress",
+			Namespace: ns.Name(),
+		},
+	}))
+	g.Expect(fileInfos[1].resources[1].descriptor).To(Equal(yml.Descriptor{
+		Kind:       "VirtualService",
+		APIVersion: "networking.istio.io/v1alpha3",
+		Metadata: yml.Metadata{
+			Name:      "route-for-myapp",
+			Namespace: ns.Name(),
+		},
+	}))
+
+	gateway = `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: some-ingress
+spec:
+  servers:
+  - port:
+      number: 90
+      name: http
+      protocol: http
+    hosts:
+    - "*.example.com"
+`
+
+	// Update the gateway resource.
+	c.ApplyConfigOrFail(t, ns, yml.JoinString(gateway, virtualService))
+	fileInfos, err = readFileInfos(c.configDir)
+	g.Expect(err).To(BeNil())
+	g.Expect(len(fileInfos)).To(Equal(2))
+	g.Expect(len(fileInfos[0].resources)).To(Equal(1))
+	g.Expect(len(fileInfos[1].resources)).To(Equal(2))
+	gatewayResource := newFileResourceMap(fileInfos)[yml.Descriptor{
+		Kind:       "Gateway",
+		APIVersion: "networking.istio.io/v1alpha3",
+		Metadata: yml.Metadata{
+			Name:      "some-ingress",
+			Namespace: ns.Name(),
+		},
+	}]
+	g.Expect(gatewayResource).ToNot(BeNil())
+	g.Expect(gatewayResource.content).To(ContainSubstring("number: 90"))
+
+	// Delete the gateway resource
+	c.DeleteConfigOrFail(t, ns, gateway)
+	fileInfos, err = readFileInfos(c.configDir)
+	g.Expect(err).To(BeNil())
+	g.Expect(len(fileInfos)).To(Equal(2))
+	g.Expect(len(fileInfos[0].resources)).To(Equal(1))
+	g.Expect(len(fileInfos[1].resources)).To(Equal(1))
+	g.Expect(fileInfos[1].resources[0].descriptor).To(Equal(yml.Descriptor{
+		Kind:       "VirtualService",
+		APIVersion: "networking.istio.io/v1alpha3",
+		Metadata: yml.Metadata{
+			Name:      "route-for-myapp",
+			Namespace: ns.Name(),
+		},
+	}))
+}
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("galley_component_unit_tests", m).
+		RequireEnvironment(environment.Native).
+		Run()
+}


### PR DESCRIPTION
In order to properly support deleting resources, it was necessary to revisit how ApplyConfig is done as well.  Previously, apply would just blindly copy the yaml to a new file in the configDir. The assumption was that the resource was always being "added" (rather than updated). I'm not certain what would happen if two resources appeared with the same name/namespace.

This PR generalizes (and fixes) the way resources are handled so that it's not concerned with files, but rather the underlying resources. The code now parses the top-portion of the yaml to properly identify each resource.  Once identified, the code now properly updates resources by writing back to the file where the resource was found.  Deletes are similar, where the original resource in the file is replaced with "" (empty files are removed).