### PR TITLE
appsv1 galley

### DIFF
--- a/galley/pkg/crd/validation/config_test.go
+++ b/galley/pkg/crd/validation/config_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/onsi/gomega"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -45,7 +45,7 @@ func TestValidatingWebhookConfig(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(
 					dummyDeployment,
-					extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment"),
+					appsv1.SchemeGroupVersion.WithKind("Deployment"),
 				),
 			},
 		},

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -29,7 +29,7 @@ import (
 	"github.com/howeyc/fsnotify"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/api/admissionregistration/v1beta1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -269,14 +269,14 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 		createInformerEndpointSource:  defaultCreateInformerEndpointSource,
 	}
 
-	if galleyDeployment, err := wh.clientset.ExtensionsV1beta1().Deployments(wh.deploymentAndServiceNamespace).Get(wh.deploymentName, v1.GetOptions{}); err != nil { // nolint: lll
+	if galleyDeployment, err := wh.clientset.AppsV1().Deployments(wh.deploymentAndServiceNamespace).Get(wh.deploymentName, v1.GetOptions{}); err != nil { // nolint: lll
 		scope.Warnf("Could not find %s/%s deployment to set ownerRef. The validatingwebhookconfiguration must be deleted manually",
 			wh.deploymentAndServiceNamespace, wh.deploymentName)
 	} else {
 		wh.ownerRefs = []v1.OwnerReference{
 			*v1.NewControllerRef(
 				galleyDeployment,
-				extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment"),
+				appsv1.SchemeGroupVersion.WithKind("Deployment"),
 			),
 		}
 	}

--- a/galley/pkg/crd/validation/webhook_test.go
+++ b/galley/pkg/crd/validation/webhook_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/ghodss/yaml"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -94,7 +94,7 @@ var (
 		},
 	}
 
-	dummyDeployment = &extensionsv1beta1.Deployment{
+	dummyDeployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "istio-galley",
 			Namespace: "istio-system",


### PR DESCRIPTION
check in changes for galley to consume K8s changes :
These resources have been deprecated since k8s v1.9 and are planned to no longer be served starting in k8s v1.16 (c.f. kubernetes/kubernetes#43214)

details are in #12211