### PR TITLE
Remove redundant port list in mixer deployment.

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -60,7 +60,6 @@
         - containerPort: 9091
         - containerPort: 15004
 {{ if ne .Values.global.proxy.stats.prometheusPort 0. }}
-        ports:
         - containerPort: {{ .Values.global.proxy.stats.prometheusPort }}
           protocol: TCP
           name: http-envoy-prom
@@ -172,7 +171,6 @@
         - containerPort: 9091
         - containerPort: 15004
 {{ if ne .Values.global.proxy.stats.prometheusPort 0. }}
-        ports:
         - containerPort: {{ .Values.global.proxy.stats.prometheusPort }}
           protocol: TCP
           name: http-envoy-prom


### PR DESCRIPTION
Fixes #13048 

The `ports:` stanzas are redundant in these cases and only a new port should be added to the already existing list vs. creating a new list.