### PR TITLE
Appsv1 pilot

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2239,7 +2239,6 @@
     "k8s.io/api/admission/v1beta1",
     "k8s.io/api/admissionregistration/v1beta1",
     "k8s.io/api/apps/v1",
-    "k8s.io/api/apps/v1beta1",
     "k8s.io/api/authentication/v1",
     "k8s.io/api/batch/v1",
     "k8s.io/api/batch/v2alpha1",

--- a/istioctl/cmd/istioctl/testdata/deployment/hello.yaml
+++ b/istioctl/cmd/istioctl/testdata/deployment/hello.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/istioctl/cmd/istioctl/testdata/deployment/hello.yaml.injected
+++ b/istioctl/cmd/istioctl/testdata/deployment/hello.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/initializer.go
+++ b/pilot/pkg/kube/inject/initializer.go
@@ -16,11 +16,10 @@ package inject
 
 import (
 	openshiftv1 "github.com/openshift/api/apps/v1"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/batch/v2alpha1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -41,14 +40,14 @@ var (
 		{v1.SchemeGroupVersion, &v1.ReplicationController{}, "replicationcontrollers", "/api"},
 		{v1.SchemeGroupVersion, &v1.Pod{}, "pods", "/api"},
 
-		{v1beta1.SchemeGroupVersion, &v1beta1.Deployment{}, "deployments", "/apis"},
-		{v1beta1.SchemeGroupVersion, &v1beta1.DaemonSet{}, "daemonsets", "/apis"},
-		{v1beta1.SchemeGroupVersion, &v1beta1.ReplicaSet{}, "replicasets", "/apis"},
+		{appsv1.SchemeGroupVersion, &appsv1.Deployment{}, "deployments", "/apis"},
+		{appsv1.SchemeGroupVersion, &appsv1.DaemonSet{}, "daemonsets", "/apis"},
+		{appsv1.SchemeGroupVersion, &appsv1.ReplicaSet{}, "replicasets", "/apis"},
 
 		{batchv1.SchemeGroupVersion, &batchv1.Job{}, "jobs", "/apis"},
 		{v2alpha1.SchemeGroupVersion, &v2alpha1.CronJob{}, "cronjobs", "/apis"},
 
-		{appsv1beta1.SchemeGroupVersion, &appsv1beta1.StatefulSet{}, "statefulsets", "/apis"},
+		{appsv1.SchemeGroupVersion, &appsv1.StatefulSet{}, "statefulsets", "/apis"},
 
 		{v1.SchemeGroupVersion, &v1.List{}, "lists", "/apis"},
 

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -7,12 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
-      tier: backend
-      track: stable
-  selector:
-    matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -5,6 +5,16 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml
@@ -3,6 +3,11 @@ kind: DaemonSet
 metadata:
   name: hello
 spec:
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -4,6 +4,11 @@ metadata:
   creationTimestamp: null
   name: hello
 spec:
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -6,7 +6,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/deployment-user-volume.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/deployment-user-volume.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user-volume

--- a/pilot/pkg/kube/inject/testdata/inject/deployment-user-volume.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/deployment-user-volume.yaml
@@ -4,6 +4,9 @@ metadata:
   name: user-volume
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: user-volume
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml
@@ -12,7 +12,7 @@ spec:
       targetPort: 80
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml
@@ -20,7 +20,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: frontend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml
@@ -18,6 +18,11 @@ metadata:
   name: frontend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello  
+      tier: frontend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -12,7 +12,7 @@ spec:
       targetPort: 80
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -19,6 +19,11 @@ metadata:
   name: frontend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello
+      tier: frontend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-host-network.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-host-network.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-host-network

--- a/pilot/pkg/kube/inject/testdata/inject/hello-host-network.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-host-network.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello-host-network
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello-host-network  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-host-network.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-host-network.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello-host-network.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-host-network.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello-host-network  
+      app: hello-host-network
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-host-network.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-host-network.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello-host-network
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello-host-network  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello-host-network  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml
@@ -2,9 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello
-
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello-host-network  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   selector:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -12,7 +12,7 @@ spec:
       track: stable
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -5,6 +5,16 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -10,11 +10,6 @@ spec:
       app: hello
       tier: backend
       track: stable
-  selector:
-    matchLabels:
-      app: hello
-      tier: backend
-      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-v1
@@ -20,7 +20,7 @@ spec:
             - name: http
               containerPort: 80
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-v2

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml
@@ -5,6 +5,12 @@ metadata:
   name: hello-v1
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
+      version: v1
   template:
     metadata:
       labels:
@@ -26,6 +32,12 @@ metadata:
   name: hello-v2
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
+      version: v2
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml
@@ -7,7 +7,7 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
       version: v1
@@ -34,7 +34,7 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
       version: v2

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -5,6 +5,12 @@ metadata:
   name: hello-v1
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
+      version: v1
   strategy: {}
   template:
     metadata:
@@ -139,6 +145,12 @@ metadata:
   name: hello-v2
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
+      version: v2
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -132,7 +132,7 @@ spec:
           secretName: istio.default
 status: {}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
       version: v1
@@ -147,7 +147,7 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
       version: v2

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: test
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -8,7 +8,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       app: hello  
       tier: backend
-      track: stabl
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -6,6 +6,11 @@ metadata:
   namespace: test
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stabl
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-readiness.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-readiness.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-readiness.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-readiness.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-readiness.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-readiness.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   replicas: 7
   selector:
-    matchLabels:
-      app: hello  
+    matchLabels: 
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml
@@ -14,7 +14,7 @@ items:
           port: 80
           targetPort: 80
       type: LoadBalancer
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: frontend

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml
@@ -20,6 +20,11 @@ items:
       name: frontend
     spec:
       replicas: 1
+      selector:
+        matchLabels:
+          app: hello  
+          tier: frontend
+          track: stable
       template:
         metadata:
           labels:

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml
@@ -22,7 +22,7 @@ items:
       replicas: 1
       selector:
         matchLabels:
-          app: hello  
+          app: hello
           tier: frontend
           track: stable
       template:

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -13,7 +13,7 @@ items:
       app: hello
       tier: frontend
     type: LoadBalancer
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -20,6 +20,11 @@ items:
     name: frontend
   spec:
     replicas: 1
+    selector:
+      matchLabels:
+        app: hello  
+        tier: frontend
+        track: stable
     strategy: {}
     template:
       metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -22,7 +22,7 @@ items:
     replicas: 1
     selector:
       matchLabels:
-        app: hello  
+        app: hello
         tier: frontend
         track: stable
     strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: List
 items:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: hello-v1
@@ -22,7 +22,7 @@ items:
                 - name: http
                   containerPort: 80
 
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: hello-v2

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml
@@ -7,6 +7,11 @@ items:
       name: hello-v1
     spec:
       replicas: 3
+      selector:
+        matchLabels:
+          app: hello  
+          tier: backend
+          track: stable
       template:
         metadata:
           labels:

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml
@@ -12,6 +12,7 @@ items:
           app: hello  
           tier: backend
           track: stable
+          version: v1
       template:
         metadata:
           labels:
@@ -33,6 +34,12 @@ items:
       name: hello-v2
     spec:
       replicas: 3
+      selector:
+        matchLabels:
+          app: hello  
+          tier: backend
+          track: stable
+          version: v2
       template:
         metadata:
           labels:

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -7,6 +7,12 @@ items:
     name: hello-v1
   spec:
     replicas: 3
+    selector:
+      matchLabels:
+        app: hello  
+        tier: backend
+        track: stable
+        version: v1
     strategy: {}
     template:
       metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -1,6 +1,6 @@
 apiVersion: v1
 items:
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     creationTimestamp: null
@@ -133,7 +133,7 @@ items:
             optional: true
             secretName: istio.default
   status: {}
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -9,7 +9,7 @@ items:
     replicas: 3
     selector:
       matchLabels:
-        app: hello  
+        app: hello
         tier: backend
         track: stable
         version: v1
@@ -146,6 +146,12 @@ items:
     name: hello-v2
   spec:
     replicas: 3
+    selector:
+      matchLabels:
+        app: hello
+        tier: backend
+        track: stable
+        version: v2
     strategy: {}
     template:
       metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml
@@ -4,6 +4,9 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   serviceName: hello
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
   replicas: 3
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
   serviceName: hello
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: statusPort

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml
@@ -4,6 +4,9 @@ metadata:
   name: statusPort
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: status
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: statusPort
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: status
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml
@@ -4,6 +4,9 @@ metadata:
   name: statusPort
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: status
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: statusPort

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: statusPort
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: status
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-excludeinboundports.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-excludeinboundports.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-excludeinboundports.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-excludeinboundports.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-excludeipranges.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-excludeipranges.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-excludeipranges.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-excludeipranges.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-includeinboundports.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-includeinboundports.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-includeinboundports.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-includeinboundports.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-includeipranges.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-includeipranges.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-includeipranges.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-includeipranges.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml
@@ -3,6 +3,11 @@ kind: DaemonSet
 metadata:
   name: hello
 spec:
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   strategy: {}
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml
@@ -12,7 +12,7 @@ spec:
       targetPort: 80
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml
@@ -20,7 +20,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: frontend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml
@@ -18,6 +18,11 @@ metadata:
   name: frontend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello  
+      tier: frontend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: frontend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello  
+      tier: frontend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: frontend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-v1
@@ -20,7 +20,7 @@ spec:
             - name: http
               containerPort: 80
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-v2

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml
@@ -5,6 +5,12 @@ metadata:
   name: hello-v1
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
+      version: v1
   template:
     metadata:
       labels:
@@ -26,6 +32,12 @@ metadata:
   name: hello-v2
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
+      version: v2
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -165,7 +165,7 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
       version: v2

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -150,7 +150,7 @@ spec:
 status: {}
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -5,6 +5,12 @@ metadata:
   name: hello-v1
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
+      version: v1
   strategy: {}
   template:
     metadata:
@@ -157,6 +163,12 @@ metadata:
   name: hello-v2
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
+      version: v2
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/hello.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml
@@ -14,7 +14,7 @@ items:
           port: 80
           targetPort: 80
       type: LoadBalancer
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: frontend

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml
@@ -20,6 +20,11 @@ items:
       name: frontend
     spec:
       replicas: 1
+      selector:
+        matchLabels:
+          app: hello  
+          tier: frontend
+          track: stable
       template:
         metadata:
           labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: frontend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello  
+      tier: frontend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: List
 items:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: hello-v1
@@ -22,7 +22,7 @@ items:
                 - name: http
                   containerPort: 80
 
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: hello-v2

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml
@@ -10,7 +10,7 @@ items:
       selector:
         matchLabels:
           app: hello  
-          tier: frontend
+          tier: backend
           track: stable
           version: v1
       template:
@@ -37,7 +37,7 @@ items:
       selector:
         matchLabels:
           app: hello  
-          tier: frontend
+          tier: backend
           track: stable
           version: v2
       template:

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml
@@ -7,6 +7,12 @@ items:
       name: hello-v1
     spec:
       replicas: 3
+      selector:
+        matchLabels:
+          app: hello  
+          tier: frontend
+          track: stable
+          version: v1
       template:
         metadata:
           labels:
@@ -28,6 +34,12 @@ items:
       name: hello-v2
     spec:
       replicas: 3
+      selector:
+        matchLabels:
+          app: hello  
+          tier: frontend
+          track: stable
+          version: v2
       template:
         metadata:
           labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -7,10 +7,10 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: hello  
-        tier: frontend
-        track: stable
-        version: v1
+      app: hello
+      tier: backend
+      track: stable
+      version: v1
   strategy: {}
   template:
     metadata:
@@ -166,9 +166,9 @@ spec:
   selector:
     matchLabels:
       app: hello  
-      tier: frontend
+      tier: backend
       track: stable
-      version: v1
+      version: v2
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -150,7 +150,7 @@ spec:
 status: {}
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -5,6 +5,12 @@ metadata:
   name: hello-v1
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello  
+        tier: frontend
+        track: stable
+        version: v1
   strategy: {}
   template:
     metadata:
@@ -157,6 +163,12 @@ metadata:
   name: hello-v2
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello  
+      tier: frontend
+      track: stable
+      version: v1
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml
@@ -4,6 +4,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   template:

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -1,10 +1,11 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  creationTimestamp: null
-  name: hello
+
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello  
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml
@@ -4,6 +4,9 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: hello
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: resource

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml
@@ -4,6 +4,9 @@ metadata:
   name: resource
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: resource
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: resource
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: resource
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml
@@ -5,6 +5,11 @@ metadata:
 spec:
   serviceName: hello
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: statusPort

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml
@@ -4,6 +4,9 @@ metadata:
   name: statusPort
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: status
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: statusPort
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: status
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traffic

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml
@@ -4,6 +4,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   template:
     metadata:
       annotations:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -5,6 +5,9 @@ metadata:
   name: traffic
 spec:
   replicas: 7
+  selector:
+    matchLabels:
+      app: traffic
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user-volume

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml
@@ -4,6 +4,11 @@ metadata:
   name: user-volume
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: user-volume
+      tier: backend
+      track: stable
   template:
     metadata:
       labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -5,6 +5,11 @@ metadata:
   name: user-volume
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: user-volume
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -605,6 +605,11 @@ func TestWebhookInject(t *testing.T) {
 			wantFile:     "TestWebhookInject_http_probe_nosidecar_rewrite.patch",
 			templateFile: "TestWebhookInject_http_probe_nosidecar_rewrite_template.yaml",
 		},
+		{
+			inputFile:    "TestWebhookInject_https_probe_rewrite.yaml",
+			wantFile:     "TestWebhookInject_https_probe_rewrite.patch",
+			templateFile: "TestWebhookInject_https_probe_rewrite_template.yaml",
+		},
 	}
 
 	for i, c := range cases {

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -613,9 +613,6 @@ func TestWebhookInject(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		if c.inputFile != "TestWebhookInject_http_probe_nosidecar_rewrite.yaml" {
-			continue
-		}
 		input := filepath.Join("testdata/webhook", c.inputFile)
 		want := filepath.Join("testdata/webhook", c.wantFile)
 		templateFile := "TestWebhookInject_template.yaml"

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -32,8 +32,8 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/onsi/gomega"
 	"k8s.io/api/admission/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/helm/pkg/chartutil"
@@ -605,14 +605,12 @@ func TestWebhookInject(t *testing.T) {
 			wantFile:     "TestWebhookInject_http_probe_nosidecar_rewrite.patch",
 			templateFile: "TestWebhookInject_http_probe_nosidecar_rewrite_template.yaml",
 		},
-		{
-			inputFile:    "TestWebhookInject_https_probe_rewrite.yaml",
-			wantFile:     "TestWebhookInject_https_probe_rewrite.patch",
-			templateFile: "TestWebhookInject_https_probe_rewrite_template.yaml",
-		},
 	}
 
 	for i, c := range cases {
+		if c.inputFile != "TestWebhookInject_http_probe_nosidecar_rewrite.yaml" {
+			continue
+		}
 		input := filepath.Join("testdata/webhook", c.inputFile)
 		want := filepath.Join("testdata/webhook", c.wantFile)
 		templateFile := "TestWebhookInject_template.yaml"
@@ -1008,16 +1006,16 @@ func applyJSONPatch(input, patch []byte, t *testing.T) []byte {
 	return prettyJSON(patchedJSON, t)
 }
 
-func jsonToDeployment(deploymentJSON []byte, t *testing.T) *extv1beta1.Deployment {
+func jsonToDeployment(deploymentJSON []byte, t *testing.T) *appsv1.Deployment {
 	t.Helper()
-	var deployment extv1beta1.Deployment
+	var deployment appsv1.Deployment
 	if err := json.Unmarshal(deploymentJSON, &deployment); err != nil {
 		t.Fatal(err)
 	}
 	return &deployment
 }
 
-func deploymentToYaml(deployment *extv1beta1.Deployment, t *testing.T) []byte {
+func deploymentToYaml(deployment *appsv1.Deployment, t *testing.T) []byte {
 	t.Helper()
 	yaml, err := yaml.Marshal(deployment)
 	if err != nil {
@@ -1026,7 +1024,7 @@ func deploymentToYaml(deployment *extv1beta1.Deployment, t *testing.T) []byte {
 	return yaml
 }
 
-func normalizeAndCompareDeployments(got, want *extv1beta1.Deployment, t *testing.T) error {
+func normalizeAndCompareDeployments(got, want *appsv1.Deployment, t *testing.T) error {
 	t.Helper()
 	// Scrub unimportant fields that tend to differ.
 	getAnnotations(got)[annotationStatus] = getAnnotations(want)[annotationStatus]
@@ -1079,11 +1077,11 @@ func normalizeAndCompareDeployments(got, want *extv1beta1.Deployment, t *testing
 	return util.Compare([]byte(gotString), []byte(wantString))
 }
 
-func getAnnotations(d *extv1beta1.Deployment) map[string]string {
+func getAnnotations(d *appsv1.Deployment) map[string]string {
 	return d.Spec.Template.ObjectMeta.Annotations
 }
 
-func istioCerts(d *extv1beta1.Deployment) *corev1.Volume {
+func istioCerts(d *appsv1.Deployment) *corev1.Volume {
 	for i := 0; i < len(d.Spec.Template.Spec.Volumes); i++ {
 		v := &d.Spec.Template.Spec.Volumes[i]
 		if v.Name == "istio-certs" {
@@ -1093,7 +1091,7 @@ func istioCerts(d *extv1beta1.Deployment) *corev1.Volume {
 	return nil
 }
 
-func istioInit(d *extv1beta1.Deployment, t *testing.T) *corev1.Container {
+func istioInit(d *appsv1.Deployment, t *testing.T) *corev1.Container {
 	t.Helper()
 	for i := 0; i < len(d.Spec.Template.Spec.InitContainers); i++ {
 		c := &d.Spec.Template.Spec.InitContainers[i]
@@ -1105,7 +1103,7 @@ func istioInit(d *extv1beta1.Deployment, t *testing.T) *corev1.Container {
 	return nil
 }
 
-func istioProxy(d *extv1beta1.Deployment, t *testing.T) *corev1.Container {
+func istioProxy(d *appsv1.Deployment, t *testing.T) *corev1.Container {
 	t.Helper()
 	for i := 0; i < len(d.Spec.Template.Spec.Containers); i++ {
 		c := &d.Spec.Template.Spec.Containers[i]


### PR DESCRIPTION
check in changes for pilot to consume K8s changes :
These resources have been deprecated since k8s v1.9 and are planned to no longer be served starting in k8s v1.16 (c.f. kubernetes/kubernetes#43214)

details are in #12211