### PR TITLE
fix validation logic so that port.name is no longer a valid PortSelector

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -2036,21 +2036,21 @@ func validateSubsetName(name string) error {
 	return nil
 }
 
-func validatePortSelector(selector *networking.PortSelector) error {
+func validatePortSelector(selector *networking.PortSelector) (errs error) {
 	if selector == nil {
 		return nil
 	}
 
-	// port selector is either a name or a number
+	// port must be a number
 	name := selector.GetName()
 	number := int(selector.GetNumber())
-	if name == "" && number == 0 {
-		// an unset value is indistinguishable from a zero value, so return both errors
-		return appendErrors(validateSubsetName(name), ValidatePort(number))
-	} else if number != 0 {
-		return ValidatePort(number)
+	if name != "" {
+		errs = appendErrors(errs, fmt.Errorf("port.name %s is no longer supported for destination", name))
 	}
-	return validateSubsetName(name)
+	if number != 0 {
+		errs = appendErrors(errs, ValidatePort(number))
+	}
+	return
 }
 
 func validateAuthNPortSelector(selector *authn.PortSelector) error {


### PR DESCRIPTION
resolves https://discuss.istio.io/t/issue-with-vs-in-istio-1-1-1/1731/4

the agreement was to patch the validation logic to not allow the port name so it can hopefully get in for 1.1.2 and then for 1.2, remove the name field from the VirtualService spec