### PR TITLE
 set AllowPrivilegeEscalation: False for sidecar injector when cni is enabled

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -222,6 +222,7 @@ data:
           {{ if and .Values.global.sds.enabled .Values.global.sds.useTrustworthyJwt }}
           runAsGroup: 1337
           {{- end }}
+          allowPrivilegeEscalation: false
           runAsUser: 1337
           {{ "[[- end ]]" }}
         resources:


### PR DESCRIPTION
 enabled

 this allows istio injection to work on psp enabled clusters