### PR TITLE
Fix tracing_datadog_golden.json for datadog tracer

### DIFF
--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -117,6 +117,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         
@@ -161,6 +162,7 @@
           }
         ]
       }
+      
       
     ],
     "listeners":[


### PR DESCRIPTION
Fix tracing_datadog_golden.json, from recently merged PR.
Other changes since the PR was opened meant the golden file had become stale.

Fixes #13078
CC @howardjohn @rshriram  

