### PR TITLE
Registrator should use "master" version

### DIFF
--- a/install/consul/templates/istio.yaml.tmpl
+++ b/install/consul/templates/istio.yaml.tmpl
@@ -54,7 +54,7 @@ services:
       - ./consul_config:/consul/config
 
   registrator:
-    image: gliderlabs/registrator:latest
+    image: gliderlabs/registrator:master
     networks:
       istiomesh:
     volumes:


### PR DESCRIPTION
The "latest" version of Registrator doesn't support ServiceMeta. This will cause a wrong tcp_proxy filter and results wrong routing.

The Envoy config:
```
"listener": {
      "name": "0.0.0.0_9080",
      "address": {
       "socket_address": {
        "address": "0.0.0.0",
        "port_value": 9080
       }
      },
      "filter_chains": [
       {
        "filters": [
         {
          "name": "envoy.tcp_proxy",
          "typed_config": {
           "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
           "stat_prefix": "outbound|9080||productpage.service.consul",
           "cluster": "outbound|9080||productpage.service.consul",
           "access_log": [
            {
             "name": "envoy.file_access_log",
             "typed_config": {
              "@type": "type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog",
              "path": "/dev/stdout",
              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
             }
            }
           ]
          }
         }
        ]
       }
      ],
      "deprecated_v1": {
       "bind_to_port": false
      }
     }
```

The associated issue:
https://github.com/gliderlabs/registrator/issues/633