### PR TITLE
fix(telemetry): remove configID from mixer self-monitoring metrics

### DIFF
--- a/mixer/pkg/runtime/config/ephemeral.go
+++ b/mixer/pkg/runtime/config/ephemeral.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"sync"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -34,7 +33,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	multierror "github.com/hashicorp/go-multierror"
 	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 
 	"istio.io/api/mixer/adapter/model/v1beta1"
 	config "istio.io/api/policy/v1beta1"
@@ -152,28 +150,33 @@ func (e *Ephemeral) BuildSnapshot() (*Snapshot, error) {
 
 	// Allocate new monitoring context to use with the new snapshot.
 	monitoringCtx := context.Background()
-	var err error
-	if monitoringCtx, err = tag.New(monitoringCtx, tag.Insert(monitoring.ConfigIDTag, strconv.FormatInt(id, 10))); err != nil {
-		log.Errorf("could not establish snapshot id in monitoring context: %v", err)
-	}
 
 	e.lock.RLock()
 
 	attributes := e.processAttributeManifests(monitoringCtx)
 
-	shandlers := e.processStaticAdapterHandlerConfigs(monitoringCtx)
+	shandlers := e.processStaticAdapterHandlerConfigs()
 
 	af := ast.NewFinder(attributes)
 	e.attributes = af
-	instances := e.processInstanceConfigs(monitoringCtx, errs)
+	instances, instErrs := e.processInstanceConfigs(monitoringCtx, errs)
 
 	// New dynamic configurations
 	dTemplates := e.processDynamicTemplateConfigs(monitoringCtx, errs)
 	dAdapters := e.processDynamicAdapterConfigs(monitoringCtx, dTemplates, errs)
 	dhandlers := e.processDynamicHandlerConfigs(monitoringCtx, dAdapters, errs)
-	dInstances := e.processDynamicInstanceConfigs(monitoringCtx, dTemplates, errs)
+	dInstances, dInstErrs := e.processDynamicInstanceConfigs(monitoringCtx, dTemplates, errs)
 
 	rules := e.processRuleConfigs(monitoringCtx, shandlers, instances, dhandlers, dInstances, errs)
+
+	stats.Record(monitoringCtx,
+		monitoring.HandlersTotal.M(int64(len(shandlers)+len(dhandlers))),
+		monitoring.InstancesTotal.M(int64(len(instances)+len(dInstances))),
+		monitoring.RulesTotal.M(int64(len(rules))),
+		monitoring.AdapterInfosTotal.M(int64(len(dAdapters))),
+		monitoring.TemplatesTotal.M(int64(len(dTemplates))),
+		monitoring.InstanceErrs.M(instErrs+dInstErrs),
+	)
 
 	s := &Snapshot{
 		ID:                id,
@@ -209,7 +212,6 @@ func (e *Ephemeral) processAttributeManifests(ctx context.Context) map[string]*c
 		cfg := obj.Spec
 		for an, at := range cfg.(*config.AttributeManifest).Attributes {
 			attrs[an] = at
-			stats.Record(ctx, monitoring.AttributesTotal.M(1))
 			log.Debugf("Attribute '%s': '%s'.", an, at.ValueType)
 		}
 	}
@@ -229,13 +231,13 @@ func (e *Ephemeral) processAttributeManifests(ctx context.Context) map[string]*c
 		for _, v := range info.AttributeManifests {
 			for an, at := range v.Attributes {
 				attrs[an] = at
-				stats.Record(ctx, monitoring.AttributesTotal.M(1))
 				log.Debugf("Attribute '%s': '%s'", an, at.ValueType)
 			}
 		}
 	}
 
 	log.Debug("Completed processing attributes.")
+	stats.Record(ctx, monitoring.AttributesTotal.M(int64(len(attrs))))
 	return attrs
 }
 
@@ -251,7 +253,7 @@ func convert(spec map[string]interface{}, target proto.Message) error {
 	return err
 }
 
-func (e *Ephemeral) processStaticAdapterHandlerConfigs(ctx context.Context) map[string]*HandlerStatic {
+func (e *Ephemeral) processStaticAdapterHandlerConfigs() map[string]*HandlerStatic {
 	handlers := make(map[string]*HandlerStatic, len(e.adapters))
 
 	for key, resource := range e.entries {
@@ -284,7 +286,6 @@ func (e *Ephemeral) processStaticAdapterHandlerConfigs(ctx context.Context) map[
 				staticConfig.Params = c
 			}
 			handlers[key.String()] = staticConfig
-			stats.Record(ctx, monitoring.HandlersTotal.M(1))
 			continue
 		}
 
@@ -304,7 +305,6 @@ func (e *Ephemeral) processStaticAdapterHandlerConfigs(ctx context.Context) map[
 		}
 
 		handlers[cfg.Name] = cfg
-		stats.Record(ctx, monitoring.HandlersTotal.M(1))
 	}
 
 	return handlers
@@ -322,6 +322,7 @@ func getCanonicalRef(n, kind, ns string, lookup func(string) interface{}) (inter
 
 func (e *Ephemeral) processDynamicHandlerConfigs(ctx context.Context, adapters map[string]*Adapter, errs *multierror.Error) map[string]*HandlerDynamic {
 	handlers := make(map[string]*HandlerDynamic, len(e.adapters))
+	var validationErrs int64
 
 	for key, resource := range e.entries {
 		if key.Kind != constant.HandlerKind {
@@ -343,7 +344,8 @@ func (e *Ephemeral) processDynamicHandlerConfigs(ctx context.Context, adapters m
 		})
 
 		if adpt == nil {
-			appendErr(ctx, errs, fmt.Sprintf("handler='%s'.adapter", handlerName), monitoring.HandlerValidationErrors, "adapter '%s' not found", hdl.Adapter)
+			validationErrs++
+			appendErr(errs, fmt.Sprintf("handler='%s'.adapter", handlerName), "adapter '%s' not found", hdl.Adapter)
 			continue
 		}
 		adapter := adpt.(*Adapter)
@@ -353,7 +355,8 @@ func (e *Ephemeral) processDynamicHandlerConfigs(ctx context.Context, adapters m
 			// validate if the param is valid
 			bytes, err := validateEncodeBytes(hdl.Params, adapter.ConfigDescSet, getParamsMsgFullName(adapter.PackageName))
 			if err != nil {
-				appendErr(ctx, errs, fmt.Sprintf("handler='%s'.params", handlerName), monitoring.HandlerValidationErrors, err.Error())
+				validationErrs++
+				appendErr(errs, fmt.Sprintf("handler='%s'.params", handlerName), err.Error())
 				continue
 			}
 			typeFQN := adapter.PackageName + ".Params"
@@ -368,8 +371,9 @@ func (e *Ephemeral) processDynamicHandlerConfigs(ctx context.Context, adapters m
 		}
 
 		handlers[cfg.Name] = cfg
-		stats.Record(ctx, monitoring.HandlersTotal.M(1))
 	}
+
+	stats.Record(ctx, monitoring.HandlerValidationErrors.M(validationErrs))
 
 	return handlers
 }
@@ -384,8 +388,9 @@ func asAny(msgFQN string, bytes []byte) *types.Any {
 }
 
 func (e *Ephemeral) processDynamicInstanceConfigs(ctx context.Context, templates map[string]*Template,
-	errs *multierror.Error) map[string]*InstanceDynamic {
+	errs *multierror.Error) (map[string]*InstanceDynamic, int64) {
 	instances := make(map[string]*InstanceDynamic, len(e.templates))
+	var instErrs int64
 
 	for key, resource := range e.entries {
 		if key.Kind != constant.InstanceKind {
@@ -410,7 +415,8 @@ func (e *Ephemeral) processDynamicInstanceConfigs(ctx context.Context, templates
 		})
 
 		if tmpl == nil {
-			appendErr(ctx, errs, fmt.Sprintf("instance='%s'.template", instanceName), monitoring.InstanceErrs, "template '%s' not found", inst.Template)
+			instErrs++
+			appendErr(errs, fmt.Sprintf("instance='%s'.template", instanceName), "template '%s' not found", inst.Template)
 			continue
 		}
 
@@ -428,8 +434,8 @@ func (e *Ephemeral) processDynamicInstanceConfigs(ctx context.Context, templates
 		var err error
 		if inst.Params != nil {
 			if params, err = toDictionary(inst.Params); err != nil {
-				appendErr(ctx, errs, fmt.Sprintf("instance='%s'.params", instanceName),
-					monitoring.InstanceErrs, "invalid params block.")
+				instErrs++
+				appendErr(errs, fmt.Sprintf("instance='%s'.params", instanceName), "invalid params block.")
 				continue
 			}
 
@@ -438,9 +444,9 @@ func (e *Ephemeral) processDynamicInstanceConfigs(ctx context.Context, templates
 			params["name"] = fmt.Sprintf("\"%s\"", instanceName)
 			enc, err = b.Build(getTemplatesMsgFullName(template.PackageName), params)
 			if err != nil {
-				appendErr(ctx, errs, fmt.Sprintf("instance='%s'.params", instanceName),
-					monitoring.InstanceErrs, "config does not conform to schema of template '%s': %v",
-					inst.Template, err.Error())
+				instErrs++
+				appendErr(errs, fmt.Sprintf("instance='%s'.params", instanceName),
+					"config does not conform to schema of template '%s': %v", inst.Template, err.Error())
 				continue
 			}
 		}
@@ -455,10 +461,9 @@ func (e *Ephemeral) processDynamicInstanceConfigs(ctx context.Context, templates
 		}
 
 		instances[cfg.Name] = cfg
-		stats.Record(ctx, monitoring.InstancesTotal.M(1))
 	}
 
-	return instances
+	return instances, instErrs
 }
 
 func getTemplatesMsgFullName(pkgName string) string {
@@ -480,8 +485,9 @@ func validateEncodeBytes(params *types.Struct, fds *descriptor.FileDescriptorSet
 	return yaml.NewEncoder(fds).EncodeBytes(d, msgName, false)
 }
 
-func (e *Ephemeral) processInstanceConfigs(ctx context.Context, errs *multierror.Error) map[string]*InstanceStatic {
+func (e *Ephemeral) processInstanceConfigs(ctx context.Context, errs *multierror.Error) (map[string]*InstanceStatic, int64) {
 	instances := make(map[string]*InstanceStatic, len(e.templates))
+	var instErrs int64
 
 	for key, resource := range e.entries {
 		var info *template.Info
@@ -497,7 +503,8 @@ func (e *Ephemeral) processInstanceConfigs(ctx context.Context, errs *multierror
 			}
 			info, found = e.templates[inst.CompiledTemplate]
 			if !found {
-				appendErr(ctx, errs, fmt.Sprintf("instance='%s'", instanceName), monitoring.InstanceErrs, "missing compiled template")
+				instErrs++
+				appendErr(errs, fmt.Sprintf("instance='%s'", instanceName), "missing compiled template")
 				continue
 			}
 
@@ -519,11 +526,13 @@ func (e *Ephemeral) processInstanceConfigs(ctx context.Context, errs *multierror
 				}
 			}
 			if err := (&jsonpb.Marshaler{}).Marshal(buf, inst.Params); err != nil {
-				appendErr(ctx, errs, fmt.Sprintf("instance='%s'", instanceName), monitoring.InstanceErrs, err.Error())
+				instErrs++
+				appendErr(errs, fmt.Sprintf("instance='%s'", instanceName), err.Error())
 				continue
 			}
 			if err := (&jsonpb.Unmarshaler{AllowUnknownFields: false}).Unmarshal(buf, params); err != nil {
-				appendErr(ctx, errs, fmt.Sprintf("instance='%s'", instanceName), monitoring.InstanceErrs, err.Error())
+				instErrs++
+				appendErr(errs, fmt.Sprintf("instance='%s'", instanceName), err.Error())
 				continue
 			}
 		} else {
@@ -543,7 +552,8 @@ func (e *Ephemeral) processInstanceConfigs(ctx context.Context, errs *multierror
 		})
 
 		if err != nil {
-			appendErr(ctx, errs, fmt.Sprintf("instance='%s'", instanceName), monitoring.InstanceErrs, err.Error())
+			instErrs++
+			appendErr(errs, fmt.Sprintf("instance='%s'", instanceName), err.Error())
 			continue
 		}
 		cfg := &InstanceStatic{
@@ -555,15 +565,15 @@ func (e *Ephemeral) processInstanceConfigs(ctx context.Context, errs *multierror
 		}
 
 		instances[cfg.Name] = cfg
-		stats.Record(ctx, monitoring.InstancesTotal.M(1))
 	}
 
-	return instances
+	return instances, instErrs
 }
 
 func (e *Ephemeral) processDynamicAdapterConfigs(ctx context.Context, availableTmpls map[string]*Template, errs *multierror.Error) map[string]*Adapter {
 	result := map[string]*Adapter{}
 	log.Debug("Begin processing adapter info configurations.")
+	var adapterErrs int64
 	for adapterInfoKey, resource := range e.entries {
 		if adapterInfoKey.Kind != constant.AdapterKind {
 			continue
@@ -571,15 +581,14 @@ func (e *Ephemeral) processDynamicAdapterConfigs(ctx context.Context, availableT
 
 		adapterName := adapterInfoKey.String()
 
-		stats.Record(ctx, monitoring.AdapterInfosTotal.M(1))
 		cfg := resource.Spec.(*v1beta1.Info)
 
 		log.Debugf("Processing incoming adapter info: name='%s'\n%v", adapterName, cfg)
 
 		fds, desc, err := GetAdapterCfgDescriptor(cfg.Config)
 		if err != nil {
-			appendErr(ctx, errs, fmt.Sprintf("adapter='%s'", adapterName), monitoring.AdapterErrs,
-				"unable to parse adapter configuration: %v", err)
+			adapterErrs++
+			appendErr(errs, fmt.Sprintf("adapter='%s'", adapterName), "unable to parse adapter configuration: %v", err)
 			continue
 		}
 		supportedTmpls := make([]*Template, 0, len(cfg.Templates))
@@ -592,8 +601,8 @@ func (e *Ephemeral) processDynamicAdapterConfigs(ctx context.Context, availableT
 				return nil
 			})
 			if template == nil {
-				appendErr(ctx, errs, fmt.Sprintf("adapter='%s'", adapterName), monitoring.AdapterErrs,
-					"unable to find template '%s'", tmplN)
+				adapterErrs++
+				appendErr(errs, fmt.Sprintf("adapter='%s'", adapterName), "unable to find template '%s'", tmplN)
 				continue
 			}
 			supportedTmpls = append(supportedTmpls, availableTmpls[tmplFullName])
@@ -610,6 +619,8 @@ func (e *Ephemeral) processDynamicAdapterConfigs(ctx context.Context, availableT
 			}
 		}
 	}
+
+	stats.Record(ctx, monitoring.AdapterErrs.M(adapterErrs))
 	return result
 }
 
@@ -631,14 +642,13 @@ func (e *Ephemeral) processRuleConfigs(
 	errs *multierror.Error) []*Rule {
 
 	log.Debug("Begin processing rule configurations.")
-
+	var ruleErrs int64
 	var rules []*Rule
 
 	for ruleKey, resource := range e.entries {
 		if ruleKey.Kind != constant.RulesKind {
 			continue
 		}
-		stats.Record(ctx, monitoring.RulesTotal.M(1))
 
 		ruleName := ruleKey.String()
 
@@ -649,7 +659,8 @@ func (e *Ephemeral) processRuleConfigs(
 
 		if cfg.Match != "" {
 			if err := assertType(e.checker(mode), cfg.Match, config.BOOL); err != nil {
-				appendErr(ctx, errs, fmt.Sprintf("rule='%s'.Match", ruleName), monitoring.RuleErrs, err.Error())
+				ruleErrs++
+				appendErr(errs, fmt.Sprintf("rule='%s'.Match", ruleName), err.Error())
 			}
 		}
 
@@ -688,8 +699,8 @@ func (e *Ephemeral) processRuleConfigs(
 			}
 
 			if !processStaticHandler && !processDynamicHandler {
-				appendErr(ctx, errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), monitoring.RuleErrs,
-					"Handler not found: handler='%s'", a.Handler)
+				ruleErrs++
+				appendErr(errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), "Handler not found: handler='%s'", a.Handler)
 				continue
 			}
 
@@ -708,22 +719,24 @@ func (e *Ephemeral) processRuleConfigs(
 					})
 
 					if inst == nil {
-						appendErr(ctx, errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), monitoring.RuleErrs,
-							"Instance not found: instance='%s'", instanceNameRef)
+						ruleErrs++
+						appendErr(errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), "Instance not found: instance='%s'", instanceNameRef)
 						continue
 					}
 
 					instance := inst.(*InstanceStatic)
 
 					if _, ok := uniqueInstances[instName]; ok {
-						appendErr(ctx, errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), monitoring.RuleErrs,
+						ruleErrs++
+						appendErr(errs, fmt.Sprintf("action='%s[%d]'", ruleName, i),
 							"action specified the same instance multiple times: instance='%s',", instName)
 						continue
 					}
 					uniqueInstances[instName] = true
 
 					if !contains(sahandler.Adapter.SupportedTemplates, instance.Template.Name) {
-						appendErr(ctx, errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), monitoring.RuleErrs,
+						ruleErrs++
+						appendErr(errs, fmt.Sprintf("action='%s[%d]'", ruleName, i),
 							"instance '%s' is of template '%s' which is not supported by handler '%s'",
 							instName, instance.Template.Name, handlerName)
 						continue
@@ -734,7 +747,8 @@ func (e *Ephemeral) processRuleConfigs(
 
 				// If there are no valid instances found for this action, then elide the action.
 				if len(actionInstances) == 0 {
-					appendErr(ctx, errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), monitoring.RuleErrs, "No valid instances found")
+					ruleErrs++
+					appendErr(errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), "No valid instances found")
 					continue
 				}
 
@@ -760,14 +774,15 @@ func (e *Ephemeral) processRuleConfigs(
 					})
 
 					if inst == nil {
-						appendErr(ctx, errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), monitoring.RuleErrs,
-							"Instance not found: instance='%s'", instanceNameRef)
+						ruleErrs++
+						appendErr(errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), "Instance not found: instance='%s'", instanceNameRef)
 						continue
 					}
 
 					instance := inst.(*InstanceDynamic)
 					if _, ok := uniqueInstances[instName]; ok {
-						appendErr(ctx, errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), monitoring.RuleErrs,
+						ruleErrs++
+						appendErr(errs, fmt.Sprintf("action='%s[%d]'", ruleName, i),
 							"action specified the same instance multiple times: instance='%s',", instName)
 						continue
 					}
@@ -782,7 +797,8 @@ func (e *Ephemeral) processRuleConfigs(
 					}
 
 					if !found {
-						appendErr(ctx, errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), monitoring.RuleErrs,
+						ruleErrs++
+						appendErr(errs, fmt.Sprintf("action='%s[%d]'", ruleName, i),
 							"instance '%s' is of template '%s' which is not supported by handler '%s'",
 							instName, instance.Template.Name, handlerName)
 						continue
@@ -793,7 +809,8 @@ func (e *Ephemeral) processRuleConfigs(
 
 				// If there are no valid instances found for this action, then elide the action.
 				if len(actionInstances) == 0 {
-					appendErr(ctx, errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), monitoring.RuleErrs, "No valid instances found")
+					ruleErrs++
+					appendErr(errs, fmt.Sprintf("action='%s[%d]'", ruleName, i), "No valid instances found")
 					continue
 				}
 
@@ -810,7 +827,8 @@ func (e *Ephemeral) processRuleConfigs(
 		// If there are no valid actions found for this rule, then elide the rule.
 		if len(actionsStat) == 0 && len(actionsDynamic) == 0 &&
 			len(cfg.RequestHeaderOperations) == 0 && len(cfg.ResponseHeaderOperations) == 0 {
-			appendErr(ctx, errs, fmt.Sprintf("rule=%s", ruleName), monitoring.RuleErrs, "No valid actions found in rule")
+			ruleErrs++
+			appendErr(errs, fmt.Sprintf("rule=%s", ruleName), "No valid actions found in rule")
 			continue
 		}
 
@@ -828,6 +846,8 @@ func (e *Ephemeral) processRuleConfigs(
 		rules = append(rules, rule)
 	}
 
+	stats.Record(ctx, monitoring.RuleErrs.M(ruleErrs))
+
 	return rules
 }
 
@@ -843,11 +863,11 @@ func contains(strs []string, w string) bool {
 func (e *Ephemeral) processDynamicTemplateConfigs(ctx context.Context, errs *multierror.Error) map[string]*Template {
 	result := map[string]*Template{}
 	log.Debug("Begin processing templates.")
+	var templateErrs int64
 	for templateKey, resource := range e.entries {
 		if templateKey.Kind != constant.TemplateKind {
 			continue
 		}
-		stats.Record(ctx, monitoring.TemplatesTotal.M(1))
 
 		templateName := templateKey.String()
 		cfg := resource.Spec.(*v1beta1.Template)
@@ -855,7 +875,8 @@ func (e *Ephemeral) processDynamicTemplateConfigs(ctx context.Context, errs *mul
 
 		fds, desc, name, variety, err := GetTmplDescriptor(cfg.Descriptor_)
 		if err != nil {
-			appendErr(ctx, errs, fmt.Sprintf("template='%s'", templateName), monitoring.TemplateErrs, "unable to parse descriptor: %v", err)
+			templateErrs++
+			appendErr(errs, fmt.Sprintf("template='%s'", templateName), "unable to parse descriptor: %v", err)
 			continue
 		}
 
@@ -887,13 +908,13 @@ func (e *Ephemeral) processDynamicTemplateConfigs(ctx context.Context, errs *mul
 			result[templateName].AttributeManifest = attributes
 		}
 	}
+	stats.Record(ctx, monitoring.TemplateErrs.M(templateErrs))
 	return result
 }
 
-func appendErr(ctx context.Context, errs *multierror.Error, field string, measure *stats.Int64Measure, format string, a ...interface{}) {
+func appendErr(errs *multierror.Error, field string, format string, a ...interface{}) {
 	err := fmt.Errorf(format, a...)
 	log.Debug(err.Error())
-	stats.Record(ctx, measure.M(1))
 	_ = multierror.Append(errs, adapter.ConfigError{Field: field, Underlying: err})
 }
 

--- a/mixer/pkg/runtime/config/ephemeral.go
+++ b/mixer/pkg/runtime/config/ephemeral.go
@@ -159,13 +159,13 @@ func (e *Ephemeral) BuildSnapshot() (*Snapshot, error) {
 
 	af := ast.NewFinder(attributes)
 	e.attributes = af
-	instances, instErrs := e.processInstanceConfigs(monitoringCtx, errs)
+	instances, instErrs := e.processInstanceConfigs(errs)
 
 	// New dynamic configurations
 	dTemplates := e.processDynamicTemplateConfigs(monitoringCtx, errs)
 	dAdapters := e.processDynamicAdapterConfigs(monitoringCtx, dTemplates, errs)
 	dhandlers := e.processDynamicHandlerConfigs(monitoringCtx, dAdapters, errs)
-	dInstances, dInstErrs := e.processDynamicInstanceConfigs(monitoringCtx, dTemplates, errs)
+	dInstances, dInstErrs := e.processDynamicInstanceConfigs(dTemplates, errs)
 
 	rules := e.processRuleConfigs(monitoringCtx, shandlers, instances, dhandlers, dInstances, errs)
 
@@ -387,8 +387,7 @@ func asAny(msgFQN string, bytes []byte) *types.Any {
 	}
 }
 
-func (e *Ephemeral) processDynamicInstanceConfigs(ctx context.Context, templates map[string]*Template,
-	errs *multierror.Error) (map[string]*InstanceDynamic, int64) {
+func (e *Ephemeral) processDynamicInstanceConfigs(templates map[string]*Template, errs *multierror.Error) (map[string]*InstanceDynamic, int64) {
 	instances := make(map[string]*InstanceDynamic, len(e.templates))
 	var instErrs int64
 
@@ -485,7 +484,7 @@ func validateEncodeBytes(params *types.Struct, fds *descriptor.FileDescriptorSet
 	return yaml.NewEncoder(fds).EncodeBytes(d, msgName, false)
 }
 
-func (e *Ephemeral) processInstanceConfigs(ctx context.Context, errs *multierror.Error) (map[string]*InstanceStatic, int64) {
+func (e *Ephemeral) processInstanceConfigs(errs *multierror.Error) (map[string]*InstanceStatic, int64) {
 	instances := make(map[string]*InstanceStatic, len(e.templates))
 	var instErrs int64
 

--- a/mixer/pkg/runtime/config/snapshot.go
+++ b/mixer/pkg/runtime/config/snapshot.go
@@ -17,8 +17,6 @@ package config
 import (
 	"context"
 
-	"go.opencensus.io/tag"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/gogo/protobuf/types"
@@ -29,9 +27,7 @@ import (
 	"istio.io/istio/mixer/pkg/lang/ast"
 	"istio.io/istio/mixer/pkg/protobuf/yaml/dynamic"
 	"istio.io/istio/mixer/pkg/runtime/lang"
-	"istio.io/istio/mixer/pkg/runtime/monitoring"
 	"istio.io/istio/mixer/pkg/template"
-	"istio.io/istio/pkg/log"
 )
 
 type (
@@ -216,17 +212,10 @@ type (
 
 // Empty returns a new, empty configuration snapshot.
 func Empty() *Snapshot {
-
-	var err error
-	ctx := context.Background()
-	if ctx, err = tag.New(ctx, tag.Insert(monitoring.ConfigIDTag, "-1")); err != nil {
-		log.Errorf("error establishing monitoring context config ID: %v", err)
-	}
-
 	return &Snapshot{
 		ID:                -1,
 		Rules:             []*Rule{},
-		MonitoringContext: ctx,
+		MonitoringContext: context.Background(),
 	}
 }
 

--- a/mixer/pkg/runtime/handler/env.go
+++ b/mixer/pkg/runtime/handler/env.go
@@ -19,10 +19,12 @@ import (
 	"sync/atomic"
 
 	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/mixer/pkg/runtime/monitoring"
+	"istio.io/istio/pkg/log"
 )
 
 type env struct {
@@ -34,10 +36,15 @@ type env struct {
 
 // NewEnv returns a new environment instance.
 func NewEnv(cfgID int64, name string, gp *pool.GoroutinePool) adapter.Env {
+	ctx := context.Background()
+	var err error
+	if ctx, err = tag.New(ctx, tag.Insert(monitoring.HandlerTag, name)); err != nil {
+		log.Errorf("could not setup context for stats: %v", err)
+	}
 	return env{
 		logger:        newLogger(name),
 		gp:            gp,
-		monitoringCtx: context.Background(),
+		monitoringCtx: ctx,
 		daemons:       new(int64),
 		workers:       new(int64),
 	}

--- a/mixer/pkg/runtime/handler/env.go
+++ b/mixer/pkg/runtime/handler/env.go
@@ -16,16 +16,13 @@ package handler
 
 import (
 	"context"
-	"strconv"
 	"sync/atomic"
 
 	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/mixer/pkg/runtime/monitoring"
-	"istio.io/istio/pkg/log"
 )
 
 type env struct {
@@ -37,16 +34,10 @@ type env struct {
 
 // NewEnv returns a new environment instance.
 func NewEnv(cfgID int64, name string, gp *pool.GoroutinePool) adapter.Env {
-	ctx := context.Background()
-	var err error
-	if ctx, err = tag.New(ctx, tag.Insert(monitoring.InitConfigIDTag, strconv.FormatInt(cfgID, 10)), tag.Insert(monitoring.HandlerTag, name)); err != nil {
-		log.Errorf("could not setup context for stats: %v", err)
-	}
-
 	return env{
 		logger:        newLogger(name),
 		gp:            gp,
-		monitoringCtx: ctx,
+		monitoringCtx: context.Background(),
 		daemons:       new(int64),
 		workers:       new(int64),
 	}

--- a/mixer/pkg/runtime/handler/table.go
+++ b/mixer/pkg/runtime/handler/table.go
@@ -124,7 +124,7 @@ func NewTable(old *Table, snapshot *config.Snapshot, gp *pool.GoroutinePool) *Ta
 
 type buildHandlerFn func(handler hndlr, instances interface{}) (h adapter.Handler, env env, err error)
 
-func createEntry(old *Table, t *Table, handler hndlr, instances interface{}, snapshotID int64, buildHandler buildHandlerFn) (new, reused, errors int64) {
+func createEntry(old *Table, t *Table, handler hndlr, instances interface{}, snapshotID int64, buildHandler buildHandlerFn) (added, reused, errors int64) {
 
 	sig := calculateSignature(handler, instances)
 
@@ -147,7 +147,7 @@ func createEntry(old *Table, t *Table, handler hndlr, instances interface{}, sna
 		return
 	}
 
-	new++
+	added++
 
 	t.entries[handler.GetName()] = Entry{
 		Name:        handler.GetName(),
@@ -157,7 +157,7 @@ func createEntry(old *Table, t *Table, handler hndlr, instances interface{}, sna
 		env:         e,
 	}
 
-	return new, reused, errors
+	return added, reused, errors
 }
 
 // Cleanup the old table by selectively closing handlers that are not used in the given table.

--- a/mixer/pkg/runtime/handler/table.go
+++ b/mixer/pkg/runtime/handler/table.go
@@ -16,11 +16,9 @@ package handler
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/pool"
@@ -71,31 +69,30 @@ func NewTable(old *Table, snapshot *config.Snapshot, gp *pool.GoroutinePool) *Ta
 	instancesByHandler := config.GetInstancesGroupedByHandlers(snapshot)
 	instancesByHandlerDynamic := config.GetInstancesGroupedByHandlersDynamic(snapshot)
 
-	var err error
-	ctx := context.Background()
-	if ctx, err = tag.New(ctx, tag.Insert(monitoring.ConfigIDTag, strconv.FormatInt(snapshot.ID, 10))); err != nil {
-		log.Errorf("not able to set context for snapshot: %v", err)
-	}
-
 	t := &Table{
 		entries:                   make(map[string]Entry, len(instancesByHandler)+len(instancesByHandlerDynamic)),
-		monitoringCtx:             ctx,
+		monitoringCtx:             context.Background(),
 		strayWorkersCheckRetries:  defaultRetryChecks,
 		strayWorkersRetryDuration: defaultRetryDuration,
 	}
 
+	var newAdapters, reusedAdapters, buildErrs int64
 	for handler, instances := range instancesByHandler {
-		createEntry(old, t, handler, instances, snapshot.ID,
+		n, r, be := createEntry(old, t, handler, instances, snapshot.ID,
 			func(handler hndlr, instances interface{}) (h adapter.Handler, e env, err error) {
 				e = NewEnv(snapshot.ID, handler.GetName(), gp).(env)
 				h, err = config.BuildHandler(handler.(*config.HandlerStatic), instances.([]*config.InstanceStatic),
 					e, snapshot.Templates)
 				return h, e, err
 			})
+
+		newAdapters += n
+		reusedAdapters += r
+		buildErrs += be
 	}
 
 	for handler, instances := range instancesByHandlerDynamic {
-		createEntry(old, t, handler, instances, snapshot.ID,
+		n, r, be := createEntry(old, t, handler, instances, snapshot.ID,
 			func(_ hndlr, _ interface{}) (h adapter.Handler, e env, err error) {
 				e = NewEnv(snapshot.ID, handler.GetName(), gp).(env)
 				tmplCfg := make([]*dynamic.TemplateConfig, 0, len(instances))
@@ -111,13 +108,23 @@ func NewTable(old *Table, snapshot *config.Snapshot, gp *pool.GoroutinePool) *Ta
 					handler.Adapter.SessionBased, handler.AdapterConfig, tmplCfg, false)
 				return h, e, err
 			})
+
+		newAdapters += n
+		reusedAdapters += r
+		buildErrs += be
 	}
+
+	stats.Record(t.monitoringCtx,
+		monitoring.NewHandlersTotal.M(newAdapters),
+		monitoring.ReusedHandlersTotal.M(reusedAdapters),
+		monitoring.BuildFailuresTotal.M(buildErrs),
+	)
 	return t
 }
 
 type buildHandlerFn func(handler hndlr, instances interface{}) (h adapter.Handler, env env, err error)
 
-func createEntry(old *Table, t *Table, handler hndlr, instances interface{}, snapshotID int64, buildHandler buildHandlerFn) {
+func createEntry(old *Table, t *Table, handler hndlr, instances interface{}, snapshotID int64, buildHandler buildHandlerFn) (new, reused, errors int64) {
 
 	sig := calculateSignature(handler, instances)
 
@@ -125,14 +132,14 @@ func createEntry(old *Table, t *Table, handler hndlr, instances interface{}, sna
 	if found && currentEntry.Signature.equals(sig) {
 		// reuse the Handler
 		t.entries[handler.GetName()] = currentEntry
-		stats.Record(t.monitoringCtx, monitoring.ReusedHandlersTotal.M(1))
+		reused++
 		return
 	}
 
 	instantiatedHandler, e, err := buildHandler(handler, instances)
 
 	if err != nil {
-		stats.Record(t.monitoringCtx, monitoring.BuildFailuresTotal.M(1))
+		errors++
 		log.Errorf(
 			"Unable to initialize adapter: snapshot='%d', handler='%s', adapter='%s', err='%s'.\n"+
 				"Please remove the handler or fix the configuration.",
@@ -140,7 +147,7 @@ func createEntry(old *Table, t *Table, handler hndlr, instances interface{}, sna
 		return
 	}
 
-	stats.Record(t.monitoringCtx, monitoring.NewHandlersTotal.M(1))
+	new++
 
 	t.entries[handler.GetName()] = Entry{
 		Name:        handler.GetName(),
@@ -149,6 +156,8 @@ func createEntry(old *Table, t *Table, handler hndlr, instances interface{}, sna
 		Signature:   sig,
 		env:         e,
 	}
+
+	return new, reused, errors
 }
 
 // Cleanup the old table by selectively closing handlers that are not used in the given table.
@@ -169,9 +178,9 @@ func (t *Table) Cleanup(current *Table) {
 		toCleanup = append(toCleanup, oldEntry)
 	}
 
+	var closed, closeErrs int64
 	for _, entry := range toCleanup {
 		log.Debugf("Closing adapter %s/%v", entry.Name, entry.Handler)
-		stats.Record(t.monitoringCtx, monitoring.ClosedHandlersTotal.M(1))
 		var err error
 		panicErr := safecall.Execute("handler.Close", func() {
 			err = entry.Handler.Close()
@@ -197,10 +206,21 @@ func (t *Table) Cleanup(current *Table) {
 		}(entry.env, entry.Name)
 
 		if err != nil {
-			stats.Record(t.monitoringCtx, monitoring.CloseFailuresTotal.M(1))
+			closeErrs++
 			log.Warnf("Error closing adapter: %s/%v: '%v'", entry.Name, entry.Handler, err)
+		} else {
+			closed++
 		}
 	}
+
+	ctx := context.Background()
+	if t != nil && t.monitoringCtx != nil {
+		ctx = t.monitoringCtx
+	}
+	stats.Record(ctx,
+		monitoring.ClosedHandlersTotal.M(closed),
+		monitoring.CloseFailuresTotal.M(closeErrs),
+	)
 }
 
 // Get returns the entry for a Handler with the given name, if it exists.

--- a/mixer/pkg/runtime/monitoring/monitoring.go
+++ b/mixer/pkg/runtime/monitoring/monitoring.go
@@ -26,9 +26,11 @@ const (
 	meshFunction = "meshFunction"
 	adapterName  = "adapter"
 	errorStr     = "error"
+	varietyStr   = "variety"
 )
 
 var (
+	// HandlerTag holds the current handler for the context.
 	HandlerTag tag.Key
 	// MeshFunctionTag holds the current mesh function (logentry, metric, etc) for the context.
 	MeshFunctionTag tag.Key
@@ -36,6 +38,8 @@ var (
 	AdapterTag tag.Key
 	// ErrorTag holds the current error for the context.
 	ErrorTag tag.Key
+	// VarietyTag holds the template variety
+	VarietyTag tag.Key
 
 	// distribution buckets
 	durationBuckets = []float64{.0001, .00025, .0005, .001, .0025, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
@@ -184,6 +188,11 @@ var (
 		"mixer/dispatcher/instances_per_request",
 		"Number of instances created per request by Mixer",
 		stats.UnitDimensionless)
+
+	DestinationsPerVarietyTotal = stats.Int64(
+		"mixer/dispatcher/destinations_per_variety_total",
+		"Number of Mixer adapter destinations by template variety type",
+		stats.UnitDimensionless)
 )
 
 func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
@@ -210,9 +219,13 @@ func init() {
 	if ErrorTag, err = tag.NewKey(errorStr); err != nil {
 		panic(err)
 	}
+	if VarietyTag, err = tag.NewKey(varietyStr); err != nil {
+		panic(err)
+	}
 
 	envConfigKeys := []tag.Key{HandlerTag}
 	dispatchKeys := []tag.Key{MeshFunctionTag, HandlerTag, AdapterTag, ErrorTag}
+	varietyKeys := []tag.Key{VarietyTag}
 
 	runtimeViews := []*view.View{
 		// config views
@@ -234,6 +247,7 @@ func init() {
 		newView(ClosedHandlersTotal, []tag.Key{}, view.LastValue()),
 		newView(BuildFailuresTotal, []tag.Key{}, view.LastValue()),
 		newView(CloseFailuresTotal, []tag.Key{}, view.LastValue()),
+		newView(DestinationsPerVarietyTotal, varietyKeys, view.LastValue()),
 
 		// env views
 		newView(WorkersTotal, envConfigKeys, view.LastValue()),

--- a/mixer/pkg/runtime/monitoring/monitoring.go
+++ b/mixer/pkg/runtime/monitoring/monitoring.go
@@ -22,8 +22,6 @@ import (
 
 const (
 	// tag names used by runtime packages
-	configID     = "configID"
-	initConfigID = "initConfigID" // the id of the config, at which the adapter was instantiated.
 	handler      = "handler"
 	meshFunction = "meshFunction"
 	adapterName  = "adapter"
@@ -31,11 +29,6 @@ const (
 )
 
 var (
-	// ConfigIDTag holds a config identifier for the context.
-	ConfigIDTag tag.Key
-	// InitConfigIDTag holds the config identifier used when the context was initialized.
-	InitConfigIDTag tag.Key
-	// HandlerTag holds the current handler for the context.
 	HandlerTag tag.Key
 	// MeshFunctionTag holds the current mesh function (logentry, metric, etc) for the context.
 	MeshFunctionTag tag.Key
@@ -205,12 +198,6 @@ func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregatio
 
 func init() {
 	var err error
-	if ConfigIDTag, err = tag.NewKey(configID); err != nil {
-		panic(err)
-	}
-	if InitConfigIDTag, err = tag.NewKey(initConfigID); err != nil {
-		panic(err)
-	}
 	if MeshFunctionTag, err = tag.NewKey(meshFunction); err != nil {
 		panic(err)
 	}
@@ -224,30 +211,29 @@ func init() {
 		panic(err)
 	}
 
-	configKeys := []tag.Key{ConfigIDTag}
-	envConfigKeys := []tag.Key{InitConfigIDTag, HandlerTag}
+	envConfigKeys := []tag.Key{HandlerTag}
 	dispatchKeys := []tag.Key{MeshFunctionTag, HandlerTag, AdapterTag, ErrorTag}
 
 	runtimeViews := []*view.View{
 		// config views
-		newView(AttributesTotal, configKeys, view.Count()),
-		newView(HandlersTotal, configKeys, view.Count()),
-		newView(InstancesTotal, configKeys, view.Count()),
-		newView(InstanceErrs, configKeys, view.Count()),
-		newView(RulesTotal, configKeys, view.Count()),
-		newView(RuleErrs, configKeys, view.Count()),
-		newView(AdapterInfosTotal, configKeys, view.Count()),
-		newView(AdapterErrs, configKeys, view.Count()),
-		newView(TemplatesTotal, configKeys, view.Count()),
-		newView(TemplateErrs, configKeys, view.Count()),
-		newView(MatchErrors, configKeys, view.Count()),
-		newView(UnsatisfiedActionHandlers, configKeys, view.Count()),
-		newView(HandlerValidationErrors, configKeys, view.Count()),
-		newView(NewHandlersTotal, configKeys, view.Count()),
-		newView(ReusedHandlersTotal, configKeys, view.Count()),
-		newView(ClosedHandlersTotal, configKeys, view.Count()),
-		newView(BuildFailuresTotal, configKeys, view.Count()),
-		newView(CloseFailuresTotal, configKeys, view.Count()),
+		newView(AttributesTotal, []tag.Key{}, view.LastValue()),
+		newView(HandlersTotal, []tag.Key{}, view.LastValue()),
+		newView(InstancesTotal, []tag.Key{}, view.LastValue()),
+		newView(InstanceErrs, []tag.Key{}, view.LastValue()),
+		newView(RulesTotal, []tag.Key{}, view.LastValue()),
+		newView(RuleErrs, []tag.Key{}, view.LastValue()),
+		newView(AdapterInfosTotal, []tag.Key{}, view.LastValue()),
+		newView(AdapterErrs, []tag.Key{}, view.LastValue()),
+		newView(TemplatesTotal, []tag.Key{}, view.LastValue()),
+		newView(TemplateErrs, []tag.Key{}, view.LastValue()),
+		newView(MatchErrors, []tag.Key{}, view.LastValue()),
+		newView(UnsatisfiedActionHandlers, []tag.Key{}, view.LastValue()),
+		newView(HandlerValidationErrors, []tag.Key{}, view.LastValue()),
+		newView(NewHandlersTotal, []tag.Key{}, view.LastValue()),
+		newView(ReusedHandlersTotal, []tag.Key{}, view.LastValue()),
+		newView(ClosedHandlersTotal, []tag.Key{}, view.LastValue()),
+		newView(BuildFailuresTotal, []tag.Key{}, view.LastValue()),
+		newView(CloseFailuresTotal, []tag.Key{}, view.LastValue()),
 
 		// env views
 		newView(WorkersTotal, envConfigKeys, view.LastValue()),


### PR DESCRIPTION
This PR removes the config identifier dimensions from Mixer's self-monitoring metrics and introduces an additional metric for tracking dispatches by template variety.

There have been several requests to remove the `configID` dimension from the self-monitoring metrics for Mixer, including https://github.com/istio/istio/issues/9077. For the 1.1 release, during the discussion around turning `istio-policy` off-by-default, we discovered that we had no way of monitoring the different modes of dispatch within Mixer.

Most of the content on this PR is turning the counter metrics into gauges (and then adjusting the code to enable setting the measurement for each gauge in a single place).

A side benefit of this PR is that now we get values for metrics in situations that we would not before (zero errors, for example).

Example snippet of the `/metrics` with this PR:

```text
# HELP mixer_config_adapter_info_config_errors_total The number of errors encountered during processing of the adapter info configuration.
# TYPE mixer_config_adapter_info_config_errors_total gauge
mixer_config_adapter_info_config_errors_total 0
# HELP mixer_config_adapter_info_configs_total The number of known adapters in the current config.
# TYPE mixer_config_adapter_info_configs_total gauge
mixer_config_adapter_info_configs_total 0
# HELP mixer_config_attributes_total The number of known attributes in the current config.
# TYPE mixer_config_attributes_total gauge
mixer_config_attributes_total 112
# HELP mixer_config_handler_configs_total The number of known handlers in the current config.
# TYPE mixer_config_handler_configs_total gauge
mixer_config_handler_configs_total 6
# HELP mixer_config_handler_validation_error_total The number of errors encountered because handler validation returned error.
# TYPE mixer_config_handler_validation_error_total gauge
mixer_config_handler_validation_error_total 0
# HELP mixer_config_instance_config_errors_total The number of errors encountered during processing of the instance configuration.
# TYPE mixer_config_instance_config_errors_total gauge
mixer_config_instance_config_errors_total 0
# HELP mixer_config_instance_configs_total The number of known instances in the current config.
# TYPE mixer_config_instance_configs_total gauge
mixer_config_instance_configs_total 14
# HELP mixer_config_rule_config_errors_total The number of errors encountered during processing of the rule configuration.
# TYPE mixer_config_rule_config_errors_total gauge
mixer_config_rule_config_errors_total 0
# HELP mixer_config_rule_config_match_error_total The number of rule conditions that was not parseable.
# TYPE mixer_config_rule_config_match_error_total gauge
mixer_config_rule_config_match_error_total 0
# HELP mixer_config_rule_configs_total The number of known rules in the current config.
# TYPE mixer_config_rule_configs_total gauge
mixer_config_rule_configs_total 12
# HELP mixer_config_template_config_errors_total The number of errors encountered during processing of the template configuration.
# TYPE mixer_config_template_config_errors_total gauge
mixer_config_template_config_errors_total 0
# HELP mixer_config_template_configs_total The number of known templates in the current config.
# TYPE mixer_config_template_configs_total gauge
mixer_config_template_configs_total 2
# HELP mixer_config_unsatisfied_action_handler_total The number of actions that failed due to handlers being unavailable.
# TYPE mixer_config_unsatisfied_action_handler_total gauge
mixer_config_unsatisfied_action_handler_total 1
# HELP mixer_dispatcher_destinations_per_variety_total Number of Mixer adapter destinations by template variety type
# TYPE mixer_dispatcher_destinations_per_variety_total gauge
mixer_dispatcher_destinations_per_variety_total{variety="TEMPLATE_VARIETY_CHECK"} 2
mixer_dispatcher_destinations_per_variety_total{variety="TEMPLATE_VARIETY_QUOTA"} 1
mixer_dispatcher_destinations_per_variety_total{variety="TEMPLATE_VARIETY_REPORT"} 2
# HELP mixer_handler_closed_handlers_total The number of handlers that were closed during config transition.
# TYPE mixer_handler_closed_handlers_total gauge
mixer_handler_closed_handlers_total 0
# HELP mixer_handler_daemons_total The current number of active daemon routines in a given adapter environment.
# TYPE mixer_handler_daemons_total gauge
mixer_handler_daemons_total{handler="memquota.istio-system"} 1
mixer_handler_daemons_total{handler="prometheus.istio-system"} 1
# HELP mixer_handler_handler_build_failures_total The number of handlers that failed creation during config transition.
# TYPE mixer_handler_handler_build_failures_total gauge
mixer_handler_handler_build_failures_total 1
# HELP mixer_handler_handler_close_failures_total The number of errors encountered while closing handlers during config transition.
# TYPE mixer_handler_handler_close_failures_total gauge
mixer_handler_handler_close_failures_total 0
# HELP mixer_handler_new_handlers_total The number of handlers that were newly created during config transition.
# TYPE mixer_handler_new_handlers_total gauge
mixer_handler_new_handlers_total 5
# HELP mixer_handler_reused_handlers_total The number of handlers that were re-used during config transition.
# TYPE mixer_handler_reused_handlers_total gauge
mixer_handler_reused_handlers_total 0
```

This is part of code mauve as it improves system debugability and addresses a known issue in monitoring.

Fixes: https://github.com/istio/istio/issues/9077