### PR TITLE
move up kiali and grafana

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/values.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/values.yaml
@@ -5,7 +5,7 @@ enabled: false
 replicaCount: 1
 image:
   repository: grafana/grafana
-  tag: 5.4.0
+  tag: 6.0.2
 ingress:
   enabled: false
   ## Used to create an Ingress record.

--- a/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
 name: kiali
 version: 1.1.0
-appVersion: 0.14
+appVersion: 0.16
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -4,7 +4,7 @@
 enabled: false # Note that if using the demo or demo-auth yaml when installing via Helm, this default will be `true`.
 replicaCount: 1
 hub: docker.io/kiali
-tag: v0.14
+tag: v0.16
 contextPath: /kiali # The root context path to access the Kiali UI.
 nodeSelector: {}
 


### PR DESCRIPTION
to address some vulnerability issue found during our image scan for older images we use in 1.1