### PR TITLE
Don't pass tracing addresses if tracing disabled

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -113,7 +113,7 @@ data:
         - {{ "[[ formatDuration .ProxyConfig.ParentShutdownDuration ]]" }}
         - --discoveryAddress
         - {{ "[[ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress ]]" }}
-      {{- if eq .Values.global.proxy.tracer "lightstep" }}
+      {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.proxy.enableTracing }}
         - --lightstepAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetAddress ]]" }}
         - --lightstepAccessToken
@@ -121,10 +121,10 @@ data:
         - --lightstepSecure={{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetSecure ]]" }}
         - --lightstepCacertPath
         - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetCacertPath ]]" }}
-      {{- else if eq .Values.global.proxy.tracer "zipkin" }}
+      {{- else if and (eq .Values.global.proxy.tracer "zipkin") .Values.global.proxy.enableTracing }}
         - --zipkinAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetZipkin.GetAddress ]]" }}
-      {{- else if eq .Values.global.proxy.tracer "datadog" }}
+      {{- else if and (eq .Values.global.proxy.tracer "datadog") .Values.global.proxy.enableTracing }}
         - --datadogAgentAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetDatadog.GetAddress ]]" }}
       {{- end }}

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -39,8 +39,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -42,8 +42,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -42,8 +42,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -44,8 +44,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -40,8 +40,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -41,8 +41,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -193,8 +191,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -60,8 +60,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -44,8 +44,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -41,8 +41,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -193,8 +191,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -40,8 +40,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -39,8 +39,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -40,8 +40,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -43,8 +43,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -43,8 +43,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -42,8 +42,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -42,8 +42,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -42,8 +42,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -42,8 +42,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --proxyAdminPort


### PR DESCRIPTION
Without this change, clusters are created for tracing services when the
are not even abled, which causes additional DNS requests.

Related: https://github.com/istio/istio/issues/12968