### PR TITLE
Add variables to the Kiali chart to support multi-namespace deployment scenario

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
@@ -10,13 +10,24 @@ metadata:
     release: {{ .Release.Name }}
 data:
   config.yaml: |
+    {{- if .Values.istio.istio_namespace }}
+    istio_namespace: {{ .Values.istio.istio_namespace }}
+    {{- else }}
     istio_namespace: {{ .Release.Namespace }}
+    {{- end }}
     server:
       port: 20001
     external_services:
       istio:
+        {{- if .Values.istio.url_service_version }}
+        url_service_version: {{ .Values.istio.url_service_version }}
+        {{- else }}
         url_service_version: http://istio-pilot:8080/version
+        {{- end }}
       jaeger:
         url: {{ .Values.dashboard.jaegerURL }}
       grafana:
         url: {{ .Values.dashboard.grafanaURL }}
+        {{- if .Values.grafana.service_namespace }}
+        service_namespace: {{ .Values.grafana.service_namespace }}
+        {{- end }}

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -53,3 +53,13 @@ prometheusAddr: http://prometheus:9090
 
 # When true, a secret will be created with a default username and password. Useful for demos.
 createDemoSecret: false
+
+istio:
+  # The namespace where Istio is installed. (Default: istio-system)
+  istio_namespace: istio-system
+  # The Service of Istio to check version. (default is http://istio-pilot:8080/version)
+  url_service_version: http://istio-pilot:8080/version
+
+# The Kubernetes namespace that holds the Grafana service. (default is istio-system)
+grafana:
+  service_namespace: istio-system


### PR DESCRIPTION
When deploying Istio in multi-namespace scenario, Kiali configmap needs to be updated to point the right:
- istio namespace (default is _istio-system_)
- pilot service (default is _http://istio-pilot:8080/version_)
- grafana namespace (default is _istio-system_)
For example:

![image](https://user-images.githubusercontent.com/13514337/55718026-9fd4ec80-59f2-11e9-891c-ec01151a7ebb.png)


Adding the required variables to handle such scenario:

```
istio:
  # The namespace where Istio is installed. (Default: istio-system)
  istio_namespace: istio-system-11
  # The Service of Istio to check version. (default is http://istio-pilot:8080/version)
  url_service_version: http://istio-pilot.istio-system-11.svc:8080/version

# The Kubernetes namespace that holds the Grafana service. (default is istio-system)
grafana:
  service_namespace: istio-dashbord-11
```
