### PR TITLE
Add `istioctl collateral --zsh` to generate zsh completion files

### DIFF
--- a/pkg/collateral/cobra.go
+++ b/pkg/collateral/cobra.go
@@ -36,6 +36,7 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 			if all {
 				c.EmitYAML = true
 				c.EmitBashCompletion = true
+				c.EmitZshCompletion = true
 				c.EmitManPages = true
 				c.EmitMarkdown = true
 				c.EmitHTMLFragmentWithFrontMatter = true
@@ -51,6 +52,7 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 	cmd.Flags().BoolVarP(&c.EmitMarkdown, "markdown", "", c.EmitMarkdown, "Produce markdown documentation files")
 	cmd.Flags().BoolVarP(&c.EmitManPages, "man", "", c.EmitManPages, "Produce man pages")
 	cmd.Flags().BoolVarP(&c.EmitBashCompletion, "bash", "", c.EmitBashCompletion, "Produce bash completion files")
+	cmd.Flags().BoolVarP(&c.EmitZshCompletion, "zsh", "", c.EmitZshCompletion, "Produce zsh completion files")
 	cmd.Flags().BoolVarP(&c.EmitYAML, "yaml", "", c.EmitYAML, "Produce YAML documentation files")
 	cmd.Flags().BoolVarP(&c.EmitHTMLFragmentWithFrontMatter, "html_fragment_with_front_matter",
 		"", c.EmitHTMLFragmentWithFrontMatter, "Produce an HTML documentation file with Hugo/Jekyll-compatible front matter.")

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -46,7 +46,7 @@ type Control struct {
 	// EmitBashCompletion controls whether to produce bash completion files.
 	EmitBashCompletion bool
 
-	// EmitZshCompletion controls whether to produce bash completion files.
+	// EmitZshCompletion controls whether to produce zsh completion files.
 	EmitZshCompletion bool
 
 	// EmitMarkdown controls whether to produce markdown documentation files.

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -46,6 +46,9 @@ type Control struct {
 	// EmitBashCompletion controls whether to produce bash completion files.
 	EmitBashCompletion bool
 
+	// EmitZshCompletion controls whether to produce bash completion files.
+	EmitZshCompletion bool
+
 	// EmitMarkdown controls whether to produce markdown documentation files.
 	EmitMarkdown bool
 
@@ -87,6 +90,12 @@ func EmitCollateral(root *cobra.Command, c *Control) error {
 	if c.EmitBashCompletion {
 		if err := root.GenBashCompletionFile(c.OutputDir + "/" + root.Name() + ".bash"); err != nil {
 			return fmt.Errorf("unable to output bash completion file: %v", err)
+		}
+	}
+
+	if c.EmitZshCompletion {
+		if err := root.GenZshCompletionFile(c.OutputDir + "/" + "_" + root.Name()); err != nil {
+			return fmt.Errorf("unable to output zsh completion file: %v", err)
 		}
 	}
 


### PR DESCRIPTION
  The current zsh completion file genereated via cobra doesn't work.
  Waiting for them to merge their PR https://github.com/spf13/cobra/pull/828 to get actual working file.