### PR TITLE
Config use_remote_address & xff_num_trusted_hops.

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -110,6 +110,12 @@ istio-ingressgateway:
     # set of clusters for internal services but without Istio mTLS, to
     # enable cross cluster routing.
     ISTIO_META_ROUTER_MODE: "sni-dnat"
+    # The Envoy HTTP connection manager options below configure
+    # how Envoy determines the trusted client address.
+    # See the following Envoy documentation on X-Forwarded-For for reference.
+    # https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#x-forwarded-for
+    # ISTIO_META_USE_REMOTE_ADDRESS: "false"
+    # ISTIO_META_XFF_NUM_TRUSTED_HOPS: "2"
   nodeSelector: {}
 
   # Specify the pod anti-affinity that allows you to constrain which nodes

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1337,8 +1337,9 @@ type httpListenerOpts struct {
 	direction  http_conn.HttpConnectionManager_Tracing_OperationName
 	// addGRPCWebFilter specifies whether the envoy.grpc_web HTTP filter
 	// should be added.
-	addGRPCWebFilter bool
-	useRemoteAddress bool
+	addGRPCWebFilter  bool
+	useRemoteAddress  bool
+	xffNumTrustedHops uint32
 }
 
 // filterChainOpts describes a filter chain: a set of filters with the same TLS context
@@ -1397,6 +1398,7 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 	} else {
 		connectionManager.UseRemoteAddress = proto.BoolFalse
 	}
+	connectionManager.XffNumTrustedHops = httpOpts.xffNumTrustedHops
 
 	// Allow websocket upgrades
 	websocketUpgrade := &http_conn.HttpConnectionManager_UpgradeConfig{UpgradeType: "websocket"}


### PR DESCRIPTION
Addresses https://github.com/istio/istio/issues/7679.

Allow configuring use_remote_address and xff_num_trusted_hops for
Istio ingress gateways with different internal or external positioning.

Envoy defaults use_remote_address=false and xff_num_trusted_hops=0,
while Istio ingress gateways are configured with
defaults use_remote_address=true and xff_num_trusted_hops=0.

Preserve these defaults, but allow for configuration from proxy node
metadata.