### PR TITLE
appsv1 mixer

### DIFF
--- a/mixer/adapter/kubernetesenv/kubernetesenv_test.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv_test.go
@@ -218,7 +218,7 @@ func TestKubegen_Generate(t *testing.T) {
 	testPodToNoControllerPodOut.SetSourcePodName("test-pod")
 	testPodToNoControllerPodOut.SetSourcePodUid("kubernetes://test-pod.testns")
 	testPodToNoControllerPodOut.SetSourceServiceAccountName("test")
-	testPodToNoControllerPodOut.SetSourceOwner("kubernetes://apis/extensions/v1beta1/namespaces/testns/deployments/test-deployment")
+	testPodToNoControllerPodOut.SetSourceOwner("kubernetes://apis/apps/v1/namespaces/testns/deployments/test-deployment")
 	testPodToNoControllerPodOut.SetSourceWorkloadName("test-deployment")
 	testPodToNoControllerPodOut.SetSourceWorkloadNamespace("testns")
 	testPodToNoControllerPodOut.SetSourceWorkloadUid("istio://testns/workloads/test-deployment")
@@ -249,7 +249,7 @@ func TestKubegen_Generate(t *testing.T) {
 	altTestPodToAltTestPod2Out.SetDestinationPodName("alt-test-pod-2")
 	altTestPodToAltTestPod2Out.SetDestinationNamespace("testns")
 	altTestPodToAltTestPod2Out.SetDestinationPodUid("kubernetes://alt-test-pod-2.testns")
-	altTestPodToAltTestPod2Out.SetDestinationOwner("kubernetes://apis/apps/v1beta2/namespaces/testns/deployments/test-deployment")
+	altTestPodToAltTestPod2Out.SetDestinationOwner("kubernetes://apis/apps/v1/namespaces/testns/deployments/test-deployment")
 	altTestPodToAltTestPod2Out.SetDestinationWorkloadName("test-deployment")
 	altTestPodToAltTestPod2Out.SetDestinationWorkloadNamespace("testns")
 	altTestPodToAltTestPod2Out.SetDestinationWorkloadUid("istio://testns/workloads/test-deployment")
@@ -313,7 +313,7 @@ func TestKubegen_Generate(t *testing.T) {
 	notFoundToNoControllerOut.SetDestinationPodName("test-pod")
 	notFoundToNoControllerOut.SetDestinationPodUid("kubernetes://test-pod.testns")
 	notFoundToNoControllerOut.SetDestinationServiceAccountName("test")
-	notFoundToNoControllerOut.SetDestinationOwner("kubernetes://apis/extensions/v1beta1/namespaces/testns/deployments/test-deployment")
+	notFoundToNoControllerOut.SetDestinationOwner("kubernetes://apis/apps/v1/namespaces/testns/deployments/test-deployment")
 	notFoundToNoControllerOut.SetDestinationWorkloadName("test-deployment")
 	notFoundToNoControllerOut.SetDestinationWorkloadNamespace("testns")
 	notFoundToNoControllerOut.SetDestinationWorkloadUid("istio://testns/workloads/test-deployment")
@@ -353,7 +353,7 @@ func TestKubegen_Generate(t *testing.T) {
 	replicaSetToReplicaSetOut := kubernetes_apa_tmpl.NewOutput()
 	replicaSetToReplicaSetOut.SetSourceLabels(map[string]string{"app": "some-app"})
 	replicaSetToReplicaSetOut.SetSourceNamespace("testns")
-	replicaSetToReplicaSetOut.SetSourceOwner("kubernetes://apis/apps/v1beta2/namespaces/testns/replicasets/not-found-replicaset")
+	replicaSetToReplicaSetOut.SetSourceOwner("kubernetes://apis/apps/v1/namespaces/testns/replicasets/not-found-replicaset")
 	replicaSetToReplicaSetOut.SetSourcePodName("appsv1beta2-replicaset-with-no-deployment-pod")
 	replicaSetToReplicaSetOut.SetSourcePodUid("kubernetes://appsv1beta2-replicaset-with-no-deployment-pod.testns")
 	replicaSetToReplicaSetOut.SetSourceWorkloadName("not-found-replicaset")
@@ -361,7 +361,7 @@ func TestKubegen_Generate(t *testing.T) {
 	replicaSetToReplicaSetOut.SetSourceWorkloadUid("istio://testns/workloads/not-found-replicaset")
 	replicaSetToReplicaSetOut.SetDestinationLabels(map[string]string{"app": "some-app"})
 	replicaSetToReplicaSetOut.SetDestinationNamespace("testns")
-	replicaSetToReplicaSetOut.SetDestinationOwner("kubernetes://apis/extensions/v1beta1/namespaces/testns/replicasets/test-replicaset-without-deployment")
+	replicaSetToReplicaSetOut.SetDestinationOwner("kubernetes://apis/apps/v1/namespaces/testns/replicasets/test-replicaset-without-deployment")
 	replicaSetToReplicaSetOut.SetDestinationPodName("extv1beta1-replicaset-with-no-deployment-pod")
 	replicaSetToReplicaSetOut.SetDestinationPodUid("kubernetes://extv1beta1-replicaset-with-no-deployment-pod.testns")
 	replicaSetToReplicaSetOut.SetDestinationWorkloadName("test-replicaset-without-deployment")
@@ -554,13 +554,13 @@ var k8sobjs = []runtime.Object{
 			Namespace: "testns",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "extensions/v1beta1",
+					APIVersion: "apps/v1",
 					Controller: &trueVar,
 					Kind:       "Deployment",
 					Name:       "test-deployment",
 				},
 				{
-					APIVersion: "extensions/v1beta1",
+					APIVersion: "apps/v1",
 					Controller: &falseVar,
 					Kind:       "Deployment",
 					Name:       "not-exist-deployment",
@@ -580,7 +580,7 @@ var k8sobjs = []runtime.Object{
 			Namespace: "testns",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "apps/v1beta2",
+					APIVersion: "apps/v1",
 					Controller: &trueVar,
 					Kind:       "Deployment",
 					Name:       "test-deployment",
@@ -642,7 +642,7 @@ var k8sobjs = []runtime.Object{
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "extensions/v1beta1",
+					APIVersion: "apps/v1",
 					Controller: &trueVar,
 					Kind:       "ReplicaSet",
 					Name:       "test-replicaset-with-deployment",
@@ -679,7 +679,7 @@ var k8sobjs = []runtime.Object{
 			Labels:    map[string]string{"app": "some-app"},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "apps/v1beta2",
+					APIVersion: "apps/v1",
 					Controller: &trueVar,
 					Kind:       "ReplicaSet",
 					Name:       "test-appsv1beta2-replicaset-with-deployment",
@@ -694,7 +694,7 @@ var k8sobjs = []runtime.Object{
 			Labels:    map[string]string{"app": "some-app"},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "extensions/v1beta1",
+					APIVersion: "apps/v1",
 					Controller: &trueVar,
 					Kind:       "ReplicaSet",
 					Name:       "test-replicaset-without-deployment",
@@ -709,7 +709,7 @@ var k8sobjs = []runtime.Object{
 			Labels:    map[string]string{"app": "some-app"},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "apps/v1beta2",
+					APIVersion: "apps/v1",
 					Controller: &trueVar,
 					Kind:       "ReplicaSet",
 					Name:       "not-found-replicaset",

--- a/mixer/adapter/stackdriver/contextgraph/workload_test.go
+++ b/mixer/adapter/stackdriver/contextgraph/workload_test.go
@@ -32,7 +32,7 @@ func TestWorkloadInstanceReify(t *testing.T) {
 		clusterLocation:   "pangea",
 		clusterName:       "global-mesh",
 		uid:               "kubernetes://istio-system/istio-telemetry-65db5b46fc-r7qhq",
-		owner:             "kubernetes://apis/extensions/v1beta1/namespaces/istio-system/deployments/istio-policy",
+		owner:             "kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-policy",
 		workloadName:      "istio-policy",
 		workloadNamespace: "istio-system",
 	}
@@ -51,13 +51,13 @@ func TestWorkloadInstanceReify(t *testing.T) {
 			"//cloudresourcemanager.googleapis.com/projects/org:project",
 			"io.istio.Owner",
 			"//istio.io/projects/org:project/meshes/mesh%2F1/clusterProjects/org2:project2/locations/pangea/clusters/" +
-				"global-mesh/owners/kubernetes%3A%2F%2Fapis%2Fextensions%2Fv1beta1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
+				"global-mesh/owners/kubernetes%3A%2F%2Fapis%2Fapps%2Fv1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
 			"pangea",
 			[4]string{
 				"mesh%2F1",
 				"org2:project2",
 				"global-mesh",
-				"kubernetes%3A%2F%2Fapis%2Fextensions%2Fv1beta1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
+				"kubernetes%3A%2F%2Fapis%2Fapps%2Fv1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
 			},
 		},
 		{
@@ -81,19 +81,19 @@ func TestWorkloadInstanceReify(t *testing.T) {
 		{
 			sourceFullName: "//istio.io/projects/org:project/meshes/mesh%2F1/workloads/istio-system/istio-policy",
 			destinationFullName: "//istio.io/projects/org:project/meshes/mesh%2F1/clusterProjects/org2:project2/" +
-				"locations/pangea/clusters/global-mesh/owners/kubernetes%3A%2F%2Fapis%2Fextensions%2Fv1beta1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
+				"locations/pangea/clusters/global-mesh/owners/kubernetes%3A%2F%2Fapis%2Fapps%2Fv1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
 			typeName: "google.cloud.contextgraph.Membership",
 		}, {
 			sourceFullName: "//istio.io/projects/org:project/meshes/mesh%2F1/clusterProjects/org2:project2/" +
-				"locations/pangea/clusters/global-mesh/owners/kubernetes%3A%2F%2Fapis%2Fextensions%2Fv1beta1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
+				"locations/pangea/clusters/global-mesh/owners/kubernetes%3A%2F%2Fapis%2Fapps%2Fv1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
 			destinationFullName: "//istio.io/projects/org:project/meshes/mesh%2F1/clusterProjects/org2:project2/" +
 				"locations/pangea/clusters/global-mesh/workloadInstances/kubernetes%3A%2F%2Fistio-system%2Fistio-telemetry-65db5b46fc-r7qhq",
 			typeName: "google.cloud.contextgraph.Membership",
 		}, {
 			sourceFullName: "//istio.io/projects/org:project/meshes/mesh%2F1/clusterProjects/org2:project2/" +
-				"locations/pangea/clusters/global-mesh/owners/kubernetes%3A%2F%2Fapis%2Fextensions%2Fv1beta1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
+				"locations/pangea/clusters/global-mesh/owners/kubernetes%3A%2F%2Fapis%2Fapps%2Fv1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
 			destinationFullName: "//container.googleapis.com/projects/org2:project2/locations/pangea/clusters/global-mesh/" +
-				"k8s/namespaces/istio-system/extensions/deployments/istio-policy",
+				"k8s/namespaces/istio-system/apps/deployments/istio-policy",
 			typeName: "google.cloud.contextgraph.Membership",
 		},
 	}
@@ -114,7 +114,7 @@ func TestWorkloadInstanceClusterLocation(t *testing.T) {
 		clusterProject:    "org2:project2",
 		clusterName:       "global-mesh",
 		uid:               "kubernetes://istio-system/istio-telemetry-65db5b46fc-r7qhq",
-		owner:             "kubernetes://apis/extensions/v1beta1/namespaces/istio-system/deployments/istio-policy",
+		owner:             "kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-policy",
 		workloadName:      "istio-policy",
 		workloadNamespace: "istio-system",
 	}
@@ -124,13 +124,13 @@ func TestWorkloadInstanceClusterLocation(t *testing.T) {
 	}{
 		{"pangea",
 			"//container.googleapis.com/projects/org2:project2/locations/pangea/" +
-				"clusters/global-mesh/k8s/namespaces/istio-system/extensions/deployments/istio-policy"},
+				"clusters/global-mesh/k8s/namespaces/istio-system/apps/deployments/istio-policy"},
 		{"us-central1-a",
 			"//container.googleapis.com/projects/org2:project2/zones/us-central1-a/" +
-				"clusters/global-mesh/k8s/namespaces/istio-system/extensions/deployments/istio-policy"},
+				"clusters/global-mesh/k8s/namespaces/istio-system/apps/deployments/istio-policy"},
 		{"us-central1",
 			"//container.googleapis.com/projects/org2:project2/locations/us-central1/" +
-				"clusters/global-mesh/k8s/namespaces/istio-system/extensions/deployments/istio-policy"},
+				"clusters/global-mesh/k8s/namespaces/istio-system/apps/deployments/istio-policy"},
 	} {
 		wi.clusterLocation = test.location
 		_, edges := wi.Reify(mockLogger{})
@@ -173,7 +173,7 @@ func TestTrafficAssertionReify(t *testing.T) {
 				// policy -> k8s membership
 				{policyOwnerEntity.fullName,
 					"//container.googleapis.com/projects/org2:project2/locations//clusters/global-mesh/" +
-						"k8s/namespaces/istio-system/extensions/deployments/istio-policy",
+						"k8s/namespaces/istio-system/apps/deployments/istio-policy",
 					membershipTypeName},
 				{policyWorkloadInstanceEntity.fullName,
 					"//container.googleapis.com/projects/org2:project2/locations//clusters/global-mesh/" +
@@ -192,7 +192,7 @@ func TestTrafficAssertionReify(t *testing.T) {
 				// telemetry -> k8s membership
 				{telemetryOwnerEntity.fullName,
 					"//container.googleapis.com/projects/org2:project2/locations//clusters/global-mesh/" +
-						"k8s/namespaces/istio-system/extensions/deployments/istio-telemetry",
+						"k8s/namespaces/istio-system/apps/deployments/istio-telemetry",
 					membershipTypeName},
 				{telemetryWorkloadInstanceEntity.fullName,
 					"//container.googleapis.com/projects/org2:project2/locations//clusters/global-mesh/" +
@@ -271,7 +271,7 @@ var istioPolicyWorkloadInstance = workloadInstance{
 	clusterProject:    "org2:project2",
 	clusterName:       "global-mesh",
 	uid:               "kubernetes://istio-policy-65db5b46fc-r7qhq.istio-system",
-	owner:             "kubernetes://apis/extensions/v1beta1/namespaces/istio-system/deployments/istio-policy",
+	owner:             "kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-policy",
 	workloadName:      "istio-policy",
 	workloadNamespace: "istio-system",
 }
@@ -282,7 +282,7 @@ var istioTelemetryWorkloadInstance = workloadInstance{
 	clusterProject:    "org2:project2",
 	clusterName:       "global-mesh",
 	uid:               "kubernetes://istio-telemetry-65db5b46fc-r7qhq.istio-system",
-	owner:             "kubernetes://apis/extensions/v1beta1/namespaces/istio-system/deployments/istio-telemetry",
+	owner:             "kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-telemetry",
 	workloadName:      "istio-telemetry",
 	workloadNamespace: "istio-system",
 }
@@ -299,9 +299,9 @@ var policyOwnerEntity = entity{
 	containerFullName: "//cloudresourcemanager.googleapis.com/projects/org:project",
 	typeName:          "io.istio.Owner",
 	fullName: "//istio.io/projects/org:project/meshes/mesh%2F1/clusterProjects/org2:project2/locations//clusters/global-mesh/" +
-		"owners/kubernetes%3A%2F%2Fapis%2Fextensions%2Fv1beta1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
+		"owners/kubernetes%3A%2F%2Fapis%2Fapps%2Fv1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
 	shortNames: [4]string{"mesh%2F1", "org2:project2", "global-mesh",
-		"kubernetes%3A%2F%2Fapis%2Fextensions%2Fv1beta1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy"},
+		"kubernetes%3A%2F%2Fapis%2Fapps%2Fv1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy"},
 }
 
 var policyWorkloadEntity = entity{
@@ -324,9 +324,9 @@ var telemetryOwnerEntity = entity{
 	containerFullName: "//cloudresourcemanager.googleapis.com/projects/org:project",
 	typeName:          "io.istio.Owner",
 	fullName: "//istio.io/projects/org:project/meshes/mesh%2F1/clusterProjects/org2:project2/locations//clusters/global-mesh/" +
-		"owners/kubernetes%3A%2F%2Fapis%2Fextensions%2Fv1beta1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-telemetry",
+		"owners/kubernetes%3A%2F%2Fapis%2Fapps%2Fv1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-telemetry",
 	shortNames: [4]string{"mesh%2F1", "org2:project2", "global-mesh",
-		"kubernetes%3A%2F%2Fapis%2Fextensions%2Fv1beta1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-telemetry"},
+		"kubernetes%3A%2F%2Fapis%2Fapps%2Fv1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-telemetry"},
 }
 
 var telemetryWorkloadEntity = entity{

--- a/mixer/test/listbackend/cmd/listadapter.yaml
+++ b/mixer/test/listbackend/cmd/listadapter.yaml
@@ -28,12 +28,16 @@ spec:
   selector:
     app: listadapter
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: listadapter
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: listadapter
+      version: v1
   template:
     metadata:
       labels:

--- a/mixer/test/prometheus/cmd/prometheusadapter.yaml
+++ b/mixer/test/prometheus/cmd/prometheusadapter.yaml
@@ -30,12 +30,16 @@ spec:
   selector:
     app: prometheusadapter
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheusadapter
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheusadapter
+      version: v1
   template:
     metadata:
       labels:


### PR DESCRIPTION
check in changes for mixer to consume K8s changes :
These resources have been deprecated since k8s v1.9 and are planned to no longer be served starting in k8s v1.16 (c.f. kubernetes/kubernetes#43214)

details are in #12211