### PR TITLE
Change exposed port of istio-pilot in consul

### DIFF
--- a/install/consul/templates/istio.yaml.tmpl
+++ b/install/consul/templates/istio.yaml.tmpl
@@ -68,9 +68,9 @@ services:
         aliases:
           - istio-pilot
     expose:
-      - "15003"
-      - "15005"
       - "15007"
+      - "15010"
+      - "15012"
     ports:
       - "8081:15007"
     command: ["discovery",


### PR DESCRIPTION
`15003` and `15005` are never used in pilot under consul env. It would be confusing to expose the two ports. Instead, 
```
   --grpcAddr string                     Discovery service grpc address (default ":15010")
   --secureGrpcAddr string               Discovery service grpc address, with https (default ":15012")
```
we know `15010` and `15012` are still using.