### PR TITLE
Implement `role` field in AuthorizationPolicy 

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1555,14 +1555,19 @@ func checkServiceRoleBinding(in *rbac.ServiceRoleBinding) error {
 			errs = appendErrors(errs, fmt.Errorf("do not use * for names or not_names (in rule %d)", i))
 		}
 	}
-	if in.RoleRef != nil && len(in.Actions) > 0 {
+	if in.RoleRef != nil && in.Role != "" {
+		errs = appendErrors(errs, fmt.Errorf("only one of `roleRef` or `role` can be specified"))
+		return errs
+	}
+	if (in.RoleRef != nil || in.Role != "" ) && len(in.Actions) > 0 {
 		errs = appendErrors(errs, fmt.Errorf("only one of `roleRef` or `actions` can be specified"))
 		return errs
 	}
-	if in.RoleRef == nil && len(in.Actions) == 0 {
-		errs = appendErrors(errs, fmt.Errorf("`roleRef` or `actions` must be specified"))
+	if in.RoleRef == nil && in.Role == "" && len(in.Actions) == 0 {
+		errs = appendErrors(errs, fmt.Errorf("`roleRef`, `role`, or `actions` must be specified"))
 	}
 	if in.RoleRef != nil {
+		rbacLog.Warnf("`roleRef` is deprecated. Please use `role` instead")
 		expectKind := "ServiceRole"
 		if in.RoleRef.Kind != expectKind {
 			errs = appendErrors(errs, fmt.Errorf("kind set to %q, currently the only supported value is %q",

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -3786,7 +3786,7 @@ func TestValidateServiceRoleBinding(t *testing.T) {
 					{User: "User1", Group: "Group1", Properties: map[string]string{"prop1": "value1"}},
 				},
 			},
-			expectErrMsg: "`roleRef` or `actions` must be specified",
+			expectErrMsg: "exactly one of `roleRef`, `role`, or `actions` must be specified",
 		},
 		{
 			name: "incorrect kind",
@@ -3806,9 +3806,20 @@ func TestValidateServiceRoleBinding(t *testing.T) {
 					{User: "User0", Group: "Group0", Properties: map[string]string{"prop0": "value0"}},
 					{User: "User1", Group: "Group1", Properties: map[string]string{"prop1": "value1"}},
 				},
+				Role: "/",
+			},
+			expectErrMsg: "`role` cannot have an empty ServiceRole name",
+		},
+		{
+			name: "no name",
+			in: &rbac.ServiceRoleBinding{
+				Subjects: []*rbac.Subject{
+					{User: "User0", Group: "Group0", Properties: map[string]string{"prop0": "value0"}},
+					{User: "User1", Group: "Group1", Properties: map[string]string{"prop1": "value1"}},
+				},
 				RoleRef: &rbac.RoleRef{Kind: "ServiceRole", Name: ""},
 			},
-			expectErrMsg: "name cannot be empty",
+			expectErrMsg: "`name` in `roleRef` cannot be empty",
 		},
 		{
 			name: "first-class field already exists",
@@ -3876,7 +3887,7 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 					},
 				},
 			},
-			expectErrMsg: "`roleRef` or `actions` must be specified",
+			expectErrMsg: "exactly one of `roleRef`, `role`, or `actions` must be specified",
 		},
 		{
 			name: "proto with both roleRef and inline role definition",
@@ -3900,7 +3911,48 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 					},
 				},
 			},
-			expectErrMsg: "only one of `roleRef` or `actions` can be specified",
+			expectErrMsg: "exactly one of `roleRef`, `role`, or `actions` must be specified",
+		},
+		{
+			name: "proto with both roleRef and role",
+			in: &rbac.AuthorizationPolicy{
+				Allow: []*rbac.ServiceRoleBinding{
+					{
+						Subjects: []*rbac.Subject{
+							{
+								Namespaces: []string{"default, istio-system"},
+							},
+						},
+						RoleRef: &rbac.RoleRef{
+							Kind: "ServiceRole",
+							Name: "service-role-1",
+						},
+						Role: "service-role-1",
+					},
+				},
+			},
+			expectErrMsg: "exactly one of `roleRef`, `role`, or `actions` must be specified",
+		},
+		{
+			name: "proto with both role and inline role definition",
+			in: &rbac.AuthorizationPolicy{
+				Allow: []*rbac.ServiceRoleBinding{
+					{
+						Subjects: []*rbac.Subject{
+							{
+								Namespaces: []string{"default, istio-system"},
+							},
+						},
+						Role: "service-role-1",
+						Actions: []*rbac.AccessRule{
+							{
+								Ports: []int32{3000},
+							},
+						},
+					},
+				},
+			},
+			expectErrMsg: "exactly one of `roleRef`, `role`, or `actions` must be specified",
 		},
 		{
 			name: "success proto with roleRef",


### PR DESCRIPTION
Add the option to use `role` instead of `roleRef` in AuthorizationPolicy.

The value of `role` refers to the ServiceRole at the local namespace or at the root namespace (currently using forward slash to refer to the root namespace, e.g. `/service-role-name`. This may be changed in the future). 

Note: if we can't find a ServiceRole at the local namespace, we **don't** look for the ServiceRole at root namespace. In another words, the user must specify `/` if they want to use ServiceRoles at root namespace.

Will update e2e tests once https://github.com/istio/istio/pull/12814 is checked in. 
For https://github.com/istio/istio/issues/12394 