### PR TITLE
Pass componentLogLevel to Envoy to disable deprecation warnings

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -109,6 +109,9 @@ spec:
         {{- if $.Values.global.proxy.logLevel }}
           - --proxyLogLevel={{ $.Values.global.proxy.logLevel }}
         {{- end}}
+        {{- if $.Values.global.proxy.componentLogLevel }}
+          - --proxyComponentLogLevel={{ $.Values.global.proxy.componentLogLevel }}
+        {{- end}}
         {{- if $.Values.global.logging.level }}
           - --log_output_level={{ $.Values.global.logging.level }}
         {{- end}}

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -115,6 +115,9 @@ containers:
 {{- if .Values.global.proxy.logLevel }}
   - --proxyLogLevel={{ .Values.global.proxy.logLevel }}
 {{- end}}
+{{- if .Values.global.proxy.componentLogLevel }}
+  - --proxyComponentLogLevel={{ .Values.global.proxy.componentLogLevel }}
+{{- end}}
   - --connectTimeout
   - "{{ formatDuration .ProxyConfig.ConnectTimeout }}"
 {{- if .Values.global.proxy.envoyStatsd.enabled }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -170,6 +170,10 @@ global:
     # Expected values are: trace|debug|info|warning|error|critical|off
     logLevel: ""
 
+    # Per Component log level for proxy, applies to gateways and sidecars. If a component level is
+    # not set, then the global "logLevel" will be used. If left empty, "misc:error" is used.
+    componentLogLevel: ""
+
     # Configure the DNS refresh rate for Envoy cluster of type STRICT_DNS
     # 5 seconds is the default refresh rate used by Envoy
     dnsRefreshRate: 5s

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -76,6 +76,7 @@ var (
 	controlPlaneAuthPolicy     string
 	customConfigFile           string
 	proxyLogLevel              string
+	proxyComponentLogLevel     string
 	concurrency                int
 	templateFile               string
 	disableInternalTelemetry   bool
@@ -375,7 +376,7 @@ var (
 
 			log.Infof("PilotSAN %#v", pilotSAN)
 
-			envoyProxy := envoy.NewProxy(proxyConfig, role.ServiceNode(), proxyLogLevel, pilotSAN, role.IPAddresses)
+			envoyProxy := envoy.NewProxy(proxyConfig, role.ServiceNode(), proxyLogLevel, proxyComponentLogLevel, pilotSAN, role.IPAddresses)
 			agent := proxy.NewAgent(envoyProxy, proxy.DefaultRetry, pilot.TerminationDrainDuration())
 			watcher := envoy.NewWatcher(tlsCertsToWatch, agent.ConfigCh())
 
@@ -545,6 +546,9 @@ func init() {
 	proxyCmd.PersistentFlags().StringVar(&proxyLogLevel, "proxyLogLevel", "warning",
 		fmt.Sprintf("The log level used to start the Envoy proxy (choose from {%s, %s, %s, %s, %s, %s, %s})",
 			"trace", "debug", "info", "warning", "error", "critical", "off"))
+	// See https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-component-log-level
+	proxyCmd.PersistentFlags().StringVar(&proxyComponentLogLevel, "proxyComponentLogLevel", "misc:error",
+		"The component log level used to start the Envoy proxy")
 	proxyCmd.PersistentFlags().IntVar(&concurrency, "concurrency", int(values.Concurrency),
 		"number of worker threads to run")
 	proxyCmd.PersistentFlags().StringVar(&templateFile, "templateFile", "",

--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -50,11 +50,14 @@ type envoy struct {
 }
 
 // NewProxy creates an instance of the proxy control commands
-func NewProxy(config meshconfig.ProxyConfig, node string, logLevel string, pilotSAN []string, nodeIPs []string) proxy.Proxy {
+func NewProxy(config meshconfig.ProxyConfig, node string, logLevel string, componentLogLevel string, pilotSAN []string, nodeIPs []string) proxy.Proxy {
 	// inject tracing flag for higher levels
 	var args []string
 	if logLevel != "" {
 		args = append(args, "-l", logLevel)
+	}
+	if componentLogLevel != "" {
+		args = append(args, "--component-log-level", componentLogLevel)
 	}
 
 	return &envoy{

--- a/pilot/pkg/proxy/envoy/proxy_test.go
+++ b/pilot/pkg/proxy/envoy/proxy_test.go
@@ -27,8 +27,20 @@ func TestEnvoyArgs(t *testing.T) {
 	config.ServiceCluster = "my-cluster"
 	config.Concurrency = 8
 
-	test := &envoy{config: config, node: "my-node", extraArgs: []string{"-l", "trace"}, nodeIPs: []string{"10.75.2.9", "192.168.11.18"}}
-	testProxy := NewProxy(config, "my-node", "trace", nil, []string{"10.75.2.9", "192.168.11.18"})
+	test := &envoy{
+		config:    config,
+		node:      "my-node",
+		extraArgs: []string{"-l", "trace", "--component-log-level", "misc:error"},
+		nodeIPs:   []string{"10.75.2.9", "192.168.11.18"},
+	}
+	testProxy := NewProxy(
+		config,
+		"my-node",
+		"trace",
+		"misc:error",
+		nil,
+		[]string{"10.75.2.9", "192.168.11.18"},
+	)
 	if !reflect.DeepEqual(testProxy, test) {
 		t.Errorf("unexpected struct got\n%v\nwant\n%v", testProxy, test)
 	}
@@ -44,6 +56,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--max-obj-name-len", fmt.Sprint(config.StatNameLength),
 		"--allow-unknown-fields",
 		"-l", "trace",
+		"--component-log-level", "misc:error",
 		"--config-yaml", `{"key": "value"}`,
 		"--concurrency", "8",
 	}


### PR DESCRIPTION
Istio users do not care about Envoy features we choose to use the are
deprecated, but we spam their logs with thousands of warnings about
deprecations. This turns off these messages, and allows proxy log level
to be tuned by operators to their preferences (including re-enabling
deprecation warnings if they wish).

Testing: We don't have a great way to/need to add automated testing here. I did run this locally and verified no deprecation warnings were emitted and that other warnings still were.