### PR TITLE
use port 80 for HTTP from details, for TLS origination

### DIFF
--- a/samples/bookinfo/src/details/details.rb
+++ b/samples/bookinfo/src/details/details.rb
@@ -79,7 +79,7 @@ end
 
 def fetch_details_from_external_service(isbn, id, headers)
     uri = URI.parse('https://www.googleapis.com/books/v1/volumes?q=isbn:' + isbn)
-    http = Net::HTTP.new(uri.host, uri.port)
+    http = Net::HTTP.new(uri.host, ENV['DO_NOT_ENCRYPT'] === 'true' ? 80:443)
     http.read_timeout = 5 # seconds
 
     # DO_NOT_ENCRYPT is used to configure the details service to use either


### PR DESCRIPTION
Istio now can rewrite the port to 443 and perform TLS origination
no need to use port 443 for HTTP traffic