### PR TITLE
Remove unused mixer.enabled value

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/values.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/values.yaml
@@ -1,7 +1,6 @@
 #
 # mixer configuration
 #
-enabled: true
 image: mixer
 
 env:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -33,7 +33,6 @@ galley:
 #
 # @see charts/mixer/values.yaml, it takes precedence
 mixer:
-  enabled: true
   policy:
     # if policy is enabled the global.disablePolicyChecks has affect.
     enabled: true


### PR DESCRIPTION
This is not a functional change; this value is never used so it is
misleading/confusing. mixer.policy.enabled and mixer.telemetry.enabled
are used.