### PR TITLE
Fixes the multicluster e2e test

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -506,7 +506,16 @@ func (k *KubeInfo) Teardown() error {
 		}
 
 		if *clusterWide {
-			istioYaml := getClusterWideInstallFile()
+			var istioYaml string
+			if *multiClusterDir != "" {
+				if *authEnable {
+					istioYaml = mcAuthInstallFileNamespace
+				} else {
+					istioYaml = mcNonAuthInstallFileNamespace
+				}
+			} else {
+				istioYaml = getClusterWideInstallFile()
+			}
 
 			testIstioYaml := filepath.Join(k.TmpDir, "yaml", istioYaml)
 
@@ -727,6 +736,11 @@ func (k *KubeInfo) deployIstio() error {
 			log.Errorf("Remote Istio %s deployment failed", testIstioYaml)
 			return err
 		}
+		if err := util.CreateMultiClusterSecret(k.Namespace, k.RemoteKubeConfig, k.KubeConfig); err != nil {
+			log.Errorf("Unable to create remote cluster secret on local cluster %s", err.Error())
+			return err
+		}
+		time.Sleep(10 * time.Second)
 	}
 
 	if *useAutomaticInjection {

--- a/tests/e2e/tests/pilot/mesh_config_verify_test.go
+++ b/tests/e2e/tests/pilot/mesh_config_verify_test.go
@@ -119,19 +119,8 @@ func createAndVerifyMCMeshConfig() error {
 		return err
 	}
 
-	// Verify that the mesh contains endpoints from the primary cluster only
-	log.Infof("Before adding remote cluster secret, verify that the mesh only contains endpoints from the primary cluster only")
-	if err = verifyMCMeshConfig(primaryPodNames, remotePodNames, primaryAppEPs); err != nil {
-		return err
-	}
-
-	// Add the remote cluster by creating a secret and configmap in the primary cluster
-	if err = addRemoteCluster(); err != nil {
-		return err
-	}
-
 	// Verify that the mesh contains endpoints from both the primary and the remote clusters
-	log.Infof("After adding remote cluster secret, verify that the mesh contains endpoints from both the primary and the remote clusters")
+	log.Infof("Verify that the mesh contains endpoints from both the primary and the remote clusters")
 	aggregatedAppEPs := aggregateAppEPs(primaryAppEPs, remoteAppEPs)
 
 	if err = verifyMCMeshConfig(primaryPodNames, remotePodNames, aggregatedAppEPs); err != nil {
@@ -143,13 +132,13 @@ func createAndVerifyMCMeshConfig() error {
 		return err
 	}
 
-	log.Infof("After deleting remote cluster secret, verify again that the mesh contains endpoints from the primary cluster only")
-	// Verify that the mesh contains the primary endpoints only
+	// Verify that the mesh contains endpoints from the primary cluster only
+	log.Infof("After deleting remote cluster secret, verify that the mesh only contains endpoints from the primary cluster only")
 	if err = verifyMCMeshConfig(primaryPodNames, remotePodNames, primaryAppEPs); err != nil {
 		return err
 	}
 
-	// Again, add the remote cluster by creating a secret and configmap in the primary cluster
+	// Add back the remote cluster by creating a secret and configmap in the primary cluster
 	if err = addRemoteCluster(); err != nil {
 		return err
 	}

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -862,7 +862,7 @@ func CreateMultiClusterSecret(namespace string, remoteKubeConfig string, localKu
 		return err
 	}
 
-	log.Infof("Secret %s labelled with %s=%s\n", secretName, secretLabel, labelValue)
+	log.Infof("Secret %s labeled with %s=%s\n", secretName, secretLabel, labelValue)
 	return nil
 }
 


### PR DESCRIPTION
The secret was being created after the apps where
deployed on the remote.  This was causes the test
to never think the apps successfully deployed since
the envoy sidecar was continually restarting.