### PR TITLE
Remove kubectl from dockerfile prereqs since it pulls it

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -168,7 +168,7 @@ docker.test_policybackend: mixer/docker/Dockerfile.test_policybackend
 docker.test_policybackend: $(ISTIO_OUT)/mixer-test-policybackend
 	$(DOCKER_RULE)
 
-docker.kubectl: docker/Dockerfile$$(suffix $$@) $(ISTIO_BIN)/kubectl
+docker.kubectl: docker/Dockerfile$$(suffix $$@)
 	$(DOCKER_RULE)
 
 # addons docker images


### PR DESCRIPTION
Looking at https://github.com/istio/istio/issues/13219

Removes the prerequisite for a local _kubectl_ as it's not used. The issue shows a failure to copy a local _kubectl_ in preparation for building the Docker image. The issue in this case is the local file is a Mac binary, so wouldn't work in the Docker image. The Docker image downloads the _kubectl_ as part of it's build so doesn't need the prerequisite file.