### PR TITLE
pre-check: fix a logic error

### DIFF
--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -78,8 +78,8 @@ func installPreCheck(istioNamespaceFlag *string, restClientGetter resource.RESTC
 	fmt.Fprintf(writer, "\n")
 	fmt.Fprintf(writer, "Istio-existence\n")
 	fmt.Fprintf(writer, "-----------------------\n")
-	ns, _ := c.getNameSpace(*istioNamespaceFlag)
-	if ns != nil {
+	_, err = c.getNameSpace(*istioNamespaceFlag)
+	if err == nil {
 		msg := fmt.Sprintf("Istio cannot be installed because the Istio namespace '%v' is already in use", *istioNamespaceFlag)
 		return errors.New(msg)
 	}

--- a/istioctl/pkg/install/pre-check_test.go
+++ b/istioctl/pkg/install/pre-check_test.go
@@ -158,7 +158,7 @@ func (m *mockClientExecPreCheckConfig) getNameSpace(ns string) (*v1.Namespace, e
 		}
 		return n, nil
 	}
-	return nil, nil
+	return nil, fmt.Errorf("namespaces \"%s\" not found", ns)
 
 }
 


### PR DESCRIPTION
`getNameSpace()` always returns an object, even if namespace does
not exist. Checking the error status is safer.