### PR TITLE
Don't apply locality label unless provided

### DIFF
--- a/pkg/test/framework/components/apps/kube.go
+++ b/pkg/test/framework/components/apps/kube.go
@@ -98,13 +98,14 @@ spec:
     matchLabels:
       app: {{ .service }}
       version: {{ .version }}
-      istio-locality: {{ .locality }}
   template:
     metadata:
       labels:
         app: {{ .service }}
         version: {{ .version }}
+{{- if ne .locality "" }}
         istio-locality: {{ .locality }}
+{{- end }}
 {{- if eq .injectProxy "false" }}
       annotations:
         sidecar.istio.io/inject: "false"


### PR DESCRIPTION
We also don't need it in match labels


This was causing failures like:
```
--- FAIL: TestMtlsHealthCheck (1.09s)
    mtls_healthcheck_test.go:78: apps.NewOrFail: kube apply of generated yaml file: exit status 1: service/healthcheck created
        error: error validating "/tmp/mtls-healthcheck-dc5f54fa27684b/_suite_context/env-kube-704200492/istio-kube-accessor-830983486/accessor_775488596": error validating data: [unknown object type "nil" in Deployment.spec.selector.matchLabels.istio-locality, unknown object type "nil" in Deployment.spec.template.metadata.labels.istio-locality]; if you choose to ignore these errors, turn validation off with --validate=false
FAIL

```

I never actually saw these in CI, so maybe not a real issue, but might as well not set the label if its not provided.