### PR TITLE
Fix egress routes generation for services of type "ExternalName"

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -467,6 +467,10 @@ type ServiceAttributes struct {
 	// ExportTo defines the visibility of Service in
 	// a namespace when the namespace is imported.
 	ExportTo map[Visibility]bool
+	// Target defines a hostname that the current headless 'alias' service is pointing at.
+	// For example Kubernetes-specific equivalent of such service would be a service of type "ExternalName". This field
+	// would be populated with its "externalName" field value.
+	Target Hostname
 }
 
 // ServiceDiscovery enumerates Istio service instances.

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -126,6 +126,7 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 			Namespace: svc.Namespace,
 			UID:       fmt.Sprintf("istio://%s/services/%s", svc.Namespace, svc.Name),
 			ExportTo:  exportTo,
+			Target:    model.Hostname(external),
 		},
 	}
 }


### PR DESCRIPTION
Fixes #13193.

ExternalName support for internal services is already implemented and
TCP case works. However the simple HTTP-case is broken due to missing
alternative hostnames in the routes config.

Extra field had to be introduced to propagate the value of the
"externalName" field. "ExternalName" is really misleading and
Kubernetes-specific, that's why a more generic name was chosen (see
"ServiceAttributes.Target").

I'm planning to add an extra integration test for this using the new integration testing framework once this gets into master branch (as the version in the release branch is lacking certain capabilities).