### PR TITLE
Refactor integration tests of Citadel

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -335,7 +335,6 @@ func TestBuildGatewayClustersWithRingHashLbDefaultMinRingSize(t *testing.T) {
 	g.Expect(cluster.LbPolicy).To(Equal(apiv2.Cluster_RING_HASH))
 	g.Expect(cluster.GetRingHashLbConfig().GetMinimumRingSize().GetValue()).To(Equal(uint64(1024)))
 	g.Expect(cluster.Name).To(Equal("outbound|8080||*.example.org"))
-	//g.Expect(cluster.Type).To(Equal(apiv2.Cluster_EDS))
 	g.Expect(cluster.ConnectTimeout).To(Equal(time.Duration(10000000001)))
 }
 

--- a/pkg/test/util/secret/secret.go
+++ b/pkg/test/util/secret/secret.go
@@ -1,4 +1,4 @@
-//  Copyright 2018 Istio Authors
+//  Copyright 2019 Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package citadel
+package secret
 
 import (
 	"crypto/x509"

--- a/tests/integration/security/citadel/secret_creation_test.go
+++ b/tests/integration/security/citadel/secret_creation_test.go
@@ -17,6 +17,8 @@ package citadel
 import (
 	"testing"
 
+	"istio.io/istio/pkg/test/util/secret"
+
 	"istio.io/istio/pkg/test/framework/label"
 
 	"istio.io/istio/pkg/test/framework"
@@ -44,7 +46,7 @@ func TestSecretCreationKubernetes(t *testing.T) {
 	}
 
 	t.Log(`checking secret "istio.default" is correctly created`)
-	if err := ExamineSecret(s); err != nil {
+	if err := secret.ExamineSecret(s); err != nil {
 		t.Error(err)
 	}
 
@@ -60,7 +62,7 @@ func TestSecretCreationKubernetes(t *testing.T) {
 		t.Error(err)
 	}
 	t.Log(`checking secret "istio.default" is correctly re-created`)
-	if err := ExamineSecret(s); err != nil {
+	if err := secret.ExamineSecret(s); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
- Citadel is a security component -> organize Citadel integration tests under the security integration tests folder.
- The common utility functions are refactored into the util folder.