### PR TITLE
allow hub concept for prometheus init container busybox image

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "prometheus.chart" -}}
 {{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Get the full busybox image name based on whether or not a hub for it has been provided
+*/}}
+{{- define "prometheus.busyboximage" -}}
+{{- if .Values.busybox.hub -}}
+{{- printf "%s/%s" .Values.busybox.hub .Values.busybox.image -}}
+{{- else -}}
+{{- printf "%s" .Values.busybox.image -}}
+{{- end -}}
+{{- end -}}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -1,6 +1,6 @@
-{{- $busyboxImageSeparator := "" }}
+{{- $hubseparator := "" }}
 {{- if .Values.busybox.hub }}
-{{- $busyboxImageSeparator = "/" }}
+{{- $hubseparator := "/" }}
 {{- end }}
 # TODO: the original template has service account, roles, etc
 apiVersion: apps/v1
@@ -35,7 +35,7 @@ spec:
 {{- if .Values.security.enabled }}
       initContainers:
       - name: prom-init
-        image: "{{ .Values.busybox.hub }}{{ $busyboxImageSeparator }}busybox:1.30.1"
+        image: "{{ .Values.busybox.hub }}{{ $hubseparator }}busybox:1.30.1"
         command: ['sh', '-c', 'counter=0; until [ "$counter" -ge 30 ]; do if [ -f /etc/istio-certs/key.pem ]; then exit 0; else echo waiting for istio certs && sleep 1 && counter=$((counter+1)); fi; done; exit 1;']
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         volumeMounts:

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -1,7 +1,4 @@
-{{- $hubseparator := "" }}
-{{- if .Values.busybox.hub }}
-{{- $hubseparator := "/" }}
-{{- end }}
+
 # TODO: the original template has service account, roles, etc
 apiVersion: apps/v1
 kind: Deployment
@@ -35,7 +32,7 @@ spec:
 {{- if .Values.security.enabled }}
       initContainers:
       - name: prom-init
-        image: "{{ .Values.busybox.hub }}{{ $hubseparator }}busybox:1.30.1"
+        image: "{{ include "prometheus.busyboximage" . }}"
         command: ['sh', '-c', 'counter=0; until [ "$counter" -ge 30 ]; do if [ -f /etc/istio-certs/key.pem ]; then exit 0; else echo waiting for istio certs && sleep 1 && counter=$((counter+1)); fi; done; exit 1;']
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         volumeMounts:

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- $busyboxImageSeparator := "" }}
+{{- if .Values.busybox.hub }}
+{{- $busyboxImageSeparator = "/" }}
+{{- end }}
 # TODO: the original template has service account, roles, etc
 apiVersion: apps/v1
 kind: Deployment
@@ -31,7 +35,7 @@ spec:
 {{- if .Values.security.enabled }}
       initContainers:
       - name: prom-init
-        image: "busybox:1.30.1"
+        image: "{{ .Values.busybox.hub }}{{ $busyboxImageSeparator }}busybox:1.30.1"
         command: ['sh', '-c', 'counter=0; until [ "$counter" -ge 30 ]; do if [ -f /etc/istio-certs/key.pem ]; then exit 0; else echo waiting for istio certs && sleep 1 && counter=$((counter+1)); fi; done; exit 1;']
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         volumeMounts:

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -1,4 +1,3 @@
-
 # TODO: the original template has service account, roles, etc
 apiVersion: apps/v1
 kind: Deployment

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -8,6 +8,7 @@ tag: v2.8.0
 retention: 6h
 nodeSelector: {}
 busybox:
+  image: "busybox:1.30.1"
   hub: ""
 
 # Specify the pod anti-affinity that allows you to constrain which nodes

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -7,6 +7,8 @@ hub: docker.io/prom
 tag: v2.8.0
 retention: 6h
 nodeSelector: {}
+busybox:
+  hub: ""
 
 # Specify the pod anti-affinity that allows you to constrain which nodes
 # your pod is eligible to be scheduled based on labels on pods that are


### PR DESCRIPTION
In the current default state-of-affairs we can use `global.hub` and other chart `*.hub` values to pull from alternate image locations, which is great. However, the prometheus chart has a hardcoded busybox image in the initContainer. Here's what I used to identify this while running a `helm template` of the istio chart:

```
$ helm template --set global.hub="myhub" --set prometheus.hub="myhub" . | grep image:
        image: "myhub/proxy_init:master-latest-daily"
        image: [[ annotation .ObjectMeta `sidecar.istio.io/proxyImage`  "myhub/proxyv2:master-latest-daily"  ]]
          image: "myhub/kubectl:master-latest-daily"
          image: "myhub/kubectl:master-latest-daily"
          image: "myhub/galley:master-latest-daily"
          image: "myhub/proxyv2:master-latest-daily"
        image: "myhub/mixer:master-latest-daily"
        image: "myhub/proxyv2:master-latest-daily"
        image: "myhub/mixer:master-latest-daily"
        image: "myhub/proxyv2:master-latest-daily"
          image: "myhub/pilot:master-latest-daily"
          image: "myhub/proxyv2:master-latest-daily"
        image: "busybox:1.30.1"
          image: "myhub/prometheus:v2.8.0"
          image: "myhub/citadel:master-latest-daily"
          image: "myhub/sidecar_injector:master-latest-daily"
```

This change allows for dynamically setting that image's location, and would allow us to rely solely on signed images from our known location(s).

The same `helm template` command looks like the following after making this change:

```
$ helm template --set global.hub="myhub" --set istio.prometheus.hub="myhub" --set prometheus.hub="myhub" --set prometheus.busybox.hub="myhub" . | grep image:
        image: "myhub/proxy_init:master-latest-daily"
        image: [[ annotation .ObjectMeta `sidecar.istio.io/proxyImage`  "myhub/proxyv2:master-latest-daily"  ]]
          image: "myhub/kubectl:master-latest-daily"
          image: "myhub/kubectl:master-latest-daily"
          image: "myhub/galley:master-latest-daily"
          image: "myhub/proxyv2:master-latest-daily"
        image: "myhub/mixer:master-latest-daily"
        image: "myhub/proxyv2:master-latest-daily"
        image: "myhub/mixer:master-latest-daily"
        image: "myhub/proxyv2:master-latest-daily"
          image: "myhub/pilot:master-latest-daily"
          image: "myhub/proxyv2:master-latest-daily"
        image: "myhub/busybox:1.30.1"
          image: "myhub/prometheus:v2.8.0"
          image: "myhub/citadel:master-latest-daily"
          image: "myhub/sidecar_injector:master-latest-daily"
```

And just to make sure, what it looks like by default after making these changes:

```
$ helm template . | grep image:
        image: "gcr.io/istio-release/proxy_init:master-latest-daily"
        image: [[ annotation .ObjectMeta `sidecar.istio.io/proxyImage`  "gcr.io/istio-release/proxyv2:master-latest-daily"  ]]
          image: "gcr.io/istio-release/kubectl:master-latest-daily"
          image: "gcr.io/istio-release/kubectl:master-latest-daily"
          image: "gcr.io/istio-release/galley:master-latest-daily"
          image: "gcr.io/istio-release/proxyv2:master-latest-daily"
        image: "gcr.io/istio-release/mixer:master-latest-daily"
        image: "gcr.io/istio-release/proxyv2:master-latest-daily"
        image: "gcr.io/istio-release/mixer:master-latest-daily"
        image: "gcr.io/istio-release/proxyv2:master-latest-daily"
          image: "gcr.io/istio-release/pilot:master-latest-daily"
          image: "gcr.io/istio-release/proxyv2:master-latest-daily"
        image: "busybox:1.30.1"
          image: "docker.io/prom/prometheus:v2.8.0"
          image: "gcr.io/istio-release/citadel:master-latest-daily"
          image: "gcr.io/istio-release/sidecar_injector:master-latest-daily"
```