### PR TITLE
[Tracing] Jaeger: Add support of ElasticSearch as a backend for traces.

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jaeger-tracing
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: jaeger-tracing
+    chart: {{ template "tracing.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  span_storage_type: {{ .Values.jaeger.span_storage_type }}
+  es.server_urls: {{ .Values.jaeger.es.server_urls }}
+  es.bulk.actions: {{ .Values.jaeger.es.bulk.actions | quote }}
+  es.bulk.flush_interval: {{ .Values.jaeger.es.bulk.flush_interval | quote }}
+  es.bulk.size: {{ .Values.jaeger.es.bulk.size | quote }}
+  es.bulk.workers: {{ .Values.jaeger.es.bulk.workers | quote }}
+  es.index_prefix: {{ .Values.jaeger.es.index_prefix }}
+  es.max_span_age: {{ .Values.jaeger.es.max_span_age | quote }}
+  es.num_replicas: {{ .Values.jaeger.es.num_replicas | quote }}
+  es.num_shards: {{ .Values.jaeger.es.num_shards | quote }}
+  es.sniffer: {{ .Values.jaeger.es.sniffer }}
+  es.tags_as_fields.all: {{ .Values.jaeger.es.tags_as_fields.all | quote }}
+  es.tags_as_fields.config_file: {{ .Values.jaeger.es.tags_as_fields.config_file }}
+  es.tags_as_fields.dot_replacement: {{ .Values.jaeger.es.tags_as_fields.dot_replacement }}
+  es.timeout: {{ .Values.jaeger.es.timeout | quote }}
+  es.tls.enable: {{ .Values.jaeger.es.tls.enable | quote }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
@@ -59,12 +59,107 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
+          - name: SPAN_STORAGE_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key: span_storage_type
+{{ if eq .Values.jaeger.span_storage_type "elasticsearch" }}
+          - name: ES_SERVER_URLS
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key: es.server_urls
+{{- if .Values.jaeger.es.username }}
+          - name: ES_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: elasticsearch
+                key: username
+          - name: ES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: elasticsearch
+                key: password
+{{- end }}
+          - name: ES_BULK_FLASH_INTERVAL
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key:  es.bulk.flush_interval
+          - name: ES_BULK_SIZE
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key:  es.bulk.size
+          - name: ES_BULK_WORKERS
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key:  es.bulk.workers
+          - name: ES_INDEX_PREFIX
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key:  es.index_prefix
+          - name: ES_MAX_SPAN_AGE
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key:  es.max_span_age
+          - name: ES_NUM_REPLICAS
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key:  es.num_replicas
+          - name: ES_NUM_SHARDS
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key:  es.num_shards
+          - name: ES_SNIFFER
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key:  es.sniffer
+          - name: ES_TAGS_AS_FIELDS_ALL
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key: es.tags_as_fields.all
+          - name: ES_TAGS_AS_FIELDS_CONFIG_FILE
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key: es.tags_as_fields.config_file
+          - name: ES_TAGS_AS_FIELDS_DOT_REPLACEMENT
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key: es.tags_as_fields.dot_replacement
+          - name: ES_TIMEOUT
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key: es.timeout
+          - name: TLS
+            valueFrom:
+              configMapKeyRef:
+                name: jaeger-tracing
+                key: es.tls.enable
+{{- end }}
           - name: COLLECTOR_ZIPKIN_HTTP_PORT
             value: "9411"
           - name: MEMORY_MAX_TRACES
             value: "{{ .Values.jaeger.memory.max_traces }}"
           - name: QUERY_BASE_PATH
             value: {{ if .Values.contextPath }} {{ .Values.contextPath }} {{ else }} /{{ .Values.provider }} {{ end }}
+{{- if and (eq .Values.jaeger.span_storage_type "elasticsearch") (.Values.jaeger.es.tls.enable) }}
+          volumeMounts:
+          - name: elasticsearch-tls
+            mountPath: "/var/run/secrets"
+            readOnly: true
+{{- end }}
           livenessProbe:
             httpGet:
               path: /
@@ -79,6 +174,12 @@ spec:
 {{- else }}
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
+      volumes:
+{{- if and (eq .Values.jaeger.span_storage_type "elasticsearch") (.Values.jaeger.es.tls.enable) }}
+        - name: elasticsearch-tls
+          secret:
+            secretName: elasticsearch-tls
+{{ end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/secret-elasticsearch.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/secret-elasticsearch.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.jaeger.es.username }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: elasticsearch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "tracing.name" . }}
+    chart: {{ template "tracing.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  username: {{ .Values.jaeger.es.username | b64enc }}
+  password: {{ .Values.jaeger.es.password | b64enc }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/tracing/values.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/values.yaml
@@ -30,8 +30,63 @@ podAntiAffinityTermLabelSelector: {}
 jaeger:
   hub: docker.io/jaegertracing
   tag: 1.9
+  # The type of backend (cassandra, elasticsearch, kafka, memory) used for trace storage.
+  # Multiple backends can be specified (currently only for writing spans) as comma-separated list,
+  # e.g. "elasticsearch, memory". (default "memory")
+  span_storage_type: memory
   memory:
     max_traces: 50000
+  # Elasticsearch backend configuration. Configuration applies when "jaeger.span_storage_type" is set to "elasticsearch"
+  es:
+    # The comma-separated list of ElasticSearch servers, must be full url i.e. http://elasticsearch:9200
+    #(default "http://elasticsearch:9200")
+    server_urls: http://elasticsearch:9200
+    # The username required by ElasticSearch. (default "elastic")
+    username:
+    # The password required by ElasticSearch. (default "changeme")
+    password:
+
+    bulk:
+      # The number of requests that can be enqueued before the bulk processor decides to commit (default 1000).
+      actions: 1000
+      # Duration after which bulk requests are committed, regardless of other tresholds. Set to zero to disable.
+      # By default, this is disabled. (default 200ms)
+      flush_interval: 200
+      # The number of bytes that the bulk requests can take up before the bulk processor decides to commit (default 5000000)
+      size: 5000000
+      # The number of workers that are able to receive bulk requests and eventually commit them to Elasticsearch (default 1)
+      workers: 1
+    # Optional prefix of Jaeger indices. For example "production" creates "production:jaeger-*".
+    index_prefix: production
+    # The maximum lookback for spans in ElasticSearch (default 72h0m0s)
+    max_span_age:
+    # The number of replicas per index in ElasticSearch (default 1)
+    num_replicas: 1
+    # The number of shards per index in ElasticSearch (default 5)
+    num_shards: 5
+    # The sniffer config for ElasticSearch; client uses sniffing process to find all nodes automatically,
+    # disable if not required.
+    sniffer:
+    tags_as_fields:
+      # (Experimental) Store all span and process tags as object fields.
+      # If true .tags-as-fields.config-file is ignored. Binary tags are always stored as nested objects. (default "false")
+      all: false
+      # (Experimental) Optional path to a file containing tag keys which will be stored as object fields.
+      # Each key should be on a separate line.
+      config_file:
+      # (Experimental) The character used to replace dots (".") in tag keys stored as object fields. (default "@")
+      dot_replacement:
+    # Timeout used for queries. A Timeout of zero means no timeout (default 0s)
+    timeout:
+    tls:
+      # Enable TLS certificate authentication, (default "false")
+      enable: true
+      # Path to TLS CA file
+      ca:
+      # Path to TLS certificate file
+      cert:
+      # Path to TLS key file
+      key:
 
 zipkin:
   hub: docker.io/openzipkin

--- a/install/kubernetes/helm/istio/charts/tracing/values.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/values.yaml
@@ -80,7 +80,7 @@ jaeger:
     timeout:
     tls:
       # Enable TLS certificate authentication, (default "false")
-      enable: true
+      enable: false
       # Path to TLS CA file
       ca:
       # Path to TLS certificate file


### PR DESCRIPTION
The target of this pull request is to provide a minimal production storage for Istio traces out of the box.
I know that there is a WIP (#9508) to adopt jaeger operator that will be available as a part of Istio Operator (expected for 1.2).
This feature enables people want to move to production before that release to have an option to backend their traces by ElasticSearch without having to change helm charts.
**Usage**:
Update you values file as following:
```
## Enable tracing
tracing:
 enabled: true
 jaeger:
   span_storage_type: elasticsearch
   es:
     server_urls: http://myelasticsearch-instance.com
     #username:
     #password:
```

**Test**:
Tested on the top of Istio 1.1.2 using a managed version of ElasticSearch 6.5.

**Documentation**:
Configuration options will be added to https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/ once the pull request is validated.
