### PR TITLE
Report circleci status to testgrid before k8s dump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,10 +64,10 @@ markJobFinishesOnGCS: &markJobFinishesOnGCS
   run:
     when: always
     command: |
-      make dumpsys || true
       make junit-report || true
       # TODO: upload the artifacts as well, for debugging !
       bin/ci2gubernator.sh --exit_code=$(cat exit_code) --junit_xml=/go/out/tests/junit.xml
+      make dumpsys || true
 
 jobs:
   e2e-simple:


### PR DESCRIPTION
The dump script often fails for the same reason the test fails. The dump
script should probably be hardened, but in the mean time we can just
make sure we report the failure (high priority) before we dump the
state.

Fixes https://github.com/istio/istio/issues/13208