### PR TITLE
Lock down development of installer

### DIFF
--- a/install/OWNERS
+++ b/install/OWNERS
@@ -1,11 +1,5 @@
+# No changes should be made here
+# Make all changes to istio-installer
 approvers:
-  - andraxylia
   - costinm
-  - gyliu513
-  - ijsnellf
-  - linsun
-  - mandarjog
-  - morvencao
-  - ostromart
   - sdake
-  - GregHanson

--- a/install/kubernetes/helm/OWNERS
+++ b/install/kubernetes/helm/OWNERS
@@ -1,4 +1,0 @@
-# No changes should be made here
-# Make all changes to istio-installer
-approvers:
-  - costinm

--- a/install/kubernetes/helm/OWNERS
+++ b/install/kubernetes/helm/OWNERS
@@ -1,0 +1,4 @@
+# No changes should be made here
+# Make all changes to istio-installer
+approvers:
+  - costinm

--- a/install/kubernetes/helm/README.md
+++ b/install/kubernetes/helm/README.md
@@ -4,6 +4,6 @@ Please follow the installation instructions from [istio.io](https://istio.io/doc
 
 # Development
 
-Istio installation is based upon a new decomposed installation technology in Istio 1.2.  As such, all development work should occur in [istio-installer](https://github.com/istio-ecosystem/istio-installer).
+Istio installation is based upon a new decomposed installation technology in Istio 1.2.  As such, all development work should occur in [istio/installer](https://github.com/istio/installer).
 
 If you have work that you feel should be backported to resolve defects, please submit to this repository on the release-1.1 branch so it can be added to the 1.1.x stream.

--- a/install/kubernetes/helm/README.md
+++ b/install/kubernetes/helm/README.md
@@ -4,6 +4,6 @@ Please follow the installation instructions from [istio.io](https://istio.io/doc
 
 # Development
 
-All development should take place in [istio-installer](https://github.com/istio-ecosystem/istio-installer). Istio 1.2 will be based on this new installer.
+Istio installation is based upon a new decomposed installation technology in Istio 1.2.  As such, all development work should occur in [istio-installer](https://github.com/istio-ecosystem/istio-installer).
 
-If for some reason changes are needed to this folder, they must be backported to istio-installer or they will not be included in 1.2.
+If you have work that you feel should be backported to resolve defects, please submit to this repository on the release-1.1 branch so it can be added to the 1.1.x stream.

--- a/install/kubernetes/helm/README.md
+++ b/install/kubernetes/helm/README.md
@@ -1,3 +1,9 @@
 # Installation using Helm
 
 Please follow the installation instructions from [istio.io](https://istio.io/docs/setup/kubernetes/install/helm/).
+
+# Development
+
+All development should take place in [istio-installer](https://github.com/istio-ecosystem/istio-installer). Istio 1.2 will be based on this new installer.
+
+If for some reason changes are needed to this folder, they must be backported to istio-installer or they will not be included in 1.2.


### PR DESCRIPTION
All development should be done on the istio-installer repo.