### PR TITLE
Split the server/client secret fetching into two k8s secrets

### DIFF
--- a/security/pkg/nodeagent/model/secret.go
+++ b/security/pkg/nodeagent/model/secret.go
@@ -24,6 +24,11 @@ type SecretItem struct {
 
 	RootCert []byte
 
+	// RootCertOwnedByCompoundSecret is true if this SecretItem was created by a
+	// K8S secret having both server cert/key and client ca and should be deleted
+	// with the secret.
+	RootCertOwnedByCompoundSecret bool
+
 	// ResourceName passed from envoy SDS discovery request.
 	// "ROOTCA" for root cert request, "default" for key/cert request.
 	ResourceName string


### PR DESCRIPTION
Fixes #13339 

This is the least intrusive change to make nodeagent fetch server cert/key and client ca cert from different k8s secrets.

It was already semi-broken if a secret ending in `-cacert` existed in k8s. This CL only extends on the existing resolution mechanism.

## Resolving behavior

- if the K8S secret has `cert`/`key`/`cacert` fields: propagate those to SDS sever **and** client ca (original behavior);
- if the K8S secret ends in `-cacert`: propagate its `cacert` to SDS client ca only

If there's a `secret` with `cacert` field **and** a `secret-cacert` then the original undefined behavior is retained (and the cache is potentially corrupted).