### PR TITLE
Do not use sh in istioctl.

### DIFF
--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -186,9 +186,8 @@ func (client *Client) ExtractExecResult(podName, podNamespace, container string,
 	if err != nil {
 		if stderr.String() != "" {
 			return nil, fmt.Errorf("error execing into %v/%v %v container: %v\n%s", podName, podNamespace, container, err, stderr.String())
-		} else {
-			return nil, fmt.Errorf("error execing into %v/%v %v container: %v", podName, podNamespace, container, err)
 		}
+		return nil, fmt.Errorf("error execing into %v/%v %v container: %v", podName, podNamespace, container, err)
 	}
 	return stdout.Bytes(), nil
 }

--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -140,7 +140,7 @@ func (client *Client) AllPilotsDiscoveryDo(pilotNamespace, method, path string, 
 	if len(pilots) == 0 {
 		return nil, errors.New("unable to find any Pilot instances")
 	}
-	cmd := []string{"sh", "-c", fmt.Sprintf("GODEBUG= %s request %s %s %s", pilotDiscoveryPath, method, path, string(body))}
+	cmd := []string{pilotDiscoveryPath, "request", method, path, string(body)}
 	result := map[string][]byte{}
 	for _, pilot := range pilots {
 		res, err := client.ExtractExecResult(pilot.Name, pilot.Namespace, discoveryContainer, cmd)
@@ -166,7 +166,7 @@ func (client *Client) PilotDiscoveryDo(pilotNamespace, method, path string, body
 	if len(pilots) == 0 {
 		return nil, errors.New("unable to find any Pilot instances")
 	}
-	cmd := []string{"sh", "-c", fmt.Sprintf("GODEBUG= %s request %s %s %s", pilotDiscoveryPath, method, path, string(body))}
+	cmd := []string{pilotDiscoveryPath, "request", method, path, string(body)}
 	return client.ExtractExecResult(pilots[0].Name, pilots[0].Namespace, discoveryContainer, cmd)
 }
 
@@ -184,10 +184,11 @@ func (client *Client) EnvoyDo(podName, podNamespace, method, path string, body [
 func (client *Client) ExtractExecResult(podName, podNamespace, container string, cmd []string) ([]byte, error) {
 	stdout, stderr, err := client.PodExec(podName, podNamespace, container, cmd)
 	if err != nil {
-		return nil, fmt.Errorf("error execing into %v/%v %v container: %v", podName, podNamespace, container, err)
-	}
-	if stderr.String() != "" {
-		fmt.Printf("Warning! error execing into %v/%v %v container: %v\n", podName, podNamespace, container, stderr.String())
+		if stderr.String() != "" {
+			return nil, fmt.Errorf("error execing into %v/%v %v container: %v\n%s", podName, podNamespace, container, err, stderr.String())
+		} else {
+			return nil, fmt.Errorf("error execing into %v/%v %v container: %v", podName, podNamespace, container, err)
+		}
 	}
 	return stdout.Bytes(), nil
 }


### PR DESCRIPTION
Currently `istioctl` uses something like

```
kubectl exec <pod> -- sh -c "GODEBUG= pilot-agent request GET <path> ..."
```

to implement some functionality like `istioctl proxy-config` and to mute debug output from the go runtime when the environment variable `GODEBUG` is set.  For distroless images, this doesn't work, because there is no `sh`.

Therefore, we ignore the output on stderr if the `kubectl exec` is successful. Otherwise the output is appended to the error.