### PR TITLE
Fix MCP dial-out mode.

### DIFF
--- a/codecov.threshold
+++ b/codecov.threshold
@@ -27,6 +27,7 @@ istio.io/istio/pilot/pkg/proxy/envoy/v2=10
 istio.io/istio/pilot/pkg/proxy/envoy/v2/rds.go=25
 istio.io/istio/pilot/pkg/serviceregistry/consul/monitor.go=20
 istio.io/istio/pkg/mcp/creds/watcher.go=100
+istio.io/istio/pkg/mcp/source/client_source.go=90
 istio.io/istio/pkg/mcp/source/source.go=90
 istio.io/istio/security/pkg/nodeagent=15
 istio.io/istio/istioctl/cmd/istioctl/kubeinject.go=41

--- a/pkg/appsignals/watcher.go
+++ b/pkg/appsignals/watcher.go
@@ -64,10 +64,13 @@ func Watch(c chan<- Signal) {
 func Notify(trigger string, signal os.Signal) {
 	handlers.Lock()
 	defer handlers.Unlock()
+	log.Infof("watcher.Notify: (trigger: %q, signal: %v)", trigger, signal)
 	for _, v := range handlers.listeners {
+		log.Debugf("watcher.Notify: Dispatching to listener '%v' (trigger: %q, signal: %v)", v, trigger, signal)
 		select {
 		case v <- Signal{trigger, signal}:
 		default:
+			log.Warnf("watcher.Notify: Signal channel is full (trigger: %q, signal: %v)", trigger, signal)
 		}
 	}
 }

--- a/pkg/mcp/sink/client_sink.go
+++ b/pkg/mcp/sink/client_sink.go
@@ -41,6 +41,7 @@ type Client struct {
 	reporter monitoring.Reporter
 }
 
+// NewClient returns a new instance of Client.
 func NewClient(client mcp.ResourceSourceClient, options *Options) *Client {
 	return &Client{
 		Sink:     New(options),

--- a/pkg/mcp/source/client_source.go
+++ b/pkg/mcp/source/client_source.go
@@ -30,7 +30,7 @@ import (
 var (
 	// try to re-establish the bi-directional grpc stream after this delay.
 	reestablishStreamDelay = time.Second
-	triggerCollection = "$triggerCollection"
+	triggerCollection      = "$triggerCollection"
 )
 
 // Client implements the client for the MCP sink service. The client is the

--- a/pkg/mcp/source/client_source.go
+++ b/pkg/mcp/source/client_source.go
@@ -30,6 +30,7 @@ import (
 var (
 	// try to re-establish the bi-directional grpc stream after this delay.
 	reestablishStreamDelay = time.Second
+	triggerCollection = "$triggerCollection"
 )
 
 // Client implements the client for the MCP sink service. The client is the
@@ -59,7 +60,7 @@ var reconnectTestProbe = func() {}
 // trigger response which we expect the server to NACK.
 func (c *Client) sendTriggerResponse(stream Stream) error {
 	trigger := &mcp.Resources{
-		Collection: "", // unimplemented collection
+		Collection: triggerCollection,
 	}
 
 	if err := stream.Send(trigger); err != nil {
@@ -72,7 +73,7 @@ func (c *Client) sendTriggerResponse(stream Stream) error {
 // isTriggerResponse checks whether the given RequestResources object is an expected NACK response to a previous
 // trigger message.
 func isTriggerResponse(msg *mcp.RequestResources) bool {
-	return msg.Collection == "" && msg.ErrorDetail != nil && codes.Code(msg.ErrorDetail.Code) == codes.Unimplemented
+	return msg.Collection == triggerCollection && msg.ErrorDetail != nil && codes.Code(msg.ErrorDetail.Code) == codes.Unimplemented
 }
 
 // Run implements mcpClient

--- a/pkg/mcp/source/client_source_test.go
+++ b/pkg/mcp/source/client_source_test.go
@@ -85,7 +85,7 @@ func TestClientSource(t *testing.T) {
 		Resources:  []*mcp.Resource{test.Type2A[0].Resource},
 	})
 
-	h.requestsChan <- test.MakeRequest(false, "", "", codes.Unimplemented)
+	h.requestsChan <- test.MakeRequest(false, triggerCollection, "", codes.Unimplemented)
 	h.requestsChan <- test.MakeRequest(false, test.FakeType0Collection, "", codes.OK)
 	h.requestsChan <- test.MakeRequest(false, test.FakeType1Collection, "", codes.OK)
 	h.requestsChan <- test.MakeRequest(false, test.FakeType2Collection, "", codes.OK)
@@ -122,11 +122,6 @@ func TestClientSource(t *testing.T) {
 	h.setOpenError(nil)
 	h.client = true
 	h.requestsChan <- test.MakeRequest(false, "", "", codes.OK)
-	proceed <- true
-
-	<-waiting
-	h.client = true
-	h.requestsChan <- test.MakeRequest(false, "", "", codes.InvalidArgument)
 	proceed <- true
 
 	<-waiting

--- a/pkg/mcp/source/source.go
+++ b/pkg/mcp/source/source.go
@@ -399,6 +399,10 @@ func (con *connection) close() {
 }
 
 func (con *connection) processClientRequest(req *mcp.RequestResources) error {
+	if isTriggerResponse(req) {
+		return nil
+	}
+
 	collection := req.Collection
 
 	con.reporter.RecordRequestSize(collection, con.id, internal.ProtoSize(req))

--- a/pkg/test/framework/components/galley/galley.go
+++ b/pkg/test/framework/components/galley/galley.go
@@ -51,8 +51,12 @@ type Instance interface {
 	WaitForSnapshot(collection string, validator SnapshotValidatorFunc) error
 }
 
-// Configuration for Galley
+// Config for Galley
 type Config struct {
+
+	// SinkAddress to dial-out to, if set.
+	SinkAddress string
+
 	// MeshConfig to use for this instance.
 	MeshConfig string
 }

--- a/pkg/test/framework/components/mcpserver/mcpserver.go
+++ b/pkg/test/framework/components/mcpserver/mcpserver.go
@@ -1,0 +1,52 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcpserver
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/mcp/sink"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+// Instance is a new mcpserver instance. MCP Server is a generic MCP server implementation for testing purposes.
+type Instance interface {
+	Address() string
+	GetCollectionStateOrFail(t *testing.T, collection string) []*sink.Object
+}
+
+// SinkConfig is configuration for the mcpserver for sink mode.
+type SinkConfig struct {
+	Collections []string
+}
+
+// NewSink returns a new instance of MCP Server in Sink mode.
+func NewSink(ctx resource.Context, cfg SinkConfig) (i Instance, err error) {
+	err = resource.UnsupportedEnvironment(ctx.Environment())
+	ctx.Environment().Case(environment.Native, func() {
+		i, err = newSinkNative(ctx, cfg)
+	})
+	return
+}
+
+// NewSinkOrFail returns a new instance of MCP server in Sink mode or fails.
+func NewSinkOrFail(t *testing.T, c resource.Context, cfg SinkConfig) Instance {
+	i, err := NewSink(c, cfg)
+	if err != nil {
+		t.Fatalf("mcpserver.NewOrFail: %v", err)
+	}
+	return i
+}

--- a/pkg/test/framework/components/mcpserver/native.go
+++ b/pkg/test/framework/components/mcpserver/native.go
@@ -1,0 +1,102 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcpserver
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	mcp "istio.io/api/mcp/v1alpha1"
+
+	"istio.io/istio/pkg/mcp/rate"
+	"istio.io/istio/pkg/mcp/server"
+	"istio.io/istio/pkg/mcp/sink"
+	"istio.io/istio/pkg/mcp/testing/monitoring"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/scopes"
+)
+
+type native struct {
+	id resource.ID
+	l  net.Listener
+	s  *grpc.Server
+	u  *sink.InMemoryUpdater
+}
+
+var _ Instance = &native{}
+var _ resource.Resource = &native{}
+var _ io.Closer = &native{}
+
+func newSinkNative(ctx resource.Context, cfg SinkConfig) (*native, error) {
+	n := &native{}
+	n.id = ctx.TrackResource(n)
+	u := sink.NewInMemoryUpdater()
+
+	so := sink.Options{
+		ID:                "mcpserver.sink",
+		CollectionOptions: sink.CollectionOptionsFromSlice(cfg.Collections),
+		Updater:           u,
+		Reporter:          monitoring.NewInMemoryStatsContext(),
+	}
+
+	l, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		return nil, err
+	}
+
+	s := grpc.NewServer()
+	srv := sink.NewServer(&so, &sink.ServerOptions{
+		AuthChecker: &server.AllowAllChecker{},
+		RateLimiter: rate.NewRateLimiter(time.Millisecond, 1000).Create(),
+	})
+
+	mcp.RegisterResourceSinkServer(s, srv)
+
+	go func() {
+		if err := s.Serve(l); err != nil {
+			scopes.Framework.Errorf("mcpserver.Serve: %v", err)
+		}
+	}()
+
+	n.l = l
+	n.s = s
+	n.u = u
+
+	return n, nil
+}
+
+// ID implements resource.Resource
+func (n *native) ID() resource.ID {
+	return n.id
+}
+
+// Address implements Instance
+func (n *native) Address() string {
+	return n.l.Addr().String()
+}
+
+// GetCollectionStateOrFail implements Instance
+func (n *native) GetCollectionStateOrFail(t *testing.T, collection string) []*sink.Object {
+	return n.u.Get(collection)
+}
+
+// Close implements io.Closer
+func (n *native) Close() error {
+	n.s.Stop()
+	return nil
+}

--- a/pkg/test/framework/components/mcpserver/native.go
+++ b/pkg/test/framework/components/mcpserver/native.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	mcp "istio.io/api/mcp/v1alpha1"
 
+	mcp "istio.io/api/mcp/v1alpha1"
 	"istio.io/istio/pkg/mcp/rate"
 	"istio.io/istio/pkg/mcp/server"
 	"istio.io/istio/pkg/mcp/sink"

--- a/tests/integration/galley/dialout/dialout_test.go
+++ b/tests/integration/galley/dialout/dialout_test.go
@@ -1,0 +1,77 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package dialout
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/mcpserver"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/structpath"
+)
+var yamlCfg = `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: helloworld-gateway
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+`
+
+func TestDialout_Basic(t *testing.T) {
+	framework.Run(t, func(ctx framework.TestContext) {
+		srv := mcpserver.NewSinkOrFail(t, ctx, mcpserver.SinkConfig{Collections: []string{"istio/networking/v1alpha3/gateways"}})
+
+		g := galley.NewOrFail(t, ctx, galley.Config{SinkAddress: srv.Address()})
+
+		ns := namespace.NewOrFail(t, ctx, "dialout", true)
+
+		g.ApplyConfigOrFail(t, ns, yamlCfg)
+
+		retry.UntilSuccessOrFail(t, func() error {
+			objects := srv.GetCollectionStateOrFail(t, "istio/networking/v1alpha3/gateways")
+			if len(objects) != 1 {
+				return fmt.Errorf("expected number of objects not found (current: %v)", len(objects))
+			}
+
+			structpath.ForProto(objects[0].Body).
+				Equals("{.Metadata.Name}", "helloworld-gateway")
+
+			return nil
+		})
+	})
+}
+
+func TestMain(m *testing.M) {
+	// TODO: Limit to Native environment until the Kubernetes environment is supported in the Galley
+	// component
+	framework.
+		NewSuite("galley_dialout", m).
+		RequireEnvironment(environment.Native).
+		Run()
+}

--- a/tests/integration/galley/dialout/dialout_test.go
+++ b/tests/integration/galley/dialout/dialout_test.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/structpath"
 )
+
 var yamlCfg = `
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway


### PR DESCRIPTION
+ The MCP dial-out mode sends an initial trigger response to trigger proper server/client communication. This is needed under certain scenarios. The original code expected a NACK response to this using a synchronous wait. However, this caused problems as the NACK can be sent *after* the actual resource requests are enqueued in the gRPC stream. This PR fixes the issue by making the handling of the trigger response in-line, as part of regular stream handling.
+ Adding a new dial-out integration tests capturing the basic scenario.
+ Adding a sleep in the Galley integration component, as the component startup is inherently racy. There is a race between setting the os signal event handlers during startup and applicatrion of configuration (and subsequent event trigger). The stop-gap solution is to sleep. The right solution is to go back to the correct ordering model for the startup of Galley.