### PR TITLE
[Testing] Adding integration test instructions (GKE)

### DIFF
--- a/tests/integration/GKE.md
+++ b/tests/integration/GKE.md
@@ -1,0 +1,124 @@
+# Running E2E tests on your own kubernetes cluster
+
+* [Step 1: Setup GCP](#step-1-setup-gcp)
+* [Step 2: Setup a Cluster](#step-2-setup-a-cluster)
+* [Step 3: Setup Istio Environment Variables](#step-3-setup-istio-environment-variables)
+
+## Step 1: Setup GCP
+This section walks you through the one-time setup for creating and configuring a Google Coud Platform (GCP) project.
+
+#### Install Google Cloud SDK
+If you haven't already installed the Google Cloud SDK installed, follow the instructions [here](https://cloud.google.com/sdk/).
+
+If you're not sure if you have it installed, you can check with:
+
+```bash
+which gcloud
+```
+
+#### Create a Project
+
+If you haven't already, [create a Google Cloud Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+    
+#### Configure GCE/GKE Service Account
+You must grant your default compute service account the correct permissions before creating the deployment.
+Otherwise, the installation will fail.
+
+> Note the **Project Number** for your project by visiting the [Dashboard Page](https://console.cloud.google.com/homehttps://console.cloud.google.com/home) of Google Cloud Console.
+
+Nativate to the [IAM
+section](https://console.cloud.google.com/permissions/projectpermissions)
+of the Google Cloud Console and make sure that your
+default compute service account (by default
+`[PROJECT_NUMBER]-compute@developer.gserviceaccount.com`)
+includes the following roles:
+
+* **Kubernetes Engine Admin** (`roles/container.admin`)
+* **Editor** (`roles/editor`, included by default)
+
+## Step 2: Setup a Cluster
+
+The following steps are automated with the script `create_cluster_gke.sh` located in this directory. To create a cluster with the script, simply run:
+
+```bash
+./tests/integration/create_cluster_gke.sh -c ${CLUSTER_NAME}
+```
+
+To list the options for the script, you can get help via `-h`:
+
+```bash
+./tests/integration/create_cluster_gke.sh -h
+```
+
+#### Create the Cluster
+
+E2E tests require a Kubernetes cluster. You can create one using the Google Container Engine using
+the following command:
+
+```bash
+gcloud container clusters \
+  create ${CLUSTER_NAME} \
+  --zone ${ZONE} \
+  --project ${PROJECT_NAME} \
+  --cluster-version ${CLUSTER_VERSION} \
+  --machine-type ${MACHINE_TYPE} \
+  --num-nodes ${NUM_NODES} \
+  --enable-kubernetes-alpha \
+  --no-enable-legacy-authorization
+ ```
+
+ - `CLUSTER_NAME`: Whatever suits your fancy, 'istio-e2e' is a good choice.
+ - `ZONE`: 'us-central1-f' is a good value to use.
+ - `PROJECT_NAME`: is the name of the GCP project that will house the cluster. You get a project by visiting [GCP](https://console.cloud.google.com).
+ - `CLUSTER_VERSION`: 1.7.3 or later.
+ - `MACHINE_TYPE`: Use 'n1-standard-4'
+ - `NUM_NODES`: Use 3.
+ - `no-enable-legacy-authorization`: Optional, needed if you want to test RBAC.
+
+#### Get cluster credentials
+```
+gcloud container clusters get-credentials ${CLUSTER_NAME} --zone ${ZONE} --project ${PROJECT_NAME}
+```
+
+#### Grant Admin Permission
+```
+kubectl create clusterrolebinding myname-cluster-admin-binding  --clusterrole=cluster-admin  --user=$(gcloud config get-value core/account)
+```
+
+## Step 3: Setup Istio Environment Variables
+
+#### Option 1: Build your own images
+
+You can set the **HUB** and **TAG** environment variables to point to your own Docker registry.
+Additionally, you can also set **GS_BUCKET** to use a different Google Storage Bucket than the default one 
+(you need write permissions) it allows you to customize Makefile rules.
+
+For example:
+
+```bash
+export HUB=myname
+export TAG=latest
+export GS_BUCKET=mybucket
+```
+
+Then you can build and push the docker images to your registry:
+```bash
+# Build images on the local docker.
+make docker
+
+# Push images to docker registry
+make push
+```
+
+On MacOS, you need to set the target operating system before building the images
+```
+GOOS=linux make docker push
+```
+
+#### Option 2: Use pre-built Istio images
+In this case, you'll need to specify the image SHA in the TAG variable. You can pick any SHA available on istio/istio.
+
+```bash
+export HUB="gcr.io/istio-testing"
+export TAG="d0142e1afe41c18917018e2fa85ab37254f7e0ca"
+```

--- a/tests/integration/create_cluster_gke.sh
+++ b/tests/integration/create_cluster_gke.sh
@@ -15,11 +15,17 @@ NUM_NODES=${NUM_NODES:-3}
 function usage() {
   echo "${0} -p PROJECT [-z ZONE] [-c CLUSTER_NAME] [-v CLUSTER_VERSION] [-m MACHINE_TYPE] [-n NUM_NODES]"
   echo ''
+  # shellcheck disable=SC2016
   echo '  -p: Specifies the GCP Project name. (defaults to $PROJECT_NAME, or current GCP project if unspecified).'
+  # shellcheck disable=SC2016
   echo '  -z: Specifies the zone. (defaults to $ZONE, or "us-central1-f").'
+  # shellcheck disable=SC2016
   echo '  -c: Specifies the cluster name. (defaults to $CLUSTER_NAME, or "istio-e2e").'
+  # shellcheck disable=SC2016
   echo '  -v: Specifies the cluster version. (defaults to $CLUSTER_VERSION, or GCP default if unspecified ).'
+  # shellcheck disable=SC2016
   echo '  -m: Specifies the machine type. (defaults to $MACHINE_TYPE, or "n1-standard-4").'
+  # shellcheck disable=SC2016
   echo '  -n: Specifies the number of nodes. (defaults to $NUM_NODES, or "3").'
   echo ''
 }

--- a/tests/integration/create_cluster_gke.sh
+++ b/tests/integration/create_cluster_gke.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# Creates and configures a GKE cluster for running the Istio e2e tests.
+# Notes:
+# * See README.md
+#
+
+PROJECT=${PROJECT:-$(gcloud config list --format 'value(core.project)' 2>/dev/null)}
+ZONE=${ZONE:-us-central1-f}
+CLUSTER_NAME=${CLUSTER_NAME:-istio-e2e}
+CLUSTER_VERSION=${CLUSTER_VERSION}
+MACHINE_TYPE=${MACHINE_TYPE:-n1-standard-4}
+NUM_NODES=${NUM_NODES:-3}
+
+function usage() {
+  echo "${0} -p PROJECT [-z ZONE] [-c CLUSTER_NAME] [-v CLUSTER_VERSION] [-m MACHINE_TYPE] [-n NUM_NODES]"
+  echo ''
+  echo '  -p: Specifies the GCP Project name. (defaults to $PROJECT_NAME, or current GCP project if unspecified).'
+  echo '  -z: Specifies the zone. (defaults to $ZONE, or "us-central1-f").'
+  echo '  -c: Specifies the cluster name. (defaults to $CLUSTER_NAME, or "istio-e2e").'
+  echo '  -v: Specifies the cluster version. (defaults to $CLUSTER_VERSION, or GCP default if unspecified ).'
+  echo '  -m: Specifies the machine type. (defaults to $MACHINE_TYPE, or "n1-standard-4").'
+  echo '  -n: Specifies the number of nodes. (defaults to $NUM_NODES, or "3").'
+  echo ''
+}
+
+# Allow command-line args to override the defaults.
+while getopts ":p:z:c:v:m:n:h" opt; do
+  case ${opt} in
+    p)
+      PROJECT=${OPTARG}
+      ;;
+    z)
+      ZONE=${OPTARG}
+      ;;
+    c)
+      CLUSTER_NAME=${OPTARG}
+      ;;
+    v)
+      CLUSTER_VERSION=${OPTARG}
+      ;;
+    m)
+      MACHINE_TYPE=${OPTARG}
+      ;;
+    n)
+      NUM_NODES=${OPTARG}
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${PROJECT}" ]]; then
+  echo "Error: PROJECT (-p) must be specified!"
+  usage
+  exit 1
+fi
+
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x # echo on
+
+function cleanup {
+  # Re-enable certificates.
+  gcloud config set container/use_client_certificate True
+}
+
+# Run cleanup before we exit.
+trap cleanup EXIT
+
+# Create the cluster
+gcloud container clusters create "$CLUSTER_NAME" \
+  --project="$PROJECT" \
+  --cluster-version="$CLUSTER_VERSION" \
+  --zone="$ZONE" \
+  --machine-type="$MACHINE_TYPE" \
+  --num-nodes="$NUM_NODES" \
+  --no-enable-legacy-authorization
+
+# This is a hack to handle the case where clusterrolebinding creation returns:
+#
+# Error from server (Forbidden): clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "client" cannot
+# create clusterrolebindings.rbac.authorization.k8s.io at the cluster scope
+gcloud config set container/use_client_certificate False
+
+# Download the credentials for the cluster.
+gcloud container clusters get-credentials "$CLUSTER_NAME" --project="$PROJECT" --zone="$ZONE"
+
+# Grant the current user admin privileges on the cluster.
+kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user="$(gcloud config get-value core/account)"


### PR DESCRIPTION
These started as a copy of of the ones under e2e. Removed instructions specific to the old test framework. Also cleaned up other instructions and added a script to simplify creation of a cluster.