### PR TITLE
feat(telemetry): introduce support for prometheus operator resources

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not (or .Values.operator.createPrometheusResource .Values.operator.createServiceMonitors) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -311,3 +312,4 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod_name
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -1,4 +1,5 @@
 # TODO: the original template has service account, roles, etc
+{{- if not (or .Values.operator.createPrometheusResource .Values.operator.createServiceMonitors) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -79,3 +80,4 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/operator.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/operator.yaml
@@ -1,0 +1,331 @@
+{{- if .Values.operator.createServiceMonitors -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istio-mesh-monitor
+  namespace: istio-system
+  labels:
+    monitoring: istio-mesh
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio, operator: In, values: [mixer]}
+  namespaceSelector:
+    matchNames:
+      - istio-system
+  endpoints:
+  - port: prometheus
+    interval: {{ .Values.scrapeInterval }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istio-component-monitor
+  namespace: istio-system
+  labels:
+    monitoring: istio-components
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio, operator: In, values: [mixer,pilot,galley,citadel]}
+  namespaceSelector:
+    matchNames:
+      - istio-system
+  endpoints:
+  - port: http-monitoring 
+    interval: {{ .Values.scrapeInterval }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: envoy-stats-monitor
+  namespace: istio-system
+  labels:
+    monitoring: istio-proxies
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio-prometheus-ignore, operator: DoesNotExist}
+  namespaceSelector:
+    any: true
+  jobLabel: envoy-stats
+  endpoints:
+  - path: /stats/prometheus
+    targetPort: 15090
+    interval: {{ .Values.scrapeInterval }}
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_container_port_name]
+      action: keep
+      regex: '.*-envoy-prom'
+    - action: labelmap
+      regex: "__meta_kubernetes_pod_label_(.+)"
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name
+    metricRelabelings:
+    - sourceLabels: [ cluster_name ]
+      regex: '(outbound|inbound|prometheus_stats).*'
+      action: drop
+    - sourceLabels: [ tcp_prefix ]
+      regex: '(outbound|inbound|prometheus_stats).*'
+      action: drop
+    - sourceLabels: [ listener_address ]
+      regex: '(.+)'
+      action: drop
+    - sourceLabels: [ http_conn_manager_listener_prefix ]
+      regex: '(.+)'
+      action: drop
+    - sourceLabels: [ http_conn_manager_prefix ]
+      regex: '(.+)'
+      action: drop
+    - sourceLabels: [ __name__ ]
+      regex: 'envoy_tls.*'
+      action: drop
+    - sourceLabels: [ __name__ ]
+      regex: 'envoy_tcp_downstream.*'
+      action: drop
+    - sourceLabels: [ __name__ ]
+      regex: 'envoy_http_(stats|admin).*'
+      action: drop
+    - sourceLabels: [ __name__ ]
+      regex: 'envoy_cluster_(lb|retry|bind|internal|max|original).*'
+      action: drop
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubernetes-pods-monitor
+  namespace: istio-system
+  labels:
+    monitoring: kube-pods
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio-prometheus-ignore, operator: DoesNotExist}
+  namespaceSelector:
+    any: true
+  jobLabel: kubernetes-pods
+  endpoints:
+  - interval: {{ .Values.scrapeInterval }}
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: 'true'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_prometheus_io_scheme]
+      action: keep
+      regex: '((;.*)|(.*;http)|(.??))'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_istio_mtls]
+      action: drop
+      regex: 'true'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: '(.+)'
+    - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: '([^:]+)(?::\d+)?;(\d+)'
+      replacement: $1:$2
+      targetLabel: __address__
+    - action: labelmap
+      regex: '__meta_kubernetes_pod_label_(.+)'
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubernetes-pods-secure-monitor
+  namespace: istio-system
+  labels:
+    monitoring: kube-pods-secure
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio-prometheus-ignore, operator: DoesNotExist}
+  namespaceSelector:
+    any: true
+  jobLabel: kubernetes-pods-secure
+  endpoints:
+  - interval: {{ .Values.scrapeInterval }}
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/secrets/istio.prometheus/root-cert.pem
+      certFile: /etc/prometheus/secrets/istio.prometheus/cert-chain.pem
+      keyFile: /etc/prometheus/secrets/istio.prometheus/key.pem
+      insecureSkipVerify: true  # prometheus does not support secure naming.
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: 'true'
+    # sidecar status annotation is added by sidecar injector and
+    # istio_workload_mtls_ability can be specifically placed on a pod to indicate its ability to receive mtls traffic.
+    - sourceLabels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
+      action: keep
+      regex: '(([^;]+);([^;]*))|(([^;]*);(true))'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+      action: drop
+      regex: '(http)'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: '(.+)'
+    - sourceLabels: [__address__]  # Only keep address that is host:port
+      action: keep    # otherwise an extra target with ':443' is added for https scheme
+      regex: '([^:]+):(\d+)'
+    - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: '([^:]+)(?::\d+)?;(\d+)'
+      replacement: $1:$2
+      targetLabel: __address__
+    - action: labelmap
+      regex: '__meta_kubernetes_pod_label_(.+)'
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubernetes-services-monitor
+  namespace: istio-system
+  labels:
+    monitoring: kube-services
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio-prometheus-ignore, operator: DoesNotExist}
+  namespaceSelector:
+    any: true
+  jobLabel: kubernetes-services
+  endpoints:
+  - interval: {{ .Values.scrapeInterval }}
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+      action: keep
+      regex: 'true'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_service_annotation_prometheus_io_scheme]
+      action: keep
+      regex: '((;.*)|(.*;http)|(.??))'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_istio_mtls]
+      action: drop
+      regex: 'true'
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: '(.+)'
+    - sourceLabels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+      action: replace
+      regex: '([^:]+)(?::\d+)?;(\d+)'
+      replacement: $1:$2
+      targetLabel: __address__
+    - action: labelmap
+      regex: '__meta_kubernetes_pod_label_(.+)'
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubernetes-services-secure-monitor
+  namespace: istio-system
+  labels:
+    monitoring: kube-services-secure
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio-prometheus-ignore, operator: DoesNotExist}
+  namespaceSelector:
+    any: true
+  jobLabel: kubernetes-services-secure
+  endpoints:
+  - interval: {{ .Values.scrapeInterval }}
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/secrets/istio.prometheus/root-cert.pem
+      certFile: /etc/prometheus/secrets/istio.prometheus/cert-chain.pem
+      keyFile: /etc/prometheus/secrets/istio.prometheus/key.pem
+      insecureSkipVerify: true  # prometheus does not support secure naming.
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+      action: keep
+      regex: 'true'
+    # sidecar status annotation is added by sidecar injector and
+    # istio_workload_mtls_ability can be specifically placed on a pod to indicate its ability to receive mtls traffic.
+    - sourceLabels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
+      action: keep
+      regex: '(([^;]+);([^;]*))|(([^;]*);(true))'
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+      action: drop
+      regex: '(http)'
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: '(.+)'
+    - sourceLabels: [__address__]  # Only keep address that is host:port
+      action: keep    # otherwise an extra target with ':443' is added for https scheme
+      regex: '([^:]+):(\d+)'
+    - sourceLabels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+      action: replace
+      regex: '([^:]+)(?::\d+)?;(\d+)'
+      replacement: $1:$2
+      targetLabel: __address__
+    - action: labelmap
+      regex: '__meta_kubernetes_pod_label_(.+)'
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name
+{{- end }}
+---
+{{ if .Values.operator.createPrometheusResource -}}
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+  namespace: istio-system
+spec:
+  image: "{{ .Values.hub }}/prometheus:{{ .Values.tag }}"
+  version: {{ .Values.tag }}
+  retention: {{ .Values.retention }}
+  scrapeInterval: {{ .Values.scrapeInterval }}
+  serviceAccountName: prometheus
+  serviceMonitorSelector:
+    any: true
+  serviceMonitorNamespaceSelector:
+    any: true
+  secrets: [ istio.prometheus ]
+  enableAdminAPI: false
+{{- if .Values.global.priorityClassName }}
+  priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
+  affinity:
+  {{- include "nodeaffinity" . | indent 2 }}
+  {{- include "podAntiAffinity" . | indent 2 }}
+  podMetadata:
+    labels:
+      app: prometheus
+      chart: {{ template "prometheus.chart" . }}
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+    annotations:
+      sidecar.istio.io/inject: "false"
+  resources:
+    requests:
+      memory: 400Mi
+{{- end -}}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/operator.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/operator.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: istio-mesh-monitor
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
   labels:
     monitoring: istio-mesh
 spec:
@@ -12,7 +12,7 @@ spec:
       - {key: istio, operator: In, values: [mixer]}
   namespaceSelector:
     matchNames:
-      - istio-system
+      - {{ .Release.Namespace }}
   endpoints:
   - port: prometheus
     interval: {{ .Values.scrapeInterval }}
@@ -21,7 +21,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: istio-component-monitor
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
   labels:
     monitoring: istio-components
 spec:
@@ -30,7 +30,7 @@ spec:
       - {key: istio, operator: In, values: [mixer,pilot,galley,citadel]}
   namespaceSelector:
     matchNames:
-      - istio-system
+      - {{ .Release.Namespace }}
   endpoints:
   - port: http-monitoring 
     interval: {{ .Values.scrapeInterval }}
@@ -39,7 +39,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: envoy-stats-monitor
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
   labels:
     monitoring: istio-proxies
 spec:
@@ -65,40 +65,12 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_name]
       action: replace
       targetLabel: pod_name
-    metricRelabelings:
-    - sourceLabels: [ cluster_name ]
-      regex: '(outbound|inbound|prometheus_stats).*'
-      action: drop
-    - sourceLabels: [ tcp_prefix ]
-      regex: '(outbound|inbound|prometheus_stats).*'
-      action: drop
-    - sourceLabels: [ listener_address ]
-      regex: '(.+)'
-      action: drop
-    - sourceLabels: [ http_conn_manager_listener_prefix ]
-      regex: '(.+)'
-      action: drop
-    - sourceLabels: [ http_conn_manager_prefix ]
-      regex: '(.+)'
-      action: drop
-    - sourceLabels: [ __name__ ]
-      regex: 'envoy_tls.*'
-      action: drop
-    - sourceLabels: [ __name__ ]
-      regex: 'envoy_tcp_downstream.*'
-      action: drop
-    - sourceLabels: [ __name__ ]
-      regex: 'envoy_http_(stats|admin).*'
-      action: drop
-    - sourceLabels: [ __name__ ]
-      regex: 'envoy_cluster_(lb|retry|bind|internal|max|original).*'
-      action: drop
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kubernetes-pods-monitor
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
   labels:
     monitoring: kube-pods
 spec:
@@ -142,7 +114,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kubernetes-pods-secure-monitor
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
   labels:
     monitoring: kube-pods-secure
 spec:
@@ -197,7 +169,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kubernetes-services-monitor
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
   labels:
     monitoring: kube-services
 spec:
@@ -241,7 +213,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kubernetes-services-secure-monitor
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
   labels:
     monitoring: kube-services-secure
 spec:
@@ -298,7 +270,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: prometheus
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
 spec:
   image: "{{ .Values.hub }}/prometheus:{{ .Values.tag }}"
   version: {{ .Values.tag }}

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -1,6 +1,9 @@
 #
 # addon prometheus configuration
 #
+# The value of `prometheus.enabled` will be ignored if any of the `prometheus.operator.*`
+# configuration options are selected. The use of the default addon is considered to be
+# mutually exclusive with Prometheus Operator configuration.
 enabled: true
 replicaCount: 1
 hub: docker.io/prom
@@ -59,9 +62,10 @@ security:
 
 # Operator configuration is used to generate Custom Resources
 # for use with the https://github.com/coreos/prometheus-operator. This support
-# currently is only offered as an alpha feature. Use of operator
-# configuration is mutually-exclusive with the templates to install the
-# Istio prometheus addon.
+# currently is only offered as an alpha feature.
+#
+# NOTE: Use of operator configuration is mutually-exclusive with the
+# templates to install the Istio prometheus addon.
 operator:
   # Enabling this option will generate all of the ServiceMonitor CRs for Istio.
   createServiceMonitors: false

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -56,3 +56,17 @@ service:
 
 security:
   enabled: true
+
+# Operator configuration is used to generate Custom Resources
+# for use with the https://github.com/coreos/prometheus-operator. This support
+# currently is only offered as an alpha feature. Use of operator
+# configuration is mutually-exclusive with the templates to install the
+# Istio prometheus addon.
+operator:
+  # Enabling this option will generate all of the ServiceMonitor CRs for Istio.
+  createServiceMonitors: false
+  # Enabling this option will generate a Prometheus resource, causing the operator
+  # to create a prometheus deployment according to the generated spec. Only use this
+  # option if you have not already created a prometheus resource and/or you desire a 
+  # distinct prometheus resource for Istio.
+  createPrometheusResource: false


### PR DESCRIPTION
This PR introduces install options for generating custom resources for the [Prometheus Operator](https://github.com/coreos/prometheus-operator). These resources mirror, as closely as they can, the existing Istio config for the Prometheus addon. This configuration is meant to provide *alpha* quality support.

The following install options are provided:
- `prometheus.operator.createServiceMonitors` will generate a bunch of `ServiceMonitor` resources for Istio endpoints. This set includes the `istio-mesh` resources (`istio-telemetry:42422` endpoints), envoy proxy stats  (`<any service>:15090/stats/prometheus` endpoints), Istio component endpoints (mixer, galley, pilot, citadel), and services/pods with prometheus scrape annotations (both for mTLS-secured services/pods and plain-text).
- `prometheus.operator.createPrometheusResource` will generate a `Prometheus` resource that will cause the operator to create Prometheus deployment in the `istio-system` namespace.

These options should only be used in clusters where the Prometheus Operator has already been installed (example: `kubectl -n prometheus-operator apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml`).

Example install using these options:

```bash
helm template install/kubernetes/helm/istio --name istio --namespace istio-system --set prometheus.operator.createServiceMonitors=true --set prometheus.operator.createPrometheusResource=true | kubectl apply -f -
```

With a cluster with mTLS used globally, applying such an install with a few example services, should yield the following results from the `/targets` endpoint for Prometheus:

![image](https://user-images.githubusercontent.com/21148125/56326077-740be200-6129-11e9-8838-b68f7e3d8a15.png)

I am looking for feedback on the install options, in particular on if they make sense (do they need to be renamed, etc.).

Motivations (Code Mauve):
- https://github.com/istio/istio/issues/10134
- https://github.com/istio/istio/issues/7528
- https://github.com/istio/istio/issues/5673
- https://github.com/istio/istio/issues/12915
- https://discuss.istio.io/t/istio-prometheus-to-scrape-metrics-from-service-specific-metrics-endpoint/926
- https://discuss.istio.io/t/how-to-update-prometheus-config/935
- https://discuss.istio.io/t/istio-1-1-daily-byo-prometheus-via-operator/418
- https://discuss.istio.io/t/is-envoy-metrics-not-pushed-via-statsd-after-1-1/1883

I recognize that it is not desirable to have this change only be in the istio/istio install directory. I'm working on a port of this over to istio-ecosystem/installer and will update this PR with that PR when available.