### PR TITLE
Fixes panic in pilot agent when provided with custom cert paths.

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -49,7 +49,7 @@ import (
 )
 
 var (
-	role             = &model.Proxy{}
+	role             = &model.Proxy{Metadata: map[string]string{}}
 	proxyIP          string
 	registry         serviceregistry.ServiceRegistry
 	statusPort       uint16


### PR DESCRIPTION
#12189 introduced ability to provide custom paths for TLS certificates in command line flags. But when invoked with flag values other than default ones, the code [attempts](https://github.com/drichelson/istio/blob/34c6388801465a5793874177821056c2cb303a13/pilot/cmd/pilot-agent/main.go#L154) to set values in the `role.Metadata` map which is not initialized. That results in the panic with the message `panic: assignment to entry in nil map` upon startup. This change initializes the map in question, allowing `pilot-agent` to start successfully.