### PR TITLE
Fix envvar linter use.

### DIFF
--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -62,7 +62,7 @@ function run_test_lint() {
 function run_envvar_lint() {
     echo 'Running envvarlinter ...'
     go build -o bin/envvarlinter tools/checker/envvarlinter/*.go
-    bin/envvarlinter
+    bin/envvarlinter mixer pilot security galley istioctl
     echo 'envvarlinter OK'
 }
 

--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	ev "istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/test/env"
 )
 
@@ -41,10 +42,7 @@ func (s *TestSetup) NewEnvoy() (*Envoy, error) {
 		return nil, err
 	}
 
-	debugLevel := os.Getenv("ENVOY_DEBUG")
-	if len(debugLevel) == 0 {
-		debugLevel = "info"
-	}
+	debugLevel := ev.RegisterStringVar("ENVOY_DEBUG", "info", "").Get()
 
 	baseID := ""
 	args := []string{"-c", confPath,
@@ -71,7 +69,7 @@ func (s *TestSetup) NewEnvoy() (*Envoy, error) {
 	}
 	/* #nosec */
 	envoyPath := filepath.Join(env.IstioBin, "envoy")
-	if path, exists := os.LookupEnv("ENVOY_PATH"); exists {
+	if path, exists := ev.RegisterStringVar("ENVOY_PATH", "", "").Lookup(); exists {
 		envoyPath = path
 	}
 	cmd := exec.Command(envoyPath, args...)

--- a/mixer/tools/mixgen/cmd/adapter.go
+++ b/mixer/tools/mixgen/cmd/adapter.go
@@ -31,6 +31,7 @@ import (
 
 	"istio.io/istio/mixer/cmd/shared"
 	"istio.io/istio/mixer/pkg/runtime/config/constant"
+	"istio.io/istio/pkg/env"
 )
 
 func adapterCfgCmd(rawArgs []string, printf, fatalf shared.FormatFn) *cobra.Command {
@@ -111,7 +112,7 @@ spec:
 		}
 	}
 
-	goPath := os.Getenv("GOPATH")
+	goPath := env.RegisterStringVar("GOPATH", "", "").Get()
 	adapterObj := &adapterCRVar{
 		RawCommand:   strings.Replace(rawCommand, goPath, "$GOPATH", -1),
 		Name:         name,

--- a/mixer/tools/mixgen/cmd/template.go
+++ b/mixer/tools/mixgen/cmd/template.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	gotemplate "text/template"
@@ -27,6 +26,7 @@ import (
 
 	"istio.io/istio/mixer/cmd/shared"
 	"istio.io/istio/mixer/pkg/runtime/config/constant"
+	"istio.io/istio/pkg/env"
 )
 
 func templateCfgCmd(rawArgs []string, printf, fatalf shared.FormatFn) *cobra.Command {
@@ -81,7 +81,7 @@ spec:
 		fatalf("template in invalid: %v", err)
 	}
 
-	goPath := os.Getenv("GOPATH")
+	goPath := env.RegisterStringVar("GOPATH", "", "").Get()
 	tmplObj := &templateCRVar{
 		Name:       name,
 		Namespace:  ns,

--- a/pilot/test/util/diff.go
+++ b/pilot/test/util/diff.go
@@ -17,18 +17,18 @@ package util
 import (
 	"errors"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/pmezard/go-difflib/difflib"
+
+	"istio.io/istio/pkg/env"
 )
 
 // Refresh controls whether to update the golden artifacts instead.
 // It is set using the environment variable REFRESH_GOLDEN.
 func Refresh() bool {
-	v, exists := os.LookupEnv("REFRESH_GOLDEN")
-	return exists && v == "true"
+	return env.RegisterBoolVar("REFRESH_GOLDEN", false, "").Get()
 }
 
 // Compare compares two byte slices. It returns an error with a

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -286,6 +285,9 @@ func applyEnvVars(cmd *cobra.Command) {
 	}
 }
 
+var defaultInitialBackoff = 10
+var initialBackoffEnvVar = env.RegisterIntVar("INITIAL_BACKOFF_MSEC", defaultInitialBackoff, "")
+
 func main() {
 	rootCmd.PersistentFlags().BoolVar(&serverOptions.EnableWorkloadSDS, enableWorkloadSDSFlag,
 		true,
@@ -319,19 +321,10 @@ func main() {
 
 	// The initial backoff time (in millisec) is a random number between 0 and initBackoff.
 	// Default to 10, a valid range is [10, 120000].
-	var initBackoff int64 = 10
-	env := os.Getenv("INITIAL_BACKOFF_MSEC")
-	if len(env) > 0 {
-		initialBackoff, err := strconv.ParseInt(env, 0, 32)
-		if err != nil {
-			log.Errorf("Failed to parse INITIAL_BACKOFF to integer with error: %v", err)
-			os.Exit(1)
-		} else if initialBackoff < 10 || initialBackoff > 120000 {
-			log.Errorf("INITIAL_BACKOFF should be within range 10 to 120000")
-			os.Exit(1)
-		} else {
-			initBackoff = initialBackoff
-		}
+	initBackoff := int64(initialBackoffEnvVar.Get())
+	if initBackoff < 10 || initBackoff > 120000 {
+		log.Errorf("INITIAL_BACKOFF_MSEC should be within range 10 to 120000")
+		os.Exit(1)
 	}
 	rootCmd.PersistentFlags().Int64Var(&workloadSdsCacheOptions.InitialBackoff, "initialBackoff",
 		initBackoff, "The initial backoff interval in milliseconds")

--- a/tools/checker/envvarlinter/main.go
+++ b/tools/checker/envvarlinter/main.go
@@ -36,7 +36,8 @@ func main() {
 			exitCode = 2
 		}
 	}
-	_ = exitCode
+
+	os.Exit(exitCode)
 }
 
 func getReport(args []string) ([]string, error) {

--- a/tools/checker/envvarlinter/rules_matcher.go
+++ b/tools/checker/envvarlinter/rules_matcher.go
@@ -30,9 +30,9 @@ type RulesMatcher struct {
 // GetRules checks path absp and decides whether absp is a test file. It returns true and test type
 // for a test file. If path absp should be skipped, it returns false.
 func (rf *RulesMatcher) GetRules(absp string, info os.FileInfo) []checker.Rule {
-	// Skip path which is not go test file or is a directory.
+	// Skip path which is a directory, a go test file, or not a go file at all.
 	paths := strings.Split(absp, "/")
-	if len(paths) == 0 || info.IsDir() || strings.HasSuffix(absp, "_test.go") {
+	if len(paths) == 0 || info.IsDir() || strings.HasSuffix(absp, "_test.go") || !strings.HasSuffix(absp, ".go") {
 		return []checker.Rule{}
 	}
 

--- a/tools/checker/flaky_test_finder/rules/is_flaky.go
+++ b/tools/checker/flaky_test_finder/rules/is_flaky.go
@@ -43,7 +43,7 @@ func (lr *IsFlaky) Check(aNode ast.Node, fs *token.FileSet, lrp *checker.Report)
 			if expr, ok := item.(*ast.ExprStmt); ok {
 				if ce, ok := expr.X.(*ast.CallExpr); ok {
 					if rules.MatchCallExpr(ce, "annotation", "IsFlaky") {
-						lrp.AddReport(fn.Name.Name)
+						lrp.AddString(fn.Name.Name)
 					}
 				}
 			}

--- a/tools/checker/report.go
+++ b/tools/checker/report.go
@@ -42,12 +42,7 @@ func (lr *Report) AddItem(pos token.Position, id string, msg string) {
 		pos.Column,
 		msg,
 		id)
-	lr.AddReport(item)
-}
-
-// AddReport creates a new report.
-func (lr *Report) AddReport(msg string) {
-	lr.items = append(lr.items, msg)
+	lr.AddString(item)
 }
 
 // AddString creates a new string line in report.


### PR DESCRIPTION
- envvar linter now fails with an error code when it finds problems.

- Stop running the linter over useless directories

- Only try to lint go files

- Fix discovered unregistered uses of env vars in the code base.