### PR TITLE
Add CRD validation functions for authn v2 policy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1763,18 +1763,21 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:710802a843bee12a00a168d119e0d6afea3ca723fb67cd6ee073a902e943f669"
+  digest = "1:492477ec25e2387e126ad714799fd5e374e3b88378326223d9b5752ff638e91c"
   name = "k8s.io/apiserver"
   packages = [
+    "pkg/authentication/authenticator",
+    "pkg/authentication/user",
     "pkg/features",
     "pkg/util/feature",
+    "plugin/pkg/authenticator/token/oidc",
   ]
   pruneopts = "NUT"
-  revision = "7ec69625ace05fbf94f1d12c51a69774cca2ecb3"
+  revision = "47f1dd8008166a8729c4ff1fbfdfc8d6fb0ae894"
 
 [[projects]]
   branch = "release-8.0"
-  digest = "1:4787de3b2e060e89a22cf9a12590c5aa8f882aec1400334998f22f5dff36f15b"
+  digest = "1:b669f12cb15d2f991be7ab0c9d928a47e99d2176e773a8b86072708d7522218b"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1952,7 +1955,7 @@
     "util/workqueue",
   ]
   pruneopts = "NUT"
-  revision = "56e7a63b5e38b614bb7cb8c49ed26dc991b324c4"
+  revision = "4022682532b3b46b46a31b4c6150cbf55174cf0f"
 
 [[projects]]
   digest = "1:97703d78f59b1906eee5cc024d06f57053995123c3628bb8fdf16f1d090b5cae"
@@ -2199,6 +2202,7 @@
     "google.golang.org/grpc/stats",
     "google.golang.org/grpc/status",
     "gopkg.in/d4l3k/messagediff.v1",
+    "gopkg.in/square/go-jose.v2",
     "gopkg.in/yaml.v2",
     "istio.io/api/authentication/v1alpha1",
     "istio.io/api/authentication/v1alpha2",
@@ -2246,6 +2250,8 @@
     "k8s.io/apimachinery/pkg/util/yaml",
     "k8s.io/apimachinery/pkg/version",
     "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/apiserver/pkg/authentication/user",
+    "k8s.io/apiserver/plugin/pkg/authenticator/token/oidc",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/dynamic",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -286,8 +286,8 @@ ignored = [
 # Need to integrate apis to master
 [[constraint]]
   name = "istio.io/api"
-  branch = "authn_v2"
   source = "https://github.com/diemtvu/api.git"
+  revision = "835ad91e9266fc7916da3ab67a4cf980bbf62545"
 
 # fortio is latest tagged by default
 

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -473,7 +473,7 @@ var (
 		Group:       "authentication",
 		Version:     "v1alpha2",
 		MessageName: "istio.authentication.v1alpha2.AuthenticationPolicy",
-		Validate:    ValidateAuthenticationPolicyAlpha2,
+		Validate:    ValidateAuthenticationPolicyV1Alpha2,
 		Collection:  metadata.IstioAuthenticationV1alpha2Authenticationpolicies.Collection.String(),
 	}
 

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1477,6 +1477,7 @@ func ValidateAuthenticationPolicy(name, namespace string, msg proto.Message) err
 
 // ValidateAuthenticationPolicyV1Alpha2 checks that AuthenticationPolicy v1alpha2 is well-formed.
 func ValidateAuthenticationPolicyV1Alpha2(name, namespace string, msg proto.Message) error {
+	// nil msg is not ok.
 	policy, ok := msg.(*authn2.AuthenticationPolicy)
 	if !ok {
 		return errors.New("cannot cast to AuthenticationPolicy (v1alpha2)")
@@ -1571,19 +1572,19 @@ func ValidateAuthnMatchV1Alpha2(match *authn2.Match) error {
 		case *authn2.StringMatch_Exact:
 			if matchType.Exact == "" {
 				errs = appendErrors(errs,
-					fmt.Errorf("StringMatch_Exact in authn policy matching path is empty"))
+					fmt.Errorf("stringmatch_exact in authn policy matching path is empty"))
 			}
 			return errs
 		case *authn2.StringMatch_Prefix:
 			if matchType.Prefix == "" {
 				errs = appendErrors(errs,
-					fmt.Errorf("StringMatch_Prefix in authn policy matching path is empty"))
+					fmt.Errorf("stringmatch_prefix in authn policy matching path is empty"))
 			}
 			return errs
 		case *authn2.StringMatch_Regex:
 			if matchType.Regex == "" {
 				errs = appendErrors(errs,
-					fmt.Errorf("StringMatch_Regex in authn policy matching path is empty"))
+					fmt.Errorf("stringmatch_regex in authn policy matching path is empty"))
 			}
 			return errs
 		}

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -25,6 +25,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 
 	authn "istio.io/api/authentication/v1alpha1"
+	authn2 "istio.io/api/authentication/v1alpha2"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mpb "istio.io/api/mixer/v1"
 	mccpb "istio.io/api/mixer/v1/config/client"
@@ -3569,6 +3570,33 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 	for _, c := range cases {
 		if got := ValidateAuthenticationPolicy(c.configName, someNamespace, c.in); (got == nil) != c.valid {
 			t.Errorf("ValidateAuthenticationPolicy(%v): got(%v) != want(%v): %v\n", c.name, got == nil, c.valid, got)
+		}
+	}
+}
+
+func TestValidateAuthenticationPolicyV1Alpha2(t *testing.T) {
+	cases := []struct {
+		name       string
+		configName string
+		in         proto.Message
+		valid      bool
+	}{
+		{
+			name:       "nil policy with namespace-wide policy name",
+			configName: DefaultAuthenticationPolicyName,
+			in:         nil,
+			valid:      false,
+		},
+		{
+			name:       "empty policy with namespace-wide policy name",
+			configName: DefaultAuthenticationPolicyName,
+			in:         &authn2.AuthenticationPolicy{},
+			valid:      true,
+		},
+	}
+	for _, c := range cases {
+		if got := ValidateAuthenticationPolicyV1Alpha2(c.configName, someNamespace, c.in); (got == nil) != c.valid {
+			t.Errorf("ValidateAuthenticationPolicyV1Alpha2(%v): got(%v) != want(%v): %v\n", c.name, got == nil, c.valid, got)
 		}
 	}
 }


### PR DESCRIPTION
Add CRD validation functions for authn v2 policy.

TODO: add tests for the authn v2 CRD validation functions when CRD stabilizes.