### PR TITLE
Fix manual injection when webhook disabled

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -1,4 +1,4 @@
-rewriteAppHTTPProbe: {{ .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe }}
+rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
 {{- if or (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
 initContainers:
 {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -883,7 +883,7 @@ func excludeInboundPort(port interface{}, excludedInboundPorts string) string {
 	return strings.Join(outPorts, ",")
 }
 
-func valueOrDefault(value string, defaultValue string) string {
+func valueOrDefault(value interface{}, defaultValue interface{}) interface{} {
 	if value == "" {
 		return defaultValue
 	}

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -884,7 +884,7 @@ func excludeInboundPort(port interface{}, excludedInboundPorts string) string {
 }
 
 func valueOrDefault(value interface{}, defaultValue interface{}) interface{} {
-	if value == "" {
+	if value == "" || value == nil {
 		return defaultValue
 	}
 	return value

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -335,7 +335,6 @@ func TestBuildGatewayClustersWithRingHashLbDefaultMinRingSize(t *testing.T) {
 	g.Expect(cluster.LbPolicy).To(Equal(apiv2.Cluster_RING_HASH))
 	g.Expect(cluster.GetRingHashLbConfig().GetMinimumRingSize().GetValue()).To(Equal(uint64(1024)))
 	g.Expect(cluster.Name).To(Equal("outbound|8080||*.example.org"))
-	//g.Expect(cluster.Type).To(Equal(apiv2.Cluster_EDS))
 	g.Expect(cluster.ConnectTimeout).To(Equal(time.Duration(10000000001)))
 }
 


### PR DESCRIPTION
If webook is disabled, then Helm values for the webhook will not be
exposed. This means that in the ConfigMap that stores the values, we
will not have the rewriteAppHTTPProbe variable, causing errors. By
defaulting this to false, we keep the same behavior but succeed in the
case when the config is not present.

I also verified this is the only case of this bug, all other variables
read in the injection template are from global.