### PR TITLE
Fix EnableFallthroughRoute for HTTPS traffic

### DIFF
--- a/tests/integration/pilot/outboundtrafficpolicy/helper.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/helper.go
@@ -129,13 +129,10 @@ func RunExternalRequestTest(expected map[string][]string, t *testing.T) {
 			}
 			for _, tc := range cases {
 				t.Run(tc.name, func(t *testing.T) {
-					if tc.protocol == "https" {
-						t.Skip("https is currently not supported until #13386 is fixed")
-					}
 					ep := dest.EndpointForPort(tc.port)
 					resp, err := client.Call(ep, apps.AppCallOptions{})
-					if err != nil {
-						t.Errorf("call failed: %v", err)
+					if err != nil && len(expected[tc.protocol]) != 0 {
+						t.Fatalf("request failed: %v", err)
 					}
 					codes := make([]string, 0, len(resp))
 					for _, r := range resp {


### PR DESCRIPTION
HTTPS traffic does not go through the route config like http, so the fix
to allow outbound traffic properly is not applied. Instead, we can do
the same thing at the listener level. Because we cannot do a direct
response here, we can't return a 502 in the case of REGISTRY_ONLY, but
we can still block the traffic (same behavior as if we had no listener
on the port).

Fixes https://github.com/istio/istio/issues/13386