### PR TITLE
Fix test flakes in pkg/cache.

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -162,7 +162,7 @@ func testCacheConcurrent(c Cache, t *testing.T) {
 
 }
 
-// WARNING: This test expects the cache to have been created with a long expiration time.
+// WARNING: This test expects the cache to have been created with no automatic eviction.
 func testCacheExpiration(c ExpiringCache, evictExpired func(time.Time), t *testing.T) {
 	now := time.Now()
 
@@ -229,6 +229,7 @@ func testCacheEvictExpired(c ExpiringCache, t *testing.T) {
 		t.Error("Got no entry, expecting it to be there")
 	}
 
+	time.Sleep(10 * time.Millisecond)
 	c.EvictExpired()
 
 	_, ok = c.Get("A")

--- a/pkg/cache/lruCache_test.go
+++ b/pkg/cache/lruCache_test.go
@@ -30,7 +30,7 @@ func TestLRUConcurrent(t *testing.T) {
 }
 
 func TestLRUExpiration(t *testing.T) {
-	lru := NewLRU(5*time.Second, 100*time.Second, 500).(*lruWrapper)
+	lru := NewLRU(5*time.Second, 0, 500).(*lruCache)
 	testCacheExpiration(lru, lru.evictExpired, t)
 }
 

--- a/pkg/cache/ttlCache.go
+++ b/pkg/cache/ttlCache.go
@@ -93,8 +93,8 @@ func NewTTLWithCallback(defaultExpiration time.Duration, evictionInterval time.D
 		callback:          callback,
 	}
 
+	c.baseTimeNanos = time.Now().UnixNano()
 	if evictionInterval > 0 {
-		c.baseTimeNanos = time.Now().UTC().UnixNano()
 		c.stopEvicter = make(chan bool, 1)
 		c.evicterTerminated.Add(1)
 		go c.evicter(evictionInterval)
@@ -134,7 +134,7 @@ func (c *ttlCache) evictExpired(t time.Time) {
 	// sampled in the Set call as calling time.Now() is relatively expensive.
 	// Doing it here provides enough precision for our needs and tends to have
 	// much lower call frequency.
-	n := t.UTC().UnixNano()
+	n := t.UnixNano()
 	atomic.StoreInt64(&c.baseTimeNanos, n)
 
 	// This loop is inherently racy. As we iterate through the

--- a/pkg/cache/ttlCache_test.go
+++ b/pkg/cache/ttlCache_test.go
@@ -31,7 +31,7 @@ func TestTTLConcurrent(t *testing.T) {
 }
 
 func TestTTLExpiration(t *testing.T) {
-	ttl := NewTTL(5*time.Second, 100*time.Second).(*ttlWrapper)
+	ttl := NewTTL(5*time.Second, 0).(*ttlCache)
 	testCacheExpiration(ttl, ttl.evictExpired, t)
 }
 


### PR DESCRIPTION
- Run the expiration tests with no background evicter goroutine, which
eliminates the non-determinism.

- Stop using time.UTC(), turns out its unnecessary when using time.UnixNanos

- Correctly initialize the base nanosecond value when using the caches with no
evicter goroutine.

- Add a missing delay in the test for EvictExpired uncovered by setting the
base nanosecond value above.

Fixed #12986 