### PR TITLE
[Test Framework] Fix forward echo timeout

### DIFF
--- a/pkg/test/application/echo/handler.go
+++ b/pkg/test/application/echo/handler.go
@@ -148,7 +148,7 @@ func (h handler) ForwardEcho(ctx context.Context, req *proto.ForwardEchoRequest)
 func (h handler) newBatchOptions(req *proto.ForwardEchoRequest) BatchOptions {
 	ops := BatchOptions{
 		URL:     req.Url,
-		Timeout: time.Duration(req.TimeoutMicros) / time.Microsecond,
+		Timeout: time.Duration(req.TimeoutMicros) * time.Microsecond,
 		Count:   int(req.Count),
 		QPS:     int(req.Qps),
 		Message: req.Message,


### PR DESCRIPTION
This was using picoseconds instead of microseconds