### PR TITLE
Treat an unset PILOT_ENABLE_FALLTHROUGH_ROUTE as enabled

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -249,7 +249,8 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 	}
 
 	// Expect two vhost blocks in RDS output for 8080 (one for http1, another for http2)
-	if len(adsResponse.Routes["8080"].VirtualHosts) != 2 {
+	// plus one extra due to mem registry
+	if len(adsResponse.Routes["8080"].VirtualHosts) != 3 {
 		t.Fatalf("Expected two VirtualHosts in RDS output. Got %d", len(adsResponse.Routes["8080"].VirtualHosts))
 	}
 }

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -136,7 +136,8 @@ var (
 	// When ALLOW_ANY traffic policy is used, a Passthrough cluster is used.
 	// When REGISTRY_ONLY traffic policy is used, a 502 error is returned.
 	EnableFallthroughRoute = func() bool {
-		return os.Getenv("PILOT_ENABLE_FALLTHROUGH_ROUTE") == "1"
+		val, set := os.LookupEnv("PILOT_ENABLE_FALLTHROUGH_ROUTE")
+		return val == "1" || !set
 	}
 
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).


### PR DESCRIPTION
Make the default behavior for PILOT_ENABLE_FALLTHROUGH_ROUTE to be set. This will remove the requirement for the flag to be set if one wants to  access an external hosts using the same port as any internal HTTP service.

To disable this flag, if needed, the user would have to set  PILOT_ENABLE_FALLTHROUGH_ROUTE  to 0. Note that this flag will be going away soon and won't be used at all. This is just setting that behavior now.