### PR TITLE
WIP: Add support for using Jaeger operator, if installed and enabled, to p…

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/cr-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/cr-jaeger.yaml
@@ -1,0 +1,15 @@
+{{ if and (eq .Values.provider "jaeger") .Values.jaeger.operator.enabled }}
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: jaeger
+  namespace: {{ .Release.Namespace }}
+spec:
+{{ toYaml .Values.jaeger.spec | indent 2 }}
+  resources:
+{{- if .Values.resources }}
+{{ toYaml .Values.resources | indent 4 }}
+{{- else }}
+{{ toYaml .Values.global.defaultResources | indent 4 }}
+{{- end }}
+{{ end }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.provider "jaeger" }}
+{{ if and (eq .Values.provider "jaeger") (not .Values.jaeger.operator.enabled) }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.provider "jaeger" }}
+{{ if and (eq .Values.provider "jaeger") (not .Values.jaeger.operator.enabled) }}
 
 apiVersion: v1
 kind: List

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
@@ -28,6 +28,9 @@ items:
         name: {{ .Values.service.name }}
     selector:
       app: {{ .Values.provider }}
+{{ if and (eq .Values.provider "jaeger") (eq .Values.jaeger.spec.strategy "production") }}
+      app.kubernetes.io/component: collector
+{{ end}}
 - apiVersion: v1
   kind: Service
   metadata:
@@ -54,3 +57,6 @@ items:
 {{ end}}
     selector:
       app: {{ .Values.provider }}
+{{ if and (eq .Values.provider "jaeger") (eq .Values.jaeger.spec.strategy "production") }}
+      app.kubernetes.io/component: query
+{{ end}}

--- a/install/kubernetes/helm/istio/charts/tracing/values.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/values.yaml
@@ -29,9 +29,60 @@ podAntiAffinityTermLabelSelector: {}
 
 jaeger:
   hub: docker.io/jaegertracing
-  tag: 1.9
+  tag: 1.11
   memory:
     max_traces: 50000
+  operator:
+    enabled: false
+  # The spec represents the Jaeger operator's custom resource (CR).
+  # CR docs can be found here: https://github.com/jaegertracing/jaeger-operator#creating-a-new-jaeger-instance
+  # Some example CRs: https://github.com/jaegertracing/jaeger-operator/tree/master/deploy/examples
+  spec:
+    strategy: allInOne
+    allInOne:
+      options:
+        query:
+          base-path: /jaeger
+    agent:
+      strategy: Sidecar
+    query:
+      options:
+        query:
+          base-path: /jaeger
+    storage:
+      type: memory
+      options:
+        memory:
+          max-traces: 50000
+        es:
+          server-urls: http://elasticsearch:9200
+        cassandra:
+          servers: cassandra
+          keyspace: jaeger_v1_datacenter3
+      cassandraCreateSchema:
+        datacenter: "datacenter3"
+        mode: "test"
+      # Setup a secret to contain the environment variables for use with storage
+      # See https://github.com/jaegertracing/jaeger-operator#secrets-support
+      secretName: ""
+    ui:
+      options:
+        dependencies:
+          # Disable dependencies tab, as information provided by tools such as Kiali will
+          # be more accurate than tracing derived data which is subject to sampling.
+          menuEnabled: false
+        tracking:
+          gaID: UA-000000-2
+        menu:
+          - label: "About Jaeger"
+            items:
+              - label: "Documentation"
+                url: "https://www.jaegertracing.io/docs/latest"
+    ingress:
+      enabled: false
+    annotations:
+      scheduler.alpha.kubernetes.io/critical-pod: ""
+      sidecar.istio.io/inject: "false"
 
 zipkin:
   hub: docker.io/openzipkin


### PR DESCRIPTION
…rovide production deployments

This PR supersedes #9508, using a similar approach to #13407, expecting the operator to have been installed previously.

The operator is enabled using `--set tracing.jaeger.operator.enabled`. By default an in-memory deployment of Jaeger would be used (equivalent to the non-operator approach).

The Jaeger operator's custom resource is defined under the `tracing.jaeger.spec` node (suggestion for another subnode name welcome).

For example, a production deployment can be enabled by using `--set tracing.jaeger.spec.strategy=production`, and alternative storage options can be defined using `--set tracing.jaeger.spec.storage.type=elasticsearch`.

More information on the operator can be found [here](https://github.com/jaegertracing/jaeger-operator/blob/master/README.adoc), with some examples of custom resources [here](https://github.com/jaegertracing/jaeger-operator/tree/master/deploy/examples).

Resolves #8893 
Resolves #8965 