### PR TITLE
Cherry Pick to 1.1: Fix EnableFallthroughRoute for HTTPS traffic

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1078,6 +1078,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(l
 	// Lets build the new listener with the filter chains. In the end, we will
 	// merge the filter chains with any existing listener on the same port/bind point
 	l := buildListener(listenerOpts)
+	appendListenerFallthroughRoute(l, &listenerOpts, pluginParams.Node)
+
 	mutable := &plugin.MutableObjects{
 		Listener:     l,
 		FilterChains: make([]plugin.FilterChain, len(l.FilterChains)),
@@ -1550,6 +1552,44 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 		ListenerFilters: listenerFilters,
 		FilterChains:    filterChains,
 		DeprecatedV1:    deprecatedV1,
+	}
+}
+
+// appendListenerFallthroughRoute adds a filter that will match all traffic and direct to the
+// PassthroughCluster. This should be appended as the final filter or it will mask the others.
+// This allows external https traffic, even when port the port (usually 443) is in use by another service.
+func appendListenerFallthroughRoute(l *xdsapi.Listener, opts *buildListenerOpts, node *model.Proxy) {
+	// If traffic policy is REGISTRY_ONLY, the traffic will already be blocked, so no action is needed.
+	if pilot.EnableFallthroughRoute() &&
+		opts.env.Mesh.OutboundTrafficPolicy.Mode == meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY {
+
+		wildcardMatch := &listener.FilterChainMatch{}
+		for _, fc := range l.FilterChains {
+			if fc.FilterChainMatch == nil || fc.FilterChainMatch == wildcardMatch {
+				// We can only have one wildcard match. If the filter chain already has one, skip it
+				// This happens in the case of HTTP, which will get a fallthrough route added later,
+				// or TCP, which is not supported
+				return
+			}
+		}
+		tcpFilter := listener.Filter{
+			Name: xdsutil.TCPProxy,
+		}
+		config := &tcp_proxy.TcpProxy{
+			StatPrefix:       util.PassthroughCluster,
+			ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: util.PassthroughCluster},
+		}
+		if util.IsXDSMarshalingToAnyEnabled(node) {
+			tcpFilter.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(config)}
+		} else {
+			tcpFilter.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(config)}
+		}
+
+		opts.filterChainOpts = append(opts.filterChainOpts, &filterChainOpts{
+			networkFilters: []listener.Filter{tcpFilter},
+		})
+		l.FilterChains = append(l.FilterChains, listener.FilterChain{FilterChainMatch: wildcardMatch})
+
 	}
 }
 


### PR DESCRIPTION
HTTPS traffic does not go through the route config like http, so the fix
to allow outbound traffic properly is not applied. Instead, we can do
the same thing at the listener level. Because we cannot do a direct
response here, we can't return a 502 in the case of REGISTRY_ONLY, but
we can still block the traffic (same behavior as if we had no listener
on the port).

Cherry pick of https://github.com/istio/istio/pull/13440