### PR TITLE
Make sure all flags get pulled during init.

### DIFF
--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -15,7 +15,6 @@
 package istio
 
 import (
-	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -33,8 +32,8 @@ type Instance interface {
 type SetupConfigFn func(cfg *Config)
 
 // SetupOnKube is a setup function that will deploy Istio on Kubernetes environment
-func SetupOnKube(i *Instance, cfn SetupConfigFn) framework.SetupFn {
-	return func(ctx framework.SuiteContext) error {
+func SetupOnKube(i *Instance, cfn SetupConfigFn) resource.SetupFn {
+	return func(ctx resource.Context) error {
 		switch ctx.Environment().EnvironmentName() {
 		case environment.Native:
 			scopes.Framework.Debugf("istio.SetupOnKube: Skipping deployment of Istio on native")

--- a/pkg/test/framework/operations.go
+++ b/pkg/test/framework/operations.go
@@ -18,11 +18,12 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 // Main runs the test suite. The Main will run the supplied setup functions before starting test execution.
 // It will not return, and will exit the process after running tests.
-func Main(testID string, m *testing.M, setupFn ...SetupFn) {
+func Main(testID string, m *testing.M, setupFn ...resource.SetupFn) {
 	r := NewSuite(testID, m)
 	for _, fn := range setupFn {
 		r = r.Setup(fn)

--- a/pkg/test/framework/resource/setup.go
+++ b/pkg/test/framework/resource/setup.go
@@ -16,4 +16,3 @@ package resource
 
 // SetupFn is a function used for performing setup actions.
 type SetupFn func(ctx Context) error
-

--- a/pkg/test/framework/resource/setup.go
+++ b/pkg/test/framework/resource/setup.go
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package framework
+package resource
 
-import (
-	// Import all packages that have static initializers.
-	_ "istio.io/istio/pkg/test/framework/components/deployment"
-	_ "istio.io/istio/pkg/test/framework/components/environment/kube"
-	_ "istio.io/istio/pkg/test/framework/components/istio"
-)
+// SetupFn is a function used for performing setup actions.
+type SetupFn func(ctx Context) error
+

--- a/tests/integration/examples/example_test.go
+++ b/tests/integration/examples/example_test.go
@@ -17,6 +17,7 @@ package examples
 import (
 	"testing"
 
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/examples/mycomponent"
 
 	"istio.io/istio/pkg/test/framework"
@@ -59,7 +60,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func mysetup(c framework.SuiteContext) error {
+func mysetup(c resource.Context) error {
 	// this function will be called as part of suite setup. You can do one-time setup here.
 	// returning an error from here will cause the suite to fail all-together.
 
@@ -80,11 +81,11 @@ func mysetup(c framework.SuiteContext) error {
 	return nil
 }
 
-func setupNative(_ framework.SuiteContext) error {
+func setupNative(_ resource.Context) error {
 	return nil
 }
 
-func setupKube(_ framework.SuiteContext) error {
+func setupKube(_ resource.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
- Not all the flags inits were being pulled in to the main framework. Adding the flags for Istio deployment as well.
- This required breaking a dependency cycle by changing and moving SetupFn function to the resource package.