### PR TITLE
Sleep to prevent test flakes in outbound traffic

### DIFF
--- a/tests/integration/pilot/outboundtrafficpolicy/helper.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/helper.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"reflect"
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/apps"
@@ -110,6 +111,9 @@ func RunExternalRequestTest(expected map[string][]string, t *testing.T) {
 
 			client := instance.GetAppOrFail("client", t).(apps.KubeApp)
 			dest := instance.GetAppOrFail("destination", t).(apps.KubeApp)
+
+			// Wait for config to propagate
+			time.Sleep(time.Second * 5)
 
 			cases := []struct {
 				name     string


### PR DESCRIPTION
We need a better solution for this for all tests, but in the mean time might as well get a quick fix to stop flakes