### PR TITLE
Support using the kiali-viewer role directly from Helm chart configuration

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/clusterrolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali{{- if .Values.dashboard.readOnly }}-viewer{{- end }}
+  name: kiali{{- if .Values.dashboard.viewOnlyMode }}-viewer{{- end }}
 subjects:
 - kind: ServiceAccount
   name: kiali-service-account

--- a/install/kubernetes/helm/istio/charts/kiali/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/clusterrolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali
+  name: kiali{{- if .Values.dashboard.readOnly }}-viewer{{- end }}
 subjects:
 - kind: ServiceAccount
   name: kiali-service-account

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -47,7 +47,7 @@ dashboard:
   secretName: kiali # You must create a secret with this name - one is not provided out-of-box.
   usernameKey: username # This is the key name within the secret whose value is the actual username.
   passphraseKey: passphrase # This is the key name within the secret whose value is the actual passphrase.
-  readOnly: false # Bind the service account to a RBAC Role with only read access
+  viewOnlyMode: false # Bind the service account to a role with only read access
   grafanaURL:  # If you have Grafana installed and it is accessible to client browsers, then set this to its external URL. Kiali will redirect users to this URL when Grafana metrics are to be shown.
   jaegerURL:  # If you have Jaeger installed and it is accessible to client browsers, then set this property to its external URL. Kiali will redirect users to this URL when Jaeger tracing is to be shown.
 prometheusAddr: http://prometheus:9090

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -47,6 +47,7 @@ dashboard:
   secretName: kiali # You must create a secret with this name - one is not provided out-of-box.
   usernameKey: username # This is the key name within the secret whose value is the actual username.
   passphraseKey: passphrase # This is the key name within the secret whose value is the actual passphrase.
+  readOnly: false # Bind the service account to a RBAC Role with only read access
   grafanaURL:  # If you have Grafana installed and it is accessible to client browsers, then set this to its external URL. Kiali will redirect users to this URL when Grafana metrics are to be shown.
   jaegerURL:  # If you have Jaeger installed and it is accessible to client browsers, then set this property to its external URL. Kiali will redirect users to this URL when Jaeger tracing is to be shown.
 prometheusAddr: http://prometheus:9090


### PR DESCRIPTION
The `ClusterRole` already exists for viewer permissions -- this just gives the option to bind the admin account to it.