### PR TITLE
Allow more than one injector webhook in a cluster

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
+            - --webhookConfigName=istio-sidecar-injector-{{ .Release.Namespace }}
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/mutatingwebhook.yaml
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-{{ .Release.Namespace }}
   labels:
     app: {{ template "sidecar-injector.name" . }}
     chart: {{ template "sidecar-injector.chart" . }}


### PR DESCRIPTION
Because webhooks' scope are global (not namespaced), by default it
is impossible to have two of them to co-exist, due to a clash in the name
(think of installing two control planes for soft multi-tenancy).

This is easily fixed if we have the namespace as part of the webhook name.

Note that this is already the case of other global objects, e.g., ClusterRole.