### PR TITLE
Remove trailing tab chars from line endings in two templates

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/configmap.yaml
@@ -1,20 +1,20 @@
-apiVersion: v1	
-kind: ConfigMap	
-metadata:	
-  name: istio-security-custom-resources	
-  namespace: {{ .Release.Namespace }}	
-  labels:	
-    app: {{ template "security.name" . }}	
-    chart: {{ template "security.chart" . }}	
-    heritage: {{ .Release.Service }}	
-    release: {{ .Release.Name }}	
-    istio: citadel	
-data:	
-  custom-resources.yaml: |-	
-    {{- if .Values.global.mtls.enabled }}	
-      {{- include "security-default.yaml.tpl" . | indent 4}}	
-    {{- else }}	
-      {{- include "security-permissive.yaml.tpl" . | indent 4}}	
-    {{- end }}	
-  run.sh: |-	
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-security-custom-resources
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ template "security.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    istio: citadel
+data:
+  custom-resources.yaml: |-
+    {{- if .Values.global.mtls.enabled }}
+      {{- include "security-default.yaml.tpl" . | indent 4}}
+    {{- else }}
+      {{- include "security-permissive.yaml.tpl" . | indent 4}}
+    {{- end }}
+  run.sh: |-
     {{- include "install-custom-resources.sh.tpl" . | indent 4}}

--- a/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
@@ -1,94 +1,94 @@
 {{- if .Values.createMeshPolicy }}
-apiVersion: v1	
-kind: ServiceAccount	
-metadata:	
-  name: istio-security-post-install-account	
-  namespace: {{ .Release.Namespace }}	
-  labels:	
-    app: {{ template "security.name" . }}	
-    chart: {{ template "security.chart" . }}	
-    heritage: {{ .Release.Service }}	
-    release: {{ .Release.Name }}	
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-security-post-install-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ template "security.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1	
-kind: ClusterRole	
-metadata:	
-  name: istio-security-post-install-{{ .Release.Namespace }}	
-  labels:	
-    app: {{ template "security.name" . }}	
-    chart: {{ template "security.chart" . }}	
-    heritage: {{ .Release.Service }}	
-    release: {{ .Release.Name }}	
-rules:	
-- apiGroups: ["authentication.istio.io"] # needed to create default authn policy	
-  resources: ["*"]	
-  verbs: ["*"]	
-- apiGroups: ["networking.istio.io"] # needed to create security destination rules	
-  resources: ["*"]	
-  verbs: ["*"]	
-- apiGroups: ["admissionregistration.k8s.io"]	
-  resources: ["validatingwebhookconfigurations"]	
-  verbs: ["get"]	
-- apiGroups: ["extensions", "apps"]	
-  resources: ["deployments", "replicasets"]	
-  verbs: ["get", "list", "watch"]	
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-security-post-install-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ template "security.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["authentication.istio.io"] # needed to create default authn policy
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["networking.istio.io"] # needed to create security destination rules
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["get"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets"]
+  verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1	
-kind: ClusterRoleBinding	
-metadata:	
-  name: istio-security-post-install-role-binding-{{ .Release.Namespace }}	
-  labels:	
-    app: {{ template "security.name" . }}	
-    chart: {{ template "security.chart" . }}	
-    heritage: {{ .Release.Service }}	
-    release: {{ .Release.Name }}	
-roleRef:	
-  apiGroup: rbac.authorization.k8s.io	
-  kind: ClusterRole	
-  name: istio-security-post-install-{{ .Release.Namespace }}	
-subjects:	
-  - kind: ServiceAccount	
-    name: istio-security-post-install-account	
-    namespace: {{ .Release.Namespace }}	
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-security-post-install-role-binding-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ template "security.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-security-post-install-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-security-post-install-account
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: batch/v1
-kind: Job	
-metadata:	
-  name: istio-security-post-install-{{ .Values.global.tag | printf "%v" | trunc 32  }}	
-  namespace: {{ .Release.Namespace }}	
-  annotations:	
-    "helm.sh/hook": post-install	
-    "helm.sh/hook-delete-policy": hook-succeeded	
-  labels:	
-    app: {{ template "security.name" . }}	
-    chart: {{ template "security.chart" . }}	
-    heritage: {{ .Release.Service }}	
-    release: {{ .Release.Name }}	
-spec:	
-  template:	
-    metadata:	
-      name: istio-security-post-install	
-      labels:	
-        app: {{ template "security.name" . }}	
-        chart: {{ template "security.chart" . }}	
-        heritage: {{ .Release.Service }}	
-        release: {{ .Release.Name }}	
-    spec:	
-      serviceAccountName: istio-security-post-install-account	
-      containers:	
-        - name: kubectl	
-          image: "{{ .Values.global.hub }}/kubectl:{{ .Values.global.tag }}"	
-          imagePullPolicy: IfNotPresent	
-          command: [ "/bin/bash", "/tmp/security/run.sh", "/tmp/security/custom-resources.yaml" ]	
-          volumeMounts:	
-            - mountPath: "/tmp/security"	
-              name: tmp-configmap-security	
-      volumes:	
-        - name: tmp-configmap-security	
-          configMap:	
-            name: istio-security-custom-resources	
-      restartPolicy: OnFailure	
-      affinity:	
+kind: Job
+metadata:
+  name: istio-security-post-install-{{ .Values.global.tag | printf "%v" | trunc 32  }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ template "security.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  template:
+    metadata:
+      name: istio-security-post-install
+      labels:
+        app: {{ template "security.name" . }}
+        chart: {{ template "security.chart" . }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: istio-security-post-install-account
+      containers:
+        - name: kubectl
+          image: "{{ .Values.global.hub }}/kubectl:{{ .Values.global.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/bash", "/tmp/security/run.sh", "/tmp/security/custom-resources.yaml" ]
+          volumeMounts:
+            - mountPath: "/tmp/security"
+              name: tmp-configmap-security
+      volumes:
+        - name: tmp-configmap-security
+          configMap:
+            name: istio-security-custom-resources
+      restartPolicy: OnFailure
+      affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
 {{- end }}


### PR DESCRIPTION
Trivial cleanup: trailing tabs were left in two templates. Tabs were kept when rendering the templates,  throwing some yaml linter warnings.