### PR TITLE
Remove init container from prometheus

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -28,16 +28,6 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
-{{- if .Values.security.enabled }}
-      initContainers:
-      - name: prom-init
-        image: "busybox:1.30.1"
-        command: ['sh', '-c', 'counter=0; until [ "$counter" -ge 30 ]; do if [ -f /etc/istio-certs/key.pem ]; then exit 0; else echo waiting for istio certs && sleep 1 && counter=$((counter+1)); fi; done; exit 1;']
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-        volumeMounts:
-          - mountPath: /etc/istio-certs
-            name: istio-certs
-{{- end }}
       containers:
         - name: prometheus
           image: "{{ .Values.hub }}/prometheus:{{ .Values.tag }}"
@@ -74,7 +64,9 @@ spec:
       - name: istio-certs
         secret:
           defaultMode: 420
+{{- if not .Values.security.enabled }}
           optional: true
+{{- end }}
           secretName: istio.default
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}


### PR DESCRIPTION
Fix #13501

Instead of using init container, make istio secret volume non-optional when citadel is installed. This removes usage of busybox in prometheus container.