### PR TITLE
Additional build of distroless images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ install/kubernetes/istio-mixer-validator.yaml
 install/kubernetes/istio-citadel-plugin-certs.yaml
 install/kubernetes/istio-citadel-standalone.yaml
 install/kubernetes/istio-citadel-with-health-check.yaml
+install/kubernetes/istio-multicluster-split-horizon.yaml
 install/kubernetes/istio-one-namespace-auth.yaml
 install/kubernetes/istio-one-namespace-trust-domain.yaml
 install/kubernetes/istio-one-namespace.yaml

--- a/Makefile
+++ b/Makefile
@@ -231,15 +231,9 @@ ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED):
                  then printf "go version $(GO_VERSION_REQUIRED)+ required, found: "; $(GO) version; exit 1; fi
 	@touch ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED)
 
-# Ensure expected GOPATH setup
-.PHONY: check-tree
-check-tree:
-	@if [ ! "$(ISTIO_GO)" -ef "$(GO_TOP)/src/istio.io/istio" ]; then \
-		echo Not building in expected path \'GOPATH/src/istio.io/istio\'. Make sure to clone Istio into that path. Istio root="$(ISTIO_GO)", GO_TOP="$(GO_TOP)" ; \
-		exit 1; fi
 
 # Downloads envoy, based on the SHA defined in the base pilot Dockerfile
-init: check-tree check-go-version $(ISTIO_OUT)/istio_is_init
+init: check-go-version $(ISTIO_OUT)/istio_is_init
 	mkdir -p ${OUT_DIR}/logs
 
 # Sync is the same as init in release branch. In master this pulls from master.

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -1,3 +1,13 @@
-FROM istionightly/base_debug
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM istionightly/base_debug as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
 ADD galley /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/galley"]

--- a/mixer/docker/Dockerfile.mixer
+++ b/mixer/docker/Dockerfile.mixer
@@ -1,7 +1,17 @@
-FROM scratch
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
 
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM scratch as default
 # obtained from debian ca-certs deb using fetch_cacerts.sh
 ADD ca-certificates.tgz /
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
+
 ADD mixs /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/mixs", "server"]

--- a/mixer/docker/Dockerfile.mixer_codegen
+++ b/mixer/docker/Dockerfile.mixer_codegen
@@ -1,4 +1,14 @@
-FROM scratch
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM scratch as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
 
 ADD mixgen /usr/local/bin/
 

--- a/mixer/docker/Dockerfile.test_policybackend
+++ b/mixer/docker/Dockerfile.test_policybackend
@@ -1,4 +1,13 @@
-FROM istionightly/base_debug
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
 
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM istionightly/base_debug as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
 ADD mixer-test-policybackend /usr/local/bin/policybackend
 ENTRYPOINT ["/usr/local/bin/policybackend", "server"]

--- a/mixer/test/listbackend/cmd/Dockerfile
+++ b/mixer/test/listbackend/cmd/Dockerfile
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM scratch as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
 
 ADD listadapter /usr/local/bin/
 

--- a/mixer/test/prometheus/cmd/Dockerfile
+++ b/mixer/test/prometheus/cmd/Dockerfile
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM scratch as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
 
 ADD prometheusadapter /usr/local/bin/
 

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -1,4 +1,14 @@
-FROM istionightly/base_debug
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM istionightly/base_debug as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
 
 ADD pilot-discovery /usr/local/bin/
 ADD cacert.pem /cacert.pem

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -1,4 +1,34 @@
-FROM istionightly/base_debug
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM istionightly/base_debug as default
+
+# Add CA certificates for SSL connections.
+# obtained from debian ca-certs deb using fetch_cacerts.sh
+ADD ca-certificates.tgz /
+
+# Copy Envoy bootstrap templates used by pilot-agent
+COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+COPY envoy_bootstrap_drain.json /var/lib/istio/envoy/envoy_bootstrap_drain.json
+COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+
+# Sudoers used to allow tcpdump and other debug utilities.
+RUN useradd -m --uid 1337 istio-proxy && \
+    echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers && \
+    chown -R istio-proxy /var/lib/istio
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/cc as distroless
+
+# Copy Envoy bootstrap templates used by pilot-agent
+COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+COPY envoy_bootstrap_drain.json /var/lib/istio/envoy/envoy_bootstrap_drain.json
+COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
+
 ARG proxy_version
 ARG istio_version
 
@@ -22,23 +52,8 @@ ADD pilot-agent /usr/local/bin/pilot-agent
 ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
-ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
-
-# Copy Envoy bootstrap templates used by pilot-agent
-COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-COPY envoy_bootstrap_drain.json /var/lib/istio/envoy/envoy_bootstrap_drain.json
-COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
-
-# Add CA certificates for SSL connections.
-# obtained from debian ca-certs deb using fetch_cacerts.sh
-ADD ca-certificates.tgz /
-
-RUN chmod 755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
-
-# Sudoers used to allow tcpdump and other debug utilities.
-RUN useradd -m --uid 1337 istio-proxy && \
-    echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers && \
-    chown -R istio-proxy /var/lib/istio
+# istio-iptables.sh is not required for envoy
+# ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -52,8 +52,7 @@ ADD pilot-agent /usr/local/bin/pilot-agent
 ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
-# istio-iptables.sh is not required for envoy
-# ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
+ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/pilot/docker/Dockerfile.sidecar_injector
+++ b/pilot/docker/Dockerfile.sidecar_injector
@@ -1,3 +1,13 @@
-FROM scratch
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM scratch as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
 ADD sidecar-injector /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/sidecar-injector"]

--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -18,9 +18,20 @@ WORKDIR /go/src/istio.io/tcp-echo-server/
 COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go
 
-# copy the tcp-echo binary to a separate container based on scratch
-FROM scratch
+
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM scratch as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
 WORKDIR /bin/
+# copy the tcp-echo binary to a separate container based on BASE_DISTRIBUTION
 COPY --from=builder /go/src/istio.io/tcp-echo-server/tcp-echo .
 ENTRYPOINT [ "/bin/tcp-echo" ]
 CMD [ "9000", "hello" ]

--- a/security/docker/Dockerfile.citadel
+++ b/security/docker/Dockerfile.citadel
@@ -1,7 +1,17 @@
-FROM scratch
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
 
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM scratch as default
 # obtained from debian ca-certs deb using fetch_cacerts.sh
 ADD ca-certificates.tgz /
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
+
 # All containers need a /tmp directory
 WORKDIR /tmp/
 ADD istio_ca /usr/local/bin/istio_ca

--- a/security/docker/Dockerfile.node-agent
+++ b/security/docker/Dockerfile.node-agent
@@ -1,4 +1,14 @@
-FROM scratch
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM scratch as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
 
 # All containers need a /tmp directory
 WORKDIR /tmp/

--- a/security/docker/Dockerfile.node-agent-k8s
+++ b/security/docker/Dockerfile.node-agent-k8s
@@ -1,4 +1,13 @@
-FROM istionightly/base_debug
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM istionightly/base_debug as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/distroless/static as distroless
+
+# This will build the final image based on either default or distroless from above
+FROM ${BASE_DISTRIBUTION}
 ADD node_agent_k8s /
-RUN chmod 755 /node_agent_k8s
 ENTRYPOINT ["/node_agent_k8s"]

--- a/tests/e2e/tests/pilot/listener_conflict_test.go
+++ b/tests/e2e/tests/pilot/listener_conflict_test.go
@@ -218,6 +218,9 @@ func (i *pilotInfo) String() string {
 	return fmt.Sprintf("pilotPod: %s, pushStatus: %s", i.pod, i.pushStatusJSON)
 }
 
+// Since curl is not available on the pilot docker image (e.g. distroless scenario)
+// we need to run the curl command (to get the pilot info) on a different pod
+// Therefore, we run a query to get the IP addresses of all pilot pods and run the curl command inside a test pod.
 func getPilotInfos() (pilotInfos, error) {
 	podIPs, err := getPilotIPs()
 	if err != nil {

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -158,7 +158,7 @@ ifeq ($(DEBUG_IMAGE),1)
 	# It is extremely helpful to debug from the test app. The savings in size are not worth the
 	# developer pain
 	cp $(ISTIO_DOCKER)/testapp/Dockerfile.app $(ISTIO_DOCKER)/testapp/Dockerfile.appdbg
-	sed -e "s,FROM scratch,FROM $(HUB)/proxy_debug:$(TAG)," $(ISTIO_DOCKER)/testapp/Dockerfile.appdbg > $(ISTIO_DOCKER)/testapp/Dockerfile.appd
+	sed -e "s,FROM \${BASE_DISTRIBUTION},FROM $(HUB)/proxy_debug:$(TAG)," $(ISTIO_DOCKER)/testapp/Dockerfile.appdbg > $(ISTIO_DOCKER)/testapp/Dockerfile.appd
 endif
 	time (cd $(ISTIO_DOCKER)/testapp && \
 		docker build -t $(HUB)/app:$(TAG) -f Dockerfile.app .)
@@ -227,7 +227,9 @@ docker.node-agent-test: $(ISTIO_DOCKER)/node_agent.key
 # 4. This rule runs $(BUILD_PRE) prior to any docker build and only if specified as a dependency variable
 # 5. This rule finally runs docker build passing $(BUILD_ARGS) to docker if they are specified as a dependency variable
 
-DOCKER_RULE=time (mkdir -p $(DOCKER_BUILD_TOP)/$@ && cp -r $^ $(DOCKER_BUILD_TOP)/$@ && cd $(DOCKER_BUILD_TOP)/$@ && $(BUILD_PRE) docker build $(BUILD_ARGS) -t $(HUB)/$(subst docker.,,$@):$(TAG) -f Dockerfile$(suffix $@) .)
+BASE_DISTRIBUTIONS:=default distroless
+DEFAULT_DISTRIBUTION=default
+DOCKER_RULE=time (mkdir -p $(DOCKER_BUILD_TOP)/$@ && cp -r $^ $(DOCKER_BUILD_TOP)/$@ && cd $(DOCKER_BUILD_TOP)/$@ && $(BUILD_PRE) set -e && for distro in $(BASE_DISTRIBUTIONS); do tag=$(TAG)-$${distro}; docker build $(BUILD_ARGS) --build-arg BASE_DISTRIBUTION=$${distro} -t $(HUB)/$(subst docker.,,$@):$${tag%-$(DEFAULT_DISTRIBUTION)} -f Dockerfile$(suffix $@) . ; done )
 
 # This target will package all docker images used in test and release, without re-building
 # go binaries. It is intended for CI/CD systems where the build is done in separate job.
@@ -252,8 +254,11 @@ docker.save: $(DOCKER_TAR_TARGETS)
 # for each docker.XXX target create a push.docker.XXX target that pushes
 # the local docker image to another hub
 # a possible optimization is to use tag.$(TGT) as a dependency to do the tag for us
-$(foreach TGT,$(DOCKER_TARGETS),$(eval push.$(TGT): | $(TGT) ; \
-	time (docker push $(HUB)/$(subst docker.,,$(TGT)):$(TAG))))
+$(foreach TGT,$(filter-out docker.app,$(DOCKER_TARGETS)),$(eval push.$(TGT): | $(TGT) ; \
+	time (set -e && for distro in $(BASE_DISTRIBUTIONS); do tag=$(TAG)-$$$${distro}; docker push $(HUB)/$(subst docker.,,$(TGT)):$$$${tag%-$(DEFAULT_DISTRIBUTION)}; done)))
+
+push.docker.app: docker.app
+	time (docker push $(HUB)/app:$(TAG))
 
 # create a DOCKER_PUSH_TARGETS that's each of DOCKER_TARGETS with a push. prefix
 DOCKER_PUSH_TARGETS:=


### PR DESCRIPTION
We did the following:
* We merged #12746, #12741, #12745, #12788, #12869 and #13395 into one PR
* We added build steps to istio-docker.mk for distroless images
* We are using the same Dockerfile for default and distroless images
* To build only the old images, you can use `make build docker docker.push BASE_DISTRIBUTIONS=default`
* Distroless images are push with a `-distroless` appended to `$TAG`