### PR TITLE
secure connection between workload and pilot,mixer through sds

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -162,6 +162,15 @@ spec:
           - istio-pilot:15010
           {{- end }}
         {{- end }}
+        {{- if $.Values.global.sds.enabled }}
+          - --sdsEnabled=true
+          - --k8sServiceAccountJWTPath
+          {{- if $.Values.global.sds.useTrustworthyJwt }}
+          - "/var/run/secrets/tokens/istio-token"
+          {{- else }}
+          - "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          {{- end }}
+        {{- end }}
         {{- if $.Values.global.trustDomain }}
           - --trust-domain={{ $.Values.global.trustDomain }}
         {{- end }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -152,6 +152,15 @@ spec:
           {{- else }}
           - istio-pilot:15011
           {{- end }}
+          {{- if $.Values.global.sds.enabled }}
+          - --sdsEnabled=true
+          - --k8sServiceAccountJWTPath
+          {{- if $.Values.global.sds.useTrustworthyJwt }}
+          - "/var/run/secrets/tokens/istio-token"
+          {{- else }}
+          - "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          {{- end }}
+          {{- end }}
         {{- else }}
           - --controlPlaneAuthPolicy
           - NONE
@@ -160,15 +169,6 @@ spec:
           - istio-pilot.{{ $.Values.global.istioNamespace }}:15010
           {{- else }}
           - istio-pilot:15010
-          {{- end }}
-        {{- end }}
-        {{- if $.Values.global.sds.enabled }}
-          - --sdsEnabled=true
-          - --k8sServiceAccountJWTPath
-          {{- if $.Values.global.sds.useTrustworthyJwt }}
-          - "/var/run/secrets/tokens/istio-token"
-          {{- else }}
-          - "/var/run/secrets/kubernetes.io/serviceaccount/token"
           {{- end }}
         {{- end }}
         {{- if $.Values.global.trustDomain }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -125,21 +125,21 @@
       {{- if $.Values.global.controlPlaneSecurityEnabled }}
         - --controlPlaneAuthPolicy
         - MUTUAL_TLS
+      {{- if $.Values.global.sds.enabled }}
+        - --sdsEnabled=true
+        - --k8sServiceAccountJWTPath
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
+        - "/var/run/secrets/tokens/istio-token"
+      {{- else }}
+        - "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      {{- end }}
+      {{- end }}
       {{- else }}
         - --controlPlaneAuthPolicy
         - NONE
       {{- end }}
       {{- if $.Values.global.trustDomain }}
         - --trust-domain={{ $.Values.global.trustDomain }}
-      {{- end }}
-      {{- if $.Values.global.sds.enabled }}
-        - --sdsEnabled=true
-        - --k8sServiceAccountJWTPath
-        {{- if $.Values.global.sds.useTrustworthyJwt }}
-        - "/var/run/secrets/tokens/istio-token"
-        {{- else }}
-        - "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        {{- end }}
       {{- end }}
         env:
         - name: POD_NAME
@@ -316,18 +316,18 @@
       {{- if $.Values.global.controlPlaneSecurityEnabled }}
         - --controlPlaneAuthPolicy
         - MUTUAL_TLS
-      {{- else }}
-        - --controlPlaneAuthPolicy
-        - NONE
-      {{- end }}
       {{- if $.Values.global.sds.enabled }}
         - --sdsEnabled=true
         - --k8sServiceAccountJWTPath
-        {{- if $.Values.global.sds.useTrustworthyJwt }}
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
         - "/var/run/secrets/tokens/istio-token"
-        {{- else }}
+      {{- else }}
         - "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- else }}
+        - --controlPlaneAuthPolicy
+        - NONE
       {{- end }}
         env:
         - name: POD_NAME

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -132,6 +132,15 @@
       {{- if $.Values.global.trustDomain }}
         - --trust-domain={{ $.Values.global.trustDomain }}
       {{- end }}
+      {{- if $.Values.global.sds.enabled }}
+        - --sdsEnabled=true
+        - --k8sServiceAccountJWTPath
+        {{- if $.Values.global.sds.useTrustworthyJwt }}
+        - "/var/run/secrets/tokens/istio-token"
+        {{- else }}
+        - "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        {{- end }}
+      {{- end }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -310,6 +319,15 @@
       {{- else }}
         - --controlPlaneAuthPolicy
         - NONE
+      {{- end }}
+      {{- if $.Values.global.sds.enabled }}
+        - --sdsEnabled=true
+        - --k8sServiceAccountJWTPath
+        {{- if $.Values.global.sds.useTrustworthyJwt }}
+        - "/var/run/secrets/tokens/istio-token"
+        {{- else }}
+        - "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        {{- end }}
       {{- end }}
         env:
         - name: POD_NAME

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -148,21 +148,21 @@ spec:
         {{- if $.Values.global.controlPlaneSecurityEnabled}}
           - --controlPlaneAuthPolicy
           - MUTUAL_TLS
+        {{- if $.Values.global.sds.enabled }}
+          - --sdsEnabled=true
+          - --k8sServiceAccountJWTPath
+        {{- if $.Values.global.sds.useTrustworthyJwt }}
+          - "/var/run/secrets/tokens/istio-token"
+        {{- else }}
+          - "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        {{- end }}
+        {{- end }}          
         {{- else }}
           - --controlPlaneAuthPolicy
           - NONE
         {{- end }}
         {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}
-        {{- end }}
-        {{- if $.Values.global.sds.enabled }}
-          - --sdsEnabled=true
-          - --k8sServiceAccountJWTPath
-          {{- if $.Values.global.sds.useTrustworthyJwt }}
-          - "/var/run/secrets/tokens/istio-token"
-          {{- else }}
-          - "/var/run/secrets/kubernetes.io/serviceaccount/token"
-          {{- end }}
         {{- end }}
           env:
           - name: POD_NAME

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -155,6 +155,15 @@ spec:
         {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}
         {{- end }}
+        {{- if $.Values.global.sds.enabled }}
+          - --sdsEnabled=true
+          - --k8sServiceAccountJWTPath
+          {{- if $.Values.global.sds.useTrustworthyJwt }}
+          - "/var/run/secrets/tokens/istio-token"
+          {{- else }}
+          - "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          {{- end }}
+        {{- end }}
           env:
           - name: POD_NAME
             valueFrom:

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -148,6 +148,15 @@ containers:
 {{- if .Values.global.trustDomain }}
   - --trust-domain={{ .Values.global.trustDomain }}
 {{- end }}
+{{- if $.Values.global.sds.enabled }}
+  - --sdsEnabled=true
+  - --k8sServiceAccountJWTPath
+  {{- if $.Values.global.sds.useTrustworthyJwt }}
+  - "/var/run/secrets/tokens/istio-token"
+  {{- else }}
+  - "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  {{- end }}
+{{- end }}
   env:
   - name: POD_NAME
     valueFrom:

--- a/install/kubernetes/helm/istio/test-values/values-istio-auth-sds.yaml
+++ b/install/kubernetes/helm/istio/test-values/values-istio-auth-sds.yaml
@@ -1,5 +1,5 @@
 global:
-  controlPlaneSecurityEnabled: false
+  controlPlaneSecurityEnabled: true
 
   mtls:
     # Default setting for service-to-service mtls. Can be set explicitly using
@@ -13,6 +13,8 @@ global:
 
   proxy:
     enableCoreDump: true
+
+  useMCP: true
 
 nodeagent:
   enabled: true

--- a/install/kubernetes/helm/istio/values-istio-sds-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-sds-auth.yaml
@@ -1,5 +1,5 @@
 global:
-  controlPlaneSecurityEnabled: false
+  controlPlaneSecurityEnabled: true
 
   mtls:
     # Default setting for service-to-service mtls. Can be set explicitly using
@@ -10,6 +10,8 @@ global:
     enabled: true
     udsPath: "unix:/var/run/sds/uds_path"
     useNormalJwt: true
+
+  useMCP: true
 
 nodeagent:
   enabled: true

--- a/install/kubernetes/helm/istio/values-istio-sds-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-sds-auth.yaml
@@ -11,8 +11,6 @@ global:
     udsPath: "unix:/var/run/sds/uds_path"
     useNormalJwt: true
 
-  useMCP: true
-
 nodeagent:
   enabled: true
   image: node-agent-k8s

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -88,6 +88,8 @@ var (
 	tlsClientRootCert          string
 	tlsCertsToWatch            []string
 	loggingOptions             = log.DefaultOptions()
+	sdsEnabled                 bool
+	k8sServiceAccountJWTPath   string
 
 	wg sync.WaitGroup
 
@@ -208,6 +210,11 @@ var (
 			proxyConfig.ProxyAdminPort = int32(proxyAdminPort)
 			proxyConfig.Concurrency = int32(concurrency)
 
+			proxyConfig.Sds = &meshconfig.SDS{
+				Enabled:      sdsEnabled,
+				K8SSaJwtPath: k8sServiceAccountJWTPath,
+			}
+
 			var pilotSAN []string
 			ns := ""
 			switch controlPlaneAuthPolicy {
@@ -299,7 +306,8 @@ var (
 
 			log.Infof("Monitored certs: %#v", tlsCertsToWatch)
 			// since Envoy needs the certs for mTLS, we wait for them to become available before starting it
-			if controlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS.String() {
+			// skip waiting cert if sds is enabled, otherwise it takes long time for pod to start.
+			if controlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS.String() && !sdsEnabled {
 				for _, cert := range tlsCertsToWatch {
 					waitForCerts(cert, 2*time.Minute)
 				}
@@ -327,6 +335,12 @@ var (
 					if disableInternalTelemetry {
 						opts["DisableReportCalls"] = "true"
 					}
+
+					if sdsEnabled {
+						opts["SDSEnabled"] = "enable"
+						opts["K8sSAJWTPath"] = k8sServiceAccountJWTPath
+					}
+
 					tmpl, err := template.ParseFiles(templateFile)
 					if err != nil {
 						return err
@@ -573,6 +587,11 @@ func init() {
 		model.DefaultKey, "Absolute path to client key file used for istio mTLS")
 	proxyCmd.PersistentFlags().StringVar(&tlsClientRootCert, "tlsClientRootCert",
 		model.DefaultRootCert, "Absolute path to client root cert file used for istio mTLS")
+
+	proxyCmd.PersistentFlags().StringVar(&k8sServiceAccountJWTPath, "k8sServiceAccountJWTPath", "",
+		"The JWT path of k8s service account.")
+	proxyCmd.PersistentFlags().BoolVar(&sdsEnabled, "sdsEnabled", false,
+		"Flag to indicate if SDS(secret discovery service) is enabled.")
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/pilot/docker/envoy_pilot.yaml.tmpl
+++ b/pilot/docker/envoy_pilot.yaml.tmpl
@@ -45,6 +45,52 @@ static_resources:
     http2_protocol_options: {}
     name: mixer_report_server
 {{- if .ControlPlaneAuth }}
+{{- if .SDSEnabled }}
+    tls_context:
+      common_tls_context:
+        tls_certificate_sds_secret_configs:
+        - name: default
+          sds_config:
+            api_config_source:
+              api_type: GRPC
+              grpc_services:
+              - google_grpc:
+                  target_uri: unix:/var/run/sds/uds_path
+                  channel_credentials:
+                    local_credentials: {}
+                  call_credentials:
+                  - from_plugin:
+                      name: envoy.grpc_credentials.file_based_metadata
+                      config:
+                        header_key: istio_sds_credentials_header-bin
+                        secret_data:
+                          filename: {{ .K8sSAJWTPath }}
+                  credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                  stat_prefix: sdsstat
+        combined_validation_context:
+          default_validation_context:
+            verify_subject_alt_name:
+            - {{ .MixerSubjectAltName }}
+          validation_context_sds_secret_config:
+            name: ROOTCA
+            sds_config:
+              api_config_source:
+                api_type: GRPC
+                grpc_services:
+                - google_grpc:
+                    target_uri: unix:/var/run/sds/uds_path
+                    channel_credentials:
+                      local_credentials: {}
+                    call_credentials:
+                    - from_plugin:
+                        name: envoy.grpc_credentials.file_based_metadata
+                        config:
+                          header_key: istio_sds_credentials_header-bin
+                          secret_data:
+                            filename: {{ .K8sSAJWTPath }}
+                    credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                    stat_prefix: sdsstat
+{{- else }}
     tls_context:
       common_tls_context:
         tls_certificates:
@@ -57,6 +103,7 @@ static_resources:
             filename: /etc/certs/root-cert.pem
           verify_subject_alt_name:
           - {{ .MixerSubjectAltName }}
+{{- end }}
 {{- end }}
     type: STRICT_DNS
     dns_lookup_family: V4_ONLY
@@ -123,6 +170,54 @@ static_resources:
           stat_prefix: "15003"
         name: envoy.http_connection_manager
 {{- if .ControlPlaneAuth }}
+{{- if .SDSEnabled }}
+      tls_context:
+        common_tls_context:
+          alpn_protocols:
+          - http/1.1
+          tls_certificate_sds_secret_configs:
+          - name: default
+            sds_config:
+              api_config_source:
+                api_type: GRPC
+                grpc_services:
+                - google_grpc:
+                    target_uri: unix:/var/run/sds/uds_path
+                    channel_credentials:
+                      local_credentials: {}
+                    call_credentials:
+                    - from_plugin:
+                        name: envoy.grpc_credentials.file_based_metadata
+                        config:
+                          header_key: istio_sds_credentials_header-bin
+                          secret_data:
+                            filename: {{ .K8sSAJWTPath }}
+                    credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                    stat_prefix: sdsstat
+          combined_validation_context:
+            default_validation_context:
+              verify_subject_alt_name: []
+            validation_context_sds_secret_config:
+              name: ROOTCA
+              sds_config:
+                api_config_source:
+                  api_type: GRPC
+                  grpc_services:
+                  - google_grpc:
+                      target_uri: unix:/var/run/sds/uds_path
+                      channel_credentials:
+                        local_credentials: {}
+                      call_credentials:
+                      - from_plugin:
+                          name: envoy.grpc_credentials.file_based_metadata
+                          config:
+                            header_key: istio_sds_credentials_header-bin
+                            secret_data:
+                              filename: {{ .K8sSAJWTPath }}
+                      credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                      stat_prefix: sdsstat
+        require_client_certificate: true
+{{- else }}
       tls_context:
         common_tls_context:
           alpn_protocols:
@@ -136,6 +231,7 @@ static_resources:
             trusted_ca:
               filename: /etc/certs/root-cert.pem
         require_client_certificate: true
+{{- end }}
 {{- end }}
     name: "15003"
   - address:
@@ -202,6 +298,54 @@ static_resources:
                   timeout: 0.000s
           stat_prefix: "15011"
         name: envoy.http_connection_manager
+{{- if .SDSEnabled }}
+      tls_context:
+        common_tls_context:
+          alpn_protocols:
+          - h2
+          tls_certificate_sds_secret_configs:
+          - name: default
+            sds_config:
+              api_config_source:
+                api_type: GRPC
+                grpc_services:
+                - google_grpc:
+                    target_uri: unix:/var/run/sds/uds_path
+                    channel_credentials:
+                      local_credentials: {}
+                    call_credentials:
+                    - from_plugin:
+                        name: envoy.grpc_credentials.file_based_metadata
+                        config:
+                          header_key: istio_sds_credentials_header-bin
+                          secret_data:
+                            filename: {{ .K8sSAJWTPath }}
+                    credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                    stat_prefix: sdsstat
+          combined_validation_context:
+            default_validation_context:
+              verify_subject_alt_name: []
+            validation_context_sds_secret_config:
+              name: ROOTCA
+              sds_config:
+                api_config_source:
+                  api_type: GRPC
+                  grpc_services:
+                  - google_grpc:
+                      target_uri: unix:/var/run/sds/uds_path
+                      channel_credentials:
+                        local_credentials: {}
+                      call_credentials:
+                      - from_plugin:
+                          name: envoy.grpc_credentials.file_based_metadata
+                          config:
+                            header_key: istio_sds_credentials_header-bin
+                            secret_data:
+                              filename: {{ .K8sSAJWTPath }}
+                      credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                      stat_prefix: sdsstat
+        require_client_certificate: true
+{{- else }}
       tls_context:
         common_tls_context:
           alpn_protocols:
@@ -215,6 +359,7 @@ static_resources:
             trusted_ca:
               filename: /etc/certs/root-cert.pem
         require_client_certificate: true
+{{- end }}
     name: "15011"
   - address:
       socket_address:
@@ -277,6 +422,54 @@ static_resources:
                   timeout: 0.000s
           stat_prefix: "15005"
         name: envoy.http_connection_manager
+{{- if .SDSEnabled }}
+      tls_context:
+        common_tls_context:
+          alpn_protocols:
+          - http/1.1
+          tls_certificate_sds_secret_configs:
+          - name: default
+            sds_config:
+              api_config_source:
+                api_type: GRPC
+                grpc_services:
+                - google_grpc:
+                    target_uri: unix:/var/run/sds/uds_path
+                    channel_credentials:
+                      local_credentials: {}
+                    call_credentials:
+                    - from_plugin:
+                        name: envoy.grpc_credentials.file_based_metadata
+                        config:
+                          header_key: istio_sds_credentials_header-bin
+                          secret_data:
+                            filename: {{ .K8sSAJWTPath }}
+                    credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                    stat_prefix: sdsstat
+          combined_validation_context:
+            default_validation_context:
+              verify_subject_alt_name: []
+            validation_context_sds_secret_config:
+              name: ROOTCA
+              sds_config:
+                api_config_source:
+                  api_type: GRPC
+                  grpc_services:
+                  - google_grpc:
+                      target_uri: unix:/var/run/sds/uds_path
+                      channel_credentials:
+                        local_credentials: {}
+                      call_credentials:
+                      - from_plugin:
+                          name: envoy.grpc_credentials.file_based_metadata
+                          config:
+                            header_key: istio_sds_credentials_header-bin
+                            secret_data:
+                              filename: {{ .K8sSAJWTPath }}
+                      credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                      stat_prefix: sdsstat
+        require_client_certificate: true
+{{- else }}
       tls_context:
         common_tls_context:
           alpn_protocols:
@@ -290,6 +483,7 @@ static_resources:
             trusted_ca:
               filename: /etc/certs/root-cert.pem
         require_client_certificate: true
+{{- end }}
     name: "15005"
   - address:
       socket_address:

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -58,6 +58,52 @@ static_resources:
     http2_protocol_options: {}
     name: mixer_report_server
 {{- if .ControlPlaneAuth }}
+{{- if .SDSEnabled }}
+    tls_context:
+      common_tls_context:
+        tls_certificate_sds_secret_configs:
+        - name: default
+          sds_config:
+            api_config_source:
+              api_type: GRPC
+              grpc_services:
+              - google_grpc:
+                  target_uri: unix:/var/run/sds/uds_path
+                  channel_credentials:
+                    local_credentials: {}
+                  call_credentials:
+                  - from_plugin:
+                      name: envoy.grpc_credentials.file_based_metadata
+                      config:
+                        header_key: istio_sds_credentials_header-bin
+                        secret_data:
+                          filename: {{ .K8sSAJWTPath }}
+                  credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                  stat_prefix: sdsstat
+        combined_validation_context:
+          default_validation_context:
+            verify_subject_alt_name:
+            - {{ .MixerSubjectAltName }}
+          validation_context_sds_secret_config:
+            name: ROOTCA
+            sds_config:
+              api_config_source:
+                api_type: GRPC
+                grpc_services:
+                - google_grpc:
+                    target_uri: unix:/var/run/sds/uds_path
+                    channel_credentials:
+                      local_credentials: {}
+                    call_credentials:
+                    - from_plugin:
+                        name: envoy.grpc_credentials.file_based_metadata
+                        config:
+                          header_key: istio_sds_credentials_header-bin
+                          secret_data:
+                            filename: {{ .K8sSAJWTPath }}
+                    credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                    stat_prefix: sdsstat
+{{- else }}
     tls_context:
       common_tls_context:
         tls_certificates:
@@ -70,6 +116,7 @@ static_resources:
             filename: /etc/certs/root-cert.pem
           verify_subject_alt_name:
           - {{ .MixerSubjectAltName }}
+{{- end }}
 {{- end }}
     type: STRICT_DNS
     dns_lookup_family: V4_ONLY
@@ -165,6 +212,54 @@ static_resources:
           stat_prefix: "15004"
         name: envoy.http_connection_manager
 {{- if .ControlPlaneAuth }}
+{{- if .SDSEnabled }}
+      tls_context:
+        common_tls_context:
+          alpn_protocols:
+          - h2
+          tls_certificate_sds_secret_configs:
+          - name: default
+            sds_config:
+              api_config_source:
+                api_type: GRPC
+                grpc_services:
+                - google_grpc:
+                    target_uri: unix:/var/run/sds/uds_path
+                    channel_credentials:
+                      local_credentials: {}
+                    call_credentials:
+                    - from_plugin:
+                        name: envoy.grpc_credentials.file_based_metadata
+                        config:
+                          header_key: istio_sds_credentials_header-bin
+                          secret_data:
+                            filename: {{ .K8sSAJWTPath }}
+                    credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                    stat_prefix: sdsstat
+          combined_validation_context:
+            default_validation_context:
+              verify_subject_alt_name: []
+            validation_context_sds_secret_config:
+              name: ROOTCA
+              sds_config:
+                api_config_source:
+                  api_type: GRPC
+                  grpc_services:
+                  - google_grpc:
+                      target_uri: unix:/var/run/sds/uds_path
+                      channel_credentials:
+                        local_credentials: {}
+                      call_credentials:
+                      - from_plugin:
+                          name: envoy.grpc_credentials.file_based_metadata
+                          config:
+                            header_key: istio_sds_credentials_header-bin
+                            secret_data:
+                              filename: {{ .K8sSAJWTPath }}
+                      credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                      stat_prefix: sdsstat
+        require_client_certificate: true
+{{- else }}
       tls_context:
         common_tls_context:
           alpn_protocols:
@@ -178,6 +273,7 @@ static_resources:
             trusted_ca:
               filename: /etc/certs/root-cert.pem
         require_client_certificate: true
+{{- end }}
 {{- end }}
     name: "15004"
   - address:

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -132,6 +132,54 @@ static_resources:
           stat_prefix: "15004"
         name: envoy.http_connection_manager
 {{- if .ControlPlaneAuth }}
+{{- if .SDSEnabled }}
+      tls_context:
+        common_tls_context:
+          alpn_protocols:
+          - h2
+          tls_certificate_sds_secret_configs:
+          - name: default
+            sds_config:
+              api_config_source:
+                api_type: GRPC
+                grpc_services:
+                - google_grpc:
+                    target_uri: unix:/var/run/sds/uds_path
+                    channel_credentials:
+                      local_credentials: {}
+                    call_credentials:
+                    - from_plugin:
+                        name: envoy.grpc_credentials.file_based_metadata
+                        config:
+                          header_key: istio_sds_credentials_header-bin
+                          secret_data:
+                            filename: {{ .K8sSAJWTPath }}
+                    credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                    stat_prefix: sdsstat
+          combined_validation_context:
+            default_validation_context:
+              verify_subject_alt_name: []
+            validation_context_sds_secret_config:
+              name: ROOTCA
+              sds_config:
+                api_config_source:
+                  api_type: GRPC
+                  grpc_services:
+                  - google_grpc:
+                      target_uri: unix:/var/run/sds/uds_path
+                      channel_credentials:
+                        local_credentials: {}
+                      call_credentials:
+                      - from_plugin:
+                          name: envoy.grpc_credentials.file_based_metadata
+                          config:
+                            header_key: istio_sds_credentials_header-bin
+                            secret_data:
+                              filename: {{ .K8sSAJWTPath }}
+                      credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                      stat_prefix: sdsstat
+        require_client_certificate: true
+{{- else }}
       tls_context:
         common_tls_context:
           alpn_protocols:
@@ -145,6 +193,7 @@ static_resources:
             trusted_ca:
               filename: /etc/certs/root-cert.pem
         require_client_certificate: true
+{{- end }}
 {{- end }}
     name: "15004"
   - address:

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -268,7 +268,7 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	// Support multiple network interfaces
 	meta["ISTIO_META_INSTANCE_IPS"] = strings.Join(nodeIPs, ",")
 
-	if config.Sds.Enabled {
+	if config.Sds != nil && config.Sds.Enabled {
 		opts["sdsEnabled"] = true
 		opts["k8sJwtPath"] = config.Sds.K8SSaJwtPath
 	}

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -268,6 +268,11 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	// Support multiple network interfaces
 	meta["ISTIO_META_INSTANCE_IPS"] = strings.Join(nodeIPs, ",")
 
+	if config.Sds.Enabled {
+		opts["sdsEnabled"] = true
+		opts["k8sJwtPath"] = config.Sds.K8SSaJwtPath
+	}
+
 	ba, err := json.Marshal(meta)
 	if err != nil {
 		return "", err

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -114,6 +114,95 @@
         "connect_timeout": "{{ .connect_timeout }}",
         "lb_policy": "ROUND_ROBIN",
         {{ if eq .config.ControlPlaneAuthPolicy 1 }}
+        {{ if .sdsEnabled }}
+        "tls_context": {
+          "common_tls_context": {
+            "alpn_protocols": [
+              "h2"
+            ],
+            "tls_certificate_sds_secret_configs":[
+              {
+                 "name":"default",
+                 "sds_config":{
+                    "api_config_source":{
+                       "api_type":"GRPC",
+                       "grpc_services":[
+                          {
+                             "google_grpc":{
+                                "target_uri":"unix:/var/run/sds/uds_path",
+                                "channel_credentials":{
+                                   "local_credentials":{
+     
+                                   }
+                                },
+                                "call_credentials":[
+                                  {
+                                    "from_plugin":{
+                                      "name":"envoy.grpc_credentials.file_based_metadata",
+                                      "config":{
+                                        "secret_data":{
+                                          "filename": "{{ .k8sJwtPath }}"
+                                        },
+                                        "header_key":"istio_sds_credentials_header-bin"
+                                      }
+                                    }
+                                 }
+                                ],
+                                "credentials_factory_name":"envoy.grpc_credentials.file_based_metadata",
+                                "stat_prefix":"sdsstat"
+                             }
+                          }
+                       ]
+                    }
+                 }
+              }
+           ],
+           "combined_validation_context":{
+            "default_validation_context":{
+               "verify_subject_alt_name":[
+                {{- range $a, $s := .pilot_SAN }}
+                "{{$s}}"
+                {{- end}}
+               ]
+            },
+            "validation_context_sds_secret_config":{
+               "name":"ROOTCA",
+               "sds_config":{
+                  "api_config_source":{
+                     "api_type":"GRPC",
+                     "grpc_services":[
+                        {
+                           "google_grpc":{
+                              "target_uri":"unix:/var/run/sds/uds_path",
+                              "channel_credentials":{
+                                 "local_credentials":{
+                                 }
+                              },
+                              "call_credentials":[
+                                 {
+                                    "from_plugin":{
+                                      "name":"envoy.grpc_credentials.file_based_metadata",
+                                      "config":{
+                                        "secret_data":{
+                                          "filename": "{{ .k8sJwtPath }}"
+                                        },
+                                        "header_key":"istio_sds_credentials_header-bin"
+                                      }
+                                    }
+                                 }
+                              ],
+                              "credentials_factory_name":"envoy.grpc_credentials.file_based_metadata",
+                              "stat_prefix":"sdsstat"
+                           }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+          }, 
+        {{ else }}
         "tls_context": {
           "common_tls_context": {
             "alpn_protocols": [
@@ -141,6 +230,7 @@
             }
           }
         },
+        {{ end }} 
         {{ end }}
         "hosts": [
           {


### PR DESCRIPTION
https://github.com/istio/istio/issues/5891, asked from https://github.com/istio/istio/issues/11434

Today when sds is enabled, controlPlaneSecurityEnabled is set to false, which means the connection between workload sidecar and control plane(pilot, mixer) are plain text. 

This PR is about secure connection between workload/controlplane(pilot, mixer), so that we could to flip the controlPlaneSecurityEnabled to true
