### PR TITLE
Refactor DiscoveryServer caches

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -838,6 +838,7 @@ func (s *DiscoveryServer) startPush(version string, push *model.PushContext, ful
 	// TODO: indicate the specific events, to only push what changed.
 
 	pendingPush := int32(len(pending))
+	proxyUpdates := s.proxyUpdates.GetAndClear()
 
 	tstart := time.Now()
 	// Will keep trying to push to sidecars until another push starts.
@@ -854,12 +855,9 @@ func (s *DiscoveryServer) startPush(version string, push *model.PushContext, ful
 		// indicates whether to do a full push for the proxy
 		proxyFull := full
 		if !full {
-			s.proxyUpdatesMutex.Lock()
-			if _, ok := s.proxyUpdates[client.modelNode.IPAddresses[0]]; ok {
+			if _, ok := proxyUpdates[client.modelNode.IPAddresses[0]]; ok {
 				proxyFull = true
-				delete(s.proxyUpdates, client.modelNode.IPAddresses[0])
 			}
-			s.proxyUpdatesMutex.Unlock()
 		}
 
 		wg.Add(1)

--- a/pilot/pkg/proxy/envoy/v2/cache/eds_inc.go
+++ b/pilot/pkg/proxy/envoy/v2/cache/eds_inc.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import "sync"
+
+// EdsUpdatedServices keeps track of all service updated since last full push.
+// Key is the hostname (servicename). Value is set when any shard part of the service is
+// updated. For 1.0.3+ it is used only for tracking incremental
+// pushes between the 2 epochs.
+type EdsUpdatedServices struct {
+	mutex sync.RWMutex
+	// key is servicename
+	cache map[string]struct{}
+}
+
+func (e *EdsUpdatedServices) Set(key string) {
+	e.mutex.Lock()
+	if e.cache == nil {
+		e.cache = make(map[string]struct{})
+	}
+	e.cache[key] = struct{}{}
+	e.mutex.Unlock()
+}
+
+// GetAndClear returns the cache and clear the cache
+func (e *EdsUpdatedServices) GetAndClear() map[string]struct{} {
+	e.mutex.Lock()
+	out := e.cache
+	e.cache = make(map[string]struct{})
+	e.mutex.Unlock()
+
+	return out
+}
+
+// ProxyUpdates keeps track of proxies that need full xDS push during the next push epoch
+type ProxyUpdates struct {
+	mutex sync.RWMutex
+	// key is proxy ip
+	cache map[string]struct{}
+}
+
+func (p *ProxyUpdates) Set(key string) {
+	p.mutex.Lock()
+	if p.cache == nil {
+		p.cache = make(map[string]struct{})
+	}
+	p.cache[key] = struct{}{}
+	p.mutex.Unlock()
+}
+
+// GetAndClear returns the cache and clear the cache
+func (p *ProxyUpdates) GetAndClear() map[string]struct{} {
+	p.mutex.Lock()
+	out := p.cache
+	p.cache = make(map[string]struct{})
+	p.mutex.Unlock()
+
+	return out
+}

--- a/pilot/pkg/proxy/envoy/v2/cache/endpoint.go
+++ b/pilot/pkg/proxy/envoy/v2/cache/endpoint.go
@@ -84,12 +84,12 @@ func (e *EndpointShardsByService) DeleteServiceShard(serviceName string, shard s
 	}
 }
 
-func (e *EndpointShardsByService) String() string {
+func (e *EndpointShardsByService) ToBytes() []byte {
 	e.mutex.RLock()
 	out, _ := json.MarshalIndent(e.cache, " ", " ")
 	e.mutex.RUnlock()
 
-	return string(out)
+	return out
 }
 
 func (e *EndpointShards) ServiceAccountExist(sa string) bool {

--- a/pilot/pkg/proxy/envoy/v2/cache/endpoint.go
+++ b/pilot/pkg/proxy/envoy/v2/cache/endpoint.go
@@ -73,12 +73,14 @@ func (e *EndpointShardsByService) Delete(key string) {
 }
 
 func (e *EndpointShardsByService) DeleteServiceShard(serviceName string, shard string) {
-	if epShards, _ := e.Get(serviceName); epShards != nil {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	if epShards := e.cache[serviceName]; epShards != nil {
 		epShards.mutex.Lock()
 		delete(epShards.Shards, shard)
 		// delete service shards totally
 		if len(epShards.Shards) == 0 {
-			e.Delete(serviceName)
+			delete(e.cache, serviceName)
 		}
 		epShards.mutex.Unlock()
 	}

--- a/pilot/pkg/proxy/envoy/v2/cache/endpoint.go
+++ b/pilot/pkg/proxy/envoy/v2/cache/endpoint.go
@@ -1,0 +1,117 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"encoding/json"
+	"sync"
+
+	"istio.io/istio/pilot/pkg/model"
+)
+
+// EndpointShards holds the set of endpoint shards of a service. Registries update
+// individual shards incrementally. The shards are aggregated and split into
+// clusters when a push for the specific cluster is needed.
+type EndpointShards struct {
+	// mutex protecting below map.
+	mutex sync.RWMutex
+
+	// Shards is used to track the shards. EDS updates are grouped by shard.
+	// Current implementation uses the registry name as key - in multicluster this is the
+	// name of the k8s cluster, derived from the config (secret).
+	Shards map[string][]*model.IstioEndpoint
+
+	// ServiceAccounts has the concatenation of all service accounts seen so far in endpoints.
+	// This is updated on push, based on shards. If the previous list is different than
+	// current list, a full push will be forced, to trigger a secure naming update.
+	// Due to the larger time, it is still possible that connection errors will occur while
+	// CDS is updated.
+	ServiceAccounts map[string]bool
+}
+
+// EndpointShards for a service. This is a global (per-server) list, built from
+// incremental updates.
+type EndpointShardsByService struct {
+	mutex sync.RWMutex
+	cache map[string]*EndpointShards
+}
+
+func (e *EndpointShardsByService) Set(key string, value *EndpointShards) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	if e.cache == nil {
+		e.cache = make(map[string]*EndpointShards)
+	}
+	e.cache[key] = value
+}
+
+func (e *EndpointShardsByService) Get(key string) (*EndpointShards, bool) {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+	value, ok := e.cache[key]
+
+	return value, ok
+}
+
+func (e *EndpointShardsByService) Delete(key string) {
+	e.mutex.Lock()
+	delete(e.cache, key)
+	e.mutex.Unlock()
+}
+
+func (e *EndpointShardsByService) DeleteServiceShard(serviceName string, shard string) {
+	if epShards, _ := e.Get(serviceName); epShards != nil {
+		epShards.mutex.Lock()
+		delete(epShards.Shards, shard)
+		// delete service shards totally
+		if len(epShards.Shards) == 0 {
+			e.Delete(serviceName)
+		}
+		epShards.mutex.Unlock()
+	}
+}
+
+func (e *EndpointShardsByService) String() string {
+	e.mutex.RLock()
+	out, _ := json.MarshalIndent(e.cache, " ", " ")
+	e.mutex.RUnlock()
+
+	return string(out)
+}
+
+func (e *EndpointShards) ServiceAccountExist(sa string) bool {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+	return e.ServiceAccounts[sa]
+}
+
+func (e *EndpointShards) SetShard(shard string, endpoints []*model.IstioEndpoint) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	e.Shards[shard] = endpoints
+}
+
+// Get all the IstioEndpoints from all shards
+func (e *EndpointShards) ListIstioEndpoints() []*model.IstioEndpoint {
+	out := []*model.IstioEndpoint{}
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+	for _, eps := range e.Shards {
+		out = append(out, eps...)
+	}
+
+	return out
+}

--- a/pilot/pkg/proxy/envoy/v2/cache/workload.go
+++ b/pilot/pkg/proxy/envoy/v2/cache/workload.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// Workload has the minimal info we need to detect if we need to push workloads, and to
+// cache data to avoid expensive model allocations.
+type Workload struct {
+	// Labels
+	Labels map[string]string
+}
+
+// WorkloadsById keeps track of information about a workload, based on direct notifications
+// from registry. This acts as a cache and allows detecting changes.
+type WorkloadsByID struct {
+	mutex sync.RWMutex
+
+	// key is workload ip
+	cache map[string]*Workload
+}
+
+func (w *WorkloadsByID) Delete(key string) {
+	w.mutex.Lock()
+	delete(w.cache, key)
+	w.mutex.Unlock()
+}
+
+func (w *WorkloadsByID) Get(key string) (*Workload, bool) {
+	w.mutex.RLock()
+	defer w.mutex.RUnlock()
+	workload, ok := w.cache[key]
+	return workload, ok
+}
+
+func (w *WorkloadsByID) Set(key string, value *Workload) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	if w.cache == nil {
+		w.cache = make(map[string]*Workload)
+	}
+	w.cache[key] = value
+}
+
+func (w *WorkloadsByID) String() string {
+	w.mutex.RLock()
+	defer w.mutex.RUnlock()
+	out, _ := json.MarshalIndent(w.cache, " ", " ")
+	return string(out)
+}

--- a/pilot/pkg/proxy/envoy/v2/cache/workload.go
+++ b/pilot/pkg/proxy/envoy/v2/cache/workload.go
@@ -57,9 +57,9 @@ func (w *WorkloadsByID) Set(key string, value *Workload) {
 	w.cache[key] = value
 }
 
-func (w *WorkloadsByID) String() string {
+func (w *WorkloadsByID) ToBytes() []byte {
 	w.mutex.RLock()
 	defer w.mutex.RUnlock()
 	out, _ := json.MarshalIndent(w.cache, " ", " ")
-	return string(out)
+	return out
 }

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -143,10 +143,7 @@ func (s *DiscoveryServer) registryz(w http.ResponseWriter, req *http.Request) {
 func (s *DiscoveryServer) endpointShardz(w http.ResponseWriter, req *http.Request) {
 	_ = req.ParseForm()
 	w.Header().Add("Content-Type", "application/json")
-	s.mutex.RLock()
-	out, _ := json.MarshalIndent(s.EndpointShardsByService, " ", " ")
-	s.mutex.RUnlock()
-	_, _ = w.Write(out)
+	_, _ = w.Write([]byte(s.EndpointShardsByService.String()))
 }
 
 // Tracks info about workloads. Currently only K8S serviceregistry populates this, based
@@ -154,10 +151,7 @@ func (s *DiscoveryServer) endpointShardz(w http.ResponseWriter, req *http.Reques
 func (s *DiscoveryServer) workloadz(w http.ResponseWriter, req *http.Request) {
 	_ = req.ParseForm()
 	w.Header().Add("Content-Type", "application/json")
-	s.mutex.RLock()
-	out, _ := json.MarshalIndent(s.WorkloadsByID, " ", " ")
-	s.mutex.RUnlock()
-	_, _ = w.Write(out)
+	_, _ = w.Write([]byte(s.WorkloadsByID.String()))
 }
 
 // Endpoint debugging

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -143,7 +143,7 @@ func (s *DiscoveryServer) registryz(w http.ResponseWriter, req *http.Request) {
 func (s *DiscoveryServer) endpointShardz(w http.ResponseWriter, req *http.Request) {
 	_ = req.ParseForm()
 	w.Header().Add("Content-Type", "application/json")
-	_, _ = w.Write([]byte(s.EndpointShardsByService.String()))
+	_, _ = w.Write(s.EndpointShardsByService.ToBytes())
 }
 
 // Tracks info about workloads. Currently only K8S serviceregistry populates this, based
@@ -151,7 +151,7 @@ func (s *DiscoveryServer) endpointShardz(w http.ResponseWriter, req *http.Reques
 func (s *DiscoveryServer) workloadz(w http.ResponseWriter, req *http.Request) {
 	_ = req.ParseForm()
 	w.Header().Add("Content-Type", "application/json")
-	_, _ = w.Write([]byte(s.WorkloadsByID.String()))
+	_, _ = w.Write(s.WorkloadsByID.ToBytes())
 }
 
 // Endpoint debugging

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -107,6 +107,9 @@ type DiscoveryServer struct {
 	// Defaults to false, can be enabled with PILOT_DEBUG_ADSZ_CONFIG=1
 	DebugConfigs bool
 
+	// mutex protecting global structs updated or read by ADS service, including EndpointShardsByService.
+	mutex sync.RWMutex
+
 	// EndpointShards for a service. This is a global (per-server) list, built from
 	// incremental updates.
 	EndpointShardsByService *cache.EndpointShardsByService

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -15,7 +15,6 @@
 package v2
 
 import (
-	"istio.io/istio/pilot/pkg/proxy/envoy/v2/cache"
 	"strconv"
 	"sync"
 	"time"
@@ -28,6 +27,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core"
+	"istio.io/istio/pilot/pkg/proxy/envoy/v2/cache"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/features/pilot"
 )
@@ -141,13 +141,13 @@ func NewDiscoveryServer(
 	env *model.Environment,
 	generator core.ConfigGenerator,
 	ctl model.Controller,
-	kuebController *kube.Controller,
+	kubeController *kube.Controller,
 	configCache model.ConfigStoreCache) *DiscoveryServer {
 	out := &DiscoveryServer{
 		Env:                     env,
 		ConfigGenerator:         generator,
 		ConfigController:        configCache,
-		KubeController:          kuebController,
+		KubeController:          kubeController,
 		EndpointShardsByService: &cache.EndpointShardsByService{},
 		WorkloadsByID:           &cache.WorkloadsByID{},
 		edsUpdatedServices:      &cache.EdsUpdatedServices{},

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -347,6 +347,7 @@ func (s *DiscoveryServer) updateServiceShards(push *model.PushContext) error {
 		}
 	}
 
+	s.mutex.Lock()
 	for k, v := range svc2account {
 		if ep, ok := s.EndpointShardsByService.Get(k); ok && ep != nil {
 			ep.ServiceAccounts = v
@@ -360,6 +361,7 @@ func (s *DiscoveryServer) updateServiceShards(push *model.PushContext) error {
 			ServiceAccounts: v,
 		})
 	}
+	s.mutex.Unlock()
 
 	return nil
 }

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -467,9 +467,6 @@ func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext
 
 // WorkloadUpdate is called when workload labels/annotations are updated.
 func (s *DiscoveryServer) WorkloadUpdate(id string, labels map[string]string, _ map[string]string) {
-	//s.mutex.Lock()
-	//defer s.mutex.Unlock()
-
 	if labels == nil {
 		// No push needed - the Endpoints object will also be triggered.
 		s.WorkloadsByID.Delete(id)

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -531,6 +531,8 @@ func (s *DiscoveryServer) edsUpdate(shard, serviceName string,
 	// or by deployment. Multiple updates are debounced, to avoid too frequent pushes.
 	// After debounce, the services are merged and pushed.
 	requireFull := false
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	// To prevent memory leak.
 	// Should delete the service EndpointShards, when endpoints deleted or service deleted.


### PR DESCRIPTION
We've met many panics caused by concurrent map r/w. So I abstract the cached resources in DiscoveryServer, to prevent missing lock in future.