### PR TITLE
update syntax: fault.abort.percent is deprecated

### DIFF
--- a/samples/bookinfo/networking/fault-injection-details-v1.yaml
+++ b/samples/bookinfo/networking/fault-injection-details-v1.yaml
@@ -9,7 +9,8 @@ spec:
   - fault:
       abort:
         httpStatus: 555
-        percent: 100
+        percentage:
+          value: 100.0
     route:
     - destination:
         host: details


### PR DESCRIPTION
use fractional percentages in fault injections, which is introduced in #8063.