### PR TITLE
This prevents RootNamespace from being set to Istio-system

### DIFF
--- a/install/kubernetes/global-default-sidecar-scope.yaml
+++ b/install/kubernetes/global-default-sidecar-scope.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: istio-config
+  labels:
+    istio-injection: disabled
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar

--- a/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
@@ -23,7 +23,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "default"
-  namespace: {{ .Release.Namespace }}
+  namespace: istio-config 
+  # {{ .Values.global.configRootNamespace }}
   labels:
     app: {{ template "security.name" . }}
     chart: {{ template "security.chart" . }}
@@ -45,7 +46,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "api-server"
-  namespace: {{ .Release.Namespace }}
+  namespace: istio-config
+  # {{ .Values.global.configRootNamespace }}
   labels:
     app: {{ template "security.name" . }}
     chart: {{ template "security.chart" . }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -425,7 +425,7 @@ global:
   # The namespace where globally shared configurations should be present.
   # DestinationRules that apply to the entire mesh (e.g., enabling mTLS),
   # default Sidecar configs, etc. should be added to this namespace.
-  # configRootNamespace: istio-config
+  configRootNamespace: istio-config
 
   # set the default set of namespaces to which services, service entries, virtual services, destination
   # rules should be exported to. Currently only one value can be provided in this list. This value

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -425,7 +425,7 @@ global:
   # The namespace where globally shared configurations should be present.
   # DestinationRules that apply to the entire mesh (e.g., enabling mTLS),
   # default Sidecar configs, etc. should be added to this namespace.
-  configRootNamespace: istio-config
+  # configRootNamespace: istio-config
 
   # set the default set of namespaces to which services, service entries, virtual services, destination
   # rules should be exported to. Currently only one value can be provided in this list. This value

--- a/install/kubernetes/namespace.yaml
+++ b/install/kubernetes/namespace.yaml
@@ -5,3 +5,9 @@ metadata:
   labels:
     istio-injection: disabled
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-config
+  labels:
+    istio-injection: disabled

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -310,6 +310,9 @@ const (
 
 	// IstioSystemNamespace is the namespace where Istio's components are deployed
 	IstioSystemNamespace = "istio-system"
+
+	// ConfigRootNamespace is a namespace for storing configurations
+	ConfigRootNamespace = "istio-config"
 )
 
 /*

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -440,7 +440,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		DisablePolicyChecks:               true,
 		PolicyCheckFailOpen:               false,
 		SidecarToTelemetrySessionAffinity: false,
-		RootNamespace:                     IstioSystemNamespace,
+		RootNamespace:                     ConfigRootNamespace,
 		ProxyListenPort:                   15001,
 		ConnectTimeout:                    types.DurationProto(1 * time.Second),
 		IngressService:                    "istio-ingressgateway",

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -440,7 +440,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		DisablePolicyChecks:               true,
 		PolicyCheckFailOpen:               false,
 		SidecarToTelemetrySessionAffinity: false,
-		RootNamespace:                     "",
+		RootNamespace:                     "istio-config",
 		ProxyListenPort:                   15001,
 		ConnectTimeout:                    types.DurationProto(1 * time.Second),
 		IngressService:                    "istio-ingressgateway",

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -440,7 +440,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		DisablePolicyChecks:               true,
 		PolicyCheckFailOpen:               false,
 		SidecarToTelemetrySessionAffinity: false,
-		RootNamespace:                     "istio-config",
+		RootNamespace:                     "",
 		ProxyListenPort:                   15001,
 		ConnectTimeout:                    types.DurationProto(1 * time.Second),
 		IngressService:                    "istio-ingressgateway",

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -440,7 +440,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		DisablePolicyChecks:               true,
 		PolicyCheckFailOpen:               false,
 		SidecarToTelemetrySessionAffinity: false,
-		RootNamespace:                     ConfigRootNamespace,
+		RootNamespace:                     "",
 		ProxyListenPort:                   15001,
 		ConnectTimeout:                    types.DurationProto(1 * time.Second),
 		IngressService:                    "istio-ingressgateway",

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -487,21 +487,11 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 		return proxy.SidecarScope.DestinationRule(service.Hostname)
 	}
 
-	// If the proxy config namespace is same as the root config namespace
-	// look for dest rules in the service's namespace first. This hack is needed
-	// because sometimes, istio-system tends to become the root config namespace.
-	// Destination rules are defined here for global purposes. We dont want these
-	// catch all destination rules to be the only dest rule, when processing CDS for
-	// proxies like the istio-ingressgateway or istio-egressgateway.
-	// If there are no service specific dest rules, we will end up picking up the same
-	// rules anyway, later in the code
-	if proxy.ConfigNamespace != ps.Env.Mesh.RootNamespace {
-		// search through the DestinationRules in proxy's namespace first
-		if ps.namespaceLocalDestRules[proxy.ConfigNamespace] != nil {
-			if host, ok := MostSpecificHostMatch(service.Hostname,
-				ps.namespaceLocalDestRules[proxy.ConfigNamespace].hosts); ok {
-				return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[host].config
-			}
+	// search through the DestinationRules in proxy's namespace first
+	if ps.namespaceLocalDestRules[proxy.ConfigNamespace] != nil {
+		if host, ok := MostSpecificHostMatch(service.Hostname,
+			ps.namespaceLocalDestRules[proxy.ConfigNamespace].hosts); ok {
+			return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[host].config
 		}
 	}
 

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -169,21 +169,6 @@ var (
 			ExportTo: []string{"*"},
 		},
 	}
-	destinationRule4 = Config{
-		ConfigMeta: ConfigMeta{
-			Type:      DestinationRule.Type,
-			Version:   DestinationRule.Version,
-			Name:      "acme",
-			Namespace: "other-namespace",
-		},
-		Spec: &networking.DestinationRule{
-			Host: "foo.ns1",
-			Subsets: []*networking.Subset{
-				{Name: "Subset 1"},
-			},
-			ExportTo: []string{"*"},
-		},
-	}
 )
 
 func TestCreateSidecarScope(t *testing.T) {

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -159,7 +159,7 @@ var (
 			Type:      DestinationRule.Type,
 			Version:   DestinationRule.Version,
 			Name:      "acme",
-			Namespace: "istio-config",
+			Namespace: ConfigRootNamespace,
 		},
 		Spec: &networking.DestinationRule{
 			Host: "foo.ns1",

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -393,7 +393,7 @@ func TestSidecarScopeDestinationRules(t *testing.T) {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
 			ps := NewPushContext()
 			meshConfig := DefaultMeshConfig()
-			meshConfig.DefaultDestinationRuleExportTo = []string{"."}
+			meshConfig.RootNamespace = ConfigRootNamespace
 			ps.Env = &Environment{
 				Mesh: &meshConfig,
 			}

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1125,6 +1125,11 @@ func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (errs error) {
 		}
 	}
 
+	if mesh.RootNamespace == IstioSystemNamespace {
+		errs = appendErrors(errs, fmt.Errorf("invalid root namespace: %s. root config namespace cannot be set to %s",
+			mesh.RootNamespace, IstioSystemNamespace))
+	}
+
 	if err := ValidatePort(int(mesh.ProxyListenPort)); err != nil {
 		errs = multierror.Append(errs, multierror.Prefix(err, "invalid proxy listen port:"))
 	}

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -616,6 +616,7 @@ func TestValidateMeshConfig(t *testing.T) {
 		ProxyListenPort:   0,
 		ConnectTimeout:    types.DurationProto(-1 * time.Second),
 		DefaultConfig:     &meshconfig.ProxyConfig{},
+		RootNamespace:     IstioSystemNamespace,
 	}
 
 	err := ValidateMeshConfig(&invalid)
@@ -625,7 +626,7 @@ func TestValidateMeshConfig(t *testing.T) {
 		switch err := err.(type) {
 		case *multierror.Error:
 			// each field must cause an error in the field
-			if len(err.Errors) < 6 {
+			if len(err.Errors) < 7 {
 				t.Errorf("expected an error for each field %v", err)
 			}
 		default:

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -712,6 +712,11 @@ func (k *KubeInfo) deployIstio() error {
 		log.Errorf("Unable to create namespace %s: %s", k.Namespace, err.Error())
 		return err
 	}
+	// Create istio-config namespace
+	if err := util.CreateNamespace("istio-config", k.KubeConfig); err != nil {
+		log.Errorf("Unable to create namespace istio-config: %s", err.Error())
+		return err
+	}
 
 	// Deploy the CNI if enabled
 	if *useCNI {


### PR DESCRIPTION
This prevents RootNamespace from being set to IstioSystemNamespace 
(istio-system) and sets is to istio-config by default.

It also updates how destination rules are looked up. This is the order:

1- search through the DestinationRules in proxy's namespace first
2- if no private/public rule matched in the calling proxy's namespace,
   check the target service's namespace for public rules
3- if no public/private rule in calling proxy's namespace matched, and
   no public rule in the target service's namespace matched, search for
   any public destination rule in the RootNamespace (config root namespace)

To do:
1- Unit tests: in the works
2- Reject proxies from being deployed in RootNamespace.

Fixes:  #13504