### PR TITLE
WIP: Filter gateway clusters based on virtual services

### DIFF
--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -79,6 +79,10 @@ var (
 	// AzDebug indicates whether to log service registry az info.
 	AzDebug = os.Getenv("VERBOSE_AZ_DEBUG") == "1"
 
+	// FilterGatewayServices enables service filtering on gateways.
+	// It reduces the size of cluster configuration sent to the gateways.
+	FilterGatewayServices = os.Getenv("PILOT_FILTER_GATEWAY_SERVICES") == "1"
+
 	// NetworkScopes isolates namespaces, limiting configuration for
 	// egress and other mesh services to only hosts defined in same namespace or
 	// 'admin' namespaces. Using services from any other namespaces will require the new NetworkScope


### PR DESCRIPTION
Filter clusters sent to gateways based on virtual services.

We have the following requirements
1. Some gateways like meshExpansion gateway, may actually want *all* clusters, so we should support that use case.
2. There are some intrinsic destinations, like istio-telemetry and others that istio knows about, and we should not make user specify those
3. EnvoyFilter API can add wasm / lua code which can use an arbitrary destination which is not known to the the system. These dependencies need to be exposed somewhere.

Proposal
1. Add annotation or field in gateway API to enable / disable filtering.
2. Pilot should always serve clusters for infrastructure servers like istio-telemetry.
3. Add a `required_hosts` field to the EnvoyFilter API. This way the API declares its dependencies.
4. Add a required_destinations field to the gateway api, to capture other hidden deps like metrics service sink or grpc access log sync .