### PR TITLE
lds: support feature that splitting inbound outbound listeners

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -184,10 +184,8 @@ containers:
         fieldPath: metadata.namespace
   - name: ISTIO_META_INTERCEPTION_MODE
     value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
-{{ if contains "*" (annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `DEFAULT_AS_NOT_STAR`) }}
-  - name: ISTIO_META_INBOUND_CAPTURE_ALL_PORT
-    value: true
-{{ end }}
+  - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+    value: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (applicationPorts .Spec.Containers) }}"
   {{- if .Values.global.network }}
   - name: ISTIO_META_NETWORK
     value: "{{ .Values.global.network }}"

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -47,7 +47,7 @@ initContainers:
     {{- end }}
   restartPolicy: Always
   env:
-  {{- if contains "*" (annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` "DEFAULT_AS_NOT_STAR") }}
+  {{- if contains "*" (annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` "") }}
   - name: INBOUND_CAPTURE_PORT
     value: 15006
   {{- end }}
@@ -184,7 +184,7 @@ containers:
         fieldPath: metadata.namespace
   - name: ISTIO_META_INTERCEPTION_MODE
     value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
-  - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+  - name: ISTIO_META_INCLUDE_INBOUND_PORTS
     value: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (applicationPorts .Spec.Containers) }}"
   {{- if .Values.global.network }}
   - name: ISTIO_META_NETWORK

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -46,6 +46,11 @@ initContainers:
     privileged: true
     {{- end }}
   restartPolicy: Always
+  env:
+  {{- if contains "*" (annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` "DEFAULT_AS_NOT_STAR") }}
+  - name: INBOUND_CAPTURE_PORT
+    value: 15006
+  {{- end }}
 {{- end }}
 {{  end -}}
 {{- if eq .Values.global.proxy.enableCoreDump true }}
@@ -179,6 +184,10 @@ containers:
         fieldPath: metadata.namespace
   - name: ISTIO_META_INTERCEPTION_MODE
     value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
+{{ if contains "*" (annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `DEFAULT_AS_NOT_STAR`) }}
+  - name: ISTIO_META_INBOUND_CAPTURE_ALL_PORT
+    value: true
+{{ end }}
   {{- if .Values.global.network }}
   - name: ISTIO_META_NETWORK
     value: "{{ .Values.global.network }}"

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"istio.io/istio/pkg/spiffe"
@@ -27,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pilot/pkg/bootstrap"
-	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/keepalive"
@@ -84,11 +82,6 @@ var (
 	}
 )
 
-const (
-	// ProxyInboundListenPortEnvKey is a environment variable that allow self defining ProxyInboundListenPort
-	ProxyInboundListenPortEnvKey = "ProxyInboundListenPort"
-)
-
 // when we run on k8s, the default trust domain is 'cluster.local', otherwise it is the empty string
 func hasKubeRegistry() bool {
 	for _, r := range serverArgs.Service.Registries {
@@ -97,20 +90,6 @@ func hasKubeRegistry() bool {
 		}
 	}
 	return false
-}
-
-func parseProxyInboundListenPortFromEnv() {
-	portString := os.Getenv(ProxyInboundListenPortEnvKey)
-	if portString == "" {
-		return
-	}
-	portNumber, err := strconv.Atoi(portString)
-	if err != nil {
-		log.Warnf("Cannot parse port from env var %s=%s, use default value %d", ProxyInboundListenPortEnvKey, portString, v1alpha3.ProxyInboundListenPort)
-	} else {
-		v1alpha3.ProxyInboundListenPort = uint32(portNumber)
-		log.Infof("Set ProxyInboundListenPort to %d", portNumber)
-	}
 }
 
 func init() {
@@ -187,10 +166,10 @@ func init() {
 		Section: "pilot-discovery CLI",
 		Manual:  "Istio Pilot Discovery",
 	}))
+
 }
 
 func main() {
-	parseProxyInboundListenPortFromEnv()
 	if err := rootCmd.Execute(); err != nil {
 		log.Errora(err)
 		os.Exit(-1)

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -99,22 +99,21 @@ func hasKubeRegistry() bool {
 	return false
 }
 
-func readProxyInboundListenPortFromEnv() {
+func parseProxyInboundListenPortFromEnv() {
 	portString := os.Getenv(ProxyInboundListenPortEnvKey)
 	if portString == "" {
 		return
 	}
 	portNumber, err := strconv.Atoi(portString)
 	if err != nil {
-		fmt.Errorf("Cannot parse port from env var %s=%s, use default value %d", ProxyInboundListenPortEnvKey, portString, v1alpha3.ProxyInboundListenPort)
+		log.Warnf("Cannot parse port from env var %s=%s, use default value %d", ProxyInboundListenPortEnvKey, portString, v1alpha3.ProxyInboundListenPort)
 	} else {
 		v1alpha3.ProxyInboundListenPort = uint32(portNumber)
-		fmt.Printf("Set ProxyInboundListenPort to %d", portNumber)
+		log.Infof("Set ProxyInboundListenPort to %d", portNumber)
 	}
 }
 
 func init() {
-	readProxyInboundListenPortFromEnv()
 	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.Service.Registries, "registries",
 		[]string{string(serviceregistry.KubernetesRegistry)},
 		fmt.Sprintf("Comma separated list of platform service registries to read from (choose one or more from {%s, %s, %s, %s})",
@@ -191,6 +190,7 @@ func init() {
 }
 
 func main() {
+	parseProxyInboundListenPortFromEnv()
 	if err := rootCmd.Execute(); err != nil {
 		log.Errora(err)
 		os.Exit(-1)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -34,7 +34,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	prom "github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -106,6 +106,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: 80,90
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"sidecar.istio.io/rewriteAppHTTPProbers":"true"}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -106,7 +106,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: 80,90
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: 80,90
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -103,6 +103,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: 80,90
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"sidecar.istio.io/rewriteAppHTTPProbers":"false"}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: 80,90
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -105,6 +105,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: 80,90
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -86,6 +86,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -106,7 +106,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: 80,90
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -106,6 +106,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: 80,90
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -86,6 +86,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -90,6 +90,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -90,7 +90,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -86,6 +86,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -96,7 +96,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: 80,90
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -96,6 +96,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: 80,90
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -76,7 +76,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: ISTIO_META_INTERCEPTION_MODE
               value: REDIRECT
-            - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+            - name: ISTIO_META_INCLUDE_INBOUND_PORTS
             image: docker.io/istio/proxyv2:unittest
             imagePullPolicy: IfNotPresent
             name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -76,6 +76,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: ISTIO_META_INTERCEPTION_MODE
               value: REDIRECT
+            - name: ISTIO_META_INBOUND_CAPTURE_PORTS
             image: docker.io/istio/proxyv2:unittest
             imagePullPolicy: IfNotPresent
             name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -80,6 +80,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -95,6 +95,8 @@ items:
                 fieldPath: metadata.namespace
           - name: ISTIO_META_INTERCEPTION_MODE
             value: REDIRECT
+          - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+            value: "80"
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -95,7 +95,7 @@ items:
                 fieldPath: metadata.namespace
           - name: ISTIO_META_INTERCEPTION_MODE
             value: REDIRECT
-          - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          - name: ISTIO_META_INCLUDE_INBOUND_PORTS
             value: "80"
           - name: ISTIO_METAJSON_LABELS
             value: |

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -80,6 +80,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -100,6 +100,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"frontend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -100,7 +100,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"frontend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -83,6 +83,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"sidecar.istio.io/inject":"false"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
@@ -247,7 +247,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "81"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -84,6 +84,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable","version":"v1"}
@@ -245,6 +247,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "81"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable","version":"v2"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -83,6 +83,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -83,6 +83,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"sidecar.istio.io/proxyImage":"docker.io/istio/proxy2_debug:unittest"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: TPROXY
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -78,6 +78,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: TPROXY
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -74,6 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -83,6 +83,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"traffic.sidecar.istio.io/kubevirtInterfaces":"net1"}

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -83,6 +83,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"traffic.sidecar.istio.io/kubevirtInterfaces":"net1,net2"}

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -101,7 +101,7 @@ items:
                 fieldPath: metadata.namespace
           - name: ISTIO_META_INTERCEPTION_MODE
             value: REDIRECT
-          - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"frontend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -101,6 +101,7 @@ items:
                 fieldPath: metadata.namespace
           - name: ISTIO_META_INTERCEPTION_MODE
             value: REDIRECT
+          - name: ISTIO_META_INBOUND_CAPTURE_PORTS
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"frontend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -86,6 +86,8 @@ items:
                 fieldPath: metadata.namespace
           - name: ISTIO_META_INTERCEPTION_MODE
             value: REDIRECT
+          - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+            value: "80"
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"backend","track":"stable","version":"v1"}
@@ -246,6 +248,8 @@ items:
                 fieldPath: metadata.namespace
           - name: ISTIO_META_INTERCEPTION_MODE
             value: REDIRECT
+          - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+            value: "81"
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"backend","track":"stable","version":"v2"}

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -86,7 +86,7 @@ items:
                 fieldPath: metadata.namespace
           - name: ISTIO_META_INTERCEPTION_MODE
             value: REDIRECT
-          - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          - name: ISTIO_META_INCLUDE_INBOUND_PORTS
             value: "80"
           - name: ISTIO_METAJSON_LABELS
             value: |
@@ -248,7 +248,7 @@ items:
                 fieldPath: metadata.namespace
           - name: ISTIO_META_INTERCEPTION_MODE
             value: REDIRECT
-          - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          - name: ISTIO_META_INCLUDE_INBOUND_PORTS
             value: "81"
           - name: ISTIO_METAJSON_LABELS
             value: |

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -67,6 +67,8 @@ spec:
           fieldPath: metadata.namespace
     - name: ISTIO_META_INTERCEPTION_MODE
       value: REDIRECT
+    - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+      value: "80"
     image: docker.io/istio/proxyv2:unittest
     imagePullPolicy: IfNotPresent
     name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -67,7 +67,7 @@ spec:
           fieldPath: metadata.namespace
     - name: ISTIO_META_INTERCEPTION_MODE
       value: REDIRECT
-    - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+    - name: ISTIO_META_INCLUDE_INBOUND_PORTS
       value: "80"
     image: docker.io/istio/proxyv2:unittest
     imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -77,6 +77,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello"}

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -76,6 +76,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"nginx"}

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -85,6 +85,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -83,6 +83,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"readiness.status.sidecar.istio.io/applicationPorts":"1,2,3","readiness.status.sidecar.istio.io/failureThreshold":"300","readiness.status.sidecar.istio.io/initialDelaySeconds":"100","readiness.status.sidecar.istio.io/periodSeconds":"200","status.sidecar.istio.io/port":"123"}

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -78,6 +78,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"status"}

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -82,6 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/includeInboundPorts":"","traffic.sidecar.istio.io/includeOutboundIPRanges":""}

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/includeInboundPorts":"","traffic.sidecar.istio.io/includeOutboundIPRanges":""}

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: '*'
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_ALL_PORT
+          value: "true"
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/includeInboundPorts":"*","traffic.sidecar.istio.io/includeOutboundIPRanges":"*"}
@@ -134,6 +136,9 @@ spec:
         - '*'
         - -d
         - 4,5,6,15020
+        env:
+        - name: INBOUND_CAPTURE_PORT
+          value: "15006"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -82,8 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_ALL_PORT
-          value: "true"
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: '*'
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/includeInboundPorts":"*","traffic.sidecar.istio.io/includeOutboundIPRanges":"*"}

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: 1,2,3
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: 1,2,3
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
             {"traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -78,6 +78,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -74,6 +74,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -4,12 +4,12 @@ metadata:
   creationTimestamp: null
   name: hello
 spec:
-  strategy: {}
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
+  strategy: {}
   template:
     metadata:
       annotations:
@@ -83,6 +83,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -140,11 +142,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -81,6 +81,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -138,11 +140,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -6,6 +6,7 @@ metadata:
 spec:
   replicas: 7
   revisionHistoryLimit: 2
+  selector: null
   strategy:
     type: Rolling
   template:
@@ -81,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -138,11 +141,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -88,6 +88,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -145,11 +146,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -88,7 +88,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 7
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
   strategy: {}
@@ -84,6 +84,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -141,11 +143,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
       version: v1
@@ -86,6 +86,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -143,11 +145,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory
@@ -247,6 +249,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "81"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -304,11 +308,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
@@ -249,7 +249,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "81"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -104,6 +104,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: 80,90
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -161,11 +163,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: 80,90
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -77,6 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -134,11 +135,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       restartPolicy: Never
       volumes:
       - emptyDir:

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -7,7 +7,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: frontend
       track: stable
   strategy: {}
@@ -88,6 +88,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -145,11 +146,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -88,7 +88,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
@@ -249,7 +249,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "81"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -86,6 +86,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -143,11 +145,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory
@@ -168,7 +170,7 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: hello  
+      app: hello
       tier: backend
       track: stable
       version: v2
@@ -247,6 +249,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "81"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -304,11 +308,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -80,6 +80,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -137,11 +139,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -78,6 +78,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -135,11 +137,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -82,6 +82,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -136,11 +138,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -87,6 +87,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -144,11 +146,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - hostPath:
           path: /mnt/disks/ssd0

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -87,7 +87,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -85,6 +85,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -142,11 +144,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -84,6 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -141,11 +142,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -84,8 +84,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_ALL_PORT
-          value: "true"
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: '*'
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -146,11 +146,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: '*'
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -84,6 +84,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_ALL_PORT
+          value: "true"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -130,6 +132,9 @@ spec:
         - '*'
         - -d
         - 4,5,6,15020
+        env:
+        - name: INBOUND_CAPTURE_PORT
+          value: "15006"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -84,6 +84,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: 1,2,3
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -141,11 +143,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: 1,2,3
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -86,6 +86,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+          value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -148,11 +150,11 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
           capabilities:
             add:
             - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_META_INBOUND_CAPTURE_PORTS
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -133,6 +133,9 @@ const (
 
 	// Router type is used for standalone proxies acting as L7/L4 routers
 	Router NodeType = "router"
+
+	// AllPortsLiteral is the string value indicating all ports
+	AllPortsLiteral = "*"
 )
 
 // IsApplicationNodeType verifies that the NodeType is one of the declared constants in the model
@@ -395,7 +398,7 @@ const (
 	// IstioIngressNamespace is the namespace where Istio ingress controller is deployed
 	IstioIngressNamespace = "istio-system"
 
-	IstioInboundCaptureAllPort = "INBOUND_CAPTURE_ALL_PORT"
+	IstioInboundCapturePorts = "INBOUND_CAPTURE_PORTS"
 )
 
 // IstioIngressWorkloadLabels is the label assigned to Istio ingress pods
@@ -667,6 +670,6 @@ func (node *Proxy) IsInboundCaptureAllPorts() bool {
 	if node.GetInterceptionMode() != InterceptionRedirect {
 		return false
 	}
-	_, ok := node.Metadata[IstioInboundCaptureAllPort]
-	return ok
+	capturePorts, ok := node.Metadata[IstioInboundCapturePorts]
+	return ok && strings.Contains(capturePorts, AllPortsLiteral)
 }

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -398,7 +398,7 @@ const (
 	// IstioIngressNamespace is the namespace where Istio ingress controller is deployed
 	IstioIngressNamespace = "istio-system"
 
-	IstioInboundCapturePorts = "INBOUND_CAPTURE_PORTS"
+	IstioIncludeInboundPorts = "INCLUDE_INBOUND_PORTS"
 )
 
 // IstioIngressWorkloadLabels is the label assigned to Istio ingress pods
@@ -670,6 +670,6 @@ func (node *Proxy) IsInboundCaptureAllPorts() bool {
 	if node.GetInterceptionMode() != InterceptionRedirect {
 		return false
 	}
-	capturePorts, ok := node.Metadata[IstioInboundCapturePorts]
+	capturePorts, ok := node.Metadata[IstioIncludeInboundPorts]
 	return ok && strings.Contains(capturePorts, AllPortsLiteral)
 }

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -394,6 +394,8 @@ const (
 
 	// IstioIngressNamespace is the namespace where Istio ingress controller is deployed
 	IstioIngressNamespace = "istio-system"
+
+	IstioInboundCaptureAllPort = "INBOUND_CAPTURE_ALL_PORT"
 )
 
 // IstioIngressWorkloadLabels is the label assigned to Istio ingress pods
@@ -658,4 +660,13 @@ func (node *Proxy) GetInterceptionMode() TrafficInterceptionMode {
 	}
 
 	return InterceptionRedirect
+}
+
+// Inbound capture listener capture all port mode only supports iptables REDIRECT
+func (node *Proxy) IsInboundCaptureAllPorts() bool {
+	if node.GetInterceptionMode() != InterceptionRedirect {
+		return false
+	}
+	_, ok := node.Metadata[IstioInboundCaptureAllPort]
+	return ok
 }

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -55,6 +55,9 @@ const (
 	// VirtualListenerName is the name for traffic capture listener
 	VirtualListenerName = "virtual"
 
+	// VirtualListenerName is the name for traffic capture listener
+	VirtualInboundListenerName = "virtualInbound"
+
 	// WildcardAddress binds to all IP addresses
 	WildcardAddress = "0.0.0.0"
 
@@ -108,6 +111,10 @@ var (
 			"upstream_transport_failure_reason": {Kind: &google_protobuf.Value_StringValue{StringValue: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"}},
 		},
 	}
+
+	// ProxyInboundListenPort is the dedicated inbound traffic capture port for sidecar proxy.
+	// See also `MeshConfig.ProxyListenPort`.
+	ProxyInboundListenPort uint32 = 15006
 )
 
 func buildAccessLog(fl *fileaccesslog.FileAccessLog, env *model.Environment) {
@@ -194,54 +201,67 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 	actualWildcard, actualLocalHostAddress := getActualWildcardAndLocalHost(node)
 
 	if mesh.ProxyListenPort > 0 {
-		inbound := configgen.buildSidecarInboundListeners(env, node, push, proxyInstances)
-		outbound := configgen.buildSidecarOutboundListeners(env, node, push, proxyInstances)
+		// Notes that the the else branch works for both split and non-split cases.
+		// TODO(silentdai): remove `if` branch once split behavior is well verified
+		if !node.IsInboundCaptureAllPorts() {
+			inbound := configgen.buildSidecarInboundListeners(env, node, push, proxyInstances)
+			outbound := configgen.buildSidecarOutboundListeners(env, node, push, proxyInstances)
 
-		listeners = append(listeners, inbound...)
-		listeners = append(listeners, outbound...)
+			listeners = append(listeners, inbound...)
+			listeners = append(listeners, outbound...)
 
-		listeners = configgen.generateManagementListeners(node, noneMode, env, listeners)
+			listeners = configgen.generateManagementListeners(node, noneMode, env, listeners)
 
-		tcpProxy := &tcp_proxy.TcpProxy{
-			StatPrefix:       util.BlackHoleCluster,
-			ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: util.BlackHoleCluster},
-		}
-
-		if mesh.OutboundTrafficPolicy.Mode == meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY {
-			// We need a passthrough filter to fill in the filter stack for orig_dst listener
-			tcpProxy = &tcp_proxy.TcpProxy{
-				StatPrefix:       util.PassthroughCluster,
-				ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: util.PassthroughCluster},
+			tcpProxy := &tcp_proxy.TcpProxy{
+				StatPrefix:       util.BlackHoleCluster,
+				ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: util.BlackHoleCluster},
 			}
-			setAccessLog(env, node, tcpProxy)
-		}
-		var transparent *google_protobuf.BoolValue
-		if node.GetInterceptionMode() == model.InterceptionTproxy {
-			transparent = proto.BoolTrue
-		}
 
-		filter := listener.Filter{
-			Name: xdsutil.TCPProxy,
-		}
+			if mesh.OutboundTrafficPolicy.Mode == meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY {
+				// We need a passthrough filter to fill in the filter stack for orig_dst listener
+				tcpProxy = &tcp_proxy.TcpProxy{
+					StatPrefix:       util.PassthroughCluster,
+					ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: util.PassthroughCluster},
+				}
+				setAccessLog(env, node, tcpProxy)
+			}
+			var transparent *google_protobuf.BoolValue
+			if node.GetInterceptionMode() == model.InterceptionTproxy {
+				transparent = proto.BoolTrue
+			}
 
-		if util.IsXDSMarshalingToAnyEnabled(node) {
-			filter.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(tcpProxy)}
-		} else {
-			filter.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(tcpProxy)}
-		}
+			filter := listener.Filter{
+				Name: xdsutil.TCPProxy,
+			}
 
-		// add an extra listener that binds to the port that is the recipient of the iptables redirect
-		listeners = append(listeners, &xdsapi.Listener{
-			Name:           VirtualListenerName,
-			Address:        util.BuildAddress(actualWildcard, uint32(mesh.ProxyListenPort)),
-			Transparent:    transparent,
-			UseOriginalDst: proto.BoolTrue,
-			FilterChains: []listener.FilterChain{
-				{
-					Filters: []listener.Filter{filter},
+			if util.IsXDSMarshalingToAnyEnabled(node) {
+				filter.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(tcpProxy)}
+			} else {
+				filter.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(tcpProxy)}
+			}
+
+			// add an extra listener that binds to the port that is the recipient of the iptables redirect
+			listeners = append(listeners, &xdsapi.Listener{
+				Name:           VirtualListenerName,
+				Address:        util.BuildAddress(actualWildcard, uint32(mesh.ProxyListenPort)),
+				Transparent:    transparent,
+				UseOriginalDst: proto.BoolTrue,
+				FilterChains: []listener.FilterChain{
+					{
+						Filters: []listener.Filter{filter},
+					},
 				},
-			},
-		})
+			})
+		} else {
+			// Any build order change need a careful code review
+			listeners = NewListenerBuilder(node).
+				buildSidecarInboundListeners(configgen, env, node, push, proxyInstances).
+				buildSidecarOutboundListeners(configgen, env, node, push, proxyInstances).
+				buildManagementListeners(configgen, env, node, push, proxyInstances).
+				buildVirtualListener(env, node).
+				buildVirtualInboundListener(env, node).
+				getListeners()
+		}
 	}
 
 	httpProxyPort := mesh.ProxyHttpPort
@@ -1223,6 +1243,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(l
 	}
 }
 
+// TODO(silentdai): duplicate with listener_builder.go. Remove this one once split is verified.
 func (configgen *ConfigGeneratorImpl) generateManagementListeners(node *model.Proxy, noneMode bool,
 	env *model.Environment, listeners []*xdsapi.Listener) []*xdsapi.Listener {
 	// Do not generate any management port listeners if the user has specified a SidecarScope object

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -17,6 +17,7 @@ package v1alpha3
 import (
 	"encoding/json"
 	"fmt"
+
 	"net"
 	"reflect"
 	"sort"
@@ -43,6 +44,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/features/pilot"
 	"istio.io/istio/pkg/proto"
+	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
 
@@ -114,7 +116,7 @@ var (
 
 	// ProxyInboundListenPort is the dedicated inbound traffic capture port for sidecar proxy.
 	// See also `MeshConfig.ProxyListenPort`.
-	ProxyInboundListenPort uint32 = 15006
+	ProxyInboundListenPort = uint32(env.RegisterIntVar("ProxyInboundListenPort", 15006, "").Get())
 )
 
 func buildAccessLog(fl *fileaccesslog.FileAccessLog, env *model.Environment) {

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -1,0 +1,213 @@
+package v1alpha3
+
+import (
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+	google_protobuf "github.com/gogo/protobuf/types"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/proto"
+	"istio.io/pkg/log"
+)
+
+// A stateful listener builder
+type ListenerBuilder struct {
+	node                   *model.Proxy
+	inboundListeners       []*xdsapi.Listener
+	outboundListeners      []*xdsapi.Listener
+	managementListeners    []*xdsapi.Listener
+	virtualListener        *xdsapi.Listener
+	virtualInboundListener *xdsapi.Listener
+}
+
+func NewListenerBuilder(node *model.Proxy) *ListenerBuilder {
+	builder := &ListenerBuilder{
+		node: node,
+	}
+	return builder
+}
+
+func (builder *ListenerBuilder) buildSidecarInboundListeners(
+	configgen *ConfigGeneratorImpl,
+	env *model.Environment, node *model.Proxy, push *model.PushContext,
+	proxyInstances []*model.ServiceInstance) *ListenerBuilder {
+	builder.inboundListeners = configgen.buildSidecarInboundListeners(env, node, push, proxyInstances)
+	return builder
+}
+
+func (builder *ListenerBuilder) buildSidecarOutboundListeners(configgen *ConfigGeneratorImpl,
+	env *model.Environment, node *model.Proxy, push *model.PushContext,
+	proxyInstances []*model.ServiceInstance) *ListenerBuilder {
+	builder.outboundListeners = configgen.buildSidecarOutboundListeners(env, node, push, proxyInstances)
+	return builder
+}
+
+func (builder *ListenerBuilder) buildManagementListeners(_ *ConfigGeneratorImpl,
+	env *model.Environment, node *model.Proxy, _ *model.PushContext,
+	_ []*model.ServiceInstance) *ListenerBuilder {
+
+	noneMode := node.GetInterceptionMode() == model.InterceptionNone
+
+	// Do not generate any management port listeners if the user has specified a SidecarScope object
+	// with ingress listeners. Specifying the ingress listener implies that the user wants
+	// to only have those specific listeners and nothing else, in the inbound path.
+	sidecarScope := node.SidecarScope
+	if sidecarScope != nil && sidecarScope.HasCustomIngressListeners ||
+		noneMode {
+		return builder
+	}
+	// Let ServiceDiscovery decide which IP and Port are used for management if
+	// there are multiple IPs
+	mgmtListeners := make([]*xdsapi.Listener, 0)
+	for _, ip := range node.IPAddresses {
+		managementPorts := env.ManagementPorts(ip)
+		management := buildSidecarInboundMgmtListeners(node, env, managementPorts, ip)
+		mgmtListeners = append(mgmtListeners, management...)
+	}
+	addresses := make(map[string]*xdsapi.Listener)
+	for _, listener := range builder.inboundListeners {
+		if listener != nil {
+			addresses[listener.Address.String()] = listener
+		}
+	}
+	for _, listener := range builder.outboundListeners {
+		if listener != nil {
+			addresses[listener.Address.String()] = listener
+		}
+	}
+
+	// If management listener port and service port are same, bad things happen
+	// when running in kubernetes, as the probes stop responding. So, append
+	// non overlapping listeners only.
+	for i := range mgmtListeners {
+		m := mgmtListeners[i]
+		addressString := m.Address.String()
+		existingListener, ok := addresses[addressString]
+		if ok {
+			log.Warnf("Omitting listener for management address %s (%s) due to collision with service listener (%s)",
+				m.Name, m.Address.String(), existingListener.Name)
+			continue
+		} else {
+			// dedup management listeners as well
+			addresses[addressString] = m
+			builder.managementListeners = append(builder.managementListeners, m)
+		}
+
+	}
+	return builder
+}
+
+func (builder *ListenerBuilder) buildVirtualListener(
+	env *model.Environment, node *model.Proxy) *ListenerBuilder {
+
+	var isTransparentProxy *google_protobuf.BoolValue
+	if node.GetInterceptionMode() == model.InterceptionTproxy {
+		isTransparentProxy = proto.BoolTrue
+	}
+
+	tcpProxyFilter := newTCPProxyListenerFilter(env, node, false)
+	actualWildcard, _ := getActualWildcardAndLocalHost(node)
+	// add an extra listener that binds to the port that is the recipient of the iptables redirect
+	builder.virtualListener = &xdsapi.Listener{
+		Name:           VirtualListenerName,
+		Address:        util.BuildAddress(actualWildcard, uint32(env.Mesh.ProxyListenPort)),
+		Transparent:    isTransparentProxy,
+		UseOriginalDst: proto.BoolTrue,
+		FilterChains: []listener.FilterChain{
+			{
+				Filters: []listener.Filter{*tcpProxyFilter},
+			},
+		},
+	}
+	return builder
+}
+
+func (builder *ListenerBuilder) buildVirtualInboundListener(env *model.Environment, node *model.Proxy) *ListenerBuilder {
+	shouldSplitInOutBound := node.IsInboundCaptureAllPorts()
+	if !shouldSplitInOutBound {
+		log.Debugf("Inbound and outbound listeners are united in for node %s", node.ID)
+		return builder
+	}
+	var isTransparentProxy *google_protobuf.BoolValue
+	if node.GetInterceptionMode() == model.InterceptionTproxy {
+		isTransparentProxy = proto.BoolTrue
+	}
+
+	tcpProxyFilter := newTCPProxyListenerFilter(env, node, true)
+	actualWildcard, _ := getActualWildcardAndLocalHost(node)
+	// add an extra listener that binds to the port that is the recipient of the iptables redirect
+	builder.virtualInboundListener = &xdsapi.Listener{
+		Name:           VirtualInboundListenerName,
+		Address:        util.BuildAddress(actualWildcard, ProxyInboundListenPort),
+		Transparent:    isTransparentProxy,
+		UseOriginalDst: proto.BoolTrue,
+		FilterChains: []listener.FilterChain{
+			{
+				Filters: []listener.Filter{*tcpProxyFilter},
+			},
+		},
+	}
+	return builder
+}
+
+func (builder *ListenerBuilder) getListeners() []*xdsapi.Listener {
+	nInbound, nOutbound, nManagement := len(builder.inboundListeners), len(builder.outboundListeners), len(builder.managementListeners)
+	nVirtual, nVirtualInbound := 0, 0
+	if builder.virtualListener != nil {
+		nVirtual = 1
+	}
+	if builder.virtualInboundListener != nil {
+		nVirtualInbound = 1
+	}
+	nListener := nInbound + nOutbound + nManagement + nVirtual + nVirtualInbound
+
+	listeners := make([]*xdsapi.Listener, 0, nListener)
+	listeners = append(listeners, builder.inboundListeners...)
+	listeners = append(listeners, builder.outboundListeners...)
+	listeners = append(listeners, builder.managementListeners...)
+	if builder.virtualListener != nil {
+		listeners = append(listeners, builder.virtualListener)
+	}
+	if builder.virtualInboundListener != nil {
+		listeners = append(listeners, builder.virtualInboundListener)
+	}
+
+	log.Debugf("Build %d listeners for node %s including %d inbound, %d outbound, %d management, %d virtual and %d virtual inbound listeners",
+		nListener,
+		builder.node.ID,
+		nInbound, nOutbound, nManagement,
+		nVirtual, nVirtualInbound)
+	return listeners
+}
+
+func newTCPProxyListenerFilter(env *model.Environment, node *model.Proxy, isInboundListener bool) *listener.Filter {
+	tcpProxy := &tcp_proxy.TcpProxy{
+		StatPrefix:       util.BlackHoleCluster,
+		ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: util.BlackHoleCluster},
+	}
+
+	if env.Mesh.OutboundTrafficPolicy.Mode == meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY ||
+		isInboundListener {
+		// We need a passthrough filter to fill in the filter stack for orig_dst listener
+		tcpProxy = &tcp_proxy.TcpProxy{
+			StatPrefix:       util.PassthroughCluster,
+			ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: util.PassthroughCluster},
+		}
+		setAccessLog(env, node, tcpProxy)
+	}
+
+	filter := listener.Filter{
+		Name: xdsutil.TCPProxy,
+	}
+
+	if util.IsXDSMarshalingToAnyEnabled(node) {
+		filter.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(tcpProxy)}
+	} else {
+		filter.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(tcpProxy)}
+	}
+	return &filter
+}

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -139,7 +139,7 @@ func TestVirtualListenerBuilder(t *testing.T) {
 
 func setInboundCaptureAllOnThisNode(proxy *model.Proxy) {
 	proxy.Metadata[model.NodeMetadataInterceptionMode] = "REDIRECT"
-	proxy.Metadata[model.IstioInboundCaptureAllPort] = "true"
+	proxy.Metadata[model.IstioInboundCapturePorts] = model.AllPortsLiteral
 }
 
 func TestVirtualInboundListenerBuilder(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -1,0 +1,194 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"strings"
+	"testing"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/plugin"
+)
+
+type LdsEnv struct {
+	configgen *ConfigGeneratorImpl
+}
+
+func getDefaultLdsEnv() *LdsEnv {
+	listenerEnv := LdsEnv{
+		configgen: NewConfigGenerator([]plugin.Plugin{&fakePlugin{}}),
+	}
+	return &listenerEnv
+}
+
+func getDefaultProxy() model.Proxy {
+	return model.Proxy{
+		Type:        model.SidecarProxy,
+		IPAddresses: []string{"1.1.1.1"},
+		ID:          "v0.default",
+		DNSDomain:   "default.example.org",
+		Metadata: map[string]string{
+			model.NodeMetadataConfigNamespace: "not-default",
+			"ISTIO_PROXY_VERSION":             "1.1",
+		},
+		ConfigNamespace: "not-default",
+	}
+}
+
+func setNilSidecarOnProxy(proxy *model.Proxy, pushContext *model.PushContext) {
+	proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(pushContext, "not-default")
+}
+
+func TestListenerBuilder(t *testing.T) {
+	// prepare
+	t.Helper()
+	ldsEnv := getDefaultLdsEnv()
+	service := buildService("test.com", wildcardIP, model.ProtocolHTTP, tnow)
+	services := []*model.Service{service}
+
+	env := buildListenerEnv(services)
+
+	if err := env.PushContext.InitContext(&env); err != nil {
+		t.Fatalf("init push context error: %s", err.Error())
+	}
+	instances := make([]*model.ServiceInstance, len(services))
+	for i, s := range services {
+		instances[i] = &model.ServiceInstance{
+			Service:  s,
+			Endpoint: buildEndpoint(s),
+		}
+	}
+	proxy := getDefaultProxy()
+	setNilSidecarOnProxy(&proxy, env.PushContext)
+
+	builder := NewListenerBuilder(&proxy)
+	listeners := builder.buildSidecarInboundListeners(ldsEnv.configgen, &env, &proxy, env.PushContext, instances).
+		getListeners()
+
+	// the listener for app
+	if len(listeners) != 1 {
+		t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
+	}
+	protocol := service.Ports[0].Protocol
+	if protocol != model.ProtocolHTTP && isHTTPListener(listeners[0]) {
+		t.Fatal("expected TCP listener, found HTTP")
+	} else if protocol == model.ProtocolHTTP && !isHTTPListener(listeners[0]) {
+		t.Fatal("expected HTTP listener, found TCP")
+	}
+	verifyInboundHTTPListenerServerName(t, listeners[0])
+	if isHTTPListener(listeners[0]) {
+		verifyInboundHTTPListenerCertDetails(t, listeners[0])
+	}
+
+	verifyInboundEnvoyListenerNumber(t, listeners[0])
+}
+
+func TestVirtualListenerBuilder(t *testing.T) {
+	// prepare
+	t.Helper()
+	ldsEnv := getDefaultLdsEnv()
+	service := buildService("test.com", wildcardIP, model.ProtocolHTTP, tnow)
+	services := []*model.Service{service}
+
+	env := buildListenerEnv(services)
+	if err := env.PushContext.InitContext(&env); err != nil {
+		t.Fatalf("init push context error: %s", err.Error())
+	}
+	instances := make([]*model.ServiceInstance, len(services))
+	for i, s := range services {
+		instances[i] = &model.ServiceInstance{
+			Service:  s,
+			Endpoint: buildEndpoint(s),
+		}
+	}
+	proxy := getDefaultProxy()
+	setNilSidecarOnProxy(&proxy, env.PushContext)
+
+	builder := NewListenerBuilder(&proxy)
+	listeners := builder.buildSidecarInboundListeners(ldsEnv.configgen, &env, &proxy, env.PushContext, instances).
+		buildVirtualListener(&env, &proxy).
+		getListeners()
+
+	// app port listener and virtual inbound listener
+	if len(listeners) != 2 {
+		t.Fatalf("expected %d listeners, found %d", 2, len(listeners))
+	}
+
+	// The rest attributes are verified in other tests
+	verifyInboundHTTPListenerServerName(t, listeners[0])
+
+	if !strings.HasPrefix(listeners[1].Name, VirtualListenerName) {
+		t.Fatalf("expect virtual listener, found %s", listeners[1].Name)
+	} else {
+		t.Logf("found virtual listener: %s", listeners[1].Name)
+	}
+
+}
+
+func setInboundCaptureAllOnThisNode(proxy *model.Proxy) {
+	proxy.Metadata[model.NodeMetadataInterceptionMode] = "REDIRECT"
+	proxy.Metadata[model.IstioInboundCaptureAllPort] = "true"
+}
+
+func TestVirtualInboundListenerBuilder(t *testing.T) {
+
+	// prepare
+	t.Helper()
+	ldsEnv := getDefaultLdsEnv()
+	service := buildService("test.com", wildcardIP, model.ProtocolHTTP, tnow)
+	services := []*model.Service{service}
+
+	env := buildListenerEnv(services)
+	if err := env.PushContext.InitContext(&env); err != nil {
+		t.Fatalf("init push context error: %s", err.Error())
+	}
+	instances := make([]*model.ServiceInstance, len(services))
+	for i, s := range services {
+		instances[i] = &model.ServiceInstance{
+			Service:  s,
+			Endpoint: buildEndpoint(s),
+		}
+	}
+
+	proxy := getDefaultProxy()
+	setInboundCaptureAllOnThisNode(&proxy)
+	setNilSidecarOnProxy(&proxy, env.PushContext)
+
+	builder := NewListenerBuilder(&proxy)
+	listeners := builder.buildSidecarInboundListeners(ldsEnv.configgen, &env, &proxy, env.PushContext, instances).
+		buildVirtualListener(&env, &proxy).
+		buildVirtualInboundListener(&env, &proxy).
+		getListeners()
+
+	// app port listener and virtual inbound listener
+	if len(listeners) != 3 {
+		t.Fatalf("expected %d listeners, found %d", 3, len(listeners))
+	}
+
+	// The rest attributes are verified in other tests
+	verifyInboundHTTPListenerServerName(t, listeners[0])
+
+	if !strings.HasPrefix(listeners[1].Name, VirtualListenerName) {
+		t.Fatalf("expect virtual listener, found %s", listeners[1].Name)
+	} else {
+		t.Logf("found virtual listener: %s", listeners[1].Name)
+	}
+
+	if !strings.HasPrefix(listeners[2].Name, VirtualInboundListenerName) {
+		t.Fatalf("expect virtual listener, found %s", listeners[2].Name)
+	} else {
+		t.Logf("found virtual inbound listener: %s", listeners[2].Name)
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -139,7 +139,7 @@ func TestVirtualListenerBuilder(t *testing.T) {
 
 func setInboundCaptureAllOnThisNode(proxy *model.Proxy) {
 	proxy.Metadata[model.NodeMetadataInterceptionMode] = "REDIRECT"
-	proxy.Metadata[model.IstioInboundCapturePorts] = model.AllPortsLiteral
+	proxy.Metadata[model.IstioIncludeInboundPorts] = model.AllPortsLiteral
 }
 
 func TestVirtualInboundListenerBuilder(t *testing.T) {

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -59,6 +59,10 @@ type Config struct {
 
 	// Annotations provides metadata hints for deployment of the instance.
 	Annotations Annotations
+
+	// IncludeInboundPorts provides the ports that inbound listener should capture
+	// "*" means capture all.
+	IncludeInboundPorts string
 }
 
 // String implements the Configuration interface (which implements fmt.Stringer)

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -79,11 +79,15 @@ spec:
 {{- if ne .Locality "" }}
         istio-locality: {{ .Locality }}
 {{- end }}
-{{- if .WorkloadAnnotations }}
       annotations:
+        foo: bar
+{{- if .WorkloadAnnotations }}
 {{- range $name, $value := .WorkloadAnnotations }}
-       {{ $name }}: {{ printf "%q" $value }}
+        {{ $name }}: {{ printf "%q" $value }}
 {{- end }}
+{{- end }}
+{{- if .IncludeInboundPorts }}
+        traffic.sidecar.istio.io/includeInboundPorts: "{{ .IncludeInboundPorts }}"
 {{- end }}
     spec:
 {{- if .ServiceAccount }}
@@ -143,7 +147,6 @@ UVoCqQmzjPoB3c3JoYFpJo-9jTN1_mNRtZUcNvYl-tDlTmBlaKEvoC5P2WGVUF3AoLsES66u4FG9Wllm
 LV92LG1WNqx_ltkT1tahSy9WiHQgyzPqwtwE72T1jAGdgVIoJy1lfSaLam_bo9rqkRlgSg-au9BAjZiD\
 Gtm9tf3lwrcgfbxccdlG4jAsTFa2aNs3dW4NLk7mFnWCJa-iWj-TgFxf9TW-9XPK0g3oYIQ0Id0CIW2S\
 iFxKGPAjB-g"
----
 `
 )
 
@@ -192,6 +195,7 @@ func generateYAML(cfg echo.Config) (string, error) {
 		"ContainerPorts":      getContainerPorts(cfg.Ports),
 		"ServiceAnnotations":  serviceAnnotations,
 		"WorkloadAnnotations": workloadAnnotations,
+		"IncludeInboundPorts": cfg.IncludeInboundPorts,
 	}
 
 	// Generate the YAML content.

--- a/tests/integration/pilot/interception/ping_test.go
+++ b/tests/integration/pilot/interception/ping_test.go
@@ -1,0 +1,166 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interception
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/tests/integration/security/util/connection"
+	"istio.io/pkg/log"
+)
+
+var (
+	ist istio.Instance
+	g   galley.Instance
+	p   pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("inbound_split_test", m).
+		RequireEnvironment(environment.Kube).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+
+}
+
+type appConnectionPair struct {
+	src, dst echo.Instance
+}
+
+func TestReachability(t *testing.T) {
+	framework.NewTest(t).Run(func(ctx framework.TestContext) {
+		doTest(t, ctx)
+	})
+}
+
+func doTest(t *testing.T, ctx framework.TestContext) {
+	ns := namespace.NewOrFail(t, ctx, "inboundsplit", true)
+
+	ports := []echo.Port{
+		{
+			Name:     "http",
+			Protocol: model.ProtocolHTTP,
+		},
+		{
+			Name:     "tcp",
+			Protocol: model.ProtocolTCP,
+		},
+	}
+
+	var inoutUnitedApp0, inoutUnitedApp1, inoutSplitApp0, inoutSplitApp1 echo.Instance
+	echoboot.NewBuilderOrFail(t, ctx).
+		With(&inoutSplitApp0, echo.Config{
+			Service:             "inoutsplitapp0",
+			Namespace:           ns,
+			Ports:               ports,
+			Galley:              g,
+			Pilot:               p,
+			IncludeInboundPorts: "*",
+		}).
+		With(&inoutSplitApp1, echo.Config{
+			Service:             "inoutsplitapp1",
+			Namespace:           ns,
+			Ports:               ports,
+			Galley:              g,
+			Pilot:               p,
+			IncludeInboundPorts: "*",
+		}).
+		With(
+			&inoutUnitedApp0, echo.Config{
+				Service:   "inoutunitedapp0",
+				Namespace: ns,
+				Ports:     ports,
+				Galley:    g,
+				Pilot:     p,
+			}).
+		With(&inoutUnitedApp1, echo.Config{
+			Service:   "inoutunitedapp1",
+			Namespace: ns,
+			Ports:     ports,
+			Galley:    g,
+			Pilot:     p,
+		}).
+		BuildOrFail(ctx)
+
+	inoutUnitedApp0.WaitUntilCallableOrFail(t, inoutUnitedApp1)
+	log.Infof("%s app ready: %s", ctx.Name(), inoutSplitApp0.Config().Service)
+	inoutSplitApp0.WaitUntilCallableOrFail(t, inoutUnitedApp1)
+	log.Infof("%s app ready: %s", ctx.Name(), inoutSplitApp0.Config().Service)
+
+	connectivityPairs := []appConnectionPair{
+		// source is inout united
+		{inoutUnitedApp0, inoutUnitedApp1},
+		{inoutUnitedApp0, inoutSplitApp1},
+
+		// source is inout split
+		{inoutSplitApp0, inoutUnitedApp1},
+		{inoutSplitApp0, inoutSplitApp1},
+
+		// self connectivity (is it required?)
+		{inoutUnitedApp0, inoutUnitedApp0},
+		{inoutSplitApp0, inoutSplitApp0},
+	}
+
+	for _, pair := range connectivityPairs {
+		connChecker := connection.Checker{
+			From: pair.src,
+			Options: echo.CallOptions{
+				Target:   pair.dst,
+				PortName: strings.ToLower(string(scheme.HTTP)),
+				Scheme:   scheme.HTTP,
+			},
+			ExpectSuccess: true,
+		}
+		subTestName := fmt.Sprintf(
+			"%s->%s:%s",
+			pair.src.Config().Service,
+			pair.dst.Config().Service,
+			connChecker.Options.PortName)
+
+		t.Run(subTestName,
+			func(t *testing.T) {
+				retry.UntilSuccessOrFail(t, connChecker.Check,
+					retry.Delay(time.Second),
+					retry.Timeout(10*time.Second))
+			})
+	}
+}


### PR DESCRIPTION
**Context**
Sidecar proxy is capturing traffic through port 150001 for both inbound and outbound traffic.

**Goal**
Split inbound capture to enable the following istio improvement
- [deprecate bind_to_port=false ](https://github.com/istio/istio/issues/10533)
On top of this PR, I will migrate to filterchain for inbound listener first
- [protocol sniff ](https://github.com/istio/istio/issues/6259)
There is no reason to sniff the outbound traffic

**Description**
Per sidecar proxy could opt-in by setting node xds metadata "INBOUND_INTERCEPTION_SPLIT"
To achieve it, set env var ISTIO_META_INBOUND_INTERCEPTION_SPLIT=true in `istio-proxy` container.

**What is NOT in this PR**
[Negotiate inbound capture port in xds protocol
](https://github.com/istio/api/pull/912)
** How to enable this feature **
- use iptables REDIRECT mode as interception method
- provide env var for iptables script INBOUND_CAPTURE_PORT=15006
- short cut for k8s deployment
Any pod running sidecar proxy could opt-in by set the annotation`sidecar.istio.io/inboundInterceptionSplit`

**Operations**
- Deploy the to the istio build with this PR. Including injector, pilot.
- Redeploy the pods with the annotation. 

Signed-off-by: Yuchen Dai <silentdai@gmail.com>