### PR TITLE
Skip failing test case

### DIFF
--- a/security/pkg/nodeagent/caclient/providers/vault/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/vault/client_test.go
@@ -247,6 +247,7 @@ func TestClientOnMockVaultCA(t *testing.T) {
 }
 
 func TestClientOnExampleHttpVaultCA(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/13668")
 	testCases := map[string]struct {
 		cliConfig clientConfig
 	}{
@@ -275,6 +276,7 @@ func TestClientOnExampleHttpVaultCA(t *testing.T) {
 }
 
 func TestClientOnExampleHttpsVaultCA(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/13668")
 	testCases := map[string]struct {
 		cliConfig clientConfig
 	}{


### PR DESCRIPTION
This test breaks all commits, likely cause by TLS certs expired. This
means all past commits will no longer pass tests, and all new commits
will be blocked. We should disable this test for now until it can be
properly fixed.

https://github.com/istio/istio/issues/13668

If a real fix is applied before this gets in then close this, but this is blocking every other dev currently