### PR TITLE
[Replaced by PR 13685] Disable SDS Vault integration test before Vault server is recovered

### DIFF
--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -54,6 +54,8 @@ const (
 )
 
 func TestSdsVaultCaFlow(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/13674")
+
 	ctx := framework.NewContext(t)
 	defer ctx.Done(t)
 	ctx.RequireOrSkip(t, environment.Kube)


### PR DESCRIPTION
Tests under
- security/pkg/nodeagent/caclient/providers/vault/
- tests/integration/security/sds_vault_flow

fail because the cluster hosting the test Vault server was deleted.

This PR disables SDS Vault integration test before a new test Vault server is created.

Issue: https://github.com/istio/istio/issues/13674

Note: this PR has been replaced by #13685, which fixes the failed integration tests for SDS Vault flow.