### PR TITLE
[Replaced by PR 13684] Disable Vault tests before Vault server is recovered [release 1.1 branch]

### DIFF
--- a/security/pkg/nodeagent/caclient/providers/vault/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/vault/client_test.go
@@ -247,6 +247,8 @@ func TestClientOnMockVaultCA(t *testing.T) {
 }
 
 func TestClientOnExampleHttpVaultCA(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/13674")
+
 	testCases := map[string]struct {
 		cliConfig clientConfig
 	}{
@@ -278,6 +280,8 @@ func TestClientOnExampleHttpVaultCA(t *testing.T) {
 }
 
 func TestClientOnExampleHttpsVaultCA(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/13674")
+
 	testCases := map[string]struct {
 		cliConfig clientConfig
 	}{


### PR DESCRIPTION
Note: this PR has been replaced by https://github.com/istio/istio/pull/13684 that fixes the failed unit tests of Vault CA integration.

Tests under

- security/pkg/nodeagent/caclient/providers/vault/

fail because the cluster hosting the test Vault server was deleted.

This PR disables Vault tests before a new test Vault server is created.

Issue: #13674