### PR TITLE
Fix unit tests of Vault CA integration

### DIFF
--- a/security/pkg/nodeagent/caclient/providers/vault/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/vault/client_test.go
@@ -45,77 +45,7 @@ var (
 	  }
 	}
   `
-	vaultServerTLSCert = `
------BEGIN CERTIFICATE-----
-MIIC3jCCAcagAwIBAgIRAIcSFH1jneS0XPz5r2QDbigwDQYJKoZIhvcNAQELBQAw
-EDEOMAwGA1UEChMFVmF1bHQwIBcNMTgxMjI2MDkwMDU3WhgPMjExODEyMDIwOTAw
-NTdaMBAxDjAMBgNVBAoTBVZhdWx0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
-CgKCAQEA2q5lfJCLAOTEjX3xV8qMLEX8zUQpd0AjD6zzOMzx51GVM7Plf7CJmaDq
-yloRz3zcrTEltHUrln5fvouvp4TetOlqEU979vvccnFLgXrSpn+Zt/EyjE0rUYY3
-5e2qxy9bP2E7zJSKONIT6zRDd2zUQGH3zUem1ZG0GFY1ZL5qFSOIy+PvuQ4u8HCa
-1CcnHmI613fVDbFbaxuF2G2MIwCZ/Fg6KBd9kgU7uCOvkbR4AtRe0ntwweIjOIas
-FiohPQzVY4obrYZiTV43HT4lGti7ySn2c96UnRSnmHLWyBb7cafd4WZN/t+OmYSd
-ooxCVQ2Zqub6NlZ5OySYOz/0BJq6DQIDAQABozEwLzAOBgNVHQ8BAf8EBAMCBaAw
-DAYDVR0TAQH/BAIwADAPBgNVHREECDAGhwQj6fn5MA0GCSqGSIb3DQEBCwUAA4IB
-AQBORvUcW0wgg/Wo1aKFaZQuPPFVLjOZat0QpCJYNDhsSIO4Y0JS+Y1cEIkvXB3S
-Q3D7IfNP0gh1fhtP/d45LQSPqpyJF5vKWAvwa/LSPKpw2+Zys4oDahcH+SEKiQco
-IhkkHNEgC4LEKEaGvY4A8Cw7uWWquUJB16AapSSnkeD2vTcxErfCO59yR7yEWDa6
-8j6QNzmGNj2YXtT86+Mmedhfh65Rrh94mhAPQHBAdCNGCUwZ6zHPQ6Z1rj+x3Wm9
-gqpveVq2olloNbnLNmM3V6F9mqSZACgADmRqf42bixeHczkTfRDKThJcpY5U44vy
-w4Nm32yDWhD6AC68rDkXX68m
------END CERTIFICATE-----
-  `
-	testCsr1 = `
------BEGIN CERTIFICATE REQUEST-----
-MIICojCCAYoCAQAwEzERMA8GA1UEAxMId29ya2xvYWQwggEiMA0GCSqGSIb3DQEB
-AQUAA4IBDwAwggEKAoIBAQCtUKHNG598mQ0wo5+AfZhn2yA8HhL1QV0XERJgBU2p
-PbH/4yIHq++kugWWbj4REE7OPvKjJRdo8yJ9OpjDXA8s5t7fchdr6BePLF6+GfkQ
-ACmnKAziRHMg22Zy+crdVEiyrMAzwujbiBxiI5hcHHB15TX+6lAxaLZJ3BLC4NBd
-YHUeEwvuBV4zLLvKSVE6jFQIvxHKk/Nh/sJvvvSIOWmXPgS6raFPKPTDJ3MjFyCU
-VEz8/HWyaEptX4C91NQxa7/CIJ/DYXtKVbP+jXGaLrLQUX+2r95H2cU604OfMz2Z
-PmYgYUovtb93llwgLKoJk3MjIGEvy4AluGqegrDe5ghfAgMBAAGgSjBIBgkqhkiG
-9w0BCQ4xOzA5MDcGA1UdEQQwMC6GLHNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMv
-ZGVmYXVsdC9zYS9kZWZhdWx0MA0GCSqGSIb3DQEBCwUAA4IBAQCRnzNqI46M1FJL
-IWaQsZj7QeJPrPmuwcGzQ5qRlXBmxAe95N+9DKpmiTwU0tOz375EEjXwVYvs1cZT
-d75Br1kaAMT70LnPUxvSjlcTNItLwlu6LoH/BuaFa5VL1dKFvjRQC3aKFKD634pX
-U82yKWa7kAVPWJAizoz+wf0RIF2KEp0wpd/FPQJaFkAiTrC8rwEhPIfKTLads4HL
-5pWcfODn5eMC7+htiteWsfdhK8Bxjz0VyzSs3BbgAHs+LFkIBGkKe0sl/ii96Bik
-SQYzPWVk89gu6nKV+fS2pA9C8dAnYOzVu9XXc+PGlcIhjnuS+/P74hN5D3aIGljW
-7WsYeEkp
------END CERTIFICATE REQUEST-----
-  `
-	citadelSANonTLS = "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3Nlcn" +
-		"ZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2" +
-		"UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubm" +
-		"FtZSI6InZhdWx0LWNpdGFkZWwtc2EtdG9rZW4tYjdyemsiLCJrdWJlcm5ldGVzLmlvL3" +
-		"NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoidmF1bHQtY2l0YWRlbC" +
-		"1zYSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Ln" +
-		"VpZCI6IjczMmFhMDYyLTBjYWYtMTFlOS1iNWFkLTQyMDEwYThhMDAwYyIsInN1YiI6In" +
-		"N5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0OnZhdWx0LWNpdGFkZWwtc2EifQ.BYX" +
-		"fKQHG3Eu384EY4KlnhFEk6iLZZHVnX03FIrC-xR-tft2AZP0wpGeRNmMMKMiFzXfBQ8j" +
-		"XzarGgPdoWFjVy0R1HuozX-g7WCAkhlMR38IhHr7EFOkue3_73dGNHAXoCQ4C9eAduDn" +
-		"r_yBClB3JMeoJXIS2tvbwZ4BrHJepu7zXJalbWE2n0oucOH2JLIrp_wcA0yCNu6wFXEX" +
-		"S7ghVsiDHKyL1_SmzsZ4gKyhlDUB1UAIbQ9XghXIAK_5Tmo_cKGbZ0MeqJeVUkDr2w-3" +
-		"ZRrnQD8lUEwhkGlgkIjEKAY4yKFliEOIDTft_gz0h6t9zGCn5OmhNolXQ4dIbsEcFgA"
-
-	citadelSATLS = "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3" +
-		"NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3" +
-		"BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZX" +
-		"QubmFtZSI6InZhdWx0LWNpdGFkZWwtc2EtdG9rZW4tcmZxZGoiLCJrdWJlcm5ldGVzLm" +
-		"lvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoidmF1bHQtY2l0YW" +
-		"RlbC1zYSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW" +
-		"50LnVpZCI6IjIzOTk5YzY1LTA4ZjMtMTFlOS1hYzAzLTQyMDEwYThhMDA3OSIsInN1Yi" +
-		"I6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0OnZhdWx0LWNpdGFkZWwtc2EifQ" +
-		".RNH1QbapJKPmktV3tCnpiz7hoYpv1TM6LXzThOtaDp7LFpeANZcJ1zVQdys3Ednlkry" +
-		"kGMepEjsdNuT6ndHfh8jRJAZuNWNPGrhxz4BeUaOqZg3v7AzJlMeFKjY_fiTYYd2gBZZ" +
-		"xkpv1FvAPihHYng2NeN2nKbiZbsnZNU1qFdvbgCISaFqTf0dh75OzgCX_1Fh6HOA7ANf" +
-		"7p522PDW_BRln0RTwUJovCpGeiNCGdujGiNLDZyBcdtikY5ry_KXTdrVAcTUvI6lxwRb" +
-		"ONNfuN8hrIDl95vJjhUlE-O-_cx8qWtXNdqJlMje1SsiPCL4uq70OepG_I4aSzC2o8aD" +
-		"tlQ"
-
-	fakeCert        = []string{"fake-certificate\n", "fake-ca1\n", "fake-ca2\n"}
-	vaultNonTLSAddr = "http://35.247.15.29:8200"
-	vaultTLSAddr    = "https://35.233.249.249:8200"
+	fakeCert = []string{"fake-certificate\n", "fake-ca1\n", "fake-ca2\n"}
 )
 
 type mockVaultServer struct {
@@ -242,64 +172,6 @@ func TestClientOnMockVaultCA(t *testing.T) {
 			} else if !reflect.DeepEqual(resp, tc.expectedCert) {
 				t.Errorf("Test case [%s]: resp: got %+v, expected %v", id, resp, tc.expectedCert)
 			}
-		}
-	}
-}
-
-func TestClientOnExampleHttpVaultCA(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/13668")
-	testCases := map[string]struct {
-		cliConfig clientConfig
-	}{
-		"Valid certs 1": {
-			cliConfig: clientConfig{vaultAddr: vaultNonTLSAddr, vaultLoginPath: "auth/kubernetes/login",
-				vaultLoginRole: "istio-cert", vaultSignCsrPath: "istio_ca/sign/istio-pki-role",
-				clientToken: citadelSANonTLS, csr: []byte(testCsr1)},
-		},
-	}
-
-	for id, tc := range testCases {
-		vaultAddr := tc.cliConfig.vaultAddr
-		cli, err := NewVaultClient(false, []byte{}, vaultAddr, tc.cliConfig.vaultLoginRole,
-			tc.cliConfig.vaultLoginPath, tc.cliConfig.vaultSignCsrPath)
-		if err != nil {
-			t.Errorf("Test case [%s]: failed to create ca client: %v", id, err)
-		}
-
-		resp, err := cli.CSRSign(context.Background(), tc.cliConfig.csr, tc.cliConfig.clientToken, 1)
-		if err != nil {
-			t.Errorf("Test case [%s]:  error (%v) is not expected", id, err.Error())
-		} else if len(resp) != 3 {
-			t.Errorf("Test case [%s]: the certificate chain length (%v) is unexpected", id, len(resp))
-		}
-	}
-}
-
-func TestClientOnExampleHttpsVaultCA(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/13668")
-	testCases := map[string]struct {
-		cliConfig clientConfig
-	}{
-		"Valid certs 1": {
-			cliConfig: clientConfig{vaultAddr: vaultTLSAddr, vaultLoginPath: "auth/kubernetes/login",
-				vaultLoginRole: "istio-cert", vaultSignCsrPath: "istio_ca/sign/istio-pki-role",
-				clientToken: citadelSATLS, csr: []byte(testCsr1)},
-		},
-	}
-
-	for id, tc := range testCases {
-		vaultAddr := tc.cliConfig.vaultAddr
-		cli, err := NewVaultClient(true, []byte(vaultServerTLSCert), vaultAddr, tc.cliConfig.vaultLoginRole,
-			tc.cliConfig.vaultLoginPath, tc.cliConfig.vaultSignCsrPath)
-		if err != nil {
-			t.Errorf("Test case [%s]: failed to create ca client: %v", id, err)
-		}
-
-		resp, err := cli.CSRSign(context.Background(), tc.cliConfig.csr, tc.cliConfig.clientToken, 1)
-		if err != nil {
-			t.Errorf("Test case [%s]:  error (%v) is not expected", id, err.Error())
-		} else if len(resp) != 3 {
-			t.Errorf("Test case [%s]: the certificate chain length (%v) is unexpected", id, len(resp))
 		}
 	}
 }

--- a/tests/integration/security/citadel_agent/vault/README.md
+++ b/tests/integration/security/citadel_agent/vault/README.md
@@ -1,0 +1,34 @@
+The integration tests in this directory use two test Vault servers hosted on Google Kubernetes Engine (GKE);
+one is a TLS Vault server and the other is a non-TLS Vault server.
+
+To set up a Vault server for testing the integration with a Citadel Agent, you can follow
+the following steps.
+
+Install and configure a Vault server. On Kubernetes platform, a detailed guide can be found
+[here](https://evalle.xyz/posts/integration-kubernetes-with-vault-auth/), which includes:
+
+- Generate X509 certificates using openssl commands for the Vault server.
+Since the server is only for testing purpose, the expiration time of X509 certificates
+can be set as a large number.
+
+- Deploy the Vault server. On Kubernetes platform, the Vault server can be deployed
+through a [Kubernetes deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment)
+that ensures that there will be one replica of the Vault server.
+
+- Initialize the Vault server and configure the [Kubernetes Auth Method](https://www.vaultproject.io/docs/auth/kubernetes.html)
+for the Vault server.
+
+After a Vault server is deployed and configured, you may expose the Vault server. 
+
+- If the server is running on Kubernetes,
+it can be exposed through a [LoadBalancer kubernetes service](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#configuration-file).
+After obtaining the external IP fo the load balancer, you can reserve the load balancer IP as
+a static IP (as opposed to an ephemeral IP addresses) so it will be a stable endpoint for the Vault service.
+On GCP platform, an external IP can be reserved as a static IP through the dashboard on "VPC Network" for "External IP addresses".
+If you have a DNS service provider, you may also set up a DNS name for the Vault endpoint.
+
+
+The maintenance for the Vault server:
+
+- On Kubernetes platform, through Kubernetes replica controller automatically monitoring
+the state of the Vault service replica (including restarting the Vault pod), the maintenance should be minimum.

--- a/tests/integration/security/citadel_agent/vault/client_test.go
+++ b/tests/integration/security/citadel_agent/vault/client_test.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"testing"
 
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/label"
+
 	vault "istio.io/istio/security/pkg/nodeagent/caclient/providers/vault"
 )
 
@@ -157,4 +160,10 @@ func TestClientOnExampleHttpsVaultCA(t *testing.T) {
 			t.Errorf("Test case [%s]: the certificate chain length (%v) is unexpected", id, len(resp))
 		}
 	}
+}
+
+// Opt-in to the test framework, implementing a TestMain and calling Run()
+func TestMain(m *testing.M) {
+	// Labels that the whole suite will be ran in post-submit.
+	framework.NewSuite("citadel_agent_vault_client_test", m).Label(label.Postsubmit).Run()
 }

--- a/tests/integration/security/citadel_agent/vault/client_test.go
+++ b/tests/integration/security/citadel_agent/vault/client_test.go
@@ -1,0 +1,160 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vault
+
+import (
+	"context"
+	"testing"
+
+	vault "istio.io/istio/security/pkg/nodeagent/caclient/providers/vault"
+)
+
+var (
+	vaultServerTLSCert = `
+-----BEGIN CERTIFICATE-----
+MIIC3jCCAcagAwIBAgIRAO1S7vuRQmo2He+RtBq3fv8wDQYJKoZIhvcNAQELBQAw
+EDEOMAwGA1UEChMFVmF1bHQwIBcNMTkwNDI3MTY1ODE1WhgPMjExOTA0MDMxNjU4
+MTVaMBAxDjAMBgNVBAoTBVZhdWx0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEA7/CTbnENEIvFZg9hmVtYnOx3OfMy/GNCuP7sqtAeVVTopAKKkcAAWQck
+rhpBooEGpCugNxXGNCuJh/2nu0AfGFRfdafwSJRoI6yHwQouDm0o4r3h9uL3tu5N
+D+x9j+eejbFsoZVn84CxGkEB6oyeXYHjc6eWh3PFGMtKuOQD4pezvDH0yNCx5waK
+htPuYtl0ebfdbyh+WQuptO+Q9VSaQNqE3ipZ461y8PduwRRll241W0gQB2iasX03
+D36F2ZrMz3KEVRVKM1yCUDCy2RPJqkXPdnVMWmDGbe8Uw69zr25JltzuRZFT9HL3
+Y1RnMTecmSc4ikTUHcMhFX3PYbfR5wIDAQABozEwLzAOBgNVHQ8BAf8EBAMCBaAw
+DAYDVR0TAQH/BAIwADAPBgNVHREECDAGhwQiU4HTMA0GCSqGSIb3DQEBCwUAA4IB
+AQCdLh6olDVQB71LD6srbfAE4EsxLEBbIRnv7Nf1S0KQwgW/QxK8DHBwJBxJkr1N
+zgEPx86f2Fo2UsY9m6rvgP3+iquyMsKi0ooUah3y3LSnONuZcdfSTl/HYd38S6Dp
+VkVOZ7781xxpFVUqQ5voQX1Y1Ipn5qw0FyIcNYWLkNX+iMf1b9kpEIWQNhRC/Yiv
+TS0VA/BzQemGyf2UB6QsuZLH+JFEZnzU859qURnNIITa1Wf4YUtka5Sp1kDnEll3
+wj4IlXKU+Wl1CzxJyn4SSQAXy/Lb08ZKrF/YSzcIISnRX5j+wa8ApOSwwA/B7iaT
+TWz1g+RlV9qHap70eIjPsQvb
+-----END CERTIFICATE-----
+  `
+	testCsr1 = `
+-----BEGIN CERTIFICATE REQUEST-----
+MIICojCCAYoCAQAwEzERMA8GA1UEAxMId29ya2xvYWQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCtUKHNG598mQ0wo5+AfZhn2yA8HhL1QV0XERJgBU2p
+PbH/4yIHq++kugWWbj4REE7OPvKjJRdo8yJ9OpjDXA8s5t7fchdr6BePLF6+GfkQ
+ACmnKAziRHMg22Zy+crdVEiyrMAzwujbiBxiI5hcHHB15TX+6lAxaLZJ3BLC4NBd
+YHUeEwvuBV4zLLvKSVE6jFQIvxHKk/Nh/sJvvvSIOWmXPgS6raFPKPTDJ3MjFyCU
+VEz8/HWyaEptX4C91NQxa7/CIJ/DYXtKVbP+jXGaLrLQUX+2r95H2cU604OfMz2Z
+PmYgYUovtb93llwgLKoJk3MjIGEvy4AluGqegrDe5ghfAgMBAAGgSjBIBgkqhkiG
+9w0BCQ4xOzA5MDcGA1UdEQQwMC6GLHNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMv
+ZGVmYXVsdC9zYS9kZWZhdWx0MA0GCSqGSIb3DQEBCwUAA4IBAQCRnzNqI46M1FJL
+IWaQsZj7QeJPrPmuwcGzQ5qRlXBmxAe95N+9DKpmiTwU0tOz375EEjXwVYvs1cZT
+d75Br1kaAMT70LnPUxvSjlcTNItLwlu6LoH/BuaFa5VL1dKFvjRQC3aKFKD634pX
+U82yKWa7kAVPWJAizoz+wf0RIF2KEp0wpd/FPQJaFkAiTrC8rwEhPIfKTLads4HL
+5pWcfODn5eMC7+htiteWsfdhK8Bxjz0VyzSs3BbgAHs+LFkIBGkKe0sl/ii96Bik
+SQYzPWVk89gu6nKV+fS2pA9C8dAnYOzVu9XXc+PGlcIhjnuS+/P74hN5D3aIGljW
+7WsYeEkp
+-----END CERTIFICATE REQUEST-----
+  `
+
+	citadelSANonTLS = "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3Nlcn" +
+		"ZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2" +
+		"UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubm" +
+		"FtZSI6InZhdWx0LWNpdGFkZWwtc2EtdG9rZW4tNjhsNzgiLCJrdWJlcm5ldGVzLmlvL3" +
+		"NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoidmF1bHQtY2l0YWRlbC" +
+		"1zYSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Ln" +
+		"VpZCI6IjcxNzllZGEzLTY4YWYtMTFlOS04MTgyLTQyMDEwYThhMDE1YiIsInN1YiI6In" +
+		"N5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0OnZhdWx0LWNpdGFkZWwtc2EifQ.P5i" +
+		"HNjeIfdvp376YBpM3rmNc7cDzlEWTdDxH6HIkeQtqlDmk_Xf6j4orb5zLYqJspW0DSe0" +
+		"cfdbpoUraFwayaf95N5OrbkHCtPAe5ySOLmKBKO83YRnNGPrpFSQTqb8rvlU291JYEHC" +
+		"LgsuHEeqjNWcGMgwXaHZzInwg6EOlqNvfss0ZxqGTSUIspxQDLrfGD5laO2PoXo29Xk_" +
+		"-xULq8uSaPXb1PATI8d48f7pcWQrxnbhpvTqD2GCqa9kdr_1DiKxkS385K_8HkqIkSvR" +
+		"4iVCISymvFxXv5v4ZSL3bo0cdOySIttdv7kUOWu4_9lo2-k3Hfz8LcQJcGl8paYsIUQ"
+
+	citadelSATLS = "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3Nlcn" +
+		"ZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2" +
+		"UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubm" +
+		"FtZSI6InZhdWx0LWNpdGFkZWwtc2EtdG9rZW4tNzR0d3MiLCJrdWJlcm5ldGVzLmlvL3" +
+		"NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoidmF1bHQtY2l0YWRlbC" +
+		"1zYSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Ln" +
+		"VpZCI6IjJhYzAzYmEyLTY5MTUtMTFlOS05NjkwLTQyMDEwYThhMDExNCIsInN1YiI6In" +
+		"N5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0OnZhdWx0LWNpdGFkZWwtc2EifQ.pZ8" +
+		"SiyNeO0p1p8HB9oXvXOAI1XCJZKk2wVHXBsTSzKWxlVD9HrHbAcSbO2dlhFpeCgknt6e" +
+		"ZywvhShZJh2F6-iHP_YoUVoCqQmzjPoB3c3JoYFpJo-9jTN1_mNRtZUcNvYl-tDlTmBl" +
+		"aKEvoC5P2WGVUF3AoLsES66u4FG9WllmLV92LG1WNqx_ltkT1tahSy9WiHQgyzPqwtwE" +
+		"72T1jAGdgVIoJy1lfSaLam_bo9rqkRlgSg-au9BAjZiDGtm9tf3lwrcgfbxccdlG4jAs" +
+		"TFa2aNs3dW4NLk7mFnWCJa-iWj-TgFxf9TW-9XPK0g3oYIQ0Id0CIW2SiFxKGPAjB-g"
+
+	vaultNonTLSAddr = "http://35.233.183.49:8200"
+	vaultTLSAddr    = "https://34.83.129.211:8200"
+)
+
+type clientConfig struct {
+	vaultAddr        string
+	vaultLoginRole   string
+	vaultLoginPath   string
+	vaultSignCsrPath string
+	clientToken      string
+	csr              []byte
+}
+
+func TestClientOnExampleHttpVaultCA(t *testing.T) {
+	testCases := map[string]struct {
+		cliConfig clientConfig
+	}{
+		"Valid certs 1": {
+			cliConfig: clientConfig{vaultAddr: vaultNonTLSAddr, vaultLoginPath: "auth/kubernetes/login",
+				vaultLoginRole: "istio-cert", vaultSignCsrPath: "istio_ca/sign/istio-pki-role",
+				clientToken: citadelSANonTLS, csr: []byte(testCsr1)},
+		},
+	}
+
+	for id, tc := range testCases {
+		vaultAddr := tc.cliConfig.vaultAddr
+		cli, err := vault.NewVaultClient(false, []byte{}, vaultAddr, tc.cliConfig.vaultLoginRole,
+			tc.cliConfig.vaultLoginPath, tc.cliConfig.vaultSignCsrPath)
+		if err != nil {
+			t.Errorf("Test case [%s]: failed to create ca client: %v", id, err)
+		}
+
+		resp, err := cli.CSRSign(context.Background(), tc.cliConfig.csr, tc.cliConfig.clientToken, 1)
+		if err != nil {
+			t.Errorf("Test case [%s]:  error (%v) is not expected", id, err.Error())
+		} else if len(resp) != 3 {
+			t.Errorf("Test case [%s]: the certificate chain length (%v) is unexpected", id, len(resp))
+		}
+	}
+}
+
+func TestClientOnExampleHttpsVaultCA(t *testing.T) {
+	testCases := map[string]struct {
+		cliConfig clientConfig
+	}{
+		"Valid certs 1": {
+			cliConfig: clientConfig{vaultAddr: vaultTLSAddr, vaultLoginPath: "auth/kubernetes/login",
+				vaultLoginRole: "istio-cert", vaultSignCsrPath: "istio_ca/sign/istio-pki-role",
+				clientToken: citadelSATLS, csr: []byte(testCsr1)},
+		},
+	}
+
+	for id, tc := range testCases {
+		vaultAddr := tc.cliConfig.vaultAddr
+		cli, err := vault.NewVaultClient(true, []byte(vaultServerTLSCert), vaultAddr, tc.cliConfig.vaultLoginRole,
+			tc.cliConfig.vaultLoginPath, tc.cliConfig.vaultSignCsrPath)
+		if err != nil {
+			t.Errorf("Test case [%s]: failed to create ca client: %v", id, err)
+		}
+
+		resp, err := cli.CSRSign(context.Background(), tc.cliConfig.csr, tc.cliConfig.clientToken, 1)
+		if err != nil {
+			t.Errorf("Test case [%s]:  error (%v) is not expected", id, err.Error())
+		} else if len(resp) != 3 {
+			t.Errorf("Test case [%s]: the certificate chain length (%v) is unexpected", id, len(resp))
+		}
+	}
+}


### PR DESCRIPTION
Tests under security/pkg/nodeagent/caclient/providers/vault/ fail because the cluster hosting the test Vault server was deleted.
This PR:
- Fixes the failed tests to use a new Vault server.
- Moves the tests using real Vault server to integration tests.

Issue: https://github.com/istio/istio/issues/13674
