### PR TITLE
Show mcp client synced status in configz page

### DIFF
--- a/pkg/mcp/configz/server/assets/assets.gen.go
+++ b/pkg/mcp/configz/server/assets/assets.gen.go
@@ -69,6 +69,9 @@ var _templatesConfigHtml = []byte(`{{ define "content" }}
         width: 500px;
         word-break: break-all;
     }
+    .unsync_error {
+        background-color: red;
+    }
     </style>
 
     <nav class="navbar navbar-expand-lg navbar-dark">
@@ -108,6 +111,7 @@ var _templatesConfigHtml = []byte(`{{ define "content" }}
                 <th>Collection</th>
                 <th>Version</th>
                 <th>Resources</th>
+                <th>Connections</th>
             </tr>
             </thead>
 
@@ -186,6 +190,19 @@ var _templatesConfigHtml = []byte(`{{ define "content" }}
                         }
                         c3.appendChild(c3_ul)
                         row.appendChild(c3);
+
+                        var c4 = document.createElement("td");
+                        var c4_ul = document.createElement("ul");
+                        for (var addr in data.Snapshots[i].Synced) {
+                            var c4_li = document.createElement("li");
+                            c4_li.innerText =  addr + " " + (data.Snapshots[i].Synced[addr] ? "Synced": "Unsynced");
+                            if (!data.Snapshots[i].Synced[addr]) {
+                                c4_li.className = "unsync_error";
+                            } 
+                            c4_ul.appendChild(c4_li);
+                        }
+                        c4.appendChild(c4_ul)
+                        row.appendChild(c4);
 
                         tbody.appendChild(row)
                     }

--- a/pkg/mcp/configz/server/assets/templates/config.html
+++ b/pkg/mcp/configz/server/assets/templates/config.html
@@ -23,6 +23,9 @@
         width: 500px;
         word-break: break-all;
     }
+    .unsync_error {
+        background-color: red;
+    }
     </style>
 
     <nav class="navbar navbar-expand-lg navbar-dark">
@@ -62,6 +65,7 @@
                 <th>Collection</th>
                 <th>Version</th>
                 <th>Resources</th>
+                <th>Connections</th>
             </tr>
             </thead>
 
@@ -140,6 +144,19 @@
                         }
                         c3.appendChild(c3_ul)
                         row.appendChild(c3);
+
+                        var c4 = document.createElement("td");
+                        var c4_ul = document.createElement("ul");
+                        for (var addr in data.Snapshots[i].Synced) {
+                            var c4_li = document.createElement("li");
+                            c4_li.innerText =  addr + " " + (data.Snapshots[i].Synced[addr] ? "Synced": "Unsynced");
+                            if (!data.Snapshots[i].Synced[addr]) {
+                                c4_li.className = "unsync_error";
+                            } 
+                            c4_ul.appendChild(c4_li);
+                        }
+                        c4.appendChild(c4_ul)
+                        row.appendChild(c4);
 
                         tbody.appendChild(row)
                     }

--- a/pkg/mcp/configz/server/configz_test.go
+++ b/pkg/mcp/configz/server/configz_test.go
@@ -24,12 +24,12 @@ import (
 
 	"github.com/gogo/protobuf/types"
 
-	"istio.io/istio/pkg/ctrlz"
-	"istio.io/istio/pkg/ctrlz/fw"
 	"istio.io/istio/pkg/mcp/snapshot"
 	"istio.io/istio/pkg/mcp/source"
 	mcptest "istio.io/istio/pkg/mcp/testing"
 	"istio.io/istio/pkg/mcp/testing/groups"
+	"istio.io/pkg/ctrlz"
+	"istio.io/pkg/ctrlz/fw"
 )
 
 const testK8sCollection = "k8s/core/v1/nodes"

--- a/pkg/mcp/configz/server/configz_test.go
+++ b/pkg/mcp/configz/server/configz_test.go
@@ -24,13 +24,12 @@ import (
 
 	"github.com/gogo/protobuf/types"
 
-	"istio.io/istio/pkg/mcp/source"
-	"istio.io/istio/pkg/mcp/testing/groups"
-
+	"istio.io/istio/pkg/ctrlz"
+	"istio.io/istio/pkg/ctrlz/fw"
 	"istio.io/istio/pkg/mcp/snapshot"
+	"istio.io/istio/pkg/mcp/source"
 	mcptest "istio.io/istio/pkg/mcp/testing"
-	"istio.io/pkg/ctrlz"
-	"istio.io/pkg/ctrlz/fw"
+	"istio.io/istio/pkg/mcp/testing/groups"
 )
 
 const testK8sCollection = "k8s/core/v1/nodes"
@@ -89,8 +88,8 @@ func testConfigJWithOneRequest(t *testing.T, baseURL string) {
 	}
 
 	exists = false
-	for _, collection := range m["Snapshots"].([]interface{}) {
-		if collection.(map[string]interface{})["Collection"].(string) == testK8sCollection {
+	for _, snapshot := range m["Snapshots"].([]interface{}) {
+		if snapshot.(map[string]interface{})["Collection"].(string) == testK8sCollection {
 			exists = true
 			break
 		}

--- a/pkg/mcp/snapshot/snapshot.go
+++ b/pkg/mcp/snapshot/snapshot.go
@@ -89,7 +89,7 @@ type StatusInfo struct {
 	lastWatchRequestTime time.Time // informational
 	watches              map[int64]*responseWatch
 	// the synced structure is {Collection: {peerAddress: synced|nosynced}}.
-	synced               map[string]map[string]bool
+	synced map[string]map[string]bool
 }
 
 // Watches returns the number of open watches.

--- a/pkg/mcp/snapshot/snapshot.go
+++ b/pkg/mcp/snapshot/snapshot.go
@@ -82,10 +82,9 @@ type responseWatch struct {
 	pushResponse source.PushResponseFunc
 }
 
-// StatusInfo records watch status information of a remote node.
+// StatusInfo records watch status information of a group.
 type StatusInfo struct {
 	mu                   sync.RWMutex
-	node                 *mcp.SinkNode
 	lastWatchRequestTime time.Time // informational
 	watches              map[int64]*responseWatch
 	// the synced structure is {Collection: {peerAddress: synced|nosynced}}.
@@ -168,7 +167,6 @@ func (c *Cache) fillStatus(group string, request *source.Request, peerAddr strin
 	info, ok := c.status[group]
 	if !ok {
 		info = &StatusInfo{
-			node:    request.SinkNode,
 			watches: make(map[int64]*responseWatch),
 			synced:  make(map[string]map[string]bool),
 		}

--- a/pkg/mcp/snapshot/snapshot_test.go
+++ b/pkg/mcp/snapshot/snapshot_test.go
@@ -89,7 +89,7 @@ func createTestWatch(c source.Watcher, collection, version string, responseC cha
 
 	cancel := c.Watch(req, func(response *source.WatchResponse) {
 		responseC <- response
-	})
+	}, "192.168.1.1:1234")
 
 	if wantResponse {
 		select {

--- a/pkg/mcp/source/source.go
+++ b/pkg/mcp/source/source.go
@@ -38,7 +38,6 @@ var scope = log.RegisterScope("mcp", "mcp debugging", 0)
 // be used with the mcp.MeshConfigRequest and mcp.RequestResources. It can
 // be removed once we fully cutover to mcp.RequestResources.
 type Request struct {
-	PeerAddr   string
 	Collection string
 
 	// Most recent version was that ACK/NACK'd by the sink
@@ -83,7 +82,7 @@ type Watcher interface {
 	//
 	// Cancel is an optional function to release resources in the
 	// producer. It can be called idempotently to cancel and release resources.
-	Watch(*Request, PushResponseFunc) CancelWatchFunc
+	Watch(*Request, PushResponseFunc, string) CancelWatchFunc
 }
 
 // CollectionOptions configures the per-collection updates.
@@ -442,13 +441,12 @@ func (con *connection) processClientRequest(req *mcp.RequestResources) error {
 		}
 
 		sr := &Request{
-			PeerAddr:    con.peerAddr,
 			SinkNode:    req.SinkNode,
 			Collection:  collection,
 			VersionInfo: versionInfo,
 			incremental: req.Incremental,
 		}
-		w.cancel = con.watcher.Watch(sr, con.queueResponse)
+		w.cancel = con.watcher.Watch(sr, con.queueResponse, con.peerAddr)
 	} else {
 		// This error path should not happen! Skip any requests that don't match the
 		// latest watch's nonce. These could be dup requests or out-of-order

--- a/pkg/mcp/source/source.go
+++ b/pkg/mcp/source/source.go
@@ -38,6 +38,7 @@ var scope = log.RegisterScope("mcp", "mcp debugging", 0)
 // be used with the mcp.MeshConfigRequest and mcp.RequestResources. It can
 // be removed once we fully cutover to mcp.RequestResources.
 type Request struct {
+	PeerAddr   string
 	Collection string
 
 	// Most recent version was that ACK/NACK'd by the sink
@@ -441,6 +442,7 @@ func (con *connection) processClientRequest(req *mcp.RequestResources) error {
 		}
 
 		sr := &Request{
+			PeerAddr:    con.peerAddr,
 			SinkNode:    req.SinkNode,
 			Collection:  collection,
 			VersionInfo: versionInfo,

--- a/pkg/mcp/source/source_test.go
+++ b/pkg/mcp/source/source_test.go
@@ -181,7 +181,7 @@ func (h *sourceTestHarness) watchesCreated(typeURL string) int {
 	return h.watchCreated[typeURL]
 }
 
-func (h *sourceTestHarness) Watch(req *Request, pushResponse PushResponseFunc) CancelWatchFunc {
+func (h *sourceTestHarness) Watch(req *Request, pushResponse PushResponseFunc, peerAddr string) CancelWatchFunc {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 


### PR DESCRIPTION
Sub-task of https://github.com/istio/istio/issues/12298 to show the mcp clients synced status
Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>

<img width="1201" alt="image" src="https://user-images.githubusercontent.com/7711311/56876802-7ac91c00-6a7c-11e9-91c4-6b923a279918.png">
