### PR TITLE
Injecting extra Grafana configurations to Kiali ConfigMap

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
@@ -19,4 +19,8 @@ data:
       jaeger:
         url: {{ .Values.dashboard.jaegerURL }}
       grafana:
+{{- if .Values.dashboard.grafana }}
+{{ toYaml .Values.dashboard.grafana | indent 8 }}
+{{- else }}
         url: {{ .Values.dashboard.grafanaURL }}
+{{- end }}


### PR DESCRIPTION
Kiali supports many options when it comes to communicating with Grafana, [according to this](https://github.com/kiali/kiali/blob/73b9ef0a5a12726550a4b05f2e8e4454b5cb2a91/operator/roles/kiali-deploy/defaults/main.yml#L39-L51).

My changes in this PR, is to check for `grafana` under `dashboard` in values in helm chart and use that otherwise will fall into default `grafanaURL` for backward compatibility.