### PR TITLE
Add support for PVC in Prometheus

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
           args:
             - '--storage.tsdb.retention={{ .Values.retention }}'
             - '--config.file=/etc/prometheus/prometheus.yml'
+            - '--storage.tsdb.path={{ .Values.persistentVolume.mountPath }}'
           ports:
             - containerPort: 9090
               name: http
@@ -67,6 +68,9 @@ spec:
             mountPath: /etc/prometheus
           - mountPath: /etc/istio-certs
             name: istio-certs
+          - name: storage-volume
+            mountPath: {{ .Values.persistentVolume.mountPath }}
+            subPath: "{{ .Values.persistentVolume.subPath }}"
       volumes:
       - name: config-volume
         configMap:
@@ -76,6 +80,13 @@ spec:
           defaultMode: 420
           optional: true
           secretName: istio.default
+      - name: storage-volume
+        {{- if .Values.persistentVolume.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.fullname" . }}{{- end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end -}}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -45,7 +45,9 @@ spec:
           args:
             - '--storage.tsdb.retention={{ .Values.retention }}'
             - '--config.file=/etc/prometheus/prometheus.yml'
+            {{- if .Values.persistentVolume.enabled }}
             - '--storage.tsdb.path={{ .Values.persistentVolume.mountPath }}'
+            {{- end }}
           ports:
             - containerPort: 9090
               name: http

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
             claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.fullname" . }}{{- end }}
         {{- else }}
           emptyDir: {}
-        {{- end -}}
+        {{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/pvc.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/pvc.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.persistentVolume.enabled -}}
+{{- if not .Values.persistentVolume.existingClaim -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{- if .Values.persistentVolume.annotations }}
+  annotations:
+{{ toYaml .Values.persistentVolume.annotations | indent 4 }}
+  {{- end }}
+  name: {{ template "prometheus.fullname" . }}
+spec:
+  accessModes:
+{{ toYaml .Values.persistentVolume.accessModes | indent 4 }}
+{{- if .Values.persistentVolume.storageClass }}
+{{- if (eq "-" .Values.persistentVolume.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+{{- end }}
+{{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.persistentVolume.size }}"
+{{- end -}}
+{{- end -}}

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -56,3 +56,47 @@ service:
 
 security:
   enabled: true
+
+persistentVolume:
+  ## If true, Prometheus server will create/use a Persistent Volume Claim
+  ## If false, use emptyDir
+  ##
+  enabled: false
+
+  ## Prometheus server data Persistent Volume access modes
+  ## Must match those of existing PV or dynamic provisioner
+  ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  accessModes:
+    - ReadWriteOnce
+
+  ## Prometheus server data Persistent Volume annotations
+  ##
+  annotations: {}
+
+  ## Prometheus server data Persistent Volume existing claim name
+  ## Requires server.persistentVolume.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  existingClaim: ""
+
+  ## Prometheus server data Persistent Volume mount root path
+  ##
+  mountPath: /data
+
+  ## Prometheus server data Persistent Volume size
+  ##
+  size: 8Gi
+
+  ## Prometheus server data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+
+  ## Subdirectory of Prometheus server data Persistent Volume to mount
+  ## Useful if the volume's root directory is not empty
+  ##
+  subPath: ""


### PR DESCRIPTION
We saw the issue in our prometheus installation that without the pvc our prometheus used a lot of disc creating a lot of pod evictions in our system.

The PVC is based on the official prometheus chart and how the pvc is setup there.