### PR TITLE
Add istio-env label when creating test namespaces.

### DIFF
--- a/pkg/test/docker/registry/incluster.go
+++ b/pkg/test/docker/registry/incluster.go
@@ -74,7 +74,7 @@ func writeTemplateInTempfile(tmpl *template.Template, data interface{}) (string,
 // Start sets up registry and returns if any error was found while doing that.
 func (r *InClusterRegistry) Start() error {
 
-	if err := r.accessor.CreateNamespace(r.namespace, "", false); err != nil {
+	if err := r.accessor.CreateNamespace(r.namespace, ""); err != nil {
 		if !strings.Contains(err.Error(), "already exist") {
 			return err
 		}

--- a/pkg/test/framework/components/apps/kube.go
+++ b/pkg/test/framework/components/apps/kube.go
@@ -32,9 +32,9 @@ import (
 	"istio.io/istio/pkg/test/deployment"
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/echo/proto"
-	deployment2 "istio.io/istio/pkg/test/framework/components/deployment"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/core/image"
 	"istio.io/istio/pkg/test/framework/resource"
 	testKube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/util/tmpl"
@@ -697,7 +697,7 @@ type deploymentFactory struct {
 }
 
 func (d *deploymentFactory) newDeployment(e *kube.Environment, namespace namespace.Instance) (*deployment.Instance, error) {
-	s, err := deployment2.SettingsFromCommandLine()
+	s, err := image.SettingsFromCommandLine()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -18,7 +18,8 @@ import (
 	"fmt"
 	"text/template"
 
-	"istio.io/istio/pkg/test/framework/components/deployment"
+	"istio.io/istio/pkg/test/framework/core/image"
+
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/util/tmpl"
 )
@@ -151,7 +152,7 @@ func init() {
 
 func generateYAML(cfg echo.Config) (string, error) {
 	// Create the parameters for the YAML template.
-	settings, err := deployment.SettingsFromCommandLine()
+	settings, err := image.SettingsFromCommandLine()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -22,14 +22,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 	yaml2 "gopkg.in/yaml.v2"
 
 	kubeCore "k8s.io/api/core/v1"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
-	"istio.io/istio/pkg/test/framework/components/deployment"
+	"istio.io/istio/pkg/test/framework/core/image"
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
@@ -171,7 +171,7 @@ func DefaultConfig(ctx resource.Context) (Config, error) {
 		return Config{}, err
 	}
 
-	deps, err := deployment.SettingsFromCommandLine()
+	deps, err := image.SettingsFromCommandLine()
 	if err != nil {
 		return Config{}, err
 	}
@@ -218,7 +218,7 @@ func checkFileExists(path string) error {
 	return nil
 }
 
-func newHelmValues(s *deployment.Settings) (map[string]string, error) {
+func newHelmValues(s *image.Settings) (map[string]string, error) {
 	userValues, err := parseHelmValues()
 	if err != nil {
 		return nil, err
@@ -228,9 +228,9 @@ func newHelmValues(s *deployment.Settings) (map[string]string, error) {
 	values := make(map[string]string)
 
 	// Common values
-	values[deployment.HubValuesKey] = s.Hub
-	values[deployment.TagValuesKey] = s.Tag
-	values[deployment.ImagePullPolicyValuesKey] = s.PullPolicy
+	values[image.HubValuesKey] = s.Hub
+	values[image.TagValuesKey] = s.Tag
+	values[image.ImagePullPolicyValuesKey] = s.PullPolicy
 
 	// Copy the user values.
 	for k, v := range userValues {
@@ -238,8 +238,8 @@ func newHelmValues(s *deployment.Settings) (map[string]string, error) {
 	}
 
 	// Always pull Docker images if using the "latest".
-	if values[deployment.TagValuesKey] == deployment.LatestTag {
-		values[deployment.ImagePullPolicyValuesKey] = string(kubeCore.PullAlways)
+	if values[image.TagValuesKey] == image.LatestTag {
+		values[image.ImagePullPolicyValuesKey] = string(kubeCore.PullAlways)
 	}
 	return values, nil
 }

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
 	k "istio.io/istio/pkg/test/kube"
 )
@@ -64,8 +65,13 @@ func (n *kubeNamespace) Close() error {
 
 func claimKube(ctx resource.Context, name string) (Instance, error) {
 	env := ctx.Environment().(*kube.Environment)
+	cfg, err := istio.DefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	if !env.Accessor.NamespaceExists(name) {
-		if err := env.CreateNamespace(name, "istio-test", true); err != nil {
+		if err := env.CreateNamespaceWithInjectionEnabled(name, "istio-test", cfg.ConfigNamespace); err != nil {
 			return nil, err
 		}
 
@@ -83,8 +89,21 @@ func newKube(ctx resource.Context, prefix string, inject bool) (Instance, error)
 
 	env := ctx.Environment().(*kube.Environment)
 	ns := fmt.Sprintf("%s-%d-%d", prefix, nsid, r)
-	if err := env.CreateNamespace(ns, "istio-test", inject); err != nil {
-		return nil, err
+
+	if inject {
+		cfg, err := istio.DefaultConfig(ctx)
+		if err != nil {
+			return nil, err
+		}
+		err = env.CreateNamespaceWithInjectionEnabled(ns, "istio-test", cfg.ConfigNamespace)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err := env.CreateNamespace(ns, "istio-test")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	n := &kubeNamespace{name: ns, a: env.Accessor}

--- a/pkg/test/framework/components/policybackend/kube.go
+++ b/pkg/test/framework/components/policybackend/kube.go
@@ -21,11 +21,12 @@ import (
 	"os"
 	"path"
 
+	"istio.io/istio/pkg/test/framework/core/image"
+
 	kubeApiCore "k8s.io/api/core/v1"
 
 	"istio.io/istio/pkg/test/deployment"
 	"istio.io/istio/pkg/test/fakes/policy"
-	deployment2 "istio.io/istio/pkg/test/framework/components/deployment"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -179,7 +180,7 @@ func newKube(ctx resource.Context) (Instance, error) {
 		return nil, err
 	}
 
-	s, err := deployment2.SettingsFromCommandLine()
+	s, err := image.SettingsFromCommandLine()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/core/image/flags.go
+++ b/pkg/test/framework/core/image/flags.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package deployment
+package image
 
 import (
 	"flag"

--- a/pkg/test/framework/core/image/settings.go
+++ b/pkg/test/framework/core/image/settings.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package deployment
+package image
 
 import "fmt"
 

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/scopes"
@@ -354,8 +354,28 @@ func (a *Accessor) GetEndpoints(ns, service string, options kubeApiMeta.GetOptio
 }
 
 // CreateNamespace with the given name. Also adds an "istio-testing" annotation.
-func (a *Accessor) CreateNamespace(ns string, istioTestingAnnotation string, injectionEnabled bool) error {
+func (a *Accessor) CreateNamespace(ns string, istioTestingAnnotation string) error {
 	scopes.Framework.Debugf("Creating namespace: %s", ns)
+
+	n := a.newNamespace(ns, istioTestingAnnotation)
+
+	_, err := a.set.CoreV1().Namespaces().Create(&n)
+	return err
+}
+
+func (a *Accessor) CreateNamespaceWithInjectionEnabled(ns string, istioTestingAnnotation string, configNamespace string) error {
+	scopes.Framework.Debugf("Creating namespace with injection enabled: %s", ns)
+
+	n := a.newNamespace(ns, istioTestingAnnotation)
+
+	n.ObjectMeta.Labels["istio-injection"] = "enabled"
+	n.ObjectMeta.Labels["istio-env"] = configNamespace
+
+	_, err := a.set.CoreV1().Namespaces().Create(&n)
+	return err
+}
+
+func (a *Accessor) newNamespace(ns string, istioTestingAnnotation string) kubeApiCore.Namespace {
 	n := kubeApiCore.Namespace{
 		ObjectMeta: kubeApiMeta.ObjectMeta{
 			Name:   ns,
@@ -365,13 +385,7 @@ func (a *Accessor) CreateNamespace(ns string, istioTestingAnnotation string, inj
 	if istioTestingAnnotation != "" {
 		n.ObjectMeta.Labels["istio-testing"] = istioTestingAnnotation
 	}
-	if injectionEnabled {
-		n.ObjectMeta.Labels["istio-injection"] = "enabled"
-		n.ObjectMeta.Labels["istio-env"] = "istio-control"
-	}
-
-	_, err := a.set.CoreV1().Namespaces().Create(&n)
-	return err
+	return n
 }
 
 // NamespaceExists returns true if the given namespace exists.

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -367,6 +367,7 @@ func (a *Accessor) CreateNamespace(ns string, istioTestingAnnotation string, inj
 	}
 	if injectionEnabled {
 		n.ObjectMeta.Labels["istio-injection"] = "enabled"
+		n.ObjectMeta.Labels["istio-env"] = "istio-control"
 	}
 
 	_, err := a.set.CoreV1().Namespaces().Create(&n)


### PR DESCRIPTION
The [installer in istio-ecosystem](https://github.com/istio-ecosystem/istio-installer)] supports multiple control planes. To identify which control plane instance should provide configuration for the pods in a namespace, the namespace label `istio-env:NAME_OF_ENV` is used instead of `istio-injected:true`.

When running the echo test in a standard istio installation with the istio-ecosystem installer, the echosrv pods do not get a sidecar, since the `istio-env`-label is missing for test namespaces. To fix this and successfully execute the test, it needs to be set to `istio-control`.