### PR TITLE
Fix the RPM proxy generation

### DIFF
--- a/tools/packaging/rpm/Dockerfile.build
+++ b/tools/packaging/rpm/Dockerfile.build
@@ -3,6 +3,7 @@ FROM centos:7
 RUN yum upgrade -y && \
     yum install -y epel-release centos-release-scl && \
     yum install -y fedpkg golang sudo make which cmake3 \
+                   automake autoconf autogen libtool \
                    devtoolset-6-gcc devtoolset-6-gcc-c++ \
                    devtoolset-6-libatomic-devel ninja-build && \
     yum clean all


### PR DESCRIPTION
It's failing with errors like:

```
Error applying patch command ./autogen.sh:
./autogen.sh: line 3: autoreconf: command not found
```