### PR TITLE
Add owner reference to model config meta object

### DIFF
--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -375,7 +375,7 @@ func (cl *Client) Get(typ, name, namespace string) *model.Config {
 func (cl *Client) Create(config model.Config) (string, error) {
 	rc, ok := cl.clientset[apiVersionFromConfig(&config)]
 	if !ok {
-		return "", fmt.Errorf("unrecognized apiVersion %q", config)
+		return "", fmt.Errorf("unrecognized apiVersion %v", config)
 	}
 
 	schema, exists := rc.descriptor.GetByType(config.Type)
@@ -409,7 +409,7 @@ func (cl *Client) Create(config model.Config) (string, error) {
 func (cl *Client) Update(config model.Config) (string, error) {
 	rc, ok := cl.clientset[apiVersionFromConfig(&config)]
 	if !ok {
-		return "", fmt.Errorf("unrecognized apiVersion %q", config)
+		return "", fmt.Errorf("unrecognized apiVersion %v", config)
 	}
 	schema, exists := rc.descriptor.GetByType(config.Type)
 	if !exists {

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -50,6 +50,7 @@ func ConvertObject(schema model.ProtoSchema, object IstioObject, domain string) 
 			Annotations:       meta.Annotations,
 			ResourceVersion:   meta.ResourceVersion,
 			CreationTimestamp: meta.CreationTimestamp.Time,
+			OwnerReference:    meta.OwnerReferences,
 		},
 		Spec: data,
 	}, nil
@@ -75,6 +76,7 @@ func ConvertObjectFromUnstructured(schema model.ProtoSchema, un *unstructured.Un
 			Annotations:       un.GetAnnotations(),
 			ResourceVersion:   un.GetResourceVersion(),
 			CreationTimestamp: un.GetCreationTimestamp().Time,
+			OwnerReference:    un.GetOwnerReferences(),
 		},
 		Spec: data,
 	}, nil
@@ -97,6 +99,7 @@ func ConvertConfig(schema model.ProtoSchema, config model.Config) (IstioObject, 
 		ResourceVersion: config.ResourceVersion,
 		Labels:          config.Labels,
 		Annotations:     config.Annotations,
+		OwnerReferences: config.OwnerReference,
 	})
 	out.SetSpec(spec)
 

--- a/pilot/pkg/config/kube/crd/conversion_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/mock"

--- a/pilot/pkg/config/kube/crd/conversion_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/mock"
 )
@@ -50,6 +52,8 @@ func TestConvert(t *testing.T) {
 	if _, err := ConvertObject(model.VirtualService, &IstioKind{Spec: map[string]interface{}{"x": 1}}, "local"); err == nil {
 		t.Errorf("expected error for converting empty object")
 	}
+	blockOwnerDeletion := false
+	controller := true
 	config := model.Config{
 		ConfigMeta: model.ConfigMeta{
 			Type:            model.VirtualService.Type,
@@ -61,6 +65,14 @@ func TestConvert(t *testing.T) {
 			ResourceVersion: "1234",
 			Labels:          map[string]string{"label": "value"},
 			Annotations:     map[string]string{"annotation": "value"},
+			OwnerReference: []v1.OwnerReference{{
+				APIVersion:         "controller.io/v1alpha1",
+				BlockOwnerDeletion: &blockOwnerDeletion,
+				Controller:         &controller,
+				Kind:               "Configuration",
+				Name:               "Controller-name",
+				UID:                "b2901f73-6082-11e9-a067-008cfac35720",
+			}},
 		},
 		Spec: mock.ExampleVirtualService,
 	}

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	authn "istio.io/api/authentication/v1alpha1"
 	mccpb "istio.io/api/mixer/v1/config/client"

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	authn "istio.io/api/authentication/v1alpha1"
 	mccpb "istio.io/api/mixer/v1/config/client"
 	networking "istio.io/api/networking/v1alpha3"
@@ -85,6 +87,11 @@ type ConfigMeta struct {
 
 	// CreationTimestamp records the creation time
 	CreationTimestamp time.Time `json:"creationTimestamp,omitempty"`
+
+	// OwnerReference is a list of objects which are dependent on this object.
+	// If there is a controller managing this object, there will be an
+	// entry with the controller field set to true.
+	OwnerReference []v1.OwnerReference `json:"ownerReferences,omitempty"`
 }
 
 // Config is a configuration unit consisting of the type of configuration, the


### PR DESCRIPTION
We are working on creating a controller (https://github.com/yahoo/k8s-athenz-istio-auth) which dynamically creates ServiceRoles and ServiceRoleBindings and would like to have an OwnerReference section in the metadata similar to other Kubernetes controllers.