### PR TITLE
Remove too noisy log

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -813,7 +813,7 @@ func (c *Controller) updateEDS(ep *v1.Endpoints, event model.Event) {
 	// TODO: Endpoints include the service labels, maybe we can use them ?
 	// nodeName is also included, not needed
 
-	log.Infof("Handle EDS endpoint %s in namespace %s -> %v %v", ep.Name, ep.Namespace, ep.Subsets, endpoints)
+	log.Infof("Handle EDS endpoint %s in namespace %s -> %v", ep.Name, ep.Namespace, ep.Subsets)
 
 	_ = c.XDSUpdater.EDSUpdate(c.ClusterID, string(hostname), endpoints)
 }


### PR DESCRIPTION
When there are tons of endpoints, it it too long log, may influence performance as well.