### PR TITLE
Fix istioctl authn when there are multiple pilot instances

### DIFF
--- a/istioctl/cmd/istioctl/authn.go
+++ b/istioctl/cmd/istioctl/authn.go
@@ -15,12 +15,14 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/istioctl/pkg/writer/pilot"
+	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 )
 
 func tlsCheck() *cobra.Command {
@@ -46,10 +48,22 @@ istioctl authn tls-check 656bd7df7c-5zp4s.default bar
 				return err
 			}
 			podName, ns := inferPodInfo(args[0], handleNamespace())
-			debug, err := kubeClient.PilotDiscoveryDo(istioNamespace, "GET",
+			results, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, "GET",
 				fmt.Sprintf("/debug/authenticationz?proxyID=%s.%s", podName, ns), nil)
 			if err != nil {
 				return err
+			}
+			var debug []v2.AuthenticationDebug
+			for i := range results {
+				if err := json.Unmarshal(results[i], &debug); err != nil {
+					return err
+				}
+				if len(debug) > 0 {
+					break
+				}
+			}
+			if len(debug) == 0 {
+				return fmt.Errorf("checked %d pilot instances and found no authentication info for this pod, check proxy status", len(results))
 			}
 			tcw := pilot.TLSCheckWriter{Writer: cmd.OutOrStdout()}
 			if len(args) >= 2 {

--- a/istioctl/pkg/writer/pilot/auth_test.go
+++ b/istioctl/pkg/writer/pilot/auth_test.go
@@ -16,7 +16,6 @@ package pilot
 
 import (
 	"bytes"
-	"encoding/json"
 	"io/ioutil"
 	"testing"
 
@@ -47,8 +46,7 @@ func TestTLSCheckWriter_PrintAll(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := &bytes.Buffer{}
 			tcw := TLSCheckWriter{Writer: got}
-			input, _ := json.Marshal(tt.input)
-			err := tcw.PrintAll(input)
+			err := tcw.PrintAll(tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -85,8 +83,7 @@ func TestTLSCheckWriter_PrintSingle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := &bytes.Buffer{}
 			tcw := TLSCheckWriter{Writer: got}
-			input, _ := json.Marshal(tt.input)
-			err := tcw.PrintSingle(input, tt.filterService)
+			err := tcw.PrintSingle(tt.input, tt.filterService)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/istioctl/pkg/writer/pilot/auth_test.go
+++ b/istioctl/pkg/writer/pilot/auth_test.go
@@ -27,19 +27,14 @@ import (
 
 func TestTLSCheckWriter_PrintAll(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   []v2.AuthenticationDebug
-		want    string
-		wantErr bool
+		name  string
+		input []v2.AuthenticationDebug
+		want  string
 	}{
 		{
 			name:  "prints full auth debug output",
 			input: authInput(),
 			want:  "testdata/multiAuth.txt",
-		},
-		{
-			name:    "error if given non-auth info",
-			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -47,11 +42,7 @@ func TestTLSCheckWriter_PrintAll(t *testing.T) {
 			got := &bytes.Buffer{}
 			tcw := TLSCheckWriter{Writer: got}
 			err := tcw.PrintAll(tt.input)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+			assert.NoError(t, err)
 			want, _ := ioutil.ReadFile(tt.want)
 			if err := util.Compare(got.Bytes(), want); err != nil {
 				t.Errorf(err.Error())
@@ -66,7 +57,6 @@ func TestTLSCheckWriter_PrintSingle(t *testing.T) {
 		input         []v2.AuthenticationDebug
 		filterService string
 		want          string
-		wantErr       bool
 	}{
 		{
 			name:          "prints filtered auth debug output",
@@ -74,21 +64,13 @@ func TestTLSCheckWriter_PrintSingle(t *testing.T) {
 			input:         authInput(),
 			want:          "testdata/singleAuth.txt",
 		},
-		{
-			name:    "error if given non-auth info",
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := &bytes.Buffer{}
 			tcw := TLSCheckWriter{Writer: got}
 			err := tcw.PrintSingle(tt.input, tt.filterService)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+			assert.NoError(t, err)
 			want, _ := ioutil.ReadFile(tt.want)
 			if err := util.Compare(got.Bytes(), want); err != nil {
 				t.Errorf(err.Error())


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/13028

If there are multiple pilot instances, only the pilot that's connected to a proxy will have the authn data. So we need to check all pilot instances and display the one that returns data.

I had to move the json unmarshal up one level so that we can inspect the contents before we attempt to print the results.

This is a fix for 1.1.x, and will be obsolete in 1.2 when https://github.com/istio/istio/pull/12774 ships.