### PR TITLE
Change time.After to time.NewTimer

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -882,7 +882,6 @@ func (s *DiscoveryServer) startPush(version string, push *model.PushContext, ful
 				adsLog.Infof("PushAll abort %s, push with newer version %s in progress %v", version, currentVersion, time.Since(tstart))
 				return
 			}
-			adsLog.Warnf("Pushing an event to ADS")
 			timer := time.NewTimer(PushTimeout)
 
 			select {
@@ -914,10 +913,8 @@ func (s *DiscoveryServer) startPush(version string, push *model.PushContext, ful
 					pushTimeoutFailures.Add(1)
 					return
 				}
-				adsLog.Warnf("Done pushing an event in ADS- Retry")
 				goto Retry
 			}
-			adsLog.Warnf("Done pushing an event in ADS")
 		}()
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -914,15 +914,8 @@ func (s *DiscoveryServer) startPush(version string, push *model.PushContext, ful
 					pushTimeoutFailures.Add(1)
 					return
 				}
-				if !timer.Stop() {
-					<-timer.C
-				}
 				adsLog.Warnf("Done pushing an event in ADS- Retry")
-
 				goto Retry
-			}
-			if !timer.Stop() {
-				<-timer.C
 			}
 			adsLog.Warnf("Done pushing an event in ADS")
 		}()


### PR DESCRIPTION
This fixes a problem where with 300 replicas on a single node cfluster,
the replicas don't enter 2/2 RUNNING state consistently but instead spam
pilot warnings about port 8080 not being present until the end of time.

time.After documentation clearly states the following:

"
After waits for the duration to elapse and then sends the
current time on the returned channel. It is equivalent to
NewTimer(d).C. `The underlying Timer is not recovered by the
garbage collector until the timer fires.` If efficiency is a concern,
use NewTimer instead and call Timer.Stop if the timer is no longer needed.
"

In the case of this ads code, we desire to stop the timer before it
expires (or reset it).  This implementation isn't quite right.  Prior
to this PR the timer expired on every single event fed to ADS because
the implementation had a defect.  This resulted in sidecars not
receiving the appropriate information they expect.