### PR TITLE
Add support for HTTP query param matching

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -550,6 +550,28 @@ func translateRouteMatch(in *networking.HTTPMatchRequest) route.RouteMatch {
 		out.Headers = append(out.Headers, &matcher)
 	}
 
+	for name, stringMatch := range in.QueryParams {
+		matcher := translateQueryParamMatch(name, stringMatch)
+		out.QueryParameters = append(out.QueryParameters, &matcher)
+	}
+
+	return out
+}
+
+// translateQueryParamMatch translates a StringMatch to a QueryParameterMatcher.
+func translateQueryParamMatch(name string, in *networking.StringMatch) route.QueryParameterMatcher {
+	out := route.QueryParameterMatcher{
+		Name: name,
+	}
+
+	switch m := in.MatchType.(type) {
+	case *networking.StringMatch_Exact:
+		out.Value = m.Exact
+	case *networking.StringMatch_Regex:
+		out.Value = m.Regex
+		out.Regex = &types.BoolValue{Value: true}
+	}
+
 	return out
 }
 


### PR DESCRIPTION
This adds support for configuring query parameter matching by translating the `query_params` configuration from `HTTPMatchRequest` into a Envoy `QueryParameterMatcher` instance. See #12782 for more details.