### PR TITLE
add samples validation linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ bin/protoc-min-version*
 bin/protoc-gen-docs*
 bin/testlinter
 bin/envvarlinter
+bin/istioctl
 # Install generated files
 install/consul/istio.yaml
 install/kubernetes/istio-demo.yaml

--- a/bin/check_samples.sh
+++ b/bin/check_samples.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+shopt -s globstar
+set -e
+
+SCRIPTPATH=$( cd "$(dirname "$0")" && pwd -P )
+ROOTDIR=$SCRIPTPATH/..
+cd "$ROOTDIR" || exit
+
+# rely on go build cache
+ISTIOCTL=bin/istioctl
+go build -o $ISTIOCTL ./istioctl/cmd/istioctl
+
+for f in samples/**/*.yaml; do
+  echo "Validating $f..."
+  $ISTIOCTL validate -x \
+    -f mixer/testdata/config/attributes.yaml \
+    -f samples/httpbin/policy/keyval-template.yaml \
+    -f "$f"
+done

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -93,6 +93,7 @@ function check_samples() {
     echo 'Checking documentation samples with istioctl'
     bin/check_samples.sh
     echo 'Samples OK'
+}
 
 ensure_pilot_types
 check_licenses

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -89,6 +89,11 @@ function check_licenses() {
     echo 'Licenses OK'
 }
 
+function check_samples() {
+    echo 'Checking documentation samples with istioctl'
+    bin/check_samples.sh
+    echo 'Samples OK'
+
 ensure_pilot_types
 check_licenses
 install_golangcilint
@@ -98,3 +103,4 @@ run_test_lint
 run_envvar_lint
 run_helm_lint
 check_grafana_dashboards
+check_samples

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -96,7 +96,7 @@ func (v *validator) validateResource(un *unstructured.Unstructured) error {
 			return err
 		}
 		if _, ok := validMixerKinds[un.GetKind()]; !ok {
-			log.Warnf("deprecated Mixer kind %q, please use %q or %q, instead", un.GetKind(),
+			log.Warnf("deprecated Mixer kind %q, please use %q or %q instead", un.GetKind(),
 				constant.HandlerKind, constant.InstanceKind)
 		}
 

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -27,9 +27,11 @@ import (
 
 	mixercrd "istio.io/istio/mixer/pkg/config/crd"
 	mixerstore "istio.io/istio/mixer/pkg/config/store"
+	"istio.io/istio/mixer/pkg/runtime/config/constant"
 	mixervalidate "istio.io/istio/mixer/pkg/validate"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/log"
 )
 
 var (
@@ -47,6 +49,15 @@ Example resource specifications include:
 		"metadata":   {},
 		"spec":       {},
 		"status":     {},
+	}
+
+	validMixerKinds = map[string]struct{}{
+		constant.RulesKind:             {},
+		constant.AdapterKind:           {},
+		constant.TemplateKind:          {},
+		constant.HandlerKind:           {},
+		constant.InstanceKind:          {},
+		constant.AttributeManifestKind: {},
 	}
 )
 
@@ -84,6 +95,11 @@ func (v *validator) validateResource(un *unstructured.Unstructured) error {
 		if err := checkFields(un); err != nil {
 			return err
 		}
+		if _, ok := validMixerKinds[un.GetKind()]; !ok {
+			log.Warnf("deprecated Mixer kind %q, please use %q or %q, instead", un.GetKind(),
+				constant.HandlerKind, constant.InstanceKind)
+		}
+
 		return v.mixerValidator.Validate(&mixerstore.BackendEvent{
 			Type: mixerstore.Update,
 			Key: mixerstore.Key{

--- a/mixer/testdata/config/attributes.yaml
+++ b/mixer/testdata/config/attributes.yaml
@@ -188,3 +188,5 @@ spec:
         valueType: STRING
       destination.workload.namespace:
         valueType: STRING
+      destination.container.name:
+        valueType: STRING

--- a/samples/bookinfo/policy/mixer-rule-ratings-ratelimit.yaml
+++ b/samples/bookinfo/policy/mixer-rule-ratings-ratelimit.yaml
@@ -37,7 +37,7 @@ spec:
   compiledTemplate: quota
   params:
     dimensions:
-      source: source.labels["app"] | source.service | "unknown"
+      source: source.labels["app"] | "unknown"
       sourceVersion: source.labels["version"] | "unknown"
       destination: destination.labels["app"] | destination.service.name | "unknown"
       destinationVersion: destination.labels["version"] | "unknown"


### PR DESCRIPTION
Validate all YAMLs in samples using structural validator.
Print deprecation warnings on deprecated Mixer kinds.

/assign @douglas-reid 
/assign @esnible 

Signed-off-by: Kuat Yessenov <kuat@google.com>