### PR TITLE
add access logs for passthrough listener

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -213,6 +213,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 				StatPrefix:       util.PassthroughCluster,
 				ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: util.PassthroughCluster},
 			}
+			setAccessLog(env, node, tcpProxy)
 		}
 		var transparent *google_protobuf.BoolValue
 		if node.GetInterceptionMode() == model.InterceptionTproxy {

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -43,9 +43,8 @@ func buildInboundNetworkFilters(env *model.Environment, node *model.Proxy, insta
 	return buildNetworkFiltersStack(node, instance.Endpoint.ServicePort, tcpFilter, clusterName)
 }
 
-// setAccessLogAndBuildTCPFilter sets the AccessLog configuration in the given
-// TcpProxy instance and builds a TCP filter out of it.
-func setAccessLogAndBuildTCPFilter(env *model.Environment, node *model.Proxy, config *tcp_proxy.TcpProxy) *listener.Filter {
+// setAccessLog sets the AccessLog configuration in the given TcpProxy instance.
+func setAccessLog(env *model.Environment, node *model.Proxy, config *tcp_proxy.TcpProxy) *tcp_proxy.TcpProxy {
 	if env.Mesh.AccessLogFile != "" {
 		fl := &fileaccesslog.FileAccessLog{
 			Path: env.Mesh.AccessLogFile,
@@ -66,6 +65,13 @@ func setAccessLogAndBuildTCPFilter(env *model.Environment, node *model.Proxy, co
 		config.AccessLog = []*accesslog.AccessLog{acc}
 
 	}
+	return config
+}
+
+// setAccessLogAndBuildTCPFilter sets the AccessLog configuration in the given
+// TcpProxy instance and builds a TCP filter out of it.
+func setAccessLogAndBuildTCPFilter(env *model.Environment, node *model.Proxy, config *tcp_proxy.TcpProxy) *listener.Filter {
+	setAccessLog(env, node, config)
 
 	tcpFilter := &listener.Filter{
 		Name: xdsutil.TCPProxy,


### PR DESCRIPTION
We would like to have logs for requests going through the passthrough listener/cluster. This will help us transition onto the mesh and identify traffic that is not yet fully onboarded.

Also ref: https://discuss.istio.io/t/telemetry-metrics-logging-on-passthroughcluster/2005