### PR TITLE
Update Ruby version in the Dockerfile for bookinfo-details app

### DIFF
--- a/samples/bookinfo/src/details/Dockerfile
+++ b/samples/bookinfo/src/details/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM ruby:2.3-slim
+FROM ruby:2.6.3-slim
 
 COPY details.rb /opt/microservices/
 


### PR DESCRIPTION
Update the version of the base image from ruby:2.3-slim to ruby:2.6.3-slim.
This is part of series of fixes to update the base images to their latest
versions to make sure they have the latest security updates.

Fixes Bug: #13262