### PR TITLE
Update the version of NodeJS in Dockerfile of bookinfo-ratings app

### DIFF
--- a/samples/bookinfo/src/ratings/Dockerfile
+++ b/samples/bookinfo/src/ratings/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM node:4-slim
+FROM node:12-slim
 
 COPY package.json /opt/microservices/
 COPY ratings.js /opt/microservices/


### PR DESCRIPTION
Update the version of NodeJS from v4.0 to v12.0 in the Dockerfile for the
bookinfo-ratings app so that it gets the latest security updates. The docker
image of this sample app shows 8 security vulnerabilities using the
imagescanner.cloud.ibm.com tool. This is caused because of the older version
of node (You can simply enter docker.io/node:4-slim and run the tool and it
shows 8 vulnerabilities which is addressed in the latest version).

Partially Fixes Bug: #13262