### PR TITLE
Add more general rbac tests and refactoring

### DIFF
--- a/pkg/test/util/connection/connection.go
+++ b/pkg/test/util/connection/connection.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	AllowHTTPRespCode = "200"
-	DenyHTTPRespCode  = "403"
-	TCPPort           = 90
+	HTTPCode200 = "200"
+	HTTPCode403 = "403"
+	TCPPort     = 90
 )
 
 type Connection struct {
@@ -44,7 +44,7 @@ func CheckConnection(t *testing.T, conn Connection) error {
 
 	results, err := conn.From.Call(ep, apps.AppCallOptions{Protocol: conn.Protocol, Path: conn.Path})
 	if conn.ExpectedSuccess {
-		if err != nil || len(results) == 0 || results[0].Code != AllowHTTPRespCode {
+		if err != nil || len(results) == 0 || results[0].Code != HTTPCode200 {
 			// Addition log for debugging purpose.
 			if err != nil {
 				t.Logf("Error: %#v\n", err)
@@ -57,7 +57,7 @@ func CheckConnection(t *testing.T, conn Connection) error {
 				conn.From.Name(), conn.To.Name(), conn.Port, conn.Protocol)
 		}
 	} else {
-		if err == nil && len(results) > 0 && results[0].Code == AllowHTTPRespCode {
+		if err == nil && len(results) > 0 && results[0].Code == HTTPCode200 {
 			return fmt.Errorf("%s to %s:%d using %s: expected failed, actually success",
 				conn.From.Name(), conn.To.Name(), conn.Port, conn.Protocol)
 		}

--- a/pkg/test/util/policy/policy.go
+++ b/pkg/test/util/policy/policy.go
@@ -43,6 +43,12 @@ func (p TestPolicy) TearDown() {
 	}
 }
 
+func TearDownMultiplePolicies(policies []*TestPolicy) {
+	for _, policy := range policies {
+		policy.TearDown()
+	}
+}
+
 // ApplyPolicyFile applies a policy file from testdata directory of the test.
 func ApplyPolicyFile(t *testing.T, env *kube.Environment, namespace string, fileName string) *TestPolicy {
 	joinedPath := path.Join(testDataDir, fileName)

--- a/tests/integration/security/rbac/v1/group/group_test.go
+++ b/tests/integration/security/rbac/v1/group/group_test.go
@@ -18,21 +18,19 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/label"
-
-	"istio.io/istio/tests/integration/security/rbac/util"
-
+	"istio.io/istio/pkg/test/framework/components/apps"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/pilot"
-
-	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/apps"
-	"istio.io/istio/pkg/test/framework/components/environment"
-	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/util/connection"
 	"istio.io/istio/pkg/test/util/policy"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/tests/integration/security/rbac/util"
+
+	"istio.io/istio/pkg/test/framework/components/istio"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
 )
 
 const (
@@ -57,7 +55,6 @@ const (
 		"NBUo-KC9PJqYpgGbaXhaGx7bEdFWjcwv3nZzvc7M__ZpaCERdwU7igUmJqYGBYQ51vr2njU9ZimyKkfDe3axcyiBZde" +
 		"7G6dabliUosJvvKOPcKIWPccCgefSj_GNfwIip3-SsFdlR7BtbVUcqR-yv-XOxJ3Uc1MI0tz3uMiiZcyPV7sNCU4KRn" +
 		"emRIMHVOfuvHsU60_GhGbiSFzgPTAa9WTltbnarTbxudb_YEOx12JiwYToeX0DCPb43W1tzIBxgm8NxUg"
-	rbacTestRejectionCode = "403"
 )
 
 var (
@@ -77,7 +74,6 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("rbac_group_list", m).
 		RequireEnvironment(environment.Kube).
-		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
 		Run()
 }
@@ -101,21 +97,21 @@ func TestGroupV1RBAC(t *testing.T) {
 	cases := []util.TestCase{
 		// Port 80 is where HTTP is served
 		{Request: connection.Connection{To: appB, From: appA, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/xyz"}, Jwt: noGroupScopeJwt,
-			ExpectAllowed: false, RejectionCode: rbacTestRejectionCode},
+			ExpectAllowed: false},
 		{Request: connection.Connection{To: appB, From: appA, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/xyz"}, Jwt: groupsScopeJwt,
-			ExpectAllowed: true, RejectionCode: rbacTestRejectionCode},
+			ExpectAllowed: true},
 		{Request: connection.Connection{To: appC, From: appA, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/xyz"}, Jwt: noGroupScopeJwt,
-			ExpectAllowed: false, RejectionCode: rbacTestRejectionCode},
+			ExpectAllowed: false},
 		{Request: connection.Connection{To: appC, From: appA, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/xyz"}, Jwt: groupsScopeJwt,
-			ExpectAllowed: true, RejectionCode: rbacTestRejectionCode},
+			ExpectAllowed: true},
 	}
 
 	testDir := ctx.WorkDir()
-	testNameSpace := appInst.Namespace().Name()
+	testNamespace := appInst.Namespace().Name()
 	rbacTmplFiles := []string{rbacClusterConfigTmpl, rbacGroupListRulesTmpl}
-	rbacYamlFiles := util.GetRbacYamlFiles(t, testDir, testNameSpace, rbacTmplFiles)
+	rbacYamlFiles := util.GetRbacYamlFiles(t, testDir, map[string]string{"Namespace": testNamespace}, rbacTmplFiles)
 
-	policy.ApplyPolicyFiles(t, env, testNameSpace, rbacYamlFiles)
+	policy.ApplyPolicyFiles(t, env, testNamespace, rbacYamlFiles)
 
 	// Sleep 60 seconds for the policy to take effect.
 	time.Sleep(60 * time.Second)

--- a/tests/integration/security/rbac/v2/basic/extended_test.go
+++ b/tests/integration/security/rbac/v2/basic/extended_test.go
@@ -1,0 +1,96 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package basic
+
+import (
+	"testing"
+	"time"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/apps"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/util/connection"
+	"istio.io/istio/pkg/test/util/policy"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/tests/integration/security/rbac/util"
+)
+
+// TestRBACV2Extended tests extended features of RBAC v2 such as global namespace and inline role def.
+func TestRBACV2Extended(t *testing.T) {
+	ctx := framework.NewContext(t)
+	defer ctx.Done(t)
+	ctx.RequireOrSkip(t, environment.Kube)
+
+	env := ctx.Environment().(*kube.Environment)
+	g := galley.NewOrFail(t, ctx, galley.Config{})
+	p := pilot.NewOrFail(t, ctx, pilot.Config{
+		Galley: g,
+	})
+	appInst := apps.NewOrFail(t, ctx, apps.Config{Pilot: p, Galley: g})
+
+	appA, _ := appInst.GetAppOrFail("a", t).(apps.KubeApp)
+	appB, _ := appInst.GetAppOrFail("b", t).(apps.KubeApp)
+	appC, _ := appInst.GetAppOrFail("c", t).(apps.KubeApp)
+
+	cases := []util.TestCase{
+		// Port 80 is where HTTP is served, 90 is where TCP is served. When an HTTP request is at port
+		// 90, this means it is a TCP request. The test framework uses HTTP to mimic TCP calls in this case.
+		{Request: connection.Connection{To: appA, From: appB, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/any-path"},
+			ExpectedRespCode: respCodeFromMtls[isMtlsEnabled]},
+		{Request: connection.Connection{To: appA, From: appB, Port: 90, Protocol: apps.AppProtocolHTTP},
+			ExpectedRespCode: respCodeFromMtls[isMtlsEnabled]},
+		{Request: connection.Connection{To: appA, From: appC, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/"},
+			ExpectedRespCode: connection.DenyHTTPRespCode},
+		{Request: connection.Connection{To: appA, From: appC, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/good-path"},
+			ExpectedRespCode: respCodeFromMtls[isMtlsEnabled]},
+		{Request: connection.Connection{To: appA, From: appC, Port: 90, Protocol: apps.AppProtocolHTTP},
+			ExpectedRespCode: connection.DenyHTTPRespCode},
+
+		{Request: connection.Connection{To: appB, From: appA, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/xyz"},
+			ExpectedRespCode: connection.AllowHTTPRespCode},
+		{Request: connection.Connection{To: appB, From: appA, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/secret"},
+			ExpectedRespCode: connection.DenyHTTPRespCode},
+		{Request: connection.Connection{To: appB, From: appA, Port: 90, Protocol: apps.AppProtocolHTTP},
+			ExpectedRespCode: connection.AllowHTTPRespCode},
+		{Request: connection.Connection{To: appB, From: appC, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/"},
+			ExpectedRespCode: connection.AllowHTTPRespCode},
+		{Request: connection.Connection{To: appB, From: appC, Port: 90, Protocol: apps.AppProtocolHTTP},
+			ExpectedRespCode: connection.AllowHTTPRespCode},
+	}
+
+	testDir := ctx.WorkDir()
+	testNamespace := appInst.Namespace().Name()
+	rootNamespace := model.DefaultMeshConfig().RootNamespace
+	namespacesForTmpl := map[string]string{"RootNamespace": rootNamespace, "Namespace": testNamespace}
+	rbacTmplFiles := []string{rbacClusterConfigTmpl, extendedRbacV2RulesTmpl}
+	rbacYamlFiles := util.GetRbacYamlFiles(t, testDir, namespacesForTmpl, rbacTmplFiles)
+
+	// Do not provide namespace here because we need to apply the policies for both root namespace and the test namespace.
+	rbacPolicies := policy.ApplyPolicyFiles(t, env, "", rbacYamlFiles)
+	defer policy.TearDownMultiplePolicies(rbacPolicies)
+
+	// Sleep 60 seconds for the policy to take effect.
+	// TODO(pitlv2109: Check to make sure policies have been created instead.
+	time.Sleep(60 * time.Second)
+	for _, tc := range cases {
+		retry.UntilSuccessOrFail(t, func() error {
+			return util.CheckRBACRequest(tc)
+		}, retry.Delay(time.Second), retry.Timeout(10*time.Second))
+	}
+}

--- a/tests/integration/security/rbac/v2/basic/extended_test.go
+++ b/tests/integration/security/rbac/v2/basic/extended_test.go
@@ -52,26 +52,26 @@ func TestRBACV2Extended(t *testing.T) {
 		// Port 80 is where HTTP is served, 90 is where TCP is served. When an HTTP request is at port
 		// 90, this means it is a TCP request. The test framework uses HTTP to mimic TCP calls in this case.
 		{Request: connection.Connection{To: appA, From: appB, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/any-path"},
-			ExpectedRespCode: respCodeFromMtls[isMtlsEnabled]},
+			ExpectAllowed: isMtlsEnabled},
 		{Request: connection.Connection{To: appA, From: appB, Port: 90, Protocol: apps.AppProtocolHTTP},
-			ExpectedRespCode: respCodeFromMtls[isMtlsEnabled]},
+			ExpectAllowed: isMtlsEnabled},
 		{Request: connection.Connection{To: appA, From: appC, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/"},
-			ExpectedRespCode: connection.DenyHTTPRespCode},
+			ExpectAllowed: false},
 		{Request: connection.Connection{To: appA, From: appC, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/good-path"},
-			ExpectedRespCode: respCodeFromMtls[isMtlsEnabled]},
+			ExpectAllowed: isMtlsEnabled},
 		{Request: connection.Connection{To: appA, From: appC, Port: 90, Protocol: apps.AppProtocolHTTP},
-			ExpectedRespCode: connection.DenyHTTPRespCode},
+			ExpectAllowed: false},
 
 		{Request: connection.Connection{To: appB, From: appA, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/xyz"},
-			ExpectedRespCode: connection.AllowHTTPRespCode},
+			ExpectAllowed: true},
 		{Request: connection.Connection{To: appB, From: appA, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/secret"},
-			ExpectedRespCode: connection.DenyHTTPRespCode},
+			ExpectAllowed: false},
 		{Request: connection.Connection{To: appB, From: appA, Port: 90, Protocol: apps.AppProtocolHTTP},
-			ExpectedRespCode: connection.AllowHTTPRespCode},
+			ExpectAllowed: true},
 		{Request: connection.Connection{To: appB, From: appC, Port: 80, Protocol: apps.AppProtocolHTTP, Path: "/"},
-			ExpectedRespCode: connection.AllowHTTPRespCode},
+			ExpectAllowed: true},
 		{Request: connection.Connection{To: appB, From: appC, Port: 90, Protocol: apps.AppProtocolHTTP},
-			ExpectedRespCode: connection.AllowHTTPRespCode},
+			ExpectAllowed: true},
 	}
 
 	testDir := ctx.WorkDir()

--- a/tests/integration/security/rbac/v2/basic/setup_test.go
+++ b/tests/integration/security/rbac/v2/basic/setup_test.go
@@ -20,7 +20,6 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/util/connection"
 )
 
 const (
@@ -30,12 +29,8 @@ const (
 )
 
 var (
-	inst             istio.Instance
-	isMtlsEnabled    bool
-	respCodeFromMtls = map[bool]string{
-		true:  connection.AllowHTTPRespCode,
-		false: connection.DenyHTTPRespCode,
-	}
+	inst          istio.Instance
+	isMtlsEnabled bool
 )
 
 func TestMain(m *testing.M) {

--- a/tests/integration/security/rbac/v2/basic/setup_test.go
+++ b/tests/integration/security/rbac/v2/basic/setup_test.go
@@ -1,0 +1,56 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package basic
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/util/connection"
+)
+
+const (
+	rbacClusterConfigTmpl   = "testdata/istio-clusterrbacconfig.yaml.tmpl"
+	basicRbacV2RulesTmpl    = "testdata/istio-rbac-v2-rules.yaml.tmpl"
+	extendedRbacV2RulesTmpl = "testdata/istio-extended-rbac-v2-rules.yaml.tmpl"
+)
+
+var (
+	inst             istio.Instance
+	isMtlsEnabled    bool
+	respCodeFromMtls = map[bool]string{
+		true:  connection.AllowHTTPRespCode,
+		false: connection.DenyHTTPRespCode,
+	}
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("rbac_v2", m).
+		// TODO(pitlv2109: Turn on the presubmit label once the test is stable.
+		RequireEnvironment(environment.Kube).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Run()
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	isMtlsEnabled = cfg.IsMtlsEnabled()
+	cfg.Values["sidecarInjectorWebhook.rewriteAppHTTPProbe"] = "true"
+}

--- a/tests/integration/security/rbac/v2/basic/testdata/istio-extended-rbac-v2-rules.yaml.tmpl
+++ b/tests/integration/security/rbac/v2/basic/testdata/istio-extended-rbac-v2-rules.yaml.tmpl
@@ -1,0 +1,72 @@
+# istio-extended-rbac-v2-rules.yaml to enforce access control for both http and tcp services using Istio RBAC v2 rules
+# such as root namespace, inline role ref, using role instead of roleRef.
+
+# For service a, authenticated service account b is allowed have both HTTP and TCP access.
+# For service a, authenticated service account c is allowed to have HTTP access at paths with prefix "good" only.
+# Two ServiceRole with the same name will be created in the root namespace and local namespace,
+# then one AuthorizationPolicy will use role with / to indicate the root namespace, and without /
+# to indicate the local namespace.
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: access-a-http
+  namespace: {{ .RootNamespace }}
+spec:
+  rules:
+    - methods: ["GET"]
+    - constraints:
+      - key: "destination.port"
+        values: ["90"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: access-a-http
+  namespace: {{ .Namespace }}
+spec:
+  rules:
+    - methods: ["GET"]
+      paths: ["good*"]
+    - constraints:
+      - key: "destination.port"
+        values: ["90"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: AuthorizationPolicy
+metadata:
+  name: authz-policy-access-a-http
+  namespace: {{ .Namespace }}
+spec:
+  allow:
+    - subjects:
+      - names: ["cluster.local/ns/{{ .Namespace }}/sa/b"]
+      role: "/access-a-http"
+    - subjects:
+      - names: ["cluster.local/ns/{{ .Namespace }}/sa/c"]
+      role: "access-a-http"
+---
+
+# For service b, allow any user to access it with GET at any paths except /secret*
+# or only access it at tcp port 90.
+# Instead of creating a separate ServiceRole policy, we create an inline role definition inside AuthorizationPolicy.
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: AuthorizationPolicy
+metadata:
+  name: authz-policy-access-b-http-tcp
+  namespace: {{ .Namespace }}
+spec:
+  workload_selector:
+    labels:
+      app: b
+  allow:
+    - subjects:
+        - names: ["allUsers"]
+      actions:
+        - methods: ["GET"]
+          not_paths: ["/secret*"]
+        - constraints:
+          - key: "destination.port"
+            values: ["90"]
+---

--- a/tests/integration/security/rbac/v2/basic/testdata/istio-rbac-v2-rules.yaml.tmpl
+++ b/tests/integration/security/rbac/v2/basic/testdata/istio-rbac-v2-rules.yaml.tmpl
@@ -3,6 +3,7 @@
 # For service a, allow no one to access it.
 # This will also result a default tcp rule for service a that denies all access.
 # This actually means nobody could access a.
+
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: ServiceRole
 metadata:
@@ -29,6 +30,7 @@ spec:
 
 # For service b, only allow authenticated user to access it with GET at any paths except /secret*
 # or only access it at tcp port 90.
+
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: ServiceRole
 metadata:
@@ -61,6 +63,7 @@ spec:
 # * Allow GET requests for any path, except paths ending with /admin for service account d.
 # * Deny all requests for service account b.
 # * Deny anyone else by default.
+
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: ServiceRole
 metadata:
@@ -103,6 +106,7 @@ spec:
 # For service d:
 # * anyone can access it via HTTP requests
 # * no one can access TCP at port 90.
+
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: ServiceRole
 metadata:


### PR DESCRIPTION
Add RBAC tests for global namespace, inline role ref, and using role instead of roleRef.
Remove `RejectionCode` and use `ExpectedAllowed` instead, since they are pretty much the same thing.

For #12394, #13439