### PR TITLE
[Test Framework] Fix null yaml files generated

### DIFF
--- a/pkg/test/util/yml/apply.go
+++ b/pkg/test/util/yml/apply.go
@@ -27,6 +27,9 @@ func ApplyNamespace(yamlText, ns string) (string, error) {
 
 	result := ""
 	for _, chunk := range chunks {
+		if chunk == "" {
+			continue
+		}
 		if result != "" {
 			result += yamlSeparator
 		}


### PR DESCRIPTION
Files were being generated with contents `null`, causing the tests to
fail when kubectl applying. This is because of trailing ---- in the
files we apply.