### PR TITLE
Upgrade mysql version for bookinfo-mysqldb app to latest

### DIFF
--- a/samples/bookinfo/src/mysql/Dockerfile
+++ b/samples/bookinfo/src/mysql/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM mysql:8.0.3
+FROM mysql:8.0.16
 # MYSQL_ROOT_PASSWORD must be supplied as an env var
 
 COPY ./mysqldb-init.sql /docker-entrypoint-initdb.d


### PR DESCRIPTION
Upgrade mysql version for bookinfo-mysqldb from 8.0.3 to latest to get the
latest security updates. Using the imagescanner.cloud.ibm.com tool that
scans docker images for security vulnerabilities, 8.0.3 shows 15 security
vulnerabilities whereas the latest version shows 3.

Partially Fixes: #13262