### PR TITLE
[Testing] Fix race in Galley file source

### DIFF
--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -134,11 +134,10 @@ func (p *Processor) Start() error {
 		scope.Info("Starting processor...")
 		defer func() {
 			scope.Debugf("Process.process: Exiting worker thread")
+			p.source.Stop()
 			close(p.eventCh)
 			p.stateStrategy.Close()
 		}()
-
-		defer p.source.Stop()
 
 		scope.Debug("Starting process loop")
 

--- a/galley/pkg/source/fs/source.go
+++ b/galley/pkg/source/fs/source.go
@@ -214,14 +214,18 @@ func (s *source) Start(handler resource.EventHandler) error {
 		s.initialCheck()
 		c := make(chan appsignals.Signal)
 		appsignals.Watch(c)
-		go func() {
-			for trigger := range c {
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case trigger := <-c:
 				if trigger.Signal == syscall.SIGUSR1 {
 					log.Scope.Infof("Triggering reload in response to: %v", trigger.Source)
 					s.reload()
 				}
 			}
-		}()
+		}
 	})
 }
 


### PR DESCRIPTION
Was seeing a panic on CI due to the event channel being closed while trying to write to it.

The recent changes to the fs source appear to be the culprit. The function provided to the worker in the Start() method was not waiting properly for shutdown.