### PR TITLE
[Test Framework] Add custom setup label

### DIFF
--- a/pkg/test/framework/label/labels.go
+++ b/pkg/test/framework/label/labels.go
@@ -20,8 +20,12 @@ const (
 
 	// Postsubmit indicates that the test should be run as part of a postsubmit run.
 	Postsubmit Instance = "postsubmit"
+
+	// CustomSetup indicates that the test requires a custom Istio installation.
+	CustomSetup Instance = "customsetup"
 )
 
 var all = NewSet(
 	Presubmit,
-	Postsubmit)
+	Postsubmit,
+	CustomSetup)

--- a/tests/integration/pilot/locality/failover/main_test.go
+++ b/tests/integration/pilot/locality/failover/main_test.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.NewSuite("locality_prioritized_failover_loadbalancing", m).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
 		Run()
 }

--- a/tests/integration/pilot/locality/prioritized/main_test.go
+++ b/tests/integration/pilot/locality/prioritized/main_test.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.NewSuite("locality_prioritized_loadbalancing", m).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
 		Run()
 }

--- a/tests/integration/pilot/outboundtrafficpolicy/allowany/traffic_allow_any_test.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/allowany/traffic_allow_any_test.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/tests/integration/pilot/outboundtrafficpolicy"
 )
 
@@ -28,6 +29,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("outbound_traffic_policy_allow_any", m).
 		RequireEnvironment(environment.Kube).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
 		Run()
 }

--- a/tests/integration/pilot/outboundtrafficpolicy/registryonly/traffic_registry_only_test.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/registryonly/traffic_registry_only_test.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/tests/integration/pilot/outboundtrafficpolicy"
 )
 
@@ -27,6 +28,7 @@ func TestMain(m *testing.M) {
 	var ist istio.Instance
 	framework.NewSuite("outbound_traffic_policy_registry_only", m).
 		RequireEnvironment(environment.Kube).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
 		Run()
 }

--- a/tests/integration/security/healthcheck/mtls_healthcheck_test.go
+++ b/tests/integration/security/healthcheck/mtls_healthcheck_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/label"
 
 	"istio.io/istio/pkg/test/framework/components/apps"
 	"istio.io/istio/pkg/test/framework/components/deployment"
@@ -38,6 +39,7 @@ var (
 func TestMain(m *testing.M) {
 	framework.NewSuite("mtls_healthcheck", m).
 		RequireEnvironment(environment.Kube).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
 		Run()
 }

--- a/tests/integration/security/rbac/v1/group/group_test.go
+++ b/tests/integration/security/rbac/v1/group/group_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
 
 	"istio.io/istio/tests/integration/security/rbac/util"
 
@@ -76,6 +77,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("rbac_group_list", m).
 		RequireEnvironment(environment.Kube).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
 		Run()
 }

--- a/tests/integration/security/rbac/v2/basic/basic_test.go
+++ b/tests/integration/security/rbac/v2/basic/basic_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/tests/integration/security/rbac/util"
 
 	"istio.io/istio/pkg/test/framework"
@@ -47,6 +48,7 @@ func TestMain(m *testing.M) {
 		NewSuite("rbac_v2", m).
 		// TODO(pitlv2109: Turn on the presubmit label once the test is stable.
 		RequireEnvironment(environment.Kube).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
 		Run()
 }

--- a/tests/integration/security/rbac/v2/group/group_test.go
+++ b/tests/integration/security/rbac/v2/group/group_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
 
 	"istio.io/istio/tests/integration/security/rbac/util"
 
@@ -76,6 +77,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("rbac_v2_group_list", m).
 		RequireEnvironment(environment.Kube).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
 		Run()
 }

--- a/tests/integration/security/sds_citadel_flow/sds_citadel_flow_test.go
+++ b/tests/integration/security/sds_citadel_flow/sds_citadel_flow_test.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/util/connection"
 	"istio.io/istio/pkg/test/util/policy"
 	"istio.io/istio/pkg/test/util/retry"
@@ -99,6 +100,7 @@ func TestMain(m *testing.M) {
 	// with the certificates issued by the SDS Citadel CA flow.
 	framework.
 		NewSuite("sds_citadel_flow_test", m).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
 		Run()
 

--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/util/connection"
 	"istio.io/istio/pkg/test/util/policy"
 	"istio.io/istio/pkg/test/util/retry"
@@ -124,6 +125,7 @@ func TestMain(m *testing.M) {
 	// Integration test for the SDS Vault CA flow, as well as mutual TLS
 	// with the certificates issued by the SDS Vault CA flow.
 	framework.NewSuite("sds_vault_flow_test", m).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
 		Run()
 }


### PR DESCRIPTION
We want to be able to run the subset of tests that don't require special Istio configuration. This allows the tests to run when the no setup flag is passed.

I considered doing this dynamically based on the setupFn, but we would have to plumb that through which didn't seem to make as much sense as using labels

https://github.com/istio/istio/issues/13765