### PR TITLE
Fix warning when using podAntiAffinity*LabelSelector base value has to be an array

### DIFF
--- a/install/kubernetes/helm/istio/charts/certmanager/values.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/values.yaml
@@ -27,5 +27,5 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []

--- a/install/kubernetes/helm/istio/charts/galley/values.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/values.yaml
@@ -24,5 +24,5 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []

--- a/install/kubernetes/helm/istio/charts/gateways/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/_affinity.tpl
@@ -62,7 +62,7 @@
         matchExpressions:
         - key: {{ $item.key }}
           operator: {{ $item.operator }}
-          {{- if $item.value }}
+          {{- if $item.values }}
           values:
           {{- $vals := split "," $item.values }}
           {{- range $i, $v := $vals }}

--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -133,8 +133,8 @@ istio-ingressgateway:
   # This pod anti-affinity rule says that the pod requires not to be scheduled
   # onto a node if that node is already running a pod with label having key
   # “security” and value “S1”.
-  podAntiAffinityLabelSelector: {}
-  podAntiAffinityTermLabelSelector: {}
+  podAntiAffinityLabelSelector: []
+  podAntiAffinityTermLabelSelector: []
 
 istio-egressgateway:
   enabled: false
@@ -208,8 +208,8 @@ istio-egressgateway:
   # This pod anti-affinity rule says that the pod requires not to be scheduled
   # onto a node if that node is already running a pod with label having key
   # “security” and value “S1”.
-  podAntiAffinityLabelSelector: {}
-  podAntiAffinityTermLabelSelector: {}
+  podAntiAffinityLabelSelector: []
+  podAntiAffinityTermLabelSelector: []
 
 # Mesh ILB gateway creates a gateway of type InternalLoadBalancer,
 # for mesh expansion. It exposes the mtls ports for Pilot,CA as well

--- a/install/kubernetes/helm/istio/charts/grafana/values.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/values.yaml
@@ -47,8 +47,8 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []
 
 contextPath: /grafana
 service:

--- a/install/kubernetes/helm/istio/charts/istiocoredns/values.yaml
+++ b/install/kubernetes/helm/istio/charts/istiocoredns/values.yaml
@@ -28,5 +28,5 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -26,8 +26,8 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []
 
 ingress:
   enabled: false

--- a/install/kubernetes/helm/istio/charts/mixer/values.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/values.yaml
@@ -66,8 +66,8 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []
 
 adapters:
   kubernetesenv:

--- a/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
+++ b/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
@@ -30,5 +30,5 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []

--- a/install/kubernetes/helm/istio/charts/pilot/values.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/values.yaml
@@ -40,8 +40,8 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []
 
 # The following is used to limit how long a sidecar can be connected
 # to a pilot. It balances out load across pilot instances at the cost of

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -26,8 +26,8 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []
 
 # Controls the frequency of prometheus scraping
 scrapeInterval: 15s

--- a/install/kubernetes/helm/istio/charts/security/values.yaml
+++ b/install/kubernetes/helm/istio/charts/security/values.yaml
@@ -26,5 +26,5 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
@@ -25,8 +25,8 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []
 
 # If true, webhook or istioctl injector will rewrite PodSpec for liveness
 # health check to redirect request to sidecar. This makes liveness check work

--- a/install/kubernetes/helm/istio/charts/tracing/values.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/values.yaml
@@ -24,8 +24,8 @@ nodeSelector: {}
 # This pod anti-affinity rule says that the pod requires not to be scheduled
 # onto a node if that node is already running a pod with label having key
 # “security” and value “S1”.
-podAntiAffinityLabelSelector: {}
-podAntiAffinityTermLabelSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []
 
 jaeger:
   hub: docker.io/jaegertracing

--- a/install/kubernetes/helm/istio/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/templates/_affinity.tpl
@@ -62,7 +62,7 @@
         matchExpressions:
         - key: {{ $item.key }}
           operator: {{ $item.operator }}
-          {{- if $item.value }}
+          {{- if $item.values }}
           values:
           {{- $vals := split "," $item.values }}
           {{- range $i, $v := $vals }}


### PR DESCRIPTION
If you use podAntiAffinityTermLabelSelector or podAntiAffinityTermSelector you have a warning on helm upgrade / install.

```
Warning: Merging destination map for chart 'gateways'. Cannot overwrite table item 'podAntiAffinityTermLabelSelector', with non table value: map[]
```

it's because default value for podAntiAffinityLabelSelector and podAntiAffinityTermLabelSelector are objects but needs to be an array to be overridden.

And I've added fix two typos too on a if on wrong entry value instead of values use later.

Additional fix for #12790