### PR TITLE
Add integration test for out of process policy checks

### DIFF
--- a/mixer/pkg/runtime/routing/builder.go
+++ b/mixer/pkg/runtime/routing/builder.go
@@ -575,9 +575,11 @@ func (b *builder) getBuilderAndMapperDynamic(
 	var instBuilder template.InstanceBuilderFn = func(attrs attribute.Bag) (interface{}, error) {
 		var err error
 		ba := make([]byte, 0, defaultInstanceSize)
-		// The encoder produces
-		if ba, err = instance.Encoder.Encode(attrs, ba); err != nil {
-			return nil, err
+		if instance.Encoder != nil {
+			// The encoder produces
+			if ba, err = instance.Encoder.Encode(attrs, ba); err != nil {
+				return nil, err
+			}
 		}
 
 		return &adapter.EncodedInstance{

--- a/pkg/test/deployment/attrmanifest.go
+++ b/pkg/test/deployment/attrmanifest.go
@@ -39,15 +39,20 @@ func ExtractAttributeManifest(workDir string) (string, error) {
 
 	// Split the template into chunks
 	parts := yml.SplitString(s)
+	// Mutiple attributes manifest exists, so concatenate them
+	attributesManifest := ""
 	for _, part := range parts {
 		// Yaml contains both the CR and the CRD. We only want CR.
 		if strings.Contains(part, "kind: attributemanifest") &&
 			!strings.Contains(part, "kind: CustomResourceDefinition") {
 
 			scopes.Framework.Debugf("Extracted AttributeManifest:\n%s\n", part)
-			return part, nil
+			attributesManifest = yml.JoinString(attributesManifest, part)
 		}
 	}
 
+	if attributesManifest != "" {
+		return attributesManifest, nil
+	}
 	return "", errors.New("attribute manifest not found in generated chart")
 }

--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -100,6 +100,9 @@ var (
 
 	// RedisInstallFilePath is the redis installation file.
 	RedisInstallFilePath = path.Join(IstioRoot, "pkg/test/framework/components/redis/redis.yaml")
+
+	// HttpbinRoot is the root folder for the httpbin samples
+	HttpbinRoot = path.Join(IstioRoot, "samples/httpbin")
 )
 
 func getDefaultIstioTop() string {

--- a/pkg/test/framework/components/httpbin/configs.go
+++ b/pkg/test/framework/components/httpbin/configs.go
@@ -16,14 +16,12 @@ package httpbin
 
 import (
 	"path"
-	"strings"
 	"testing"
 
-	"istio.io/istio/pkg/test/util/yml"
-
-	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/pkg/test/util/yml"
 )
 
 // ConfigFile represents config yaml files for different httpbin scenarios.
@@ -39,7 +37,7 @@ func (l ConfigFile) LoadWithNamespaceOrFail(t testing.TB, namespace string) stri
 	t.Helper()
 	p := path.Join(env.HttpbinRoot, string(l))
 
-	content, err := test.ReadConfigFile(p)
+	content, err := file.AsString(p)
 	if err != nil {
 		t.Fatalf("unable to load config %s at %v, err:%v", l, p, err)
 	}
@@ -48,15 +46,8 @@ func (l ConfigFile) LoadWithNamespaceOrFail(t testing.TB, namespace string) stri
 		if err != nil {
 			t.Fatalf("cannot apply namespace config to httpbin yaml content: %v", content)
 		}
-		content = replaceHttpbinAppAddressWithFQDNAddress(content, namespace)
 	}
 
 	scopes.Framework.Debugf("Loaded Httpbin file: %s\n%s\n", p, content)
-	return content
-}
-
-func replaceHttpbinAppAddressWithFQDNAddress(fileContent, namespace string) string {
-	content := fileContent
-	content = strings.Replace(content, "host: httpbin", "host: httpbin."+namespace+".svc.cluster.local", -1)
 	return content
 }

--- a/pkg/test/framework/components/httpbin/configs.go
+++ b/pkg/test/framework/components/httpbin/configs.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpbin
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	"istio.io/istio/pkg/test/util/yml"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/scopes"
+)
+
+// ConfigFile represents config yaml files for different httpbin scenarios.
+type ConfigFile string
+
+const (
+	// NetworkingHttpbinGateway uses "httpbin-gateway.yaml"
+	NetworkingHttpbinGateway ConfigFile = "httpbin-gateway.yaml"
+)
+
+// LoadWithNamespaceOrFail loads a httpbin configuration file for the namespace and returns its contents.
+func (l ConfigFile) LoadWithNamespaceOrFail(t testing.TB, namespace string) string {
+	t.Helper()
+	p := path.Join(env.HttpbinRoot, string(l))
+
+	content, err := test.ReadConfigFile(p)
+	if err != nil {
+		t.Fatalf("unable to load config %s at %v, err:%v", l, p, err)
+	}
+	if namespace != "" {
+		content, err = yml.ApplyNamespace(content, namespace)
+		if err != nil {
+			t.Fatalf("cannot apply namespace config to httpbin yaml content: %v", content)
+		}
+		content = replaceHttpbinAppAddressWithFQDNAddress(content, namespace)
+	}
+
+	scopes.Framework.Debugf("Loaded Httpbin file: %s\n%s\n", p, content)
+	return content
+}
+
+func replaceHttpbinAppAddressWithFQDNAddress(fileContent, namespace string) string {
+	content := fileContent
+	content = strings.Replace(content, "host: httpbin", "host: httpbin."+namespace+".svc.cluster.local", -1)
+	return content
+}

--- a/pkg/test/framework/components/httpbin/httpbin.go
+++ b/pkg/test/framework/components/httpbin/httpbin.go
@@ -1,0 +1,52 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpbin
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework/components/deployment"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+// Config for httpbin
+type Config struct {
+	Namespace namespace.Instance
+}
+
+// Deploy deploys httpbin instance or return a error
+func Deploy(ctx resource.Context, cfg Config) (i deployment.Instance, err error) {
+	err = resource.UnsupportedEnvironment(ctx.Environment())
+
+	ctx.Environment().Case(environment.Kube, func() {
+		i, err = deploy(ctx, cfg)
+	})
+
+	return
+}
+
+// DeployOrFail returns a new instance of deployed Httpbin or fails test
+func DeployOrFail(t *testing.T, ctx resource.Context, cfg Config) deployment.Instance {
+	t.Helper()
+
+	i, err := Deploy(ctx, cfg)
+	if err != nil {
+		t.Fatalf("httpbin.DeployOrFail: %v", err)
+	}
+
+	return i
+}

--- a/pkg/test/framework/components/httpbin/kube.go
+++ b/pkg/test/framework/components/httpbin/kube.go
@@ -1,0 +1,56 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpbin
+
+import (
+	"io/ioutil"
+	"path"
+
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/components/deployment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+type httpbinConfig string
+
+const (
+	// Httpbin uses "httpbin.yaml"
+	Httpbin httpbinConfig = "httpbin.yaml"
+)
+
+func deploy(ctx resource.Context, cfg Config) (i deployment.Instance, err error) {
+	ns := cfg.Namespace
+	if ns == nil {
+		ns, err = namespace.Claim(ctx, "default")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	yamlFile := path.Join(env.HttpbinRoot, string(Httpbin))
+	by, err := ioutil.ReadFile(yamlFile)
+	if err != nil {
+		return nil, err
+	}
+
+	depcfg := deployment.Config{
+		Name:      "httpbin",
+		Namespace: ns,
+		Yaml:      string(by),
+	}
+
+	return deployment.New(ctx, depcfg)
+}

--- a/pkg/test/framework/components/httpbin/kube.go
+++ b/pkg/test/framework/components/httpbin/kube.go
@@ -15,13 +15,13 @@
 package httpbin
 
 import (
-	"io/ioutil"
 	"path"
 
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/components/deployment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/file"
 )
 
 type httpbinConfig string
@@ -41,7 +41,7 @@ func deploy(ctx resource.Context, cfg Config) (i deployment.Instance, err error)
 	}
 
 	yamlFile := path.Join(env.HttpbinRoot, string(Httpbin))
-	by, err := ioutil.ReadFile(yamlFile)
+	yml, err := file.AsString(yamlFile)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func deploy(ctx resource.Context, cfg Config) (i deployment.Instance, err error)
 	depcfg := deployment.Config{
 		Name:      "httpbin",
 		Namespace: ns,
-		Yaml:      string(by),
+		Yaml:      yml,
 	}
 
 	return deployment.New(ctx, depcfg)

--- a/pkg/test/framework/components/ingress/ingress.go
+++ b/pkg/test/framework/components/ingress/ingress.go
@@ -15,6 +15,8 @@
 package ingress
 
 import (
+	"net/http"
+
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -34,7 +36,7 @@ type Instance interface {
 	CallOrFail(t test.Failer, path string) CallResponse
 
 	// Call makes an HTTP call with the given headers through ingress, where the URL has the given path.
-	CallWithHeaders(path string, header map[string]string) (CallResponse, error)
+	CallWithHeaders(path string, header http.Header) (CallResponse, error)
 }
 
 type Config struct {

--- a/pkg/test/framework/components/ingress/ingress.go
+++ b/pkg/test/framework/components/ingress/ingress.go
@@ -29,9 +29,12 @@ type Instance interface {
 	// when running under Minikube).
 	Address() string
 
-	//  Call makes an HTTP call through ingress, where the URL has the given path.
+	// Call makes an HTTP call through ingress, where the URL has the given path.
 	Call(path string) (CallResponse, error)
 	CallOrFail(t test.Failer, path string) CallResponse
+
+	// Call makes an HTTP call with the given headers through ingress, where the URL has the given path.
+	CallWithHeaders(path string, header map[string]string) (CallResponse, error)
 }
 
 type Config struct {

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -133,7 +133,7 @@ func (c *kubeComponent) Call(path string) (CallResponse, error) {
 	return c.CallWithHeaders(path, nil)
 }
 
-func (c *kubeComponent) CallWithHeaders(path string, headers map[string]string) (CallResponse, error) {
+func (c *kubeComponent) CallWithHeaders(path string, header http.Header) (CallResponse, error) {
 	client := &http.Client{
 		Timeout: 1 * time.Minute,
 	}
@@ -149,9 +149,7 @@ func (c *kubeComponent) CallWithHeaders(path string, headers map[string]string) 
 	if err != nil {
 		return CallResponse{}, err
 	}
-	for k, v := range headers {
-		req.Header.Add(k, v)
-	}
+	req.Header = header
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -120,7 +120,20 @@ func (c *kubeComponent) Address() string {
 	return c.address
 }
 
+func (c *kubeComponent) CallOrFail(t test.Failer, path string) CallResponse {
+	t.Helper()
+	resp, err := c.Call(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
 func (c *kubeComponent) Call(path string) (CallResponse, error) {
+	return c.CallWithHeaders(path, nil)
+}
+
+func (c *kubeComponent) CallWithHeaders(path string, headers map[string]string) (CallResponse, error) {
 	client := &http.Client{
 		Timeout: 1 * time.Minute,
 	}
@@ -135,6 +148,11 @@ func (c *kubeComponent) Call(path string) (CallResponse, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return CallResponse{}, err
+	}
+	if headers != nil {
+		for k, v := range headers {
+			req.Header.Add(k, v)
+		}
 	}
 
 	resp, err := client.Do(req)
@@ -160,13 +178,4 @@ func (c *kubeComponent) Call(path string) (CallResponse, error) {
 	}
 
 	return response, nil
-}
-
-func (c *kubeComponent) CallOrFail(t test.Failer, path string) CallResponse {
-	t.Helper()
-	resp, err := c.Call(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return resp
 }

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -149,10 +149,8 @@ func (c *kubeComponent) CallWithHeaders(path string, headers map[string]string) 
 	if err != nil {
 		return CallResponse{}, err
 	}
-	if headers != nil {
-		for k, v := range headers {
-			req.Header.Add(k, v)
-		}
+	for k, v := range headers {
+		req.Header.Add(k, v)
 	}
 
 	resp, err := client.Do(req)

--- a/pkg/test/framework/components/policybackend/kube.go
+++ b/pkg/test/framework/components/policybackend/kube.go
@@ -84,7 +84,8 @@ spec:
 apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
-  name: {{.namespace}}
+  name: {{.name}}
+  namespace: {{.mixerNamespace}}
 spec:
   params:
     backend_address: policy-backend.%s.svc.cluster.local:1071
@@ -246,6 +247,7 @@ func (c *kubeComponent) CreateConfigSnippet(name string, mixerNS string, am Adap
 	switch am {
 	case InProcess:
 		ih, err := tmpl.Evaluate(inProcessHandlerKube, map[string]interface{}{
+			"name":           name,
 			"mixerNamespace": mixerNS,
 		})
 		if err != nil {

--- a/pkg/test/framework/components/policybackend/kube.go
+++ b/pkg/test/framework/components/policybackend/kube.go
@@ -97,6 +97,7 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
   name: allowhandler
+  namespace: %s
 spec:
   adapter: policybackend
   connection:
@@ -111,6 +112,7 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
   name: denyhandler
+  namespace: %s
 spec:
   adapter: policybackend
   connection:
@@ -123,6 +125,7 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
   name: keyval
+  namespace: %s
 spec:
   adapter: policybackend
   connection:
@@ -244,7 +247,8 @@ func (c *kubeComponent) CreateConfigSnippet(name string, namespace string, am Ad
 	case InProcess:
 		return fmt.Sprintf(inProcessHandlerKube, name, c.namespace.Name())
 	case OutOfProcess:
-		handler := fmt.Sprintf(outOfProcessHandlerKube, c.namespace.Name(), c.namespace.Name(), c.namespace.Name())
+		handler := fmt.Sprintf(outOfProcessHandlerKube, namespace, c.namespace.Name(),
+			namespace, c.namespace.Name(), namespace, c.namespace.Name())
 		return handler
 	default:
 		scopes.CI.Errorf("Error generating config snippet for policy backend: unsupported adapter mode")

--- a/pkg/test/framework/components/policybackend/policybackend.go
+++ b/pkg/test/framework/components/policybackend/policybackend.go
@@ -60,7 +60,7 @@ type Instance interface {
 
 	// CreateConfigSnippet for the Mixer adapter to talk to this policy backend.
 	// If adapter mode is in process, the supplied name will be the name of the handler.
-	CreateConfigSnippet(name string, namespace string, am AdapterMode) string
+	CreateConfigSnippet(name string, mixerNS string, am AdapterMode) string
 }
 
 // New returns a new instance of echo.

--- a/tests/integration/mixer/out_of_process/out_of_process_test.go
+++ b/tests/integration/mixer/out_of_process/out_of_process_test.go
@@ -1,0 +1,276 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package out_of_process_adapter_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/httpbin"
+	"istio.io/istio/pkg/test/framework/components/ingress"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/mixer"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/policybackend"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const (
+	keyvalTmpl       = "../../../../mixer/test/keyval/template.yaml"
+	adapterConfig    = "../../../../pkg/test/fakes/policy/policybackend.yaml"
+	checknothingTmpl = "../../../../mixer/template/checknothing/template.yaml"
+	statusOK         = 200
+	statusTeapot     = 418
+)
+
+var (
+	ist istio.Instance
+)
+
+func TestRouteDirective(t *testing.T) {
+	ctx := framework.NewContext(t)
+	defer ctx.Done(t)
+
+	ctx.RequireOrSkip(t, environment.Kube)
+	httpbinNs, err := namespace.New(ctx, "httpbin-test", true)
+	istioSystemNs := namespace.ClaimOrFail(t, ctx, "istio-system")
+
+	g := galley.NewOrFail(t, ctx, galley.Config{})
+	_ = mixer.NewOrFail(t, ctx, mixer.Config{Galley: g})
+	_ = httpbin.DeployOrFail(t, ctx, httpbin.Config{Namespace: httpbinNs})
+	be := policybackend.NewOrFail(t, ctx)
+
+	// Get out of process adapter related config, which includes dyanmic template for keyval and checknothing,
+	// and dynamic adapter config for policy backend.
+	oopConfig, err := readOOPConfig()
+	if err != nil {
+		t.Fatalf("unable to read out of process adapter config: %v", err)
+	}
+
+	// Apply all configs needed by out of process adapter, which includes all needed dynamic templates,
+	// adapter config, instances and handlers.
+	g.ApplyConfigOrFail(t, istioSystemNs,
+		oopConfig,
+		testOOPKeyValInstace,
+		be.CreateConfigSnippet("policy-backend", istioSystemNs.Name(), policybackend.OutOfProcess),
+	)
+	g.ApplyConfigOrFail(t, httpbinNs,
+		httpbin.NetworkingHttpbinGateway.LoadWithNamespaceOrFail(t, httpbinNs.Name()))
+	ing := ingress.NewOrFail(t, ctx, ingress.Config{Istio: ist})
+
+	var response ingress.CallResponse
+
+	t.Log("visit httpbin")
+	retry.UntilSuccessOrFail(t, func() error {
+		response, err = ing.Call("/")
+		if err != nil {
+			return fmt.Errorf("unable to connect to httpbin: %v", err)
+		}
+		return nil
+	}, retry.Delay(3*time.Second), retry.Timeout(30*time.Second))
+
+	// Test rule that adds header.
+	t.Log("apply rule to add 'group' header")
+	g.ApplyConfigOrFail(t, istioSystemNs, testOOPKeyValGroupRule)
+
+	// Retry visiting httpbin until gets "user-group" header
+	retry.UntilSuccessOrFail(t, func() error {
+		response, err = ing.CallWithHeaders("/headers", map[string]string{"user": "jason"})
+		if err != nil {
+			return fmt.Errorf("unable to connect to httpbin: %v", err)
+		}
+		if response.Code != statusOK {
+			return fmt.Errorf("visit returns non-ok code: %v", response.Code)
+		}
+
+		var result, headers map[string]interface{}
+		if json.Unmarshal([]byte(response.Body), &result) != nil {
+			return fmt.Errorf("cannot unmarshal json string %v", response.Body)
+		}
+		if _, ok := result["headers"]; !ok {
+			return fmt.Errorf("cannot find headers in httpbin response: %v", response.Body)
+		}
+		headers = result["headers"].(map[string]interface{})
+		for key, val := range headers {
+			if strings.ToLower(key) == "user-group" && strings.ToLower(val.(string)) == "admin" {
+				return nil
+			}
+		}
+		return fmt.Errorf("cannot find user-group header in request headers: %v", headers)
+	}, retry.Delay(3*time.Second), retry.Timeout(40*time.Second))
+
+	t.Log("find user-group: admin header")
+	g.DeleteConfigOrFail(t, istioSystemNs, testOOPKeyValGroupRule)
+
+	// Test header editing and route directive.
+	t.Log("apply rule to edit path header")
+	g.ApplyConfigOrFail(t, istioSystemNs, testOOPKeyValPathRule)
+	retry.UntilSuccessOrFail(t, func() error {
+		response, err = ing.Call("/headers")
+		if err != nil {
+			return fmt.Errorf("unable to connect to httpbin: %v", err)
+		}
+		if response.Code != statusTeapot {
+			return fmt.Errorf("httpbin does not return teapot: %v", response.Code)
+		}
+		return nil
+	}, retry.Delay(3*time.Second), retry.Timeout(40*time.Second))
+	t.Log("httpbin returns status 418")
+	g.DeleteConfigOrFail(t, istioSystemNs, testOOPKeyValPathRule)
+}
+
+func TestCheck(t *testing.T) {
+	ctx := framework.NewContext(t)
+	defer ctx.Done(t)
+
+	gal := galley.NewOrFail(t, ctx, galley.Config{})
+	mxr := mixer.NewOrFail(t, ctx, mixer.Config{
+		Galley: gal,
+	})
+	be := policybackend.NewOrFail(t, ctx)
+
+	ns := namespace.NewOrFail(t, ctx, "testcheck-deny-oop", false)
+	istioSystemNs := namespace.ClaimOrFail(t, ctx, "istio-system")
+
+	// Get out of process adapter related config, which includes dyanmic template for keyval and checknothing,
+	// and dynamic adapter config for policy backend.
+	oopConfig, err := readOOPConfig()
+	if err != nil {
+		t.Fatalf("cannot read out of process config file: %v", err)
+	}
+
+	gal.ApplyConfigOrFail(
+		t,
+		istioSystemNs,
+		oopConfig,
+		testOOPCheckConfig,
+		be.CreateConfigSnippet("", "", policybackend.OutOfProcess))
+
+	retry.UntilSuccessOrFail(t, func() error {
+		result := mxr.Check(t, map[string]interface{}{
+			"context.protocol":      "http",
+			"destination.name":      "someworkload",
+			"destination.namespace": ns.Name(),
+			"response.time":         time.Now(),
+			"request.time":          time.Now(),
+			"destination.service":   `svc.` + ns.Name(),
+			"origin.ip":             []byte{1, 2, 3, 4},
+		})
+
+		if result.Succeeded() {
+			return fmt.Errorf("check should not pass: %v", result.Raw)
+		}
+
+		return nil
+	}, retry.Timeout(time.Second*40))
+}
+
+// readOOPConfig reads out of process adapter config, which includes dyanmic template for keyval and checknothing,
+// and dynamic adapter config for policy backend.
+func readOOPConfig() (string, error) {
+	oopConfig := ""
+	if tmpl, err := test.ReadConfigFile(checknothingTmpl); err == nil {
+		oopConfig += "\n" + tmpl
+	} else {
+		return "", err
+	}
+	if tmpl, err := test.ReadConfigFile(keyvalTmpl); err == nil {
+		oopConfig += "\n" + tmpl
+	} else {
+		return "", err
+	}
+	if cfg, err := test.ReadConfigFile(adapterConfig); err == nil {
+		oopConfig += "\n" + cfg
+	} else {
+		return "", err
+	}
+
+	return strings.TrimSpace(oopConfig), nil
+}
+
+func TestMain(m *testing.M) {
+	framework.NewSuite("out_of_process_adapter_test", m).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		Run()
+}
+
+var testOOPKeyValInstace = `
+apiVersion: config.istio.io/v1alpha2
+kind: instance
+metadata:
+  name: keyval
+  namespace: istio-system
+spec:
+  template: keyval
+  params:
+    key: request.headers["user"] | ""
+`
+
+var testOOPKeyValGroupRule = `
+apiVersion: config.istio.io/v1alpha2
+kind: rule
+metadata:
+  name: keyval
+spec:
+  actions:
+  - handler: keyval.istio-system
+    instances: [ keyval ]
+    name: x
+  requestHeaderOperations:
+  - name: user-group
+    values: [ x.output.value ]
+`
+
+var testOOPKeyValPathRule = `
+apiVersion: config.istio.io/v1alpha2
+kind: rule
+metadata:
+  name: keyval
+spec:
+  match: source.labels["istio"] == "ingressgateway"
+  actions:
+  - handler: keyval.istio-system
+    instances: [ keyval ]
+  requestHeaderOperations:
+  - name: :path
+    values: [ '"/status/418"' ]
+`
+
+var testOOPCheckConfig = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: checknothing1	
+spec:
+  template: checknothing
+  params:
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: denyrule
+spec:
+  actions:
+  - handler: denyhandler
+    instances:
+    - checknothing1
+`

--- a/tests/integration/mixer/out_of_process/out_of_process_test.go
+++ b/tests/integration/mixer/out_of_process/out_of_process_test.go
@@ -111,7 +111,7 @@ func TestRouteDirective(t *testing.T) {
 		}
 		headers = result["headers"].(map[string]interface{})
 		for key, val := range headers {
-			if strings.ToLower(key) == "user-group" && strings.ToLower(val.(string)) == "admin" {
+			if strings.EqualFold(key, "user-group") && strings.EqualFold(val.(string), "admin") {
 				return nil
 			}
 		}

--- a/tests/integration/mixer/out_of_process/out_of_process_test.go
+++ b/tests/integration/mixer/out_of_process/out_of_process_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/galley"
@@ -31,6 +30,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/mixer"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/policybackend"
+	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -46,159 +46,169 @@ var (
 	ist istio.Instance
 )
 
+// TestRouteDirective is to test using an out of process policy adapter to manipulate request headers and routing.
+// It follows this task: https://istio.io/docs/tasks/policy-enforcement/control-headers/
 func TestRouteDirective(t *testing.T) {
-	ctx := framework.NewContext(t)
-	defer ctx.Done(t)
+	framework.
+		NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			httpbinNs, err := namespace.New(ctx, "httpbin-test", true)
+			istioSystemNs := namespace.ClaimOrFail(t, ctx, "istio-system")
 
-	ctx.RequireOrSkip(t, environment.Kube)
-	httpbinNs, err := namespace.New(ctx, "httpbin-test", true)
-	istioSystemNs := namespace.ClaimOrFail(t, ctx, "istio-system")
+			g := galley.NewOrFail(t, ctx, galley.Config{})
+			_ = mixer.NewOrFail(t, ctx, mixer.Config{Galley: g})
+			_ = httpbin.DeployOrFail(t, ctx, httpbin.Config{Namespace: httpbinNs})
+			be := policybackend.NewOrFail(t, ctx)
 
-	g := galley.NewOrFail(t, ctx, galley.Config{})
-	_ = mixer.NewOrFail(t, ctx, mixer.Config{Galley: g})
-	_ = httpbin.DeployOrFail(t, ctx, httpbin.Config{Namespace: httpbinNs})
-	be := policybackend.NewOrFail(t, ctx)
-
-	// Get out of process adapter related config, which includes dyanmic template for keyval and checknothing,
-	// and dynamic adapter config for policy backend.
-	oopConfig, err := readOOPConfig()
-	if err != nil {
-		t.Fatalf("unable to read out of process adapter config: %v", err)
-	}
-
-	// Apply all configs needed by out of process adapter, which includes all needed dynamic templates,
-	// adapter config, instances and handlers.
-	g.ApplyConfigOrFail(t, istioSystemNs,
-		oopConfig,
-		testOOPKeyValInstace,
-		be.CreateConfigSnippet("policy-backend", istioSystemNs.Name(), policybackend.OutOfProcess),
-	)
-	g.ApplyConfigOrFail(t, httpbinNs,
-		httpbin.NetworkingHttpbinGateway.LoadWithNamespaceOrFail(t, httpbinNs.Name()))
-	ing := ingress.NewOrFail(t, ctx, ingress.Config{Istio: ist})
-
-	var response ingress.CallResponse
-
-	t.Log("visit httpbin")
-	retry.UntilSuccessOrFail(t, func() error {
-		response, err = ing.Call("/")
-		if err != nil {
-			return fmt.Errorf("unable to connect to httpbin: %v", err)
-		}
-		return nil
-	}, retry.Delay(3*time.Second), retry.Timeout(30*time.Second))
-
-	// Test rule that adds header.
-	t.Log("apply rule to add 'group' header")
-	g.ApplyConfigOrFail(t, istioSystemNs, testOOPKeyValGroupRule)
-
-	// Retry visiting httpbin until gets "user-group" header
-	retry.UntilSuccessOrFail(t, func() error {
-		response, err = ing.CallWithHeaders("/headers", map[string]string{"user": "jason"})
-		if err != nil {
-			return fmt.Errorf("unable to connect to httpbin: %v", err)
-		}
-		if response.Code != statusOK {
-			return fmt.Errorf("visit returns non-ok code: %v", response.Code)
-		}
-
-		var result, headers map[string]interface{}
-		if json.Unmarshal([]byte(response.Body), &result) != nil {
-			return fmt.Errorf("cannot unmarshal json string %v", response.Body)
-		}
-		if _, ok := result["headers"]; !ok {
-			return fmt.Errorf("cannot find headers in httpbin response: %v", response.Body)
-		}
-		headers = result["headers"].(map[string]interface{})
-		for key, val := range headers {
-			if strings.EqualFold(key, "user-group") && strings.EqualFold(val.(string), "admin") {
-				return nil
+			// Get out of process adapter related config, which includes dyanmic template for keyval and checknothing,
+			// and dynamic adapter config for policy backend.
+			oopConfig, err := readOOPConfig()
+			if err != nil {
+				t.Fatalf("unable to read out of process adapter config: %v", err)
 			}
-		}
-		return fmt.Errorf("cannot find user-group header in request headers: %v", headers)
-	}, retry.Delay(3*time.Second), retry.Timeout(40*time.Second))
 
-	t.Log("find user-group: admin header")
-	g.DeleteConfigOrFail(t, istioSystemNs, testOOPKeyValGroupRule)
+			// Apply all configs needed by out of process adapter, which includes all needed dynamic templates,
+			// adapter config, instances and handlers.
+			g.ApplyConfigOrFail(t, istioSystemNs,
+				oopConfig,
+				testOOPKeyValInstace,
+				be.CreateConfigSnippet("policy-backend", istioSystemNs.Name(), policybackend.OutOfProcess),
+			)
+			g.ApplyConfigOrFail(t, httpbinNs,
+				httpbin.NetworkingHttpbinGateway.LoadWithNamespaceOrFail(t, httpbinNs.Name()))
+			ing := ingress.NewOrFail(t, ctx, ingress.Config{Istio: ist})
 
-	// Test header editing and route directive.
-	t.Log("apply rule to edit path header")
-	g.ApplyConfigOrFail(t, istioSystemNs, testOOPKeyValPathRule)
-	retry.UntilSuccessOrFail(t, func() error {
-		response, err = ing.Call("/headers")
-		if err != nil {
-			return fmt.Errorf("unable to connect to httpbin: %v", err)
-		}
-		if response.Code != statusTeapot {
-			return fmt.Errorf("httpbin does not return teapot: %v", response.Code)
-		}
-		return nil
-	}, retry.Delay(3*time.Second), retry.Timeout(40*time.Second))
-	t.Log("httpbin returns status 418")
-	g.DeleteConfigOrFail(t, istioSystemNs, testOOPKeyValPathRule)
+			var response ingress.CallResponse
+
+			retry.UntilSuccessOrFail(t, func() error {
+				t.Logf("try visiting httpbin to get 200")
+				response, err = ing.Call("/")
+				if err != nil {
+					return fmt.Errorf("unable to connect to httpbin: %v", err)
+				}
+				if response.Code != 200 {
+					return fmt.Errorf("get non-ok response code %v", response.Code)
+				}
+				return nil
+			}, retry.Delay(3*time.Second), retry.Timeout(30*time.Second))
+
+			// Test rule that adds header.
+			t.Logf("apply rule to add 'group' header")
+			g.ApplyConfigOrFail(t, istioSystemNs, testOOPKeyValGroupRule)
+
+			// Retry visiting httpbin until gets "user-group" header
+			retry.UntilSuccessOrFail(t, func() error {
+				t.Logf("try visiting httpbin with 'user: jason' header, want user-group header to be added")
+				response, err = ing.CallWithHeaders("/headers", map[string]string{"user": "jason"})
+				if err != nil {
+					return fmt.Errorf("unable to connect to httpbin: %v", err)
+				}
+				if response.Code != statusOK {
+					return fmt.Errorf("visit returns non-ok code: %v", response.Code)
+				}
+
+				var result, headers map[string]interface{}
+				if json.Unmarshal([]byte(response.Body), &result) != nil {
+					return fmt.Errorf("cannot unmarshal json string %v", response.Body)
+				}
+				if _, ok := result["headers"]; !ok {
+					return fmt.Errorf("cannot find headers in httpbin response: %v", response.Body)
+				}
+				headers = result["headers"].(map[string]interface{})
+				for key, val := range headers {
+					if strings.EqualFold(key, "user-group") && strings.EqualFold(val.(string), "admin") {
+						return nil
+					}
+				}
+				return fmt.Errorf("cannot find user-group header in request headers: %v", headers)
+			}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
+
+			t.Logf("find user-group: admin header")
+			g.DeleteConfigOrFail(t, istioSystemNs, testOOPKeyValGroupRule)
+
+			// Test header editing and route directive.
+			t.Logf("apply rule to edit path header")
+			g.ApplyConfigOrFail(t, istioSystemNs, testOOPKeyValPathRule)
+			retry.UntilSuccessOrFail(t, func() error {
+				t.Logf("try visiting httpbin with 'user: jason' header, want to get status 418")
+				response, err = ing.CallWithHeaders("/headers", map[string]string{"user": "jason"})
+				if err != nil {
+					return fmt.Errorf("unable to connect to httpbin: %v", err)
+				}
+				if response.Code != statusTeapot {
+					return fmt.Errorf("httpbin does not return teapot: %v", response.Code)
+				}
+				return nil
+			}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
+			t.Logf("httpbin returns status 418")
+			g.DeleteConfigOrFail(t, istioSystemNs, testOOPKeyValPathRule)
+		})
 }
 
+// TestCheck tests policy check deniel with an out of process policy adapter.
 func TestCheck(t *testing.T) {
-	ctx := framework.NewContext(t)
-	defer ctx.Done(t)
+	framework.
+		NewTest(t).
+		Run(func(ctx framework.TestContext) {
+			gal := galley.NewOrFail(t, ctx, galley.Config{})
+			mxr := mixer.NewOrFail(t, ctx, mixer.Config{
+				Galley: gal,
+			})
+			be := policybackend.NewOrFail(t, ctx)
 
-	gal := galley.NewOrFail(t, ctx, galley.Config{})
-	mxr := mixer.NewOrFail(t, ctx, mixer.Config{
-		Galley: gal,
-	})
-	be := policybackend.NewOrFail(t, ctx)
+			ns := namespace.NewOrFail(t, ctx, "testcheck-deny-oop", false)
+			istioSystemNs := namespace.ClaimOrFail(t, ctx, "istio-system")
 
-	ns := namespace.NewOrFail(t, ctx, "testcheck-deny-oop", false)
-	istioSystemNs := namespace.ClaimOrFail(t, ctx, "istio-system")
+			// Get out of process adapter related config, which includes dyanmic template for keyval and checknothing,
+			// and dynamic adapter config for policy backend.
+			oopConfig, err := readOOPConfig()
+			if err != nil {
+				t.Fatalf("cannot read out of process config file: %v", err)
+			}
 
-	// Get out of process adapter related config, which includes dyanmic template for keyval and checknothing,
-	// and dynamic adapter config for policy backend.
-	oopConfig, err := readOOPConfig()
-	if err != nil {
-		t.Fatalf("cannot read out of process config file: %v", err)
-	}
+			gal.ApplyConfigOrFail(
+				t,
+				istioSystemNs,
+				oopConfig,
+				testOOPCheckConfig,
+				be.CreateConfigSnippet("", "", policybackend.OutOfProcess))
 
-	gal.ApplyConfigOrFail(
-		t,
-		istioSystemNs,
-		oopConfig,
-		testOOPCheckConfig,
-		be.CreateConfigSnippet("", "", policybackend.OutOfProcess))
+			retry.UntilSuccessOrFail(t, func() error {
+				result := mxr.Check(t, map[string]interface{}{
+					"context.protocol":      "http",
+					"destination.name":      "someworkload",
+					"destination.namespace": ns.Name(),
+					"response.time":         time.Now(),
+					"request.time":          time.Now(),
+					"destination.service":   `svc.` + ns.Name(),
+					"origin.ip":             []byte{1, 2, 3, 4},
+				})
 
-	retry.UntilSuccessOrFail(t, func() error {
-		result := mxr.Check(t, map[string]interface{}{
-			"context.protocol":      "http",
-			"destination.name":      "someworkload",
-			"destination.namespace": ns.Name(),
-			"response.time":         time.Now(),
-			"request.time":          time.Now(),
-			"destination.service":   `svc.` + ns.Name(),
-			"origin.ip":             []byte{1, 2, 3, 4},
+				if result.Succeeded() {
+					return fmt.Errorf("check should not pass: %v", result.Raw)
+				}
+
+				return nil
+			}, retry.Timeout(time.Second*40))
 		})
-
-		if result.Succeeded() {
-			return fmt.Errorf("check should not pass: %v", result.Raw)
-		}
-
-		return nil
-	}, retry.Timeout(time.Second*40))
 }
 
 // readOOPConfig reads out of process adapter config, which includes dyanmic template for keyval and checknothing,
 // and dynamic adapter config for policy backend.
 func readOOPConfig() (string, error) {
 	oopConfig := ""
-	if tmpl, err := test.ReadConfigFile(checknothingTmpl); err == nil {
+	if tmpl, err := file.AsString(checknothingTmpl); err == nil {
 		oopConfig += "\n" + tmpl
 	} else {
 		return "", err
 	}
-	if tmpl, err := test.ReadConfigFile(keyvalTmpl); err == nil {
+	if tmpl, err := file.AsString(keyvalTmpl); err == nil {
 		oopConfig += "\n" + tmpl
 	} else {
 		return "", err
 	}
-	if cfg, err := test.ReadConfigFile(adapterConfig); err == nil {
+	if cfg, err := file.AsString(adapterConfig); err == nil {
 		oopConfig += "\n" + cfg
 	} else {
 		return "", err

--- a/tests/integration/mixer/out_of_process/out_of_process_test.go
+++ b/tests/integration/mixer/out_of_process/out_of_process_test.go
@@ -99,7 +99,6 @@ func TestRouteDirective(t *testing.T) {
 
 			// Retry visiting httpbin until gets "user-group" header
 			retry.UntilSuccessOrFail(t, func() error {
-				t.Logf("try visiting httpbin with 'user: jason' header, want user-group header to be added")
 				response, err = ing.CallWithHeaders("/headers", map[string]string{"user": "jason"})
 				if err != nil {
 					return fmt.Errorf("unable to connect to httpbin: %v", err)
@@ -121,6 +120,7 @@ func TestRouteDirective(t *testing.T) {
 						return nil
 					}
 				}
+				t.Logf("try visiting httpbin with 'user: jason' header, got %v want user-group header", headers)
 				return fmt.Errorf("cannot find user-group header in request headers: %v", headers)
 			}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
 
@@ -131,7 +131,6 @@ func TestRouteDirective(t *testing.T) {
 			t.Logf("apply rule to edit path header")
 			g.ApplyConfigOrFail(t, istioSystemNs, testOOPKeyValPathRule)
 			retry.UntilSuccessOrFail(t, func() error {
-				t.Logf("try visiting httpbin with 'user: jason' header, want to get status 418")
 				response, err = ing.CallWithHeaders("/headers", map[string]string{"user": "jason"})
 				if err != nil {
 					return fmt.Errorf("unable to connect to httpbin: %v", err)
@@ -139,6 +138,7 @@ func TestRouteDirective(t *testing.T) {
 				if response.Code != statusTeapot {
 					return fmt.Errorf("httpbin does not return teapot: %v", response.Code)
 				}
+				t.Logf("try visiting httpbin with 'user: jason' header, got %v, want to get status %v", response.Code, statusTeapot)
 				return nil
 			}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
 			t.Logf("httpbin returns status 418")

--- a/tests/integration/mixer/out_of_process/out_of_process_test.go
+++ b/tests/integration/mixer/out_of_process/out_of_process_test.go
@@ -17,6 +17,7 @@ package out_of_process_adapter_test
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -99,7 +100,7 @@ func TestRouteDirective(t *testing.T) {
 
 			// Retry visiting httpbin until gets "user-group" header
 			retry.UntilSuccessOrFail(t, func() error {
-				response, err = ing.CallWithHeaders("/headers", map[string]string{"user": "jason"})
+				response, err = ing.CallWithHeaders("/headers", http.Header{"user": []string{"jason"}})
 				if err != nil {
 					return fmt.Errorf("unable to connect to httpbin: %v", err)
 				}
@@ -131,7 +132,7 @@ func TestRouteDirective(t *testing.T) {
 			t.Logf("apply rule to edit path header")
 			g.ApplyConfigOrFail(t, istioSystemNs, testOOPKeyValPathRule)
 			retry.UntilSuccessOrFail(t, func() error {
-				response, err = ing.CallWithHeaders("/headers", map[string]string{"user": "jason"})
+				response, err = ing.CallWithHeaders("/headers", http.Header{"user": []string{"jason"}})
 				if err != nil {
 					return fmt.Errorf("unable to connect to httpbin: %v", err)
 				}


### PR DESCRIPTION
Add two integration tests to cover out of process adapter check and route directive. Both tests uses the fake policy backend. #12506