### PR TITLE
(hzxuzhonghu) Always allow unknown fields when apply json string

### DIFF
--- a/pilot/pkg/config/kube/crd/conversion_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_test.go
@@ -47,8 +47,8 @@ func TestConvert(t *testing.T) {
 	if _, err := ConvertConfig(model.VirtualService, model.Config{}); err == nil {
 		t.Errorf("expected error for converting empty config")
 	}
-	if _, err := ConvertObject(model.VirtualService, &IstioKind{Spec: map[string]interface{}{"x": 1}}, "local"); err == nil {
-		t.Errorf("expected error for converting empty object")
+	if _, err := ConvertObject(model.VirtualService, &IstioKind{Spec: map[string]interface{}{"x": 1}}, "local"); err != nil {
+		t.Errorf("error for converting object: %s", err)
 	}
 	config := model.Config{
 		ConfigMeta: model.ConfigMeta{

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -457,7 +457,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 // input YAML with defaults applied to omitted configuration values.
 func ApplyMeshConfigDefaults(yaml string) (*meshconfig.MeshConfig, error) {
 	out := DefaultMeshConfig()
-	if err := ApplyYAML(yaml, &out, false); err != nil {
+	if err := ApplyYAML(yaml, &out); err != nil {
 		return nil, multierror.Prefix(err, "failed to convert to proto.")
 	}
 
@@ -474,7 +474,7 @@ func ApplyMeshConfigDefaults(yaml string) (*meshconfig.MeshConfig, error) {
 		if err != nil {
 			return nil, multierror.Prefix(err, "failed to re-encode default proxy config")
 		}
-		if err := ApplyYAML(origProxyConfigYAML, out.DefaultConfig, false); err != nil {
+		if err := ApplyYAML(origProxyConfigYAML, out.DefaultConfig); err != nil {
 			return nil, multierror.Prefix(err, "failed to convert to proto.")
 		}
 	}
@@ -497,7 +497,7 @@ func EmptyMeshNetworks() meshconfig.MeshNetworks {
 // input YAML.
 func LoadMeshNetworksConfig(yaml string) (*meshconfig.MeshNetworks, error) {
 	out := EmptyMeshNetworks()
-	if err := ApplyYAML(yaml, &out, false); err != nil {
+	if err := ApplyYAML(yaml, &out); err != nil {
 		return nil, multierror.Prefix(err, "failed to convert to proto.")
 	}
 

--- a/pilot/pkg/model/conversion.go
+++ b/pilot/pkg/model/conversion.go
@@ -96,8 +96,14 @@ func (ps *ProtoSchema) FromJSON(js string) (proto.Message, error) {
 // ApplyJSON unmarshals a JSON string into a proto message.
 func ApplyJSON(js string, pb proto.Message) error {
 	reader := strings.NewReader(js)
-	m := jsonpb.Unmarshaler{AllowUnknownFields: true}
-	return m.Unmarshal(reader, pb)
+	m := jsonpb.Unmarshaler{}
+	if err := m.Unmarshal(reader, pb); err != nil {
+		log.Debugf("Failed to decode proto: %q. Trying decode with AllowUnknownFields=true", err)
+		m.AllowUnknownFields = true
+		reader.Reset(js)
+		return m.Unmarshal(reader, pb)
+	}
+	return nil
 }
 
 // FromYAML converts a canonical YAML to a proto message

--- a/pilot/pkg/model/conversion.go
+++ b/pilot/pkg/model/conversion.go
@@ -87,28 +87,17 @@ func (ps *ProtoSchema) FromJSON(js string) (proto.Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = ApplyJSON(js, pb, true); err != nil {
+	if err = ApplyJSON(js, pb); err != nil {
 		return nil, err
 	}
 	return pb, nil
 }
 
-// ApplyJSON unmarshals a JSON string into a proto message. Unknown fields will produce an
-//// error unless strict is set to false.
-func ApplyJSON(js string, pb proto.Message, strict bool) error {
+// ApplyJSON unmarshals a JSON string into a proto message.
+func ApplyJSON(js string, pb proto.Message) error {
 	reader := strings.NewReader(js)
-	m := jsonpb.Unmarshaler{}
-	if err := m.Unmarshal(reader, pb); err != nil {
-		if strict {
-			return err
-		}
-
-		log.Warnf("Failed to decode proto: %q. Trying decode with AllowUnknownFields=true", err)
-		m.AllowUnknownFields = true
-		reader.Reset(js)
-		return m.Unmarshal(reader, pb)
-	}
-	return nil
+	m := jsonpb.Unmarshaler{AllowUnknownFields: true}
+	return m.Unmarshal(reader, pb)
 }
 
 // FromYAML converts a canonical YAML to a proto message
@@ -117,20 +106,20 @@ func (ps *ProtoSchema) FromYAML(yml string) (proto.Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = ApplyYAML(yml, pb, true); err != nil {
+	if err = ApplyYAML(yml, pb); err != nil {
 		return nil, err
 	}
 	return pb, nil
 }
 
-// ApplyYAML unmarshals a YAML string into a proto message. Unknown fields will produce an
-// error unless strict is set to false.
-func ApplyYAML(yml string, pb proto.Message, strict bool) error {
+// ApplyYAML unmarshals a YAML string into a proto message.
+// Unknown fields are allowed.
+func ApplyYAML(yml string, pb proto.Message) error {
 	js, err := yaml.YAMLToJSON([]byte(yml))
 	if err != nil {
 		return err
 	}
-	return ApplyJSON(string(js), pb, strict)
+	return ApplyJSON(string(js), pb)
 }
 
 // FromJSONMap converts from a generic map to a proto message using canonical JSON encoding

--- a/pilot/pkg/model/conversion_test.go
+++ b/pilot/pkg/model/conversion_test.go
@@ -33,30 +33,21 @@ func TestApplyJSON(t *testing.T) {
 	cases := []struct {
 		in      string
 		want    *meshconfig.MeshConfig
-		strict  bool
 		wantErr bool
 	}{
 		{
-			in:     `{"enableTracing": true}`,
-			want:   &meshconfig.MeshConfig{EnableTracing: true},
-			strict: true,
+			in:   `{"enableTracing": true}`,
+			want: &meshconfig.MeshConfig{EnableTracing: true},
 		},
 		{
-			in:      `{"enableTracing": true, "unknownField": "unknownValue"}`,
-			want:    &meshconfig.MeshConfig{EnableTracing: true},
-			strict:  true,
-			wantErr: true,
-		},
-		{
-			in:     `{"enableTracing": true, "unknownField": "unknownValue"}`,
-			want:   &meshconfig.MeshConfig{EnableTracing: true},
-			strict: false,
+			in:   `{"enableTracing": true, "unknownField": "unknownValue"}`,
+			want: &meshconfig.MeshConfig{EnableTracing: true},
 		},
 	}
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("[%v]", i), func(tt *testing.T) {
 			var got meshconfig.MeshConfig
-			err := model.ApplyJSON(c.in, &got, c.strict)
+			err := model.ApplyJSON(c.in, &got)
 			if err != nil {
 				if !c.wantErr {
 					tt.Fatalf("got unexpected error: %v", err)


### PR DESCRIPTION
Apparently @hzxuzhonghu is on vacation and can't rebase his change so tests are failing

Not sure if this is the best approach to this but it seems better than merging a PR with failing unit tests

This is a copy of https://github.com/istio/istio/pull/13699/