### PR TITLE
Add basic feature file linting.

### DIFF
--- a/tools/featurectl/bad-feature.yaml
+++ b/tools/featurectl/bad-feature.yaml
@@ -1,0 +1,8 @@
+features:
+- name:           Multicluster.Kubernetes.SingleVPC
+  description:    Ingest endpoints from another K8S cluster on same VPC using MCP
+  testTypes:     
+  - integration
+  - stability
+  targetLayers:   xds
+  priority: wrong type

--- a/tools/featurectl/cmd/lint.go
+++ b/tools/featurectl/cmd/lint.go
@@ -1,0 +1,60 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	linter "istio.io/istio/tools/featurectl/pkg/linter"
+)
+
+// lintCmd represents the lint command
+var lintCmd = &cobra.Command{
+	Use:   "lint files...",
+	Short: "Lint specified feature yaml files",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("lint called")
+		linter := linter.FeatureLinter{}
+		for _, arg := range args {
+			if err := linter.ProcessFile(arg); err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(lintCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// lintCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// lintCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/tools/featurectl/cmd/root.go
+++ b/tools/featurectl/cmd/root.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "featurectl",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	//	Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.featurectl.yaml)")
+
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Search config in home directory with name ".featurectl" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigName(".featurectl")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/tools/featurectl/example-feature.yaml
+++ b/tools/featurectl/example-feature.yaml
@@ -1,0 +1,8 @@
+features:
+- name:           Multicluster.Kubernetes.SingleVPC
+  description:    Ingest endpoints from another K8S cluster on same VPC using MCP
+  testTypes:     
+  - integration
+  - stability
+  targetLayers:   xds
+  priority: 0

--- a/tools/featurectl/main.go
+++ b/tools/featurectl/main.go
@@ -1,0 +1,21 @@
+// Copyright © 2019 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "istio.io/istio/tools/featurectl/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/tools/featurectl/pkg/linter/featurelinter.go
+++ b/tools/featurectl/pkg/linter/featurelinter.go
@@ -1,0 +1,72 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featurectl
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+)
+
+type Feature struct {
+	Name         string
+	Description  string
+	TargetLayers string
+	Priority     int
+	TestTypes    []string
+	SourceFile   string `json:"-"`
+}
+
+type FeatureSet struct {
+	Features []Feature
+}
+
+type FeatureLinter struct {
+	features map[string]Feature
+}
+
+func (f *FeatureLinter) ProcessFile(filePath string) (err error) {
+	var bytes []byte
+	if bytes, err = ioutil.ReadFile(filePath); err != nil {
+		return
+	}
+	var fs FeatureSet
+	if err = yaml.Unmarshal(bytes, &fs); err != nil {
+		return
+	}
+	for _, feature := range fs.Features {
+		feature.SourceFile = filePath
+		if err = f.ProcessFeature(feature); err != nil {
+			return
+		}
+	}
+	return nil
+}
+
+func (f *FeatureLinter) ProcessFeature(feature Feature) error {
+	// golang has no way to initialize this map by default, afaict
+	if f.features == nil {
+		f.features = map[string]Feature{}
+	}
+	if dup, ok := f.features[feature.Name]; ok {
+		return fmt.Errorf(fmt.Sprintf("Duplicate feature detected. %s is defined in %s and %s", feature.Name, feature.SourceFile, dup.SourceFile))
+	}
+	f.features[feature.Name] = feature
+	if len(feature.Description) < 1 {
+		return fmt.Errorf("Description is required")
+	}
+	return nil
+}

--- a/tools/featurectl/pkg/linter/featurelinter_test.go
+++ b/tools/featurectl/pkg/linter/featurelinter_test.go
@@ -1,0 +1,33 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featurectl
+
+import "testing"
+
+func TestGoodFeature(t *testing.T) {
+	f := FeatureLinter{}
+	err := f.ProcessFile("../../example-feature.yaml")
+	if err != nil {
+		t.Errorf("Failed to parse good feauture file: %s", err)
+	}
+}
+
+func TestBadFeature(t *testing.T) {
+	f := FeatureLinter{}
+	err := f.ProcessFile("./bad-feature.yaml")
+	if err == nil {
+		t.Error("Linting bad feature file succeeded, but should have failed.")
+	}
+}


### PR DESCRIPTION
This command will ensure that feature files are well formed, conform to basic validation rules, and do not contain duplicate feature definitions.