### PR TITLE
Add a kustomize file for bookinfo

### DIFF
--- a/samples/bookinfo/platform/kube/kustomization.yaml
+++ b/samples/bookinfo/platform/kube/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - namespace.yaml
+  - bookinfo.yaml
+
+namespace: bookinfo

--- a/samples/bookinfo/platform/kube/namespace.yaml
+++ b/samples/bookinfo/platform/kube/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+  label:
+    istio-env: istio-system


### PR DESCRIPTION
The kustomize will use the new installer ( which is based on kustomize ), needed for one-line install.