### PR TITLE
fix pilot-agent request url

### DIFF
--- a/pilot/cmd/pilot-agent/request.go
+++ b/pilot/cmd/pilot-agent/request.go
@@ -33,7 +33,7 @@ var (
 		Args:  cobra.MinimumNArgs(2),
 		RunE: func(c *cobra.Command, args []string) error {
 			command := &request.Command{
-				Address: "127.0.0.1:15000",
+				Address: "localhost:15000",
 				Client: &http.Client{
 					Timeout: 60 * time.Second,
 				},


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Currently pilot-agent uses hardcoded `Address: “127.0.0.1:15000”` for remote requests, specifically from `istioctl`. This PR changes it to use `localhost` instead. It will allow support ipv4 and ipv6 admin endpoints for remote requests. 