### PR TITLE
Fix issue #12752. Add delay after applying configuration change

### DIFF
--- a/pilot/pkg/proxy/agent_test.go
+++ b/pilot/pkg/proxy/agent_test.go
@@ -143,6 +143,7 @@ func TestApplyThrice(t *testing.T) {
 		if epoch == 1 {
 			go func() {
 				a.ConfigCh() <- good
+				time.Sleep(time.Millisecond*10)
 				cancel()
 			}()
 		} else if epoch != 0 {

--- a/pilot/pkg/proxy/agent_test.go
+++ b/pilot/pkg/proxy/agent_test.go
@@ -143,7 +143,7 @@ func TestApplyThrice(t *testing.T) {
 		if epoch == 1 {
 			go func() {
 				a.ConfigCh() <- good
-				time.Sleep(time.Millisecond * 10)
+				time.Sleep(time.Second)
 				cancel()
 			}()
 		} else if epoch != 0 {

--- a/pilot/pkg/proxy/agent_test.go
+++ b/pilot/pkg/proxy/agent_test.go
@@ -143,7 +143,7 @@ func TestApplyThrice(t *testing.T) {
 		if epoch == 1 {
 			go func() {
 				a.ConfigCh() <- good
-				time.Sleep(time.Millisecond*10)
+				time.Sleep(time.Millisecond * 10)
 				cancel()
 			}()
 		} else if epoch != 0 {


### PR DESCRIPTION
Issue #12752

There is a race condition between `terminate()` and code applying configuration changes. Add a 10ms delay after sending configuration change message.

Run `go test ./pilot/pkg/proxy/ -run ApplyThrice -count 1000`. All tests passed.