### PR TITLE
Require outlierDetection for EDS locality failover

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -27,6 +27,9 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/prometheus/client_golang/prometheus"
 
+	networkingapi "istio.io/api/networking/v1alpha3"
+	networking "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -836,11 +839,11 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, e
 			// Make a shallow copy of the cla as we are mutating the endpoints with priorities/weights relative to the calling proxy
 			clonedCLA := util.CloneClusterLoadAssignment(l)
 			l = &clonedCLA
-			// TODO(#12961) get outlierDetection from the cluster
-			// For now, we should default to allowing Failover rather than rejecting. Even if we do not know
-			// what the outlierDetection is for the Cluster, it is reasonable to require the user to provide
-			// outlier detection without enforcing this in code, as this is an alpha feature behind a flag.
-			loadbalancer.ApplyLocalityLBSetting(con.modelNode.Locality, l, s.Env.Mesh.LocalityLbSetting, true)
+
+			// Failover should only be enabled when there is an outlier detection, otherwise Envoy
+			// will never detect the hosts are unhealthy and redirect traffic.
+			enableFailover := hasOutlierDetection(push, con.modelNode, clusterName)
+			loadbalancer.ApplyLocalityLBSetting(con.modelNode.Locality, l, s.Env.Mesh.LocalityLbSetting, enableFailover)
 		}
 
 		endpoints += len(l.Endpoints)
@@ -868,6 +871,49 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, e
 			con.ConID, len(con.Clusters), endpoints, emptyClusters)
 	}
 	return nil
+}
+
+// getDestinationRule gets the DestinationRule for a given hostname. As an optimization, this also gets the service port,
+// which is needed to access the traffic policy from the destination rule.
+func getDestinationRule(push *model.PushContext, proxy *model.Proxy, hostname model.Hostname, clusterPort int) (*networkingapi.DestinationRule, *model.Port) {
+	for _, service := range push.Services(proxy) {
+		if service.Hostname == hostname {
+			config := push.DestinationRule(proxy, service)
+			if config == nil {
+				continue
+			}
+			for _, p := range service.Ports {
+				if p.Port == clusterPort {
+					return config.Spec.(*networkingapi.DestinationRule), p
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+func hasOutlierDetection(push *model.PushContext, proxy *model.Proxy, clusterName string) bool {
+	_, subsetName, hostname, portNumber := model.ParseSubsetKey(clusterName)
+
+	destinationRule, port := getDestinationRule(push, proxy, hostname, portNumber)
+	if destinationRule == nil || port == nil {
+		return false
+	}
+
+	_, outlierDetection, _, _ := networking.SelectTrafficPolicyComponents(destinationRule.TrafficPolicy, port)
+	if outlierDetection != nil {
+		return true
+	}
+
+	for _, subset := range destinationRule.Subsets {
+		if subset.Name == subsetName {
+			_, outlierDetection, _, _ := networking.SelectTrafficPolicyComponents(subset.TrafficPolicy, port)
+			if outlierDetection != nil {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // addEdsCon will track the eds connection with clusters, for optimized event-based push and debug

--- a/tests/testdata/config/destination-rule-locality.yaml
+++ b/tests/testdata/config/destination-rule-locality.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: locality
+  namespace: default
+spec:
+  host: locality.cluster.local
+  trafficPolicy:
+    outlierDetection:
+      consecutiveErrors: 1
+      interval: 1s
+      baseEjectionTime: 3m
+      maxEjectionPercent: 100


### PR DESCRIPTION
Without outlierDetection, failover is not safe as Envoy cannot detect
hosts are unhealthy. Because of this, all traffic will be locked into
the same locality, even if there are no healthy hosts in the locality.
To prevent this, we will only apply failover settings when outlier
detection is present. While the logic to get the outlierDetection is
fairly involved, computationally it is not too expensive. Performance tests show slightly less CPU usage actually, I think because we skip all of the locality computations when we don't have the outlierDetection, so it balances out (or was just subtle variances).

Fixes https://github.com/istio/istio/issues/12961