### PR TITLE
Pass the original user agent to applications in app probes

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -216,6 +216,9 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 		appReq.Header[header.Name] = []string{header.Value}
 	}
 
+	// Pass the user agent from the original request
+	appReq.Header["User-Agent"] = []string{req.UserAgent()}
+
 	// Send the request.
 	response, err := httpClient.Do(appReq)
 	if err != nil {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -212,12 +212,13 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	for _, header := range prober.HTTPHeaders {
-		appReq.Header[header.Name] = []string{header.Value}
-	}
 
-	// Pass the user agent from the original request
-	appReq.Header["User-Agent"] = []string{req.UserAgent()}
+	// Forward incoming headers to the application.
+	for name, values := range req.Header {
+		newValues := make([]string, len(values))
+		copy(newValues, values)
+		appReq.Header[name] = newValues
+	}
 
 	// Send the request.
 	response, err := httpClient.Do(appReq)


### PR DESCRIPTION
When rewriting app probes, probes sent to applications contain the user agent `Go-http-client/...` instead of the original `kube-probe/...`. Due to the change in user agent, the KNative Serving activator component would fail its healthchecks (knative/serving#3751).

This PR sends the original user agent to the applications.