### PR TITLE
Add namespace blacklist option for default injection

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/mutatingwebhook.yaml
@@ -28,6 +28,9 @@ webhooks:
         operator: NotIn
         values:
         - {{ .Release.Namespace }}
+{{- range .Values.enableNamespacesBlacklist }}
+        - {{ . }}
+{{- end }}
       - key: istio-injection
         operator: NotIn
         values:

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
@@ -5,6 +5,9 @@ enabled: true
 replicaCount: 1
 image: sidecar_injector
 enableNamespacesByDefault: false
+# These namespaces are excluded from default injection when
+# enableNamespacesByDefault is true.
+enableNamespacesBlacklist: []
 nodeSelector: {}
 
 # Specify the pod anti-affinity that allows you to constrain which nodes


### PR DESCRIPTION
If the `sidecarInjectorWebhook` chart is deployed with `enableNamespacesByDefault: true`, a user can exclude a namespace by labeling it with `istio-injection=disabled`.

In some environments however, namespaces are managed by external tools which don't add labels to their namespaces. As a cluster operator I'd like to specify a list of namespaces which should always be excluded from Istio injection without modifications to the namespace resource.

I've added an option so one can provide a list of namespaces which will be added to the already present `matchExpressions` statement that excludes the Istio namespace.