### PR TITLE
Initial istioctl integration test in new framework

### DIFF
--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-func TestMain(_ *testing.T) {
+func TestIstioctlMain(_ *testing.T) {
 	os.Args = []string{"istioctl", "version", "--remote=false"}
 	main()
 }

--- a/pkg/test/framework/components/istioctl/istioctl.go
+++ b/pkg/test/framework/components/istioctl/istioctl.go
@@ -36,21 +36,23 @@ type Config struct {
 	// currently nothing, we might add stuff like OS env settings later
 }
 
-// The test code will be linked with istioctl, and never runs a seperate istioctl binary
+// The test code will be linked with istioctl, and never runs a separate istioctl binary
 type eitherComponent struct {
+	config Config
 	id     resource.ID
 	ctx    resource.Context
-	config Config
 }
 
 // New returns a new instance of "istioctl".
 func New(ctx resource.Context, cfg Config) (i Instance, err error) {
 	err = resource.UnsupportedEnvironment(ctx.Environment())
 	ctx.Environment().Case(environment.Native, func() {
-		i, err = newEither(ctx, cfg)
+		i = newEither(ctx, cfg)
+		err = nil
 	})
 	ctx.Environment().Case(environment.Kube, func() {
-		i, err = newEither(ctx, cfg)
+		i = newEither(ctx, cfg)
+		err = nil
 	})
 
 	return
@@ -65,14 +67,14 @@ func NewOrFail(t *testing.T, c resource.Context, config Config) Instance {
 	return i
 }
 
-func newEither(ctx resource.Context, config Config) (Instance, error) {
+func newEither(ctx resource.Context, config Config) Instance {
 	n := &eitherComponent{
 		ctx:    ctx,
 		config: config,
 	}
 	n.id = ctx.TrackResource(n)
 
-	return n, nil
+	return n
 }
 
 // ID implements resource.Instance

--- a/pkg/test/framework/components/istioctl/istioctl.go
+++ b/pkg/test/framework/components/istioctl/istioctl.go
@@ -1,0 +1,90 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package istioctl
+
+import (
+	"bytes"
+	"testing"
+
+	"istio.io/istio/istioctl/cmd"
+
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+type Instance interface {
+	// Invoke invokes an istioctl command and returns the output and exception.
+	// Cobra commands don't make it easy to separate stdout and stderr and the string parameter
+	// will receive both.
+	Invoke(args []string) (string, error)
+}
+
+// Structured config for the istioctl component
+type Config struct {
+	// currently nothing, we might add stuff like OS env settings later
+}
+
+// The test code will be linked with istioctl, and never runs a seperate istioctl binary
+type eitherComponent struct {
+	id     resource.ID
+	ctx    resource.Context
+	config Config
+}
+
+// New returns a new instance of "istioctl".
+func New(ctx resource.Context, cfg Config) (i Instance, err error) {
+	err = resource.UnsupportedEnvironment(ctx.Environment())
+	ctx.Environment().Case(environment.Native, func() {
+		i, err = newEither(ctx, cfg)
+	})
+	ctx.Environment().Case(environment.Kube, func() {
+		i, err = newEither(ctx, cfg)
+	})
+
+	return
+}
+
+// NewOrFail returns a new instance of "istioctl".
+func NewOrFail(t *testing.T, c resource.Context, config Config) Instance {
+	i, err := New(c, config)
+	if err != nil {
+		t.Fatalf("istioctl.NewOrFail:: %v", err)
+	}
+	return i
+}
+
+func newEither(ctx resource.Context, config Config) (Instance, error) {
+	n := &eitherComponent{
+		ctx:    ctx,
+		config: config,
+	}
+	n.id = ctx.TrackResource(n)
+
+	return n, nil
+}
+
+// ID implements resource.Instance
+func (c *eitherComponent) ID() resource.ID {
+	return c.id
+}
+
+// GetDiscoveryAddress gets the discovery address for pilot.
+func (c *eitherComponent) Invoke(args []string) (string, error) {
+	var out bytes.Buffer
+	rootCmd := cmd.GetRootCmd(args)
+	rootCmd.SetOutput(&out)
+	fErr := rootCmd.Execute()
+	return out.String(), fErr
+}

--- a/pkg/test/framework/components/istioctl/istioctl.go
+++ b/pkg/test/framework/components/istioctl/istioctl.go
@@ -15,10 +15,7 @@
 package istioctl
 
 import (
-	"bytes"
 	"testing"
-
-	"istio.io/istio/istioctl/cmd"
 
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -36,22 +33,15 @@ type Config struct {
 	// currently nothing, we might add stuff like OS env settings later
 }
 
-// The test code will be linked with istioctl, and never runs a separate istioctl binary
-type eitherComponent struct {
-	config Config
-	id     resource.ID
-	ctx    resource.Context
-}
-
 // New returns a new instance of "istioctl".
 func New(ctx resource.Context, cfg Config) (i Instance, err error) {
 	err = resource.UnsupportedEnvironment(ctx.Environment())
 	ctx.Environment().Case(environment.Native, func() {
-		i = newEither(ctx, cfg)
+		i = newNative(ctx, cfg)
 		err = nil
 	})
 	ctx.Environment().Case(environment.Kube, func() {
-		i = newEither(ctx, cfg)
+		i = newKube(ctx, cfg)
 		err = nil
 	})
 
@@ -65,28 +55,4 @@ func NewOrFail(t *testing.T, c resource.Context, config Config) Instance {
 		t.Fatalf("istioctl.NewOrFail:: %v", err)
 	}
 	return i
-}
-
-func newEither(ctx resource.Context, config Config) Instance {
-	n := &eitherComponent{
-		ctx:    ctx,
-		config: config,
-	}
-	n.id = ctx.TrackResource(n)
-
-	return n
-}
-
-// ID implements resource.Instance
-func (c *eitherComponent) ID() resource.ID {
-	return c.id
-}
-
-// GetDiscoveryAddress gets the discovery address for pilot.
-func (c *eitherComponent) Invoke(args []string) (string, error) {
-	var out bytes.Buffer
-	rootCmd := cmd.GetRootCmd(args)
-	rootCmd.SetOutput(&out)
-	fErr := rootCmd.Execute()
-	return out.String(), fErr
 }

--- a/pkg/test/framework/components/istioctl/kube.go
+++ b/pkg/test/framework/components/istioctl/kube.go
@@ -1,0 +1,60 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package istioctl
+
+import (
+	"bytes"
+
+	"istio.io/istio/istioctl/cmd"
+
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+type kubeComponent struct {
+	config Config
+	id     resource.ID
+	ctx    resource.Context
+	env    *kube.Environment
+}
+
+func newKube(ctx resource.Context, config Config) Instance {
+	n := &kubeComponent{
+		ctx:    ctx,
+		config: config,
+		env:    ctx.Environment().(*kube.Environment),
+	}
+	n.id = ctx.TrackResource(n)
+
+	return n
+}
+
+// ID implements resource.Instance
+func (c *kubeComponent) ID() resource.ID {
+	return c.id
+}
+
+// Invoke gets the discovery address for pilot.
+func (c *kubeComponent) Invoke(args []string) (string, error) {
+	var envArgs = []string{
+		"--kubeconfig",
+		c.env.Settings().KubeConfig,
+	}
+	var out bytes.Buffer
+	rootCmd := cmd.GetRootCmd(append(envArgs, args...))
+	rootCmd.SetOutput(&out)
+	fErr := rootCmd.Execute()
+	return out.String(), fErr
+}

--- a/pkg/test/framework/components/istioctl/native.go
+++ b/pkg/test/framework/components/istioctl/native.go
@@ -1,0 +1,54 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package istioctl
+
+import (
+	"bytes"
+
+	"istio.io/istio/istioctl/cmd"
+
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+// Note: The native tests don't talk to a K8s API server, so most istioctl commands won't work
+type nativeComponent struct {
+	config Config
+	id     resource.ID
+	ctx    resource.Context
+}
+
+func newNative(ctx resource.Context, config Config) Instance {
+	n := &nativeComponent{
+		ctx:    ctx,
+		config: config,
+	}
+	n.id = ctx.TrackResource(n)
+
+	return n
+}
+
+// ID implements resource.Instance
+func (c *nativeComponent) ID() resource.ID {
+	return c.id
+}
+
+// Invoke gets the discovery address for pilot.
+func (c *nativeComponent) Invoke(args []string) (string, error) {
+	var out bytes.Buffer
+	rootCmd := cmd.GetRootCmd(args)
+	rootCmd.SetOutput(&out)
+	fErr := rootCmd.Execute()
+	return out.String(), fErr
+}

--- a/tests/integration/istioctl/istioctl_test.go
+++ b/tests/integration/istioctl/istioctl_test.go
@@ -1,0 +1,83 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"istio.io/istio/istioctl/cmd"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	i   istio.Instance
+	env *kube.Environment
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("istioctl_integration_test", m).
+		Label(label.Presubmit).
+
+		// The following is how to deploy Istio on Kubernetes, as part of the suite setup.
+		// The deployment must work. If you're breaking this, you'll break many integration tests.
+		SetupOnEnv(environment.Kube, istio.Setup(&i, nil)).
+		SetupOnEnv(environment.Kube, func(ctx resource.Context) error {
+			env = ctx.Environment().(*kube.Environment)
+			return nil
+		}).
+
+		// Finally execute the test suite
+		Run()
+}
+
+// TestVersion does "istioctl version --remote=true" to verify the CLI understands the data plane version data
+func TestVersion(t *testing.T) {
+	framework.Run(t, func(ctx framework.TestContext) {
+		args := []string{"version", "--remote=true"}
+
+		var out bytes.Buffer
+		rootCmd := cmd.GetRootCmd(args)
+		rootCmd.SetOutput(&out)
+		fErr := rootCmd.Execute()
+		output := out.String()
+
+		if fErr != nil {
+			t.Fatalf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), fErr)
+		}
+
+		expectedRegexp := regexp.MustCompile(`client version: [a-z0-9\-]*
+citadel version: [a-z0-9\-]*
+galley version: [a-z0-9\-]*
+ingressgateway version: [a-z0-9\-]*
+pilot version: [a-z0-9\-]*
+policy version: [a-z0-9\-]*
+sidecar-injector version: [a-z0-9\-]*
+telemetry version: [a-z0-9\-]*`)
+		if expectedRegexp != nil && !expectedRegexp.MatchString(output) {
+			t.Fatalf("Output didn't match for 'istioctl %s'\n got %v\nwant: %v",
+				strings.Join(args, " "), output, expectedRegexp)
+		}
+	})
+}

--- a/tests/integration/istioctl/istioctl_test.go
+++ b/tests/integration/istioctl/istioctl_test.go
@@ -15,18 +15,16 @@
 package istioctl
 
 import (
-	"bytes"
 	"regexp"
 	"strings"
 	"testing"
-
-	"istio.io/istio/istioctl/cmd"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -61,13 +59,11 @@ func TestVersion(t *testing.T) {
 			g := galley.NewOrFail(t, ctx, galley.Config{})
 			_ = pilot.NewOrFail(t, ctx, pilot.Config{Galley: g})
 
+			istioCtl := istioctl.NewOrFail(t, ctx, istioctl.Config{})
+
 			args := []string{"version", "--remote=true"}
 
-			var out bytes.Buffer
-			rootCmd := cmd.GetRootCmd(args)
-			rootCmd.SetOutput(&out)
-			fErr := rootCmd.Execute()
-			output := out.String()
+			output, fErr := istioCtl.Invoke(args)
 
 			if fErr != nil {
 				t.Fatalf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), fErr)
@@ -79,6 +75,7 @@ func TestVersion(t *testing.T) {
 				regexp.MustCompile(`egressgateway version: [a-z0-9\-]*`),
 				regexp.MustCompile(`ingressgateway version: [a-z0-9\-]*`),
 				regexp.MustCompile(`pilot version: [a-z0-9\-]*`),
+				regexp.MustCompile(`galley version: [a-z0-9\-]*`),
 				regexp.MustCompile(`policy version: [a-z0-9\-]*`),
 				regexp.MustCompile(`sidecar-injector version: [a-z0-9\-]*`),
 				regexp.MustCompile(`telemetry version: [a-z0-9\-]*`),


### PR DESCRIPTION
A simple test of `istioctl version` with `--remote=true` option.

There were no istioctl-specific integration tests.

Please review my usage of the new test framework because this is my first time using it.