### PR TITLE
Change the version tag for base image from latest

### DIFF
--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM websphere-liberty:latest
+FROM websphere-liberty:19.0.0.4-javaee8
 
 ENV SERVERDIRNAME reviews
 


### PR DESCRIPTION
The bookinfo-review sample app uses websphere-liberty:latest to create a base
image. This PR changes the latest tag to reflect an actual version. As a best
practise, we do not want to use the latest tag since that could point to different
versions as the release of the base image changes.

Partially Fixes:#13262