### PR TITLE
Fix istioctl flaky test

### DIFF
--- a/istioctl/cmd/istioctl_test.go
+++ b/istioctl/cmd/istioctl_test.go
@@ -201,7 +201,7 @@ No resources found.
 		},
 		{
 			configs: testDestinationRules,
-			args:    strings.Split("get destinationrules", " "),
+			args:    strings.Split("get destinationrules -n default", " "),
 			expectedOutput: `Command "get" is deprecated, Use ` + "`kubectl get`" + ` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)
 DESTINATION-RULE NAME   HOST               SUBSETS   NAMESPACE   AGE
 googleapis              *.googleapis.com             default     0s
@@ -209,7 +209,7 @@ googleapis              *.googleapis.com             default     0s
 		},
 		{
 			configs: testServiceEntries,
-			args:    strings.Split("get serviceentries", " "),
+			args:    strings.Split("get serviceentries -n default", " "),
 			expectedOutput: `Command "get" is deprecated, Use ` + "`kubectl get`" + ` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)
 SERVICE-ENTRY NAME   HOSTS              PORTS      NAMESPACE   AGE
 googleapis           *.googleapis.com   HTTP/443   default     0s


### PR DESCRIPTION
If kubeconfig file has a context which doesn't point to
namespace 'default', the `istioctl get <xxx>` will fail
to retrieve the mocked objects.

Fix that by explicitly specifying the namespace for the get
command just like the other test cases do.