### PR TITLE
don't disconnect sds connection when receive empty resourcename

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -162,6 +162,11 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				return err
 			}
 
+			if resourceName == "" {
+				log.Infof("Received empty resource name from %q", discReq.Node.Id)
+				continue
+			}
+
 			con.proxyID = discReq.Node.Id
 			con.ResourceName = resourceName
 
@@ -290,6 +295,10 @@ func NotifyProxy(conID, resourceName string, secret *model.SecretItem) error {
 func parseDiscoveryRequest(discReq *xdsapi.DiscoveryRequest) (string /*resourceName*/, error) {
 	if discReq.Node.Id == "" {
 		return "", fmt.Errorf("discovery request %+v missing node id", discReq)
+	}
+
+	if len(discReq.ResourceNames) == 0 {
+		return "", nil
 	}
 
 	if len(discReq.ResourceNames) == 1 {


### PR DESCRIPTION
previous nodeagent send err response when receiving discovery request with empty resource name (so that sds client will try to reconnect)

from debug logs, seems everytime empty resource name indicate sds client is trying to reconnect on new stream (see below), it should be fine to just ignore discovery request(with empty resourcename), like rds and eds  

```

2019-05-08T22:33:45.588194Z	info	****received empty resource name from "ingress~10.56.3.8~istio-ingress-custom-ns-f984d4449-7rhn7.custom-ns~custom-ns.svc.cluster.local"
2019-05-08T22:33:45.588299Z	info	SDS: connection with "ingress~10.56.3.8~istio-ingress-custom-ns-f984d4449-7rhn7.custom-ns~custom-ns.svc.cluster.local-12" terminated rpc error: code = Canceled desc = context canceled
2019-05-08T22:33:45.589937Z	info	transport: loopyWriter.run returning. connection error: desc = "transport is closing"
2019-05-08T22:33:46.355387Z	debug	Received first SDS request from "ingress~10.56.3.8~istio-ingress-custom-ns-f984d4449-7rhn7.custom-ns~custom-ns.svc.cluster.local", connectionID "ingress~10.56.3.8~istio-ingress-custom-ns-f984d4449-7rhn7.custom-ns~custom-ns.svc.cluster.local-13", resourceName "ingressgateway-wildcard-certs", versionInfo ""
```

#13853 