### PR TITLE
Added contextPath to deployment to allow for path base ingress

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -76,6 +76,8 @@ spec:
 {{- end }}
           - name: GF_PATHS_DATA
             value: /data/grafana
+          - name: GF_SERVER_ROOT_URL
+            value: {{ if $.Values.contextPath }} {{ $.Values.contextPath }} {{ else }} / {{ end }}
           resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
This allows contextPath to be used to set the GF_SERVER_ROOT_URL which is necessary in PathBase ingresses.