### PR TITLE
fix consul sidecar templates to update proxy_init image tag

### DIFF
--- a/samples/bookinfo/platform/consul/templates/bookinfo.sidecars.yaml.tmpl
+++ b/samples/bookinfo/platform/consul/templates/bookinfo.sidecars.yaml.tmpl
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1-init:
-    image: docker.io/istio/proxy_init:0.7.1
+    image: docker.io/istio/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_details-v1_1"
@@ -34,7 +34,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster details-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   ratings-v1-init:
-    image: docker.io/istio/proxy_init:0.7.1
+    image: docker.io/istio/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_ratings-v1_1"
@@ -52,7 +52,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster ratings-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   productpage-v1-init:
-    image: docker.io/istio/proxy_init:0.7.1
+    image: docker.io/istio/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_productpage-v1_1"
@@ -70,7 +70,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster productpage-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v1-init:
-    image: docker.io/istio/proxy_init:0.7.1
+    image: docker.io/istio/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_reviews-v1_1"
@@ -88,7 +88,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster reviews-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v2-init:
-    image: docker.io/istio/proxy_init:0.7.1
+    image: docker.io/istio/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_reviews-v2_1"
@@ -106,7 +106,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster reviews-v2 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v3-init:
-    image: docker.io/istio/proxy_init:0.7.1
+    image: docker.io/istio/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_reviews-v3_1"


### PR DESCRIPTION
proxy_init image tag was not getting updated during the release cut process

partially resolves https://discuss.istio.io/t/quickstart-bookinfo-app-consul-docker-is-redirecting-outbound-to-only-one-microservice/2208