### PR TITLE
[Test Framework] Fix flaky k8s test: TestEcho/NoSidecar

### DIFF
--- a/tests/integration/pilot/locality/failover_test.go
+++ b/tests/integration/pilot/locality/failover_test.go
@@ -72,8 +72,6 @@ func TestFailover(t *testing.T) {
 	//t.Parallel()
 
 	t.Run("CDS", func(t *testing.T) {
-		t.Parallel()
-
 		framework.NewTest(t).
 			RequiresEnvironment(environment.Kube).
 			// TODO(https://github.com/istio/istio/issues/13812)
@@ -108,8 +106,6 @@ func TestFailover(t *testing.T) {
 	})
 
 	t.Run("EDS", func(t *testing.T) {
-		t.Parallel()
-
 		framework.NewTest(t).
 			RequiresEnvironment(environment.Kube).
 			Run(func(ctx framework.TestContext) {

--- a/tests/integration/pilot/locality/prioritized_test.go
+++ b/tests/integration/pilot/locality/prioritized_test.go
@@ -63,8 +63,6 @@ func TestPrioritized(t *testing.T) {
 	//t.Parallel()
 
 	t.Run("CDS", func(t *testing.T) {
-		t.Parallel()
-
 		framework.NewTest(t).
 			RequiresEnvironment(environment.Kube).
 			Run(func(ctx framework.TestContext) {
@@ -94,8 +92,6 @@ func TestPrioritized(t *testing.T) {
 	})
 
 	t.Run("EDS", func(t *testing.T) {
-		t.Parallel()
-
 		framework.NewTest(t).
 			RequiresEnvironment(environment.Kube).
 			Run(func(ctx framework.TestContext) {

--- a/tests/integration/security/healthcheck/mtls_healthcheck_test.go
+++ b/tests/integration/security/healthcheck/mtls_healthcheck_test.go
@@ -52,11 +52,12 @@ spec:
 			g.ApplyConfigOrFail(t, ns, policyYAML)
 			defer g.DeleteConfigOrFail(t, ns, policyYAML)
 
-			_ = echoboot.NewOrFail(t, ctx, echo.Config{
+			healthcheck := echoboot.NewOrFail(t, ctx, echo.Config{
 				Service: "healthcheck",
 				Pilot:   p,
 				Galley:  g,
 			})
+			healthcheck.WaitUntilReadyOrFail(t)
 
 			// TODO(incfly): add a negative test once we have a per deployment annotation support for this feature.
 		})

--- a/tests/integration/security/rbac/v1/group/group_test.go
+++ b/tests/integration/security/rbac/v1/group/group_test.go
@@ -95,6 +95,7 @@ func TestRBACV1Group(t *testing.T) {
 				Galley:         g,
 				Pilot:          p,
 			})
+			a.WaitUntilReadyOrFail(t, b, c)
 
 			cases := []util.TestCase{
 				{

--- a/tests/integration/security/rbac/v2/basic/basic_test.go
+++ b/tests/integration/security/rbac/v2/basic/basic_test.go
@@ -91,6 +91,7 @@ func TestRBACV2Basic(t *testing.T) {
 				Galley:         g,
 				Pilot:          p,
 			})
+			a.WaitUntilReadyOrFail(t, b, c, d)
 
 			cases := []util.TestCase{
 				{

--- a/tests/integration/security/rbac/v2/group/group_test.go
+++ b/tests/integration/security/rbac/v2/group/group_test.go
@@ -97,6 +97,7 @@ func TestRBACV2Group(t *testing.T) {
 				Galley:         g,
 				Pilot:          p,
 			})
+			a.WaitUntilReadyOrFail(t, b, c)
 
 			cases := []util.TestCase{
 				// Port 80 is where HTTP is served

--- a/tests/integration/security/sds_citadel_flow/sds_citadel_flow_test.go
+++ b/tests/integration/security/sds_citadel_flow/sds_citadel_flow_test.go
@@ -70,6 +70,7 @@ func TestSdsCitadelCaFlow(t *testing.T) {
 				Galley:         g,
 				Pilot:          p,
 			})
+			a.WaitUntilReadyOrFail(t, b)
 
 			checkers := []connection.Checker{
 				{

--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -70,6 +70,7 @@ func TestSdsVaultCaFlow(t *testing.T) {
 				Galley:         g,
 				Pilot:          p,
 			})
+			a.WaitUntilReadyOrFail(t, b)
 
 			checkers := []connection.Checker{
 				{


### PR DESCRIPTION
This is only flaky on k8s.  I suspect the issue is that when the workloads have no sidecars, we're trying to call out before the system has propagated services/endpoints. Adding a short sleep *should* resolve this.

Fixes #13553