### PR TITLE
Delete depupdate circleci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,23 +553,6 @@ jobs:
       - store_artifacts:
           path: /tmp
 
-  # Run nightly, to verify 'dep ensure --update' works
-  depupdate:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: mkdir -p /go/out
-      - run:
-          name: Updating all dependencies
-          command: dep ensure --update
-      - run: ( cd vendor ; git status  ) # just to see what changes
-      - run: make init build
-      - run:
-          name: Status and artifacts
-          command: dep status -dot > /go/out/dep.dot
-      - store_artifacts:
-          path: /go/out/dep.dot
-
   codecov:
     <<: *defaults
     resource_class: xlarge
@@ -753,7 +736,6 @@ workflows:
                  - release-1.0
                  - dev-networking
     jobs: #daisy chained steps ending with docker push
-      - depupdate
       - build
       - test
       - e2e-simple:
@@ -786,7 +768,6 @@ workflows:
                  - release-1.0
                  - dev-networking
     jobs:
-      - depupdate
       - build
       - test
       - e2e-simple:


### PR DESCRIPTION
Since we no longer use dep, this is not needed. With go modules this type of test doesn't make much sense, as we update individual modules not everything like with dep, so I think we do not need a replacement