### PR TITLE
add branch info to circle ci test logs

### DIFF
--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -68,5 +68,9 @@ if [ -n "$CIRCLE_PR_NUMBER" ] || [ -n "$CIRCLE_PULL_REQUEST" ]; then
 	ARGS+=("--stage=presubmit")
 fi
 
+if [ ${CIRCLE_BRANCH} == "master" ]; then
+        ARGS+="--branch=${CIRCLE_BRANCH}"
+fi
+
 ci2gubernator=${GOPATH}/bin/ci2gubernator
 $ci2gubernator "${@}" "${ARGS[@]}" || true

--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -68,8 +68,8 @@ if [ -n "$CIRCLE_PR_NUMBER" ] || [ -n "$CIRCLE_PULL_REQUEST" ]; then
 	ARGS+=("--stage=presubmit")
 fi
 
-if [ ${CIRCLE_BRANCH} == "master" ]; then
-        ARGS+="--branch=${CIRCLE_BRANCH}"
+if [ "${CIRCLE_BRANCH}" == "master" ]; then
+  ARGS+=("--branch=${CIRCLE_BRANCH}")
 fi
 
 ci2gubernator=${GOPATH}/bin/ci2gubernator


### PR DESCRIPTION
It will propagate to save logs under circle/presubmit/master/test instead of circle/presubmit/test