### PR TITLE
[Test Framework] Introduce Failer interface

### DIFF
--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -19,10 +19,10 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"testing"
 
 	"github.com/hashicorp/go-multierror"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/common/response"
 	"istio.io/istio/pkg/test/echo/proto"
 )
@@ -85,7 +85,8 @@ func (r ParsedResponses) Check(check func(int, *ParsedResponse) error) (err erro
 	return
 }
 
-func (r ParsedResponses) CheckOrFail(t testing.TB, check func(int, *ParsedResponse) error) ParsedResponses {
+func (r ParsedResponses) CheckOrFail(t test.Failer, check func(int, *ParsedResponse) error) ParsedResponses {
+	t.Helper()
 	if err := r.Check(check); err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +102,8 @@ func (r ParsedResponses) CheckOK() error {
 	})
 }
 
-func (r ParsedResponses) CheckOKOrFail(t testing.TB) ParsedResponses {
+func (r ParsedResponses) CheckOKOrFail(t test.Failer) ParsedResponses {
+	t.Helper()
 	if err := r.CheckOK(); err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +119,8 @@ func (r ParsedResponses) CheckHost(expected string) error {
 	})
 }
 
-func (r ParsedResponses) CheckHostOrFail(t testing.TB, expected string) ParsedResponses {
+func (r ParsedResponses) CheckHostOrFail(t test.Failer, expected string) ParsedResponses {
+	t.Helper()
 	if err := r.CheckHost(expected); err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +137,8 @@ func (r ParsedResponses) CheckPort(expected int) error {
 	})
 }
 
-func (r ParsedResponses) CheckPortOrFail(t testing.TB, expected int) ParsedResponses {
+func (r ParsedResponses) CheckPortOrFail(t test.Failer, expected int) ParsedResponses {
+	t.Helper()
 	if err := r.CheckPort(expected); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/test/eventually.go
+++ b/pkg/test/eventually.go
@@ -15,7 +15,6 @@
 package test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -25,7 +24,7 @@ import (
 type Condition func() bool
 
 // Eventually polls cond until it completes (returns true) or times out (resulting in a test failure).
-func Eventually(t *testing.T, name string, cond Condition) {
+func Eventually(t Failer, name string, cond Condition) {
 	t.Helper()
 	EventualOpts{backoff.NewExponentialBackOff()}.Eventually(t, name, cond)
 }
@@ -53,7 +52,7 @@ func NewEventualOpts(interval, deadline time.Duration) *EventualOpts {
 //
 // name is printed as part of the test failure message when we exceed the deadline to help identify the test case failing.
 // cond does not need to be thread-safe: it is only called from the current goroutine. cond itself can also fail the test early using t.Fatal.
-func (e EventualOpts) Eventually(t *testing.T, name string, cond Condition) {
+func (e EventualOpts) Eventually(t Failer, name string, cond Condition) {
 	t.Helper()
 
 	// Check once before we start polling.

--- a/pkg/test/failer.go
+++ b/pkg/test/failer.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Istio Authors
+// Copyright 2019 Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,26 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tmpl
+package test
 
-import (
-	"text/template"
+import "testing"
 
-	"istio.io/istio/pkg/test"
-)
+var _ Failer = &testing.T{}
 
-// Parse the given template content.
-func Parse(tpl string) (*template.Template, error) {
-	t := template.New("test template")
-	return t.Parse(tpl)
-}
-
-// ParseOrFail calls Parse and fails tests if it returns error.
-func ParseOrFail(t test.Failer, tpl string) *template.Template {
-	t.Helper()
-	tpl2, err := Parse(tpl)
-	if err != nil {
-		t.Fatalf("tmpl.ParseOrFail: %v", err)
-	}
-	return tpl2
+// Failer is an interface to be provided to test functions of the form XXXOrFail. This is a
+// substitute for testing.TB, which cannot be implemented outside of the testing
+// package.
+type Failer interface {
+	Fail()
+	FailNow()
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Helper()
 }

--- a/pkg/test/framework/components/bookinfo/bookinfo.go
+++ b/pkg/test/framework/components/bookinfo/bookinfo.go
@@ -15,8 +15,7 @@
 package bookinfo
 
 import (
-	"testing"
-
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/deployment"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -40,7 +39,7 @@ func Deploy(ctx resource.Context, cfg Config) (i deployment.Instance, err error)
 }
 
 // DeployOrFail returns a new instance of deployed BookInfo or fails test
-func DeployOrFail(t *testing.T, ctx resource.Context, cfg Config) deployment.Instance {
+func DeployOrFail(t test.Failer, ctx resource.Context, cfg Config) deployment.Instance {
 	t.Helper()
 
 	i, err := Deploy(ctx, cfg)

--- a/pkg/test/framework/components/bookinfo/configs.go
+++ b/pkg/test/framework/components/bookinfo/configs.go
@@ -16,8 +16,6 @@ package bookinfo
 
 import (
 	"path"
-	"testing"
-
 	"strings"
 
 	"fmt"
@@ -57,7 +55,7 @@ const (
 
 // LoadGatewayFileWithNamespaceOrFail loads a Book Info Gateway configuration file from the system, changes it to be fit
 // for the namespace provided and returns its contents.
-func (l ConfigFile) LoadGatewayFileWithNamespaceOrFail(t testing.TB, namespace string) string {
+func (l ConfigFile) LoadGatewayFileWithNamespaceOrFail(t test.Failer, namespace string) string {
 	t.Helper()
 
 	content, err := l.LoadGatewayFileWithNamespace(namespace)
@@ -70,7 +68,7 @@ func (l ConfigFile) LoadGatewayFileWithNamespaceOrFail(t testing.TB, namespace s
 
 // LoadWithNamespaceOrFail loads a Book Info configuration file from the systemchanges it to be fit
 // for the namespace provided and returns its contents.
-func (l ConfigFile) LoadWithNamespaceOrFail(t testing.TB, namespace string) string {
+func (l ConfigFile) LoadWithNamespaceOrFail(t test.Failer, namespace string) string {
 	t.Helper()
 
 	content, err := l.LoadWithNamespace(namespace)
@@ -112,11 +110,12 @@ func (l ConfigFile) LoadWithNamespace(namespace string) (string, error) {
 }
 
 // LoadOrFail loads a Book Info configuration file from the system and returns its contents.
-func (l ConfigFile) LoadOrFail(t testing.TB) string {
+func (l ConfigFile) LoadOrFail(t test.Failer) string {
+	t.Helper()
 	return l.LoadWithNamespaceOrFail(t, "")
 }
 
-func GetDestinationRuleConfigFile(t testing.TB, ctx resource.Context) ConfigFile {
+func GetDestinationRuleConfigFile(t test.Failer, ctx resource.Context) ConfigFile {
 	t.Helper()
 
 	cfg, err := istio.DefaultConfig(ctx)

--- a/pkg/test/framework/components/citadel/citadel.go
+++ b/pkg/test/framework/components/citadel/citadel.go
@@ -15,13 +15,12 @@
 package citadel
 
 import (
-	"testing"
-
-	corev1 "k8s.io/api/core/v1"
-
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Citadel represents a deployed Citadel instance.
@@ -29,9 +28,9 @@ type Instance interface {
 	resource.Resource
 
 	WaitForSecretToExist() (*corev1.Secret, error)
-	WaitForSecretToExistOrFail(t testing.TB) *corev1.Secret
+	WaitForSecretToExistOrFail(t test.Failer) *corev1.Secret
 	DeleteSecret() error
-	DeleteSecretOrFail(t testing.TB)
+	DeleteSecretOrFail(t test.Failer)
 }
 
 type Config struct {
@@ -51,7 +50,7 @@ func New(ctx resource.Context, cfg Config) (i Instance, err error) {
 }
 
 // Deploy returns a new instance of Citadel or fails test
-func NewOrFail(t *testing.T, ctx resource.Context, cfg Config) Instance {
+func NewOrFail(t test.Failer, ctx resource.Context, cfg Config) Instance {
 	t.Helper()
 
 	i, err := New(ctx, cfg)

--- a/pkg/test/framework/components/citadel/kube.go
+++ b/pkg/test/framework/components/citadel/kube.go
@@ -16,16 +16,16 @@ package citadel
 
 import (
 	"fmt"
-	"testing"
 	"time"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
 
 	v1 "k8s.io/api/core/v1"
 	mv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-
-	"istio.io/istio/pkg/test/framework/components/environment/kube"
-	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/resource"
 )
 
 const (
@@ -81,7 +81,7 @@ func (c *kubeComponent) WaitForSecretToExist() (*v1.Secret, error) {
 	}
 }
 
-func (c *kubeComponent) WaitForSecretToExistOrFail(t testing.TB) *v1.Secret {
+func (c *kubeComponent) WaitForSecretToExistOrFail(t test.Failer) *v1.Secret {
 	t.Helper()
 	s, err := c.WaitForSecretToExist()
 	if err != nil {
@@ -95,7 +95,7 @@ func (c *kubeComponent) DeleteSecret() error {
 	return c.secret.Delete(secretName, &mv1.DeleteOptions{GracePeriodSeconds: &immediate})
 }
 
-func (c *kubeComponent) DeleteSecretOrFail(t testing.TB) {
+func (c *kubeComponent) DeleteSecretOrFail(t test.Failer) {
 	t.Helper()
 	if err := c.DeleteSecret(); err != nil {
 		t.Fatal(err)

--- a/pkg/test/framework/components/echo/common/envoy_test.go
+++ b/pkg/test/framework/components/echo/common/envoy_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-
 	"github.com/gogo/protobuf/jsonpb"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
@@ -156,7 +156,7 @@ func (e *config) ID() resource.ID {
 	panic("not implemented")
 }
 
-func (e *config) WorkloadsOrFail(t testing.TB) []echo.Workload {
+func (e *config) WorkloadsOrFail(t test.Failer) []echo.Workload {
 	panic("not implemented")
 }
 
@@ -164,7 +164,7 @@ func (e *config) WaitUntilReady(_ ...echo.Instance) error {
 	panic("not implemented")
 }
 
-func (e *config) WaitUntilReadyOrFail(_ testing.TB, _ ...echo.Instance) {
+func (e *config) WaitUntilReadyOrFail(_ test.Failer, _ ...echo.Instance) {
 	panic("not implemented")
 }
 
@@ -172,7 +172,7 @@ func (e *config) Call(_ echo.CallOptions) (client.ParsedResponses, error) {
 	panic("not implemented")
 }
 
-func (e *config) CallOrFail(_ testing.TB, _ echo.CallOptions) client.ParsedResponses {
+func (e *config) CallOrFail(_ test.Failer, _ echo.CallOptions) client.ParsedResponses {
 	panic("not implemented")
 }
 

--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -15,11 +15,10 @@
 package echo
 
 import (
-	"testing"
-
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
@@ -41,16 +40,16 @@ type Instance interface {
 	// (i.e. clusters, routes, listeners from Pilot) in order to enable outbound
 	// communication from this instance to each instance in the list.
 	WaitUntilReady(outbound ...Instance) error
-	WaitUntilReadyOrFail(t testing.TB, outbound ...Instance)
+	WaitUntilReadyOrFail(t test.Failer, outbound ...Instance)
 
 	// Workloads retrieves the list of all deployed workloads for this Echo service.
 	// Guarantees at least one workload, if error == nil.
 	Workloads() ([]Workload, error)
-	WorkloadsOrFail(t testing.TB) []Workload
+	WorkloadsOrFail(t test.Failer) []Workload
 
 	// Call makes a call from this Instance to a target Instance.
 	Call(options CallOptions) (client.ParsedResponses, error)
-	CallOrFail(t testing.TB, options CallOptions) client.ParsedResponses
+	CallOrFail(t test.Failer, options CallOptions) client.ParsedResponses
 }
 
 // Port exposed by an Echo Instance
@@ -87,15 +86,15 @@ type Sidecar interface {
 
 	// Info about the Envoy instance.
 	Info() (*envoyAdmin.ServerInfo, error)
-	InfoOrFail(t testing.TB) *envoyAdmin.ServerInfo
+	InfoOrFail(t test.Failer) *envoyAdmin.ServerInfo
 
 	// Config of the Envoy instance.
 	Config() (*envoyAdmin.ConfigDump, error)
-	ConfigOrFail(t testing.TB) *envoyAdmin.ConfigDump
+	ConfigOrFail(t test.Failer) *envoyAdmin.ConfigDump
 
 	// WaitForConfig queries the Envoy configuration an executes the given accept handler. If the
 	// response is not accepted, the request will be retried until either a timeout or a response
 	// has been accepted.
 	WaitForConfig(accept func(*envoyAdmin.ConfigDump) (bool, error), options ...retry.Option) error
-	WaitForConfigOrFail(t testing.TB, accept func(*envoyAdmin.ConfigDump) (bool, error), options ...retry.Option)
+	WaitForConfigOrFail(t test.Failer, accept func(*envoyAdmin.ConfigDump) (bool, error), options ...retry.Option)
 }

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -15,8 +15,7 @@
 package echoboot
 
 import (
-	"testing"
-
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/kube"
 	"istio.io/istio/pkg/test/framework/components/echo/native"
@@ -39,7 +38,7 @@ func New(ctx resource.Context, cfg echo.Config) (i echo.Instance, err error) {
 }
 
 // NewOrFail returns a new instance of echo, or fails t if there is an error.
-func NewOrFail(t *testing.T, ctx resource.Context, cfg echo.Config) echo.Instance {
+func NewOrFail(t test.Failer, ctx resource.Context, cfg echo.Config) echo.Instance {
 	t.Helper()
 	i, err := New(ctx, cfg)
 	if err != nil {

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -20,11 +20,11 @@ import (
 	"io"
 	"strings"
 	"sync"
-	"testing"
 
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test"
 	appEcho "istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
@@ -182,7 +182,8 @@ func (c *instance) Workloads() ([]echo.Workload, error) {
 	return out, nil
 }
 
-func (c *instance) WorkloadsOrFail(t testing.TB) []echo.Workload {
+func (c *instance) WorkloadsOrFail(t test.Failer) []echo.Workload {
+	t.Helper()
 	out, err := c.Workloads()
 	if err != nil {
 		t.Fatal(err)
@@ -276,7 +277,8 @@ func (c *instance) WaitUntilReady(outboundInstances ...echo.Instance) error {
 	return nil
 }
 
-func (c *instance) WaitUntilReadyOrFail(t testing.TB, outboundInstances ...echo.Instance) {
+func (c *instance) WaitUntilReadyOrFail(t test.Failer, outboundInstances ...echo.Instance) {
+	t.Helper()
 	if err := c.WaitUntilReady(outboundInstances...); err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +349,8 @@ func (c *instance) Call(opts echo.CallOptions) (appEcho.ParsedResponses, error) 
 	return out, nil
 }
 
-func (c *instance) CallOrFail(t testing.TB, opts echo.CallOptions) appEcho.ParsedResponses {
+func (c *instance) CallOrFail(t test.Failer, opts echo.CallOptions) appEcho.ParsedResponses {
+	t.Helper()
 	r, err := c.Call(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/test/framework/components/echo/kube/sidecar.go
+++ b/pkg/test/framework/components/echo/kube/sidecar.go
@@ -18,13 +18,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"testing"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
 	"istio.io/istio/pkg/test/kube"
@@ -88,7 +88,8 @@ func (s *sidecar) Info() (*envoyAdmin.ServerInfo, error) {
 	return msg, nil
 }
 
-func (s *sidecar) InfoOrFail(t testing.TB) *envoyAdmin.ServerInfo {
+func (s *sidecar) InfoOrFail(t test.Failer) *envoyAdmin.ServerInfo {
+	t.Helper()
 	info, err := s.Info()
 	if err != nil {
 		t.Fatal(err)
@@ -105,7 +106,8 @@ func (s *sidecar) Config() (*envoyAdmin.ConfigDump, error) {
 	return msg, nil
 }
 
-func (s *sidecar) ConfigOrFail(t testing.TB) *envoyAdmin.ConfigDump {
+func (s *sidecar) ConfigOrFail(t test.Failer) *envoyAdmin.ConfigDump {
+	t.Helper()
 	cfg, err := s.Config()
 	if err != nil {
 		t.Fatal(err)
@@ -117,7 +119,8 @@ func (s *sidecar) WaitForConfig(accept func(*envoyAdmin.ConfigDump) (bool, error
 	return common.WaitForConfig(s.Config, accept, options...)
 }
 
-func (s *sidecar) WaitForConfigOrFail(t testing.TB, accept func(*envoyAdmin.ConfigDump) (bool, error), options ...retry.Option) {
+func (s *sidecar) WaitForConfigOrFail(t test.Failer, accept func(*envoyAdmin.ConfigDump) (bool, error), options ...retry.Option) {
+	t.Helper()
 	if err := s.WaitForConfig(accept, options...); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/test/framework/components/echo/native/instance.go
+++ b/pkg/test/framework/components/echo/native/instance.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"testing"
 
 	"github.com/hashicorp/go-multierror"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
@@ -87,7 +87,8 @@ func (c *instance) WaitUntilReady(outboundInstances ...echo.Instance) error {
 	return c.workload.sidecar.WaitForConfig(common.OutboundConfigAcceptFunc(outboundInstances...))
 }
 
-func (c *instance) WaitUntilReadyOrFail(t testing.TB, outboundInstances ...echo.Instance) {
+func (c *instance) WaitUntilReadyOrFail(t test.Failer, outboundInstances ...echo.Instance) {
+	t.Helper()
 	if err := c.WaitUntilReady(outboundInstances...); err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +106,8 @@ func (c *instance) Workloads() ([]echo.Workload, error) {
 	return []echo.Workload{c.workload}, nil
 }
 
-func (c *instance) WorkloadsOrFail(t testing.TB) []echo.Workload {
+func (c *instance) WorkloadsOrFail(t test.Failer) []echo.Workload {
+	t.Helper()
 	out, err := c.Workloads()
 	if err != nil {
 		t.Fatal(err)
@@ -130,7 +132,8 @@ func (c *instance) Call(opts echo.CallOptions) (client.ParsedResponses, error) {
 	return out, nil
 }
 
-func (c *instance) CallOrFail(t testing.TB, opts echo.CallOptions) client.ParsedResponses {
+func (c *instance) CallOrFail(t test.Failer, opts echo.CallOptions) client.ParsedResponses {
+	t.Helper()
 	r, err := c.Call(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/test/framework/components/echo/native/sidecar.go
+++ b/pkg/test/framework/components/echo/native/sidecar.go
@@ -21,12 +21,12 @@ import (
 	"io/ioutil"
 	"net"
 	"strings"
-	"testing"
 	"text/template"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/envoy"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
@@ -226,7 +226,8 @@ func (s *sidecar) Info() (*envoyAdmin.ServerInfo, error) {
 	return envoy.GetServerInfo(s.adminPort)
 }
 
-func (s *sidecar) InfoOrFail(t testing.TB) *envoyAdmin.ServerInfo {
+func (s *sidecar) InfoOrFail(t test.Failer) *envoyAdmin.ServerInfo {
+	t.Helper()
 	info, err := s.Info()
 	if err != nil {
 		t.Fatal(err)
@@ -238,7 +239,8 @@ func (s *sidecar) Config() (*envoyAdmin.ConfigDump, error) {
 	return envoy.GetConfigDump(s.adminPort)
 }
 
-func (s *sidecar) ConfigOrFail(t testing.TB) *envoyAdmin.ConfigDump {
+func (s *sidecar) ConfigOrFail(t test.Failer) *envoyAdmin.ConfigDump {
+	t.Helper()
 	cfg, err := s.Config()
 	if err != nil {
 		t.Fatal(err)
@@ -250,7 +252,8 @@ func (s *sidecar) WaitForConfig(accept func(*envoyAdmin.ConfigDump) (bool, error
 	return common.WaitForConfig(s.Config, accept, options...)
 }
 
-func (s *sidecar) WaitForConfigOrFail(t testing.TB, accept func(*envoyAdmin.ConfigDump) (bool, error), options ...retry.Option) {
+func (s *sidecar) WaitForConfigOrFail(t test.Failer, accept func(*envoyAdmin.ConfigDump) (bool, error), options ...retry.Option) {
+	t.Helper()
 	if err := s.WaitForConfig(accept, options...); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/test/framework/components/galley/galley.go
+++ b/pkg/test/framework/components/galley/galley.go
@@ -15,8 +15,7 @@
 package galley
 
 import (
-	"testing"
-
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -33,13 +32,13 @@ type Instance interface {
 	ApplyConfig(ns namespace.Instance, yamlText ...string) error
 
 	// ApplyConfigOrFail applies the given config yaml text via Galley.
-	ApplyConfigOrFail(t *testing.T, ns namespace.Instance, yamlText ...string)
+	ApplyConfigOrFail(t test.Failer, ns namespace.Instance, yamlText ...string)
 
 	// DeleteConfig deletes the given config yaml text via Galley.
 	DeleteConfig(ns namespace.Instance, yamlText ...string) error
 
 	// DeleteConfigOrFail deletes the given config yaml text via Galley.
-	DeleteConfigOrFail(t *testing.T, ns namespace.Instance, yamlText ...string)
+	DeleteConfigOrFail(t test.Failer, ns namespace.Instance, yamlText ...string)
 
 	// ApplyConfigDir recursively applies all the config files in the specified directory
 	ApplyConfigDir(ns namespace.Instance, configDir string) error
@@ -51,7 +50,7 @@ type Instance interface {
 	WaitForSnapshot(collection string, validator SnapshotValidatorFunc) error
 
 	// WaitForSnapshotOrFail calls WaitForSnapshot and fails the test if it fails.
-	WaitForSnapshotOrFail(t *testing.T, collection string, validator SnapshotValidatorFunc)
+	WaitForSnapshotOrFail(t test.Failer, collection string, validator SnapshotValidatorFunc)
 }
 
 // Config for Galley
@@ -77,7 +76,7 @@ func New(ctx resource.Context, cfg Config) (i Instance, err error) {
 }
 
 // NewOrFail returns a new Galley instance, or fails test.
-func NewOrFail(t *testing.T, c resource.Context, cfg Config) Instance {
+func NewOrFail(t test.Failer, c resource.Context, cfg Config) Instance {
 	t.Helper()
 
 	i, err := New(c, cfg)

--- a/pkg/test/framework/components/galley/kube.go
+++ b/pkg/test/framework/components/galley/kube.go
@@ -20,10 +20,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"testing"
 
 	"github.com/pkg/errors"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -168,7 +168,7 @@ func (c *kubeComponent) ApplyConfig(ns namespace.Instance, yamlText ...string) e
 }
 
 // ApplyConfigOrFail applies the given config yaml file via Galley.
-func (c *kubeComponent) ApplyConfigOrFail(t *testing.T, ns namespace.Instance, yamlText ...string) {
+func (c *kubeComponent) ApplyConfigOrFail(t test.Failer, ns namespace.Instance, yamlText ...string) {
 	t.Helper()
 	err := c.ApplyConfig(ns, yamlText...)
 	if err != nil {
@@ -193,7 +193,7 @@ func (c *kubeComponent) DeleteConfig(ns namespace.Instance, yamlText ...string) 
 }
 
 // DeleteConfigOrFail implements Galley.DeleteConfigOrFail.
-func (c *kubeComponent) DeleteConfigOrFail(t *testing.T, ns namespace.Instance, yamlText ...string) {
+func (c *kubeComponent) DeleteConfigOrFail(t test.Failer, ns namespace.Instance, yamlText ...string) {
 	t.Helper()
 	err := c.DeleteConfig(ns, yamlText...)
 	if err != nil {
@@ -224,7 +224,7 @@ func (c *kubeComponent) WaitForSnapshot(collection string, validator SnapshotVal
 }
 
 // WaitForSnapshotOrFail implements Galley.WaitForSnapshotOrFail.
-func (c *kubeComponent) WaitForSnapshotOrFail(t *testing.T, collection string, validator SnapshotValidatorFunc) {
+func (c *kubeComponent) WaitForSnapshotOrFail(t test.Failer, collection string, validator SnapshotValidatorFunc) {
 	t.Helper()
 	if err := c.WaitForSnapshot(collection, validator); err != nil {
 		t.Fatalf("WaitForSnapshotOrFail: %v", err)

--- a/pkg/test/framework/components/galley/native.go
+++ b/pkg/test/framework/components/galley/native.go
@@ -22,13 +22,13 @@ import (
 	"path"
 	"path/filepath"
 	"syscall"
-	"testing"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/galley/pkg/server"
 	"istio.io/istio/pkg/appsignals"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/deployment"
 	"istio.io/istio/pkg/test/framework/components/environment/native"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -130,7 +130,7 @@ func (c *nativeComponent) ApplyConfig(ns namespace.Instance, yamlText ...string)
 }
 
 // ApplyConfigOrFail applies the given config yaml file via Galley.
-func (c *nativeComponent) ApplyConfigOrFail(t *testing.T, ns namespace.Instance, yamlText ...string) {
+func (c *nativeComponent) ApplyConfigOrFail(t test.Failer, ns namespace.Instance, yamlText ...string) {
 	t.Helper()
 	err := c.ApplyConfig(ns, yamlText...)
 	if err != nil {
@@ -158,7 +158,7 @@ func (c *nativeComponent) DeleteConfig(ns namespace.Instance, yamlText ...string
 }
 
 // DeleteConfigOrFail implements Galley.DeleteConfigOrFail.
-func (c *nativeComponent) DeleteConfigOrFail(t *testing.T, ns namespace.Instance, yamlText ...string) {
+func (c *nativeComponent) DeleteConfigOrFail(t test.Failer, ns namespace.Instance, yamlText ...string) {
 	t.Helper()
 	err := c.DeleteConfig(ns, yamlText...)
 	if err != nil {
@@ -205,7 +205,7 @@ func (c *nativeComponent) WaitForSnapshot(collection string, validator SnapshotV
 }
 
 // WaitForSnapshotOrFail implements Galley.WaitForSnapshotOrFail.
-func (c *nativeComponent) WaitForSnapshotOrFail(t *testing.T, collection string, validator SnapshotValidatorFunc) {
+func (c *nativeComponent) WaitForSnapshotOrFail(t test.Failer, collection string, validator SnapshotValidatorFunc) {
 	t.Helper()
 	if err := c.WaitForSnapshot(collection, validator); err != nil {
 		t.Fatalf("WaitForSnapshotOrFail: %v", err)

--- a/pkg/test/framework/components/ingress/ingress.go
+++ b/pkg/test/framework/components/ingress/ingress.go
@@ -15,8 +15,7 @@
 package ingress
 
 import (
-	"testing"
-
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -32,6 +31,7 @@ type Instance interface {
 
 	//  Call makes an HTTP call through ingress, where the URL has the given path.
 	Call(path string) (CallResponse, error)
+	CallOrFail(t test.Failer, path string) CallResponse
 }
 
 type Config struct {
@@ -57,7 +57,7 @@ func New(ctx resource.Context, cfg Config) (i Instance, err error) {
 }
 
 // Deploy returns a new Ingress instance or fails test
-func NewOrFail(t *testing.T, ctx resource.Context, cfg Config) Instance {
+func NewOrFail(t test.Failer, ctx resource.Context, cfg Config) Instance {
 	t.Helper()
 	i, err := New(ctx, cfg)
 	if err != nil {

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
@@ -159,4 +160,13 @@ func (c *kubeComponent) Call(path string) (CallResponse, error) {
 	}
 
 	return response, nil
+}
+
+func (c *kubeComponent) CallOrFail(t test.Failer, path string) CallResponse {
+	t.Helper()
+	resp, err := c.Call(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
 }

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -19,18 +19,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 	"time"
 
-	homedir "github.com/mitchellh/go-homedir"
-	yaml2 "gopkg.in/yaml.v2"
+	"github.com/mitchellh/go-homedir"
 
-	kubeCore "k8s.io/api/core/v1"
+	yaml2 "gopkg.in/yaml.v2"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/core/image"
 	"istio.io/istio/pkg/test/framework/resource"
+
+	kubeCore "k8s.io/api/core/v1"
 )
 
 const (
@@ -192,7 +192,7 @@ func DefaultConfig(ctx resource.Context) (Config, error) {
 }
 
 // DefaultConfigOrFail calls DefaultConfig and fails t if an error occurs.
-func DefaultConfigOrFail(t testing.TB, ctx resource.Context) Config {
+func DefaultConfigOrFail(t test.Failer, ctx resource.Context) Config {
 	cfg, err := DefaultConfig(ctx)
 	if err != nil {
 		t.Fatalf("Get istio config: %v", err)

--- a/pkg/test/framework/components/mcpserver/mcpserver.go
+++ b/pkg/test/framework/components/mcpserver/mcpserver.go
@@ -15,9 +15,8 @@
 package mcpserver
 
 import (
-	"testing"
-
 	"istio.io/istio/pkg/mcp/sink"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/resource"
 )
@@ -25,7 +24,7 @@ import (
 // Instance is a new mcpserver instance. MCP Server is a generic MCP server implementation for testing purposes.
 type Instance interface {
 	Address() string
-	GetCollectionStateOrFail(t *testing.T, collection string) []*sink.Object
+	GetCollectionStateOrFail(t test.Failer, collection string) []*sink.Object
 }
 
 // SinkConfig is configuration for the mcpserver for sink mode.
@@ -43,7 +42,8 @@ func NewSink(ctx resource.Context, cfg SinkConfig) (i Instance, err error) {
 }
 
 // NewSinkOrFail returns a new instance of MCP server in Sink mode or fails.
-func NewSinkOrFail(t *testing.T, c resource.Context, cfg SinkConfig) Instance {
+func NewSinkOrFail(t test.Failer, c resource.Context, cfg SinkConfig) Instance {
+	t.Helper()
 	i, err := NewSink(c, cfg)
 	if err != nil {
 		t.Fatalf("mcpserver.NewOrFail: %v", err)

--- a/pkg/test/framework/components/mcpserver/native.go
+++ b/pkg/test/framework/components/mcpserver/native.go
@@ -17,7 +17,6 @@ package mcpserver
 import (
 	"io"
 	"net"
-	"testing"
 	"time"
 
 	"google.golang.org/grpc"
@@ -27,6 +26,7 @@ import (
 	"istio.io/istio/pkg/mcp/server"
 	"istio.io/istio/pkg/mcp/sink"
 	"istio.io/istio/pkg/mcp/testing/monitoring"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
 )
@@ -91,7 +91,8 @@ func (n *native) Address() string {
 }
 
 // GetCollectionStateOrFail implements Instance
-func (n *native) GetCollectionStateOrFail(t *testing.T, collection string) []*sink.Object {
+func (n *native) GetCollectionStateOrFail(t test.Failer, collection string) []*sink.Object {
+	t.Helper()
 	return n.u.Get(collection)
 }
 

--- a/pkg/test/framework/components/mixer/client.go
+++ b/pkg/test/framework/components/mixer/client.go
@@ -16,14 +16,15 @@ package mixer
 
 import (
 	"context"
-	"testing"
 
 	"github.com/hashicorp/go-multierror"
+
 	"google.golang.org/grpc"
 
 	istioMixerV1 "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/server"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/kube"
 )
@@ -54,7 +55,7 @@ type client struct {
 }
 
 // Report implements DeployedMixer.Report.
-func (c *client) Report(t testing.TB, attributes map[string]interface{}) {
+func (c *client) Report(t test.Failer, attributes map[string]interface{}) {
 	t.Helper()
 
 	req := istioMixerV1.ReportRequest{
@@ -68,7 +69,7 @@ func (c *client) Report(t testing.TB, attributes map[string]interface{}) {
 }
 
 // Check implements DeployedMixer.Check.
-func (c *client) Check(t testing.TB, attributes map[string]interface{}) CheckResponse {
+func (c *client) Check(t test.Failer, attributes map[string]interface{}) CheckResponse {
 	t.Helper()
 
 	req := istioMixerV1.CheckRequest{

--- a/pkg/test/framework/components/mixer/mixer.go
+++ b/pkg/test/framework/components/mixer/mixer.go
@@ -16,11 +16,11 @@ package mixer
 
 import (
 	"net"
-	"testing"
 
 	"github.com/gogo/googleapis/google/rpc"
 
 	istioMixerV1 "istio.io/api/mixer/v1"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -28,8 +28,8 @@ import (
 
 type Instance interface {
 	resource.Resource
-	Report(t testing.TB, attributes map[string]interface{})
-	Check(t testing.TB, attributes map[string]interface{}) CheckResponse
+	Report(t test.Failer, attributes map[string]interface{})
+	Check(t test.Failer, attributes map[string]interface{}) CheckResponse
 	GetCheckAddress() net.Addr
 	GetReportAddress() net.Addr
 }
@@ -60,7 +60,8 @@ func New(ctx resource.Context, cfg Config) (i Instance, err error) {
 	return
 }
 
-func NewOrFail(t *testing.T, c resource.Context, config Config) Instance {
+func NewOrFail(t test.Failer, c resource.Context, config Config) Instance {
+	t.Helper()
 	i, err := New(c, config)
 	if err != nil {
 		t.Fatalf("mixer.NewOrFail:: %v", err)

--- a/pkg/test/framework/components/mixer/native.go
+++ b/pkg/test/framework/components/mixer/native.go
@@ -17,16 +17,17 @@ package mixer
 import (
 	"io"
 	"net"
-	"testing"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
+
 	"google.golang.org/grpc"
 
 	istioMixerV1 "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/adapter"
 	"istio.io/istio/mixer/pkg/server"
 	generatedTmplRepo "istio.io/istio/mixer/template"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/deployment"
 	"istio.io/istio/pkg/test/framework/components/environment/native"
 	"istio.io/istio/pkg/test/framework/components/galley"
@@ -149,11 +150,11 @@ func (c *nativeComponent) ID() resource.ID {
 	return c.id
 }
 
-func (c *nativeComponent) Report(t testing.TB, attributes map[string]interface{}) {
+func (c *nativeComponent) Report(t test.Failer, attributes map[string]interface{}) {
 	c.client.Report(t, attributes)
 }
 
-func (c *nativeComponent) Check(t testing.TB, attributes map[string]interface{}) CheckResponse {
+func (c *nativeComponent) Check(t test.Failer, attributes map[string]interface{}) CheckResponse {
 	return c.client.Check(t, attributes)
 }
 

--- a/pkg/test/framework/components/namespace/namespace.go
+++ b/pkg/test/framework/components/namespace/namespace.go
@@ -15,8 +15,7 @@
 package namespace
 
 import (
-	"testing"
-
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/resource"
 )
@@ -40,7 +39,8 @@ func Claim(ctx resource.Context, name string) (i Instance, err error) {
 }
 
 // ClaimOrFail calls Claim and fails test if it returns error
-func ClaimOrFail(t *testing.T, ctx resource.Context, name string) Instance {
+func ClaimOrFail(t test.Failer, ctx resource.Context, name string) Instance {
+	t.Helper()
 	i, err := Claim(ctx, name)
 	if err != nil {
 		t.Fatalf("namespace.ClaimOrFail:: %v", err)
@@ -62,7 +62,8 @@ func New(ctx resource.Context, prefix string, inject bool) (i Instance, err erro
 }
 
 // NewOrFail calls New and fails test if it returns error
-func NewOrFail(t *testing.T, ctx resource.Context, prefix string, inject bool) Instance {
+func NewOrFail(t test.Failer, ctx resource.Context, prefix string, inject bool) Instance {
+	t.Helper()
 	i, err := New(ctx, prefix, inject)
 	if err != nil {
 		t.Fatalf("namespace.NewOrFail: %v", err)

--- a/pkg/test/framework/components/pilot/client.go
+++ b/pkg/test/framework/components/pilot/client.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"net"
 	"sync"
-	"testing"
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -27,6 +26,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"google.golang.org/grpc"
+
+	"istio.io/istio/pkg/test"
 )
 
 type client struct {
@@ -66,7 +67,8 @@ func (c *client) CallDiscovery(req *xdsapi.DiscoveryRequest) (*xdsapi.DiscoveryR
 	return c.stream.Recv()
 }
 
-func (c *client) CallDiscoveryOrFail(t testing.TB, req *xdsapi.DiscoveryRequest) *xdsapi.DiscoveryResponse {
+func (c *client) CallDiscoveryOrFail(t test.Failer, req *xdsapi.DiscoveryRequest) *xdsapi.DiscoveryResponse {
+	t.Helper()
 	resp, err := c.CallDiscovery(req)
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +85,8 @@ func (c *client) StartDiscovery(req *xdsapi.DiscoveryRequest) error {
 	return nil
 }
 
-func (c *client) StartDiscoveryOrFail(t testing.TB, req *xdsapi.DiscoveryRequest) {
+func (c *client) StartDiscoveryOrFail(t test.Failer, req *xdsapi.DiscoveryRequest) {
+	t.Helper()
 	if err := c.StartDiscovery(req); err != nil {
 		t.Fatal(err)
 	}
@@ -133,9 +136,10 @@ func (c *client) WatchDiscovery(timeout time.Duration,
 	}
 }
 
-func (c *client) WatchDiscoveryOrFail(t testing.TB, timeout time.Duration,
+func (c *client) WatchDiscoveryOrFail(t test.Failer, timeout time.Duration,
 	accept func(*xdsapi.DiscoveryResponse) (bool, error)) {
 
+	t.Helper()
 	if err := c.WatchDiscovery(timeout, accept); err != nil {
 		t.Fatalf("no resource accepted: %v", err)
 	}

--- a/pkg/test/framework/components/pilot/pilot.go
+++ b/pkg/test/framework/components/pilot/pilot.go
@@ -16,15 +16,14 @@ package pilot
 
 import (
 	"fmt"
-	"testing"
 	"time"
-
-	"istio.io/istio/pkg/test/framework/components/environment"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdscore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	meshConfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/resource"
 )
@@ -45,12 +44,12 @@ type Instance interface {
 	resource.Resource
 
 	CallDiscovery(req *xdsapi.DiscoveryRequest) (*xdsapi.DiscoveryResponse, error)
-	CallDiscoveryOrFail(t testing.TB, req *xdsapi.DiscoveryRequest) *xdsapi.DiscoveryResponse
+	CallDiscoveryOrFail(t test.Failer, req *xdsapi.DiscoveryRequest) *xdsapi.DiscoveryResponse
 
 	StartDiscovery(req *xdsapi.DiscoveryRequest) error
-	StartDiscoveryOrFail(t testing.TB, req *xdsapi.DiscoveryRequest)
+	StartDiscoveryOrFail(t test.Failer, req *xdsapi.DiscoveryRequest)
 	WatchDiscovery(duration time.Duration, accept func(*xdsapi.DiscoveryResponse) (bool, error)) error
-	WatchDiscoveryOrFail(t testing.TB, duration time.Duration, accept func(*xdsapi.DiscoveryResponse) (bool, error))
+	WatchDiscoveryOrFail(t test.Failer, duration time.Duration, accept func(*xdsapi.DiscoveryResponse) (bool, error))
 }
 
 // Structured config for the Pilot component
@@ -77,7 +76,7 @@ func New(ctx resource.Context, cfg Config) (i Instance, err error) {
 }
 
 // NewOrFail returns a new Pilot instance, or fails test.
-func NewOrFail(t *testing.T, c resource.Context, config Config) Instance {
+func NewOrFail(t test.Failer, c resource.Context, config Config) Instance {
 	i, err := New(c, config)
 	if err != nil {
 		t.Fatalf("pilot.NewOrFail: %v", err)

--- a/pkg/test/framework/components/policybackend/client.go
+++ b/pkg/test/framework/components/policybackend/client.go
@@ -17,13 +17,13 @@ package policybackend
 import (
 	"fmt"
 	"reflect"
-	"testing"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/fakes/policy"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -33,7 +33,7 @@ type client struct {
 }
 
 // DenyCheck implementation
-func (c *client) DenyCheck(t testing.TB, deny bool) {
+func (c *client) DenyCheck(t test.Failer, deny bool) {
 	t.Helper()
 
 	if err := c.controller.DenyCheck(deny); err != nil {
@@ -42,7 +42,7 @@ func (c *client) DenyCheck(t testing.TB, deny bool) {
 }
 
 // AllowCheck implementation
-func (c *client) AllowCheck(t testing.TB, d time.Duration, count int32) {
+func (c *client) AllowCheck(t test.Failer, d time.Duration, count int32) {
 	t.Helper()
 
 	if err := c.controller.AllowCheck(d, count); err != nil {
@@ -51,7 +51,7 @@ func (c *client) AllowCheck(t testing.TB, d time.Duration, count int32) {
 }
 
 // ExpectReport implementation
-func (c *client) ExpectReport(t testing.TB, expected ...proto.Message) {
+func (c *client) ExpectReport(t test.Failer, expected ...proto.Message) {
 	t.Helper()
 
 	_, err := retry.Do(func() (interface{}, bool, error) {
@@ -74,7 +74,7 @@ func (c *client) ExpectReport(t testing.TB, expected ...proto.Message) {
 }
 
 // ExpectReportJSON checks that the backend has received the given report request.
-func (c *client) ExpectReportJSON(t testing.TB, expected ...string) {
+func (c *client) ExpectReportJSON(t test.Failer, expected ...string) {
 	t.Helper()
 
 	_, err := retry.Do(func() (interface{}, bool, error) {
@@ -110,7 +110,7 @@ func (c *client) ExpectReportJSON(t testing.TB, expected ...string) {
 	}
 }
 
-func (c *client) GetReports(t testing.TB) []proto.Message {
+func (c *client) GetReports(t test.Failer) []proto.Message {
 	t.Helper()
 	reports, err := c.controller.GetReports()
 	if err != nil {

--- a/pkg/test/framework/components/policybackend/policybackend.go
+++ b/pkg/test/framework/components/policybackend/policybackend.go
@@ -15,11 +15,11 @@
 package policybackend
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/resource"
 )
@@ -41,22 +41,22 @@ type Instance interface {
 
 	// DenyCheck indicates that the policy backend should deny all incoming check requests when deny is
 	// set to true.
-	DenyCheck(t testing.TB, deny bool)
+	DenyCheck(t test.Failer, deny bool)
 
 	// AllowCheck indicates the policy backend should allow all incoming check requests,
 	// it also indicates the valid duration and valid count in the check result.
-	AllowCheck(t testing.TB, d time.Duration, c int32)
+	AllowCheck(t test.Failer, d time.Duration, c int32)
 
 	// ExpectReport checks that the backend has received the given report requests. The requests are consumed
 	// after the call completes.
-	ExpectReport(t testing.TB, expected ...proto.Message)
+	ExpectReport(t test.Failer, expected ...proto.Message)
 
 	// ExpectReportJSON checks that the backend has received the given report request.  The requests are
 	// consumed after the call completes.
-	ExpectReportJSON(t testing.TB, expected ...string)
+	ExpectReportJSON(t test.Failer, expected ...string)
 
 	// GetReports reeturns the currently accumulated set of reports.
-	GetReports(t testing.TB) []proto.Message
+	GetReports(t test.Failer) []proto.Message
 
 	// CreateConfigSnippet for the Mixer adapter to talk to this policy backend.
 	// If adapter mode is in process, the supplied name will be the name of the handler.
@@ -75,7 +75,8 @@ func New(ctx resource.Context) (i Instance, err error) {
 	return
 }
 
-func NewOrFail(t *testing.T, s resource.Context) Instance {
+func NewOrFail(t test.Failer, s resource.Context) Instance {
+	t.Helper()
 	i, err := New(s)
 	if err != nil {
 		t.Fatalf("policybackend.NewOrFail: %v", err)

--- a/pkg/test/framework/components/policybackend/util.go
+++ b/pkg/test/framework/components/policybackend/util.go
@@ -17,14 +17,15 @@ package policybackend
 import (
 	"encoding/json"
 	"reflect"
-	"testing"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+
+	"istio.io/istio/pkg/test"
 )
 
 // ContainsReportJSON checks whether the given proto array contains the expected string
-func ContainsReportJSON(t testing.TB, reports []proto.Message, expected string) bool {
+func ContainsReportJSON(t test.Failer, reports []proto.Message, expected string) bool {
 	t.Helper()
 
 	e, err := jsonStringToMap(expected)
@@ -69,7 +70,7 @@ func jsonStringToMap(s string) (map[string]interface{}, error) {
 	return i, nil
 }
 
-func jsonStringsToMaps(t testing.TB, arr []string) []map[string]interface{} {
+func jsonStringsToMaps(t test.Failer, arr []string) []map[string]interface{} {
 	var result []map[string]interface{}
 
 	for _, a := range arr {

--- a/pkg/test/framework/components/prometheus/kube.go
+++ b/pkg/test/framework/components/prometheus/kube.go
@@ -24,6 +24,7 @@ import (
 	prometheusApiV1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -153,6 +154,14 @@ func (c *kubeComponent) WaitForQuiesce(format string, args ...interface{}) (mode
 	return v, err
 }
 
+func (c *kubeComponent) WaitForQuiesceOrFail(t test.Failer, format string, args ...interface{}) model.Value {
+	v, err := c.WaitForQuiesce(format, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
 func (c *kubeComponent) WaitForOneOrMore(format string, args ...interface{}) error {
 
 	time.Sleep(time.Second * 5)
@@ -189,6 +198,12 @@ func (c *kubeComponent) WaitForOneOrMore(format string, args ...interface{}) err
 	}, retryTimeout, retryDelay)
 
 	return err
+}
+
+func (c *kubeComponent) WaitForOneOrMoreOrFail(t test.Failer, format string, args ...interface{}) {
+	if err := c.WaitForOneOrMore(format, args...); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func reduce(v model.Vector, labels map[string]string) model.Vector {
@@ -230,6 +245,14 @@ func (c *kubeComponent) Sum(val model.Value, labels map[string]string) (float64,
 		return valueCount, nil
 	}
 	return 0, fmt.Errorf("value not found for %#v", labels)
+}
+
+func (c *kubeComponent) SumOrFail(t test.Failer, val model.Value, labels map[string]string) float64 {
+	v, err := c.Sum(val, labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
 }
 
 // Close implements io.Closer.

--- a/pkg/test/framework/components/prometheus/prometheus.go
+++ b/pkg/test/framework/components/prometheus/prometheus.go
@@ -15,13 +15,11 @@
 package prometheus
 
 import (
-	"testing"
-
-	"istio.io/istio/pkg/test/framework/components/environment"
-
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	prom "github.com/prometheus/common/model"
 
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
@@ -33,12 +31,15 @@ type Instance interface {
 
 	// WaitForQuiesce runs the provided query periodically until the result gets stable.
 	WaitForQuiesce(fmt string, args ...interface{}) (prom.Value, error)
+	WaitForQuiesceOrFail(t test.Failer, fmt string, args ...interface{}) prom.Value
 
 	// WaitForOneOrMore runs the provided query and waits until one (or more for vector) values are available.
 	WaitForOneOrMore(fmt string, args ...interface{}) error
+	WaitForOneOrMoreOrFail(t test.Failer, fmt string, args ...interface{})
 
 	// Sum all the samples that has the given labels in the given vector value.
 	Sum(val prom.Value, labels map[string]string) (float64, error)
+	SumOrFail(t test.Failer, val prom.Value, labels map[string]string) float64
 }
 
 // New returns a new instance of echo.
@@ -51,7 +52,7 @@ func New(ctx resource.Context) (i Instance, err error) {
 }
 
 // NewOrFail returns a new Prometheus instance or fails test.
-func NewOrFail(t *testing.T, ctx resource.Context) Instance {
+func NewOrFail(t test.Failer, ctx resource.Context) Instance {
 	t.Helper()
 	i, err := New(ctx)
 	if err != nil {

--- a/pkg/test/framework/components/redis/redis.go
+++ b/pkg/test/framework/components/redis/redis.go
@@ -15,8 +15,7 @@
 package redis
 
 import (
-	"testing"
-
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/resource"
 )
@@ -37,7 +36,7 @@ func New(ctx resource.Context) (i Instance, err error) {
 }
 
 // NewOrFail returns a new Redis instance or fails test.
-func NewOrFail(t *testing.T, ctx resource.Context) Instance {
+func NewOrFail(t test.Failer, ctx resource.Context) Instance {
 	t.Helper()
 	i, err := New(ctx)
 	if err != nil {

--- a/pkg/test/util/file/file.go
+++ b/pkg/test/util/file/file.go
@@ -16,12 +16,14 @@ package file
 
 import (
 	"io/ioutil"
-	"testing"
+
+	"istio.io/istio/pkg/test"
 )
 
 // AsBytes is a utility function that reads the content of the given file
 // and fails the test if an error occurs.
-func AsBytes(t testing.TB, filename string) []byte {
+func AsBytes(t test.Failer, filename string) []byte {
+	t.Helper()
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
 		t.Fatal(err)
@@ -30,6 +32,7 @@ func AsBytes(t testing.TB, filename string) []byte {
 }
 
 // AsString calls AsBytes and then converts to string.
-func AsString(t testing.TB, filename string) string {
+func AsString(t test.Failer, filename string) string {
+	t.Helper()
 	return string(AsBytes(t, filename))
 }

--- a/pkg/test/util/retry/retry.go
+++ b/pkg/test/util/retry/retry.go
@@ -16,8 +16,9 @@ package retry
 
 import (
 	"fmt"
-	"testing"
 	"time"
+
+	"istio.io/istio/pkg/test"
 )
 
 const (
@@ -75,7 +76,7 @@ func UntilSuccess(fn func() error, options ...Option) error {
 }
 
 // UntilSuccessOrFail calls UntilSuccess, and fails t with Fatalf if it ends up returning an error
-func UntilSuccessOrFail(t *testing.T, fn func() error, options ...Option) {
+func UntilSuccessOrFail(t test.Failer, fn func() error, options ...Option) {
 	t.Helper()
 	err := UntilSuccess(fn, options...)
 	if err != nil {

--- a/pkg/test/util/structpath/instance.go
+++ b/pkg/test/util/structpath/instance.go
@@ -22,12 +22,13 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-	"testing"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 
 	"gopkg.in/d4l3k/messagediff.v1"
+
+	"istio.io/istio/pkg/test"
 
 	"k8s.io/client-go/util/jsonpath"
 )
@@ -253,7 +254,7 @@ func (i *Instance) Check() error {
 
 // CheckOrFail calls Check on this selection and fails the given test if an
 // error is encountered.
-func (i *Instance) CheckOrFail(t *testing.T) *Instance {
+func (i *Instance) CheckOrFail(t test.Failer) *Instance {
 	t.Helper()
 	if err := i.Check(); err != nil {
 		t.Fatal(err)

--- a/pkg/test/util/tmpl/evaluate.go
+++ b/pkg/test/util/tmpl/evaluate.go
@@ -15,7 +15,7 @@
 package tmpl
 
 import (
-	"testing"
+	"istio.io/istio/pkg/test"
 )
 
 // Evaluate parses the template and then executes it with the given parameters.
@@ -29,7 +29,7 @@ func Evaluate(tpl string, data interface{}) (string, error) {
 }
 
 // EvaluateOrFail calls Evaluate and fails tests if it returns error.
-func EvaluateOrFail(t testing.TB, tpl string, data interface{}) string {
+func EvaluateOrFail(t test.Failer, tpl string, data interface{}) string {
 	t.Helper()
 	s, err := Evaluate(tpl, data)
 	if err != nil {
@@ -52,7 +52,8 @@ func EvaluateAll(data interface{}, templates ...string) ([]string, error) {
 }
 
 // EvaluateAllOrFail calls Evaluate and fails t if an error occurs.
-func EvaluateAllOrFail(t testing.TB, data interface{}, templates ...string) []string {
+func EvaluateAllOrFail(t test.Failer, data interface{}, templates ...string) []string {
+	t.Helper()
 	out, err := EvaluateAll(data, templates...)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/test/util/tmpl/execute.go
+++ b/pkg/test/util/tmpl/execute.go
@@ -16,8 +16,9 @@ package tmpl
 
 import (
 	"bytes"
-	"testing"
 	"text/template"
+
+	"istio.io/istio/pkg/test"
 )
 
 // Execute the template with the given parameters.
@@ -31,7 +32,8 @@ func Execute(t *template.Template, data interface{}) (string, error) {
 }
 
 // ExecuteOrFail calls Execute and fails the test if it returns an error.
-func ExecuteOrFail(t testing.TB, t2 *template.Template, data interface{}) string {
+func ExecuteOrFail(t test.Failer, t2 *template.Template, data interface{}) string {
+	t.Helper()
 	s, err := Execute(t2, data)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/integration/echo/echo_test.go
+++ b/tests/integration/echo/echo_test.go
@@ -121,14 +121,13 @@ func TestEcho(t *testing.T) {
 					configTest.Label(label.Flaky)
 				}
 				configTest.Run(func(ctx framework.TestContext) {
-					t := ctx.GoTest()
 
-					ns := namespace.NewOrFail(t, ctx, "echo", true)
+					ns := namespace.NewOrFail(ctx, ctx, "echo", true)
 
-					a := echoboot.NewOrFail(t, ctx, config.apply("a", ns))
-					b := echoboot.NewOrFail(t, ctx, config.apply("b", ns))
+					a := echoboot.NewOrFail(ctx, ctx, config.apply("a", ns))
+					b := echoboot.NewOrFail(ctx, ctx, config.apply("b", ns))
 
-					a.WaitUntilReadyOrFail(t, b)
+					a.WaitUntilReadyOrFail(ctx, b)
 
 					for _, o := range callOptions {
 						// Make a copy of the options for the test.
@@ -141,8 +140,6 @@ func TestEcho(t *testing.T) {
 						}
 
 						ctx.NewSubTest(testName).Run(func(ctx framework.TestContext) {
-							t := ctx.GoTest()
-
 							ctx.Environment().Case(environment.Native, func() {
 								if config.testName != "NoSidecar" {
 									switch opts.Scheme {
@@ -152,9 +149,9 @@ func TestEcho(t *testing.T) {
 									}
 								}
 							})
-							a.CallOrFail(t, opts).
-								CheckOKOrFail(t).
-								CheckHostOrFail(t, "b")
+							a.CallOrFail(ctx, opts).
+								CheckOKOrFail(ctx).
+								CheckHostOrFail(ctx, "b")
 						})
 					}
 				})


### PR DESCRIPTION
Replaces use of `testing.T` and `testing.TB` throughout the test package.

This allows the `TestContext` to be used in place of `testing.TB` so that it doesn't have to expose the underlying golang test.