### PR TITLE
Added support for outbound port exclusions

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -24,6 +24,10 @@ initContainers:
   - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (includeInboundPorts .Spec.Containers) }}"
   - "-d"
   - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+  {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") -}}
+  - "-o"
+  - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
+  {{ end -}}
   {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
   - "-k"
   - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -210,6 +210,7 @@ global:
     # be allowed by the sidecar
     includeIPRanges: "*"
     excludeIPRanges: ""
+    excludeOutboundPorts: ""
 
     # pod internal interfaces
     kubevirtInterfaces: ""

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -78,6 +78,7 @@ var (
 		annotations.Register("traffic.sidecar.istio.io/excludeOutboundIPRanges", "").Name:      ValidateExcludeIPRanges,
 		annotations.Register("traffic.sidecar.istio.io/includeInboundPorts", "").Name:          ValidateIncludeInboundPorts,
 		annotations.Register("traffic.sidecar.istio.io/excludeInboundPorts", "").Name:          ValidateExcludeInboundPorts,
+		annotations.Register("traffic.sidecar.istio.io/excludeOutboundPorts", "").Name:         ValidateExcludeOutboundPorts,
 		annotations.Register("traffic.sidecar.istio.io/kubevirtInterfaces", "").Name:           alwaysValidFunc,
 	}
 )
@@ -196,6 +197,9 @@ type Params struct {
 	// Comma separated list of inbound ports. If set, inbound traffic will not be redirected for those ports.
 	// Exclusions are only applied if configured to redirect all inbound traffic. By default, no ports are excluded.
 	ExcludeInboundPorts string `json:"excludeInboundPorts"`
+	// Comma separated list of outbound ports. If set, outbound traffic will not be redirected for those ports.
+	// By default, no ports are excluded.
+	ExcludeOutboundPorts string `json:"excludeOutboundPorts"`
 	// Comma separated list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound
 	// By default, no interfaces are configured.
 	KubevirtInterfaces           string                 `json:"kubevirtInterfaces"`
@@ -377,6 +381,11 @@ func ValidateIncludeInboundPorts(ports string) error {
 // ValidateExcludeInboundPorts validates the excludeInboundPorts parameter
 func ValidateExcludeInboundPorts(ports string) error {
 	return validatePortList("excludeInboundPorts", ports)
+}
+
+// ValidateExcludeInboundPorts validates the excludeInboundPorts parameter
+func ValidateExcludeOutboundPorts(ports string) error {
+	return validatePortList("excludeOutboundPorts", ports)
 }
 
 // validateStatusPort validates the statusPort parameter

--- a/pilot/pkg/kube/inject/inject_test.go
+++ b/pilot/pkg/kube/inject/inject_test.go
@@ -739,6 +739,10 @@ func TestInvalidAnnotations(t *testing.T) {
 			annotation: "excludeinboundports",
 			in:         "traffic-annotations-bad-excludeinboundports.yaml",
 		},
+		{
+			annotation: "excludeoutboundports",
+			in:         "traffic-annotations-bad-excludeoutboundports.yaml",
+		},
 	}
 
 	for _, c := range cases {

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-excludeoutboundports.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-bad-excludeoutboundports.yaml
@@ -10,11 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        traffic.sidecar.istio.io/includeInboundPorts: "1,2,3"
-        traffic.sidecar.istio.io/excludeInboundPorts: "4,5,6"
-        traffic.sidecar.istio.io/excludeOutboundPorts: "7,8,9"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: "127.0.0.1/24,10.96.0.1/24"
-        traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.96.0.2/24,10.96.0.3/24"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "bad"
       labels:
         app: traffic
     spec:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -15,6 +15,7 @@ spec:
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
+        traffic.sidecar.istio.io/excludeOutboundPorts: 7,8,9
         traffic.sidecar.istio.io/includeInboundPorts: 1,2,3
         traffic.sidecar.istio.io/includeOutboundIPRanges: 127.0.0.1/24,10.96.0.1/24
       creationTimestamp: null
@@ -84,7 +85,7 @@ spec:
           value: REDIRECT
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
-            {"traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
+            {"traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
@@ -134,6 +135,8 @@ spec:
         - 1,2,3
         - -d
         - 4,5,6,15020
+        - -o
+        - 7,8,9
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml
@@ -12,6 +12,7 @@ spec:
       annotations:
         traffic.sidecar.istio.io/includeInboundPorts: "1,2,3"
         traffic.sidecar.istio.io/excludeInboundPorts: "4,5,6"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "7,8,9"
         traffic.sidecar.istio.io/includeOutboundIPRanges: "127.0.0.1/24,10.96.0.1/24"
         traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.96.0.2/24,10.96.0.3/24"
       labels:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -15,6 +15,7 @@ spec:
         sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
+        traffic.sidecar.istio.io/excludeOutboundPorts: 7,8,9
         traffic.sidecar.istio.io/includeInboundPorts: 1,2,3
         traffic.sidecar.istio.io/includeOutboundIPRanges: 127.0.0.1/24,10.96.0.1/24
       creationTimestamp: null
@@ -130,6 +131,8 @@ spec:
         - 1,2,3
         - -d
         - 4,5,6,15020
+        - -o
+        - 7,8,9
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -46,6 +46,7 @@ function usage() {
   echo '  -x: Comma separated list of IP ranges in CIDR form to be excluded from redirection. Only applies when all '
   # shellcheck disable=SC2016
   echo '      outbound traffic (i.e. "*") is being redirected (default to $ISTIO_SERVICE_EXCLUDE_CIDR).'
+  echo '  -o: Comma separated list of outbound ports to be excluded from redirection to Envoy (optional).'
   echo '  -k: Comma separated list of virtual interfaces whose inbound traffic (from VM)'
   echo '      will be treated as outbound (optional)'
   echo '  -t: Unit testing, only functions are loaded and no other instructions are executed.'
@@ -147,9 +148,10 @@ INBOUND_PORTS_INCLUDE=${ISTIO_INBOUND_PORTS-}
 INBOUND_PORTS_EXCLUDE=${ISTIO_LOCAL_EXCLUDE_PORTS-}
 OUTBOUND_IP_RANGES_INCLUDE=${ISTIO_SERVICE_CIDR-}
 OUTBOUND_IP_RANGES_EXCLUDE=${ISTIO_SERVICE_EXCLUDE_CIDR-}
+OUTBOUND_PORTS_EXCLUDE=${ISTIO_LOCAL_OUTBOUND_PORTS_EXCLUDE-}
 KUBEVIRT_INTERFACES=
 
-while getopts ":p:u:g:m:b:d:i:x:k:h:t" opt; do
+while getopts ":p:u:g:m:b:d:o:i:x:k:h:t" opt; do
   case ${opt} in
     p)
       PROXY_PORT=${OPTARG}
@@ -174,6 +176,9 @@ while getopts ":p:u:g:m:b:d:i:x:k:h:t" opt; do
       ;;
     x)
       OUTBOUND_IP_RANGES_EXCLUDE=${OPTARG}
+      ;;
+    o)
+      OUTBOUND_PORTS_EXCLUDE=${OPTARG}
       ;;
     k)
       KUBEVIRT_INTERFACES=${OPTARG}
@@ -312,6 +317,7 @@ echo "INBOUND_PORTS_INCLUDE=${INBOUND_PORTS_INCLUDE}"
 echo "INBOUND_PORTS_EXCLUDE=${INBOUND_PORTS_EXCLUDE}"
 echo "OUTBOUND_IP_RANGES_INCLUDE=${OUTBOUND_IP_RANGES_INCLUDE}"
 echo "OUTBOUND_IP_RANGES_EXCLUDE=${OUTBOUND_IP_RANGES_EXCLUDE}"
+echo "OUTBOUND_PORTS_EXCLUDE=${OUTBOUND_PORTS_EXCLUDE}"
 echo "KUBEVIRT_INTERFACES=${KUBEVIRT_INTERFACES}"
 echo "ENABLE_INBOUND_IPV6=${ENABLE_INBOUND_IPV6}"
 echo
@@ -410,8 +416,16 @@ iptables -t nat -N ISTIO_OUTPUT
 # Jump to the ISTIO_OUTPUT chain from OUTPUT chain for all tcp traffic.
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 
+# Apply port based exclusions. Must be applied before connections back to self
+# are redirected.
+if [ -n "${OUTBOUND_PORTS_EXCLUDE}" ]; then
+  for port in ${OUTBOUND_PORTS_EXCLUDE}; do
+    iptables -t nat -A ISTIO_OUTPUT -p tcp --dport "${port}" -j RETURN
+  done
+fi
+
 if [ -z "${DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK-}" ]; then
-  # Redirect app calls to back itself via Envoy when using the service VIP or endpoint
+  # Redirect app calls back to itself via Envoy when using the service VIP or endpoint
   # address, e.g. appN => Envoy (client) => Envoy (server) => appN.
   iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
 fi
@@ -531,6 +545,14 @@ if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
 
   # Jump to the ISTIO_OUTPUT chain from OUTPUT chain for all tcp traffic.
   ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+
+  # Apply port based exclusions. Must be applied before connections back to self
+  # are redirected.
+  if [ -n "${OUTBOUND_PORTS_EXCLUDE}" ]; then
+    for port in ${OUTBOUND_PORTS_EXCLUDE}; do
+      ip6tables -t nat -A ISTIO_OUTPUT -p tcp --dport "${port}" -j RETURN
+    done
+  fi
 
   # Redirect app calls to back itself via Envoy when using the service VIP or endpoint
   # address, e.g. appN => Envoy (client) => Envoy (server) => appN.


### PR DESCRIPTION
Currently inbound ports can be excluded from redirection, and outbound IP addresses can be excluded from redirection, but not outbound ports. This fills out the support for that, by adding an `traffic.sidecar.istio.io/excludeOutboundPorts` annotation.

This is particularly useful for services that want to be a part of the service mesh (eg, offer a REST API, and consume the REST APIs of other services), however they also need to form a cluster with pods in the same deployment, using a clustering technology such as Akka, in order to implement their service. The cluster communication should not go through the service mesh for the following reasons:

* Typically the cluster needs to be established before the ready check passes, but Istio shouldn't (and doesn't) start allowing traffic through envoy until the service is ready. So, in order to establish the cluster and still implement a meaningful readiness check, cluster traffic must bypass envoy.
* When the pod shuts down, the cluster needs to be gracefully left (otherwise other pods in the cluster won't know whether the pod has crashed, or whether there was a network partition, and this takes a lot longer for the cluster to safely resolve and decide how to handle than gracefully leaving). This requires a small amount of communication for handoff. However, when the pod shuts down, envoy shuts down immediately, preventing this graceful leaving from happening).
* The cluster communication really isn't suitable for a service mesh, it is inherently point to point, nodes need to be able to address other nodes, etc. So it's best to let the service mesh do what it's good at, and get out of the way for communication that is not part of service mesh.

With this feature, I have been able to trivially establish Akka clusters in Istio, something that required a lot of bending over backwards before and had a sub-optimal configuration in the end (eg, no readiness checks, no graceful cluster leaves). For more context, see:

* https://discuss.istio.io/t/stateful-applications-and-istio/535

There has also been other communication about this on the old `istio-user` mailing list, however it appears that list has been deleted, so that information has been lost :(