### PR TITLE
Reuse function getPodKey in pilot

### DIFF
--- a/pilot/pkg/serviceregistry/kube/pod.go
+++ b/pilot/pkg/serviceregistry/kube/pod.go
@@ -124,10 +124,7 @@ func (pc *PodCache) getPodKey(addr string) (string, bool) {
 
 // getPodByIp returns the pod or nil if pod not found or an error occurred
 func (pc *PodCache) getPodByIP(addr string) *v1.Pod {
-	pc.RLock()
-	defer pc.RUnlock()
-
-	key, exists := pc.keys[addr]
+	key, exists := pc.getPodKey(addr)
 	if !exists {
 		return nil
 	}


### PR DESCRIPTION
Reuse function `getPodKey` and there is no need to hold pod cache lock when getting pod from podstore.