### PR TITLE
Configure dnsRefreshRate in bootstrap config

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -121,6 +121,8 @@ containers:
 {{- if .Values.global.proxy.componentLogLevel }}
   - --proxyComponentLogLevel={{ .Values.global.proxy.componentLogLevel }}
 {{- end}}
+  - --dnsRefreshRate
+  - {{ .Values.global.proxy.dnsRefreshRate }}
   - --connectTimeout
   - "{{ formatDuration .ProxyConfig.ConnectTimeout }}"
 {{- if .Values.global.proxy.envoyStatsd.enabled }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -182,6 +182,7 @@ global:
 
     # Configure the DNS refresh rate for Envoy cluster of type STRICT_DNS
     # 5 seconds is the default refresh rate used by Envoy
+    # This must be given it terms of seconds. For example, 600s is valid but 5m is invalid.
     dnsRefreshRate: 5s
 
     #If set to true, istio-proxy container will have privileged securityContext

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -559,7 +559,7 @@ func init() {
 	// See https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-component-log-level
 	proxyCmd.PersistentFlags().StringVar(&proxyComponentLogLevel, "proxyComponentLogLevel", "misc:error",
 		"The component log level used to start the Envoy proxy")
-	proxyCmd.PersistentFlags().StringVar(&dnsRefreshRate, "dnsRefreshRate", "5m",
+	proxyCmd.PersistentFlags().StringVar(&dnsRefreshRate, "dnsRefreshRate", "300s",
 		"The dns_refresh_rate for bootstrap STRICT_DNS clusters")
 	proxyCmd.PersistentFlags().IntVar(&concurrency, "concurrency", int(values.Concurrency),
 		"number of worker threads to run")

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -76,6 +76,7 @@ var (
 	customConfigFile           string
 	proxyLogLevel              string
 	proxyComponentLogLevel     string
+	dnsRefreshRate             string
 	concurrency                int
 	templateFile               string
 	disableInternalTelemetry   bool
@@ -385,7 +386,7 @@ var (
 
 			log.Infof("PilotSAN %#v", pilotSAN)
 
-			envoyProxy := envoy.NewProxy(proxyConfig, role.ServiceNode(), proxyLogLevel, proxyComponentLogLevel, pilotSAN, role.IPAddresses)
+			envoyProxy := envoy.NewProxy(proxyConfig, role.ServiceNode(), proxyLogLevel, proxyComponentLogLevel, pilotSAN, role.IPAddresses, dnsRefreshRate)
 			agent := proxy.NewAgent(envoyProxy, proxy.DefaultRetry, pilot.TerminationDrainDuration())
 			watcher := envoy.NewWatcher(tlsCertsToWatch, agent.ConfigCh())
 
@@ -558,6 +559,8 @@ func init() {
 	// See https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-component-log-level
 	proxyCmd.PersistentFlags().StringVar(&proxyComponentLogLevel, "proxyComponentLogLevel", "misc:error",
 		"The component log level used to start the Envoy proxy")
+	proxyCmd.PersistentFlags().StringVar(&dnsRefreshRate, "dnsRefreshRate", "5m",
+		"The dns_refresh_rate for bootstrap STRICT_DNS clusters")
 	proxyCmd.PersistentFlags().IntVar(&concurrency, "concurrency", int(values.Concurrency),
 		"number of worker threads to run")
 	proxyCmd.PersistentFlags().StringVar(&templateFile, "templateFile", "",

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -69,6 +69,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -66,6 +66,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -68,6 +68,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -49,6 +49,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -69,6 +69,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -49,6 +49,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -53,6 +53,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -49,6 +49,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -59,6 +59,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -39,6 +39,8 @@ spec:
             - 1m0s
             - --discoveryAddress
             - istio-pilot:15010
+            - --dnsRefreshRate
+            - 5s
             - --connectTimeout
             - 1s
             - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -43,6 +43,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -58,6 +58,8 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
+          - --dnsRefreshRate
+          - 5s
           - --connectTimeout
           - 1s
           - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -43,6 +43,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 42s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 42s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -63,6 +63,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -46,6 +46,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -47,6 +47,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -206,6 +208,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -46,6 +46,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -46,6 +46,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -37,6 +37,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -46,6 +46,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -46,6 +46,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -64,6 +64,8 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
+          - --dnsRefreshRate
+          - 5s
           - --connectTimeout
           - 1s
           - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -49,6 +49,8 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
+          - --dnsRefreshRate
+          - 5s
           - --connectTimeout
           - 1s
           - --proxyAdminPort
@@ -207,6 +209,8 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
+          - --dnsRefreshRate
+          - 5s
           - --connectTimeout
           - 1s
           - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -30,6 +30,8 @@ spec:
     - 1m0s
     - --discoveryAddress
     - istio-pilot:15010
+    - --dnsRefreshRate
+    - 5s
     - --connectTimeout
     - 1s
     - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -40,6 +40,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -39,6 +39,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -48,6 +48,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -46,6 +46,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -41,6 +41,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -41,6 +41,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -41,6 +41,8 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -46,6 +46,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -44,6 +44,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -44,6 +44,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -51,6 +51,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -47,6 +47,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -49,6 +49,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -208,6 +210,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -67,6 +67,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -40,6 +40,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -51,6 +51,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -49,6 +49,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -208,6 +210,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -43,6 +43,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -41,6 +41,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -45,6 +45,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -50,6 +50,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -48,6 +48,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -47,6 +47,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -47,6 +47,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -47,6 +47,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -49,6 +49,8 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
+        - --dnsRefreshRate
+        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort

--- a/pilot/pkg/proxy/envoy/proxy_test.go
+++ b/pilot/pkg/proxy/envoy/proxy_test.go
@@ -28,10 +28,11 @@ func TestEnvoyArgs(t *testing.T) {
 	config.Concurrency = 8
 
 	test := &envoy{
-		config:    config,
-		node:      "my-node",
-		extraArgs: []string{"-l", "trace", "--component-log-level", "misc:error"},
-		nodeIPs:   []string{"10.75.2.9", "192.168.11.18"},
+		config:         config,
+		node:           "my-node",
+		extraArgs:      []string{"-l", "trace", "--component-log-level", "misc:error"},
+		nodeIPs:        []string{"10.75.2.9", "192.168.11.18"},
+		dnsRefreshRate: "60s",
 	}
 	testProxy := NewProxy(
 		config,
@@ -40,6 +41,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"misc:error",
 		nil,
 		[]string{"10.75.2.9", "192.168.11.18"},
+		"60s",
 	)
 	if !reflect.DeepEqual(testProxy, test) {
 		t.Errorf("unexpected struct got\n%v\nwant\n%v", testProxy, test)

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -202,7 +202,7 @@ var overrideVar = env.RegisterStringVar("ISTIO_BOOTSTRAP", "", "")
 // WriteBootstrap generates an envoy config based on config and epoch, and returns the filename.
 // TODO: in v2 some of the LDS ports (port, http_port) should be configured in the bootstrap.
 func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilotSAN []string,
-	opts map[string]interface{}, localEnv []string, nodeIPs []string) (string, error) {
+	opts map[string]interface{}, localEnv []string, nodeIPs []string, dnsRefreshRate string) (string, error) {
 	if opts == nil {
 		opts = map[string]interface{}{}
 	}
@@ -287,10 +287,13 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	// Pass unmodified config.DiscoveryAddress for Google gRPC Envoy client target_uri parameter
 	opts["discovery_address"] = config.DiscoveryAddress
 
+	opts["dns_refresh_rate"] = dnsRefreshRate
+
 	// Setting default to ipv4 local host, wildcard and dns policy
 	opts["localhost"] = "127.0.0.1"
 	opts["wildcard"] = "0.0.0.0"
 	opts["dns_lookup_family"] = "V4_ONLY"
+
 	// Check if nodeIP carries IPv4 or IPv6 and set up proxy accordingly
 	if isIPv6Proxy(nodeIPs) {
 		opts["localhost"] = "::1"

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -102,7 +102,8 @@ func TestGolden(t *testing.T) {
 
 			_, localEnv := createEnv(t, c.labels, c.annotations)
 			fn, err := WriteBootstrap(cfg, "sidecar~1.2.3.4~foo~bar", 0, []string{
-				"spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"}, nil, localEnv, []string{"10.3.3.3", "10.4.4.4", "10.5.5.5", "10.6.6.6"})
+				"spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"}, nil, localEnv,
+				[]string{"10.3.3.3", "10.4.4.4", "10.5.5.5", "10.6.6.6"}, "60s")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -112,6 +112,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "7s",
         "lb_policy": "ROUND_ROBIN",
@@ -175,6 +176,7 @@
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -189,6 +191,7 @@
       {
         "name": "envoy_metrics_service",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -112,6 +112,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -112,6 +112,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -112,6 +112,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "7s",
         "lb_policy": "ROUND_ROBIN",
@@ -175,6 +176,7 @@
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -103,6 +103,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -117,6 +117,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -155,6 +156,8 @@
         "name": "datadog_agent",
         "connect_timeout": "1s",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
+        "dns_lookup_family": "V4_ONLY",
         "lb_policy": "ROUND_ROBIN",
         "hosts": [
           {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -112,6 +112,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -163,7 +164,9 @@
           }
         },
         
-        "type": "LOGICAL_DNS",
+        "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "hosts": [

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -112,6 +112,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -149,6 +150,7 @@
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/tools/hyperistio/hyperistio.go
+++ b/tools/hyperistio/hyperistio.go
@@ -122,7 +122,7 @@ func startEnvoy() error {
 		DrainDuration:    types.DurationProto(30 * time.Second), // crash if 0
 		StatNameLength:   189,
 	}
-	cfgF, err := agent.WriteBootstrap(cfg, "sidecar~127.0.0.2~a~a", 1, []string{}, nil, os.Environ(), []string{})
+	cfgF, err := agent.WriteBootstrap(cfg, "sidecar~127.0.0.2~a~a", 1, []string{}, nil, os.Environ(), []string{}, "60s")
 	if err != nil {
 		return err
 	}

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -110,6 +110,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "{{ .connect_timeout }}",
         "lb_policy": "ROUND_ROBIN",
@@ -175,6 +176,7 @@
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -203,7 +205,9 @@
           }
         },
         {{ end }}
-        "type": "LOGICAL_DNS",
+        "type": "STRICT_DNS",
+        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
+        "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "hosts": [
@@ -218,6 +222,8 @@
         "name": "datadog_agent",
         "connect_timeout": "1s",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
+        "dns_lookup_family": "{{ .dns_lookup_family }}",
         "lb_policy": "ROUND_ROBIN",
         "hosts": [
           {
@@ -231,6 +237,7 @@
       {
         "name": "envoy_metrics_service",
         "type": "STRICT_DNS",
+        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",


### PR DESCRIPTION
We previously added configuration for dns_refresh_rate, which applies to
STRICT_DNS clusters for ServiceEntries. However, this didn't get passed
through to the bootstrap config. This is especially critical as we plan
to change the default dns_refresh_rate, so we need to also have this
apply to the bootstrap.

A part of https://github.com/istio/istio/issues/13710