### PR TITLE
Modify dns refresh rate default to 5m

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -181,8 +181,8 @@ global:
     componentLogLevel: ""
 
     # Configure the DNS refresh rate for Envoy cluster of type STRICT_DNS
-    # 5 seconds is the default refresh rate used by Envoy
-    dnsRefreshRate: 5s
+    # This must be given it terms of seconds. For example, 300s is valid but 5m is invalid.
+    dnsRefreshRate: 300s
 
     #If set to true, istio-proxy container will have privileged securityContext
     privileged: false


### PR DESCRIPTION
A part of istio/istio#13710

5m default was discussed in the networking WG

This is needed in master and not just istio/installer as we are targeting a backport to 1.1.7