### PR TITLE
fixes to consul demo 

### DIFF
--- a/samples/bookinfo/platform/consul/bookinfo.yaml
+++ b/samples/bookinfo/platform/consul/bookinfo.yaml
@@ -28,6 +28,7 @@ services:
       - SERVICE_NAME=details
       - SERVICE_TAGS=version|v1
       - SERVICE_PROTOCOL=http
+      - SERVICE_VERSION=v1
     expose:
       - "9080"
 
@@ -44,6 +45,7 @@ services:
       - SERVICE_NAME=ratings
       - SERVICE_TAGS=version|v1
       - SERVICE_PROTOCOL=http
+      - SERVICE_VERSION=v1
     expose:
       - "9080"
 
@@ -61,6 +63,7 @@ services:
       - SERVICE_TAGS=version|v1
       - SERVICE_PROTOCOL=http
       - SERVICE_9443_IGNORE=1
+      - SERVICE_VERSION=v1
     expose:
       - "9080"
 
@@ -78,6 +81,7 @@ services:
       - SERVICE_TAGS=version|v2
       - SERVICE_PROTOCOL=http
       - SERVICE_9443_IGNORE=1
+      - SERVICE_VERSION=v2
     expose:
       - "9080"
 
@@ -95,6 +99,7 @@ services:
       - SERVICE_TAGS=version|v3
       - SERVICE_PROTOCOL=http
       - SERVICE_9443_IGNORE=1
+      - SERVICE_VERSION=v3
     expose:
       - "9080"
 
@@ -112,6 +117,7 @@ services:
       - SERVICE_NAME=productpage
       - SERVICE_TAGS=version|v1
       - SERVICE_PROTOCOL=http
+      - SERVICE_VERSION=v1
     ports:
       - "9081:9080"
     expose:

--- a/samples/bookinfo/platform/consul/templates/bookinfo.sidecars.yaml.tmpl
+++ b/samples/bookinfo/platform/consul/templates/bookinfo.sidecars.yaml.tmpl
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1-init:
-    image: docker.io/istio/proxy_init:{PROXY_TAG}
+    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_details-v1_1"
@@ -40,7 +40,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster details-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   ratings-v1-init:
-    image: docker.io/istio/proxy_init:{PROXY_TAG}
+    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_ratings-v1_1"
@@ -64,7 +64,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster ratings-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   productpage-v1-init:
-    image: docker.io/istio/proxy_init:{PROXY_TAG}
+    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_productpage-v1_1"
@@ -88,7 +88,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster productpage-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v1-init:
-    image: docker.io/istio/proxy_init:{PROXY_TAG}
+    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_reviews-v1_1"
@@ -112,7 +112,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster reviews-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v2-init:
-    image: docker.io/istio/proxy_init:{PROXY_TAG}
+    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_reviews-v2_1"
@@ -136,7 +136,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster reviews-v2 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v3-init:
-    image: docker.io/istio/proxy_init:{PROXY_TAG}
+    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_reviews-v3_1"

--- a/samples/bookinfo/platform/consul/templates/bookinfo.sidecars.yaml.tmpl
+++ b/samples/bookinfo/platform/consul/templates/bookinfo.sidecars.yaml.tmpl
@@ -25,6 +25,12 @@ services:
       - "15001"
       - -u
       - "1337"
+      - -m
+      - REDIRECT
+      - -i
+      - "*"
+      - -b
+      - "9080"
   details-v1-sidecar:
     image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
     network_mode: "container:consul_details-v1_1"
@@ -43,6 +49,12 @@ services:
       - "15001"
       - -u
       - "1337"
+      - -m
+      - REDIRECT
+      - -i
+      - "*"
+      - -b
+      - "9080"
   ratings-v1-sidecar:
     image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
     network_mode: "container:consul_ratings-v1_1"
@@ -61,6 +73,12 @@ services:
       - "15001"
       - -u
       - "1337"
+      - -m
+      - REDIRECT
+      - -i
+      - "*"
+      - -b
+      - "9080"
   productpage-v1-sidecar:
     image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
     network_mode: "container:consul_productpage-v1_1"
@@ -79,6 +97,12 @@ services:
       - "15001"
       - -u
       - "1337"
+      - -m
+      - REDIRECT
+      - -i
+      - "*"
+      - -b
+      - "9080"
   reviews-v1-sidecar:
     image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
     network_mode: "container:consul_reviews-v1_1"
@@ -97,6 +121,12 @@ services:
       - "15001"
       - -u
       - "1337"
+      - -m
+      - REDIRECT
+      - -i
+      - "*"
+      - -b
+      - "9080"
   reviews-v2-sidecar:
     image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
     network_mode: "container:consul_reviews-v2_1"
@@ -115,6 +145,12 @@ services:
       - "15001"
       - -u
       - "1337"
+      - -m
+      - REDIRECT
+      - -i
+      - "*"
+      - -b
+      - "9080"
   reviews-v3-sidecar:
     image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
     network_mode: "container:consul_reviews-v3_1"


### PR DESCRIPTION
fixes for latest changes of registrator image and fixed init container args so that traffic is captured

resolves:
https://discuss.istio.io/t/quickstart-bookinfo-app-consul-docker-is-redirecting-outbound-to-only-one-microservice/2208/2