### PR TITLE
[Test Framework] Fix ready timeout endpoints

### DIFF
--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/scopes"
@@ -290,7 +290,7 @@ func (a *Accessor) WaitUntilServiceEndpointsAreReady(ns string, name string, opt
 			}
 		}
 		return fmt.Errorf("%s/%v endpoint not ready: no ready addresses", ns, name)
-	}, opts...)
+	}, newRetryOptions(opts...)...)
 
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This is causing a lot of failures on CI because we're not specifying the timeout, so it's defaulting to 30 seconds (from the retry package).

Fixes #13969