### PR TITLE
Add timeout for secret cache update/delete to avoid blocking secret watch

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -446,16 +446,7 @@ func (sc *SecretCache) rotate() {
 				defer wg.Done()
 				if sc.isTokenExpired() {
 					log.Debugf("Token for %q expired for proxy %q", e.ResourceName, connectionID)
-
-					if sc.notifyCallback != nil {
-						// Send the notification to close the stream connection if both cert and token have expired.
-						if err := sc.notifyCallback(key.ConnectionID, key.ResourceName, nil /*nil indicates close the streaming connection to proxy*/); err != nil {
-							log.Errorf("Failed to notify for proxy %q: %v", connectionID, err)
-						}
-					} else {
-						log.Warnf("secret cache notify callback isn't set")
-					}
-
+					sc.callbackWithTimeout(key.ConnectionID, key.ResourceName, nil /*nil indicates close the streaming connection to proxy*/)
 					return
 				}
 

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -279,8 +279,8 @@ func (sc *SecretCache) DeleteSecret(connectionID, resourceName string) {
 func waitTimeout(wg *sync.WaitGroup, timeoutMessage string) {
 	c := make(chan struct{})
 	go func() {
-			defer close(c)
-			wg.Wait()
+		defer close(c)
+		wg.Wait()
 	}()
 	select {
 	case <-c:


### PR DESCRIPTION
Root cause of the issue is when a connection is terminated, sds service did not completely remove the reference to them in the local cache. As a result, secretcache update will try to send notification to all of them, which will get stuck if the connection is already closed.

This PR add a timeout to the update threads so that secret watch thread can be unblocked. Another fixes in parallel is to clean up the connection cache properly when connection close, and/or avoid notifying dead connection.


Issue: #13853
