### PR TITLE
test framework: initialize only uninitialized instance

### DIFF
--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -203,7 +203,7 @@ func initAllWorkloads(accessor *kube.Accessor, instances []echo.Instance) error 
 	var aggregateErr error
 	wg := sync.WaitGroup{}
 
-	for i, inst := range instances {
+	for i, inst := range needInit {
 		wg.Add(1)
 
 		instanceIndex := i


### PR DESCRIPTION
Encounter out of bound error when partial of the instances are initialized.

It's pretty clear that we need only go over uninitialized instances.