### PR TITLE
Fixing tags in helm charts

### DIFF
--- a/release/gcb/helm_values.sh
+++ b/release/gcb/helm_values.sh
@@ -33,6 +33,11 @@ function fix_values_yaml() {
   # Update version string in yaml files.
   sed -i "s|hub: gcr.io/istio-release|hub: ${CB_DOCKER_HUB}|g" ./"istio-${CB_VERSION}"/install/kubernetes/helm/istio*/values.yaml
   sed -i "s|tag: .*-latest-daily|tag: ${CB_VERSION}|g"         ./"istio-${CB_VERSION}"/install/kubernetes/helm/istio*/values.yaml
+  current_tag=$(grep "appVersion" ./"istio-${CB_VERSION}"/install/kubernetes/helm/istio/Chart.yaml  | cut -d ' ' -f2)
+  if [ ${current_tag} != ${CB_VERSION} ]; then
+    find . -type f -exec sed -i "s/${current_tag}/${CB_VERSION}/g" {} \;
+  fi
+  sed -i "s|tag: .*-latest-daily|tag: ${CB_VERSION}|g"         ./"istio-${CB_VERSION}"/install/kubernetes/helm/istio*/values.yaml
 
   # replace prerelease with release location for istio.io repo
   if [ "${CB_PIPELINE_TYPE}" = "monthly" ]; then

--- a/release/gcb/helm_values.sh
+++ b/release/gcb/helm_values.sh
@@ -37,7 +37,6 @@ function fix_values_yaml() {
   if [ ${current_tag} != ${CB_VERSION} ]; then
     find . -type f -exec sed -i "s/${current_tag}/${CB_VERSION}/g" {} \;
   fi
-  sed -i "s|tag: .*-latest-daily|tag: ${CB_VERSION}|g"         ./"istio-${CB_VERSION}"/install/kubernetes/helm/istio*/values.yaml
 
   # replace prerelease with release location for istio.io repo
   if [ "${CB_PIPELINE_TYPE}" = "monthly" ]; then

--- a/release/gcb/helm_values.sh
+++ b/release/gcb/helm_values.sh
@@ -34,8 +34,11 @@ function fix_values_yaml() {
   sed -i "s|hub: gcr.io/istio-release|hub: ${CB_DOCKER_HUB}|g" ./"istio-${CB_VERSION}"/install/kubernetes/helm/istio*/values.yaml
   sed -i "s|tag: .*-latest-daily|tag: ${CB_VERSION}|g"         ./"istio-${CB_VERSION}"/install/kubernetes/helm/istio*/values.yaml
   current_tag=$(grep "appVersion" ./"istio-${CB_VERSION}"/install/kubernetes/helm/istio/Chart.yaml  | cut -d ' ' -f2)
-  if [ ${current_tag} != ${CB_VERSION} ]; then
-    find . -type f -exec sed -i "s/${current_tag}/${CB_VERSION}/g" {} \;
+  if [ "${current_tag}" != "${CB_VERSION}" ]; then
+    find . -type f -exec sed -i "s/tag: ${current_tag}/tag: ${CB_VERSION}/g" {} \;
+    find . -type f -exec sed -i "s/version: ${current_tag}/version: ${CB_VERSION}/g" {} \;
+    find . -type f -exec sed -i "s/appVersion: ${current_tag}/appVersion: ${CB_VERSION}/g" {} \;
+    find . -type f -exec sed -i "s/istio-release\/releases\/${current_tag}/istio-release\/releases\/${CB_VERSION}/g" {} \;
   fi
 
   # replace prerelease with release location for istio.io repo


### PR DESCRIPTION
Currently all releases (daily, RCs) have tag 1.1.0. Instead I am updating current_tag to $CB_VERSION
Which is 1.1.X for RCs and master-2019XY-09-16 for daily.
 