### PR TITLE
[Test Framework] Refactor Echo API to hide waiting

### DIFF
--- a/pkg/test/framework/components/echo/common/envoy_test.go
+++ b/pkg/test/framework/components/echo/common/envoy_test.go
@@ -160,11 +160,11 @@ func (e *config) WorkloadsOrFail(t test.Failer) []echo.Workload {
 	panic("not implemented")
 }
 
-func (e *config) WaitUntilReady(_ ...echo.Instance) error {
+func (e *config) WaitUntilCallable(_ ...echo.Instance) error {
 	panic("not implemented")
 }
 
-func (e *config) WaitUntilReadyOrFail(_ test.Failer, _ ...echo.Instance) {
+func (e *config) WaitUntilCallableOrFail(_ test.Failer, _ ...echo.Instance) {
 	panic("not implemented")
 }
 

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -23,27 +23,27 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
-// New returns a new instance of echo.
-func New(ctx resource.Context, cfg echo.Config) (i echo.Instance, err error) {
+// NewBuilder for Echo Instances.
+func NewBuilder(ctx resource.Context) (b echo.Builder, err error) {
 	err = resource.UnsupportedEnvironment(ctx.Environment())
 
 	ctx.Environment().Case(environment.Native, func() {
-		i, err = native.New(ctx, cfg)
+		b = native.NewBuilder(ctx)
+		err = nil
 	})
 
 	ctx.Environment().Case(environment.Kube, func() {
-		i, err = kube.New(ctx, cfg)
+		b = kube.NewBuilder(ctx)
+		err = nil
 	})
 	return
 }
 
-// NewOrFail returns a new instance of echo, or fails t if there is an error.
-func NewOrFail(t test.Failer, ctx resource.Context, cfg echo.Config) echo.Instance {
-	t.Helper()
-	i, err := New(ctx, cfg)
+// NewBuilder for Echo Instances.
+func NewBuilderOrFail(t test.Failer, ctx resource.Context) echo.Builder {
+	b, err := NewBuilder(ctx)
 	if err != nil {
-		t.Fatalf("echo.NewOrFail: %v", err)
+		t.Fatalf("echo.NewBuilderOrFail: %v", err)
 	}
-
-	return i
+	return b
 }

--- a/pkg/test/framework/components/echo/kube/builder.go
+++ b/pkg/test/framework/components/echo/kube/builder.go
@@ -1,0 +1,157 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	kubeEnv "istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/resource"
+
+	kubeCore "k8s.io/api/core/v1"
+)
+
+var _ echo.Builder = &builder{}
+
+type builder struct {
+	ctx        resource.Context
+	references []*echo.Instance
+	configs    []echo.Config
+}
+
+func NewBuilder(ctx resource.Context) echo.Builder {
+	return &builder{
+		ctx: ctx,
+	}
+}
+
+func (b *builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
+	b.references = append(b.references, i)
+	b.configs = append(b.configs, cfg)
+	return b
+}
+
+func (b *builder) Build() error {
+	instances, err := b.newInstances()
+	if err != nil {
+		return err
+	}
+
+	if err := b.initializeInstances(instances); err != nil {
+		return err
+	}
+
+	if err := b.waitUntilAllCallable(instances); err != nil {
+		return err
+	}
+
+	// Success... update the caller's references.
+	for i, inst := range instances {
+		*b.references[i] = inst
+	}
+	return nil
+}
+
+func (b *builder) BuildOrFail(t test.Failer) {
+	if err := b.Build(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (b *builder) newInstances() ([]echo.Instance, error) {
+	instances := make([]echo.Instance, 0, len(b.configs))
+	for _, cfg := range b.configs {
+		inst, err := newInstance(b.ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, inst)
+	}
+	return instances, nil
+}
+
+func (b *builder) initializeInstances(instances []echo.Instance) error {
+	env := b.ctx.Environment().(*kubeEnv.Environment)
+
+	// Wait to receive the k8s Endpoints for each Echo Instance.
+	wg := sync.WaitGroup{}
+	instanceEndpoints := make([]*kubeCore.Endpoints, len(instances))
+	aggregateErrMux := &sync.Mutex{}
+	var aggregateErr error
+	for i, inst := range instances {
+		wg.Add(1)
+
+		instanceIndex := i
+		serviceName := inst.Config().Service
+		serviceNamespace := inst.Config().Namespace.Name()
+
+		// Run the waits in parallel.
+		go func() {
+			defer wg.Done()
+
+			// Wait until all the endpoints are ready for this service
+			_, endpoints, err := env.WaitUntilServiceEndpointsAreReady(serviceNamespace, serviceName)
+			if err != nil {
+				aggregateErrMux.Lock()
+				aggregateErr = multierror.Append(aggregateErr, err)
+				aggregateErrMux.Unlock()
+				return
+			}
+			instanceEndpoints[instanceIndex] = endpoints
+		}()
+	}
+
+	wg.Wait()
+
+	if aggregateErr != nil {
+		return aggregateErr
+	}
+
+	// Initialize the workloads for each instance.
+	for i, inst := range instances {
+		if err := inst.(*instance).initialize(instanceEndpoints[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *builder) waitUntilAllCallable(instances []echo.Instance) error {
+	// Now wait for each endpoint to be callable from all others.
+	wg := sync.WaitGroup{}
+	aggregateErrMux := &sync.Mutex{}
+	var aggregateErr error
+	for _, inst := range instances {
+		wg.Add(1)
+
+		source := inst
+		go func() {
+			defer wg.Done()
+
+			if err := source.WaitUntilCallable(instances...); err != nil {
+				aggregateErrMux.Lock()
+				aggregateErr = multierror.Append(aggregateErr, err)
+				aggregateErrMux.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	return aggregateErr
+}

--- a/pkg/test/framework/components/echo/native/builder.go
+++ b/pkg/test/framework/components/echo/native/builder.go
@@ -1,0 +1,103 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package native
+
+import (
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var _ echo.Builder = &builder{}
+
+type builder struct {
+	ctx        resource.Context
+	references []*echo.Instance
+	configs    []echo.Config
+}
+
+func NewBuilder(ctx resource.Context) echo.Builder {
+	return &builder{
+		ctx: ctx,
+	}
+}
+
+func (b *builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
+	b.references = append(b.references, i)
+	b.configs = append(b.configs, cfg)
+	return b
+}
+
+func (b *builder) Build() error {
+	instances, err := b.newInstances()
+	if err != nil {
+		return err
+	}
+
+	if err := b.waitUntilAllCallable(instances); err != nil {
+		return err
+	}
+
+	// Success... update the caller's references.
+	for i, inst := range instances {
+		*b.references[i] = inst
+	}
+	return nil
+}
+
+func (b *builder) BuildOrFail(t test.Failer) {
+	if err := b.Build(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (b *builder) newInstances() ([]echo.Instance, error) {
+	instances := make([]echo.Instance, 0, len(b.configs))
+	for _, cfg := range b.configs {
+		inst, err := newInstance(b.ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, inst)
+	}
+	return instances, nil
+}
+
+func (b *builder) waitUntilAllCallable(instances []echo.Instance) error {
+	// Now wait for each endpoint to be callable from all others.
+	wg := sync.WaitGroup{}
+	aggregateErrMux := &sync.Mutex{}
+	var aggregateErr error
+	for _, inst := range instances {
+		wg.Add(1)
+
+		source := inst
+		go func() {
+			defer wg.Done()
+			if err := source.WaitUntilCallable(instances...); err != nil {
+				aggregateErrMux.Lock()
+				aggregateErr = multierror.Append(aggregateErr, err)
+				aggregateErrMux.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	return aggregateErr
+}

--- a/pkg/test/framework/components/echo/native/instance.go
+++ b/pkg/test/framework/components/echo/native/instance.go
@@ -41,8 +41,7 @@ type instance struct {
 	workload *workload
 }
 
-// New creates a new native echo instance.
-func New(ctx resource.Context, cfg echo.Config) (out echo.Instance, err error) {
+func newInstance(ctx resource.Context, cfg echo.Config) (out echo.Instance, err error) {
 	env := ctx.Environment().(*native.Environment)
 
 	// Fill in defaults for any missing values.
@@ -68,7 +67,7 @@ func (c *instance) ID() resource.ID {
 	return c.id
 }
 
-func (c *instance) WaitUntilReady(outboundInstances ...echo.Instance) error {
+func (c *instance) WaitUntilCallable(instances ...echo.Instance) error {
 	// No need to check for inbound readiness, since inbound ports for the native echo instance
 	// are configured by bootstrap.
 
@@ -77,19 +76,12 @@ func (c *instance) WaitUntilReady(outboundInstances ...echo.Instance) error {
 		return nil
 	}
 
-	// Wait until all of the outbound instances are ready.
-	for _, outbound := range outboundInstances {
-		if err := outbound.WaitUntilReady(); err != nil {
-			return err
-		}
-	}
-
-	return c.workload.sidecar.WaitForConfig(common.OutboundConfigAcceptFunc(outboundInstances...))
+	return c.workload.sidecar.WaitForConfig(common.OutboundConfigAcceptFunc(instances...))
 }
 
-func (c *instance) WaitUntilReadyOrFail(t test.Failer, outboundInstances ...echo.Instance) {
+func (c *instance) WaitUntilCallableOrFail(t test.Failer, instances ...echo.Instance) {
 	t.Helper()
-	if err := c.WaitUntilReady(outboundInstances...); err != nil {
+	if err := c.WaitUntilCallable(instances...); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tests/integration/echo/echo_test.go
+++ b/tests/integration/echo/echo_test.go
@@ -124,10 +124,11 @@ func TestEcho(t *testing.T) {
 
 					ns := namespace.NewOrFail(ctx, ctx, "echo", true)
 
-					a := echoboot.NewOrFail(ctx, ctx, config.apply("a", ns))
-					b := echoboot.NewOrFail(ctx, ctx, config.apply("b", ns))
-
-					a.WaitUntilReadyOrFail(ctx, b)
+					var a, b echo.Instance
+					echoboot.NewBuilderOrFail(ctx, ctx).
+						With(&a, config.apply("a", ns)).
+						With(&b, config.apply("b", ns)).
+						BuildOrFail(ctx)
 
 					for _, o := range callOptions {
 						// Make a copy of the options for the test.

--- a/tests/integration/pilot/locality/failover_test.go
+++ b/tests/integration/pilot/locality/failover_test.go
@@ -20,6 +20,8 @@ import (
 
 	"istio.io/common/pkg/log"
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/label"
@@ -81,10 +83,13 @@ func TestFailover(t *testing.T) {
 			Run(func(ctx framework.TestContext) {
 
 				ns := namespace.NewOrFail(t, ctx, "failover-eds", true)
-				a := newEcho(t, ctx, ns, "a")
-				b := newEcho(t, ctx, ns, "b")
-				c := newEcho(t, ctx, ns, "c")
-				a.WaitUntilReadyOrFail(t, b, c)
+
+				var a, b, c echo.Instance
+				echoboot.NewBuilderOrFail(t, ctx).
+					With(&a, echoConfig(ns, "a")).
+					With(&b, echoConfig(ns, "b")).
+					With(&c, echoConfig(ns, "c")).
+					BuildOrFail(t)
 
 				fakeHostname := fmt.Sprintf("fake-cds-external-service-%v.com", r.Int())
 
@@ -115,10 +120,13 @@ func TestFailover(t *testing.T) {
 			Run(func(ctx framework.TestContext) {
 
 				ns := namespace.NewOrFail(t, ctx, "failover-eds", true)
-				a := newEcho(t, ctx, ns, "a")
-				b := newEcho(t, ctx, ns, "b")
-				c := newEcho(t, ctx, ns, "c")
-				a.WaitUntilReadyOrFail(t, b, c)
+
+				var a, b, c echo.Instance
+				echoboot.NewBuilderOrFail(t, ctx).
+					With(&a, echoConfig(ns, "a")).
+					With(&b, echoConfig(ns, "b")).
+					With(&c, echoConfig(ns, "c")).
+					BuildOrFail(t)
 
 				fakeHostname := fmt.Sprintf("fake-eds-external-service-%v.com", r.Int())
 				deploy(t, ns, serviceConfig{

--- a/tests/integration/pilot/locality/main_test.go
+++ b/tests/integration/pilot/locality/main_test.go
@@ -26,7 +26,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -143,9 +142,8 @@ func setupConfig(cfg *istio.Config) {
 	cfg.Values["global.localityLbSetting.failover[0].to"] = "closeregion"
 }
 
-func newEcho(t *testing.T, ctx resource.Context, ns namespace.Instance, name string) echo.Instance {
-	t.Helper()
-	return echoboot.NewOrFail(t, ctx, echo.Config{
+func echoConfig(ns namespace.Instance, name string) echo.Config {
+	return echo.Config{
 		Service:   name,
 		Namespace: ns,
 		Locality:  "region.zone.subzone",
@@ -159,7 +157,7 @@ func newEcho(t *testing.T, ctx resource.Context, ns namespace.Instance, name str
 		},
 		Galley: g,
 		Pilot:  p,
-	})
+	}
 }
 
 type serviceConfig struct {

--- a/tests/integration/pilot/locality/prioritized_test.go
+++ b/tests/integration/pilot/locality/prioritized_test.go
@@ -20,6 +20,8 @@ import (
 
 	"istio.io/common/pkg/log"
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 )
@@ -70,10 +72,13 @@ func TestPrioritized(t *testing.T) {
 			Run(func(ctx framework.TestContext) {
 
 				ns := namespace.NewOrFail(t, ctx, "failover-eds", true)
-				a := newEcho(t, ctx, ns, "a")
-				b := newEcho(t, ctx, ns, "b")
-				c := newEcho(t, ctx, ns, "c")
-				a.WaitUntilReadyOrFail(t, b, c)
+
+				var a, b, c echo.Instance
+				echoboot.NewBuilderOrFail(t, ctx).
+					With(&a, echoConfig(ns, "a")).
+					With(&b, echoConfig(ns, "b")).
+					With(&c, echoConfig(ns, "c")).
+					BuildOrFail(t)
 
 				fakeHostname := fmt.Sprintf("fake-cds-external-service-%v.com", r.Int())
 				deploy(t, ns, serviceConfig{
@@ -101,10 +106,13 @@ func TestPrioritized(t *testing.T) {
 			Run(func(ctx framework.TestContext) {
 
 				ns := namespace.NewOrFail(t, ctx, "failover-eds", true)
-				a := newEcho(t, ctx, ns, "a")
-				b := newEcho(t, ctx, ns, "b")
-				c := newEcho(t, ctx, ns, "c")
-				a.WaitUntilReadyOrFail(t, b, c)
+
+				var a, b, c echo.Instance
+				echoboot.NewBuilderOrFail(t, ctx).
+					With(&a, echoConfig(ns, "a")).
+					With(&b, echoConfig(ns, "b")).
+					With(&c, echoConfig(ns, "c")).
+					BuildOrFail(t)
 
 				fakeHostname := fmt.Sprintf("fake-eds-external-service-%v.com", r.Int())
 				deploy(t, ns, serviceConfig{

--- a/tests/integration/pilot/outboundtrafficpolicy/helper.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/helper.go
@@ -102,33 +102,36 @@ func RunExternalRequestTest(expected map[string][]string, t *testing.T) {
 				t.Errorf("failed to apply service entries: %v", err)
 			}
 
-			client := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:   "client",
-				Namespace: appsNamespace,
-				Sidecar:   true,
-				Pilot:     p,
-				Galley:    g,
-			})
-			dest := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:   "destination",
-				Namespace: appsNamespace,
-				Sidecar:   true,
-				Pilot:     p,
-				Galley:    g,
-				Ports: []echo.Port{
-					{
-						Name:     "http",
-						Protocol: model.ProtocolHTTP,
-					},
-					{
-						Name:     "https",
-						Protocol: model.ProtocolHTTPS,
-					},
-				},
-			})
-
 			// Wait for config to propagate
 			time.Sleep(time.Second * 5)
+
+			var client, dest echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&client, echo.Config{
+					Service:   "client",
+					Namespace: appsNamespace,
+					Sidecar:   true,
+					Pilot:     p,
+					Galley:    g,
+				}).
+				With(&dest, echo.Config{
+					Service:   "destination",
+					Namespace: appsNamespace,
+					Sidecar:   true,
+					Pilot:     p,
+					Galley:    g,
+					Ports: []echo.Port{
+						{
+							Name:     "http",
+							Protocol: model.ProtocolHTTP,
+						},
+						{
+							Name:     "https",
+							Protocol: model.ProtocolHTTPS,
+						},
+					},
+				}).
+				BuildOrFail(t)
 
 			cases := []struct {
 				name     string

--- a/tests/integration/security/authn/permissive_test.go
+++ b/tests/integration/security/authn/permissive_test.go
@@ -99,24 +99,26 @@ spec:
 `
 			g.ApplyConfigOrFail(t, ns, policy)
 
-			a := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:   "a",
-				Namespace: ns,
-				Sidecar:   true,
-				Galley:    g,
-				Pilot:     p,
-				Ports: []echo.Port{
-					{
-						Name:     "http",
-						Protocol: model.ProtocolHTTP,
+			var a echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, echo.Config{
+					Service:   "a",
+					Namespace: ns,
+					Sidecar:   true,
+					Galley:    g,
+					Pilot:     p,
+					Ports: []echo.Port{
+						{
+							Name:     "http",
+							Protocol: model.ProtocolHTTP,
+						},
+						{
+							Name:     "tcp",
+							Protocol: model.ProtocolTCP,
+						},
 					},
-					{
-						Name:     "tcp",
-						Protocol: model.ProtocolTCP,
-					},
-				},
-			})
-			a.WaitUntilReadyOrFail(t)
+				}).
+				BuildOrFail(t)
 
 			nodeID := a.WorkloadsOrFail(t)[0].Sidecar().NodeID()
 			req := pilot.NewDiscoveryRequest(nodeID, pilot.Listener)

--- a/tests/integration/security/healthcheck/mtls_healthcheck_test.go
+++ b/tests/integration/security/healthcheck/mtls_healthcheck_test.go
@@ -52,11 +52,14 @@ spec:
 			g.ApplyConfigOrFail(t, ns, policyYAML)
 			defer g.DeleteConfigOrFail(t, ns, policyYAML)
 
-			_ = echoboot.NewOrFail(t, ctx, echo.Config{
-				Service: "healthcheck",
-				Pilot:   p,
-				Galley:  g,
-			})
+			var healthcheck echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&healthcheck, echo.Config{
+					Service: "healthcheck",
+					Pilot:   p,
+					Galley:  g,
+				}).
+				BuildOrFail(t)
 
 			// TODO(incfly): add a negative test once we have a per deployment annotation support for this feature.
 		})

--- a/tests/integration/security/rbac/v1/group/group_test.go
+++ b/tests/integration/security/rbac/v1/group/group_test.go
@@ -69,32 +69,36 @@ func TestRBACV1Group(t *testing.T) {
 					Protocol: model.ProtocolHTTP,
 				},
 			}
-			a := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:   "a",
-				Namespace: ns,
-				Sidecar:   true,
-				Ports:     ports,
-				Galley:    g,
-				Pilot:     p,
-			})
-			b := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "b",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
-			c := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "c",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
+
+			var a, b, c echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, echo.Config{
+					Service:   "a",
+					Namespace: ns,
+					Sidecar:   true,
+					Ports:     ports,
+					Galley:    g,
+					Pilot:     p,
+				}).
+				With(&b, echo.Config{
+					Service:        "b",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&c, echo.Config{
+					Service:        "c",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				BuildOrFail(t)
 
 			cases := []util.TestCase{
 				{

--- a/tests/integration/security/rbac/v2/basic/basic_test.go
+++ b/tests/integration/security/rbac/v2/basic/basic_test.go
@@ -55,42 +55,46 @@ func TestRBACV2Basic(t *testing.T) {
 					ServicePort: 90,
 				},
 			}
-			a := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "a",
-				Namespace:      ns,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Ports:          ports,
-				Galley:         g,
-				Pilot:          p,
-			})
-			b := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "b",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
-			c := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "c",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
-			d := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "d",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
+
+			var a, b, c, d echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, echo.Config{
+					Service:        "a",
+					Namespace:      ns,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Ports:          ports,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&b, echo.Config{
+					Service:        "b",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&c, echo.Config{
+					Service:        "c",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&d, echo.Config{
+					Service:        "d",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				BuildOrFail(t)
 
 			cases := []util.TestCase{
 				{

--- a/tests/integration/security/rbac/v2/basic/extended_test.go
+++ b/tests/integration/security/rbac/v2/basic/extended_test.go
@@ -55,33 +55,37 @@ func TestRBACV2Extended(t *testing.T) {
 					ServicePort: 90,
 				},
 			}
-			a := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "a",
-				Namespace:      ns,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Ports:          ports,
-				Galley:         g,
-				Pilot:          p,
-			})
-			b := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "b",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
-			c := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "c",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
+
+			var a, b, c echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, echo.Config{
+					Service:        "a",
+					Namespace:      ns,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Ports:          ports,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&b, echo.Config{
+					Service:        "b",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&c, echo.Config{
+					Service:        "c",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				BuildOrFail(t)
 
 			cases := []util.TestCase{
 				{

--- a/tests/integration/security/rbac/v2/group/group_test.go
+++ b/tests/integration/security/rbac/v2/group/group_test.go
@@ -71,32 +71,37 @@ func TestRBACV2Group(t *testing.T) {
 					ServicePort: 80,
 				},
 			}
-			a := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:   "a",
-				Namespace: ns,
-				Sidecar:   true,
-				Ports:     ports,
-				Galley:    g,
-				Pilot:     p,
-			})
-			b := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "b",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
-			c := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "c",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
+
+			var a, b, c echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, echo.Config{
+					Service:        "a",
+					Namespace:      ns,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Ports:          ports,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&b, echo.Config{
+					Service:        "b",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&c, echo.Config{
+					Service:        "c",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				BuildOrFail(t)
 
 			cases := []util.TestCase{
 				// Port 80 is where HTTP is served

--- a/tests/integration/security/reachability/reachability_test.go
+++ b/tests/integration/security/reachability/reachability_test.go
@@ -64,43 +64,45 @@ func TestReachability(t *testing.T) {
 				},
 			}
 
-			a := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:   "a",
-				Namespace: ns,
-				Sidecar:   true,
-				Ports:     ports,
-				Galley:    g,
-				Pilot:     p,
-			})
-			b := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "b",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
-			headless := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "headless",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Headless:       true,
-				Galley:         g,
-				Pilot:          p,
-			})
-			naked := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:   "naked",
-				Namespace: ns,
-				Ports:     ports,
-				Sidecar:   false,
-				Galley:    g,
-				Pilot:     p,
-			})
-
-			a.WaitUntilReadyOrFail(t, b, headless, naked)
+			var a, b, headless, naked echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, echo.Config{
+					Service:        "a",
+					Namespace:      ns,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Ports:          ports,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&b, echo.Config{
+					Service:        "b",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&headless, echo.Config{
+					Service:        "headless",
+					Namespace:      ns,
+					Ports:          ports,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Headless:       true,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&naked, echo.Config{
+					Service:   "naked",
+					Namespace: ns,
+					Ports:     ports,
+					Sidecar:   false,
+					Galley:    g,
+					Pilot:     p,
+				}).
+				BuildOrFail(t)
 
 			testCases := []struct {
 				configFile string

--- a/tests/integration/security/sds_citadel_flow/sds_citadel_flow_test.go
+++ b/tests/integration/security/sds_citadel_flow/sds_citadel_flow_test.go
@@ -53,23 +53,27 @@ func TestSdsCitadelCaFlow(t *testing.T) {
 				},
 			}
 
-			a := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:   "a",
-				Namespace: ns,
-				Sidecar:   true,
-				Ports:     ports,
-				Galley:    g,
-				Pilot:     p,
-			})
-			b := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "b",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
+			var a, b echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, echo.Config{
+					Service:        "a",
+					Namespace:      ns,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Ports:          ports,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&b, echo.Config{
+					Service:        "b",
+					Namespace:      ns,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Ports:          ports,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				BuildOrFail(t)
 
 			checkers := []connection.Checker{
 				{

--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -53,23 +53,27 @@ func TestSdsVaultCaFlow(t *testing.T) {
 				},
 			}
 
-			a := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:   "a",
-				Namespace: ns,
-				Sidecar:   true,
-				Ports:     ports,
-				Galley:    g,
-				Pilot:     p,
-			})
-			b := echoboot.NewOrFail(t, ctx, echo.Config{
-				Service:        "b",
-				Namespace:      ns,
-				Ports:          ports,
-				Sidecar:        true,
-				ServiceAccount: true,
-				Galley:         g,
-				Pilot:          p,
-			})
+			var a, b echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, echo.Config{
+					Service:        "a",
+					Namespace:      ns,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Ports:          ports,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				With(&b, echo.Config{
+					Service:        "b",
+					Namespace:      ns,
+					Sidecar:        true,
+					ServiceAccount: true,
+					Ports:          ports,
+					Galley:         g,
+					Pilot:          p,
+				}).
+				BuildOrFail(t)
 
 			checkers := []connection.Checker{
 				{


### PR DESCRIPTION
The current API allows you to create instances and immediately start using them, which will likely fail without first calling `WaitUntilReady`.

This PR changes the construction of Echo Instances to a Builder pattern, where you first add configuration for all of the Instances that will communicate to each other and then call Build() which creates the Instances.

In addition, this PR addresses the flaky TestEcho/NoSidecar test, which is only flaky on k8s. I suspect the issue is that when the workloads have no sidecars, we're trying to call out before the system has propagated services/endpoints. Adding a short sleep should resolve this.

Fixes #13553