### PR TITLE
Add neverInjectSelector and alwaysInjectSelector properties to Helm chart

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -16,6 +16,10 @@ data:
 
   config: |-
     policy: {{ .Values.global.proxy.autoInject }}
+    alwaysInjectSelector:
+{{ toYaml .Values.global.proxy.alwaysInjectSelector | indent 20}}
+    neverInjectSelector:
+{{ toYaml .Values.global.proxy.neverInjectSelector | indent 20 }}
     template: |-
 {{ .Files.Get "files/injection-template.yaml" | indent 6 }}
 {{- end }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -224,6 +224,14 @@ global:
     # This controls the 'policy' in the sidecar injector.
     autoInject: enabled
 
+    # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or
+    # always skip the injection on pods that match that label selector, regardless of the global policy.
+    # See https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#more-control-adding-exceptions
+
+    neverInjectSelector: []
+
+    alwaysInjectSelector: []
+
     # Sets the destination Statsd in envoy (the value of the "--statsdUdpAddress" proxy argument
     # would be <host>:<port>).
     # Disabled by default.


### PR DESCRIPTION
Capability to specify alwaysInjectSelector and neverInjectSelector in the Helm chart.

Resolves #14020