### PR TITLE
fix race condition when sds client/server end connection at same time

### DIFF
--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -86,6 +86,10 @@ const (
 	// The environmental variable name for key rotation job running interval.
 	// example value format like "20m"
 	SecretRotationJobRunInterval = "SECRET_JOB_RUN_INTERVAL"
+
+	// The environmental variable name for staled connection recyle job running interval.
+	// example value format like "5m"
+	staledConnectionRecyleInterval = "STALED_CONNECTION_RECYLE_RUN_INTERVAL"
 )
 
 var (
@@ -199,6 +203,11 @@ func init() {
 		alwaysValidTokenFlagEnv = env
 	}
 
+	staledConnectionRecyleIntervalEnv := 5 * time.Minute
+	if env, err := time.ParseDuration(os.Getenv(staledConnectionRecyleInterval)); err == nil {
+		staledConnectionRecyleIntervalEnv = env
+	}
+
 	rootCmd.PersistentFlags().BoolVar(&serverOptions.EnableWorkloadSDS, "enableWorkloadSDS",
 		enableWorkloadSdsEnv,
 		"If true, node agent works as SDS server and provisions key/certificate to workload proxies.")
@@ -227,6 +236,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&workloadSdsCacheOptions.AlwaysValidTokenFlag, "alwaysValidTokenFlag",
 		alwaysValidTokenFlagEnv,
 		"If true, node agent assume token passed from envoy is always valid.")
+
+	rootCmd.PersistentFlags().DurationVar(&serverOptions.RecyleInterval, "staledConnectionRecyleInternal",
+		staledConnectionRecyleIntervalEnv, "Staled client connections recyle job running interval")
 
 	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultAddress, "vaultAddress", os.Getenv(vaultAddress),
 		"Vault address")

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -207,6 +207,7 @@ func init() {
 	if env, err := time.ParseDuration(os.Getenv(staledConnectionRecyleInterval)); err == nil {
 		staledConnectionRecyleIntervalEnv = env
 	}
+	serverOptions.RecyleInterval = staledConnectionRecyleIntervalEnv
 
 	rootCmd.PersistentFlags().BoolVar(&serverOptions.EnableWorkloadSDS, "enableWorkloadSDS",
 		enableWorkloadSdsEnv,
@@ -236,9 +237,6 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&workloadSdsCacheOptions.AlwaysValidTokenFlag, "alwaysValidTokenFlag",
 		alwaysValidTokenFlagEnv,
 		"If true, node agent assume token passed from envoy is always valid.")
-
-	rootCmd.PersistentFlags().DurationVar(&serverOptions.RecyleInterval, "staledConnectionRecyleInternal",
-		staledConnectionRecyleIntervalEnv, "Staled client connections recyle job running interval")
 
 	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultAddress, "vaultAddress", os.Getenv(vaultAddress),
 		"Vault address")

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -87,9 +87,9 @@ const (
 	// example value format like "20m"
 	SecretRotationJobRunInterval = "SECRET_JOB_RUN_INTERVAL"
 
-	// The environmental variable name for staled connection recyle job running interval.
+	// The environmental variable name for staled connection recycle job running interval.
 	// example value format like "5m"
-	staledConnectionRecyleInterval = "STALED_CONNECTION_RECYLE_RUN_INTERVAL"
+	staledConnectionRecycleInterval = "STALED_CONNECTION_RECYCLE_RUN_INTERVAL"
 )
 
 var (
@@ -203,11 +203,11 @@ func init() {
 		alwaysValidTokenFlagEnv = env
 	}
 
-	staledConnectionRecyleIntervalEnv := 5 * time.Minute
-	if env, err := time.ParseDuration(os.Getenv(staledConnectionRecyleInterval)); err == nil {
-		staledConnectionRecyleIntervalEnv = env
+	staledConnectionRecycleIntervalEnv := 5 * time.Minute
+	if env, err := time.ParseDuration(os.Getenv(staledConnectionRecycleInterval)); err == nil {
+		staledConnectionRecycleIntervalEnv = env
 	}
-	serverOptions.RecyleInterval = staledConnectionRecyleIntervalEnv
+	serverOptions.RecycleInterval = staledConnectionRecycleIntervalEnv
 
 	rootCmd.PersistentFlags().BoolVar(&serverOptions.EnableWorkloadSDS, "enableWorkloadSDS",
 		enableWorkloadSdsEnv,

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -390,12 +390,6 @@ func addConn(k cache.ConnKey, conn *sdsConnection) {
 	sdsClients[k] = conn
 }
 
-func removeConn(k cache.ConnKey) {
-	sdsClientsMutex.Lock()
-	defer sdsClientsMutex.Unlock()
-	delete(sdsClients, k)
-}
-
 func pushSDS(con *sdsConnection) error {
 	response, err := sdsDiscoveryResponse(con.secret, con.conID)
 	if err != nil {

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -310,13 +310,14 @@ func (s *sdsservice) clearStaledClients() {
 	sdsClientsMutex.Lock()
 	defer sdsClientsMutex.Unlock()
 
-	len := len(staledClientKeys)
-	for i := 0; i < len; i++ {
+	sLen := len(staledClientKeys)
+	for i := 0; i < sLen; i++ {
 		log.Debugf("remove staled clients %+v", staledClientKeys[i])
 		delete(sdsClients, staledClientKeys[i])
 	}
 
-	staledClientKeys = staledClientKeys[len:]
+	// truncate staledClientKeys to remove keys that deleted above.
+	staledClientKeys = staledClientKeys[sLen:]
 }
 
 // NotifyProxy send notification to proxy about secret update,
@@ -344,6 +345,9 @@ func recyleConnection(conID, resourceName string) {
 		ConnectionID: conID,
 		ResourceName: resourceName,
 	}
+
+	sdsClientsMutex.Lock()
+	defer sdsClientsMutex.Unlock()
 	staledClientKeys = append(staledClientKeys, key)
 }
 

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -310,14 +310,12 @@ func (s *sdsservice) clearStaledClients() {
 	sdsClientsMutex.Lock()
 	defer sdsClientsMutex.Unlock()
 
-	sLen := len(staledClientKeys)
-	for i := 0; i < sLen; i++ {
-		log.Debugf("remove staled clients %+v", staledClientKeys[i])
-		delete(sdsClients, staledClientKeys[i])
+	for _, k := range staledClientKeys {
+		log.Debugf("remove staled clients %+v", k)
+		delete(sdsClients, k)
 	}
 
-	// truncate staledClientKeys to remove keys that deleted above.
-	staledClientKeys = staledClientKeys[sLen:]
+	staledClientKeys = staledClientKeys[:0]
 }
 
 // NotifyProxy send notification to proxy about secret update,

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -115,7 +115,7 @@ type sdsservice struct {
 }
 
 // newSDSService creates Secret Discovery Service which implements envoy v2 SDS API.
-func newSDSService(st cache.SecretManager, skipTokenVerification bool, recyleInterval time.Duration) *sdsservice {
+func newSDSService(st cache.SecretManager, skipTokenVerification bool, recycleInterval time.Duration) *sdsservice {
 	if st == nil {
 		return nil
 	}
@@ -123,7 +123,7 @@ func newSDSService(st cache.SecretManager, skipTokenVerification bool, recyleInt
 	ret := &sdsservice{
 		st:             st,
 		skipToken:      skipTokenVerification,
-		tickerInterval: recyleInterval,
+		tickerInterval: recycleInterval,
 		closing:        make(chan bool),
 	}
 
@@ -211,7 +211,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			}
 
 			defer func() {
-				recyleConnection(con.conID, con.ResourceName)
+				recycleConnection(con.conID, con.ResourceName)
 
 				// Remove the secret from cache, otherwise refresh job will process this item(if envoy fails to reconnect)
 				// and cause some confusing logs like 'fails to notify because connection isn't found'.
@@ -242,7 +242,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 
 			if con.secret == nil {
 				defer func() {
-					recyleConnection(con.conID, con.ResourceName)
+					recycleConnection(con.conID, con.ResourceName)
 					s.st.DeleteSecret(con.conID, con.ResourceName)
 				}()
 
@@ -340,7 +340,7 @@ func NotifyProxy(conID, resourceName string, secret *model.SecretItem) error {
 	return nil
 }
 
-func recyleConnection(conID, resourceName string) {
+func recycleConnection(conID, resourceName string) {
 	key := cache.ConnKey{
 		ConnectionID: conID,
 		ResourceName: resourceName,

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -67,7 +67,7 @@ func TestStreamSecretsForWorkloadSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          5 * time.Minute,
+		RecyleInterval:          30 * time.Second,
 		IngressGatewayUDSPath:   "",
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
@@ -78,7 +78,7 @@ func TestStreamSecretsForGatewaySds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       false,
-		RecyleInterval:          5 * time.Minute,
+		RecyleInterval:          30 * time.Second,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         "",
 	}
@@ -89,7 +89,7 @@ func TestStreamSecretsForBothSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          5 * time.Minute,
+		RecyleInterval:          30 * time.Second,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
@@ -100,7 +100,7 @@ func TestFetchSecretsForWorkloadSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          5 * time.Minute,
+		RecyleInterval:          30 * time.Second,
 		IngressGatewayUDSPath:   "",
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
@@ -111,7 +111,7 @@ func TestFetchSecretsForGatewaySds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       false,
-		RecyleInterval:          5 * time.Minute,
+		RecyleInterval:          30 * time.Second,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         "",
 	}
@@ -122,7 +122,7 @@ func TestFetchSecretsForBothSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          5 * time.Minute,
+		RecyleInterval:          30 * time.Second,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
 	}
@@ -133,7 +133,7 @@ func TestStreamSecretsInvalidResourceName(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          5 * time.Minute,
+		RecyleInterval:          30 * time.Second,
 		IngressGatewayUDSPath:   "",
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
 	}
@@ -246,7 +246,7 @@ func TestStreamSecretsPush(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          5 * time.Minute,
+		RecyleInterval:          2 * time.Second,
 		WorkloadUDSPath:         socket,
 	}
 	st := &mockSecretStore{
@@ -326,6 +326,12 @@ func TestStreamSecretsPush(t *testing.T) {
 		t.Fatalf("Found cached secret after stream close, expected the secret to not exist")
 	}
 
+	// Wait the recyle job run to clear all staled client connections.
+	time.Sleep(10 * time.Second)
+
+	if len(sdsClients) != 0 {
+		t.Fatalf("sdsClients, got %d, expected 0", len(sdsClients))
+	}
 }
 
 func verifySDSSResponse(t *testing.T, resp *api.DiscoveryResponse, expectedPrivateKey []byte, expectedCertChain []byte) {

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -67,6 +67,7 @@ func TestStreamSecretsForWorkloadSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
+		RecyleInterval:          5 * time.Minute,
 		IngressGatewayUDSPath:   "",
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
@@ -77,6 +78,7 @@ func TestStreamSecretsForGatewaySds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       false,
+		RecyleInterval:          5 * time.Minute,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         "",
 	}
@@ -87,6 +89,7 @@ func TestStreamSecretsForBothSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       true,
+		RecyleInterval:          5 * time.Minute,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
@@ -97,6 +100,7 @@ func TestFetchSecretsForWorkloadSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
+		RecyleInterval:          5 * time.Minute,
 		IngressGatewayUDSPath:   "",
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
@@ -107,6 +111,7 @@ func TestFetchSecretsForGatewaySds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       false,
+		RecyleInterval:          5 * time.Minute,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         "",
 	}
@@ -117,6 +122,7 @@ func TestFetchSecretsForBothSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       true,
+		RecyleInterval:          5 * time.Minute,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
 	}
@@ -127,6 +133,7 @@ func TestStreamSecretsInvalidResourceName(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
+		RecyleInterval:          5 * time.Minute,
 		IngressGatewayUDSPath:   "",
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
 	}
@@ -239,6 +246,7 @@ func TestStreamSecretsPush(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
+		RecyleInterval:          5 * time.Minute,
 		WorkloadUDSPath:         socket,
 	}
 	st := &mockSecretStore{
@@ -314,9 +322,6 @@ func TestStreamSecretsPush(t *testing.T) {
 		t.Fatalf("stream.Recv failed, expected error")
 	}
 
-	if len(sdsClients) != 0 {
-		t.Fatalf("sdsClients, got %d, expected 0", len(sdsClients))
-	}
 	if _, found := st.secrets.Load(key); found {
 		t.Fatalf("Found cached secret after stream close, expected the secret to not exist")
 	}

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -329,6 +329,9 @@ func TestStreamSecretsPush(t *testing.T) {
 	// Wait the recycle job run to clear all staled client connections.
 	time.Sleep(10 * time.Second)
 
+	// Add RLock to avoid racetest fail.
+	sdsClientsMutex.RLock()
+	defer sdsClientsMutex.RUnlock()
 	if len(sdsClients) != 0 {
 		t.Fatalf("sdsClients, got %d, expected 0", len(sdsClients))
 	}

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -67,7 +67,7 @@ func TestStreamSecretsForWorkloadSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          30 * time.Second,
+		RecycleInterval:         30 * time.Second,
 		IngressGatewayUDSPath:   "",
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
@@ -78,7 +78,7 @@ func TestStreamSecretsForGatewaySds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       false,
-		RecyleInterval:          30 * time.Second,
+		RecycleInterval:         30 * time.Second,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         "",
 	}
@@ -89,7 +89,7 @@ func TestStreamSecretsForBothSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          30 * time.Second,
+		RecycleInterval:         30 * time.Second,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
@@ -100,7 +100,7 @@ func TestFetchSecretsForWorkloadSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          30 * time.Second,
+		RecycleInterval:         30 * time.Second,
 		IngressGatewayUDSPath:   "",
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
@@ -111,7 +111,7 @@ func TestFetchSecretsForGatewaySds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       false,
-		RecyleInterval:          30 * time.Second,
+		RecycleInterval:         30 * time.Second,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         "",
 	}
@@ -122,7 +122,7 @@ func TestFetchSecretsForBothSds(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: true,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          30 * time.Second,
+		RecycleInterval:         30 * time.Second,
 		IngressGatewayUDSPath:   fmt.Sprintf("/tmp/gateway_gotest%q.sock", string(uuid.NewUUID())),
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
 	}
@@ -133,7 +133,7 @@ func TestStreamSecretsInvalidResourceName(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          30 * time.Second,
+		RecycleInterval:         30 * time.Second,
 		IngressGatewayUDSPath:   "",
 		WorkloadUDSPath:         fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
 	}
@@ -246,7 +246,7 @@ func TestStreamSecretsPush(t *testing.T) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
-		RecyleInterval:          2 * time.Second,
+		RecycleInterval:         2 * time.Second,
 		WorkloadUDSPath:         socket,
 	}
 	st := &mockSecretStore{
@@ -326,7 +326,7 @@ func TestStreamSecretsPush(t *testing.T) {
 		t.Fatalf("Found cached secret after stream close, expected the secret to not exist")
 	}
 
-	// Wait the recyle job run to clear all staled client connections.
+	// Wait the recycle job run to clear all staled client connections.
 	time.Sleep(10 * time.Second)
 
 	if len(sdsClients) != 0 {

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -83,8 +83,8 @@ type Options struct {
 	// AlwaysValidTokenFlag is set to true for if token used is always valid(ex, normal k8s JWT)
 	AlwaysValidTokenFlag bool
 
-	// Recyle job running interval (to clean up staled sds client connections).
-	RecyleInterval time.Duration
+	// Recycle job running interval (to clean up staled sds client connections).
+	RecycleInterval time.Duration
 }
 
 // Server is the gPRC server that exposes SDS through UDS.
@@ -102,8 +102,8 @@ type Server struct {
 // NewServer creates and starts the Grpc server for SDS.
 func NewServer(options Options, workloadSecretCache, gatewaySecretCache cache.SecretManager) (*Server, error) {
 	s := &Server{
-		workloadSds: newSDSService(workloadSecretCache, false, options.RecyleInterval),
-		gatewaySds:  newSDSService(gatewaySecretCache, true, options.RecyleInterval),
+		workloadSds: newSDSService(workloadSecretCache, false, options.RecycleInterval),
+		gatewaySds:  newSDSService(gatewaySecretCache, true, options.RecycleInterval),
 	}
 	if options.EnableWorkloadSDS {
 		if err := s.initWorkloadSdsService(&options); err != nil {


### PR DESCRIPTION
Problem:
1. sds client try to end connection when delete gateway CRD;
2. sds server try to end connection when delete k8s secret;
When delete gateway/secret at almost same time, both sds client/server try to end connection, which trigger race condition in connection push/destroy, it cause server side hangs. 

Fix:
when delete gateway/secret, instead destroying connection right away, put connections into recycle map and use a timer job to clean up the recycle map.

Issue:
https://github.com/istio/istio/issues/13853

