### PR TITLE
Remove unused circle targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -748,12 +748,6 @@ workflows:
       - e2e-pilot-auth-v1alpha3-v2-non-mcp: # auth+v1alpha3+v2 without MCP
           requires:
             - build
-      - test-integration-local:
-          requires:
-            - build
-      - test-integration-kubernetes:
-          requires:
-            - build
 
   all:
     jobs:
@@ -787,12 +781,6 @@ workflows:
           requires:
             - build
       - e2e-pilot-auth-v1alpha3-v2-non-mcp: # auth+v1alpha3+v2 without MCP
-          requires:
-            - build
-      - test-integration-local:
-          requires:
-            - build
-      - test-integration-kubernetes:
           requires:
             - build
 


### PR DESCRIPTION
These tests were deleted, but not removed from the list of tests to run,
which just causes them to fail in PRs.

I think this is the right fix for https://circleci.com/gh/istio/istio/416614?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link, @ozevren ?