### PR TITLE
Sort Config in stable ordering

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -648,6 +648,14 @@ func (store *istioConfigStore) ServiceEntries() []Config {
 // sortConfigByCreationTime sorts the list of config objects in ascending order by their creation time (if available).
 func sortConfigByCreationTime(configs []Config) []Config {
 	sort.SliceStable(configs, func(i, j int) bool {
+		// If creation time is the same, then behavior is nondeterministic. In this case, we can
+		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
+		// CreationTimestamp is stored in seconds, so this is not uncommon.
+		if configs[i].CreationTimestamp == configs[j].CreationTimestamp {
+			in := configs[i].Name + "." + configs[i].Namespace
+			jn := configs[j].Name + "." + configs[j].Namespace
+			return in < jn
+		}
 		return configs[i].CreationTimestamp.Before(configs[j].CreationTimestamp)
 	})
 	return configs

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gogo/protobuf/proto"
@@ -885,6 +886,54 @@ func TestIstioConfigStore_ServiceEntries(t *testing.T) {
 
 	if len(cfgs) != 1 {
 		t.Fatalf("did not find 1 matched ServiceEntry, \n%v", cfgs)
+	}
+}
+
+func TestIstioConfigStore_Gateway(t *testing.T) {
+	workloadLabels := model.LabelsCollection{}
+	now := time.Now()
+	gw1 := model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Name:              "name1",
+			Namespace:         "zzz",
+			CreationTimestamp: now,
+		},
+		Spec: &networking.Gateway{},
+	}
+	gw2 := model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Name:              "name1",
+			Namespace:         "aaa",
+			CreationTimestamp: now,
+		},
+		Spec: &networking.Gateway{},
+	}
+	gw3 := model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Name:              "name1",
+			Namespace:         "ns2",
+			CreationTimestamp: now.Add(time.Second * -1),
+		},
+		Spec: &networking.Gateway{},
+	}
+
+	l := &fakeStore{
+		cfg: map[string][]model.Config{
+			model.Gateway.Type: {gw1, gw2, gw3},
+		},
+	}
+	ii := model.MakeIstioStore(l)
+
+	// Gateways should be returned in a stable order
+	expectedConfig := []model.Config{
+		gw3, // first config by timestamp
+		gw2, // timestamp match with gw1, but name comes first
+		gw1, // timestamp match with gw2, but name comes last
+	}
+	cfgs := ii.Gateways(workloadLabels)
+
+	if !reflect.DeepEqual(expectedConfig, cfgs) {
+		t.Errorf("Got different Config, Excepted:\n%v\n, Got: \n%v\n", expectedConfig, cfgs)
 	}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -18,10 +18,13 @@ import (
 	"fmt"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/features/pilot"
+	"istio.io/istio/pkg/proto"
 )
 
 func (s *DiscoveryServer) pushRoute(con *XdsConnection, push *model.PushContext) error {
@@ -67,7 +70,19 @@ func (s *DiscoveryServer) generateRawRoutes(con *XdsConnection, push *model.Push
 
 		if r == nil {
 			adsLog.Warnf("RDS: got nil value for route %s for node %v: %v", routeName, con.modelNode, err)
-			continue
+
+			// Don't send an empty route, instead ignore the request. This may cause Envoy to block
+			// listeners waiting for this route
+			if pilot.DisableEmptyRouteResponse {
+				continue
+			}
+
+			// Explicitly send an empty route configuration
+			r = &xdsapi.RouteConfiguration{
+				Name:             routeName,
+				VirtualHosts:     []route.VirtualHost{},
+				ValidateClusters: proto.BoolFalse,
+			}
 		}
 
 		if err = r.Validate(); err != nil {

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -145,6 +145,13 @@ var (
 	// this flag) is to just skip the invalid route.
 	DisablePartialRouteResponse = os.Getenv("PILOT_DISABLE_PARTIAL_ROUTE_RESPONSE") == "1"
 
+	// DisableEmptyRouteResponse provides an option to disable a partial route response. This
+	// will cause Pilot to ignore a route request if Pilot generates a nil route (due to an error).
+	// This may cause Envoy to wait forever for the route, blocking listeners from receiving traffic.
+	// The default behavior (without this flag set) is to explicitly send an empty route. This
+	// will break routing for that particular route, but allow others on the same listener to work.
+	DisableEmptyRouteResponse = os.Getenv("PILOT_DISABLE_EMPTY_ROUTE_RESPONSE") == "1"
+
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
 	DisableXDSMarshalingToAny = func() bool {
 		return os.Getenv("PILOT_DISABLE_XDS_MARSHALING_TO_ANY") == "1"


### PR DESCRIPTION
Because we sort Configs by CreationTimestamp, we can run into
nondeterministic behavior if two Configs have the same timestamp. Since
the resolution is 1s, this isn't uncommon. This specifically causes
issues for Gateways, where two gateways with overlapping hosts, created
at the same time, can cause Pilot to fail to generate routes correctly
and lead to Envoy listeners stuck in a warming state (never accept
traffic). This can be mitigated by sorting by the name.namespace of the
config if they have a matching creation timestamp.