### PR TITLE
fix stackdriver config in post-submit test

### DIFF
--- a/samples/fortio/stackdriver.yaml
+++ b/samples/fortio/stackdriver.yaml
@@ -8,12 +8,12 @@ spec:
     appCredentials: y
     pushInterval: 5s
     metricInfo:
-      server-request-count.metric.{{.Namespace}}:
+      server-request-count.instance.{{.Namespace}}:
         kind: 3 # CUMULATIVE
         value: 2 # INT64
         metric_type: "istio.io/service/server/request_count"
     logInfo:
-      server-accesslog-stackdriver.logentry.{{.Namespace}}:
+      server-accesslog-stackdriver.instance.{{.Namespace}}:
         labelNames:
         - source_uid
         - source_ip

--- a/tests/e2e/tests/stackdriver/stackdriver_test.go
+++ b/tests/e2e/tests/stackdriver/stackdriver_test.go
@@ -203,7 +203,7 @@ func TestMetrics(t *testing.T) {
 
 func TestLogs(t *testing.T) {
 	const (
-		logNameTmpl = "projects/%s/logs/server-accesslog-stackdriver.logentry.%s"
+		logNameTmpl = "projects/%s/logs/server-accesslog-stackdriver.instance.%s"
 		filterTmpl  = `logName = "%s" AND resource.type = "k8s_container" AND resource.labels.namespace_name = "%s"`
 	)
 


### PR DESCRIPTION
See https://storage.googleapis.com/istio-prow/pr-logs/pull/istio-releases_pipeline/614/release-e2e-stackdriver/328/artifacts/stackdriver-test-b7907d954749471583c6/istio-telemetry-66b4858cfb-25wb7_container:mixer.log

/assign @douglas-reid 
/assign @bianpengyuan 

Signed-off-by: Kuat Yessenov <kuat@google.com>