### PR TITLE
Require outlierDetection for EDS locality failover

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -57,7 +57,8 @@ func TestEds(t *testing.T) {
 
 	// enable locality load balancing and add relevant endpoints in order to test
 	os.Setenv("PILOT_ENABLE_LOCALITY_LOAD_BALANCING", "ON")
-	addLocalityEndpoints(server)
+	addLocalityEndpoints(server, "locality.cluster.local")
+	addLocalityEndpoints(server, "locality-no-outlier-detection.cluster.local")
 
 	// Add the test ads clients to list of service instances in order to test the context dependent locality coloring.
 	addTestClientEndpoints(server)
@@ -211,6 +212,10 @@ func testEndpoints(expected string, cluster string, adsc *adsc.ADSC, t *testing.
 func testLocalityPrioritizedEndpoints(adsc *adsc.ADSC, adsc2 *adsc.ADSC, t *testing.T) {
 	verifyLocalityPriorities(asdcLocality, adsc.EDS["outbound|80||locality.cluster.local"].GetEndpoints(), t)
 	verifyLocalityPriorities(asdc2Locality, adsc2.EDS["outbound|80||locality.cluster.local"].GetEndpoints(), t)
+
+	// No outlier detection specified for this cluster, so we shouldn't apply priority.
+	verifyNoLocalityPriorities(adsc.EDS["outbound|80||locality-no-outlier-detection.cluster.local"].GetEndpoints(), t)
+	verifyNoLocalityPriorities(adsc2.EDS["outbound|80||locality-no-outlier-detection.cluster.local"].GetEndpoints(), t)
 }
 
 // Tests that Services with multiple ports sharing the same port number are properly sent endpoints.
@@ -226,6 +231,14 @@ func testOverlappingPorts(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.
 
 	// After the incremental push, we should still see the endpoint
 	testEndpoints("10.0.0.53", "outbound|53||overlapping.cluster.local", adsc, t)
+}
+
+func verifyNoLocalityPriorities(eps []endpoint.LocalityLbEndpoints, t *testing.T) {
+	for _, ep := range eps {
+		if ep.GetPriority() != 0 {
+			t.Errorf("expected no locality priorities to apply, got priority %v.", ep.GetPriority())
+		}
+	}
 }
 
 func verifyLocalityPriorities(proxyLocality string, eps []endpoint.LocalityLbEndpoints, t *testing.T) {
@@ -557,9 +570,9 @@ func addUdsEndpoint(server *bootstrap.Server) {
 	server.EnvoyXdsServer.Push(true, nil)
 }
 
-func addLocalityEndpoints(server *bootstrap.Server) {
-	server.EnvoyXdsServer.MemRegistry.AddService("locality.cluster.local", &model.Service{
-		Hostname: "locality.cluster.local",
+func addLocalityEndpoints(server *bootstrap.Server, hostname model.Hostname) {
+	server.EnvoyXdsServer.MemRegistry.AddService(hostname, &model.Service{
+		Hostname: hostname,
 		Ports: model.PortList{
 			{
 				Name:     "http",
@@ -578,7 +591,7 @@ func addLocalityEndpoints(server *bootstrap.Server) {
 		"region2/zone2/subzone2",
 	}
 	for i, locality := range localities {
-		server.EnvoyXdsServer.MemRegistry.AddInstance("locality.cluster.local", &model.ServiceInstance{
+		server.EnvoyXdsServer.MemRegistry.AddInstance(hostname, &model.ServiceInstance{
 			Endpoint: model.NetworkEndpoint{
 				Address: fmt.Sprintf("10.0.0.%v", i),
 				Port:    80,

--- a/tests/testdata/config/destination-rule-locality.yaml
+++ b/tests/testdata/config/destination-rule-locality.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: locality
+  namespace: default
+spec:
+  host: locality.cluster.local
+  trafficPolicy:
+    outlierDetection:
+      consecutiveErrors: 1
+      interval: 1s
+      baseEjectionTime: 3m
+      maxEjectionPercent: 100


### PR DESCRIPTION
copy https://github.com/istio/istio/pull/13828 to master (where it was approved, but decided to push back to 1.2)


Without outlierDetection, failover is not safe as Envoy cannot detecthosts are unhealthy. Because of this, all traffic will be locked intothe same locality, even if there are no healthy hosts in the locality.To prevent this, we will only apply failover settings when outlierdetection is present. While the logic to get the outlierDetection isfairly involved, computationally it is not too expensive. Performance tests show slightly less CPU usage actually, I think because we skip all of the locality computations when we don't have the outlierDetection, so it balances out (or was just subtle variances).

Fixes #12961

