### PR TITLE
Removing Gopkg check from mixer_codegen

### DIFF
--- a/bin/mixer_codegen.sh
+++ b/bin/mixer_codegen.sh
@@ -22,11 +22,6 @@ die () {
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOTDIR="$(dirname "$SCRIPTPATH")"
 
-if [ ! -e "$ROOTDIR/Gopkg.lock" ]; then
-  echo "Please run 'dep ensure' first"
-  exit 1
-fi
-
 set -e
 
 outdir=$ROOTDIR


### PR DESCRIPTION
After migrating to go.mod this check breaks the script to generate configuration.