### PR TITLE
Add ability for Galley to serve Mesh Config.

### DIFF
--- a/galley/pkg/runtime/config.go
+++ b/galley/pkg/runtime/config.go
@@ -14,7 +14,10 @@
 
 package runtime
 
-import "istio.io/istio/galley/pkg/meshconfig"
+import (
+	"istio.io/istio/galley/pkg/meshconfig"
+	"istio.io/istio/galley/pkg/runtime/resource"
+)
 
 // Config used by the runtime
 type Config struct {
@@ -23,4 +26,7 @@ type Config struct {
 
 	// Domain suffix to use
 	DomainSuffix string
+
+	// Schema for runtime
+	Schema *resource.Schema
 }

--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"istio.io/istio/galley/pkg/metadata"
 	"istio.io/istio/galley/pkg/runtime/groups"
 	"istio.io/istio/galley/pkg/runtime/monitoring"
 	"istio.io/istio/galley/pkg/runtime/processing"
@@ -76,13 +75,12 @@ type postProcessHookFn func()
 func NewProcessor(src Source, distributor Distributor, cfg *Config) *Processor {
 	stateStrategy := publish.NewStrategyWithDefaults()
 
-	return newProcessor(src, cfg, metadata.Types, stateStrategy, distributor, nil)
+	return newProcessor(src, cfg, stateStrategy, distributor, nil)
 }
 
 func newProcessor(
 	src Source,
 	cfg *Config,
-	schema *resource.Schema,
 	stateStrategy *publish.Strategy,
 	distributor Distributor,
 	postProcessHook postProcessHookFn) *Processor {
@@ -104,7 +102,7 @@ func newProcessor(
 			stateStrategy.OnChange()
 		}
 	})
-	p.state = newState(schema, cfg, stateListener)
+	p.state = newState(cfg, stateListener)
 
 	// Publish ServiceEntry events as soon as they occur.
 	p.serviceEntryHandler = serviceentry.NewHandler(cfg.DomainSuffix, processing.ListenerFromFn(func(_ resource.Collection) {
@@ -114,7 +112,37 @@ func newProcessor(
 	}))
 
 	p.handler = buildDispatcher(p.state, p.serviceEntryHandler)
+
+	p.seedMesh()
+
 	return p
+}
+
+func (p *Processor) seedMesh() {
+	i, ok := p.state.config.Schema.Lookup("istio/mesh/v1alpha1/MeshConfig")
+	if !ok {
+		return
+	}
+	m := p.state.config.Mesh.Get()
+	e := resource.Event{
+		Kind: resource.Added,
+		Entry: resource.Entry{
+			Metadata: resource.Metadata{
+				CreateTime: time.Now(),
+			},
+			ID: resource.VersionedKey{
+				Key: resource.Key{
+					Collection: i.Collection,
+					FullName: resource.FullNameFromNamespaceAndName(
+						"istio-system",
+						"meshconfig"),
+				},
+				Version: "1",
+			},
+			Item: &m,
+		},
+	}
+	p.state.Handle(e)
 }
 
 // Start the processor. This will cause processor to listen to incoming events from the provider
@@ -215,7 +243,7 @@ func buildDispatcher(state *State, serviceEntryHandler processing.Handler) *proc
 	b := processing.NewDispatcherBuilder()
 
 	// Route all types to the state, except for those required by the serviceEntryHandler.
-	stateSchema := resource.NewSchemaBuilder().RegisterSchema(state.schema).UnregisterSchema(serviceentry.Schema).Build()
+	stateSchema := resource.NewSchemaBuilder().RegisterSchema(state.config.Schema).UnregisterSchema(serviceentry.Schema).Build()
 	for _, spec := range stateSchema.All() {
 		b.Add(spec.Collection, state)
 	}

--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -133,6 +133,8 @@ func (p *Processor) seedMesh() {
 			ID: resource.VersionedKey{
 				Key: resource.Key{
 					Collection: i.Collection,
+					//TODO Replace istio-system with appropriate name We may
+					//need to serve multiple meshconfigs.
 					FullName: resource.FullNameFromNamespaceAndName(
 						"istio-system",
 						"meshconfig"),

--- a/galley/pkg/runtime/processor_test.go
+++ b/galley/pkg/runtime/processor_test.go
@@ -71,7 +71,10 @@ func TestProcessor_Start_Error(t *testing.T) {
 	defer restoreLogLevel(prevLevel)
 
 	distributor := snapshot.New(groups.IndexFunction)
-	cfg := &Config{Mesh: meshconfig.NewInMemory()}
+	cfg := &Config{
+		Mesh:   meshconfig.NewInMemory(),
+		Schema: resources.TestSchema,
+	}
 	p := NewProcessor(&erroneousSource{}, distributor, cfg)
 
 	err := p.Start()
@@ -211,7 +214,7 @@ func awaitFullSync(t *testing.T, p *Processor) {
 
 func newTestProcessor(src Source, stateStrategy *publish.Strategy,
 	distributor Distributor, hookFn postProcessHookFn) *Processor {
-	return newProcessor(src, cfg, resources.TestSchema, stateStrategy, distributor, hookFn)
+	return newProcessor(src, cfg, stateStrategy, distributor, hookFn)
 }
 
 func setDebugLogLevel() log.Level {
@@ -222,4 +225,29 @@ func setDebugLogLevel() log.Level {
 
 func restoreLogLevel(level log.Level) {
 	runtimeLog.Scope.SetOutputLevel(level)
+}
+
+func TestProcessor_MeshConfig(t *testing.T) {
+	distributor := snapshot.New(groups.IndexFunction)
+	src := NewInMemorySource()
+	b := resource.NewSchemaBuilder()
+	b.RegisterSchema(resources.TestSchema)
+	b.Register(
+		"istio/mesh/v1alpha1/MeshConfig",
+		"type.googleapis.com/istio.mesh.v1alpha1.MeshConfig")
+	types := b.Build()
+	i := types.Get("istio/mesh/v1alpha1/MeshConfig")
+
+	cfg := &Config{
+		Mesh:   meshconfig.NewInMemory(),
+		Schema: types,
+	}
+	p := NewProcessor(src, distributor, cfg)
+	st, ok := p.state.getResourceTypeState(i.Collection)
+	if ok != true {
+		t.Fatalf("Could not get resource type state")
+	}
+	if st.version != 1 {
+		t.Errorf("Meshconfig version not set")
+	}
 }

--- a/galley/pkg/runtime/state.go
+++ b/galley/pkg/runtime/state.go
@@ -38,7 +38,6 @@ var _ processing.Handler = &State{}
 
 // State is the in-memory state of Galley.
 type State struct {
-	schema   *resource.Schema
 	listener processing.Listener
 
 	config *Config
@@ -71,10 +70,9 @@ type resourceTypeState struct {
 	versions map[resource.FullName]resource.Version
 }
 
-func newState(schema *resource.Schema, cfg *Config, listener processing.Listener) *State {
+func newState(cfg *Config, listener processing.Listener) *State {
 	now := time.Now()
 	s := &State{
-		schema:           schema,
 		listener:         listener,
 		config:           cfg,
 		entries:          make(map[resource.Collection]*resourceTypeState),
@@ -83,7 +81,7 @@ func newState(schema *resource.Schema, cfg *Config, listener processing.Listener
 
 	// pre-populate state for all known types so that built snapshots
 	// includes valid default version for empty resource collections.
-	for _, info := range schema.All() {
+	for _, info := range cfg.Schema.All() {
 		s.entries[info.Collection] = &resourceTypeState{
 			entries:  make(map[resource.FullName]*mcp.Resource),
 			versions: make(map[resource.FullName]resource.Version),

--- a/galley/pkg/runtime/state_test.go
+++ b/galley/pkg/runtime/state_test.go
@@ -33,8 +33,11 @@ var (
 	fakeCreateTime0 time.Time
 	fakeCreateTime1 time.Time
 
-	cfg = &Config{Mesh: meshconfig.NewInMemory()}
-	fn  = resource.FullNameFromNamespaceAndName("", "fn")
+	cfg = &Config{
+		Mesh:   meshconfig.NewInMemory(),
+		Schema: resources.TestSchema,
+	}
+	fn = resource.FullNameFromNamespaceAndName("", "fn")
 )
 
 func init() {
@@ -305,5 +308,5 @@ func newTestState() *State {
 		// When the state indicates a change occurred, update the publishing strategy
 		stateStrategy.OnChange()
 	})
-	return newState(resources.TestSchema, cfg, stateListener)
+	return newState(cfg, stateListener)
 }

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -31,6 +31,7 @@ import (
 	kubeMeta "istio.io/istio/galley/pkg/metadata/kube"
 	"istio.io/istio/galley/pkg/runtime"
 	"istio.io/istio/galley/pkg/runtime/groups"
+	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/galley/pkg/source/fs"
 	kubeSource "istio.io/istio/galley/pkg/source/kube"
 	"istio.io/istio/galley/pkg/source/kube/client"
@@ -146,9 +147,17 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 		}
 	}
 
+	b := resource.NewSchemaBuilder()
+	b.RegisterSchema(metadata.Types)
+	b.Register(
+		"istio/mesh/v1alpha1/MeshConfig",
+		"type.googleapis.com/istio.mesh.v1alpha1.MeshConfig")
+	types := b.Build()
+
 	processorCfg := runtime.Config{
 		DomainSuffix: a.DomainSuffix,
 		Mesh:         mesh,
+		Schema:       types,
 	}
 	distributor := snapshot.New(groups.IndexFunction)
 	s.processor = runtime.NewProcessor(src, distributor, &processorCfg)
@@ -180,7 +189,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 	options := &source.Options{
 		Watcher:            distributor,
 		Reporter:           s.reporter,
-		CollectionsOptions: source.CollectionOptionsFromSlice(metadata.Types.Collections()),
+		CollectionsOptions: source.CollectionOptionsFromSlice(types.Collections()),
 		ConnRateLimiter:    mcprate.NewRateLimiter(time.Second, 100), // TODO(Nino-K): https://github.com/istio/istio/issues/12074
 	}
 

--- a/galley/pkg/source/fs/source_test.go
+++ b/galley/pkg/source/fs/source_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"istio.io/istio/galley/pkg/meshconfig"
+	"istio.io/istio/galley/pkg/metadata"
 	kubeMeta "istio.io/istio/galley/pkg/metadata/kube"
 	"istio.io/istio/galley/pkg/runtime"
 	"istio.io/istio/galley/pkg/runtime/resource"
@@ -489,7 +490,10 @@ func TestSnapshotDistribution(t *testing.T) {
 	d := runtime.NewInMemoryDistributor()
 
 	// Create and start the runtime processor.
-	cfg := &runtime.Config{Mesh: meshconfig.NewInMemory()}
+	cfg := &runtime.Config{
+		Mesh:   meshconfig.NewInMemory(),
+		Schema: metadata.Types,
+	}
 	processor := runtime.NewProcessor(s, d, cfg)
 	err := processor.Start()
 	if err != nil {

--- a/galley/pkg/testing/testdata/dataset.gen.go
+++ b/galley/pkg/testing/testdata/dataset.gen.go
@@ -10,6 +10,8 @@
 // dataset/extensions/v1beta1/ingress_merge_0_meshconfig.yaml
 // dataset/extensions/v1beta1/ingress_merge_1.yaml
 // dataset/extensions/v1beta1/ingress_merge_1_expected.json
+// dataset/mesh.istio.io/v1alpha1/meshconfig.yaml
+// dataset/mesh.istio.io/v1alpha1/meshconfig_expected.json
 // dataset/networking.istio.io/v1alpha3/destinationRule.yaml
 // dataset/networking.istio.io/v1alpha3/destinationRule_expected.json
 // dataset/networking.istio.io/v1alpha3/gateway.yaml
@@ -604,6 +606,63 @@ func datasetExtensionsV1beta1Ingress_merge_1_expectedJson() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_merge_1_expected.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _datasetMeshIstioIoV1alpha1MeshconfigYaml = []byte(``)
+
+func datasetMeshIstioIoV1alpha1MeshconfigYamlBytes() ([]byte, error) {
+	return _datasetMeshIstioIoV1alpha1MeshconfigYaml, nil
+}
+
+func datasetMeshIstioIoV1alpha1MeshconfigYaml() (*asset, error) {
+	bytes, err := datasetMeshIstioIoV1alpha1MeshconfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "dataset/mesh.istio.io/v1alpha1/meshconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _datasetMeshIstioIoV1alpha1Meshconfig_expectedJson = []byte(`{
+    "istio/mesh/v1alpha1/MeshConfig": [
+        {
+            "TypeURL": "type.googleapis.com/istio.mesh.v1alpha1.MeshConfig",
+            "Metadata": {
+                "name": "istio-system/meshconfig"
+            },
+            "Body": {
+                "access_log_file": "/dev/stdout",
+                "connect_timeout": {
+                    "seconds": 1
+                },
+                "enable_tracing": true,
+                "ingress_class": "istio",
+                "ingress_controller_mode": 2,
+                "outbound_traffic_policy": {
+                    "mode": 1
+                },
+                "proxy_listen_port": 15001
+            }
+        }
+    ]
+}
+`)
+
+func datasetMeshIstioIoV1alpha1Meshconfig_expectedJsonBytes() ([]byte, error) {
+	return _datasetMeshIstioIoV1alpha1Meshconfig_expectedJson, nil
+}
+
+func datasetMeshIstioIoV1alpha1Meshconfig_expectedJson() (*asset, error) {
+	bytes, err := datasetMeshIstioIoV1alpha1Meshconfig_expectedJsonBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "dataset/mesh.istio.io/v1alpha1/meshconfig_expected.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1892,6 +1951,8 @@ var _bindata = map[string]func() (*asset, error){
 	"dataset/extensions/v1beta1/ingress_merge_0_meshconfig.yaml": datasetExtensionsV1beta1Ingress_merge_0_meshconfigYaml,
 	"dataset/extensions/v1beta1/ingress_merge_1.yaml": datasetExtensionsV1beta1Ingress_merge_1Yaml,
 	"dataset/extensions/v1beta1/ingress_merge_1_expected.json": datasetExtensionsV1beta1Ingress_merge_1_expectedJson,
+	"dataset/mesh.istio.io/v1alpha1/meshconfig.yaml": datasetMeshIstioIoV1alpha1MeshconfigYaml,
+	"dataset/mesh.istio.io/v1alpha1/meshconfig_expected.json": datasetMeshIstioIoV1alpha1Meshconfig_expectedJson,
 	"dataset/networking.istio.io/v1alpha3/destinationRule.yaml": datasetNetworkingIstioIoV1alpha3DestinationruleYaml,
 	"dataset/networking.istio.io/v1alpha3/destinationRule_expected.json": datasetNetworkingIstioIoV1alpha3Destinationrule_expectedJson,
 	"dataset/networking.istio.io/v1alpha3/gateway.yaml": datasetNetworkingIstioIoV1alpha3GatewayYaml,
@@ -1957,6 +2018,12 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"ingress_merge_0_meshconfig.yaml": &bintree{datasetExtensionsV1beta1Ingress_merge_0_meshconfigYaml, map[string]*bintree{}},
 				"ingress_merge_1.yaml": &bintree{datasetExtensionsV1beta1Ingress_merge_1Yaml, map[string]*bintree{}},
 				"ingress_merge_1_expected.json": &bintree{datasetExtensionsV1beta1Ingress_merge_1_expectedJson, map[string]*bintree{}},
+			}},
+		}},
+		"mesh.istio.io": &bintree{nil, map[string]*bintree{
+			"v1alpha1": &bintree{nil, map[string]*bintree{
+				"meshconfig.yaml": &bintree{datasetMeshIstioIoV1alpha1MeshconfigYaml, map[string]*bintree{}},
+				"meshconfig_expected.json": &bintree{datasetMeshIstioIoV1alpha1Meshconfig_expectedJson, map[string]*bintree{}},
 			}},
 		}},
 		"networking.istio.io": &bintree{nil, map[string]*bintree{

--- a/galley/pkg/testing/testdata/dataset/mesh.istio.io/v1alpha1/meshconfig_expected.json
+++ b/galley/pkg/testing/testdata/dataset/mesh.istio.io/v1alpha1/meshconfig_expected.json
@@ -1,0 +1,23 @@
+{
+    "istio/mesh/v1alpha1/MeshConfig": [
+        {
+            "TypeURL": "type.googleapis.com/istio.mesh.v1alpha1.MeshConfig",
+            "Metadata": {
+                "name": "istio-system/meshconfig"
+            },
+            "Body": {
+                "access_log_file": "/dev/stdout",
+                "connect_timeout": {
+                    "seconds": 1
+                },
+                "enable_tracing": true,
+                "ingress_class": "istio",
+                "ingress_controller_mode": 2,
+                "outbound_traffic_policy": {
+                    "mode": 1
+                },
+                "proxy_listen_port": 15001
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Update pkg/runtime to accept schema through config, instead of using metadata.Types directly. Processor now adds meshconfig when created. pkg/server adds meshconfig to schema before passing to processor and source.CollectionsOptions. Add meshconfig to integration test.