### PR TITLE
Add istio state metrics for some of the networking resources

### DIFF
--- a/galley/pkg/runtime/monitoring/monitoring.go
+++ b/galley/pkg/runtime/monitoring/monitoring.go
@@ -158,10 +158,13 @@ func RecordDetailedStateType(namespace, name string, collection fmt.Stringer, co
 		tag.Insert(NameTag, name), tag.Insert(VersionTag, collectionStr[2]))
 	if err != nil {
 		log.Scope.Errorf("error creating monitoring context for counting state: %v", err)
-	} else {
-		RecordDetailedStateTypeWithContext(ctx, strings.Replace(collection.String(),
-			fmt.Sprintf("%s/", collectionStr[2]), "", 1), count)
+		return
 	}
+
+	// We remove version from the collection name as it has been added as the VersionTag in the measurement.
+	collectionName := strings.Replace(collection.String(),
+		fmt.Sprintf("%s/", collectionStr[2]), "", 1)
+	RecordDetailedStateTypeWithContext(ctx, collectionName, count)
 }
 
 // RecordDetailedStateTypeWithContext
@@ -207,7 +210,7 @@ func getStateTypeConfigKeys() ([]tag.Key, error) {
 }
 
 func registerNewStateTypeConfigView(collection string) error {
-	stateTypeConfigTotal[collection] = stats.Int64(fmt.Sprintf("galley/runtime/state/%s_total", collection),
+	stateTypeConfigTotal[collection] = stats.Int64(fmt.Sprintf("galley/%s_total", collection),
 		fmt.Sprintf("The number of valid %v known to galley at a point in time", collection),
 		stats.UnitDimensionless)
 	err := view.Register(

--- a/galley/pkg/runtime/monitoring/monitoring.go
+++ b/galley/pkg/runtime/monitoring/monitoring.go
@@ -210,7 +210,7 @@ func getStateTypeConfigKeys() ([]tag.Key, error) {
 }
 
 func registerNewStateTypeConfigView(collection string) error {
-	stateTypeConfigTotal[collection] = stats.Int64(fmt.Sprintf("galley/%s_total", collection),
+	stateTypeConfigTotal[collection] = stats.Int64(fmt.Sprintf("galley/%s", collection),
 		fmt.Sprintf("The number of valid %v known to galley at a point in time", collection),
 		stats.UnitDimensionless)
 	err := view.Register(

--- a/galley/pkg/runtime/monitoring/monitoring.go
+++ b/galley/pkg/runtime/monitoring/monitoring.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"istio.io/istio/galley/pkg/runtime/log"
-	"istio.io/istio/galley/pkg/runtime/resource"
 )
 
 const (
@@ -145,7 +144,7 @@ func RecordStateTypeCountWithContext(ctx context.Context, count int) {
 }
 
 // RecordDetailedStateType
-func RecordDetailedStateType(namespace, name string, collection resource.Collection, count int) {
+func RecordDetailedStateType(namespace, name string, collection fmt.Stringer, count int) {
 	collectionStr := strings.Split(collection.String(), "/")
 	// collection is of the format istio/<kind>/<version>/<name>
 	if len(collectionStr) < 4 {

--- a/galley/pkg/runtime/monitoring/monitoring.go
+++ b/galley/pkg/runtime/monitoring/monitoring.go
@@ -94,7 +94,8 @@ var (
 	durationDistributionMs = view.Distribution(0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8193, 16384, 32768, 65536,
 		131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608)
 
-	stateTypeConfigTotal sync.Map
+	stateTypeConfigTotal     map[string]*stats.Int64Measure
+	stateTypeCollectionMutex sync.RWMutex
 )
 
 // RecordStrategyOnChange
@@ -168,21 +169,16 @@ func RecordDetailedStateTypeWithContext(ctx context.Context, collection string, 
 	if ctx == nil {
 		return
 	}
-	measure, ok := stateTypeConfigTotal.Load(collection)
-	if !ok {
-		var err error
-		measure, err = registerNewStateTypeConfigView(collection)
+	stateTypeCollectionMutex.Lock()
+	defer stateTypeCollectionMutex.Unlock()
+	if stateTypeConfigTotal[collection] == nil {
+		err := registerNewStateTypeConfigView(collection)
 		if err != nil {
 			log.Scope.Errorf("could not register collection %v for monitoring", err)
 			return
 		}
 	}
-	int64Measure, ok := measure.(*stats.Int64Measure)
-	if !ok {
-		log.Scope.Errorf("could not get stats int64measure for collection %v", collection)
-		return
-	}
-	stats.Record(ctx, int64Measure.M(int64(count)))
+	stats.Record(ctx, stateTypeConfigTotal[collection].M(int64(count)))
 }
 
 func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
@@ -210,19 +206,18 @@ func getStateTypeConfigKeys() ([]tag.Key, error) {
 	return []tag.Key{NamespaceTag, NameTag, VersionTag}, err
 }
 
-func registerNewStateTypeConfigView(collection string) (*stats.Int64Measure, error) {
-	measure := stats.Int64(fmt.Sprintf("galley/runtime/state/%s_total", collection),
+func registerNewStateTypeConfigView(collection string) error {
+	stateTypeConfigTotal[collection] = stats.Int64(fmt.Sprintf("galley/runtime/state/%s_total", collection),
 		fmt.Sprintf("The number of valid %v known to galley at a point in time", collection),
 		stats.UnitDimensionless)
-	stateTypeConfigTotal.Store(collection, measure)
 	nameKeys, err := getStateTypeConfigKeys()
 	if err != nil {
-		return measure, err
+		return err
 	}
 	err = view.Register(
-		newView(measure, nameKeys, view.LastValue()),
+		newView(stateTypeConfigTotal[collection], nameKeys, view.LastValue()),
 	)
-	return measure, err
+	return err
 }
 
 func init() {
@@ -250,4 +245,6 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	stateTypeConfigTotal = make(map[string]*stats.Int64Measure)
 }

--- a/galley/pkg/runtime/monitoring/monitoring.go
+++ b/galley/pkg/runtime/monitoring/monitoring.go
@@ -44,7 +44,7 @@ var (
 	NameTag tag.Key
 	// VersionTag holds version of the resource for the context.
 	VersionTag tag.Key
-	// Array that stores key tags for runtime state metrics.
+	// StateTypeConfigKeys holds key tags for runtime state metrics.
 	StateTypeConfigKeys []tag.Key
 )
 

--- a/galley/pkg/runtime/state.go
+++ b/galley/pkg/runtime/state.go
@@ -322,9 +322,9 @@ func (s *State) String() string {
 
 func monitorEntry(resourceKey resource.VersionedKey, added bool) {
 	namespace, name := resourceKey.FullName.InterpretAsNamespaceAndName()
-	count := 1
+	value := 1
 	if !added {
-		count = 0
+		value = 0
 	}
-	monitoring.RecordDetailedStateType(namespace, name, resourceKey.Collection, count)
+	monitoring.RecordDetailedStateType(namespace, name, resourceKey.Collection, value)
 }

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -215,6 +215,7 @@ func TestTcpMetric(t *testing.T) {
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite("mixer_telemetry_metrics", m).
+		RequireEnvironment(environment.Kube).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
 		Setup(testsetup).
 		Run()

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -155,8 +155,7 @@ func TestStateMetrics(t *testing.T) {
 
 			util.AllowRuleSync(t)
 
-			query := fmt.Sprintf("sum(galley_runtime_state_istio_networking_destinationrules_total" +
-				"{namespace=\"%s\",version=\"v1alpha3\"})", bookinfoNs.Name())
+			query := fmt.Sprintf("sum(galley_runtime_state_istio_networking_destinationrules_total{namespace=\"%s\",version=\"v1alpha3\"})", bookinfoNs.Name())
 			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_destinationrules_total", 4)
 
 			query = fmt.Sprintf("sum(galley_runtime_state_istio_networking_virtualservices_total{namespace=\"%s\"})", bookinfoNs.Name())

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -29,12 +29,17 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/tmpl"
 	util "istio.io/istio/tests/integration/mixer"
 )
 
 var (
-	ist istio.Instance
+	ist               istio.Instance
+	bookinfoNamespace *namespace.Instance
+	galInst           *galley.Instance
+	ingInst           *ingress.Instance
+	promInst          *prometheus.Instance
 )
 
 // This file contains Mixer tests that are ported from Mixer E2E tests
@@ -70,37 +75,28 @@ func TestIngessToPrometheus_IngressMetric(t *testing.T) {
 func testMetric(t *testing.T, ctx framework.TestContext, label string, labelValue string) { // nolint:interfacer
 	t.Helper()
 
-	g := galley.NewOrFail(t, ctx, galley.Config{})
-	_ = mixer.NewOrFail(t, ctx, mixer.Config{Galley: g})
-
-	bookinfoNs, err := namespace.New(ctx, "istio-bookinfo", true)
-	if err != nil {
-		t.Fatalf("Could not create istio-bookinfo Namespace; err:%v", err)
-	}
-	d := bookinfo.DeployOrFail(t, ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookInfo})
-
+	bookinfoNs, g, ing, prom := setupComponentsOrFail(t)
 	g.ApplyConfigOrFail(
 		t,
-		d.Namespace(),
-		bookinfo.NetworkingBookinfoGateway.LoadGatewayFileWithNamespaceOrFail(t, bookinfoNs.Name()))
-	g.ApplyConfigOrFail(
-		t,
-		d.Namespace(),
+		bookinfoNs,
 		bookinfo.GetDestinationRuleConfigFile(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 		bookinfo.NetworkingVirtualServiceAllV1.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 	)
+	defer g.DeleteConfigOrFail(t,
+		bookinfoNs,
+		bookinfo.GetDestinationRuleConfigFile(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
+		bookinfo.NetworkingVirtualServiceAllV1.LoadWithNamespaceOrFail(t, bookinfoNs.Name()))
 
-	prom := prometheus.NewOrFail(t, ctx)
-	ing := ingress.NewOrFail(t, ctx, ingress.Config{Istio: ist})
+	util.AllowRuleSync(t)
 
 	// Warm up
-	err = util.VisitProductPage(ing, 30*time.Second, 200, t)
+	err := util.VisitProductPage(ing, 30*time.Second, 200, t)
 	if err != nil {
 		t.Fatalf("unable to retrieve 200 from product page: %v", err)
 	}
 
-	label = tmpl.EvaluateOrFail(t, label, map[string]string{"TestNamespace": d.Namespace().Name()})
-	labelValue = tmpl.EvaluateOrFail(t, labelValue, map[string]string{"TestNamespace": d.Namespace().Name()})
+	label = tmpl.EvaluateOrFail(t, label, map[string]string{"TestNamespace": bookinfoNs.Name()})
+	labelValue = tmpl.EvaluateOrFail(t, labelValue, map[string]string{"TestNamespace": bookinfoNs.Name()})
 
 	// Wait for some data to arrive.
 	initial, err := prom.WaitForQuiesce(`istio_requests_total{%s=%q,response_code="200"}`, label, labelValue)
@@ -138,6 +134,38 @@ func testMetric(t *testing.T, ctx framework.TestContext, label string, labelValu
 	}
 }
 
+func TestStateMetrics(t *testing.T) {
+	framework.
+		NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			bookinfoNs, g, _, prom := setupComponentsOrFail(t)
+
+			g.ApplyConfigOrFail(
+				t,
+				bookinfoNs,
+				bookinfo.GetDestinationRuleConfigFile(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
+				bookinfo.NetworkingVirtualServiceAllV1.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
+			)
+			defer g.DeleteConfigOrFail(t,
+				bookinfoNs,
+				bookinfo.GetDestinationRuleConfigFile(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
+				bookinfo.NetworkingVirtualServiceAllV1.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
+			)
+
+			util.AllowRuleSync(t)
+
+			query := fmt.Sprintf("sum(galley_runtime_state_istio_networking_v1alpha3_destinationrules{namespace=\"%s\"})", bookinfoNs.Name())
+			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_v1alpha3_destinationrules", 4)
+
+			query = fmt.Sprintf("sum(galley_runtime_state_istio_networking_v1alpha3_virtualservices{namespace=\"%s\"})", bookinfoNs.Name())
+			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_v1alpha3_virtualservices", 5)
+
+			query = fmt.Sprintf("sum(galley_runtime_state_istio_networking_v1alpha3_gateways{namespace=\"%s\"})", bookinfoNs.Name())
+			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_v1alpha3_gateways", 1)
+		})
+}
+
 // Port of TestTcpMetric
 func TestTcpMetric(t *testing.T) {
 	framework.
@@ -146,49 +174,41 @@ func TestTcpMetric(t *testing.T) {
 		Label(label.Flaky).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			bookinfoNs, err := namespace.New(ctx, "istio-bookinfo", true)
-			if err != nil {
-				t.Fatalf("Could not create istio-bookinfo Namespace; err:%v", err)
-			}
-			d := bookinfo.DeployOrFail(t, ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookInfo})
+			bookinfoNs, g, ing, prom := setupComponentsOrFail(t)
+
 			_ = bookinfo.DeployOrFail(t, ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookinfoRatingsv2})
 			_ = bookinfo.DeployOrFail(t, ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookinfoDb})
 
-			g := galley.NewOrFail(t, ctx, galley.Config{})
-			_ = mixer.NewOrFail(t, ctx, mixer.Config{Galley: g})
-
 			g.ApplyConfigOrFail(
 				t,
-				d.Namespace(),
-				bookinfo.NetworkingBookinfoGateway.LoadGatewayFileWithNamespaceOrFail(t, bookinfoNs.Name()))
-			g.ApplyConfigOrFail(
-				t,
-				d.Namespace(),
+				bookinfoNs,
+				bookinfo.GetDestinationRuleConfigFile(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
+				bookinfo.NetworkingTCPDbRule.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
+			)
+			defer g.DeleteConfigOrFail(t,
+				bookinfoNs,
 				bookinfo.GetDestinationRuleConfigFile(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 				bookinfo.NetworkingTCPDbRule.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 			)
 
 			util.AllowRuleSync(t)
 
-			prom := prometheus.NewOrFail(t, ctx)
-			ing := ingress.NewOrFail(t, ctx, ingress.Config{Istio: ist})
-
-			err = util.VisitProductPage(ing, 30*time.Second, 200, t)
+			err := util.VisitProductPage(ing, 30*time.Second, 200, t)
 			if err != nil {
 				t.Fatalf("unable to retrieve 200 from product page: %v", err)
 			}
 
 			query := fmt.Sprintf("sum(istio_tcp_sent_bytes_total{destination_app=\"%s\"})", "mongodb")
-			util.ValidateMetric(t, prom, query, "istio_tcp_sent_bytes_total")
+			util.ValidateMetric(t, prom, query, "istio_tcp_sent_bytes_total", 1)
 
 			query = fmt.Sprintf("sum(istio_tcp_received_bytes_total{destination_app=\"%s\"})", "mongodb")
-			util.ValidateMetric(t, prom, query, "istio_tcp_received_bytes_total")
+			util.ValidateMetric(t, prom, query, "istio_tcp_received_bytes_total", 1)
 
 			query = fmt.Sprintf("sum(istio_tcp_connections_opened_total{destination_app=\"%s\"})", "mongodb")
-			util.ValidateMetric(t, prom, query, "istio_tcp_connections_opened_total")
+			util.ValidateMetric(t, prom, query, "istio_tcp_connections_opened_total", 1)
 
 			query = fmt.Sprintf("sum(istio_tcp_connections_closed_total{destination_app=\"%s\"})", "mongodb")
-			util.ValidateMetric(t, prom, query, "istio_tcp_connections_closed_total")
+			util.ValidateMetric(t, prom, query, "istio_tcp_connections_closed_total", 1)
 		})
 }
 
@@ -196,5 +216,68 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("mixer_telemetry_metrics", m).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		Setup(testsetup).
 		Run()
+}
+
+func testsetup(ctx resource.Context) error {
+	bookinfoNs, err := namespace.New(ctx, "istio-bookinfo", true)
+	if err != nil {
+		return err
+	}
+	bookinfoNamespace = &bookinfoNs
+	if _, err := bookinfo.Deploy(ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookInfo}); err != nil {
+		return err
+	}
+	g, err := galley.New(ctx, galley.Config{})
+	if err != nil {
+		return err
+	}
+	galInst = &g
+	if _, err = mixer.New(ctx, mixer.Config{Galley: g}); err != nil {
+		return err
+	}
+	ing, err := ingress.New(ctx, ingress.Config{Istio: ist})
+	if err != nil {
+		return err
+	}
+	ingInst = &ing
+	prom, err := prometheus.New(ctx)
+	if err != nil {
+		return err
+	}
+	promInst = &prom
+
+	yamlText, err := bookinfo.NetworkingBookinfoGateway.LoadGatewayFileWithNamespace(bookinfoNs.Name())
+	if err != nil {
+		return err
+	}
+	err = g.ApplyConfig(bookinfoNs, yamlText)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setupComponentsOrFail(t *testing.T) (bookinfoNs namespace.Instance, g galley.Instance,
+	ing ingress.Instance, prom prometheus.Instance) {
+	if bookinfoNamespace == nil {
+		t.Fatalf("bookinfo namespace not allocated in setup")
+	}
+	bookinfoNs = *bookinfoNamespace
+	if galInst == nil {
+		t.Fatalf("galley not setup")
+	}
+	g = *galInst
+	if ingInst == nil {
+		t.Fatalf("ingress not setup")
+	}
+	ing = *ingInst
+	if promInst == nil {
+		t.Fatalf("prometheus not setup")
+	}
+	prom = *promInst
+
+	return
 }

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -155,14 +155,15 @@ func TestStateMetrics(t *testing.T) {
 
 			util.AllowRuleSync(t)
 
-			query := fmt.Sprintf("sum(galley_runtime_state_istio_networking_v1alpha3_destinationrules{namespace=\"%s\"})", bookinfoNs.Name())
-			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_v1alpha3_destinationrules", 4)
+			query := fmt.Sprintf("sum(galley_runtime_state_istio_networking_destinationrules_total" +
+				"{namespace=\"%s\",version=\"v1alpha3\"})", bookinfoNs.Name())
+			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_destinationrules_total", 4)
 
-			query = fmt.Sprintf("sum(galley_runtime_state_istio_networking_v1alpha3_virtualservices{namespace=\"%s\"})", bookinfoNs.Name())
-			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_v1alpha3_virtualservices", 5)
+			query = fmt.Sprintf("sum(galley_runtime_state_istio_networking_virtualservices_total{namespace=\"%s\"})", bookinfoNs.Name())
+			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_virtualservices_total", 5)
 
-			query = fmt.Sprintf("sum(galley_runtime_state_istio_networking_v1alpha3_gateways{namespace=\"%s\"})", bookinfoNs.Name())
-			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_v1alpha3_gateways", 1)
+			query = fmt.Sprintf("sum(galley_runtime_state_istio_networking_gateways_total{namespace=\"%s\"})", bookinfoNs.Name())
+			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_gateways_total", 1)
 		})
 }
 

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -155,14 +155,14 @@ func TestStateMetrics(t *testing.T) {
 
 			util.AllowRuleSync(t)
 
-			query := fmt.Sprintf("sum(galley_runtime_state_istio_networking_destinationrules_total{namespace=\"%s\",version=\"v1alpha3\"})", bookinfoNs.Name())
-			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_destinationrules_total", 4)
+			query := fmt.Sprintf("sum(galley_istio_networking_destinationrules{namespace=\"%s\",version=\"v1alpha3\"})", bookinfoNs.Name())
+			util.ValidateMetric(t, prom, query, "galley_istio_networking_destinationrules", 4)
 
-			query = fmt.Sprintf("sum(galley_runtime_state_istio_networking_virtualservices_total{namespace=\"%s\"})", bookinfoNs.Name())
-			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_virtualservices_total", 5)
+			query = fmt.Sprintf("sum(galley_istio_networking_virtualservices{namespace=\"%s\"})", bookinfoNs.Name())
+			util.ValidateMetric(t, prom, query, "galley_istio_networking_virtualservices", 5)
 
-			query = fmt.Sprintf("sum(galley_runtime_state_istio_networking_gateways_total{namespace=\"%s\"})", bookinfoNs.Name())
-			util.ValidateMetric(t, prom, query, "galley_runtime_state_istio_networking_gateways_total", 1)
+			query = fmt.Sprintf("sum(galley_istio_networking_gateways{namespace=\"%s\"})", bookinfoNs.Name())
+			util.ValidateMetric(t, prom, query, "galley_istio_networking_gateways", 1)
 		})
 }
 

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -223,7 +223,7 @@ func testsetup(ctx resource.Context) (err error) {
 	if _, err := bookinfo.Deploy(ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookInfo}); err != nil {
 		return err
 	}
-	g, err := galley.New(ctx, galley.Config{})
+	g, err = galley.New(ctx, galley.Config{})
 	if err != nil {
 		return err
 	}

--- a/tests/integration/mixer/util.go
+++ b/tests/integration/mixer/util.go
@@ -77,9 +77,8 @@ func VisitProductPage(ing ingress.Instance, timeout time.Duration, wantStatus in
 	}
 }
 
-func ValidateMetric(t *testing.T, prometheus prometheus.Instance, query, metricName string) {
+func ValidateMetric(t *testing.T, prometheus prometheus.Instance, query, metricName string, want float64) {
 	got, err := getMetric(t, prometheus, query, metricName)
-	want := float64(1)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
Ref: https://docs.google.com/document/d/1KMUKRMtbpp-K7hvrG5WKBJgoSABydUh4KCHXxKTg8Bk/edit?ts=5ca534e3
Ref: https://github.com/istio/istio/issues/882

Example Scrape after running bookinfo task for virtual services:

galley_runtime_state_virtual_service_info{instance="10.32.1.67:15014",job="galley",name="bookinfo",namespace="istio-bookinfo-1-74002"} | 1
-- | --
galley_runtime_state_virtual_service_info{instance="10.32.1.67:15014",job="galley",name="details",namespace="istio-bookinfo-1-74002"} | 1
galley_runtime_state_virtual_service_info{instance="10.32.1.67:15014",job="galley",name="productpage",namespace="istio-bookinfo-1-74002"} | 1
galley_runtime_state_virtual_service_info{instance="10.32.1.67:15014",job="galley",name="ratings",namespace="istio-bookinfo-1-74002"} | 1
galley_runtime_state_virtual_service_info{instance="10.32.1.67:15014",job="galley",name="reviews",namespace="istio-bookinfo-1-74002"} | 1

