### PR TITLE
List workload ports in proxy metadata.

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -182,6 +182,8 @@ containers:
     valueFrom:
       fieldRef:
         fieldPath: metadata.name
+  - name: ISTIO_META_WORKLOAD_PORTS
+    value: {{ "\"[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (includeInboundPorts .Spec.Containers) ]]\"" }}
   - name: ISTIO_META_CONFIG_NAMESPACE
     valueFrom:
       fieldRef:

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -183,7 +183,7 @@ containers:
       fieldRef:
         fieldPath: metadata.name
   - name: ISTIO_META_WORKLOAD_PORTS
-    value: {{ "\"[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (includeInboundPorts .Spec.Containers) ]]\"" }}
+    value: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (includeInboundPorts .Spec.Containers) }}"
   - name: ISTIO_META_CONFIG_NAMESPACE
     valueFrom:
       fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -101,8 +101,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: 80,90
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
-        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -100,6 +100,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -97,6 +97,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -98,8 +98,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: 80,90
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -99,6 +99,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -100,8 +100,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: 80,90
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -81,8 +81,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -80,6 +80,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -100,6 +100,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -101,8 +101,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: 80,90
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -81,8 +81,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -80,6 +80,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -84,6 +84,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -85,8 +85,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -81,8 +81,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -80,6 +80,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -91,8 +91,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: 80,90
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"e4658cf3ff7a74b528c83019f0824692e13f99418dcc35b203552484d0ec861f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -90,6 +90,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -70,6 +70,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ISTIO_META_WORKLOAD_PORTS
+              value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+                (includeInboundPorts .Spec.Containers) ]]'
             - name: ISTIO_META_CONFIG_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -71,8 +71,6 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: ISTIO_META_WORKLOAD_PORTS
-              value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-                (includeInboundPorts .Spec.Containers) ]]'
             - name: ISTIO_META_CONFIG_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -74,6 +74,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -75,8 +75,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -89,6 +89,9 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: ISTIO_META_WORKLOAD_PORTS
+            value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+              (includeInboundPorts .Spec.Containers) ]]'
           - name: ISTIO_META_CONFIG_NAMESPACE
             valueFrom:
               fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -90,8 +90,7 @@ items:
               fieldRef:
                 fieldPath: metadata.name
           - name: ISTIO_META_WORKLOAD_PORTS
-            value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-              (includeInboundPorts .Spec.Containers) ]]'
+            value: "80"
           - name: ISTIO_META_CONFIG_NAMESPACE
             valueFrom:
               fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -74,6 +74,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -75,8 +75,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -94,6 +94,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -95,8 +95,6 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -78,8 +78,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -79,8 +79,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:
@@ -245,8 +244,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "81"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -78,6 +78,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:
@@ -241,6 +244,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -78,8 +78,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -78,8 +78,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -73,8 +73,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -72,6 +72,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -69,8 +69,6 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -68,6 +68,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -78,8 +78,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -78,8 +78,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -96,8 +96,6 @@ items:
               fieldRef:
                 fieldPath: metadata.name
           - name: ISTIO_META_WORKLOAD_PORTS
-            value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-              (includeInboundPorts .Spec.Containers) ]]'
           - name: ISTIO_META_CONFIG_NAMESPACE
             valueFrom:
               fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -95,6 +95,9 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: ISTIO_META_WORKLOAD_PORTS
+            value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+              (includeInboundPorts .Spec.Containers) ]]'
           - name: ISTIO_META_CONFIG_NAMESPACE
             valueFrom:
               fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -81,8 +81,7 @@ items:
               fieldRef:
                 fieldPath: metadata.name
           - name: ISTIO_META_WORKLOAD_PORTS
-            value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-              (includeInboundPorts .Spec.Containers) ]]'
+            value: "80"
           - name: ISTIO_META_CONFIG_NAMESPACE
             valueFrom:
               fieldRef:
@@ -246,8 +245,7 @@ items:
               fieldRef:
                 fieldPath: metadata.name
           - name: ISTIO_META_WORKLOAD_PORTS
-            value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-              (includeInboundPorts .Spec.Containers) ]]'
+            value: "81"
           - name: ISTIO_META_CONFIG_NAMESPACE
             valueFrom:
               fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -80,6 +80,9 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: ISTIO_META_WORKLOAD_PORTS
+            value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+              (includeInboundPorts .Spec.Containers) ]]'
           - name: ISTIO_META_CONFIG_NAMESPACE
             valueFrom:
               fieldRef:
@@ -242,6 +245,9 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: ISTIO_META_WORKLOAD_PORTS
+            value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+              (includeInboundPorts .Spec.Containers) ]]'
           - name: ISTIO_META_CONFIG_NAMESPACE
             valueFrom:
               fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -61,6 +61,9 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+    - name: ISTIO_META_WORKLOAD_PORTS
+      value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+        (includeInboundPorts .Spec.Containers) ]]'
     - name: ISTIO_META_CONFIG_NAMESPACE
       valueFrom:
         fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -62,8 +62,7 @@ spec:
         fieldRef:
           fieldPath: metadata.name
     - name: ISTIO_META_WORKLOAD_PORTS
-      value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-        (includeInboundPorts .Spec.Containers) ]]'
+      value: "80"
     - name: ISTIO_META_CONFIG_NAMESPACE
       valueFrom:
         fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -71,6 +71,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -72,8 +72,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -71,8 +71,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -70,6 +70,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -79,6 +79,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -80,8 +80,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -78,8 +78,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -73,8 +73,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -72,6 +72,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -77,8 +77,6 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: '*'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -78,8 +78,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: 1,2,3
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -73,8 +73,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -72,6 +72,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -68,6 +68,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -69,8 +69,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -78,8 +78,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -6,6 +6,7 @@ metadata:
 spec:
   replicas: 7
   revisionHistoryLimit: 2
+  selector: null
   strategy:
     type: Rolling
   template:
@@ -75,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -83,8 +83,6 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -82,6 +82,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -79,8 +79,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -78,6 +78,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -80,6 +80,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:
@@ -243,6 +246,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -81,8 +81,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:
@@ -247,8 +246,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "81"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -98,6 +98,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -99,8 +99,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: 80,90
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -73,8 +73,6 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -4,6 +4,7 @@ metadata:
   creationTimestamp: null
   name: pi
 spec:
+  selector: null
   strategy: {}
   template:
     metadata:
@@ -71,6 +72,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -83,8 +83,6 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -82,6 +82,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -80,6 +80,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:
@@ -243,6 +246,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -81,8 +81,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:
@@ -247,8 +246,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "81"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -74,6 +74,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -75,8 +75,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -73,8 +73,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -72,6 +72,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -77,8 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -76,6 +76,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -81,6 +81,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -82,8 +82,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -79,6 +79,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -80,8 +80,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -79,8 +79,6 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -78,6 +78,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -79,8 +79,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: '*'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -78,6 +78,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -80,8 +80,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: 1,2,3
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -79,6 +79,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -81,8 +81,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_WORKLOAD_PORTS
-          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
-            (includeInboundPorts .Spec.Containers) ]]'
+          value: "80"
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -80,6 +80,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_WORKLOAD_PORTS
+          value: '[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts`
+            (includeInboundPorts .Spec.Containers) ]]'
         - name: ISTIO_META_CONFIG_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
This information is to provide extra visibility of the node. It's not used by Pilot for configuration.