### PR TITLE
Make all test create image to get rid run_after_success

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -57,11 +57,6 @@ E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
 # clusters. There is no need to cleanup in the test jobs.
 E2E_ARGS+=("--skip_cleanup")
 
-export HUB=${HUB:-"gcr.io/istio-testing"}
-export TAG="${TAG:-${GIT_SHA}}"
-
-make init
-
 # getopts only handles single character flags
 for ((i=1; i<=$#; i++)); do
     case ${!i} in
@@ -76,6 +71,11 @@ for ((i=1; i<=$#; i++)); do
     esac
     E2E_ARGS+=( "${!i}" )
 done
+
+export HUB=${HUB:-"gcr.io/istio-testing"}
+export TAG="${TAG:-${GIT_SHA}}""${SINGLE_TEST}"
+
+make init
 
 # upload images
 time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -45,6 +45,7 @@ export CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
 
 # shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
+setup_and_export_git_sha
 setup_e2e_cluster
 
 if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
@@ -75,6 +76,9 @@ for ((i=1; i<=$#; i++)); do
     esac
     E2E_ARGS+=( "${!i}" )
 done
+
+# upload images
+time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"
 
 time ISTIO_DOCKER_HUB=$HUB \
   E2E_ARGS="${E2E_ARGS[*]}" \


### PR DESCRIPTION
Make all prow tests to create image to get rid of run_after_success mechanism. This is the first PR on working toward upgrading PROW to head binary.