### PR TITLE
Fix version subcommand output

### DIFF
--- a/bin/get_workspace_status.sh
+++ b/bin/get_workspace_status.sh
@@ -43,10 +43,10 @@ fi
 GIT_DESCRIBE_TAG=$(git describe)
 
 # used by bin/gobuild.sh
-echo "istio.io/istio/pkg/version.buildVersion=${VERSION}"
-echo "istio.io/istio/pkg/version.buildGitRevision=${BUILD_GIT_REVISION}"
-echo "istio.io/istio/pkg/version.buildUser=$(whoami)"
-echo "istio.io/istio/pkg/version.buildHost=$(hostname -f)"
-echo "istio.io/istio/pkg/version.buildDockerHub=${DOCKER_HUB}"
-echo "istio.io/istio/pkg/version.buildStatus=${tree_status}"
-echo "istio.io/istio/pkg/version.buildTag=${GIT_DESCRIBE_TAG}"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildVersion=${VERSION}"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildGitRevision=${BUILD_GIT_REVISION}"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildUser=$(whoami)"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildHost=$(hostname -f)"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildDockerHub=${DOCKER_HUB}"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildStatus=${tree_status}"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildTag=${GIT_DESCRIBE_TAG}"


### PR DESCRIPTION
Since we moved version package to its own repo we need to update
references to it in build time otherwise we get 'Unknown' for all
version fields.