### PR TITLE
Update Vendor Files to match go.mod

### DIFF
--- a/vendor/istio.io/api/networking/v1alpha3/sidecar.pb.go
+++ b/vendor/istio.io/api/networking/v1alpha3/sidecar.pb.go
@@ -415,12 +415,12 @@ type IstioEgressListener struct {
 	// port.
 	Port *Port `protobuf:"bytes,1,opt,name=port,proto3" json:"port,omitempty"`
 	// The ip or the Unix domain socket to which the listener should be bound
-	// to. Port MUST be specified if bind is not an ip. Format: `x.x.x.x` or
+	// to. Port MUST be specified if bind is not empty. Format: `x.x.x.x` or
 	// `unix:///path/to/uds` or `unix://@foobar` (Linux abstract namespace). If
 	// omitted, Istio will automatically configure the defaults based on imported
 	// services, the workload instances to which this configuration is applied to and
 	// the captureMode. If captureMode is NONE, bind will default to
-	// 127.0.0.1 if no loopback ip is specified.
+	// 127.0.0.1.
 	Bind string `protobuf:"bytes,2,opt,name=bind,proto3" json:"bind,omitempty"`
 	// When the bind address is an IP, the captureMode option dictates
 	// how traffic to the listener is expected to be captured (or not).

--- a/vendor/istio.io/api/networking/v1alpha3/sidecar.pb.html
+++ b/vendor/istio.io/api/networking/v1alpha3/sidecar.pb.html
@@ -254,12 +254,12 @@ port.</p>
 <td><code>string</code></td>
 <td>
 <p>The ip or the Unix domain socket to which the listener should be bound
-to. Port MUST be specified if bind is not an ip. Format: <code>x.x.x.x</code> or
+to. Port MUST be specified if bind is not empty. Format: <code>x.x.x.x</code> or
 <code>unix:///path/to/uds</code> or <code>unix://@foobar</code> (Linux abstract namespace). If
 omitted, Istio will automatically configure the defaults based on imported
 services, the workload instances to which this configuration is applied to and
 the captureMode. If captureMode is NONE, bind will default to
-127.0.0.1 if no loopback ip is specified.</p>
+127.0.0.1.</p>
 
 </td>
 </tr>

--- a/vendor/istio.io/api/networking/v1alpha3/sidecar.proto
+++ b/vendor/istio.io/api/networking/v1alpha3/sidecar.proto
@@ -265,12 +265,12 @@ message IstioEgressListener {
   Port port = 1;
 
   // The ip or the Unix domain socket to which the listener should be bound
-  // to. Port MUST be specified if bind is not an ip. Format: `x.x.x.x` or
+  // to. Port MUST be specified if bind is not empty. Format: `x.x.x.x` or
   // `unix:///path/to/uds` or `unix://@foobar` (Linux abstract namespace). If
   // omitted, Istio will automatically configure the defaults based on imported
   // services, the workload instances to which this configuration is applied to and
   // the captureMode. If captureMode is NONE, bind will default to
-  // 127.0.0.1 if no loopback ip is specified.
+  // 127.0.0.1.
   string bind = 2;
 
   // When the bind address is an IP, the captureMode option dictates

--- a/vendor/istio.io/api/networking/v1alpha3/virtual_service.pb.go
+++ b/vendor/istio.io/api/networking/v1alpha3/virtual_service.pb.go
@@ -138,15 +138,16 @@ type VirtualService struct {
 	// referred to using their alphanumeric names. IP addresses are allowed
 	// only for services defined via the Gateway.
 	Hosts []string `protobuf:"bytes,1,rep,name=hosts,proto3" json:"hosts,omitempty"`
-	// The names of gateways that should apply these rules. If omitted, the
-	// rules are only applied to sidecars inside the mesh. If a list of gateway
-	// names is provided, the rules will not be applied to sidecars inside the
-	// mesh unless the reserved gateway name `mesh` is included in the list.
-	// Gateways defined in a different namespace can be selected by prefixing
-	// the gateway name with `namespace/`.
-	//
-	// The selection condition imposed by this field can be overridden using
-	// the source field in the match conditions of protocol-specific routes.
+	// The names of gateways and sidecars that should apply these routes. A
+	// single VirtualService is used for sidecars inside the mesh as well as
+	// for one or more gateways. The selection condition imposed by this
+	// field can be overridden using the source field in the match conditions
+	// of protocol-specific routes. The reserved word `mesh` is used to imply
+	// all the sidecars in the mesh. When this field is omitted, the default
+	// gateway (`mesh`) will be used, which would apply the rule to all
+	// sidecars in the mesh. If a list of gateway names is provided, the
+	// rules will apply only to the gateways. To apply the rules to both
+	// gateways and sidecars, specify `mesh` as one of the gateway names.
 	Gateways []string `protobuf:"bytes,2,rep,name=gateways,proto3" json:"gateways,omitempty"`
 	// An ordered list of route rules for HTTP traffic. HTTP routes will be
 	// applied to platform service ports named 'http-*'/'http2-*'/'grpc-*', gateway

--- a/vendor/istio.io/api/networking/v1alpha3/virtual_service.pb.html
+++ b/vendor/istio.io/api/networking/v1alpha3/virtual_service.pb.html
@@ -1701,15 +1701,16 @@ only for services defined via the Gateway.</p>
 <td><code>gateways</code></td>
 <td><code>string[]</code></td>
 <td>
-<p>The names of gateways that should apply these rules. If omitted, the
-rules are only applied to sidecars inside the mesh. If a list of gateway
-names is provided, the rules will not be applied to sidecars inside the
-mesh unless the reserved gateway name <code>mesh</code> is included in the list.
-Gateways defined in a different namespace can be selected by prefixing
-the gateway name with <code>namespace/</code>.</p>
-
-<p>The selection condition imposed by this field can be overridden using
-the source field in the match conditions of protocol-specific routes.</p>
+<p>The names of gateways and sidecars that should apply these routes. A
+single VirtualService is used for sidecars inside the mesh as well as
+for one or more gateways. The selection condition imposed by this
+field can be overridden using the source field in the match conditions
+of protocol-specific routes. The reserved word <code>mesh</code> is used to imply
+all the sidecars in the mesh. When this field is omitted, the default
+gateway (<code>mesh</code>) will be used, which would apply the rule to all
+sidecars in the mesh. If a list of gateway names is provided, the
+rules will apply only to the gateways. To apply the rules to both
+gateways and sidecars, specify <code>mesh</code> as one of the gateway names.</p>
 
 </td>
 </tr>

--- a/vendor/istio.io/api/networking/v1alpha3/virtual_service.proto
+++ b/vendor/istio.io/api/networking/v1alpha3/virtual_service.proto
@@ -140,15 +140,16 @@ message VirtualService {
   // only for services defined via the Gateway.
   repeated string hosts = 1;
 
-  // The names of gateways that should apply these rules. If omitted, the
-  // rules are only applied to sidecars inside the mesh. If a list of gateway
-  // names is provided, the rules will not be applied to sidecars inside the
-  // mesh unless the reserved gateway name `mesh` is included in the list.
-  // Gateways defined in a different namespace can be selected by prefixing
-  // the gateway name with `namespace/`.
-  //
-  // The selection condition imposed by this field can be overridden using
-  // the source field in the match conditions of protocol-specific routes.
+  // The names of gateways and sidecars that should apply these routes. A
+  // single VirtualService is used for sidecars inside the mesh as well as
+  // for one or more gateways. The selection condition imposed by this
+  // field can be overridden using the source field in the match conditions
+  // of protocol-specific routes. The reserved word `mesh` is used to imply
+  // all the sidecars in the mesh. When this field is omitted, the default
+  // gateway (`mesh`) will be used, which would apply the rule to all
+  // sidecars in the mesh. If a list of gateway names is provided, the
+  // rules will apply only to the gateways. To apply the rules to both
+  // gateways and sidecars, specify `mesh` as one of the gateway names.
   repeated string gateways = 2;
 
   // An ordered list of route rules for HTTP traffic. HTTP routes will be

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -732,10 +732,10 @@ k8s.io/apimachinery/pkg/util/intstr
 k8s.io/apimachinery/pkg/runtime/serializer/json
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/watch
+k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/yaml
-k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/strategicpatch


### PR DESCRIPTION
The vendor directory was out of sync, likely due to someone not running `go mod vendor` before committing.  See https://github.com/istio/istio/wiki/Vendor-FAQ#how-do-i-add--change-a-dependency