### PR TITLE
Change dnsRefreshRate from flag to env var

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -130,8 +130,6 @@ containers:
 {{- if .Values.global.proxy.componentLogLevel }}
   - --proxyComponentLogLevel={{ .Values.global.proxy.componentLogLevel }}
 {{- end}}
-  - --dnsRefreshRate
-  - {{ .Values.global.proxy.dnsRefreshRate }}
   - --connectTimeout
   - "{{ formatDuration .ProxyConfig.ConnectTimeout }}"
 {{- if .Values.global.proxy.envoyStatsd.enabled }}
@@ -212,6 +210,8 @@ containers:
   - name: ISTIO_META_SDS_TOKEN_PATH
     value: "{{ .Values.global.sds.customTokenDirectory -}}/sdstoken"
   {{- end }}
+  - name: ISTIO_DNS_REFRESH_RATE
+    value: {{ .Values.global.proxy.dnsRefreshRate }}
   imagePullPolicy: {{ .Values.global.imagePullPolicy }}
   {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
   readinessProbe:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -176,7 +176,6 @@ global:
 
     # Configure the DNS refresh rate for Envoy cluster of type STRICT_DNS
     # 5 seconds is the default refresh rate used by Envoy
-    # This must be given it terms of seconds. For example, 600s is valid but 5m is invalid.
     dnsRefreshRate: 5s
 
     #If set to true, istio-proxy container will have privileged securityContext

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -90,6 +90,11 @@ var (
 	podNamespaceVar      = env.RegisterStringVar("POD_NAMESPACE", "", "")
 	istioNamespaceVar    = env.RegisterStringVar("ISTIO_NAMESPACE", "", "")
 	kubeAppProberNameVar = env.RegisterStringVar(status.KubeAppProberEnvName, "", "")
+	dnsRefreshRateVar    = env.RegisterDurationVar(
+		"ISTIO_DNS_REFRESH_RATE",
+		time.Second*5,
+		"Configure the DNS refresh rate for Envoy cluster.",
+	)
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",
@@ -359,7 +364,7 @@ var (
 
 			log.Infof("PilotSAN %#v", pilotSAN)
 
-			envoyProxy := envoy.NewProxy(proxyConfig, role.ServiceNode(), proxyLogLevel, proxyComponentLogLevel, pilotSAN, role.IPAddresses, dnsRefreshRate)
+			envoyProxy := envoy.NewProxy(proxyConfig, role.ServiceNode(), proxyLogLevel, proxyComponentLogLevel, pilotSAN, role.IPAddresses, dnsRefreshRateVar.Get())
 			agent := proxy.NewAgent(envoyProxy, proxy.DefaultRetry, pilot.TerminationDrainDuration())
 			watcher := envoy.NewWatcher(tlsCertsToWatch, agent.ConfigCh())
 

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -69,8 +69,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -114,6 +112,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333},"/app-health/world/livez":{"port":90}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -66,8 +66,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -111,6 +109,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -68,8 +68,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -110,6 +108,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333},"/app-health/world/livez":{"port":90}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -91,6 +89,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"path":"/ip","port":8000}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -69,8 +69,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -111,6 +109,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333,"scheme":"HTTPS"},"/app-health/world/livez":{"port":90}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -91,6 +89,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"port":80}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -53,8 +53,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -95,6 +93,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -67,9 +67,9 @@ spec:
         - --parentShutdownDuration
         - 1m0s
         - --discoveryAddress
-<<<<<<< HEAD
+
         - istio-pilot:15010
-=======
+
         - istio-pilot:15007
         - --zipkinAddress
         - ""

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -91,6 +89,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"port":3333}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -59,8 +59,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -101,6 +99,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"path":"/ip","port":8000},"/app-health/world/readyz":{"path":"/ipv6","port":9000}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -39,8 +39,6 @@ spec:
             - 1m0s
             - --discoveryAddress
             - istio-pilot:15010
-            - --dnsRefreshRate
-            - 5s
             - --connectTimeout
             - 1s
             - --proxyAdminPort
@@ -77,6 +75,8 @@ spec:
             - name: ISTIO_META_INTERCEPTION_MODE
               value: REDIRECT
             - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+            - name: ISTIO_DNS_REFRESH_RATE
+              value: 5s
             image: docker.io/istio/proxyv2:unittest
             imagePullPolicy: IfNotPresent
             name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -43,8 +43,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -85,6 +83,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -58,8 +58,6 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
-          - --dnsRefreshRate
-          - 5s
           - --connectTimeout
           - 1s
           - --proxyAdminPort
@@ -100,6 +98,8 @@ items:
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"backend","track":"stable"}
+          - name: ISTIO_DNS_REFRESH_RATE
+            value: 5s
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -43,8 +43,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -85,6 +83,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 42s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 42s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -63,8 +63,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -104,6 +102,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"frontend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: Always
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -91,6 +89,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -47,8 +47,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -89,6 +87,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable","version":"v1"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -210,8 +210,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -252,6 +250,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable","version":"v2"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -88,6 +86,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: Never
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -91,6 +89,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxy2_debug:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -83,6 +81,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -37,8 +37,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -75,6 +73,8 @@ spec:
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -91,6 +89,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -91,6 +89,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -64,8 +64,6 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
-          - --dnsRefreshRate
-          - 5s
           - --connectTimeout
           - 1s
           - --proxyAdminPort
@@ -105,6 +103,8 @@ items:
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"frontend","track":"stable"}
+          - name: ISTIO_DNS_REFRESH_RATE
+            value: 5s
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -49,8 +49,6 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
-          - --dnsRefreshRate
-          - 5s
           - --connectTimeout
           - 1s
           - --proxyAdminPort
@@ -91,6 +89,8 @@ items:
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"backend","track":"stable","version":"v1"}
+          - name: ISTIO_DNS_REFRESH_RATE
+            value: 5s
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
@@ -211,8 +211,6 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
-          - --dnsRefreshRate
-          - 5s
           - --connectTimeout
           - 1s
           - --proxyAdminPort
@@ -253,6 +251,8 @@ items:
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"backend","track":"stable","version":"v2"}
+          - name: ISTIO_DNS_REFRESH_RATE
+            value: 5s
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -30,8 +30,6 @@ spec:
     - 1m0s
     - --discoveryAddress
     - istio-pilot:15010
-    - --dnsRefreshRate
-    - 5s
     - --connectTimeout
     - 1s
     - --proxyAdminPort
@@ -69,6 +67,8 @@ spec:
       value: REDIRECT
     - name: ISTIO_META_INCLUDE_INBOUND_PORTS
       value: "80"
+    - name: ISTIO_DNS_REFRESH_RATE
+      value: 5s
     image: docker.io/istio/proxyv2:unittest
     imagePullPolicy: IfNotPresent
     name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -40,8 +40,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -82,6 +80,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -39,8 +39,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -81,6 +79,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"nginx"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -90,6 +88,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -91,6 +89,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"status"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -41,8 +41,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -83,6 +81,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"status"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -89,6 +87,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -90,6 +88,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -91,6 +89,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -41,8 +41,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -83,6 +81,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -41,8 +41,6 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -79,6 +77,8 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -85,6 +83,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -6,6 +6,7 @@ metadata:
 spec:
   replicas: 7
   revisionHistoryLimit: 2
+  selector: null
   strategy:
     type: Rolling
   template:
@@ -44,8 +45,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -83,6 +82,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -84,6 +82,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -51,8 +51,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -89,6 +87,8 @@ spec:
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -47,8 +47,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -86,6 +84,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -88,6 +86,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -212,8 +212,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -251,6 +249,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "81"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -67,8 +67,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -106,6 +104,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: 80,90
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -4,6 +4,7 @@ metadata:
   creationTimestamp: null
   name: pi
 spec:
+  selector: null
   strategy: {}
   template:
     metadata:
@@ -40,8 +41,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -78,6 +77,8 @@ spec:
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -51,8 +51,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -89,6 +87,8 @@ spec:
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -88,6 +86,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -212,8 +212,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -251,6 +249,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "81"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -43,8 +43,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -82,6 +80,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -41,8 +41,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -80,6 +78,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -84,6 +82,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -50,8 +50,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -89,6 +87,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -47,8 +47,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -85,6 +83,8 @@ spec:
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -47,8 +47,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -86,6 +84,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: '*'
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -87,6 +85,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: 1,2,3
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 5s
         - --connectTimeout
         - 1s
         - --proxyAdminPort
@@ -88,6 +86,8 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_DNS_REFRESH_RATE
+          value: 5s
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -48,12 +48,12 @@ type envoy struct {
 	opts           map[string]interface{}
 	errChan        chan error
 	nodeIPs        []string
-	dnsRefreshRate string
+	dnsRefreshRate time.Duration
 }
 
 // NewProxy creates an instance of the proxy control commands
 func NewProxy(config meshconfig.ProxyConfig, node string, logLevel string,
-	componentLogLevel string, pilotSAN []string, nodeIPs []string, dnsRefreshRate string) proxy.Proxy {
+	componentLogLevel string, pilotSAN []string, nodeIPs []string, dnsRefreshRate time.Duration) proxy.Proxy {
 	// inject tracing flag for higher levels
 	var args []string
 	if logLevel != "" {

--- a/pilot/pkg/proxy/envoy/proxy_test.go
+++ b/pilot/pkg/proxy/envoy/proxy_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"istio.io/istio/pilot/pkg/model"
 )
@@ -32,7 +33,7 @@ func TestEnvoyArgs(t *testing.T) {
 		node:           "my-node",
 		extraArgs:      []string{"-l", "trace", "--component-log-level", "misc:error"},
 		nodeIPs:        []string{"10.75.2.9", "192.168.11.18"},
-		dnsRefreshRate: "60s",
+		dnsRefreshRate: time.Minute,
 	}
 	testProxy := NewProxy(
 		config,
@@ -41,7 +42,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"misc:error",
 		nil,
 		[]string{"10.75.2.9", "192.168.11.18"},
-		"60s",
+		time.Minute,
 	)
 	if !reflect.DeepEqual(testProxy, test) {
 		t.Errorf("unexpected struct got\n%v\nwant\n%v", testProxy, test)

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -202,7 +202,7 @@ var overrideVar = env.RegisterStringVar("ISTIO_BOOTSTRAP", "", "")
 // WriteBootstrap generates an envoy config based on config and epoch, and returns the filename.
 // TODO: in v2 some of the LDS ports (port, http_port) should be configured in the bootstrap.
 func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilotSAN []string,
-	opts map[string]interface{}, localEnv []string, nodeIPs []string, dnsRefreshRate string) (string, error) {
+	opts map[string]interface{}, localEnv []string, nodeIPs []string, dnsRefreshRate time.Duration) (string, error) {
 	if opts == nil {
 		opts = map[string]interface{}{}
 	}
@@ -287,7 +287,7 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	// Pass unmodified config.DiscoveryAddress for Google gRPC Envoy client target_uri parameter
 	opts["discovery_address"] = config.DiscoveryAddress
 
-	opts["dns_refresh_rate"] = dnsRefreshRate
+	opts["dns_refresh_rate"] = fmt.Sprintf("%ds", int(dnsRefreshRate.Seconds()))
 
 	// Setting default to ipv4 local host, wildcard and dns policy
 	opts["localhost"] = "127.0.0.1"

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"regexp"
 	"testing"
+	"time"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 	"github.com/ghodss/yaml"
@@ -103,7 +104,7 @@ func TestGolden(t *testing.T) {
 			_, localEnv := createEnv(t, c.labels, c.annotations)
 			fn, err := WriteBootstrap(cfg, "sidecar~1.2.3.4~foo~bar", 0, []string{
 				"spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"}, nil, localEnv,
-				[]string{"10.3.3.3", "10.4.4.4", "10.5.5.5", "10.6.6.6"}, "60s")
+				[]string{"10.3.3.3", "10.4.4.4", "10.5.5.5", "10.6.6.6"}, time.Minute)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tools/hyperistio/hyperistio.go
+++ b/tools/hyperistio/hyperistio.go
@@ -122,7 +122,7 @@ func startEnvoy() error {
 		DrainDuration:    types.DurationProto(30 * time.Second), // crash if 0
 		StatNameLength:   189,
 	}
-	cfgF, err := agent.WriteBootstrap(cfg, "sidecar~127.0.0.2~a~a", 1, []string{}, nil, os.Environ(), []string{}, "60s")
+	cfgF, err := agent.WriteBootstrap(cfg, "sidecar~127.0.0.2~a~a", 1, []string{}, nil, os.Environ(), []string{}, time.Minute)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding a new flag to proxy-agent makes update/rollback problamatic,
because if you have a version mismatch you will get "unknown flag"
errors. Instead, we can just use an env variable which is safer.

This is basically a partial revert of https://github.com/istio/istio/pull/13982 and converting to env instead of flag.