### PR TITLE
rbac: add tests for path with double dots

### DIFF
--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -43,10 +43,10 @@ type CallOptions struct {
 	// Path specifies the URL path for the request.
 	Path string
 
-	// NoEscapePath disables escaping the `Path` when constructing the URL path for the request.
-	// For example, the path "/%2E" will be used as-is and will NOT be escaped to "%252E" when this
-	// flag is set to true.
-	NoEscapePath bool
+	// UseRawURL specifies to construct the URL for the request as-is, without any escaping. For example,
+	// the code "%2E" in the path will be escaped to "%252E" when UseRawURL is false and it will be used as-is
+	// when UseRawURL is true.
+	UseRawURL bool
 
 	// Count indicates the number of exchanges that should be made with the service endpoint.
 	// If Count <= 0, defaults to 1.

--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -43,6 +43,11 @@ type CallOptions struct {
 	// Path specifies the URL path for the request.
 	Path string
 
+	// NoEscapePath disables escaping the `Path` when constructing the URL path for the request.
+	// For example, the path "/%2E" will be used as-is and will NOT be escaped to "%252E" when this
+	// flag is set to true.
+	NoEscapePath bool
+
 	// Count indicates the number of exchanges that should be made with the service endpoint.
 	// If Count <= 0, defaults to 1.
 	Count int

--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -43,11 +43,6 @@ type CallOptions struct {
 	// Path specifies the URL path for the request.
 	Path string
 
-	// UseRawURL specifies to construct the URL for the request as-is, without any escaping. For example,
-	// the code "%2E" in the path will be escaped to "%252E" when UseRawURL is false and it will be used as-is
-	// when UseRawURL is true.
-	UseRawURL bool
-
 	// Count indicates the number of exchanges that should be made with the service endpoint.
 	// If Count <= 0, defaults to 1.
 	Count int

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -59,6 +59,13 @@ func CallEcho(c *client.Instance, opts *echo.CallOptions, outboundPortSelector O
 		Host:   net.JoinHostPort(opts.Host, strconv.Itoa(port)),
 		Path:   opts.Path,
 	}
+	var urlStr string
+	if opts.NoEscapePath {
+		targetURL.Path = ""
+		urlStr = targetURL.String() + opts.Path
+	} else {
+		urlStr = targetURL.String()
+	}
 	targetService := opts.Target.Config().Service
 
 	protoHeaders := []*proto.Header{
@@ -74,7 +81,7 @@ func CallEcho(c *client.Instance, opts *echo.CallOptions, outboundPortSelector O
 	}
 
 	req := &proto.ForwardEchoRequest{
-		Url:           targetURL.String(),
+		Url:           urlStr,
 		Count:         int32(opts.Count),
 		Headers:       protoHeaders,
 		TimeoutMicros: common.DurationToMicros(opts.Timeout),

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"reflect"
 	"strconv"
 
@@ -54,17 +53,7 @@ func CallEcho(c *client.Instance, opts *echo.CallOptions, outboundPortSelector O
 	}
 
 	// Forward a request from 'this' service to the destination service.
-	targetURL := &url.URL{
-		Scheme: string(opts.Scheme),
-		Host:   net.JoinHostPort(opts.Host, strconv.Itoa(port)),
-		Path:   opts.Path,
-	}
-	var urlStr string
-	if opts.UseRawURL {
-		urlStr = fmt.Sprintf("%s://%s%s", string(opts.Scheme), net.JoinHostPort(opts.Host, strconv.Itoa(port)), opts.Path)
-	} else {
-		urlStr = targetURL.String()
-	}
+	targetURL := fmt.Sprintf("%s://%s%s", string(opts.Scheme), net.JoinHostPort(opts.Host, strconv.Itoa(port)), opts.Path)
 	targetService := opts.Target.Config().Service
 
 	protoHeaders := []*proto.Header{
@@ -80,7 +69,7 @@ func CallEcho(c *client.Instance, opts *echo.CallOptions, outboundPortSelector O
 	}
 
 	req := &proto.ForwardEchoRequest{
-		Url:           urlStr,
+		Url:           targetURL,
 		Count:         int32(opts.Count),
 		Headers:       protoHeaders,
 		TimeoutMicros: common.DurationToMicros(opts.Timeout),

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -60,9 +60,8 @@ func CallEcho(c *client.Instance, opts *echo.CallOptions, outboundPortSelector O
 		Path:   opts.Path,
 	}
 	var urlStr string
-	if opts.NoEscapePath {
-		targetURL.Path = ""
-		urlStr = targetURL.String() + opts.Path
+	if opts.UseRawURL {
+		urlStr = fmt.Sprintf("%s://%s%s", string(opts.Scheme), net.JoinHostPort(opts.Host, strconv.Itoa(port)), opts.Path)
 	} else {
 		urlStr = targetURL.String()
 	}

--- a/tests/integration/security/rbac/util/rbac_util.go
+++ b/tests/integration/security/rbac/util/rbac_util.go
@@ -79,8 +79,14 @@ func (tc TestCase) CheckRBACRequest() error {
 			if err != nil {
 				return getError(req, "deny with code 403", fmt.Sprintf("error: %v", err))
 			}
-			if len(resp) == 0 || resp[0].Code != response.StatusCodeForbidden {
-				return getError(req, "deny with code 403", fmt.Sprintf("resp: %v", resp))
+			var result string
+			if len(resp) == 0 {
+				result = "no response"
+			} else if resp[0].Code != response.StatusCodeForbidden {
+				result = resp[0].Code
+			}
+			if result != "" {
+				return getError(req, "deny with code 403", result)
 			}
 		}
 	}

--- a/tests/integration/security/rbac/v1/path/main_test.go
+++ b/tests/integration/security/rbac/v1/path/main_test.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst istio.Instance
+	g    galley.Instance
+	p    pilot.Instance
+)
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.Values["sidecarInjectorWebhook.rewriteAppHTTPProbe"] = "true"
+
+	// TODO(https://github.com/istio/istio/issues/14084) remove this
+	cfg.Values["pilot.env.PILOT_ENABLE_FALLTHROUGH_ROUTE"] = "0"
+}
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("rbac_v1_path", m).
+		RequireEnvironment(environment.Kube).
+		Label(label.CustomSetup).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+}

--- a/tests/integration/security/rbac/v1/path/path_test.go
+++ b/tests/integration/security/rbac/v1/path/path_test.go
@@ -76,11 +76,12 @@ func TestRBACV1Path(t *testing.T) {
 					Request: connection.Checker{
 						From: b,
 						Options: echo.CallOptions{
-							Target:       a,
-							PortName:     "http",
-							Scheme:       scheme.HTTP,
-							Path:         path,
-							NoEscapePath: true,
+							Target:   a,
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Path:     path,
+							// UseRawURL ensures the code "%2E" in the path will be used as-is, not escaped.
+							UseRawURL: true,
 						},
 					},
 					ExpectAllowed: expectAllowed,

--- a/tests/integration/security/rbac/v1/path/path_test.go
+++ b/tests/integration/security/rbac/v1/path/path_test.go
@@ -80,8 +80,6 @@ func TestRBACV1Path(t *testing.T) {
 							PortName: "http",
 							Scheme:   scheme.HTTP,
 							Path:     path,
-							// UseRawURL ensures the code "%2E" in the path will be used as-is, not escaped.
-							UseRawURL: true,
 						},
 					},
 					ExpectAllowed: expectAllowed,

--- a/tests/integration/security/rbac/v1/path/path_test.go
+++ b/tests/integration/security/rbac/v1/path/path_test.go
@@ -37,6 +37,8 @@ const (
 	rbacPolicyYamlTmpl = "testdata/rbac-policy.yaml.tmpl"
 )
 
+// TestRBACV1Path tests the path is normalized before using in authorization. For example, a request
+// with path "/a/../b" should be normalized to "/b" before using in authorization.
 func TestRBACV1Path(t *testing.T) {
 	framework.NewTest(t).
 		RequiresEnvironment(environment.Kube).
@@ -69,7 +71,7 @@ func TestRBACV1Path(t *testing.T) {
 				}).
 				BuildOrFail(t)
 
-			newTestCase := func(path string, expect bool) util.TestCase {
+			newTestCase := func(path string, expectAllowed bool) util.TestCase {
 				return util.TestCase{
 					Request: connection.Checker{
 						From: b,
@@ -81,7 +83,7 @@ func TestRBACV1Path(t *testing.T) {
 							NoEscapePath: true,
 						},
 					},
-					ExpectAllowed: expect,
+					ExpectAllowed: expectAllowed,
 				}
 			}
 			cases := []util.TestCase{

--- a/tests/integration/security/rbac/v1/path/path_test.go
+++ b/tests/integration/security/rbac/v1/path/path_test.go
@@ -1,0 +1,124 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/tmpl"
+	"istio.io/istio/tests/integration/security/rbac/util"
+	"istio.io/istio/tests/integration/security/util/connection"
+)
+
+const (
+	rbacPolicyYamlTmpl = "testdata/rbac-policy.yaml.tmpl"
+)
+
+func TestRBACV1Path(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+
+			ns := namespace.NewOrFail(t, ctx, "rbacv1-path-test", true)
+			ports := []echo.Port{
+				{
+					Name:        "http",
+					Protocol:    model.ProtocolHTTP,
+					ServicePort: 80,
+				},
+			}
+
+			var a, b echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, echo.Config{
+					Service:   "a",
+					Namespace: ns,
+					Ports:     ports,
+					Galley:    g,
+					Pilot:     p,
+				}).
+				With(&b, echo.Config{
+					Service:   "b",
+					Namespace: ns,
+					Ports:     ports,
+					Galley:    g,
+					Pilot:     p,
+				}).
+				BuildOrFail(t)
+
+			newTestCase := func(path string, expect bool) util.TestCase {
+				return util.TestCase{
+					Request: connection.Checker{
+						From: b,
+						Options: echo.CallOptions{
+							Target:       a,
+							PortName:     "http",
+							Scheme:       scheme.HTTP,
+							Path:         path,
+							NoEscapePath: true,
+						},
+					},
+					ExpectAllowed: expect,
+				}
+			}
+			cases := []util.TestCase{
+				newTestCase("/public", true),
+				newTestCase("/private", false),
+				newTestCase("/public/../private", false),
+				newTestCase("/public/./../private", false),
+				newTestCase("/public/.././private", false),
+				newTestCase("/public/%2E%2E/private", false),
+				newTestCase("/public/%2e%2e/private", false),
+				newTestCase("/public/%2E/%2E%2E/private", false),
+				newTestCase("/public/%2e/%2e%2e/private", false),
+				newTestCase("/public/%2E%2E/%2E/private", false),
+				newTestCase("/public/%2e%2e/%2e/private", false),
+			}
+
+			args := map[string]string{
+				"Namespace": ns.Name(),
+			}
+			policies := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, rbacPolicyYamlTmpl))
+			g.ApplyConfigOrFail(t, ns, policies...)
+			defer g.DeleteConfigOrFail(t, ns, policies...)
+
+			// Sleep 60 seconds for the policy to take effect.
+			// TODO: query pilot or app to know instead of sleep.
+			time.Sleep(60 * time.Second)
+
+			for _, tc := range cases {
+				testName := fmt.Sprintf("%s->%s:%s%s[%v]",
+					tc.Request.From.Config().Service,
+					tc.Request.Options.Target.Config().Service,
+					tc.Request.Options.PortName,
+					tc.Request.Options.Path,
+					tc.ExpectAllowed)
+				t.Run(testName, func(t *testing.T) {
+					retry.UntilSuccessOrFail(t, tc.CheckRBACRequest, retry.Delay(5*time.Second), retry.Timeout(30*time.Second))
+				})
+			}
+		})
+}

--- a/tests/integration/security/rbac/v1/path/testdata/rbac-policy.yaml.tmpl
+++ b/tests/integration/security/rbac/v1/path/testdata/rbac-policy.yaml.tmpl
@@ -1,0 +1,37 @@
+# Enable istio RBAC
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ClusterRbacConfig
+metadata:
+  name: default
+spec:
+  mode: 'ON_WITH_INCLUSION'
+  inclusion:
+    namespaces: ["{{ .Namespace }}"]
+---
+
+# For service a:
+# * Allow GET requests at path with prefix "/public".
+# * Deny any other requests by default.
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: viewer
+spec:
+  rules:
+  - services: ["a.{{ .Namespace }}.svc.cluster.local"]
+    methods: ["GET"]
+    paths: ["/public*"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: viewer-binding
+spec:
+  subjects:
+  - user: "*"
+  roleRef:
+    kind: ServiceRole
+    name: "viewer"
+---


### PR DESCRIPTION
Note the tests won't pass until https://github.com/istio/istio/issues/14185.

@nmittler We want to use the raw path in this test but I couldn't find any option to skip the path escape in the `url` package so I added an option `NoEscapePath` and construct manually, please let me know if you think there is better way to do this, thanks.

#13439