### PR TITLE
Fix istioctl version information (blocking release)

### DIFF
--- a/bin/get_workspace_status.sh
+++ b/bin/get_workspace_status.sh
@@ -43,10 +43,10 @@ fi
 GIT_DESCRIBE_TAG=$(git describe)
 
 # used by bin/gobuild.sh
-echo "istio.io/istio/pkg/version.buildVersion=${VERSION}"
-echo "istio.io/istio/pkg/version.buildGitRevision=${BUILD_GIT_REVISION}"
-echo "istio.io/istio/pkg/version.buildUser=$(whoami)"
-echo "istio.io/istio/pkg/version.buildHost=$(hostname -f)"
-echo "istio.io/istio/pkg/version.buildDockerHub=${DOCKER_HUB}"
-echo "istio.io/istio/pkg/version.buildStatus=${tree_status}"
-echo "istio.io/istio/pkg/version.buildTag=${GIT_DESCRIBE_TAG}"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildVersion=${VERSION}"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildGitRevision=${BUILD_GIT_REVISION}"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildUser=$(whoami)"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildHost=$(hostname -f)"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildDockerHub=${DOCKER_HUB}"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildStatus=${tree_status}"
+echo "istio.io/istio/vendor/istio.io/pkg/version.buildTag=${GIT_DESCRIBE_TAG}"


### PR DESCRIPTION
The version library moved to another repo, so we need to update the
location here. ldflags locations are relative to the GOPATH, so we have
to do the long vendor directory, not the stanard istio.io/pkg.

Fixes https://github.com/istio/istio/issues/14182

