### PR TITLE
Allow unknown flags in pilot-agent

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -590,10 +590,20 @@ func waitForCerts(fname string, maxWait time.Duration) {
 }
 
 func main() {
+	ignoreUnknownFlagsAndWarn(proxyCmd)
 	if err := rootCmd.Execute(); err != nil {
 		log.Errora(err)
 		os.Exit(-1)
 	}
+}
+
+// ignoreUnknownFlagsAndWarn will configure the command to allow unknown flags. It will parse the
+// flags before enabling this, so that a warning can be emitted if there is an unknown flag.
+func ignoreUnknownFlagsAndWarn(cmd *cobra.Command) {
+	if err := cmd.ParseFlags(os.Args); err != nil {
+		log.Warnf("Failed to parse flags, will retry with unknown flags enabled: %v", err)
+	}
+	cmd.FParseErrWhitelist.UnknownFlags = true
 }
 
 // isIPv6Proxy check the addresses slice and returns true for a valid IPv6 address


### PR DESCRIPTION
This allows us to add flags to pilot-agent without rollbacks or upgrades
causing incompatibility issues. A warning message is emitted if an
unknown flag is provided, so it is less likely to go unnoticed by users.