### PR TITLE
Add stats inclusion suffixes, prefixes, regexps

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -50,38 +50,6 @@ data:
         action: replace
         target_label: pod_name
 
-      metric_relabel_configs:
-      # Exclude some of the envoy metrics that have massive cardinality
-      # This list may need to be pruned further moving forward, as informed
-      # by performance and scalability testing.
-      - source_labels: [ cluster_name ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ tcp_prefix ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ listener_address ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_listener_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tls.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tcp_downstream.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_http_(stats|admin).*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_cluster_(lb|retry|bind|internal|max|original).*'
-        action: drop
-
     - job_name: 'istio-policy'
       kubernetes_sd_configs:
       - role: endpoints

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -52,23 +52,72 @@ const (
 
 	lightstepAccessTokenBase = "lightstep_access_token.txt"
 
-	// statsPatterns gives the developer control over Envoy stats collection
-	EnvoyStatsMatcherInclusionPatterns = "sidecar.istio.io/statsInclusionPrefixes"
-)
+	// statsMatchers give the operator control over Envoy stats collection.
+	EnvoyStatsMatcherInclusionPrefixes = "sidecar.istio.io/statsInclusionPrefixes"
+	EnvoyStatsMatcherInclusionSuffixes = "sidecar.istio.io/statsInclusionSuffixes"
+	EnvoyStatsMatcherInclusionRegexps  = "sidecar.istio.io/statsInclusionRegexps"
 
-var _ = annotations.Register(EnvoyStatsMatcherInclusionPatterns, "Control over Envoy stats collection.")
+	// Options are used in the boostrap template.
+	envoyStatsMatcherInclusionPrefixOption = "inclusionPrefix"
+	envoyStatsMatcherInclusionSuffixOption = "inclusionSuffix"
+	envoyStatsMatcherInclusionRegexpOption = "inclusionRegexps"
+)
 
 var (
-	// default value for EnvoyStatsMatcherInclusionPatterns
-	defaultEnvoyStatsMatcherInclusionPatterns = []string{
-		"cluster_manager",
-		"listener_manager",
-		"http_mixer_filter",
-		"tcp_mixer_filter",
-		"server",
-		"cluster.xds-grpc",
-	}
+	_ = annotations.Register(EnvoyStatsMatcherInclusionPrefixes,
+		"Specifies the comma separated list of prefixes of the stats to be emitted by Envoy.")
+	_ = annotations.Register(EnvoyStatsMatcherInclusionSuffixes,
+		"Specifies the comma separated list of suffixes of the stats to be emitted by Envoy.")
+	_ = annotations.Register(EnvoyStatsMatcherInclusionRegexps,
+		"Specifies the comma separated list of regexes the stats should match to be emitted by Envoy.")
+
+	// required stats are used by readiness checks.
+	requiredEnvoyStatsMatcherInclusionPrefixes = "cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grpc"
 )
+
+// substituteValues substitutes variables known to the boostrap like pod_ip.
+// "http.{pod_ip}_" with pod_id = [10.3.3.3,10.4.4.4] --> [http.10.3.3.3_,http.10.4.4.4_]
+func substituteValues(patterns []string, varName string, values []string) []string {
+	ret := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		if !strings.Contains(pattern, varName) {
+			ret = append(ret, pattern)
+			continue
+		}
+
+		for _, val := range values {
+			ret = append(ret, strings.Replace(pattern, varName, val, -1))
+		}
+	}
+	return ret
+}
+
+// setStatsOptions configures stats inclusion list based on annotations.
+func setStatsOptions(opts map[string]interface{}, meta map[string]string, nodeIPs []string) {
+
+	setStatsOption := func(metaKey string, optKey string, required string) {
+		var inclusionOption []string
+		if inclusionPatterns, ok := meta[metaKey]; ok {
+			inclusionOption = strings.Split(inclusionPatterns, ",")
+		}
+
+		inclusionOption = append(inclusionOption,
+			strings.Split(required, ",")...)
+
+		// At the sidecar we can limit downstream metrics collection to the inbound listener.
+		// Inbound downstream metrics are named as: http.{pod_ip}_{port}.downstream_rq_*
+		// Other outbound downstream metrics are numerous and not very interesting for a sidecar.
+		// specifying http.{pod_ip}_  as a prefix will capture these downstream metrics.
+		inclusionOption = substituteValues(inclusionOption, "{pod_ip}", nodeIPs)
+		opts[optKey] = inclusionOption
+	}
+
+	setStatsOption(EnvoyStatsMatcherInclusionPrefixes, envoyStatsMatcherInclusionPrefixOption, requiredEnvoyStatsMatcherInclusionPrefixes)
+
+	setStatsOption(EnvoyStatsMatcherInclusionSuffixes, envoyStatsMatcherInclusionSuffixOption, "")
+
+	setStatsOption(EnvoyStatsMatcherInclusionRegexps, envoyStatsMatcherInclusionRegexpOption, "")
+}
 
 func defaultPilotSan() []string {
 	return []string{
@@ -259,11 +308,7 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	// Support passing extra info from node environment as metadata
 	meta := getNodeMetaData(localEnv)
 
-	if inclusionPatterns, ok := meta[EnvoyStatsMatcherInclusionPatterns]; ok {
-		opts["inclusionPatterns"] = strings.Split(inclusionPatterns, ",")
-	} else {
-		opts["inclusionPatterns"] = defaultEnvoyStatsMatcherInclusionPatterns
-	}
+	setStatsOptions(opts, meta, nodeIPs)
 
 	// Support multiple network interfaces
 	meta["ISTIO_META_INSTANCE_IPS"] = strings.Join(nodeIPs, ",")

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -101,15 +101,20 @@ func setStatsOptions(opts map[string]interface{}, meta map[string]string, nodeIP
 			inclusionOption = strings.Split(inclusionPatterns, ",")
 		}
 
-		inclusionOption = append(inclusionOption,
-			strings.Split(required, ",")...)
+		if len(required) > 0 {
+			inclusionOption = append(inclusionOption,
+				strings.Split(required, ",")...)
+		}
 
 		// At the sidecar we can limit downstream metrics collection to the inbound listener.
 		// Inbound downstream metrics are named as: http.{pod_ip}_{port}.downstream_rq_*
 		// Other outbound downstream metrics are numerous and not very interesting for a sidecar.
 		// specifying http.{pod_ip}_  as a prefix will capture these downstream metrics.
 		inclusionOption = substituteValues(inclusionOption, "{pod_ip}", nodeIPs)
-		opts[optKey] = inclusionOption
+
+		if len(inclusionOption) > 0 {
+			opts[optKey] = inclusionOption
+		}
 	}
 
 	setStatsOption(EnvoyStatsMatcherInclusionPrefixes, envoyStatsMatcherInclusionPrefixOption, requiredEnvoyStatsMatcherInclusionPrefixes)

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -20,7 +20,10 @@ import (
 	"path"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
+
+	"github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 	"github.com/ghodss/yaml"
@@ -30,6 +33,27 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/test/env"
+)
+
+type stats struct {
+	prefixes string
+	suffixes string
+	regexps  string
+}
+
+var (
+	// The following set of inclusions add minimal upstream and downstream metrics.
+	// Upstream metrics record client side measurements.
+	// Downstream metrics record server side measurements.
+	upstreamStatsSuffixes = "upstream_rq_1xx,upstream_rq_2xx,upstream_rq_3xx,upstream_rq_4xx,upstream_rq_5xx," +
+		"upstream_rq_time,upstream_cx_tx_bytes_total,upstream_cx_rx_bytes_total,upstream_cx_total"
+
+	// example downstream metric: http.10.16.48.230_8080.downstream_rq_2xx
+	// http.<pod_ip>_<port>.downstream_rq_2xx
+	// This metric is collected at the inbound listener at a sidecar.
+	// All the other downstream metrics at a sidecar are from the application to the local sidecar.
+	downstreamStatsSuffixes = "downstream_rq_1xx,downstream_rq_2xx,downstream_rq_3xx,downstream_rq_4xx,downstream_rq_5xx," +
+		"downstream_rq_time,downstream_cx_tx_bytes_total,downstream_cx_rx_bytes_total,downstream_cx_total"
 )
 
 // Generate configs for the default configs used by istio.
@@ -46,6 +70,7 @@ func TestGolden(t *testing.T) {
 		labels                     map[string]string
 		annotations                map[string]string
 		expectLightstepAccessToken bool
+		stats                      stats
 	}{
 		{
 			base: "auth",
@@ -83,8 +108,34 @@ func TestGolden(t *testing.T) {
 		{
 			base: "stats_inclusion",
 			annotations: map[string]string{
-				"sidecar.istio.io/statsInclusionPrefixes": "cluster_manager,cluster.xds-grpc,listener.",
+				"sidecar.istio.io/statsInclusionPrefixes": "prefix1,prefix2",
+				"sidecar.istio.io/statsInclusionSuffixes": "suffix1,suffix2",
 			},
+			stats: stats{prefixes: "prefix1,prefix2",
+				suffixes: "suffix1,suffix2"},
+		},
+		{
+			base: "stats_inclusion",
+			annotations: map[string]string{
+				"sidecar.istio.io/statsInclusionSuffixes": upstreamStatsSuffixes + "," + downstreamStatsSuffixes,
+			},
+			stats: stats{
+				suffixes: upstreamStatsSuffixes + "," + downstreamStatsSuffixes},
+		},
+		{
+			base: "stats_inclusion",
+			annotations: map[string]string{
+				"sidecar.istio.io/statsInclusionPrefixes": "http.{pod_ip}_",
+			},
+			// {pod_ip} is unrolled
+			stats: stats{prefixes: "http.10.3.3.3_,http.10.4.4.4_,http.10.5.5.5_,http.10.6.6.6_"},
+		},
+		{
+			base: "stats_inclusion",
+			annotations: map[string]string{
+				"sidecar.istio.io/statsInclusionRegexps": "http.[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*_8080.downstream_rq_time",
+			},
+			stats: stats{regexps: "http.[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*_8080.downstream_rq_time"},
 		},
 	}
 
@@ -160,6 +211,8 @@ func TestGolden(t *testing.T) {
 				t.Fatalf("invalid json %v\n%s", err, string(read))
 			}
 
+			checkStatsMatcher(t, &realM, &goldenM, c.stats)
+
 			if !reflect.DeepEqual(realM, goldenM) {
 				s, _ := diff.PrettyDiff(realM, goldenM)
 				t.Logf("difference: %s", s)
@@ -184,6 +237,55 @@ func TestGolden(t *testing.T) {
 		})
 	}
 
+}
+
+func checkListStringMatcher(t *testing.T, got *matcher.ListStringMatcher, want string, typ string) {
+	var patterns []string
+	for _, pattern := range got.GetPatterns() {
+		var pat string
+		switch typ {
+		case "prefix":
+			pat = pattern.GetPrefix()
+		case "suffix":
+			pat = pattern.GetSuffix()
+		case "regexp":
+			pat = pattern.GetRegex()
+		}
+
+		if pat != "" {
+			patterns = append(patterns, pat)
+		}
+	}
+	gotPattern := strings.Join(patterns, ",")
+	if want != gotPattern {
+		t.Fatalf("%s mismatch:\ngot: %s\nwant: %s", typ, gotPattern, want)
+	}
+}
+
+func checkStatsMatcher(t *testing.T, got, want *v2.Bootstrap, stats stats) {
+	gsm := got.GetStatsConfig().GetStatsMatcher()
+
+	if stats.prefixes == "" {
+		stats.prefixes = requiredEnvoyStatsMatcherInclusionPrefixes
+	} else {
+		stats.prefixes += "," + requiredEnvoyStatsMatcherInclusionPrefixes
+	}
+
+	checkListStringMatcher(t, gsm.GetInclusionList(), stats.prefixes, "prefix")
+	checkListStringMatcher(t, gsm.GetInclusionList(), stats.suffixes, "suffix")
+	checkListStringMatcher(t, gsm.GetInclusionList(), stats.regexps, "regexp")
+
+	// remove StatsMatcher for general matching
+	got.StatsConfig.StatsMatcher = nil
+	want.StatsConfig.StatsMatcher = nil
+
+	// remove StatsMatcher metadata from matching
+	delete(got.Node.Metadata.Fields, EnvoyStatsMatcherInclusionPrefixes)
+	delete(want.Node.Metadata.Fields, EnvoyStatsMatcherInclusionPrefixes)
+	delete(got.Node.Metadata.Fields, EnvoyStatsMatcherInclusionSuffixes)
+	delete(want.Node.Metadata.Fields, EnvoyStatsMatcherInclusionSuffixes)
+	delete(got.Node.Metadata.Fields, EnvoyStatsMatcherInclusionRegexps)
+	delete(want.Node.Metadata.Fields, EnvoyStatsMatcherInclusionRegexps)
 }
 
 type regexReplacement struct {

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -23,9 +23,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/type/matcher"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
@@ -269,6 +268,10 @@ func checkStatsMatcher(t *testing.T, got, want *v2.Bootstrap, stats stats) {
 		stats.prefixes = requiredEnvoyStatsMatcherInclusionPrefixes
 	} else {
 		stats.prefixes += "," + requiredEnvoyStatsMatcherInclusionPrefixes
+	}
+
+	if err := gsm.Validate(); err != nil {
+		t.Fatalf("Generated invalid matcher: %v", err)
 	}
 
 	checkListStringMatcher(t, gsm.GetInclusionList(), stats.prefixes, "prefix")

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -54,10 +54,20 @@
     "stats_matcher": {
       "inclusion_list": {
         "patterns": [
-          {{- range $a, $s := .inclusionPatterns }}
-            {
-              "prefix": "{{$s}}"
-            },
+          {{- range $a, $s := .inclusionPrefix }}
+          {
+          "prefix": "{{$s}}"
+          },
+          {{- end }}
+          {{- range $a, $s := .inclusionSuffix }}
+          {
+          "suffix": "{{$s}}"
+          },
+          {{- end }}
+          {{- range $a, $s := .inclusionRegexps }}
+          {
+          "regex": "{{js $s}}"
+          },
           {{- end }}
         ]
       }


### PR DESCRIPTION
1. Add inclusion suffix, prefix and regexes
2. Add substitution of pod_ip in stats, that can reduce the number of stats.
3. Make it explicit that these are required stats: `cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grpc`
  These are needed for correct functioning of readiness.
  This PR ensures that these stats will always be collected.