### PR TITLE
Update CircleCI Makfile to use same vars as current image

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,12 +1,12 @@
 # Builder version
-CI_VERSION ?= go1.11-k8s1.10.4-helm2.7.2-minikube0.25
-CI_HUB ?= istio
+CI_VERSION ?= 2019-04-22
+CI_HUB ?= gcr.io
 
 ci.image:
-	docker build -t "${CI_HUB}/ci:$(CI_VERSION)" -f Dockerfile .
+	docker build -t "${CI_HUB}/istio-testing/circleci:$(CI_VERSION)" -f Dockerfile .
 
 ci.push:
-	docker push --config=/tmp/circle "${CI_HUB}/ci:$(CI_VERSION)" 
+	docker push --config=/tmp/circle "${CI_HUB}/istio-testing/circleci:$(CI_VERSION)" 
 
 ci.run:
 	docker run --rm -u $(shell id -u) -it \


### PR DESCRIPTION
  The image used by CircleCI was updated in #13531 but the Makefile vars were not.