### PR TITLE
[Test Framework] Always apply config for Native Echo

### DIFF
--- a/galley/pkg/source/fs/source.go
+++ b/galley/pkg/source/fs/source.go
@@ -212,7 +212,7 @@ func (s *source) Start(handler resource.EventHandler) error {
 	return s.worker.Start(nil, func(ctx context.Context) {
 		s.handler = handler
 		s.initialCheck()
-		c := make(chan appsignals.Signal)
+		c := make(chan appsignals.Signal, 1)
 		appsignals.Watch(c)
 
 		for {

--- a/pkg/test/framework/components/echo/native/workload.go
+++ b/pkg/test/framework/components/echo/native/workload.go
@@ -115,19 +115,6 @@ func newWorkload(ctx resource.Context, cfg *echo.Config) (w *workload, err error
 			return nil, err
 		}
 
-		// Apply the service config to Galley.
-		svcCfg := serviceConfig{
-			service:  cfg.Service,
-			ns:       cfg.Namespace,
-			domain:   env.Domain,
-			version:  cfg.Version,
-			ports:    out.sidecar.GetPorts(),
-			locality: cfg.Locality,
-		}
-		if _, err = svcCfg.applyTo(cfg.Galley); err != nil {
-			return nil, err
-		}
-
 		// Update the ports in the configuration to reflect the port mapping between Envoy and the Application.
 		cfg.Ports = out.sidecar.GetPorts()
 	} else {
@@ -143,6 +130,19 @@ func newWorkload(ctx resource.Context, cfg *echo.Config) (w *workload, err error
 				InstancePort: p.Port,
 			})
 		}
+	}
+
+	// Apply the service config to Galley.
+	svcCfg := serviceConfig{
+		service:  cfg.Service,
+		ns:       cfg.Namespace,
+		domain:   env.Domain,
+		version:  cfg.Version,
+		ports:    cfg.Ports,
+		locality: cfg.Locality,
+	}
+	if _, err = svcCfg.applyTo(cfg.Galley); err != nil {
+		return nil, err
 	}
 
 	// Get the GRPC port.


### PR DESCRIPTION
Currently the native echo component only applies a configuration to Galley if it has a sidecar. This means that other echo instances will never receive an outbound configuration for it.