### PR TITLE
Report Istio version in istioctl proxy-status

### DIFF
--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -93,7 +93,7 @@ func statusPrintln(w io.Writer, status *writerStatus) error {
 	routeSynced := xdsStatus(status.RouteSent, status.RouteAcked)
 	endpointSynced := xdsStatus(status.EndpointSent, status.EndpointAcked)
 	fmt.Fprintf(w, "%v\t%v\t%v\t%v (%v%%)\t%v\t%v\t%v\n",
-		status.ProxyID, clusterSynced, listenerSynced, endpointSynced, status.EndpointPercent, routeSynced, status.pilot, status.ProxyVersion)
+		status.ProxyID, clusterSynced, listenerSynced, endpointSynced, status.EndpointPercent, routeSynced, status.pilot, status.IstioVersion)
 	return nil
 }
 

--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -92,8 +92,15 @@ func statusPrintln(w io.Writer, status *writerStatus) error {
 	listenerSynced := xdsStatus(status.ListenerSent, status.ListenerAcked)
 	routeSynced := xdsStatus(status.RouteSent, status.RouteAcked)
 	endpointSynced := xdsStatus(status.EndpointSent, status.EndpointAcked)
+	version := status.IstioVersion
+	if version == "" {
+		// If we can't find an Istio version (talking to a 1.1 pilot), fallback to the proxy version
+		// This is misleading, as the proxy version isn't always the same as the Istio version,
+		// but it is better than not providing any information.
+		version = status.ProxyVersion
+	}
 	fmt.Fprintf(w, "%v\t%v\t%v\t%v (%v%%)\t%v\t%v\t%v\n",
-		status.ProxyID, clusterSynced, listenerSynced, endpointSynced, status.EndpointPercent, routeSynced, status.pilot, status.IstioVersion)
+		status.ProxyID, clusterSynced, listenerSynced, endpointSynced, status.EndpointPercent, routeSynced, status.pilot, version)
 	return nil
 }
 

--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -97,7 +97,7 @@ func statusPrintln(w io.Writer, status *writerStatus) error {
 		// If we can't find an Istio version (talking to a 1.1 pilot), fallback to the proxy version
 		// This is misleading, as the proxy version isn't always the same as the Istio version,
 		// but it is better than not providing any information.
-		version = status.ProxyVersion
+		version = status.ProxyVersion + "*"
 	}
 	fmt.Fprintf(w, "%v\t%v\t%v\t%v (%v%%)\t%v\t%v\t%v\n",
 		status.ProxyID, clusterSynced, listenerSynced, endpointSynced, status.EndpointPercent, routeSynced, status.pilot, version)

--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -117,7 +117,7 @@ func TestStatusWriter_PrintSingle(t *testing.T) {
 				"pilot2": statusInputProxyVersion(),
 			},
 			filterPod: "proxy2",
-			want:      "testdata/singleStatus.txt",
+			want:      "testdata/singleStatusFallback.txt",
 		},
 		{
 			name: "error if given non-syncstatus info",

--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -112,6 +112,14 @@ func TestStatusWriter_PrintSingle(t *testing.T) {
 			want:      "testdata/singleStatus.txt",
 		},
 		{
+			name: "fallback to proxy version",
+			input: map[string][]v2.SyncStatus{
+				"pilot2": statusInputProxyVersion(),
+			},
+			filterPod: "proxy2",
+			want:      "testdata/singleStatus.txt",
+		},
+		{
 			name: "error if given non-syncstatus info",
 			input: map[string][]v2.SyncStatus{
 				"pilot1": {},
@@ -190,6 +198,23 @@ func statusInput3() []v2.SyncStatus {
 			ListenerAcked: "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			EndpointSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			EndpointAcked: time.Time{}.String(),
+			RouteSent:     "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			RouteAcked:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+		},
+	}
+}
+
+func statusInputProxyVersion() []v2.SyncStatus {
+	return []v2.SyncStatus{
+		{
+			ProxyID:       "proxy2",
+			ProxyVersion:  "1.1",
+			ClusterSent:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			ClusterAcked:  "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
+			ListenerSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			ListenerAcked: "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			EndpointSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			EndpointAcked: "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
 			RouteSent:     "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			RouteAcked:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 		},

--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -151,7 +151,7 @@ func statusInput1() []v2.SyncStatus {
 	return []v2.SyncStatus{
 		{
 			ProxyID:         "proxy1",
-			ProxyVersion:    "1.0",
+			IstioVersion:    "1.1",
 			ClusterSent:     "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			ClusterAcked:    "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
 			ListenerSent:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
@@ -167,7 +167,7 @@ func statusInput2() []v2.SyncStatus {
 	return []v2.SyncStatus{
 		{
 			ProxyID:       "proxy2",
-			ProxyVersion:  "1.0",
+			IstioVersion:  "1.1",
 			ClusterSent:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			ClusterAcked:  "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
 			ListenerSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
@@ -184,7 +184,7 @@ func statusInput3() []v2.SyncStatus {
 	return []v2.SyncStatus{
 		{
 			ProxyID:       "proxy3",
-			ProxyVersion:  "1.0",
+			IstioVersion:  "1.1",
 			ClusterSent:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			ClusterAcked:  time.Time{}.String(),
 			ListenerAcked: "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
@@ -1,4 +1,4 @@
 NAME       CDS                            LDS          EDS                                 RDS          PILOT      VERSION
-proxy1     STALE (1h0m0s)                 SYNCED       SYNCED (100%)                       NOT SENT     pilot1     1.0
-proxy2     STALE (1h0m0s)                 SYNCED       STALE (1h0m0s) (0%)                 SYNCED       pilot2     1.0
-proxy3     STALE (Never Acknowledged)     NOT SENT     STALE (Never Acknowledged) (0%)     SYNCED       pilot3     1.0
+proxy1     STALE (1h0m0s)                 SYNCED       SYNCED (100%)                       NOT SENT     pilot1     1.1
+proxy2     STALE (1h0m0s)                 SYNCED       STALE (1h0m0s) (0%)                 SYNCED       pilot2     1.1
+proxy3     STALE (Never Acknowledged)     NOT SENT     STALE (Never Acknowledged) (0%)     SYNCED       pilot3     1.1

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
@@ -1,3 +1,3 @@
 NAME       CDS                LDS        EDS                     RDS          PILOT      VERSION
-proxy1     STALE (1h0m0s)     SYNCED     SYNCED (100%)           NOT SENT     pilot1     1.0
-proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED       pilot1     1.0
+proxy1     STALE (1h0m0s)     SYNCED     SYNCED (100%)           NOT SENT     pilot1     1.1
+proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED       pilot1     1.1

--- a/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
@@ -1,2 +1,2 @@
 NAME       CDS                LDS        EDS                     RDS        PILOT      VERSION
-proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED     pilot2     1.0
+proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED     pilot2     1.1

--- a/istioctl/pkg/writer/pilot/testdata/singleStatusFallback.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatusFallback.txt
@@ -1,0 +1,2 @@
+NAME       CDS                LDS        EDS                     RDS        PILOT      VERSION
+proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED     pilot2     1.1*

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -163,6 +163,12 @@ func (node *Proxy) GetProxyVersion() (string, bool) {
 	return version, found
 }
 
+// GetIstioVersion returns the Istio version of the proxy, and whether it is present
+func (node *Proxy) GetIstioVersion() (string, bool) {
+	version, found := node.Metadata[NodeMetadataIstioVersion]
+	return version, found
+}
+
 // RouterMode decides the behavior of Istio Gateway (normal or sni-dnat)
 type RouterMode string
 
@@ -536,6 +542,9 @@ func isValidIPAddress(ip string) bool {
 const (
 	// NodeMetadataIstioProxyVersion specifies the Envoy version associated with the proxy
 	NodeMetadataIstioProxyVersion = "ISTIO_PROXY_VERSION"
+
+	// NodeMetadataIstioVersion specifies the Istio version associated with the proxy
+	NodeMetadataIstioVersion = "ISTIO_VERSION"
 
 	// NodeMetadataNetwork defines the network the node belongs to. It is an optional metadata,
 	// set at injection time. When set, the Endpoints returned to a note and not on same network

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -69,6 +69,7 @@ func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controll
 type SyncStatus struct {
 	ProxyID         string `json:"proxy,omitempty"`
 	ProxyVersion    string `json:"proxy_version,omitempty"`
+	IstioVersion    string `json:"istio_version,omitempty"`
 	ClusterSent     string `json:"cluster_sent,omitempty"`
 	ClusterAcked    string `json:"cluster_acked,omitempty"`
 	ListenerSent    string `json:"listener_sent,omitempty"`
@@ -88,9 +89,11 @@ func Syncz(w http.ResponseWriter, _ *http.Request) {
 		con.mu.RLock()
 		if con.modelNode != nil {
 			proxyVersion, _ := con.modelNode.GetProxyVersion()
+			istioVersion, _ := con.modelNode.GetIstioVersion()
 			syncz = append(syncz, SyncStatus{
 				ProxyID:         con.modelNode.ID,
 				ProxyVersion:    proxyVersion,
+				IstioVersion:    istioVersion,
 				ClusterSent:     con.ClusterNonceSent,
 				ClusterAcked:    con.ClusterNonceAcked,
 				ListenerSent:    con.ListenerNonceSent,


### PR DESCRIPTION
Currently we report the "proxy version", which is more of an internal
detail of of compatibility. Users actually are expecting to get the
Istio version. This changes what version is presented. Since this wasn't
exposed in /syncz, it had to be added there as well.

Fixes https://github.com/istio/istio/issues/13950
Fixes https://github.com/istio/istio/issues/9597