### PR TITLE
Remove warning for unknown flags in pilot-agent

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -96,11 +96,19 @@ var (
 		Short:        "Istio Pilot agent.",
 		Long:         "Istio Pilot agent runs in the sidecar or gateway container and bootstraps Envoy.",
 		SilenceUsage: true,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			// Allow unknown flags for backward-compatibility.
+			UnknownFlags: true,
+		},
 	}
 
 	proxyCmd = &cobra.Command{
 		Use:   "proxy",
 		Short: "Envoy proxy agent",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			// Allow unknown flags for backward-compatibility.
+			UnknownFlags: true,
+		},
 		RunE: func(c *cobra.Command, args []string) error {
 			cmd.PrintFlags(c.Flags())
 			if err := log.Configure(loggingOptions); err != nil {
@@ -590,20 +598,10 @@ func waitForCerts(fname string, maxWait time.Duration) {
 }
 
 func main() {
-	ignoreUnknownFlagsAndWarn(proxyCmd)
 	if err := rootCmd.Execute(); err != nil {
 		log.Errora(err)
 		os.Exit(-1)
 	}
-}
-
-// ignoreUnknownFlagsAndWarn will configure the command to allow unknown flags. It will parse the
-// flags before enabling this, so that a warning can be emitted if there is an unknown flag.
-func ignoreUnknownFlagsAndWarn(cmd *cobra.Command) {
-	if err := cmd.ParseFlags(os.Args); err != nil {
-		log.Warnf("Failed to parse flags, will retry with unknown flags enabled: %v", err)
-	}
-	cmd.FParseErrWhitelist.UnknownFlags = true
 }
 
 // isIPv6Proxy check the addresses slice and returns true for a valid IPv6 address


### PR DESCRIPTION
It seems there is no way to parse the args, then set the flag whitelist,
only when we run a certain command. This means that if we run something
like `version -o json` we will get error messages when we shouldn't.
This maybe would be a worthwhile trade off to get the warning messages
when we do actually pass a wrong flag to the proxy command, but because
it breaks istioctl I think the simplest way to go about this is to just
not have a warning message. Typically pilot-agent is configured by the
injector, so we don't really have too much concern of users
misconfiguring it without knowning.

Fixes https://github.com/istio/istio/issues/14224