### PR TITLE
Clean up pilot logging

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1277,8 +1277,8 @@ func (configgen *ConfigGeneratorImpl) generateManagementListeners(node *model.Pr
 			m := mgmtListeners[i]
 			l := util.GetByAddress(listeners, m.Address.String())
 			if l != nil {
-				log.Warnf("Omitting listener for management address %s (%s) due to collision with service listener %s (%s)",
-					m.Name, m.Address.String(), l.Name, l.Address.String())
+				log.Warnf("Omitting listener for management address %s due to collision with service listener %s",
+					m.Name, l.Name)
 				continue
 			}
 			listeners = append(listeners, m)

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -88,8 +88,8 @@ func (builder *ListenerBuilder) buildManagementListeners(_ *ConfigGeneratorImpl,
 		addressString := m.Address.String()
 		existingListener, ok := addresses[addressString]
 		if ok {
-			log.Warnf("Omitting listener for management address %s (%s) due to collision with service listener (%s)",
-				m.Name, m.Address.String(), existingListener.Name)
+			log.Warnf("Omitting listener for management address %s due to collision with service listener (%s)",
+				m.Name, existingListener.Name)
 			continue
 		} else {
 			// dedup management listeners as well

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -436,7 +436,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				// CDS REQ is the first request an envoy makes. This shows up
 				// immediately after connect. It is followed by EDS REQ as
 				// soon as the CDS push is returned.
-				adsLog.Infof("ADS:CDS: REQ %v %s %v raw: %s", peerAddr, con.ConID, time.Since(t0), discReq.String())
+				adsLog.Infof("ADS:CDS: REQ %v %s %v version:%s", peerAddr, con.ConID, time.Since(t0), discReq.VersionInfo)
 				con.CDSWatch = true
 				err := s.pushCds(con, s.globalPushContext(), versionInfo())
 				if err != nil {

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -812,13 +812,15 @@ func (c *Controller) updateEDS(ep *v1.Endpoints, event model.Event) {
 
 	// TODO: Endpoints include the service labels, maybe we can use them ?
 	// nodeName is also included, not needed
-	addresses := []string{}
-	for _, ss := range ep.Subsets {
-		for _, a := range ss.Addresses {
-			addresses = append(addresses, a.IP)
+	if log.InfoEnabled() {
+		var addresses []string
+		for _, ss := range ep.Subsets {
+			for _, a := range ss.Addresses {
+				addresses = append(addresses, a.IP)
+			}
 		}
+		log.Infof("Handle EDS endpoint %s in namespace %s -> %v", ep.Name, ep.Namespace, addresses)
 	}
-	log.Infof("Handle EDS endpoint %s in namespace %s -> %v", ep.Name, ep.Namespace, addresses)
 
 	_ = c.XDSUpdater.EDSUpdate(c.ClusterID, string(hostname), endpoints)
 }

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -781,7 +781,7 @@ func (c *Controller) updateEDS(ep *v1.Endpoints, event model.Event) {
 			for _, ea := range ss.Addresses {
 				pod := c.pods.getPodByIP(ea.IP)
 				if pod == nil {
-					log.Warnf("Endpoint without pod %s %v", ea.IP, ep)
+					log.Warnf("Endpoint without pod %s %s.%s", ea.IP, ep.Name, ep.Namespace)
 					if c.Env != nil {
 						c.Env.PushContext.Add(model.EndpointNoPod, string(hostname), nil, ea.IP)
 					}
@@ -812,8 +812,13 @@ func (c *Controller) updateEDS(ep *v1.Endpoints, event model.Event) {
 
 	// TODO: Endpoints include the service labels, maybe we can use them ?
 	// nodeName is also included, not needed
-
-	log.Infof("Handle EDS endpoint %s in namespace %s -> %v", ep.Name, ep.Namespace, ep.Subsets)
+	addresses := []string{}
+	for _, ss := range ep.Subsets {
+		for _, a := range ss.Addresses {
+			addresses = append(addresses, a.IP)
+		}
+	}
+	log.Infof("Handle EDS endpoint %s in namespace %s -> %v", ep.Name, ep.Namespace, addresses)
 
 	_ = c.XDSUpdater.EDSUpdate(c.ClusterID, string(hostname), endpoints)
 }


### PR DESCRIPTION
Some of the logs print out the complete struct, which is pretty hard to
read and is completely duplicated information. This cleans up some of
these, so logs are easier to grok.