### PR TITLE
Revert "Lock down development of installer (#13350)"

### DIFF
--- a/install/OWNERS
+++ b/install/OWNERS
@@ -1,5 +1,11 @@
-# No changes should be made here
-# Make all changes to istio-installer
 approvers:
+  - andraxylia
   - costinm
+  - gyliu513
+  - ijsnellf
+  - linsun
+  - mandarjog
+  - morvencao
+  - ostromart
   - sdake
+  - GregHanson

--- a/install/OWNERS
+++ b/install/OWNERS
@@ -1,11 +1,9 @@
 approvers:
-  - andraxylia
   - costinm
-  - gyliu513
-  - ijsnellf
+  - sdake
   - linsun
+  - rshriram
+  - howardjohn
   - mandarjog
   - morvencao
   - ostromart
-  - sdake
-  - GregHanson

--- a/install/kubernetes/helm/README.md
+++ b/install/kubernetes/helm/README.md
@@ -1,9 +1,3 @@
 # Installation using Helm
 
 Please follow the installation instructions from [istio.io](https://istio.io/docs/setup/kubernetes/install/helm/).
-
-# Development
-
-Istio installation is based upon a new decomposed installation technology in Istio 1.2.  As such, all development work should occur in [istio/installer](https://github.com/istio/installer).
-
-If you have work that you feel should be backported to resolve defects, please submit to this repository on the release-1.1 branch so it can be added to the 1.1.x stream.

--- a/install/kubernetes/helm/README.md
+++ b/install/kubernetes/helm/README.md
@@ -1,3 +1,7 @@
 # Installation using Helm
 
 Please follow the installation instructions from [istio.io](https://istio.io/docs/setup/kubernetes/install/helm/).
+
+# Development
+
+Future development for the installer is taking place on [istio/installer](https://github.com/istio/installer). Please add new features to this repository, as only bug fixes will be allowed here.


### PR DESCRIPTION
This reverts commit a08b48897e9d73d3f76f216a8f7cff76ea89549b.

The TOC decided we will be using the existing installer as default for 1.2 still, so we need to undo this. This is especially important since we locked down the owners and both of them will be at kubecon/vacation