### PR TITLE
Jinja version pined in bookinfo has CVE-2019-10906

### DIFF
--- a/samples/bookinfo/src/productpage/requirements.txt
+++ b/samples/bookinfo/src/productpage/requirements.txt
@@ -13,7 +13,7 @@ greenlet==0.4.15
 idna==2.8
 itsdangerous==1.1.0
 jaeger-client==3.13.0
-Jinja2==2.10
+Jinja2==2.10.1
 json2html==1.2.1
 MarkupSafe==0.23
 nose==1.3.7


### PR DESCRIPTION
requirements.txt containing this vulnerable version triggered a github alert this morning.

@vadimeisenbergibm would you mind reviewing that, if I understand correctly this was fixed and reintroduced by you in #13690 
Details about vulnerability available [here](https://nvd.nist.gov/vuln/detail/CVE-2019-10906).