### PR TITLE
fix #14235

### DIFF
--- a/mixer/pkg/runtime/routing/builder.go
+++ b/mixer/pkg/runtime/routing/builder.go
@@ -734,15 +734,17 @@ func (b *builder) addRuleOperations(
 		b.table.entries[tpb.TEMPLATE_VARIETY_CHECK] = &varietyTable{}
 	}
 	if b.table.entries[tpb.TEMPLATE_VARIETY_CHECK].entries == nil {
-		b.table.entries[tpb.TEMPLATE_VARIETY_CHECK].entries = map[string]*NamespaceTable{
-			namespace: {
-				entries:    []*Destination{},
-				directives: []*DirectiveGroup{},
-			},
-		}
+		b.table.entries[tpb.TEMPLATE_VARIETY_CHECK].entries = make(map[string]*NamespaceTable)
 	}
 
-	byNamespace := b.table.entries[tpb.TEMPLATE_VARIETY_CHECK].entries[namespace]
+	byNamespace, found := b.table.entries[tpb.TEMPLATE_VARIETY_CHECK].entries[namespace]
+	if !found {
+		byNamespace = &NamespaceTable{
+			entries:    []*Destination{},
+			directives: []*DirectiveGroup{},
+		}
+		b.table.entries[tpb.TEMPLATE_VARIETY_CHECK].entries[namespace] = byNamespace
+	}
 
 	var group *DirectiveGroup
 	for _, set := range byNamespace.directives {

--- a/mixer/pkg/runtime/routing/builder_test.go
+++ b/mixer/pkg/runtime/routing/builder_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gogo/protobuf/types"
 
+	tpb "istio.io/api/mixer/adapter/model/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/runtime/config"
 	"istio.io/istio/mixer/pkg/runtime/handler"
@@ -563,6 +564,30 @@ func buildTableWithTemplatesAndAdapters(templates map[string]*template.Info, ada
 	ht := handler.NewTable(handler.Empty(), s, nil)
 
 	return BuildTable(ht, s, "istio-system", debugInfo), s
+}
+
+func TestAddRuleOperations(t *testing.T) {
+	b := &builder{
+		table: &Table{entries: make(map[tpb.TemplateVariety]*varietyTable)},
+	}
+	// put something into the table for a different namespace
+	b.table.entries[tpb.TEMPLATE_VARIETY_CHECK] = &varietyTable{
+		entries: map[string]*NamespaceTable{
+			"ns2": {
+				entries:    []*Destination{},
+				directives: []*DirectiveGroup{},
+			},
+		},
+	}
+
+	// catch the panic
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fail()
+		}
+	}()
+
+	b.addRuleOperations("ns1", nil, nil)
 }
 
 func TestNonPointerAdapter(t *testing.T) {


### PR DESCRIPTION
Fixes #14235

The error occurs when a rule with no actions and some header operations is supplied in a config with at least two namespaces.

/assign @douglas-reid 
 
Signed-off-by: Kuat Yessenov <kuat@google.com>