### PR TITLE
refactor and add test for node-agent command

### DIFF
--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -112,6 +112,11 @@ const (
 	// The environmental variable name for staled connection recycle job running interval.
 	// example value format like "5m"
 	staledConnectionRecycleInterval = "STALED_CONNECTION_RECYCLE_RUN_INTERVAL"
+
+	// The environmental variable name for the initial backoff in milliseconds.
+	// example value format like "10"
+	InitialBackoff = "INITIAL_BACKOFF_MSEC"
+	InitialBackoffFlag = "initialBackoff"
 )
 
 var (
@@ -134,18 +139,8 @@ var (
 
 			gatewaySdsCacheOptions = workloadSdsCacheOptions
 
-			if serverOptions.EnableIngressGatewaySDS && serverOptions.EnableWorkloadSDS &&
-				serverOptions.IngressGatewayUDSPath == serverOptions.WorkloadUDSPath {
-				log.Error("UDS paths for ingress gateway and workload are the same")
-				os.Exit(1)
-			}
-			if serverOptions.CAProviderName == "" && serverOptions.EnableWorkloadSDS {
-				log.Error("CA Provider is missing")
-				os.Exit(1)
-			}
-			if serverOptions.CAEndpoint == "" && serverOptions.EnableWorkloadSDS {
-				log.Error("CA Endpoint is missing")
-				os.Exit(1)
+			if err := validateOptions(); err != nil {
+				return err
 			}
 
 			stop := make(chan struct{})
@@ -224,6 +219,7 @@ var (
 	secretRefreshGraceDurationEnv      = env.RegisterDurationVar(SecretRefreshGraceDuration, 1*time.Hour, "").Get()
 	secretRotationIntervalEnv          = env.RegisterDurationVar(SecretRotationInterval, 10*time.Minute, "").Get()
 	staledConnectionRecycleIntervalEnv = env.RegisterDurationVar(staledConnectionRecycleInterval, 5*time.Minute, "").Get()
+	initialBackoffEnv                  = env.RegisterIntVar(InitialBackoff, 10, "").Get()
 )
 
 func applyEnvVars(cmd *cobra.Command) {
@@ -292,10 +288,35 @@ func applyEnvVars(cmd *cobra.Command) {
 	}
 
 	serverOptions.RecycleInterval = staledConnectionRecycleIntervalEnv
+
+	if !cmd.Flag(InitialBackoffFlag).Changed {
+		workloadSdsCacheOptions.InitialBackoff = int64(initialBackoffEnv)
+	}
 }
 
-var defaultInitialBackoff = 10
-var initialBackoffEnvVar = env.RegisterIntVar("INITIAL_BACKOFF_MSEC", defaultInitialBackoff, "")
+func validateOptions() error {
+	// The initial backoff time (in millisec) is a random number between 0 and initBackoff.
+	// Default to 10, a valid range is [10, 120000].
+	initBackoff := workloadSdsCacheOptions.InitialBackoff
+	if initBackoff < 10 || initBackoff > 120000 {
+		return fmt.Errorf("initial backoff should be within range 10 to 120000, found: %d", initBackoff)
+	}
+
+	if serverOptions.EnableIngressGatewaySDS && serverOptions.EnableWorkloadSDS &&
+			serverOptions.IngressGatewayUDSPath == serverOptions.WorkloadUDSPath {
+		return fmt.Errorf("UDS paths for ingress gateway and workload cannot be the same: %s", serverOptions.IngressGatewayUDSPath)
+	}
+
+	if serverOptions.EnableWorkloadSDS {
+		if serverOptions.CAProviderName == "" {
+			return fmt.Errorf("CA provider cannot be empty when workload SDS is enabled")
+		}
+		if serverOptions.CAEndpoint == "" {
+			return fmt.Errorf("CA endpoint cannot be empty when workload SDS is enabled")
+		}
+	}
+	return nil
+}
 
 func main() {
 	rootCmd.PersistentFlags().BoolVar(&serverOptions.EnableWorkloadSDS, enableWorkloadSDSFlag,
@@ -328,15 +349,7 @@ func main() {
 	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.RotationInterval, secretRotationIntervalFlag,
 		10*time.Minute, "Secret rotation job running interval")
 
-	// The initial backoff time (in millisec) is a random number between 0 and initBackoff.
-	// Default to 10, a valid range is [10, 120000].
-	initBackoff := int64(initialBackoffEnvVar.Get())
-	if initBackoff < 10 || initBackoff > 120000 {
-		log.Errorf("INITIAL_BACKOFF_MSEC should be within range 10 to 120000")
-		os.Exit(1)
-	}
-	rootCmd.PersistentFlags().Int64Var(&workloadSdsCacheOptions.InitialBackoff, "initialBackoff",
-		initBackoff, "The initial backoff interval in milliseconds")
+	rootCmd.PersistentFlags().Int64Var(&workloadSdsCacheOptions.InitialBackoff, InitialBackoffFlag,	10, "The initial backoff interval in milliseconds")
 
 	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.EvictionDuration, "secretEvictionDuration",
 		24*time.Hour, "Secret eviction time duration")

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/istio/security/pkg/nodeagent/sds"
@@ -31,7 +30,6 @@ import (
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 	"istio.io/pkg/version"
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
@@ -115,7 +113,7 @@ const (
 
 	// The environmental variable name for the initial backoff in milliseconds.
 	// example value format like "10"
-	InitialBackoff = "INITIAL_BACKOFF_MSEC"
+	InitialBackoff     = "INITIAL_BACKOFF_MSEC"
 	InitialBackoffFlag = "initialBackoff"
 )
 
@@ -303,7 +301,7 @@ func validateOptions() error {
 	}
 
 	if serverOptions.EnableIngressGatewaySDS && serverOptions.EnableWorkloadSDS &&
-			serverOptions.IngressGatewayUDSPath == serverOptions.WorkloadUDSPath {
+		serverOptions.IngressGatewayUDSPath == serverOptions.WorkloadUDSPath {
 		return fmt.Errorf("UDS paths for ingress gateway and workload cannot be the same: %s", serverOptions.IngressGatewayUDSPath)
 	}
 
@@ -349,7 +347,8 @@ func main() {
 	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.RotationInterval, secretRotationIntervalFlag,
 		10*time.Minute, "Secret rotation job running interval")
 
-	rootCmd.PersistentFlags().Int64Var(&workloadSdsCacheOptions.InitialBackoff, InitialBackoffFlag,	10, "The initial backoff interval in milliseconds")
+	rootCmd.PersistentFlags().Int64Var(&workloadSdsCacheOptions.InitialBackoff, InitialBackoffFlag, 10,
+		"The initial backoff interval in milliseconds, must be within the range [10, 120000]")
 
 	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.EvictionDuration, "secretEvictionDuration",
 		24*time.Hour, "Secret eviction time duration")

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/istio/security/pkg/nodeagent/sds"
@@ -30,7 +32,6 @@ import (
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 	"istio.io/pkg/version"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 const (

--- a/security/cmd/node_agent_k8s/main_test.go
+++ b/security/cmd/node_agent_k8s/main_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"istio.io/istio/security/pkg/nodeagent/cache"
+	"istio.io/istio/security/pkg/nodeagent/sds"
+	"strings"
+	"testing"
+)
+
+func TestValidateOptions(t *testing.T) {
+	cases := []struct{
+		name            string
+		setExtraOptions func()
+		errorMsg        string
+	}{
+		{
+			name: "valid options",
+		},
+		{
+			name: "initial backoff too small",
+			setExtraOptions: func() {
+				workloadSdsCacheOptions.InitialBackoff = 9
+			},
+			errorMsg: "initial backoff should be within range 10 to 120000",
+		},
+		{
+			name: "initial backoff too large",
+			setExtraOptions: func() {
+				workloadSdsCacheOptions.InitialBackoff = 120001
+			},
+			errorMsg: "initial backoff should be within range 10 to 120000",
+		},
+		{
+			name: "same path for workload SDS and ingress SDS",
+			setExtraOptions: func() {
+				serverOptions.IngressGatewayUDSPath = "/same"
+				serverOptions.WorkloadUDSPath = "/same"
+			},
+			errorMsg: "UDS paths for ingress gateway and workload cannot be the same",
+		},
+		{
+			name: "empty CA provider when workload SDS enabled",
+			setExtraOptions: func() {
+				serverOptions.CAProviderName = ""
+			},
+			errorMsg: "CA provider cannot be empty when workload SDS is enabled",
+		},
+		{
+			name: "empty CA endpoint when workload SDS enabled",
+			setExtraOptions: func() {
+				serverOptions.CAEndpoint = ""
+			},
+			errorMsg: "CA endpoint cannot be empty when workload SDS is enabled",
+		},
+	}
+
+	for _, c := range cases {
+
+		// Set the valid options as the base for the testing.
+		workloadSdsCacheOptions = cache.Options{
+			InitialBackoff: 10,
+		}
+		serverOptions = sds.Options{
+			EnableIngressGatewaySDS: true,
+			EnableWorkloadSDS: true,
+			IngressGatewayUDSPath: "/abc",
+			WorkloadUDSPath: "/xyz",
+			CAEndpoint: "endpoint",
+			CAProviderName: "provider",
+		}
+
+		// Set extra options from each test case
+		if c.setExtraOptions != nil {
+			c.setExtraOptions()
+		}
+
+		got := validateOptions()
+		if c.errorMsg == "" {
+			if got != nil {
+				t.Errorf("got %q but expect no error", got)
+			}
+		} else {
+			if !strings.HasPrefix(got.Error(), c.errorMsg) {
+				t.Errorf("got %q but expect to have error: %q", got, c.errorMsg)
+			}
+		}
+	}
+}

--- a/security/cmd/node_agent_k8s/main_test.go
+++ b/security/cmd/node_agent_k8s/main_test.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"istio.io/istio/security/pkg/nodeagent/cache"
-	"istio.io/istio/security/pkg/nodeagent/sds"
 	"strings"
 	"testing"
+
+	"istio.io/istio/security/pkg/nodeagent/cache"
+	"istio.io/istio/security/pkg/nodeagent/sds"
 )
 
 func TestValidateOptions(t *testing.T) {
-	cases := []struct{
+	cases := []struct {
 		name            string
 		setExtraOptions func()
 		errorMsg        string
@@ -62,11 +63,11 @@ func TestValidateOptions(t *testing.T) {
 		}
 		serverOptions = sds.Options{
 			EnableIngressGatewaySDS: true,
-			EnableWorkloadSDS: true,
-			IngressGatewayUDSPath: "/abc",
-			WorkloadUDSPath: "/xyz",
-			CAEndpoint: "endpoint",
-			CAProviderName: "provider",
+			EnableWorkloadSDS:       true,
+			IngressGatewayUDSPath:   "/abc",
+			WorkloadUDSPath:         "/xyz",
+			CAEndpoint:              "endpoint",
+			CAProviderName:          "provider",
 		}
 
 		// Set extra options from each test case


### PR DESCRIPTION
- refactored the `initialBackoff` flag to have the same style like other flags (the current one changes the default value in the command flag based on environment variable, which seems not right)
- refactored the validation to a single function
- added tests for the validation logic

We probably should refactor some of the functions out and make the `main.go` small and only related to the command line parsing.

https://github.com/istio/istio/issues/13439