### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -513,7 +513,7 @@ common-test:
 
 .PHONY: selected-pkg-test
 selected-pkg-test:
-	find ${WHAT} -name "*_test.go"|xargs -i dirname {}|uniq|xargs -i go test ${T} {}
+	find ${WHAT} -name "*_test.go" | xargs -I {} dirname {} | uniq | xargs -I {} go test ${T} ./{}
 
 #-----------------------------------------------------------------------------
 # Target: coverage


### PR DESCRIPTION
Currently, running `make test WHAT=<component>` doesn't work:
* `-i` is deprecated on `xargs` and has been replaced with `-I {}`
* the list of files to run run `go test` against need to be prefixed with `./` (as with other test commands), otherwise it will try to find them in $GOROOT and $GOPATH