### PR TITLE
Add initial_fetch_timeout option to Pilot

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -25,6 +25,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/config/grpc_credential/v2alpha"
 	"github.com/gogo/protobuf/types"
 
+	"istio.io/istio/pkg/features/pilot"
+
 	authn "istio.io/api/authentication/v1alpha1"
 )
 
@@ -106,6 +108,7 @@ func ConstructSdsSecretConfigForGatewayListener(name, sdsUdsPath string) *auth.S
 					},
 				},
 			},
+			InitialFetchTimeout: pilot.InitialFetchTimeout,
 		},
 	}
 }
@@ -165,6 +168,7 @@ func ConstructSdsSecretConfig(name, sdsUdsPath string, useK8sSATrustworthyJwt, u
 					},
 				},
 			},
+			InitialFetchTimeout: pilot.InitialFetchTimeout,
 		},
 	}
 }

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/config/grpc_credential/v2alpha"
 	"github.com/gogo/protobuf/types"
+
+	"istio.io/istio/pkg/features/pilot"
 )
 
 func TestParseJwksURI(t *testing.T) {
@@ -121,6 +123,7 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 			expected: &auth.SdsSecretConfig{
 				Name: "spiffe://cluster.local/ns/bar/sa/foo",
 				SdsConfig: &core.ConfigSource{
+					InitialFetchTimeout: pilot.InitialFetchTimeout,
 					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 						ApiConfigSource: &core.ApiConfigSource{
 							ApiType: core.ApiConfigSource_GRPC,
@@ -193,6 +196,7 @@ func TestConstructSdsSecretConfigForGatewayListener(t *testing.T) {
 			expected: &auth.SdsSecretConfig{
 				Name: "spiffe://cluster.local/ns/bar/sa/foo",
 				SdsConfig: &core.ConfigSource{
+					InitialFetchTimeout: pilot.InitialFetchTimeout,
 					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 						ApiConfigSource: &core.ApiConfigSource{
 							ApiType: core.ApiConfigSource_GRPC,
@@ -250,6 +254,7 @@ func constructGCECallCredConfig() *core.GrpcService_GoogleGrpc_CallCredentials {
 func constructsdsconfighelper(tokenFileName, headerKey string, metaConfig *v2alpha.FileBasedMetadataConfig) *core.ConfigSource {
 	any := findOrMarshalFileBasedMetadataConfig(tokenFileName, headerKey, metaConfig)
 	return &core.ConfigSource{
+		InitialFetchTimeout: pilot.InitialFetchTimeout,
 		ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 			ApiConfigSource: &core.ApiConfigSource{
 				ApiType: core.ApiConfigSource_GRPC,

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -27,6 +27,8 @@ import (
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
 
+	"istio.io/istio/pkg/features/pilot"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -265,6 +267,7 @@ func updateEds(cluster *apiv2.Cluster) {
 			ConfigSourceSpecifier: &core.ConfigSource_Ads{
 				Ads: &core.AggregatedConfigSource{},
 			},
+			InitialFetchTimeout: pilot.InitialFetchTimeout,
 		},
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/features/pilot"
 	"istio.io/istio/pkg/proto"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -81,6 +82,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 						{
 							Name: "ingress-sds-resource-name",
 							SdsConfig: &core.ConfigSource{
+								InitialFetchTimeout: pilot.InitialFetchTimeout,
 								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 									ApiConfigSource: &core.ApiConfigSource{
 										ApiType: core.ApiConfigSource_GRPC,
@@ -122,6 +124,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 						{
 							Name: "ingress-sds-resource-name",
 							SdsConfig: &core.ConfigSource{
+								InitialFetchTimeout: pilot.InitialFetchTimeout,
 								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 									ApiConfigSource: &core.ApiConfigSource{
 										ApiType: core.ApiConfigSource_GRPC,
@@ -234,6 +237,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 						{
 							Name: "ingress-sds-resource-name",
 							SdsConfig: &core.ConfigSource{
+								InitialFetchTimeout: pilot.InitialFetchTimeout,
 								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 									ApiConfigSource: &core.ApiConfigSource{
 										ApiType: core.ApiConfigSource_GRPC,
@@ -260,6 +264,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
 								Name: "ingress-sds-resource-name-cacert",
 								SdsConfig: &core.ConfigSource{
+									InitialFetchTimeout: pilot.InitialFetchTimeout,
 									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 										ApiConfigSource: &core.ApiConfigSource{
 											ApiType: core.ApiConfigSource_GRPC,

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1461,6 +1461,7 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 					ConfigSourceSpecifier: &core.ConfigSource_Ads{
 						Ads: &core.AggregatedConfigSource{},
 					},
+					InitialFetchTimeout: pilot.InitialFetchTimeout,
 				},
 				RouteConfigName: httpOpts.rds,
 			},

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"testing"
 
+	"istio.io/istio/pkg/features/pilot"
+
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
@@ -727,6 +729,7 @@ func constructSDSConfig(name, sdsudspath string) *auth.SdsSecretConfig {
 	return &auth.SdsSecretConfig{
 		Name: name,
 		SdsConfig: &core.ConfigSource{
+			InitialFetchTimeout: pilot.InitialFetchTimeout,
 			ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 				ApiConfigSource: &core.ApiConfigSource{
 					ApiType: core.ApiConfigSource_GRPC,

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/gogo/protobuf/types"
+
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
@@ -88,6 +90,15 @@ var (
 	// Alpha in 1.1, may become the default or be turned into a Sidecar API or mesh setting. Only applies to namespaces
 	// where Sidecar is enabled.
 	HTTP10 = env.RegisterBoolVar("PILOT_HTTP10", false, "").Get()
+
+	initialFetchTimeoutVar = env.RegisterDurationVar(
+		"PILOT_INITIAL_FETCH_TIMEOUT",
+		0,
+		"Specifies the initial_fetch_timeout for config. If this time is reached without "+
+			"a response to the config requested by Envoy, the Envoy will move on with the init phase. "+
+			"This prevents envoy from getting stuck waiting on config during startup.",
+	)
+	InitialFetchTimeout = types.DurationProto(initialFetchTimeoutVar.Get())
 
 	// TerminationDrainDuration is the amount of time allowed for connections to complete on pilot-agent shutdown.
 	// On receiving SIGTERM or SIGINT, pilot-agent tells the active Envoy to start draining,


### PR DESCRIPTION
This is defaulted to 0s, which is the same as not setting a timeout, so
this change is effectively off by default. When it is on, this change
will be useful to prevent states where listeners get stuck during
initialization, which can make gateways/sidecars not able to recieve traffic.