### PR TITLE
[Cherrypick 1.1 -> 1.2] Sort Config in stable ordering (#14080)

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -670,6 +670,14 @@ func (store *istioConfigStore) ServiceEntries() []Config {
 // sortConfigByCreationTime sorts the list of config objects in ascending order by their creation time (if available).
 func sortConfigByCreationTime(configs []Config) []Config {
 	sort.SliceStable(configs, func(i, j int) bool {
+		// If creation time is the same, then behavior is nondeterministic. In this case, we can
+		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
+		// CreationTimestamp is stored in seconds, so this is not uncommon.
+		if configs[i].CreationTimestamp == configs[j].CreationTimestamp {
+			in := configs[i].Name + "." + configs[i].Namespace
+			jn := configs[j].Name + "." + configs[j].Namespace
+			return in < jn
+		}
 		return configs[i].CreationTimestamp.Before(configs[j].CreationTimestamp)
 	})
 	return configs

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -133,6 +133,13 @@ var (
 	// this flag) is to just skip the invalid route.
 	DisablePartialRouteResponse = os.Getenv("PILOT_DISABLE_PARTIAL_ROUTE_RESPONSE") == "1"
 
+	// DisableEmptyRouteResponse provides an option to disable a partial route response. This
+	// will cause Pilot to ignore a route request if Pilot generates a nil route (due to an error).
+	// This may cause Envoy to wait forever for the route, blocking listeners from receiving traffic.
+	// The default behavior (without this flag set) is to explicitly send an empty route. This
+	// will break routing for that particular route, but allow others on the same listener to work.
+	DisableEmptyRouteResponse = os.Getenv("PILOT_DISABLE_EMPTY_ROUTE_RESPONSE") == "1"
+
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
 	disableXDSMarshalingToAnyVar = env.RegisterStringVar("PILOT_DISABLE_XDS_MARSHALING_TO_ANY", "", "")
 	DisableXDSMarshalingToAny    = func() bool {


### PR DESCRIPTION
Because we sort Configs by CreationTimestamp, we can run into
nondeterministic behavior if two Configs have the same timestamp. Since
the resolution is 1s, this isn't uncommon. This specifically causes
issues for Gateways, where two gateways with overlapping hosts, created
at the same time, can cause Pilot to fail to generate routes correctly
and lead to Envoy listeners stuck in a warming state (never accept
traffic). This can be mitigated by sorting by the name.namespace of the
config if they have a matching creation timestamp.