### PR TITLE
Mark locality LB tests as flaky

### DIFF
--- a/tests/integration/pilot/locality/failover_test.go
+++ b/tests/integration/pilot/locality/failover_test.go
@@ -109,6 +109,8 @@ func TestFailover(t *testing.T) {
 
 			ctx.NewSubTest("EDS").
 				RequiresEnvironment(environment.Kube).
+				// TODO(https://github.com/istio/istio/issues/13812)
+				Label(label.Flaky).
 				RunParallel(func(ctx framework.TestContext) {
 					ns := namespace.NewOrFail(ctx, ctx, "locality-failover-eds", true)
 

--- a/tests/integration/pilot/locality/prioritized_test.go
+++ b/tests/integration/pilot/locality/prioritized_test.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/pkg/log"
 )
 
@@ -66,6 +67,8 @@ func TestPrioritized(t *testing.T) {
 
 			ctx.NewSubTest("CDS").
 				RequiresEnvironment(environment.Kube).
+				// TODO(https://github.com/istio/istio/issues/13812)
+				Label(label.Flaky).
 				RunParallel(func(ctx framework.TestContext) {
 					ns := namespace.NewOrFail(ctx, ctx, "locality-prioritized-cds", true)
 
@@ -95,6 +98,8 @@ func TestPrioritized(t *testing.T) {
 
 			ctx.NewSubTest("EDS").
 				RequiresEnvironment(environment.Kube).
+				// TODO(https://github.com/istio/istio/issues/13812)
+				Label(label.Flaky).
 				RunParallel(func(ctx framework.TestContext) {
 
 					ns := namespace.NewOrFail(ctx, ctx, "locality-prioritized-eds", true)


### PR DESCRIPTION
We had marked on of the 4 tests as flaky previously, but all 4 fail very
regularly, so they don't provide a good signal. Long term we should find
out the root cause of this, but for now we can mark them as flaky so
real failures don't go unnoticed.