### PR TITLE
Cherry pick #14043

### DIFF
--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -108,6 +108,11 @@ const (
 	// example value format like "20m"
 	SecretRotationInterval     = "SECRET_JOB_RUN_INTERVAL"
 	secretRotationIntervalFlag = "secretRotationInterval"
+
+	// The environmental variable name for staled connection recycle job running interval.
+	// example value format like "5m"
+	staledConnectionRecycleInterval = "STALED_CONNECTION_RECYCLE_RUN_INTERVAL"
+	staledConnectionRecycleIntervalFlag = "staledConnectionRecycleInterval"
 )
 
 var (
@@ -219,6 +224,7 @@ var (
 	secretTTLEnv                  = env.RegisterDurationVar(secretTTL, 24*time.Hour, "").Get()
 	secretRefreshGraceDurationEnv = env.RegisterDurationVar(SecretRefreshGraceDuration, 1*time.Hour, "").Get()
 	secretRotationIntervalEnv     = env.RegisterDurationVar(SecretRotationInterval, 10*time.Minute, "").Get()
+	staledConnectionRecycleIntervalEnv = env.RegisterDurationVar(staledConnectionRecycleInterval, 5 * time.Minute, "").Get()
 )
 
 func applyEnvVars(cmd *cobra.Command) {
@@ -236,6 +242,10 @@ func applyEnvVars(cmd *cobra.Command) {
 
 	if !cmd.Flag(alwaysValidTokenFlagFlag).Changed {
 		serverOptions.AlwaysValidTokenFlag = alwaysValidTokenFlagEnv
+	}
+
+	if !cmd.Flag(staledConnectionRecycleIntervalFlag).Changed {
+		serverOptions.RecycleInterval = staledConnectionRecycleIntervalEnv
 	}
 
 	if !cmd.Flag(caProviderFlag).Changed {
@@ -333,6 +343,9 @@ func main() {
 
 	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.EvictionDuration, "secretEvictionDuration",
 		24*time.Hour, "Secret eviction time duration")
+
+	rootCmd.PersistentFlags().DurationVar(&serverOptions.RecycleInterval, staledConnectionRecycleIntervalFlag,
+		5 * time.Minute, "Staled connection recycle interval.")
 
 	rootCmd.PersistentFlags().BoolVar(&workloadSdsCacheOptions.AlwaysValidTokenFlag, alwaysValidTokenFlagFlag,
 		false,

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -112,7 +112,6 @@ const (
 	// The environmental variable name for staled connection recycle job running interval.
 	// example value format like "5m"
 	staledConnectionRecycleInterval     = "STALED_CONNECTION_RECYCLE_RUN_INTERVAL"
-	staledConnectionRecycleIntervalFlag = "staledConnectionRecycleInterval"
 )
 
 var (
@@ -244,10 +243,6 @@ func applyEnvVars(cmd *cobra.Command) {
 		serverOptions.AlwaysValidTokenFlag = alwaysValidTokenFlagEnv
 	}
 
-	if !cmd.Flag(staledConnectionRecycleIntervalFlag).Changed {
-		serverOptions.RecycleInterval = staledConnectionRecycleIntervalEnv
-	}
-
 	if !cmd.Flag(caProviderFlag).Changed {
 		serverOptions.CAProviderName = caProviderEnv
 	}
@@ -343,9 +338,6 @@ func main() {
 
 	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.EvictionDuration, "secretEvictionDuration",
 		24*time.Hour, "Secret eviction time duration")
-
-	rootCmd.PersistentFlags().DurationVar(&serverOptions.RecycleInterval, staledConnectionRecycleIntervalFlag,
-		5*time.Minute, "Staled connection recycle interval.")
 
 	rootCmd.PersistentFlags().BoolVar(&workloadSdsCacheOptions.AlwaysValidTokenFlag, alwaysValidTokenFlagFlag,
 		false,

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -111,7 +111,7 @@ const (
 
 	// The environmental variable name for staled connection recycle job running interval.
 	// example value format like "5m"
-	staledConnectionRecycleInterval = "STALED_CONNECTION_RECYCLE_RUN_INTERVAL"
+	staledConnectionRecycleInterval     = "STALED_CONNECTION_RECYCLE_RUN_INTERVAL"
 	staledConnectionRecycleIntervalFlag = "staledConnectionRecycleInterval"
 )
 
@@ -208,23 +208,23 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache, gatewaySecr
 }
 
 var (
-	pluginNamesEnv                = env.RegisterStringVar(pluginNames, "", "").Get()
-	enableWorkloadSDSEnv          = env.RegisterBoolVar(enableWorkloadSDS, true, "").Get()
-	enableIngressGatewaySDSEnv    = env.RegisterBoolVar(enableIngressGatewaySDS, false, "").Get()
-	alwaysValidTokenFlagEnv       = env.RegisterBoolVar(alwaysValidTokenFlag, false, "").Get()
-	skipValidateCertFlagEnv       = env.RegisterBoolVar(skipValidateCertFlag, false, "").Get()
-	caProviderEnv                 = env.RegisterStringVar(caProvider, "", "").Get()
-	caEndpointEnv                 = env.RegisterStringVar(caEndpoint, "", "").Get()
-	trustDomainEnv                = env.RegisterStringVar(trustDomain, "", "").Get()
-	vaultAddressEnv               = env.RegisterStringVar(vaultAddress, "", "").Get()
-	vaultRoleEnv                  = env.RegisterStringVar(vaultRole, "", "").Get()
-	vaultAuthPathEnv              = env.RegisterStringVar(vaultAuthPath, "", "").Get()
-	vaultSignCsrPathEnv           = env.RegisterStringVar(vaultSignCsrPath, "", "").Get()
-	vaultTLSRootCertEnv           = env.RegisterStringVar(vaultTLSRootCert, "", "").Get()
-	secretTTLEnv                  = env.RegisterDurationVar(secretTTL, 24*time.Hour, "").Get()
-	secretRefreshGraceDurationEnv = env.RegisterDurationVar(SecretRefreshGraceDuration, 1*time.Hour, "").Get()
-	secretRotationIntervalEnv     = env.RegisterDurationVar(SecretRotationInterval, 10*time.Minute, "").Get()
-	staledConnectionRecycleIntervalEnv = env.RegisterDurationVar(staledConnectionRecycleInterval, 5 * time.Minute, "").Get()
+	pluginNamesEnv                     = env.RegisterStringVar(pluginNames, "", "").Get()
+	enableWorkloadSDSEnv               = env.RegisterBoolVar(enableWorkloadSDS, true, "").Get()
+	enableIngressGatewaySDSEnv         = env.RegisterBoolVar(enableIngressGatewaySDS, false, "").Get()
+	alwaysValidTokenFlagEnv            = env.RegisterBoolVar(alwaysValidTokenFlag, false, "").Get()
+	skipValidateCertFlagEnv            = env.RegisterBoolVar(skipValidateCertFlag, false, "").Get()
+	caProviderEnv                      = env.RegisterStringVar(caProvider, "", "").Get()
+	caEndpointEnv                      = env.RegisterStringVar(caEndpoint, "", "").Get()
+	trustDomainEnv                     = env.RegisterStringVar(trustDomain, "", "").Get()
+	vaultAddressEnv                    = env.RegisterStringVar(vaultAddress, "", "").Get()
+	vaultRoleEnv                       = env.RegisterStringVar(vaultRole, "", "").Get()
+	vaultAuthPathEnv                   = env.RegisterStringVar(vaultAuthPath, "", "").Get()
+	vaultSignCsrPathEnv                = env.RegisterStringVar(vaultSignCsrPath, "", "").Get()
+	vaultTLSRootCertEnv                = env.RegisterStringVar(vaultTLSRootCert, "", "").Get()
+	secretTTLEnv                       = env.RegisterDurationVar(secretTTL, 24*time.Hour, "").Get()
+	secretRefreshGraceDurationEnv      = env.RegisterDurationVar(SecretRefreshGraceDuration, 1*time.Hour, "").Get()
+	secretRotationIntervalEnv          = env.RegisterDurationVar(SecretRotationInterval, 10*time.Minute, "").Get()
+	staledConnectionRecycleIntervalEnv = env.RegisterDurationVar(staledConnectionRecycleInterval, 5*time.Minute, "").Get()
 )
 
 func applyEnvVars(cmd *cobra.Command) {
@@ -345,7 +345,7 @@ func main() {
 		24*time.Hour, "Secret eviction time duration")
 
 	rootCmd.PersistentFlags().DurationVar(&serverOptions.RecycleInterval, staledConnectionRecycleIntervalFlag,
-		5 * time.Minute, "Staled connection recycle interval.")
+		5*time.Minute, "Staled connection recycle interval.")
 
 	rootCmd.PersistentFlags().BoolVar(&workloadSdsCacheOptions.AlwaysValidTokenFlag, alwaysValidTokenFlagFlag,
 		false,

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -111,7 +111,7 @@ const (
 
 	// The environmental variable name for staled connection recycle job running interval.
 	// example value format like "5m"
-	staledConnectionRecycleInterval     = "STALED_CONNECTION_RECYCLE_RUN_INTERVAL"
+	staledConnectionRecycleInterval = "STALED_CONNECTION_RECYCLE_RUN_INTERVAL"
 )
 
 var (
@@ -290,6 +290,8 @@ func applyEnvVars(cmd *cobra.Command) {
 	if !cmd.Flag(skipValidateCertFlag).Changed {
 		workloadSdsCacheOptions.SkipValidateCert = skipValidateCertFlagEnv
 	}
+
+	serverOptions.RecycleInterval = staledConnectionRecycleIntervalEnv
 }
 
 var defaultInitialBackoff = 10

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -61,6 +61,10 @@ const (
 
 	// initialBackOffIntervalInMilliSec is the initial backoff time interval when hitting non-retryable error in CSR request.
 	initialBackOffIntervalInMilliSec = 50
+
+	// Timeout the K8s update/delete notification threads. This is to make sure to unblock the
+	// secret watch main thread in case those child threads got stuck due to any reason.
+	notifyK8sSecretTimeout = 30 * time.Second
 )
 
 type k8sJwtPayload struct {
@@ -298,6 +302,26 @@ func (sc *SecretCache) DeleteSecret(connectionID, resourceName string) {
 	sc.secrets.Delete(key)
 }
 
+func (sc *SecretCache) callbackWithTimeout(connectionID string, secretName string, secret *model.SecretItem) {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		if sc.notifyCallback != nil {
+			if err := sc.notifyCallback(connectionID, secretName, secret); err != nil {
+				log.Errorf("Failed to notify secret change for proxy %q: %v", connectionID, err)
+			}
+		} else {
+			log.Warnf("secret cache notify callback isn't set")
+		}
+	}()
+	select {
+	case <-c:
+		return // completed normally
+	case <-time.After(notifyK8sSecretTimeout):
+		log.Warnf("Notify secret change for proxy %q got timeout", connectionID)
+	}
+}
+
 // Close shuts down the secret cache.
 func (sc *SecretCache) Close() {
 	sc.closing <- true
@@ -331,13 +355,7 @@ func (sc *SecretCache) DeleteK8sSecret(secretName string) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				if sc.notifyCallback != nil {
-					if err := sc.notifyCallback(connectionID, secretName, nil /*nil indicates close the streaming connection to proxy*/); err != nil {
-						log.Errorf("Failed to notify secret change for proxy %q: %v", connectionID, err)
-					}
-				} else {
-					log.Warn("secret cache notify callback isn't set")
-				}
+				sc.callbackWithTimeout(connectionID, secretName, nil /*nil indicates close the streaming connection to proxy*/)
 			}()
 			// Currently only one ingress gateway is running, therefore there is at most one cache entry.
 			// Stop the iteration once we have deleted that cache entry.
@@ -382,13 +400,7 @@ func (sc *SecretCache) UpdateK8sSecret(secretName string, ns model.SecretItem) {
 					}
 				}
 				secretMap.Store(key, newSecret)
-				if sc.notifyCallback != nil {
-					if err := sc.notifyCallback(connectionID, secretName, newSecret); err != nil {
-						log.Errorf("Failed to notify secret change for proxy %q: %v", connectionID, err)
-					}
-				} else {
-					log.Warn("secret cache notify callback isn't set")
-				}
+				sc.callbackWithTimeout(connectionID, secretName, newSecret)
 			}()
 			// Currently only one ingress gateway is running, therefore there is at most one cache entry.
 			// Stop the iteration once we have updated that cache entry.
@@ -439,15 +451,7 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 				Version:      t.String(),
 			}
 			secretMap.Store(key, ns)
-
-			if sc.notifyCallback != nil {
-				// Push the updated root cert to client.
-				if err := sc.notifyCallback(connectionID, resourceName, ns); err != nil {
-					log.Errorf("Failed to notify for proxy %q for resource %q: %v", connectionID, resourceName, err)
-				}
-			} else {
-				log.Warn("secret cache notify callback isn't set")
-			}
+			sc.callbackWithTimeout(connectionID, resourceName, ns)
 
 			return true
 		}
@@ -473,13 +477,7 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 			if sc.isTokenExpired() {
 				log.Debugf("Token for %q expired for proxy %q", resourceName, connectionID)
 
-				if sc.notifyCallback != nil {
-					if err := sc.notifyCallback(connectionID, resourceName, nil /*nil indicates close the streaming connection to proxy*/); err != nil {
-						log.Errorf("Failed to notify for proxy %q: %v", connectionID, err)
-					}
-				} else {
-					log.Warn("secret cache notify callback isn't set")
-				}
+				sc.callbackWithTimeout(key.ConnectionID, key.ResourceName, nil /*nil indicates close the streaming connection to proxy*/)
 
 				return true
 			}
@@ -500,13 +498,7 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 
 				secretMap.Store(key, ns)
 
-				if sc.notifyCallback != nil {
-					if err := sc.notifyCallback(connectionID, resourceName, ns); err != nil {
-						log.Errorf("Failed to notify secret change for proxy %q: %v", connectionID, err)
-					}
-				} else {
-					log.Warn("secret cache notify callback isn't set")
-				}
+				sc.callbackWithTimeout(connectionID, key.ResourceName, ns)
 
 			}()
 		}

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -82,6 +82,9 @@ type Options struct {
 	EnableIngressGatewaySDS bool
 	// AlwaysValidTokenFlag is set to true for if token used is always valid(ex, normal k8s JWT)
 	AlwaysValidTokenFlag bool
+
+	// Recycle job running interval (to clean up staled sds client connections).
+	RecycleInterval time.Duration
 }
 
 // Server is the gPRC server that exposes SDS through UDS.
@@ -99,8 +102,8 @@ type Server struct {
 // NewServer creates and starts the Grpc server for SDS.
 func NewServer(options Options, workloadSecretCache, gatewaySecretCache cache.SecretManager) (*Server, error) {
 	s := &Server{
-		workloadSds: newSDSService(workloadSecretCache, false),
-		gatewaySds:  newSDSService(gatewaySecretCache, true),
+		workloadSds: newSDSService(workloadSecretCache, false, options.RecycleInterval),
+		gatewaySds:  newSDSService(gatewaySecretCache, true, options.RecycleInterval),
 	}
 	if options.EnableWorkloadSDS {
 		if err := s.initWorkloadSdsService(&options); err != nil {
@@ -136,9 +139,11 @@ func (s *Server) Stop() {
 	}
 
 	if s.grpcWorkloadServer != nil {
+		s.workloadSds.Stop()
 		s.grpcWorkloadServer.Stop()
 	}
 	if s.grpcGatewayServer != nil {
+		s.gatewaySds.Stop()
 		s.grpcGatewayServer.Stop()
 	}
 }


### PR DESCRIPTION
Cherry pick #14043

Problem:

sds client try to end connection when delete gateway CRD;
sds server try to end connection when delete k8s secret;
When delete gateway/secret at almost same time, both sds client/server try to end connection, which trigger race condition in connection push/destroy, it cause server side hangs.
Fix:
when delete gateway/secret, instead destroying connection right away, put connections into recycle map and use a timer job to clean up the recycle map.

Issue:
#13853