### PR TITLE
use docker cache make build faster

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,9 +1,9 @@
 # Builder version
-CI_VERSION ?= go1.11-k8s1.10.4-helm2.7.2-minikube0.25
+CI_VERSION ?= go1.11-k8s1.10.4-helm2.7.2-minikube0.25-dockerfile1.0
 CI_HUB ?= istio
 
 ci.image:
-	docker build -t "${CI_HUB}/ci:$(CI_VERSION)" -f Dockerfile .
+	docker build --cache-from="${CI_HUB}/ci:$(CI_VERSION)" -t "${CI_HUB}/ci:$(CI_VERSION)" -f Dockerfile .
 
 ci.push:
 	docker push --config=/tmp/circle "${CI_HUB}/ci:$(CI_VERSION)" 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,6 +601,8 @@ jobs:
       - image: koalaman/shellcheck-alpine:v0.6.0
     steps:
       - checkout
+      - setup_remote_docker: 
+          docker_layer_caching: true
       - run:
           name: Check Scripts
           command: /root/project/bin/check_shell_scripts.sh


### PR DESCRIPTION
Dockerfile not changing often, add dockerfile version in CI_VERSION suffix, then using ``--cache-from`` making build docker image faster, also the docker image for shellcheck.