### PR TITLE
Let configgen depend on plugin interface rather than impl

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -30,6 +30,8 @@ import (
 	"sync"
 	"time"
 
+	pluginregistry "istio.io/istio/pilot/pkg/networking/plugin/registry"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gogo/protobuf/types"
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -57,7 +59,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/memory"
 	configmonitor "istio.io/istio/pilot/pkg/config/monitor"
 	"istio.io/istio/pilot/pkg/model"
-	istio_networking "istio.io/istio/pilot/pkg/networking/core"
+	istio_networking "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/proxy/envoy"
@@ -900,7 +902,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 	s.mux = discovery.RestContainer.ServeMux
 
 	s.EnvoyXdsServer = envoyv2.NewDiscoveryServer(environment,
-		istio_networking.NewConfigGenerator(args.Plugins),
+		istio_networking.NewConfigGenerator(pluginregistry.NewPlugins(args.Plugins)),
 		s.ServiceController, s.kubeRegistry, s.configController)
 	s.EnvoyXdsServer.InitDebug(s.mux, s.ServiceController)
 	if s.kubeRegistry != nil {

--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -18,8 +18,6 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
-	"istio.io/istio/pilot/pkg/networking/plugin/registry"
 )
 
 // ConfigGenerator represents the interfaces to be implemented by code that generates xDS responses
@@ -34,9 +32,4 @@ type ConfigGenerator interface {
 
 	// BuildHTTPRoutes returns the list of HTTP routes for the given proxy. This is the RDS output
 	BuildHTTPRoutes(env *model.Environment, node *model.Proxy, push *model.PushContext, routeName string) (*v2.RouteConfiguration, error)
-}
-
-// NewConfigGenerator creates a new instance of the dataplane configuration generator
-func NewConfigGenerator(plugins []string) ConfigGenerator {
-	return v1alpha3.NewConfigGenerator(registry.NewPlugins(plugins))
 }


### PR DESCRIPTION
Depend on interface rather impl is more elegant, especially for an interface package.
And what's more, original dependency cause plugin impl is depended by main logic of pilot and prevent extension from making use of main logic.