### PR TITLE
Cherrypick #10379 back on master (Addresses #13880)

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -412,9 +412,9 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, labels map[string]string, _ 
 	inboundUpdates.With(prometheus.Labels{"type": "workload"}).Add(1)
 	if labels == nil {
 		// No push needed - the Endpoints object will also be triggered.
-	        s.mutex.Lock()
+		s.mutex.Lock()
 		delete(s.WorkloadsByID, id)
-	        s.mutex.Unlock()
+		s.mutex.Unlock()
 		return
 	}
 	s.mutex.RLock()

--- a/pilot/pkg/serviceregistry/kube/pod.go
+++ b/pilot/pkg/serviceregistry/kube/pod.go
@@ -51,9 +51,6 @@ func newPodCache(ch cacheHandler, c *Controller) *PodCache {
 
 // event updates the IP-based index (pc.keys).
 func (pc *PodCache) event(obj interface{}, ev model.Event) error {
-	pc.Lock()
-	defer pc.Unlock()
-
 	// When a pod is deleted obj could be an *v1.Pod or a DeletionFinalStateUnknown marker item.
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
@@ -79,7 +76,9 @@ func (pc *PodCache) event(obj interface{}, ev model.Event) error {
 			switch pod.Status.Phase {
 			case v1.PodPending, v1.PodRunning:
 				// add to cache if the pod is running or pending
+				pc.Lock()
 				pc.keys[ip] = key
+				pc.Unlock()
 				if pc.c != nil && pc.c.XDSUpdater != nil {
 					pc.c.XDSUpdater.WorkloadUpdate(ip, pod.ObjectMeta.Labels, pod.ObjectMeta.Annotations)
 				}
@@ -87,8 +86,10 @@ func (pc *PodCache) event(obj interface{}, ev model.Event) error {
 		case model.EventUpdate:
 			if pod.DeletionTimestamp != nil {
 				// delete only if this pod was in the cache
-				if pc.keys[ip] == key {
+				if k, _ := pc.getPodKey(ip); k == key {
+					pc.Lock()
 					delete(pc.keys, ip)
+					pc.Unlock()
 					if pc.c != nil && pc.c.XDSUpdater != nil {
 						pc.c.XDSUpdater.WorkloadUpdate(ip, nil, nil)
 					}
@@ -98,14 +99,18 @@ func (pc *PodCache) event(obj interface{}, ev model.Event) error {
 			switch pod.Status.Phase {
 			case v1.PodPending, v1.PodRunning:
 				// add to cache if the pod is running or pending
+				pc.Lock()
 				pc.keys[ip] = key
+				pc.Unlock()
 				if pc.c != nil && pc.c.XDSUpdater != nil {
 					pc.c.XDSUpdater.WorkloadUpdate(ip, pod.ObjectMeta.Labels, pod.ObjectMeta.Annotations)
 				}
 			default:
 				// delete if the pod switched to other states and is in the cache
-				if pc.keys[ip] == key {
+				if k, _ := pc.getPodKey(ip); k == key {
+					pc.Lock()
 					delete(pc.keys, ip)
+					pc.Unlock()
 					if pc.c != nil && pc.c.XDSUpdater != nil {
 						pc.c.XDSUpdater.WorkloadUpdate(ip, nil, nil)
 					}
@@ -113,8 +118,10 @@ func (pc *PodCache) event(obj interface{}, ev model.Event) error {
 			}
 		case model.EventDelete:
 			// delete only if this pod was in the cache
-			if pc.keys[ip] == key {
+			if k, _ := pc.getPodKey(ip); k == key {
+				pc.Lock()
 				delete(pc.keys, ip)
+				pc.Unlock()
 				if pc.c != nil && pc.c.XDSUpdater != nil {
 					pc.c.XDSUpdater.WorkloadUpdate(ip, nil, nil)
 				}
@@ -127,8 +134,8 @@ func (pc *PodCache) event(obj interface{}, ev model.Event) error {
 // nolint: unparam
 func (pc *PodCache) getPodKey(addr string) (string, bool) {
 	pc.RLock()
-	defer pc.RUnlock()
 	key, exists := pc.keys[addr]
+	pc.RUnlock()
 	return key, exists
 }
 


### PR DESCRIPTION
- I'm not sure of the status of
  pilot/pkg/proxy/envoy/v2/discovery.go
  that currently contains a mutex locking strategy dating back from October
  while #10379 1.0 change happened 2 months later.
  The pushContext mutex strategy seems replaced by some version mutex,
  I will gladly have another pair of eyes looking at that.

As for the mutex logic of eds.go, I followed #10379 @costinm would be the best judge to know if this cherrypick makes sense or not.