### PR TITLE
Add pod locality in updateEDS

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -387,15 +387,21 @@ type ServiceInstance struct {
 //
 // This is used by CDS/EDS to group the endpoints by locality.
 func (si *ServiceInstance) GetLocality() string {
-	if si.Labels != nil && si.Labels[LocalityLabel] != "" {
+	return GetLocalityOrDefault(si.Endpoint.Locality, si.Labels)
+}
+
+// Gets the locality from the labels, or falls back to to a default locality if not found
+// Because Kubernetes labels don't support `/`, we replace "." with "/" as a workaround
+func GetLocalityOrDefault(defaultLocality string, labels map[string]string) string {
+	if labels != nil && labels[LocalityLabel] != "" {
 		// if there are /'s present we don't need to replace
-		if strings.Contains(si.Labels[LocalityLabel], "/") {
-			return si.Labels[LocalityLabel]
+		if strings.Contains(labels[LocalityLabel], "/") {
+			return labels[LocalityLabel]
 		}
 		// replace "." with "/"
-		return strings.Replace(si.Labels[LocalityLabel], k8sSeparator, "/", -1)
+		return strings.Replace(labels[LocalityLabel], k8sSeparator, "/", -1)
 	}
-	return si.Endpoint.Locality
+	return defaultLocality
 }
 
 // IstioEndpoint has the information about a single address+port for a specific

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -804,6 +804,7 @@ func (c *Controller) updateEDS(ep *v1.Endpoints, event model.Event) {
 						UID:             uid,
 						ServiceAccount:  secureNamingSAN(pod),
 						Network:         c.endpointNetwork(ea.IP),
+						Locality:        c.GetPodLocality(pod),
 					})
 				}
 			}

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -319,8 +319,8 @@ func (c *Controller) GetPodLocality(pod *v1.Pod) string {
 	if region == "" && zone == "" {
 		return ""
 	}
-
-	return fmt.Sprintf("%v/%v", region, zone)
+	locality := fmt.Sprintf("%v/%v", region, zone)
+	return model.GetLocalityOrDefault(locality, pod.Labels)
 }
 
 // ManagementPorts implements a service catalog operation


### PR DESCRIPTION
Without this change, new endpoints added in this method will be missing
the locality. This generally means only the first replica will get a
locality assigned to it. This means if locality LB is enabled, only one
replica will receive traffic.

Fixes: https://github.com/istio/istio/issues/13994
