### PR TITLE
Enable vulnerability scanning for Istio docker images

### DIFF
--- a/samples/bookinfo/build_push_update_images.sh
+++ b/samples/bookinfo/build_push_update_images.sh
@@ -16,13 +16,43 @@
 
 set -o errexit
 
-if [ "$#" -ne 1 ]; then
-    echo Missing version parameter
-    echo Usage: build_push_update_images.sh \<version\>
+display_usage() {
+    echo
+    echo "USAGE: ./build_push_update_images.sh <version> [-h|--help] [--scan-images]"
+    echo "	version : Version of the sample app images (Required)"
+    echo "	-h|--help : Prints usage information"
+    echo -e "	--scan-images : Enable security vulnerability scans for docker images \n\t\t\trelated to bookinfo sample apps. By default, this feature \n\t\t\tis disabled."
     exit 1
+}
+
+# Check if there is atleast one input argument
+if [[ -z "$1" ]] ; then
+	echo "Missing version parameter"
+        display_usage
+else
+	VERSION="$1"
 fi
 
-VERSION=$1
+# Process the input arguments. By default, image scanning is disabled. 
+index=0
+ENABLE_IMAGE_SCAN=false
+for i in "$@"
+do
+	case "$i" in
+		"--scan-images" )
+		   ENABLE_IMAGE_SCAN=true ;;
+		-h|--help )
+                   echo
+		   echo "Build the docker images for bookinfo sample apps, push them to docker hub and update the yaml files."
+		   display_usage ;;
+                * )
+                   if [[ $index -ne 0 ]]; then
+                     echo "Unknown argument: $i"
+                     display_usage 
+		   fi;;
+	esac
+  	((index++))
+done
 
 #Build docker images
 src/build-services.sh "${VERSION}"
@@ -34,11 +64,46 @@ do
   IMAGES+=" "
 done
 
-#push images
+#
+# Run security vulnerability scanning on bookinfo sample app images using
+# the ImageScanner tool. If the reuqest is handled successfully, it gives
+# the output in JSON format which has the following format:
+#   {
+#	"Progress": "Scan completed: OK",
+#	"Results": {
+#		"ID": "94be3d24-cd0b-402c-837c-99d453ec8797",
+#		"Scan_Time": 1559143715,
+#		"Status": "OK",
+#		"Vulnerabilities": [],
+#		"Configuration_Issues": []
+#	}
+#    }
+#
+function run_vulnerability_scanning() {
+  RESULT_DIR="vulnerability_scan_results"
+  CURL_RESPONSE=$(curl -s --create-dirs -o "$RESULT_DIR/$1_$VERSION"  -w "%{http_code}" http://imagescanner.cloud.ibm.com/scan?image="docker.io/$2")
+  if [ "$CURL_RESPONSE" -eq 200 ]; then
+     mv "$RESULT_DIR/$1_$VERSION" "$RESULT_DIR/$1_$VERSION.json"
+  fi
+}
+
+# Push images. Scan images if ENABLE_IMAGE_SCAN is true.
 for IMAGE in ${IMAGES}; 
 do 
   echo "Pushing: ${IMAGE}" 
   docker push "${IMAGE}"; 
+  
+  # $IMAGE has the following format: istio/examples-bookinfo*:"$v".
+  # We want to get the sample app name from $IMAGE (the examples-bookinfo* portion)
+  # to create the file to store the results of the scan for that image. The first
+  # part of the $IMAGE_NAME gets examples-bookinfo*:"$v", and the second part gets
+  # 'examples-bookinfo*'.
+  if [[ "$ENABLE_IMAGE_SCAN" == "true"  ]]; then
+  	echo "Scanning ${IMAGE} for security vulnerabilities"
+  	IMAGE_NAME=${IMAGE#*/}
+  	IMAGE_NAME=${IMAGE_NAME%:*}
+  	run_vulnerability_scanning "${IMAGE_NAME}" "${IMAGE}"
+  fi
 done
 
 #Update image references in the yaml files


### PR DESCRIPTION
Currently we build and push docker images for Istio components and sample apps as
part of our build process. In this PR, we have included a way to enable security
vulnerability scanning of these images using IBM's image scanning tool - ImageScanner
(imagescanner.cloud.ibm.com). The results of the image scans are put under a new folder
'vulnerability_scan_results' which will be available to view later.

Fixes Bug: #13262