### PR TITLE
cluster endpoints conflicts when creating internal serviceentry

### DIFF
--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -4176,10 +4176,59 @@ func TestValidateNetworkEndpointAddress(t *testing.T) {
 			&NetworkEndpoint{Address: "260.3.4.5", Port: 76},
 			false,
 		},
+		{
+			"FQDN invalid",
+			&NetworkEndpoint{Address: "foo.bar.svc.cluster.local", Port: 80},
+			false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidateNetworkEndpointAddress(tc.ne)
+			if tc.valid && err != nil {
+				t.Fatalf("ValidateAddress() => want error nil got %v", err)
+			} else if !tc.valid && err == nil {
+				t.Fatalf("ValidateAddress() => want error got nil")
+			}
+		})
+	}
+}
+
+func TestValidateIstioEndpointAddress(t *testing.T) {
+	testCases := []struct {
+		name  string
+		ne    *IstioEndpoint
+		valid bool
+	}{
+		{
+			"Unix OK",
+			&IstioEndpoint{Family: AddressFamilyUnix, Address: "/absolute/path"},
+			true,
+		},
+		{
+			"IP OK",
+			&IstioEndpoint{Address: "12.3.4.5"},
+			true,
+		},
+		{
+			"Unix not absolute",
+			&IstioEndpoint{Family: AddressFamilyUnix, Address: "./socket"},
+			false,
+		},
+		{
+			"IP invalid",
+			&IstioEndpoint{Address: "260.3.4.5"},
+			false,
+		},
+		{
+			"FQDN invalid",
+			&IstioEndpoint{Address: "foo.bar.svc.cluster.local"},
+			false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateIstioEndpointAddress(tc.ne)
 			if tc.valid && err != nil {
 				t.Fatalf("ValidateAddress() => want error nil got %v", err)
 			} else if !tc.valid && err == nil {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -357,6 +357,9 @@ func buildLocalityLbEndpoints(env *model.Environment, proxyNetworkView map[strin
 			// Endpoint's network doesn't match the set of networks that the proxy wants to see.
 			continue
 		}
+		if service.Resolution != instance.Service.Resolution {
+			continue
+		}
 		host := util.BuildAddress(instance.Endpoint.Address, uint32(instance.Endpoint.Port))
 		ep := endpoint.LbEndpoint{
 			HostIdentifier: &endpoint.LbEndpoint_Endpoint{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -783,6 +783,13 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 		Ports:       model.PortList{servicePort},
 		Resolution:  model.DNSLB,
 	}
+	service2 := &model.Service{
+		Hostname:    model.Hostname("*.example.org"),
+		Address:     "1.1.1.2",
+		ClusterVIPs: make(map[string]string),
+		Ports:       model.PortList{servicePort},
+		Resolution:  model.ClientSideLB,
+	}
 	instances := []*model.ServiceInstance{
 		{
 			Service: service,
@@ -791,7 +798,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 				Port:        10001,
 				ServicePort: servicePort,
 				Locality:    "region1/zone1/subzone1",
-				LbWeight:    30,
+				LbWeight:    20,
 			},
 		},
 		{
@@ -801,7 +808,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 				Port:        10001,
 				ServicePort: servicePort,
 				Locality:    "region1/zone1/subzone1",
-				LbWeight:    30,
+				LbWeight:    20,
 			},
 		},
 		{
@@ -811,7 +818,17 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 				Port:        10001,
 				ServicePort: servicePort,
 				Locality:    "region2/zone1/subzone1",
-				LbWeight:    40,
+				LbWeight:    30,
+			},
+		},
+		{
+			Service: service2,
+			Endpoint: model.NetworkEndpoint{
+				Address:     "192.168.1.4",
+				Port:        10001,
+				ServicePort: servicePort,
+				Locality:    "region2/zone1/subzone1",
+				LbWeight:    30,
 			},
 		},
 	}
@@ -825,9 +842,9 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 	g.Expect(len(localityLbEndpoints)).To(Equal(2))
 	for _, ep := range localityLbEndpoints {
 		if ep.Locality.Region == "region1" {
-			g.Expect(ep.LoadBalancingWeight.GetValue()).To(Equal(uint32(60)))
-		} else if ep.Locality.Region == "region2" {
 			g.Expect(ep.LoadBalancingWeight.GetValue()).To(Equal(uint32(40)))
+		} else if ep.Locality.Region == "region2" {
+			g.Expect(ep.LoadBalancingWeight.GetValue()).To(Equal(uint32(30)))
 		}
 	}
 }


### PR DESCRIPTION
1. set **default_service_export_to: [.]** in configmap istio

2. httpbin is a internal service in namespace bar with a endpoint: ip 172.17.0.20 and port 5000, to access httpbin from foo, I created a internal serviceentry in foo
    ```
    apiVersion: networking.istio.io/v1alpha3
    kind: ServiceEntry
    metadata:
      name: internal-svc-mesh
      namespace: bar
    spec:
      hosts:
      - httpbin.bar.svc.cluser.local
      location: MESH_INTERNAL
      ports:
      - number: 80
        name: http
        protocol: HTTP
      resolution: DNS
    ```

    I found pilot will generate a outbound cluster "outbound|80||httpbin.bar.svc.cluser.local" for sidecar in foo below:
    ```
    {
      "name": "outbound|80||httpbin.bar.svc.cluster.local",
      "type": "STRICT_DNS",
      "connect_timeout": "1s",
      "circuit_breakers": {
       "thresholds": [
        {
         "max_retries": 1024
        }
       ]
      },
      "dns_refresh_rate": "5s",
      "dns_lookup_family": "V4_ONLY",
      "load_assignment": {
       "cluster_name": "outbound|80||httpbin.bar.svc.cluster.local",
       "endpoints": [
        {
         "lb_endpoints": [
          {
           "endpoint": {
            "address": {
             "socket_address": {
              "address": "httpbin.bar.svc.cluster.local",
              "port_value": 80
             }
            }
           },
           "load_balancing_weight": 1
          },
          {
           "endpoint": {
            "address": {
             "socket_address": {
              "address": "172.17.0.20",
              "port_value":5000
             }
            }
           },
           "load_balancing_weight": 1
          }
         ]
        }
       ]
      }
     }
    ```

With cluster "outbound|80||httpbin.bar.svc.cluser.local" configuration, there are two **Questions** here:
1. Endpoint with address 172.17.0.20 and port 5000 is conflict with resolution dns
2. Envoy applys cds failed with such configuration in ipv6 scenario even if i changed dns_lookup_family to V6_ONLY
