### PR TITLE
add -f - support and also some other check for istio pre-req

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -122,7 +122,7 @@ debug and diagnose their Istio mesh.
 	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(contextCmd)
 
-	rootCmd.AddCommand(validate.NewValidateCommand())
+	rootCmd.AddCommand(validate.NewValidateCommand(&istioNamespace))
 
 	return rootCmd
 }

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -19,11 +19,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	mixercrd "istio.io/istio/mixer/pkg/config/crd"
 	mixerstore "istio.io/istio/mixer/pkg/config/store"
@@ -31,6 +33,7 @@ import (
 	mixervalidate "istio.io/istio/mixer/pkg/validate"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/pkg/log"
 )
 
@@ -59,6 +62,11 @@ Example resource specifications include:
 		constant.InstanceKind:          {},
 		constant.AttributeManifestKind: {},
 	}
+	istioDeploymentLabel = []string{
+		"app",
+		"version",
+	}
+	serviceProtocolUDP = "UDP"
 )
 
 type validator struct {
@@ -75,7 +83,7 @@ func checkFields(un *unstructured.Unstructured) error {
 	return errs
 }
 
-func (v *validator) validateResource(un *unstructured.Unstructured) error {
+func (v *validator) validateResource(istioNamespace string, un *unstructured.Unstructured) error {
 	schema, exists := model.IstioConfigTypes.GetByType(crd.CamelCaseToKebabCase(un.GetKind()))
 	if exists {
 		obj, err := crd.ConvertObjectFromUnstructured(schema, un, "")
@@ -110,11 +118,84 @@ func (v *validator) validateResource(un *unstructured.Unstructured) error {
 			Value: mixercrd.ToBackEndResource(un),
 		})
 	}
+	var errs error
+	if un.IsList() {
+		un.EachListItem(func(item runtime.Object) error { // nolint: errcheck
+			castItem := item.(*unstructured.Unstructured)
+			if castItem.GetKind() == "Service" {
+				err := v.validateServicePortPrefix(istioNamespace, castItem)
+				if err != nil {
+					errs = multierror.Append(errs, err)
+				}
+			}
+			if castItem.GetKind() == "Deployment" {
+				v.validateDeploymentLabel(istioNamespace, castItem)
+			}
+			return nil
+		})
+	}
 
+	if errs != nil {
+		return errs
+	}
+	if un.GetKind() == "Service" {
+		return v.validateServicePortPrefix(istioNamespace, un)
+	}
+
+	if un.GetKind() == "Deployment" {
+		v.validateDeploymentLabel(istioNamespace, un)
+		return nil
+	}
 	return nil
 }
 
-func (v *validator) validateFile(reader io.Reader) error {
+func (v *validator) validateServicePortPrefix(istioNamespace string, un *unstructured.Unstructured) error {
+	var errs error
+	if un.GetNamespace() == handleNamespace(istioNamespace) {
+		return nil
+	}
+	spec := un.Object["spec"].(map[string]interface{})
+	if _, ok := spec["ports"]; ok {
+		ports := spec["ports"].([]interface{})
+		for _, port := range ports {
+			p := port.(map[string]interface{})
+			if p["protocol"] != nil && strings.EqualFold(p["protocol"].(string), serviceProtocolUDP) {
+				continue
+			}
+			if p["name"] == nil {
+				errs = multierror.Append(errs, fmt.Errorf("service %q has an unnamed port. This is not recommended,"+
+					" see https://istio.io/docs/setup/kubernetes/prepare/requirements/", fmt.Sprintf("%s/%s/:",
+					un.GetName(), un.GetNamespace())))
+				continue
+			}
+			if servicePortPrefixed(p["name"].(string)) {
+				errs = multierror.Append(errs, fmt.Errorf("service %q port %q does not follow the Istio naming convention."+
+					" See https://istio.io/docs/setup/kubernetes/prepare/requirements/", fmt.Sprintf("%s/%s/:",
+					un.GetName(), un.GetNamespace()), p["name"].(string)))
+			}
+		}
+	}
+	if errs != nil {
+		return errs
+	}
+	return nil
+}
+
+func (v *validator) validateDeploymentLabel(istioNamespace string, un *unstructured.Unstructured) {
+	if un.GetNamespace() == handleNamespace(istioNamespace) {
+		return
+	}
+	labels := un.GetLabels()
+	for _, l := range istioDeploymentLabel {
+		if _, ok := labels[l]; !ok {
+			log.Warnf("deployment %q may not provide Istio metrics and telemetry without label %q."+
+				" See https://istio.io/docs/setup/kubernetes/prepare/requirements/ \n", fmt.Sprintf("%s/%s:",
+				un.GetName(), un.GetNamespace()), l)
+		}
+	}
+}
+
+func (v *validator) validateFile(istioNamespace *string, reader io.Reader) error {
 	decoder := yaml.NewDecoder(reader)
 	var errs error
 	for {
@@ -133,7 +214,7 @@ func (v *validator) validateFile(reader io.Reader) error {
 		}
 		out := transformInterfaceMap(raw)
 		un := unstructured.Unstructured{Object: out}
-		err = v.validateResource(&un)
+		err = v.validateResource(*istioNamespace, &un)
 		if err != nil {
 			errs = multierror.Append(errs, multierror.Prefix(err, fmt.Sprintf("%s/%s/%s:",
 				un.GetKind(), un.GetNamespace(), un.GetName())))
@@ -141,7 +222,7 @@ func (v *validator) validateFile(reader io.Reader) error {
 	}
 }
 
-func validateFiles(filenames []string, referential bool, writer io.Writer) error {
+func validateFiles(istioNamespace *string, filenames []string, referential bool, writer io.Writer) error {
 	if len(filenames) == 0 {
 		return errMissingFilename
 	}
@@ -150,42 +231,59 @@ func validateFiles(filenames []string, referential bool, writer io.Writer) error
 		mixerValidator: mixervalidate.NewDefaultValidator(referential),
 	}
 
-	var errs error
+	var errs, err error
+	var reader io.Reader
 	for _, filename := range filenames {
-		reader, err := os.Open(filename)
+		if filename == "-" {
+			reader = os.Stdin
+		} else {
+			reader, err = os.Open(filename)
+		}
 		if err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("cannot read file %q: %v", filename, err))
 			continue
 		}
-		err = v.validateFile(reader)
+		err = v.validateFile(istioNamespace, reader)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}
 	}
-
 	if errs != nil {
 		return errs
 	}
-
 	for _, fname := range filenames {
-		fmt.Fprintf(writer, "%q is valid\n", fname)
+		if fname == "-" {
+			fmt.Fprintf(writer, "validation succeed\n")
+			break
+		} else {
+			fmt.Fprintf(writer, "%q is valid\n", fname)
+		}
 	}
 
 	return nil
 }
 
 // NewValidateCommand creates a new command for validating Istio k8s resources.
-func NewValidateCommand() *cobra.Command {
+func NewValidateCommand(istioNamespace *string) *cobra.Command {
 	var filenames []string
 	var referential bool
 
 	c := &cobra.Command{
-		Use:     "validate -f FILENAME [options]",
-		Short:   "Validate Istio policy and rules",
-		Example: `istioctl validate -f bookinfo-gateway.yaml`,
-		Args:    cobra.NoArgs,
+		Use:   "validate -f FILENAME [options]",
+		Short: "Validate Istio policy and rules",
+		Example: `
+		# Validate bookinfo-gateway.yaml
+		istioctl validate -f bookinfo-gateway.yaml
+		
+		# Validate current deployments under 'default' namespace within the cluster
+		kubectl get deployments -o yaml |istioctl validate -f -
+
+		# Validate current services under 'default' namespace within the cluster
+		kubectl get services -o yaml |istioctl validate -f -
+`,
+		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
-			return validateFiles(filenames, referential, c.OutOrStdout())
+			return validateFiles(istioNamespace, filenames, referential, c.OutOrStderr())
 		},
 	}
 
@@ -221,4 +319,19 @@ func transformMapValue(in interface{}) interface{} {
 	default:
 		return v
 	}
+}
+
+func servicePortPrefixed(n string) bool {
+	i := strings.IndexByte(n, '-')
+	if i >= 0 {
+		n = n[:i]
+	}
+	protocol := model.ParseProtocol(n)
+	return protocol == model.ProtocolUnsupported
+}
+func handleNamespace(istioNamespace string) string {
+	if istioNamespace == "" {
+		istioNamespace = kube.IstioNamespace
+	}
+	return istioNamespace
 }


### PR DESCRIPTION
- make things like ```kubectl get svc -o yaml | istioctl validate -f -``` work

- validate svc and report back if it's port has no naming prefix

- validate deployment and report back if it lacks of `app` or `version' label

- report success when validation passed