### PR TITLE
cherry pick the commit of the weight for pod antiaffinity term.

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/_affinity.tpl
@@ -88,5 +88,6 @@
             {{- end }}
             {{- end }}
         topologyKey: {{ $item.topologyKey }}
+      weight: 100
     {{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/templates/_affinity.tpl
@@ -88,5 +88,6 @@
             {{- end }}
             {{- end }}
         topologyKey: {{ $item.topologyKey }}
+      weight: 100
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Merge https://github.com/istio/istio/pull/14419 to release-1.2


(cherry picked from commit 67846c4a068e9692e7d2a4d3dccf3cc99b9b35c7)