### PR TITLE
Cherry-Pick #14270 (Update Go to 1.12 for e2e-tests) to release-1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ initWorkingDir: &initWorkingDir
     GOROOT=$(go env GOROOT)
     sudo rm -r $(go env GOROOT)
     sudo mkdir $GOROOT
-    curl https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz | sudo tar xz -C $GOROOT --strip-components=1
+    curl https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz | sudo tar xz -C $GOROOT --strip-components=1
 
 recordZeroExitCodeIfTestPassed: &recordZeroExitCodeIfTestPassed
   run:

--- a/docker/Dockerfile.go_generate_dependency
+++ b/docker/Dockerfile.go_generate_dependency
@@ -2,7 +2,7 @@ FROM alpine:3.7 as go_generate_dependency_builder
 RUN apk add --no-cache build-base git
 
 RUN apk update
-RUN apk add --no-cache go>1.10
+RUN apk add --no-cache go>1.12
 ENV GOPATH=/go \
     PATH=/go/bin/:$PATH
 RUN go get -u -v \

--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # build a tcp-echo binary using the golang container
-FROM golang:1.11 as builder
+FROM golang:1.12 as builder
 WORKDIR /go/src/istio.io/tcp-echo-server/
 COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go

--- a/tools/packaging/rpm/istio/istio.spec
+++ b/tools/packaging/rpm/istio/istio.spec
@@ -45,7 +45,7 @@ Source7:        istio-auth-node-agent.service
 # e.g. el6 has ppc64 arch without gcc-go, so EA tag is required
 ExclusiveArch:  %{?go_arches:%{go_arches}}%{!?go_arches:%{ix86} x86_64 aarch64 %{arm}}
 # If go_compiler is not set to 1, there is no virtual provide. Use golang instead.
-BuildRequires:  golang >= 1.10
+BuildRequires:  golang >= 1.12
 
 %description
 Istio is an open platform that provides a uniform way to connect, manage


### PR DESCRIPTION
First portion of #14420 

* Update Go to 1.12
* Update circleci to use golang 1.12.5 explicitly
* Prow is still using Golang 1.10.4

