### PR TITLE
Add Pilot owners to pkg/features/pilot

### DIFF
--- a/pkg/features/pilot/OWNERS
+++ b/pkg/features/pilot/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - andraxylia
+  - costinm
+  - diemtvu
+  - GregHanson
+  - hzxuzhonghu
+  - nmittler
+  - rshriram
+  - vadimeisenbergibm
+  - zackbutcher
+  - howardjohn


### PR DESCRIPTION
Otherwise changes to pilot features requires approval requires pkg
owners, who are not directly responsible for pilot features.

File is copied from pilot/owners