### PR TITLE
Restore message on istioctl validate success

### DIFF
--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -141,7 +141,7 @@ func (v *validator) validateFile(reader io.Reader) error {
 	}
 }
 
-func validateFiles(filenames []string, referential bool) error {
+func validateFiles(filenames []string, referential bool, writer io.Writer) error {
 	if len(filenames) == 0 {
 		return errMissingFilename
 	}
@@ -162,7 +162,16 @@ func validateFiles(filenames []string, referential bool) error {
 			errs = multierror.Append(errs, err)
 		}
 	}
-	return errs
+
+	if errs != nil {
+		return errs
+	}
+
+	for _, fname := range filenames {
+		fmt.Fprintf(writer, "%q is valid\n", fname)
+	}
+
+	return nil
 }
 
 // NewValidateCommand creates a new command for validating Istio k8s resources.
@@ -176,7 +185,7 @@ func NewValidateCommand() *cobra.Command {
 		Example: `istioctl validate -f bookinfo-gateway.yaml`,
 		Args:    cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
-			return validateFiles(filenames, referential)
+			return validateFiles(filenames, referential, c.OutOrStdout())
 		},
 	}
 


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/14238

Background: Commit https://github.com/istio/istio/commit/995276a3da1d7f54f6881f987c58ba322366ab5a#diff-baef65426d2d2b26ba35559728c3e783 removed the informational message on `istioctl validate` success.