### PR TITLE
Optimize util.GetByAddress and add tests

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1277,7 +1277,7 @@ func (configgen *ConfigGeneratorImpl) generateManagementListeners(node *model.Pr
 		// non overlapping listeners only.
 		for i := range mgmtListeners {
 			m := mgmtListeners[i]
-			l := util.GetByAddress(listeners, m.Address.String())
+			l := util.GetByAddress(listeners, m.Address)
 			if l != nil {
 				log.Warnf("Omitting listener for management address %s due to collision with service listener %s",
 					m.Name, l.Name)

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -188,9 +188,9 @@ func LocalityLbWeightNormalize(endpoints []endpoint.LocalityLbEndpoints) []endpo
 
 // GetByAddress returns a listener by its address
 // TODO(mostrowski): consider passing map around to save iteration.
-func GetByAddress(listeners []*xdsapi.Listener, addr string) *xdsapi.Listener {
+func GetByAddress(listeners []*xdsapi.Listener, addr core.Address) *xdsapi.Listener {
 	for _, listener := range listeners {
-		if listener != nil && listener.Address.String() == addr {
+		if listener != nil && listener.Address.Equal(addr) {
 			return listener
 		}
 	}

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -542,10 +542,10 @@ var (
 func BenchmarkGetByAddress(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		GetByAddress([]*v2.Listener{
+			listener80,
 			listener81,
 			listenerip,
-			listener80,
-		}, listener81.Address)
+		}, listenerip.Address)
 	}
 }
 

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -533,10 +533,23 @@ func TestIsHTTPFilterChain(t *testing.T) {
 	}
 }
 
+var (
+	listener80 = &v2.Listener{Address: BuildAddress("0.0.0.0", 80)}
+	listener81 = &v2.Listener{Address: BuildAddress("0.0.0.0", 81)}
+	listenerip = &v2.Listener{Address: BuildAddress("1.1.1.1", 80)}
+)
+
+func BenchmarkGetByAddress(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		GetByAddress([]*v2.Listener{
+			listener81,
+			listenerip,
+			listener80,
+		}, listener81.Address)
+	}
+}
+
 func TestGetByAddress(t *testing.T) {
-	listener80 := &v2.Listener{Address: BuildAddress("0.0.0.0", 80)}
-	listener81 := &v2.Listener{Address: BuildAddress("0.0.0.0", 81)}
-	listenerip := &v2.Listener{Address: BuildAddress("1.1.1.1", 80)}
 	tests := []struct {
 		name      string
 		listeners []*v2.Listener

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -532,3 +532,49 @@ func TestIsHTTPFilterChain(t *testing.T) {
 		t.Errorf("tcp filter chain detected as http filter chain")
 	}
 }
+
+func TestGetByAddress(t *testing.T) {
+	listener80 := &v2.Listener{Address: BuildAddress("0.0.0.0", 80),}
+	listener81 := &v2.Listener{Address: BuildAddress("0.0.0.0", 81),}
+	listenerip := &v2.Listener{Address: BuildAddress("1.1.1.1", 80),}
+	tests := []struct {
+		name      string
+		listeners []*v2.Listener
+		address   core.Address
+		expected  *v2.Listener
+	}{
+		{
+			"no listeners",
+			[]*v2.Listener{},
+			BuildAddress("0.0.0.0", 80),
+			nil,
+		},
+		{
+			"single listener",
+			[]*v2.Listener{
+				listener80,
+			},
+			BuildAddress("0.0.0.0", 80),
+			listener80,
+		},
+		{
+			"multiple listeners",
+			[]*v2.Listener{
+				listener81,
+				listenerip,
+				listener80,
+			},
+			BuildAddress("0.0.0.0", 80),
+			listener80,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetByAddress(tt.listeners, tt.address.String())
+			if got != tt.expected {
+				t.Errorf("Got %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -534,9 +534,9 @@ func TestIsHTTPFilterChain(t *testing.T) {
 }
 
 func TestGetByAddress(t *testing.T) {
-	listener80 := &v2.Listener{Address: BuildAddress("0.0.0.0", 80),}
-	listener81 := &v2.Listener{Address: BuildAddress("0.0.0.0", 81),}
-	listenerip := &v2.Listener{Address: BuildAddress("1.1.1.1", 80),}
+	listener80 := &v2.Listener{Address: BuildAddress("0.0.0.0", 80)}
+	listener81 := &v2.Listener{Address: BuildAddress("0.0.0.0", 81)}
+	listenerip := &v2.Listener{Address: BuildAddress("1.1.1.1", 80)}
 	tests := []struct {
 		name      string
 		listeners []*v2.Listener
@@ -571,7 +571,7 @@ func TestGetByAddress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetByAddress(tt.listeners, tt.address.String())
+			got := GetByAddress(tt.listeners, tt.address)
 			if got != tt.expected {
 				t.Errorf("Got %v, expected %v", got, tt.expected)
 			}


### PR DESCRIPTION
Profiling shows pilot sometimes spending up to 3% of CPU in this
function, which is needlessly converting to a string. We can trivially
improve this by using .Equal.