### PR TITLE
Update bookinfo sample to propagate Datadog headers

### DIFF
--- a/samples/bookinfo/build_push_update_images.sh
+++ b/samples/bookinfo/build_push_update_images.sh
@@ -18,9 +18,10 @@ set -o errexit
 
 display_usage() {
     echo
-    echo "USAGE: ./build_push_update_images.sh <version> [-h|--help] [--scan-images]"
+    echo "USAGE: ./build_push_update_images.sh <version> [-h|--help] [--prefix=value] [--scan-images]"
     echo "	version : Version of the sample app images (Required)"
     echo "	-h|--help : Prints usage information"
+    echo "	--prefix: Use the value as the prefix for image names. By default, 'istio' is used"
     echo -e "	--scan-images : Enable security vulnerability scans for docker images \n\t\t\trelated to bookinfo sample apps. By default, this feature \n\t\t\tis disabled."
     exit 1
 }
@@ -31,36 +32,37 @@ if [[ -z "$1" ]] ; then
         display_usage
 else
 	VERSION="$1"
+	shift
 fi
 
 # Process the input arguments. By default, image scanning is disabled. 
-index=0
+PREFIX=istio
 ENABLE_IMAGE_SCAN=false
+echo "$@"
 for i in "$@"
 do
 	case "$i" in
-		"--scan-images" )
+		--prefix=* )
+		   PREFIX="${i#--prefix=}" ;;
+		--scan-images )
 		   ENABLE_IMAGE_SCAN=true ;;
 		-h|--help )
-                   echo
+		   echo
 		   echo "Build the docker images for bookinfo sample apps, push them to docker hub and update the yaml files."
 		   display_usage ;;
-                * )
-                   if [[ $index -ne 0 ]]; then
-                     echo "Unknown argument: $i"
-                     display_usage 
-		   fi;;
+		* )
+		   echo "Unknown argument: $i"
+		   display_usage ;;
 	esac
-  	((index++))
 done
 
 #Build docker images
-src/build-services.sh "${VERSION}"
+src/build-services.sh "${VERSION}" "$PREFIX"
 
 #get all the new image names and tags
 for v in ${VERSION} "latest"
 do
-  IMAGES+=$(docker images -f reference=istio/examples-bookinfo*:"$v" --format "{{.Repository}}:$v")
+  IMAGES+=$(docker images -f reference="$PREFIX/examples-bookinfo*:$v" --format "{{.Repository}}:$v")
   IMAGES+=" "
 done
 

--- a/samples/bookinfo/build_push_update_images.sh
+++ b/samples/bookinfo/build_push_update_images.sh
@@ -57,12 +57,12 @@ do
 done
 
 #Build docker images
-src/build-services.sh "${VERSION}" "$PREFIX"
+src/build-services.sh "${VERSION}" "${PREFIX}"
 
 #get all the new image names and tags
 for v in ${VERSION} "latest"
 do
-  IMAGES+=$(docker images -f reference="$PREFIX/examples-bookinfo*:$v" --format "{{.Repository}}:$v")
+  IMAGES+=$(docker images -f reference="${PREFIX}/examples-bookinfo*:$v" --format "{{.Repository}}:$v")
   IMAGES+=" "
 done
 

--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -27,16 +27,16 @@ PREFIX=$2
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 pushd "$SCRIPTDIR/productpage"
-  docker build --pull -t "$PREFIX/examples-bookinfo-productpage-v1:${VERSION}" -t "$PREFIX/examples-bookinfo-productpage-v1:latest" .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-productpage-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-productpage-v1:latest" .
   #flooding
-  docker build --pull -t "$PREFIX/examples-bookinfo-productpage-v-flooding:${VERSION}" -t "$PREFIX/examples-bookinfo-productpage-v-flooding:latest" --build-arg flood_factor=100 .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-productpage-v-flooding:${VERSION}" -t "${PREFIX}/examples-bookinfo-productpage-v-flooding:latest" --build-arg flood_factor=100 .
 popd
 
 pushd "$SCRIPTDIR/details"
   #plain build -- no calling external book service to fetch topics
-  docker build --pull -t "$PREFIX/examples-bookinfo-details-v1:${VERSION}" -t "$PREFIX/examples-bookinfo-details-v1:latest" --build-arg service_version=v1 .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-details-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-details-v1:latest" --build-arg service_version=v1 .
   #with calling external book service to fetch topic for the book
-  docker build --pull -t "$PREFIX/examples-bookinfo-details-v2:${VERSION}" -t "$PREFIX/examples-bookinfo-details-v2:latest" --build-arg service_version=v2 \
+  docker build --pull -t "${PREFIX}/examples-bookinfo-details-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-details-v2:latest" --build-arg service_version=v2 \
 	 --build-arg enable_external_book_service=true .
 popd
 
@@ -45,29 +45,29 @@ pushd "$SCRIPTDIR/reviews"
   docker run --rm -u root -v "$(pwd)":/home/gradle/project -w /home/gradle/project gradle:4.8.1 gradle clean build
   pushd reviews-wlpcfg
     #plain build -- no ratings
-    docker build --pull -t "$PREFIX/examples-bookinfo-reviews-v1:${VERSION}" -t "$PREFIX/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 .
+    docker build --pull -t "${PREFIX}/examples-bookinfo-reviews-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 .
     #with ratings black stars
-    docker build --pull -t "$PREFIX/examples-bookinfo-reviews-v2:${VERSION}" -t "$PREFIX/examples-bookinfo-reviews-v2:latest" --build-arg service_version=v2 \
+    docker build --pull -t "${PREFIX}/examples-bookinfo-reviews-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v2:latest" --build-arg service_version=v2 \
 	   --build-arg enable_ratings=true .
     #with ratings red stars
-    docker build --pull -t "$PREFIX/examples-bookinfo-reviews-v3:${VERSION}" -t "$PREFIX/examples-bookinfo-reviews-v3:latest" --build-arg service_version=v3 \
+    docker build --pull -t "${PREFIX}/examples-bookinfo-reviews-v3:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v3:latest" --build-arg service_version=v3 \
 	   --build-arg enable_ratings=true --build-arg star_color=red .
   popd
 popd
 
 pushd "$SCRIPTDIR/ratings"
-  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v1:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v1:latest" --build-arg service_version=v1 .
-  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v2:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v2:latest" --build-arg service_version=v2 .
-  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v-faulty:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v-faulty:latest" --build-arg service_version=v-faulty .
-  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v-delayed:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v-delayed:latest" --build-arg service_version=v-delayed .
-  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v-unavailable:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v-unavailable:latest" --build-arg service_version=v-unavailable .
-  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v-unhealthy:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v-unhealthy:latest" --build-arg service_version=v-unhealthy .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v1:latest" --build-arg service_version=v1 .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v2:latest" --build-arg service_version=v2 .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v-faulty:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-faulty:latest" --build-arg service_version=v-faulty .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v-delayed:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-delayed:latest" --build-arg service_version=v-delayed .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v-unavailable:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-unavailable:latest" --build-arg service_version=v-unavailable .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v-unhealthy:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-unhealthy:latest" --build-arg service_version=v-unhealthy .
 popd
 
 pushd "$SCRIPTDIR/mysql"
-  docker build --pull -t "$PREFIX/examples-bookinfo-mysqldb:${VERSION}" -t "$PREFIX/examples-bookinfo-mysqldb:latest" .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-mysqldb:${VERSION}" -t "${PREFIX}/examples-bookinfo-mysqldb:latest" .
 popd
 
 pushd "$SCRIPTDIR/mongodb"
-  docker build --pull -t "$PREFIX/examples-bookinfo-mongodb:${VERSION}" -t "$PREFIX/examples-bookinfo-mongodb:latest" .
+  docker build --pull -t "${PREFIX}/examples-bookinfo-mongodb:${VERSION}" -t "${PREFIX}/examples-bookinfo-mongodb:latest" .
 popd

--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -16,26 +16,27 @@
 
 set -o errexit
 
-if [ "$#" -ne 1 ]; then
-    echo Missing version parameter
-    echo Usage: build-services.sh \<version\>
+if [ "$#" -ne 2 ]; then
+    echo "Incorrect parameters"
+    echo "Usage: build-services.sh <version> <prefix>"
     exit 1
 fi
 
 VERSION=$1
+PREFIX=$2
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 pushd "$SCRIPTDIR/productpage"
-  docker build --pull -t "istio/examples-bookinfo-productpage-v1:${VERSION}" -t istio/examples-bookinfo-productpage-v1:latest .
+  docker build --pull -t "$PREFIX/examples-bookinfo-productpage-v1:${VERSION}" -t "$PREFIX/examples-bookinfo-productpage-v1:latest" .
   #flooding
-  docker build --pull -t "istio/examples-bookinfo-productpage-v-flooding:${VERSION}" -t istio/examples-bookinfo-productpage-v-flooding:latest --build-arg flood_factor=100 .
+  docker build --pull -t "$PREFIX/examples-bookinfo-productpage-v-flooding:${VERSION}" -t "$PREFIX/examples-bookinfo-productpage-v-flooding:latest" --build-arg flood_factor=100 .
 popd
 
 pushd "$SCRIPTDIR/details"
   #plain build -- no calling external book service to fetch topics
-  docker build --pull -t "istio/examples-bookinfo-details-v1:${VERSION}" -t istio/examples-bookinfo-details-v1:latest --build-arg service_version=v1 .
+  docker build --pull -t "$PREFIX/examples-bookinfo-details-v1:${VERSION}" -t "$PREFIX/examples-bookinfo-details-v1:latest" --build-arg service_version=v1 .
   #with calling external book service to fetch topic for the book
-  docker build --pull -t "istio/examples-bookinfo-details-v2:${VERSION}" -t istio/examples-bookinfo-details-v2:latest --build-arg service_version=v2 \
+  docker build --pull -t "$PREFIX/examples-bookinfo-details-v2:${VERSION}" -t "$PREFIX/examples-bookinfo-details-v2:latest" --build-arg service_version=v2 \
 	 --build-arg enable_external_book_service=true .
 popd
 
@@ -44,29 +45,29 @@ pushd "$SCRIPTDIR/reviews"
   docker run --rm -u root -v "$(pwd)":/home/gradle/project -w /home/gradle/project gradle:4.8.1 gradle clean build
   pushd reviews-wlpcfg
     #plain build -- no ratings
-    docker build --pull -t "istio/examples-bookinfo-reviews-v1:${VERSION}" -t istio/examples-bookinfo-reviews-v1:latest --build-arg service_version=v1 .
+    docker build --pull -t "$PREFIX/examples-bookinfo-reviews-v1:${VERSION}" -t "$PREFIX/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 .
     #with ratings black stars
-    docker build --pull -t "istio/examples-bookinfo-reviews-v2:${VERSION}" -t istio/examples-bookinfo-reviews-v2:latest --build-arg service_version=v2 \
+    docker build --pull -t "$PREFIX/examples-bookinfo-reviews-v2:${VERSION}" -t "$PREFIX/examples-bookinfo-reviews-v2:latest" --build-arg service_version=v2 \
 	   --build-arg enable_ratings=true .
     #with ratings red stars
-    docker build --pull -t "istio/examples-bookinfo-reviews-v3:${VERSION}" -t istio/examples-bookinfo-reviews-v3:latest --build-arg service_version=v3 \
+    docker build --pull -t "$PREFIX/examples-bookinfo-reviews-v3:${VERSION}" -t "$PREFIX/examples-bookinfo-reviews-v3:latest" --build-arg service_version=v3 \
 	   --build-arg enable_ratings=true --build-arg star_color=red .
   popd
 popd
 
 pushd "$SCRIPTDIR/ratings"
-  docker build --pull -t "istio/examples-bookinfo-ratings-v1:${VERSION}" -t istio/examples-bookinfo-ratings-v1:latest --build-arg service_version=v1 .
-  docker build --pull -t "istio/examples-bookinfo-ratings-v2:${VERSION}" -t istio/examples-bookinfo-ratings-v2:latest --build-arg service_version=v2 .
-  docker build --pull -t "istio/examples-bookinfo-ratings-v-faulty:${VERSION}" -t istio/examples-bookinfo-ratings-v-faulty:latest --build-arg service_version=v-faulty .
-  docker build --pull -t "istio/examples-bookinfo-ratings-v-delayed:${VERSION}" -t istio/examples-bookinfo-ratings-v-delayed:latest --build-arg service_version=v-delayed .
-  docker build --pull -t "istio/examples-bookinfo-ratings-v-unavailable:${VERSION}" -t istio/examples-bookinfo-ratings-v-unavailable:latest --build-arg service_version=v-unavailable .
-  docker build --pull -t "istio/examples-bookinfo-ratings-v-unhealthy:${VERSION}" -t istio/examples-bookinfo-ratings-v-unhealthy:latest --build-arg service_version=v-unhealthy .
+  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v1:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v1:latest" --build-arg service_version=v1 .
+  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v2:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v2:latest" --build-arg service_version=v2 .
+  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v-faulty:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v-faulty:latest" --build-arg service_version=v-faulty .
+  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v-delayed:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v-delayed:latest" --build-arg service_version=v-delayed .
+  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v-unavailable:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v-unavailable:latest" --build-arg service_version=v-unavailable .
+  docker build --pull -t "$PREFIX/examples-bookinfo-ratings-v-unhealthy:${VERSION}" -t "$PREFIX/examples-bookinfo-ratings-v-unhealthy:latest" --build-arg service_version=v-unhealthy .
 popd
 
 pushd "$SCRIPTDIR/mysql"
-  docker build --pull -t "istio/examples-bookinfo-mysqldb:${VERSION}" -t istio/examples-bookinfo-mysqldb:latest .
+  docker build --pull -t "$PREFIX/examples-bookinfo-mysqldb:${VERSION}" -t "$PREFIX/examples-bookinfo-mysqldb:latest" .
 popd
 
 pushd "$SCRIPTDIR/mongodb"
-  docker build --pull -t "istio/examples-bookinfo-mongodb:${VERSION}" -t istio/examples-bookinfo-mongodb:latest .
+  docker build --pull -t "$PREFIX/examples-bookinfo-mongodb:${VERSION}" -t "$PREFIX/examples-bookinfo-mongodb:latest" .
 popd

--- a/samples/bookinfo/src/details/details.rb
+++ b/samples/bookinfo/src/details/details.rb
@@ -135,7 +135,10 @@ def get_forward_headers(request)
                        'x-b3-parentspanid',
                        'x-b3-sampled',
                        'x-b3-flags',
-                       'x-ot-span-context'
+                       'x-ot-span-context',
+                       'x-datadog-trace-id',
+                       'x-datadog-parent-id',
+                       'x-datadog-sampled'
                      ]
 
   request.each do |header, value|

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -182,7 +182,7 @@ def getForwardHeaders(request):
     if 'user' in session:
         headers['end-user'] = session['user']
 
-    incoming_headers = ['x-request-id']
+    incoming_headers = ['x-request-id', 'x-datadog-trace-id', 'x-datadog-parent-id', 'x-datadog-sampled']
 
     # Add user-agent to headers manually
     if 'user-agent' in request.headers:

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -44,6 +44,8 @@ public class LibertyRestEndpoint extends Application {
     private final static String services_domain = System.getenv("SERVICES_DOMAIN") == null ? "" : ("." + System.getenv("SERVICES_DOMAIN"));
     private final static String ratings_hostname = System.getenv("RATINGS_HOSTNAME") == null ? "ratings" : System.getenv("RATINGS_HOSTNAME");
     private final static String ratings_service = "http://" + ratings_hostname + services_domain + ":9080/ratings";
+    // HTTP headers to propagate for distributed tracing are documented at
+    // https://istio.io/docs/tasks/telemetry/distributed-tracing/overview/#trace-context-propagation
     private final static String[] headers_to_proagate = {"x-request-id","x-b3-traceid","x-b3-spanid","x-b3-sampled","x-b3-flags",
       "x-ot-span-context","x-datadog-trace-id","x-datadog-parent-id","x-datadog-sampled", "end-user","user-agent"};
 
@@ -96,7 +98,7 @@ public class LibertyRestEndpoint extends Application {
       Invocation.Builder builder = ratingsTarget.request(MediaType.APPLICATION_JSON);
       for (String header : headers_to_proagate) {
         String value = requestHeaders.getHeaderString(header);
-        if(value != null) {
+        if (value != null) {
           builder.header(header,value);
         }
       }

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -23,7 +23,6 @@ import javax.json.JsonReader;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -32,6 +31,8 @@ import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.client.ResponseProcessingException;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -43,6 +44,8 @@ public class LibertyRestEndpoint extends Application {
     private final static String services_domain = System.getenv("SERVICES_DOMAIN") == null ? "" : ("." + System.getenv("SERVICES_DOMAIN"));
     private final static String ratings_hostname = System.getenv("RATINGS_HOSTNAME") == null ? "ratings" : System.getenv("RATINGS_HOSTNAME");
     private final static String ratings_service = "http://" + ratings_hostname + services_domain + ":9080/ratings";
+    private final static String[] headers_to_proagate = {"x-request-id","x-b3-traceid","x-b3-spanid","x-b3-sampled","x-b3-flags",
+      "x-ot-span-context","x-datadog-trace-id","x-datadog-parent-id","x-datadog-sampled", "end-user","user-agent"};
 
     private String getJsonResponse (String productId, int starsReviewer1, int starsReviewer2) {
     	String result = "{";
@@ -83,8 +86,7 @@ public class LibertyRestEndpoint extends Application {
     	return result;
     }
     
-    private JsonObject getRatings(String productId, String user, String useragent, String xreq, String xtraceid, String xspanid,
-                                  String xparentspanid, String xsampled, String xflags, String xotspan){
+    private JsonObject getRatings(String productId, HttpHeaders requestHeaders) {
       ClientBuilder cb = ClientBuilder.newBuilder();
       String timeout = star_color.equals("black") ? "10000" : "2500";
       cb.property("com.ibm.ws.jaxrs.client.connection.timeout", timeout);
@@ -92,32 +94,11 @@ public class LibertyRestEndpoint extends Application {
       Client client = cb.build();
       WebTarget ratingsTarget = client.target(ratings_service + "/" + productId);
       Invocation.Builder builder = ratingsTarget.request(MediaType.APPLICATION_JSON);
-      if(xreq!=null) {
-        builder.header("x-request-id",xreq);
-      }
-      if(xtraceid!=null) {
-        builder.header("x-b3-traceid",xtraceid);
-      }
-      if(xspanid!=null) {
-        builder.header("x-b3-spanid",xspanid);
-      }
-      if(xparentspanid!=null) {
-        builder.header("x-b3-parentspanid",xparentspanid);
-      }
-      if(xsampled!=null) {
-        builder.header("x-b3-sampled",xsampled);
-      }
-      if(xflags!=null) {
-        builder.header("x-b3-flags",xflags);
-      }
-      if(xotspan!=null) {
-        builder.header("x-ot-span-context",xotspan);
-      }
-      if(user!=null) {
-        builder.header("end-user", user);
-      }
-      if(useragent!=null) {
-        builder.header("user-agent", useragent);
+      for (String header : headers_to_proagate) {
+        String value = requestHeaders.getHeaderString(header);
+        if(value != null) {
+          builder.header(header,value);
+        }
       }
       Response r = builder.get();
       int statusCode = r.getStatusInfo().getStatusCode();
@@ -141,21 +122,12 @@ public class LibertyRestEndpoint extends Application {
 
     @GET
     @Path("/reviews/{productId}")
-    public Response bookReviewsById(@PathParam("productId") int productId,
-                                    @HeaderParam("end-user") String user,
-                                    @HeaderParam("user-agent") String useragent,
-                                    @HeaderParam("x-request-id") String xreq,
-                                    @HeaderParam("x-b3-traceid") String xtraceid,
-                                    @HeaderParam("x-b3-spanid") String xspanid,
-                                    @HeaderParam("x-b3-parentspanid") String xparentspanid,
-                                    @HeaderParam("x-b3-sampled") String xsampled,
-                                    @HeaderParam("x-b3-flags") String xflags,
-                                    @HeaderParam("x-ot-span-context") String xotspan) {
+    public Response bookReviewsById(@PathParam("productId") int productId, @Context HttpHeaders requestHeaders) {
       int starsReviewer1 = -1;
       int starsReviewer2 = -1;
 
       if (ratings_enabled) {
-        JsonObject ratingsResponse = getRatings(Integer.toString(productId), user, useragent, xreq, xtraceid, xspanid, xparentspanid, xsampled, xflags, xotspan);
+        JsonObject ratingsResponse = getRatings(Integer.toString(productId), requestHeaders);
         if (ratingsResponse != null) {
           if (ratingsResponse.containsKey("ratings")) {
             JsonObject ratings = ratingsResponse.getJsonObject("ratings");


### PR DESCRIPTION
This updates the productpage, reviews and details apps in bookinfo to also propagate the headers used by Datadog for distributed tracing.
The largest change is in the `reviews` Java app, to pass fewer parameters in the `getRatings` function, instead of one for each header.

Minor change to the build scripts to add an image prefix parameter.
The default naming is `istio/examples-bookinfo-*` which I am unable to push to.
With the optional prefix in the `build_push_update_images.sh` script, I can run with a prefix that I am permitted to push to, eg: `build_push_update_images.sh 1.14.0 cgilmour` -> images named `cgilmour/examples-bookinfo-*`.
The default behavior works the same as before.
