### PR TITLE
Fix crossgrade test crd application

### DIFF
--- a/tests/upgrade/test_crossgrade.sh
+++ b/tests/upgrade/test_crossgrade.sh
@@ -192,7 +192,7 @@ installIstioSystemAtVersionHelmTemplate() {
     if [[ "${release_path}" == *"1.1"* || "${release_path}" == *"1.2"* || "${release_path}" == *"master"* ]]; then
         # See https://preliminary.istio.io/docs/setup/kubernetes/helm-install/
         helm init --client-only
-        for i in install/kubernetes/helm/istio-init/files/crd*yaml; do
+        for i in "${3}"/install/kubernetes/helm/istio-init/files/crd*yaml; do
             echo_and_run kubectl apply -f "${i}"
         done
         sleep 5 # Per official Istio documentation!


### PR DESCRIPTION
Previously, CRDs were just applied in the current directory, which would
be the revision being tested. However, different versions have different
CRDs, so they should be applied from the release directory.