### PR TITLE
Fix security vulnerabilities for istio components

### DIFF
--- a/docker/Dockerfile.bionic_debug
+++ b/docker/Dockerfile.bionic_debug
@@ -5,6 +5,7 @@ FROM ubuntu:bionic
 # Do not add more stuff to this list that isn't small or critically useful.
 # If you occasionally need something on the container do
 # sudo apt-get update && apt-get whichever
+
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       curl \
@@ -17,6 +18,7 @@ RUN apt-get update && \
       net-tools \
       lsof \
       sudo && \
+      apt-get upgrade -y && \
       apt-get clean -y && \
       rm -rf /var/cache/debconf/* /var/lib/apt/lists/* \
         /var/log/* /tmp/*  /var/tmp/*

--- a/docker/Dockerfile.xenial_debug
+++ b/docker/Dockerfile.xenial_debug
@@ -21,6 +21,7 @@ RUN apt-get update && \
       net-tools \
       lsof \
       linux-tools-generic \
-      sudo && apt-get upgrade -y && \
-      apt-get clean && \
-    rm -rf  /var/log/*log /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
+      sudo \
+   && apt-get upgrade -y \
+   && apt-get clean \
+   && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old


### PR DESCRIPTION
The following security vulnerability was discovered during our
image scanning - CVE-2016-7076, related to installing the 'sudo'
package (https://usn.ubuntu.com/3968-1/). 

The fix includes:
- pinning the version of packages to the latest version for both
  docker/.Dockerfile.xenial_debug & docker/Dockerfile.bionic_debug
- cleaning up the apt-cache folder after installing packages for
  docker/.Dockerfile.xenial_debug (already done in
  docker/Dockerfile.bionic_debug)
- upgrading the base packages using `apt-get upgrade` for
  docker/Dockerfile.bionic_debug (already done in
  docker/Dockerfile.bionic_debug). Without this step, the image was
  showing security vulnerabilities

To verify the pinned versions of the packages, please refer: https://packages.ubuntu.com/search?keywords=search and verify the versions of packages for xenial/xenial-updates and bionic/bionic-updates release.

Fixes Bug:#14220