### PR TITLE
Add gRPC integration test for RBAC v1

### DIFF
--- a/tests/integration/security/rbac/v1/grpc/grpc_test.go
+++ b/tests/integration/security/rbac/v1/grpc/grpc_test.go
@@ -1,0 +1,110 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/istio/tests/integration/security/util"
+
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/tmpl"
+	rbacUtil "istio.io/istio/tests/integration/security/rbac/util"
+	"istio.io/istio/tests/integration/security/util/connection"
+)
+
+func TestRBACV1GRPC(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(t, ctx, "rbacv2-grpc-test", true)
+			var a, b, c, d echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, util.EchoConfig("c", ns, false, nil, g, p)).
+				With(&d, util.EchoConfig("d", ns, false, nil, g, p)).
+				BuildOrFail(t)
+
+			cases := []rbacUtil.TestCase{
+				{
+					Request: connection.Checker{
+						From: b,
+						Options: echo.CallOptions{
+							Target:   a,
+							PortName: "grpc",
+							Scheme:   scheme.GRPC,
+						},
+					},
+					ExpectAllowed: isMtlsEnabled,
+				},
+				{
+					Request: connection.Checker{
+						From: c,
+						Options: echo.CallOptions{
+							Target:   a,
+							PortName: "grpc",
+							Scheme:   scheme.GRPC,
+						},
+					},
+					ExpectAllowed: false,
+				},
+				{
+					Request: connection.Checker{
+						From: d,
+						Options: echo.CallOptions{
+							Target:   a,
+							PortName: "grpc",
+							Scheme:   scheme.GRPC,
+						},
+					},
+					ExpectAllowed: isMtlsEnabled,
+				},
+			}
+
+			namespaceTmpl := map[string]string{
+				"Namespace": ns.Name(),
+			}
+
+			policies := tmpl.EvaluateAllOrFail(t, namespaceTmpl,
+				file.AsStringOrFail(t, "testdata/istio-clusterrbacconfig.yaml.tmpl"),
+				file.AsStringOrFail(t, "testdata/istio-rbac-v1-grpc-rules.yaml.tmpl"))
+			g.ApplyConfigOrFail(t, ns, policies...)
+			defer g.DeleteConfigOrFail(t, ns, policies...)
+
+			// Sleep 60 seconds for the policy to take effect.
+			time.Sleep(60 * time.Second)
+			for _, tc := range cases {
+				testName := fmt.Sprintf("%s->%s:%s%s[%v]",
+					tc.Request.From.Config().Service,
+					tc.Request.Options.Target.Config().Service,
+					tc.Request.Options.PortName,
+					tc.Request.Options.Path,
+					tc.ExpectAllowed)
+				t.Run(testName, func(t *testing.T) {
+					retry.UntilSuccessOrFail(t, tc.CheckRBACRequest, retry.Delay(time.Second), retry.Timeout(10*time.Second))
+				})
+			}
+		})
+}

--- a/tests/integration/security/rbac/v1/grpc/main_test.go
+++ b/tests/integration/security/rbac/v1/grpc/main_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst          istio.Instance
+	g             galley.Instance
+	p             pilot.Instance
+	isMtlsEnabled bool
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("rbac_v1", m).
+		RequireEnvironment(environment.Kube).
+		Label(label.CustomSetup).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	isMtlsEnabled = cfg.IsMtlsEnabled()
+	cfg.Values["sidecarInjectorWebhook.rewriteAppHTTPProbe"] = "true"
+
+	// TODO(https://github.com/istio/istio/issues/14084) remove this
+	cfg.Values["pilot.env.PILOT_ENABLE_FALLTHROUGH_ROUTE"] = "0"
+}

--- a/tests/integration/security/rbac/v1/grpc/testdata/istio-clusterrbacconfig.yaml.tmpl
+++ b/tests/integration/security/rbac/v1/grpc/testdata/istio-clusterrbacconfig.yaml.tmpl
@@ -1,0 +1,10 @@
+# Enable istio RBAC
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ClusterRbacConfig
+metadata:
+  name: default
+spec:
+  mode: 'ON_WITH_INCLUSION'
+  inclusion:
+    namespaces: ["{{ .Namespace }}"]
+---

--- a/tests/integration/security/rbac/v1/grpc/testdata/istio-rbac-v1-grpc-rules.yaml.tmpl
+++ b/tests/integration/security/rbac/v1/grpc/testdata/istio-rbac-v1-grpc-rules.yaml.tmpl
@@ -1,0 +1,82 @@
+# istio-rbac-v1-grpc-rules.yaml to enforce access control for gRPC services using Istio RBAC v1 rules.
+
+# For service a:
+# * Allow b to call a's Echo method.
+# * Service c cannot talk to a since GET, DELETE, and PUT are not supported in gRPC.
+# * Allow d to call any methods of a.
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: access-grpc-echo
+  namespace: {{ .Namespace }}
+spec:
+  rules:
+    - services: ["a.{{ .Namespace }}.svc.cluster.local"]
+      paths: ["/proto.EchoTestService/Echo"]
+      # This is optional, since gRPC can only allow POST.
+      # If methods are not specified, it will allow all methods, which include POST.
+      methods: ["POST"]
+---
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: bind-access-grpc-echo
+  namespace: {{ .Namespace }}
+spec:
+  subjects:
+  - user: "cluster.local/ns/{{ .Namespace }}/sa/b"
+  roleRef:
+    kind: ServiceRole
+    name: access-grpc-echo
+---
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: not-access-grpc-not-post
+  namespace: {{ .Namespace }}
+spec:
+  rules:
+    - services: ["a.{{ .Namespace }}.svc.cluster.local"]
+      paths: ["/proto.EchoTestService/Echo"]
+      # Since gRPC only allows POST, this will be denied (even though paths should be allowed).
+      # In practice, users should not define methods when writing rules for gRPC services.
+      methods: ["GET", "DELETE", "PUT"]
+---
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: bind-not-access-grpc-not-post
+  namespace: {{ .Namespace }}
+spec:
+  subjects:
+  - user: "cluster.local/ns/{{ .Namespace }}/sa/c"
+  roleRef:
+    kind: ServiceRole
+    name: not-access-grpc-not-post
+---
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: access-grpc-any
+  namespace: {{ .Namespace }}
+spec:
+  rules:
+    - services: ["a.{{ .Namespace }}.svc.cluster.local"]
+---
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: bind-access-grpc-any
+  namespace: {{ .Namespace }}
+spec:
+  subjects:
+  - user: "cluster.local/ns/{{ .Namespace }}/sa/d"
+  roleRef:
+    kind: ServiceRole
+    name: access-grpc-any

--- a/tests/integration/security/rbac/v2/basic/testdata/istio-rbac-grpc-rules.yaml.tmpl
+++ b/tests/integration/security/rbac/v2/basic/testdata/istio-rbac-grpc-rules.yaml.tmpl
@@ -41,7 +41,7 @@ spec:
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: AuthorizationPolicy
 metadata:
-  name: authz-policy-access-a-http
+  name: authz-policy-a-grpc
   namespace: {{ .Namespace }}
 spec:
   workload_selector:


### PR DESCRIPTION
For #14213 

This is the same as #14371, except it uses RBAC v1 API. I also manually tested with both mtls on and off. 