### PR TITLE
Fix proxyImage annotation in injector

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -79,7 +79,7 @@ initContainers:
 {{- end }}
 containers:
 - name: istio-proxy
-{{- if contains "/" .Values.global.proxy.image }}
+{{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
   image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
 {{- else }}
   image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"


### PR DESCRIPTION
Previously, if you had an image like istio/proxy:1.1.7 it would add the
image and tag again, causing this to fail.

Fixes https://github.com/istio/istio/issues/14365