### PR TITLE
[WIP] Add retry and more logs to support multiple citadel instance 

### DIFF
--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -34,7 +34,7 @@ func TestGenCertKeyFromOptions(t *testing.T) {
 
 	// Options to generate a CA cert.
 	caCertOptions := CertOptions{
-		Host:         "test_ca.com",
+		Host:         "test_ca.com",fg
 		NotBefore:    caCertNotBefore,
 		TTL:          caCertTTL,
 		SignerCert:   nil,


### PR DESCRIPTION
- Add retry for secret upsert/deletion
- Differentiate update conflict error from others for future debugging, monitoring
- Fix typo

TODO
- Performance test
- More metrics
- Improve citadel root cert generation logic so multiple citadel can have the same config, and they can all use self-signed option.