### PR TITLE
Enable IP Whitelist test

### DIFF
--- a/tests/integration/mixer/policy/white_black_listing_test.go
+++ b/tests/integration/mixer/policy/white_black_listing_test.go
@@ -70,6 +70,7 @@ func TestWhiteListing(t *testing.T) {
 			t,
 			bookinfoNs,
 			bookinfo.PolicyDenyIPRule.LoadWithNamespaceOrFail(t, bookinfoNs.Name()))
+		util.AllowRuleSync(t)
 		// Verify you can't access productpage now.
 		util.SendTrafficAndWaitForExpectedStatus(ing, t, "Sending traffic...", "", 30, http.StatusForbidden)
 	})

--- a/tests/integration/mixer/policy/white_black_listing_test.go
+++ b/tests/integration/mixer/policy/white_black_listing_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestWhiteListing(t *testing.T) {
 	framework.Run(t, func(ctx framework.TestContext) {
-		t.Skipf("https://github.com/istio/istio/issues/13845")
 		if galInst == nil {
 			t.Fatalf("galley not setup")
 		}

--- a/tests/integration/mixer/util.go
+++ b/tests/integration/mixer/util.go
@@ -154,7 +154,7 @@ func SendTrafficAndWaitForExpectedStatus(ingress ingress.Instance, t *testing.T,
 	httpStatusCode int) {
 	retry := util.Retrier{
 		BaseDelay: 15 * time.Second,
-		Retries:   3,
+		Retries:   5,
 	}
 
 	retryFn := func(_ context.Context, i int) error {

--- a/tests/integration/mixer/util.go
+++ b/tests/integration/mixer/util.go
@@ -154,7 +154,7 @@ func SendTrafficAndWaitForExpectedStatus(ingress ingress.Instance, t *testing.T,
 	httpStatusCode int) {
 	retry := util.Retrier{
 		BaseDelay: 15 * time.Second,
-		Retries:   5,
+		Retries:   3,
 	}
 
 	retryFn := func(_ context.Context, i int) error {


### PR DESCRIPTION
Adding a sleep for 15 seconds for the rules to sync seems to be the best way right now to make sure rules are synced and test to pass reliably.

Fixes https://github.com/istio/istio/issues/13845