### PR TITLE
[1.2] Remove admin access during envoy drain period (#14250)

### DIFF
--- a/tools/packaging/common/envoy_bootstrap_drain.json
+++ b/tools/packaging/common/envoy_bootstrap_drain.json
@@ -1,11 +1,2 @@
 {
-  "admin": {
-    "access_log_path": "/dev/null",
-    "address": {
-      "socket_address": {
-        "address": "{{ .localhost }}",
-        "port_value": 15000
-      }
-    }
-  }
 }


### PR DESCRIPTION
During the drain, we attempt to use .localhost, which doesn't work
because we don't template the drain. It is possible for us to just add
templating to the drain to fix this. I chose not to because
* It adds complexity
* There is more that can go wrong with writing to a new file
* Admin interface doesn't really add any value in the last 5s of life
for the proxy

(cherry picked from commit 26c34d4b0fe90ea13359021b87a8d68ea0044c68)
Cherry pick from #14250