### PR TITLE
[1.2] Backport 1.1.7 upgrade tests

### DIFF
--- a/prow/upgrade-tests-1.0.1.sh
+++ b/prow/upgrade-tests-1.0.1.sh
@@ -28,8 +28,10 @@ set -x
 #   prow/upgrade-tests-1.0.1.sh
 
 # Set up inputs needed by test_upgrade.sh
+export SOURCE_HUB=${SOURCE_HUB:-$HUB}
 export SOURCE_VERSION=1.0.1
 export SOURCE_RELEASE_PATH="https://github.com/istio/istio/releases/download/${SOURCE_VERSION}"
+export TARGET_HUB=${TARGET_HUB:-$HUB}
 export TARGET_VERSION=${TAG}
 export TARGET_RELEASE_PATH=${ISTIO_REL_URL}
 

--- a/prow/upgrade-tests-1.1.7.sh
+++ b/prow/upgrade-tests-1.1.7.sh
@@ -25,11 +25,11 @@ set -x
 # UPGRADE_TEST_LOCAL="true" HUB=gcr.io/istio-release \
 #   ISTIO_REL_URL=https://storage.googleapis.com/istio-release-pipeline-data/daily-build/master-20190107-09-15 \
 #   TAG=master-20190107-09-15 \
-#   prow/upgrade-tests-1.0.2.sh
+#   prow/upgrade-tests-1.0.1.sh
 
 # Set up inputs needed by test_upgrade.sh
-export SOURCE_HUB=${SOURCE_HUB:-$HUB}
-export SOURCE_VERSION=1.0.2
+export SOURCE_HUB=${SOURCE_HUB:-istio}
+export SOURCE_VERSION=1.1.7
 export SOURCE_RELEASE_PATH="https://github.com/istio/istio/releases/download/${SOURCE_VERSION}"
 export TARGET_HUB=${TARGET_HUB:-$HUB}
 export TARGET_VERSION=${TAG}

--- a/prow/upgrade-tests.sh
+++ b/prow/upgrade-tests.sh
@@ -35,7 +35,7 @@ UPGRADE_TEST_LOCAL="${UPGRADE_TEST_LOCAL:-}"
 #
 # Expects HUB, SOURCE_VERSION, TARGET_VERSION, SOURCE_RELEASE_PATH, and TARGET_RELEASE_PATH as inputs.
 
-echo "Testing upgrade and downgrade between ${HUB}/${SOURCE_VERSION} and ${HUB}/${TARGET_VERSION}"
+echo "Testing upgrade and downgrade between ${SOURCE_HUB}/${SOURCE_VERSION} and ${TARGET_HUB}/${TARGET_VERSION}"
 
 # shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
@@ -62,7 +62,8 @@ fi
 # Install fortio which is needed by the upgrade test.
 go get fortio.org/fortio
 
-
 # Kick off tests
-"${ROOT}/tests/upgrade/test_crossgrade.sh" --from_hub="${HUB}" --from_tag="${SOURCE_VERSION}" --from_path="istio-${SOURCE_VERSION}" --to_hub="${HUB}" --to_tag="${TARGET_VERSION}" --to_path="istio-${TARGET_VERSION}" --cloud="GKE"
-
+"${ROOT}/tests/upgrade/test_crossgrade.sh" \
+  --from_hub="${SOURCE_HUB}" --from_tag="${SOURCE_VERSION}" --from_path="istio-${SOURCE_VERSION}" \
+  --to_hub="${TARGET_HUB}" --to_tag="${TARGET_VERSION}" --to_path="istio-${TARGET_VERSION}" \
+  --cloud="GKE"

--- a/tests/upgrade/test_crossgrade.sh
+++ b/tests/upgrade/test_crossgrade.sh
@@ -189,7 +189,7 @@ installIstioSystemAtVersionHelmTemplate() {
         auth_opts="--set global.mtls.enabled=true --set global.controlPlaneSecurityEnabled=true "
     fi
     release_path="${3}"/install/kubernetes/helm/istio
-    if [[ "${release_path}" == *"1.1"* || "${release_path}" == *"master"* ]]; then
+    if [[ "${release_path}" == *"1.1"* || "${release_path}" == *"1.2"* || "${release_path}" == *"master"* ]]; then
         # See https://preliminary.istio.io/docs/setup/kubernetes/helm-install/
         helm init --client-only
         for i in install/kubernetes/helm/istio-init/files/crd*yaml; do

--- a/tests/upgrade/test_crossgrade.sh
+++ b/tests/upgrade/test_crossgrade.sh
@@ -192,7 +192,7 @@ installIstioSystemAtVersionHelmTemplate() {
     if [[ "${release_path}" == *"1.1"* || "${release_path}" == *"1.2"* || "${release_path}" == *"master"* ]]; then
         # See https://preliminary.istio.io/docs/setup/kubernetes/helm-install/
         helm init --client-only
-        for i in install/kubernetes/helm/istio-init/files/crd*yaml; do
+        for i in "${3}"/install/kubernetes/helm/istio-init/files/crd*yaml; do
             echo_and_run kubectl apply -f "${i}"
         done
         sleep 5 # Per official Istio documentation!


### PR DESCRIPTION
Backport of #11452 + #14361

This is needed because the release will run from 1.2 so we need it in that branch for it to run