### PR TITLE
Refactor security integration tests

### DIFF
--- a/tests/integration/security/authn/permissive_test.go
+++ b/tests/integration/security/authn/permissive_test.go
@@ -20,11 +20,12 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/tests/integration/security/util"
+
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	lis "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/gogo/protobuf/types"
 
-	"istio.io/istio/pilot/pkg/model"
 	authn_applier "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -101,22 +102,7 @@ spec:
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, echo.Config{
-					Service:   "a",
-					Namespace: ns,
-					Galley:    g,
-					Pilot:     p,
-					Ports: []echo.Port{
-						{
-							Name:     "http",
-							Protocol: model.ProtocolHTTP,
-						},
-						{
-							Name:     "tcp",
-							Protocol: model.ProtocolTCP,
-						},
-					},
-				}).
+				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			nodeID := a.WorkloadsOrFail(t)[0].Sidecar().NodeID()

--- a/tests/integration/security/rbac/util/rbac_util.go
+++ b/tests/integration/security/rbac/util/rbac_util.go
@@ -18,8 +18,11 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"testing"
+	"time"
 
 	"istio.io/istio/pkg/test/echo/common/response"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/tests/integration/security/util/connection"
 )
 
@@ -85,4 +88,18 @@ func (tc TestCase) CheckRBACRequest() error {
 		}
 	}
 	return nil
+}
+
+func RunRBACTest(t *testing.T, cases []TestCase) {
+	for _, tc := range cases {
+		testName := fmt.Sprintf("%s->%s:%s%s[%v]",
+			tc.Request.From.Config().Service,
+			tc.Request.Options.Target.Config().Service,
+			tc.Request.Options.PortName,
+			tc.Request.Options.Path,
+			tc.ExpectAllowed)
+		t.Run(testName, func(t *testing.T) {
+			retry.UntilSuccessOrFail(t, tc.CheckRBACRequest, retry.Delay(time.Second), retry.Timeout(10*time.Second))
+		})
+	}
 }

--- a/tests/integration/security/rbac/v1/group/group_test.go
+++ b/tests/integration/security/rbac/v1/group/group_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	util2 "istio.io/istio/tests/integration/security/util"
+	securityUtil "istio.io/istio/tests/integration/security/util"
 
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
@@ -65,9 +65,9 @@ func TestRBACV1Group(t *testing.T) {
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util2.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util2.EchoConfig("b", ns, false, nil, g, p)).
-				With(&c, util2.EchoConfig("c", ns, false, nil, g, p)).
+				With(&a, securityUtil.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, securityUtil.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, securityUtil.EchoConfig("c", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			cases := []util.TestCase{

--- a/tests/integration/security/rbac/v1/group/group_test.go
+++ b/tests/integration/security/rbac/v1/group/group_test.go
@@ -15,11 +15,11 @@
 package group
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"istio.io/istio/pilot/pkg/model"
+	util2 "istio.io/istio/tests/integration/security/util"
+
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -27,7 +27,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/util/file"
-	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/tests/integration/security/rbac/util"
 	"istio.io/istio/tests/integration/security/util/connection"
@@ -63,38 +62,12 @@ func TestRBACV1Group(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 
 			ns := namespace.NewOrFail(t, ctx, "rbacv1-group-test", true)
-			ports := []echo.Port{
-				{
-					Name:     "http",
-					Protocol: model.ProtocolHTTP,
-				},
-			}
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, echo.Config{
-					Service:   "a",
-					Namespace: ns,
-					Ports:     ports,
-					Galley:    g,
-					Pilot:     p,
-				}).
-				With(&b, echo.Config{
-					Service:        "b",
-					Namespace:      ns,
-					Ports:          ports,
-					ServiceAccount: true,
-					Galley:         g,
-					Pilot:          p,
-				}).
-				With(&c, echo.Config{
-					Service:        "c",
-					Namespace:      ns,
-					Ports:          ports,
-					ServiceAccount: true,
-					Galley:         g,
-					Pilot:          p,
-				}).
+				With(&a, util2.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util2.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, util2.EchoConfig("c", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			cases := []util.TestCase{
@@ -166,16 +139,6 @@ func TestRBACV1Group(t *testing.T) {
 			// TODO: query pilot or app to know instead of sleep.
 			time.Sleep(60 * time.Second)
 
-			for _, tc := range cases {
-				testName := fmt.Sprintf("%s->%s:%s%s[%v]",
-					tc.Request.From.Config().Service,
-					tc.Request.Options.Target.Config().Service,
-					tc.Request.Options.PortName,
-					tc.Request.Options.Path,
-					tc.ExpectAllowed)
-				t.Run(testName, func(t *testing.T) {
-					retry.UntilSuccessOrFail(t, tc.CheckRBACRequest, retry.Delay(10*time.Second), retry.Timeout(120*time.Second))
-				})
-			}
+			util.RunRBACTest(t, cases)
 		})
 }

--- a/tests/integration/security/rbac/v2/basic/basic_test.go
+++ b/tests/integration/security/rbac/v2/basic/basic_test.go
@@ -15,11 +15,11 @@
 package basic
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"istio.io/istio/pilot/pkg/model"
+	util2 "istio.io/istio/tests/integration/security/util"
+
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -27,7 +27,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/util/file"
-	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/tests/integration/security/rbac/util"
 	"istio.io/istio/tests/integration/security/util/connection"
@@ -43,53 +42,13 @@ func TestRBACV2Basic(t *testing.T) {
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(t, ctx, "rbacv2-basic-test", true)
-			ports := []echo.Port{
-				{
-					Name:        "http",
-					Protocol:    model.ProtocolHTTP,
-					ServicePort: 80,
-				},
-				{
-					Name:        "tcp",
-					Protocol:    model.ProtocolTCP,
-					ServicePort: 90,
-				},
-			}
 
 			var a, b, c, d echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, echo.Config{
-					Service:        "a",
-					Namespace:      ns,
-					ServiceAccount: true,
-					Ports:          ports,
-					Galley:         g,
-					Pilot:          p,
-				}).
-				With(&b, echo.Config{
-					Service:        "b",
-					Namespace:      ns,
-					Ports:          ports,
-					ServiceAccount: true,
-					Galley:         g,
-					Pilot:          p,
-				}).
-				With(&c, echo.Config{
-					Service:        "c",
-					Namespace:      ns,
-					Ports:          ports,
-					ServiceAccount: true,
-					Galley:         g,
-					Pilot:          p,
-				}).
-				With(&d, echo.Config{
-					Service:        "d",
-					Namespace:      ns,
-					Ports:          ports,
-					ServiceAccount: true,
-					Galley:         g,
-					Pilot:          p,
-				}).
+				With(&a, util2.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util2.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, util2.EchoConfig("c", ns, false, nil, g, p)).
+				With(&d, util2.EchoConfig("d", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			cases := []util.TestCase{
@@ -435,16 +394,6 @@ func TestRBACV2Basic(t *testing.T) {
 			// TODO(pitlv2109: Check to make sure policies have been created instead.
 			time.Sleep(60 * time.Second)
 
-			for _, tc := range cases {
-				testName := fmt.Sprintf("%s->%s:%s%s[%v]",
-					tc.Request.From.Config().Service,
-					tc.Request.Options.Target.Config().Service,
-					tc.Request.Options.PortName,
-					tc.Request.Options.Path,
-					tc.ExpectAllowed)
-				t.Run(testName, func(t *testing.T) {
-					retry.UntilSuccessOrFail(t, tc.CheckRBACRequest, retry.Delay(time.Second), retry.Timeout(10*time.Second))
-				})
-			}
+			util.RunRBACTest(t, cases)
 		})
 }

--- a/tests/integration/security/rbac/v2/basic/basic_test.go
+++ b/tests/integration/security/rbac/v2/basic/basic_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	util2 "istio.io/istio/tests/integration/security/util"
+	securityUtil "istio.io/istio/tests/integration/security/util"
 
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
@@ -45,10 +45,10 @@ func TestRBACV2Basic(t *testing.T) {
 
 			var a, b, c, d echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util2.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util2.EchoConfig("b", ns, false, nil, g, p)).
-				With(&c, util2.EchoConfig("c", ns, false, nil, g, p)).
-				With(&d, util2.EchoConfig("d", ns, false, nil, g, p)).
+				With(&a, securityUtil.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, securityUtil.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, securityUtil.EchoConfig("c", ns, false, nil, g, p)).
+				With(&d, securityUtil.EchoConfig("d", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			cases := []util.TestCase{

--- a/tests/integration/security/rbac/v2/basic/extended_test.go
+++ b/tests/integration/security/rbac/v2/basic/extended_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	util2 "istio.io/istio/tests/integration/security/util"
+	securityUtil "istio.io/istio/tests/integration/security/util"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/echo/common/scheme"
@@ -46,9 +46,9 @@ func TestRBACV2Extended(t *testing.T) {
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util2.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util2.EchoConfig("b", ns, false, nil, g, p)).
-				With(&c, util2.EchoConfig("c", ns, false, nil, g, p)).
+				With(&a, securityUtil.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, securityUtil.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, securityUtil.EchoConfig("c", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			cases := []util.TestCase{

--- a/tests/integration/security/rbac/v2/basic/extended_test.go
+++ b/tests/integration/security/rbac/v2/basic/extended_test.go
@@ -15,9 +15,10 @@
 package basic
 
 import (
-	"fmt"
 	"testing"
 	"time"
+
+	util2 "istio.io/istio/tests/integration/security/util"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/echo/common/scheme"
@@ -27,7 +28,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/util/file"
-	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/tests/integration/security/rbac/util"
 	"istio.io/istio/tests/integration/security/util/connection"
@@ -43,45 +43,12 @@ func TestRBACV2Extended(t *testing.T) {
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(t, ctx, "rbacv2-extended-test", true)
-			ports := []echo.Port{
-				{
-					Name:        "http",
-					Protocol:    model.ProtocolHTTP,
-					ServicePort: 80,
-				},
-				{
-					Name:        "tcp",
-					Protocol:    model.ProtocolTCP,
-					ServicePort: 90,
-				},
-			}
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, echo.Config{
-					Service:        "a",
-					Namespace:      ns,
-					ServiceAccount: true,
-					Ports:          ports,
-					Galley:         g,
-					Pilot:          p,
-				}).
-				With(&b, echo.Config{
-					Service:        "b",
-					Namespace:      ns,
-					Ports:          ports,
-					ServiceAccount: true,
-					Galley:         g,
-					Pilot:          p,
-				}).
-				With(&c, echo.Config{
-					Service:        "c",
-					Namespace:      ns,
-					Ports:          ports,
-					ServiceAccount: true,
-					Galley:         g,
-					Pilot:          p,
-				}).
+				With(&a, util2.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util2.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, util2.EchoConfig("c", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			cases := []util.TestCase{
@@ -235,16 +202,6 @@ func TestRBACV2Extended(t *testing.T) {
 			// TODO(pitlv2109): Check to make sure policies have been created instead.
 			time.Sleep(60 * time.Second)
 
-			for _, tc := range cases {
-				testName := fmt.Sprintf("%s->%s:%s%s[%v]",
-					tc.Request.From.Config().Service,
-					tc.Request.Options.Target.Config().Service,
-					tc.Request.Options.PortName,
-					tc.Request.Options.Path,
-					tc.ExpectAllowed)
-				t.Run(testName, func(t *testing.T) {
-					retry.UntilSuccessOrFail(t, tc.CheckRBACRequest, retry.Delay(time.Second), retry.Timeout(10*time.Second))
-				})
-			}
+			util.RunRBACTest(t, cases)
 		})
 }

--- a/tests/integration/security/rbac/v2/basic/grpc_test.go
+++ b/tests/integration/security/rbac/v2/basic/grpc_test.go
@@ -15,7 +15,6 @@
 package basic
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -28,7 +27,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/util/file"
-	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 	rbacUtil "istio.io/istio/tests/integration/security/rbac/util"
 	"istio.io/istio/tests/integration/security/util/connection"
@@ -100,16 +98,6 @@ func TestRBACV2GRPC(t *testing.T) {
 			// Sleep 60 seconds for the policy to take effect.
 			// TODO: Check to make sure policies have been created instead.
 			time.Sleep(60 * time.Second)
-			for _, tc := range cases {
-				testName := fmt.Sprintf("%s->%s:%s%s[%v]",
-					tc.Request.From.Config().Service,
-					tc.Request.Options.Target.Config().Service,
-					tc.Request.Options.PortName,
-					tc.Request.Options.Path,
-					tc.ExpectAllowed)
-				t.Run(testName, func(t *testing.T) {
-					retry.UntilSuccessOrFail(t, tc.CheckRBACRequest, retry.Delay(time.Second), retry.Timeout(10*time.Second))
-				})
-			}
+			rbacUtil.RunRBACTest(t, cases)
 		})
 }

--- a/tests/integration/security/rbac/v2/basic/testdata/istio-extended-rbac-v2-rules.yaml.tmpl
+++ b/tests/integration/security/rbac/v2/basic/testdata/istio-extended-rbac-v2-rules.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
       not_paths: ["/bad-path*"]
     - constraints:
       - key: "destination.port"
-        values: ["90"]
+        values: ["9090"]
 ---
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: ServiceRole
@@ -49,7 +49,7 @@ spec:
 ---
 
 # For service b, allow any user to access it with GET at any paths except /secret*
-# or only access it at tcp port 90.
+# or only access it at tcp port 9090.
 # Instead of creating a separate ServiceRole policy, we create an inline role definition inside AuthorizationPolicy.
 
 apiVersion: "rbac.istio.io/v1alpha1"
@@ -69,5 +69,5 @@ spec:
           not_paths: ["/secret*"]
         - constraints:
           - key: "destination.port"
-            values: ["90"]
+            values: ["9090"]
 ---

--- a/tests/integration/security/rbac/v2/basic/testdata/istio-rbac-v2-rules.yaml.tmpl
+++ b/tests/integration/security/rbac/v2/basic/testdata/istio-rbac-v2-rules.yaml.tmpl
@@ -29,7 +29,7 @@ spec:
 ---
 
 # For service b, only allow authenticated user to access it with GET at any paths except /secret*
-# or only access it at tcp port 90.
+# or only access it at tcp port 9090.
 
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: ServiceRole
@@ -41,7 +41,7 @@ spec:
       not_paths: ["/secret*"]
     - constraints:
         - key: "destination.port"
-          values: ["90"]
+          values: ["9090"]
 ---
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: AuthorizationPolicy
@@ -105,7 +105,7 @@ spec:
 
 # For service d:
 # * anyone can access it via HTTP requests
-# * no one can access TCP at port 90.
+# * no one can access TCP at port 9090.
 
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: ServiceRole
@@ -114,7 +114,7 @@ metadata:
 spec:
   rules:
     - methods: ["*"]
-    - not_ports: [90]
+    - not_ports: [9090]
 ---
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: AuthorizationPolicy

--- a/tests/integration/security/rbac/v2/group/group_test.go
+++ b/tests/integration/security/rbac/v2/group/group_test.go
@@ -15,11 +15,11 @@
 package group
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"istio.io/istio/pilot/pkg/model"
+	util2 "istio.io/istio/tests/integration/security/util"
+
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -27,7 +27,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/util/file"
-	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/tests/integration/security/rbac/util"
 	"istio.io/istio/tests/integration/security/util/connection"
@@ -64,44 +63,15 @@ func TestRBACV2Group(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 
 			ns := namespace.NewOrFail(t, ctx, "rbacv2-group-test", true)
-			ports := []echo.Port{
-				{
-					Name:        "http",
-					Protocol:    model.ProtocolHTTP,
-					ServicePort: 80,
-				},
-			}
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, echo.Config{
-					Service:        "a",
-					Namespace:      ns,
-					ServiceAccount: true,
-					Ports:          ports,
-					Galley:         g,
-					Pilot:          p,
-				}).
-				With(&b, echo.Config{
-					Service:        "b",
-					Namespace:      ns,
-					Ports:          ports,
-					ServiceAccount: true,
-					Galley:         g,
-					Pilot:          p,
-				}).
-				With(&c, echo.Config{
-					Service:        "c",
-					Namespace:      ns,
-					Ports:          ports,
-					ServiceAccount: true,
-					Galley:         g,
-					Pilot:          p,
-				}).
+				With(&a, util2.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util2.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, util2.EchoConfig("c", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			cases := []util.TestCase{
-				// Port 80 is where HTTP is served
 				{
 					Request: connection.Checker{
 						From: a,
@@ -170,16 +140,6 @@ func TestRBACV2Group(t *testing.T) {
 			// TODO(lei-tang): programmatically check that policies have taken effect instead.
 			time.Sleep(60 * time.Second)
 
-			for _, tc := range cases {
-				testName := fmt.Sprintf("%s->%s:%s%s[%v]",
-					tc.Request.From.Config().Service,
-					tc.Request.Options.Target.Config().Service,
-					tc.Request.Options.PortName,
-					tc.Request.Options.Path,
-					tc.ExpectAllowed)
-				t.Run(testName, func(t *testing.T) {
-					retry.UntilSuccessOrFail(t, tc.CheckRBACRequest, retry.Delay(10*time.Second), retry.Timeout(120*time.Second))
-				})
-			}
+			util.RunRBACTest(t, cases)
 		})
 }

--- a/tests/integration/security/rbac/v2/group/group_test.go
+++ b/tests/integration/security/rbac/v2/group/group_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	util2 "istio.io/istio/tests/integration/security/util"
+	securityUtil "istio.io/istio/tests/integration/security/util"
 
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
@@ -66,9 +66,9 @@ func TestRBACV2Group(t *testing.T) {
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util2.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util2.EchoConfig("b", ns, false, nil, g, p)).
-				With(&c, util2.EchoConfig("c", ns, false, nil, g, p)).
+				With(&a, securityUtil.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, securityUtil.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, securityUtil.EchoConfig("c", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			cases := []util.TestCase{

--- a/tests/integration/security/reachability/reachability_test.go
+++ b/tests/integration/security/reachability/reachability_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/tests/integration/security/util"
+
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -48,11 +49,11 @@ func TestReachability(t *testing.T) {
 
 			var a, b, headless, naked echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, config("a", ns, false, nil)).
-				With(&b, config("b", ns, false, nil)).
-				With(&headless, config("headless", ns, true, nil)).
-				With(&naked, config("naked", ns, false, echo.NewAnnotations().
-					SetBool(echo.SidecarInject, false))).
+				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
+				With(&headless, util.EchoConfig("headless", ns, false, nil, g, p)).
+				With(&naked, util.EchoConfig("naked", ns, false, echo.NewAnnotations().
+					SetBool(echo.SidecarInject, false), g, p)).
 				BuildOrFail(ctx)
 
 			callOptions := []echo.CallOptions{
@@ -236,30 +237,4 @@ func TestReachability(t *testing.T) {
 				})
 			}
 		})
-}
-
-func config(name string, ns namespace.Instance, headless bool, annos echo.Annotations) echo.Config {
-	return echo.Config{
-		Service:        name,
-		Namespace:      ns,
-		ServiceAccount: true,
-		Headless:       headless,
-		Annotations:    annos,
-		Ports: []echo.Port{
-			{
-				Name:     "http",
-				Protocol: model.ProtocolHTTP,
-			},
-			{
-				Name:     "tcp",
-				Protocol: model.ProtocolTCP,
-			},
-			{
-				Name:     "grpc",
-				Protocol: model.ProtocolGRPC,
-			},
-		},
-		Galley: g,
-		Pilot:  p,
-	}
 }

--- a/tests/integration/security/sds_citadel_flow/sds_citadel_flow_test.go
+++ b/tests/integration/security/sds_citadel_flow/sds_citadel_flow_test.go
@@ -18,7 +18,8 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/tests/integration/security/util"
+
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -38,37 +39,12 @@ func TestSdsCitadelCaFlow(t *testing.T) {
 			istioCfg := istio.DefaultConfigOrFail(t, ctx)
 
 			namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
-			ns := namespace.NewOrFail(t, ctx, "reachability", true)
-
-			ports := []echo.Port{
-				{
-					Name:     "http",
-					Protocol: model.ProtocolHTTP,
-				},
-				{
-					Name:     "tcp",
-					Protocol: model.ProtocolTCP,
-				},
-			}
+			ns := namespace.NewOrFail(t, ctx, "sds-citadel-flow", true)
 
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, echo.Config{
-					Service:        "a",
-					Namespace:      ns,
-					ServiceAccount: true,
-					Ports:          ports,
-					Galley:         g,
-					Pilot:          p,
-				}).
-				With(&b, echo.Config{
-					Service:        "b",
-					Namespace:      ns,
-					ServiceAccount: true,
-					Ports:          ports,
-					Galley:         g,
-					Pilot:          p,
-				}).
+				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			checkers := []connection.Checker{

--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -18,7 +18,8 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/tests/integration/security/util"
+
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -40,37 +41,12 @@ func TestSdsVaultCaFlow(t *testing.T) {
 			istioCfg := istio.DefaultConfigOrFail(t, ctx)
 
 			namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
-			ns := namespace.NewOrFail(t, ctx, "reachability", true)
-
-			ports := []echo.Port{
-				{
-					Name:     "http",
-					Protocol: model.ProtocolHTTP,
-				},
-				{
-					Name:     "tcp",
-					Protocol: model.ProtocolTCP,
-				},
-			}
+			ns := namespace.NewOrFail(t, ctx, "sds-vault-flow", true)
 
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, echo.Config{
-					Service:        "a",
-					Namespace:      ns,
-					ServiceAccount: true,
-					Ports:          ports,
-					Galley:         g,
-					Pilot:          p,
-				}).
-				With(&b, echo.Config{
-					Service:        "b",
-					Namespace:      ns,
-					ServiceAccount: true,
-					Ports:          ports,
-					Galley:         g,
-					Pilot:          p,
-				}).
+				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			checkers := []connection.Checker{


### PR DESCRIPTION
* Make RBAC test runner function a utility function.
* Change TCP port to 9090 (default TCP port for Echo instances).
* Refactor Echo instance initialization. 

#13439 