### PR TITLE
clearing envoy stats should not break sidecar /ready probe (#14476)

### DIFF
--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -26,10 +26,11 @@ import (
 
 // Probe for readiness.
 type Probe struct {
-	LocalHostAddr    string
-	AdminPort        uint16
-	ApplicationPorts []uint16
-	NodeType         model.NodeType
+	LocalHostAddr       string
+	AdminPort           uint16
+	receivedFirstUpdate bool
+	ApplicationPorts    []uint16
+	NodeType            model.NodeType
 }
 
 // Check executes the probe and returns an error if the probe fails.
@@ -75,6 +76,10 @@ func (p *Probe) checkInboundConfigured() error {
 
 // checkUpdated checks to make sure updates have been received from Pilot
 func (p *Probe) checkUpdated() error {
+	if p.receivedFirstUpdate {
+		return nil
+	}
+
 	s, err := util.GetStats(p.LocalHostAddr, p.AdminPort)
 	if err != nil {
 		return err
@@ -83,6 +88,7 @@ func (p *Probe) checkUpdated() error {
 	CDSUpdated := s.CDSUpdatesSuccess > 0 || s.CDSUpdatesRejection > 0
 	LDSUpdated := s.LDSUpdatesSuccess > 0 || s.LDSUpdatesRejection > 0
 	if CDSUpdated && LDSUpdated {
+		p.receivedFirstUpdate = true
 		return nil
 	}
 


### PR DESCRIPTION
cherry-pick: https://github.com/istio/istio/pull/14476

* clearing envoy stats should not break sidecar /ready probe

* skip the call the /stats alltogether

* add probe check unit tests

* lint fixes