### PR TITLE
Prolong proxytracing e2e test retry timeout

### DIFF
--- a/tests/integration/telemetry/tracing/tracing_test.go
+++ b/tests/integration/telemetry/tracing/tracing_test.go
@@ -71,7 +71,7 @@ func TestProxyTracing(t *testing.T) {
 					return errors.New("cannot find expected traces")
 				}
 				return nil
-			}, retry.Delay(3*time.Second), retry.Timeout(40*time.Second))
+			}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
 		})
 }
 


### PR DESCRIPTION
Attempt for #14492.

Proxy tracing e2e test is being flaky. Based on build logs, Failures are all because of retry timeout. Some successful runs take about 40s to finish, which is close to the retry timeout. This PR doubles the retry timeout to eliminate the flake.