### PR TITLE
watch certs directory instead of cert files to prevent breaking watch in kubernetes

### DIFF
--- a/pilot/pkg/proxy/envoy/watcher.go
+++ b/pilot/pkg/proxy/envoy/watcher.go
@@ -20,6 +20,7 @@ import (
 	"hash"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/howeyc/fsnotify"
@@ -124,13 +125,23 @@ func watchCerts(ctx context.Context, certs []string, watchFileEventsFn watchFile
 		}
 	}()
 
-	// watch all files
+	// watch cert folders instead of files because
+	// watch breaks in kubernetes when secrets are updated.
+	// This happens because secrets are symbolic links pointing to files
+	// which are updated by kubernetes. On updating secrets, kubernetes
+	// deletes the existing file, which sends a DELETE file event and breaks the watch
+	certDirs := make(map[string]bool)
 	for _, c := range certs {
-		if err := fw.Watch(c); err != nil {
-			log.Warnf("watching %s encounters an error %v", c, err)
+		if !certDirs[filepath.Dir(c)] {
+			certDirs[filepath.Dir(c)] = true
+		}
+	}
+	for dir := range certDirs {
+		if err := fw.Watch(dir); err != nil {
+			log.Warnf("watching %s encountered an error %v", dir, err)
 			return
 		}
-		log.Infof("watching %s for changes", c)
+		log.Infof("watching %s for changes", dir)
 	}
 	watchFileEventsFn(ctx, fw.Event, minDelay, updateFunc)
 }

--- a/pilot/pkg/proxy/envoy/watcher.go
+++ b/pilot/pkg/proxy/envoy/watcher.go
@@ -132,9 +132,7 @@ func watchCerts(ctx context.Context, certs []string, watchFileEventsFn watchFile
 	// deletes the existing file, which sends a DELETE file event and breaks the watch
 	certDirs := make(map[string]bool)
 	for _, c := range certs {
-		if !certDirs[filepath.Dir(c)] {
-			certDirs[filepath.Dir(c)] = true
-		}
+		certDirs[filepath.Dir(c)] = true
 	}
 	for dir := range certDirs {
 		if err := fw.Watch(dir); err != nil {

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -107,12 +107,17 @@ func TestWatchCerts_Multiple(t *testing.T) {
 }
 
 func TestWatchCerts(t *testing.T) {
-	name, err := ioutil.TempDir(os.TempDir(), "certs")
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "certs")
 	if err != nil {
 		t.Errorf("failed to create a temp dir: %v", err)
 	}
+	// create a temp file
+	tmpFile, err := ioutil.TempFile(tmpDir, "test.file")
+	if err != nil {
+		t.Errorf("failed to create a temp file in testdata/certs: %v", err)
+	}
 	defer func() {
-		if err := os.RemoveAll(name); err != nil {
+		if err := os.RemoveAll(tmpDir); err != nil {
 			t.Errorf("failed to remove temp dir: %v", err)
 		}
 	}()
@@ -124,14 +129,15 @@ func TestWatchCerts(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	go watchCerts(ctx, []string{name}, watchFileEvents, 50*time.Millisecond, callbackFunc)
+	go watchCerts(ctx, []string{tmpFile.Name()}, watchFileEvents, 50*time.Millisecond, callbackFunc)
 
 	// sleep one second to make sure the watcher is set up before change is made
 	time.Sleep(time.Second)
 
-	// make a change to the watched dir
-	if _, err := ioutil.TempFile(name, "test.file"); err != nil {
-		t.Errorf("failed to create a temp file in testdata/certs: %v", err)
+	// make a change in the file to trigger watch
+	_, err = tmpFile.Write([]byte("foo"))
+	if err != nil {
+		t.Errorf("failed to update file %s: %v", tmpFile.Name(), err)
 	}
 
 	select {

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -109,19 +109,19 @@ func TestWatchCerts_Multiple(t *testing.T) {
 func TestWatchCerts(t *testing.T) {
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "certs")
 	if err != nil {
-		t.Errorf("failed to create a temp dir: %v", err)
+		t.Fatalf("failed to create a temp dir: %v", err)
 	}
 	// create a temp file
 	tmpFile, err := ioutil.TempFile(tmpDir, "test.file")
 	if err != nil {
-		t.Errorf("failed to create a temp file in testdata/certs: %v", err)
+		t.Fatalf("failed to create a temp file in testdata/certs: %v", err)
 	}
 	defer func() {
 		if err := tmpFile.Close(); err != nil {
-			t.Errorf("failed to close file %s: %v", tmpFile.Name(), err)
+			t.Fatalf("failed to close file %s: %v", tmpFile.Name(), err)
 		}
 		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Errorf("failed to remove temp dir: %v", err)
+			t.Fatalf("failed to remove temp dir: %v", err)
 		}
 	}()
 
@@ -138,13 +138,12 @@ func TestWatchCerts(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// modify file
-	_, err = tmpFile.Write([]byte("foo"))
-	if err != nil {
-		t.Errorf("failed to update file %s: %v", tmpFile.Name(), err)
+	if _, err := tmpFile.Write([]byte("foo")); err != nil {
+		t.Fatalf("failed to update file %s: %v", tmpFile.Name(), err)
 	}
-	err = tmpFile.Sync()
-	if err != nil {
-		t.Errorf("failed to sync file %s: %v", tmpFile.Name(), err)
+
+	if err := tmpFile.Sync(); err != nil {
+		t.Fatalf("failed to sync file %s: %v", tmpFile.Name(), err)
 	}
 
 	select {
@@ -152,7 +151,7 @@ func TestWatchCerts(t *testing.T) {
 		// expected
 		cancel()
 	case <-time.After(time.Second):
-		t.Errorf("The callback is not called within time limit " + time.Now().String() + " when file was modified")
+		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was modified")
 		cancel()
 	}
 
@@ -166,7 +165,7 @@ func TestWatchCerts(t *testing.T) {
 	// delete the file
 	err = os.Remove(tmpFile.Name())
 	if err != nil {
-		t.Errorf("failed to delete file %s: %v", tmpFile.Name(), err)
+		t.Fatalf("failed to delete file %s: %v", tmpFile.Name(), err)
 	}
 
 	select {
@@ -174,7 +173,7 @@ func TestWatchCerts(t *testing.T) {
 		// expected
 		cancel()
 	case <-time.After(time.Second):
-		t.Errorf("The callback is not called within time limit " + time.Now().String() + " when file was deleted")
+		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was deleted")
 		cancel()
 	}
 

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -132,6 +132,8 @@ func TestWatchCerts(t *testing.T) {
 
 	// test modify file event
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	go watchCerts(ctx, []string{tmpFile.Name()}, watchFileEvents, 50*time.Millisecond, callbackFunc)
 
 	// sleep one second to make sure the watcher is set up before change is made
@@ -149,14 +151,12 @@ func TestWatchCerts(t *testing.T) {
 	select {
 	case <-called:
 		// expected
-		cancel()
+		break
 	case <-time.After(time.Second):
-		cancel()
 		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was modified")
 	}
 
 	// test delete file event
-	ctx, cancel = context.WithCancel(context.Background())
 	go watchCerts(ctx, []string{tmpFile.Name()}, watchFileEvents, 50*time.Millisecond, callbackFunc)
 
 	// sleep one second to make sure the watcher is set up before change is made
@@ -171,9 +171,8 @@ func TestWatchCerts(t *testing.T) {
 	select {
 	case <-called:
 		// expected
-		cancel()
+		break
 	case <-time.After(time.Second):
-		cancel()
 		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was deleted")
 	}
 

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -117,9 +117,6 @@ func TestWatchCerts(t *testing.T) {
 		t.Errorf("failed to create a temp file in testdata/certs: %v", err)
 	}
 	defer func() {
-		if err := tmpFile.Close(); err != nil {
-			t.Errorf("failed to close file %s: %v", tmpFile.Name(), err)
-		}
 
 		if err := os.RemoveAll(tmpDir); err != nil {
 			t.Errorf("failed to remove temp dir: %v", err)
@@ -142,6 +139,9 @@ func TestWatchCerts(t *testing.T) {
 	_, err = tmpFile.Write([]byte("foo"))
 	if err != nil {
 		t.Errorf("failed to update file %s: %v", tmpFile.Name(), err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Errorf("failed to close file %s: %v", tmpFile.Name(), err)
 	}
 
 	select {

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -117,7 +117,9 @@ func TestWatchCerts(t *testing.T) {
 		t.Errorf("failed to create a temp file in testdata/certs: %v", err)
 	}
 	defer func() {
-
+		if err := tmpFile.Close(); err != nil {
+			t.Errorf("failed to close file %s: %v", tmpFile.Name(), err)
+		}
 		if err := os.RemoveAll(tmpDir); err != nil {
 			t.Errorf("failed to remove temp dir: %v", err)
 		}
@@ -140,8 +142,9 @@ func TestWatchCerts(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to update file %s: %v", tmpFile.Name(), err)
 	}
-	if err := tmpFile.Close(); err != nil {
-		t.Errorf("failed to close file %s: %v", tmpFile.Name(), err)
+	err = tmpFile.Sync()
+	if err != nil {
+		t.Errorf("failed to sync file %s: %v", tmpFile.Name(), err)
 	}
 
 	select {

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -117,6 +117,10 @@ func TestWatchCerts(t *testing.T) {
 		t.Errorf("failed to create a temp file in testdata/certs: %v", err)
 	}
 	defer func() {
+		if err := tmpFile.Close(); err != nil {
+			t.Errorf("failed to close file %s: %v", tmpFile.Name(), err)
+		}
+
 		if err := os.RemoveAll(tmpDir); err != nil {
 			t.Errorf("failed to remove temp dir: %v", err)
 		}

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -151,8 +151,8 @@ func TestWatchCerts(t *testing.T) {
 		// expected
 		cancel()
 	case <-time.After(time.Second):
-		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was modified")
 		cancel()
+		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was modified")
 	}
 
 	// test delete file event
@@ -173,8 +173,8 @@ func TestWatchCerts(t *testing.T) {
 		// expected
 		cancel()
 	case <-time.After(time.Second):
-		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was deleted")
 		cancel()
+		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was deleted")
 	}
 
 	// call with nil

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -118,10 +118,10 @@ func TestWatchCerts(t *testing.T) {
 	}
 	defer func() {
 		if err := tmpFile.Close(); err != nil {
-			t.Fatalf("failed to close file %s: %v", tmpFile.Name(), err)
+			t.Errorf("failed to close file %s: %v", tmpFile.Name(), err)
 		}
 		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Fatalf("failed to remove temp dir: %v", err)
+			t.Errorf("failed to remove temp dir: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
## Goal

Kubernetes secret is a symlink, and when a secret is updated, kubernetes creates a new file which breaks the watch on the symlink.

If secret name is foo it is represented as
```
foo -> ..data/foo 
```

`..data/foo`
 
is updated by kubernetes and when it does it, it probably does a Rename, which changes the inode and sends a DELETE event to whoever is watching on `foo`

This PR re-introduces watching on the cert directory instead of files.

## Issue
https://github.com/istio/istio/issues/14539