### PR TITLE
Correct link to example docs

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,4 +1,4 @@
 # Istio Samples
 
 This directory contains sample applications highlighting Istio's various
-features. To run these samples, check out the tutorials [here](https://istio.io/docs/guides/).
+features. To run these samples, check out the tutorials [here](https://istio.io/docs/examples/).


### PR DESCRIPTION
Add a working link to examples documentation.