### PR TITLE
[1.2] Apply locality overrides in bootstrap (#14353)

### DIFF
--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -27,6 +27,8 @@ import (
 	"text/template"
 	"time"
 
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/pkg/annotations"
 
 	"github.com/gogo/protobuf/types"
@@ -301,17 +303,24 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	opts["cluster"] = config.ServiceCluster
 	opts["nodeID"] = node
 
-	// Populate the platform locality if available.
-	l := platform.GetPlatformLocality()
+	// Support passing extra info from node environment as metadata
+	meta := getNodeMetaData(localEnv)
+
+	localityOverride := model.GetLocalityOrDefault("", meta)
+	l := util.ConvertLocality(localityOverride)
+	if l == nil {
+		// Populate the platform locality if available.
+		l = platform.GetPlatformLocality()
+	}
 	if l.Region != "" {
 		opts["region"] = l.Region
 	}
 	if l.Zone != "" {
 		opts["zone"] = l.Zone
 	}
-
-	// Support passing extra info from node environment as metadata
-	meta := getNodeMetaData(localEnv)
+	if l.SubZone != "" {
+		opts["sub_zone"] = l.SubZone
+	}
 
 	setStatsOptions(opts, meta, nodeIPs)
 

--- a/pkg/bootstrap/platform/locality.go
+++ b/pkg/bootstrap/platform/locality.go
@@ -19,15 +19,10 @@ import (
 	"regexp"
 
 	"cloud.google.com/go/compute/metadata"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	"istio.io/pkg/log"
 )
-
-type Locality struct {
-	Region  string
-	Zone    string
-	SubZone string
-}
 
 // Converts a GCP zone into a region.
 func gcpZoneToRegion(z string) (string, error) {
@@ -41,22 +36,22 @@ func gcpZoneToRegion(z string) (string, error) {
 }
 
 // GetLocality returns the platform-specific region and zone. Currently only GCP is supported.
-func GetPlatformLocality() Locality {
-	var l Locality
+func GetPlatformLocality() *core.Locality {
+	var l core.Locality
 	if metadata.OnGCE() {
 		z, zerr := metadata.Zone()
 		if zerr != nil {
 			log.Warnf("Error fetching GCP zone: %v", zerr)
-			return l
+			return &l
 		}
 		r, rerr := gcpZoneToRegion(z)
 		if rerr != nil {
 			log.Warnf("Error fetching GCP region: %v", rerr)
-			return l
+			return &l
 		}
 		l.Region = r
 		l.Zone = z
 	}
 
-	return l
+	return &l
 }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -2,8 +2,22 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-    "locality": {},
-    "metadata": {"ISTIO_META_INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","INTERCEPTION_MODE":"REDIRECT","ISTIO_PROXY_SHA":"istio-proxy:sha","ISTIO_PROXY_VERSION":"istio-proxy:version","ISTIO_VERSION":"release-3.1","POD_NAME":"svc-0-0-0-6944fb884d-4pgx8","istio":"sidecar","istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}"}
+    "locality": {
+      "region": "region",
+      "zone": "zone",
+      "sub_zone": "sub_zone"
+    },
+    "metadata": {
+      "ISTIO_META_INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6",
+      "INTERCEPTION_MODE":"REDIRECT",
+      "ISTIO_PROXY_SHA":"istio-proxy:sha",
+      "ISTIO_PROXY_VERSION":"istio-proxy:version",
+      "ISTIO_VERSION":"release-3.1",
+      "POD_NAME":"svc-0-0-0-6944fb884d-4pgx8",
+      "istio":"sidecar",
+      "istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}",
+      "istio-locality": "region.zone.sub_zone"
+    }
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/tests/integration/pilot/locality/failover_test.go
+++ b/tests/integration/pilot/locality/failover_test.go
@@ -23,7 +23,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/pkg/log"
 )
 
@@ -75,8 +74,6 @@ func TestFailover(t *testing.T) {
 
 			ctx.NewSubTest("CDS").
 				RequiresEnvironment(environment.Kube).
-				// TODO(https://github.com/istio/istio/issues/13812)
-				Label(label.Flaky).
 				RunParallel(func(ctx framework.TestContext) {
 					ns := namespace.NewOrFail(ctx, ctx, "locality-failover-cds", true)
 
@@ -100,7 +97,7 @@ func TestFailover(t *testing.T) {
 						ServiceCLocality:           "notcloseregion/zone/subzone",
 						NonExistantService:         "nonexistantservice",
 						NonExistantServiceLocality: "region/zone/subzone",
-					})
+					}, a)
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (CDS) via %v", fakeHostname)
@@ -131,7 +128,7 @@ func TestFailover(t *testing.T) {
 						ServiceCLocality:           "notcloseregion/zone/subzone",
 						NonExistantService:         "10.10.10.10",
 						NonExistantServiceLocality: "region/zone/subzone",
-					})
+					}, a)
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (EDS) via %v", fakeHostname)

--- a/tests/integration/pilot/locality/prioritized_test.go
+++ b/tests/integration/pilot/locality/prioritized_test.go
@@ -86,7 +86,7 @@ func TestPrioritized(t *testing.T) {
 						ServiceBLocality: "region/zone/subzone",
 						ServiceCAddress:  "c",
 						ServiceCLocality: "notregion/notzone/notsubzone",
-					})
+					}, a)
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (CDS) via %v", fakeHostname)
@@ -116,7 +116,7 @@ func TestPrioritized(t *testing.T) {
 						ServiceBLocality: "region/zone/subzone",
 						ServiceCAddress:  c.WorkloadsOrFail(ctx)[0].Address(),
 						ServiceCLocality: "notregion/notzone/notsubzone",
-					})
+					}, a)
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (EDS) via %v", fakeHostname)


### PR DESCRIPTION
* Apply locality overrides in bootstrap

We have some logic to apply locality in the bootstrap, but it only works
on GCE. In Pilot, we provide an option to override locality directly via
labels. However, the pilot logic for capturing this is read from service
instance, if it exists, then fallback to bootstrap locality. This can
cause a race condition if the service instance isn't populated by then,
so we can account for this by just adding the locality to the bootstrap
as well.

Additionally, add better waiting during the locality LB test, which is
now passing 100% of the time with this change.

* Fix subzone, add test

* Remove println

Backport of #14353
(cherry picked from commit e0a9255849950e6137a4487a8be0882b53a3878e)

Justification for 1.2:
* This fixes flaky tests
* This is a bug fix
* This should have no impact on users not using locality LB, which is an alpha feature turned off by default and has no known production users.
* For users that do use this, we have more tests added for this case