### PR TITLE
Adding a linter to verify Dockerfile

### DIFF
--- a/bin/check_dockerfiles.sh
+++ b/bin/check_dockerfiles.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Find Dockerfiles running an apt-get update but no uprade
+
+BASE_DIR="$(cd "$(dirname "${0}")" && pwd -P)"
+ISTIO_ROOT="$(cd "$(dirname "${BASE_DIR}")" && pwd -P)"
+
+STALE_DOCKERFILES=$( \
+  find "${ISTIO_ROOT}" \
+  -name 'Dockerfile*' | \
+  while read -r f; do
+    if [ "" != "$(grep "apt-get update" $f)" ] ; then \
+      if [ "" == "$(grep "apt-get upgrade" $f)" ] ; then \
+        echo "$f:"; \
+      fi ; \
+    fi; \
+  done)
+
+if [ "" != $STALE_DOCKERFILES ]; then
+  exit 1
+fi

--- a/bin/check_dockerfiles.sh
+++ b/bin/check_dockerfiles.sh
@@ -23,13 +23,13 @@ STALE_DOCKERFILES=$( \
   find "${ISTIO_ROOT}" \
   -name 'Dockerfile*' | \
   while read -r f; do
-    if [ "" != "$(grep "apt-get update" $f)" ] ; then \
-      if [ "" == "$(grep "apt-get upgrade" $f)" ] ; then \
+    if [ "" != "$(grep "apt-get update" "$f")" ] ; then \
+      if [ "" = "$(grep "apt-get upgrade" "$f")" ] ; then \
         echo "$f:"; \
       fi ; \
     fi; \
   done)
 
-if [ "" != $STALE_DOCKERFILES ]; then
+if [ "" != "$STALE_DOCKERFILES" ]; then
   exit 1
 fi

--- a/bin/check_dockerfiles.sh
+++ b/bin/check_dockerfiles.sh
@@ -31,5 +31,6 @@ STALE_DOCKERFILES=$( \
   done)
 
 if [ "" != "$STALE_DOCKERFILES" ]; then
+  echo "$STALE_DOCKERFILES"
   exit 1
 fi

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -76,6 +76,12 @@ function check_samples() {
     echo 'Samples OK'
 }
 
+function check_dockerfiles() {
+    echo 'Checking Dockerfiles'
+    bin/check_dockerfiles.sh
+    echo 'Dockerfiles OK'
+}
+
 ensure_pilot_types
 check_licenses
 run_adapter_lint
@@ -84,6 +90,7 @@ run_envvar_lint
 run_helm_lint
 check_grafana_dashboards
 check_samples
+check_dockerfiles
 
 "${WORKSPACE}/scripts/run_golangci.sh"
 "${WORKSPACE}/scripts/check_license.sh"


### PR DESCRIPTION
This checks that every dockerfile intending to make an apt-get update
actually performs an upgrade afterwards

This is to prevent any issue similar to #14220