### PR TITLE
[1.1] Update jwt resolver to mitigate network errors

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -59,7 +59,7 @@ const (
 )
 
 // JwtKeyResolver resolves JWT public key and JwksURI.
-var JwtKeyResolver = newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+var JwtKeyResolver = newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
 // GetConsolidateAuthenticationPolicy returns the authentication policy for
 // service specified by hostname and port, if defined. It also tries to resolve JWKS URI if necessary.

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -61,9 +61,9 @@ const (
 	getRemoteContentRetryInSec = 1
 
 	// How many times should we retry the failed network fetch on main flow. The main flow
-	// means it's called when Pilot is pushing configs. We should retry more conservatively to make sure
-	// not to block Pilot too long.
-	networkFetchRetryCountOnMainFlow = 1
+	// means it's called when Pilot is pushing configs. Do not retry to make sure not to block Pilot
+	// too long.
+	networkFetchRetryCountOnMainFlow = 0
 
 	// How many times should we retry the failed network fetch on refresh flow. The refresh flow
 	// means it's called when the periodically refresh job is triggered. We can retry more aggressively

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -55,9 +55,9 @@ const (
 	// JwtPubKeyRefreshInterval is the running interval of JWT pubKey refresh job.
 	JwtPubKeyRefreshInterval = time.Minute * 20
 
-	// jwtPubKeyFetchRetryInSec is the retry interval between the attempt to retry fetching
-	// the public key from network.
-	jwtPubKeyFetchRetryInSec = 1
+	// getRemoteContentRetryInSec is the retry interval between the attempt to retry getting the remote
+	// content from network.
+	getRemoteContentRetryInSec = 1
 )
 
 var (
@@ -280,9 +280,9 @@ func (r *jwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte,
 		if err == nil {
 			return body, nil
 		}
-		log.Warnf("Failed to fetch JWT public key from %q, retry in %d seconds: %s",
-			uri, jwtPubKeyFetchRetryInSec, err)
-		time.Sleep(jwtPubKeyFetchRetryInSec * time.Second)
+		log.Warnf("Failed to get remote content from %q, retry in %d seconds: %s",
+			uri, getRemoteContentRetryInSec, err)
+		time.Sleep(getRemoteContentRetryInSec * time.Second)
 	}
 
 	// Return the last fetch directly, reaching here means we have tried `retry` times, this will be

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -15,7 +15,6 @@
 package model
 
 import (
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -200,13 +199,13 @@ func TestGetPublicKeyWithRetry(t *testing.T) {
 	ms.ReturnErrorForFirstNumHits = 3
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
 
-	// The first request should fail for all of its 2 fetches (1 retry).
+	// The first call should fail for its 1st and 2nd request.
 	pk, err := r.GetPublicKey(mockCertURL)
-	if err == nil || !strings.Contains(err.Error(), "unsuccessful response") {
+	if err == nil {
 		t.Errorf("GetPublicKey(%+v) fails: expected error, got (%s)", mockCertURL, pk)
 	}
 
-	// The second request should succeed for the last of its 2 fetches (1 retry).
+	// The second call should fail for its 1st request but succeed for its 2nd request.
 	pk, err = r.GetPublicKey(mockCertURL)
 	if err != nil {
 		t.Errorf("GetPublicKey(%+v) fails: expected no error, got (%s)", mockCertURL, err)
@@ -220,7 +219,7 @@ func TestGetPublicKeyWithRetry(t *testing.T) {
 	}
 }
 
-func TestJwtPubKeyRefreshAndEviction(t *testing.T) {
+func TestJwtPubKeyEvictionForNotUsed(t *testing.T) {
 	r := newJwksResolver(100*time.Millisecond /*EvictionDuration*/, 2*time.Millisecond /*RefreshInterval*/)
 	defer r.Close()
 
@@ -229,10 +228,84 @@ func TestJwtPubKeyRefreshAndEviction(t *testing.T) {
 
 	// Mock server returns JwtPubKey2 for later calls.
 	// Verify the refresher has run and got new key from mock server.
-	verifyPubkeyRefresh(t, r, ms, test.JwtPubKey2)
+	verifyKeyRefresh(t, r, ms, test.JwtPubKey2)
 
-	// Verify the public key is evicted.
-	verifyPubkeyEviction(t, r, ms)
+	// Wait until unused keys are evicted.
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+	retries := 0
+	for ; retries < 3; retries++ {
+		time.Sleep(time.Second)
+		// Verify the public key is evicted.
+		if _, found := r.keyEntries.Load(mockCertURL); found {
+			// Retry after some sleep.
+			continue
+		}
+		break
+	}
+	if retries == 3 {
+		t.Errorf("Unused keys failed to be evicted")
+	}
+}
+
+func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
+	r := newJwksResolver(2*time.Second /*EvictionDuration*/, 100*time.Millisecond /*RefreshInterval*/)
+	defer r.Close()
+
+	ms := startMockServer(t)
+	defer ms.Stop()
+
+	// Configures the mock server to return error after the first request.
+	ms.ReturnErrorAfterFirstNumHits = 1
+
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+
+	// Keep getting the public key to change the lastUsedTime of the public key.
+	done := make(chan struct{})
+	go func() {
+		c := time.NewTicker(100 * time.Millisecond)
+		for {
+			select {
+			case <-done:
+				return
+			case <-c.C:
+				_, _ = r.GetPublicKey(mockCertURL)
+			}
+		}
+	}()
+	defer func() {
+		done <- struct{}{}
+	}()
+
+	pk, err := r.GetPublicKey(mockCertURL)
+	if err != nil {
+		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
+	}
+	// Mock server returns JwtPubKey1 for first call.
+	if test.JwtPubKey1 != pk {
+		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
+	}
+
+	// Verify the cached public key is removed after failed to refresh longer than the eviction duration.
+	time.Sleep(5 * time.Second)
+	_, err = r.GetPublicKey(mockCertURL)
+	if err == nil {
+		t.Errorf("GetPublicKey(%+v) fails: expected error, got no error", mockCertURL)
+	}
+}
+
+func TestJwtPubKeyLastRefreshedTime(t *testing.T) {
+	r := newJwksResolver(JwtPubKeyEvictionDuration, 2*time.Millisecond /*RefreshInterval*/)
+	defer r.Close()
+
+	ms := startMockServer(t)
+	defer ms.Stop()
+
+	// Mock server returns JwtPubKey2 for later calls.
+	// Verify the refresher has run and got new key from mock server.
+	verifyKeyRefresh(t, r, ms, test.JwtPubKey2)
+
+	// The lastRefreshedTime should change for each successful refresh.
+	verifyKeyLastRefreshedTime(t, r, ms, true /* wantChanged */)
 }
 
 func TestJwtPubKeyRefreshWithNetworkError(t *testing.T) {
@@ -242,11 +315,14 @@ func TestJwtPubKeyRefreshWithNetworkError(t *testing.T) {
 	ms := startMockServer(t)
 	defer ms.Stop()
 
-	// Configures the mock server to return error after the first requests.
+	// Configures the mock server to return error after the first request.
 	ms.ReturnErrorAfterFirstNumHits = 1
 
 	// The refresh job should continue using the previously fetched public key (JwtPubKey1).
-	verifyPubkeyRefresh(t, r, ms, test.JwtPubKey1)
+	verifyKeyRefresh(t, r, ms, test.JwtPubKey1)
+
+	// The lastRefreshedTime should not change the refresh failed due to network error.
+	verifyKeyLastRefreshedTime(t, r, ms, false /* wantChanged */)
 }
 
 func startMockServer(t *testing.T) *test.MockOpenIDDiscoveryServer {
@@ -259,28 +335,17 @@ func startMockServer(t *testing.T) *test.MockOpenIDDiscoveryServer {
 	return ms
 }
 
-func verifyPubkeyRefresh(t *testing.T, r *jwksResolver, ms *test.MockOpenIDDiscoveryServer, expectedJwtPubkey string) {
+func verifyKeyRefresh(t *testing.T, r *jwksResolver, ms *test.MockOpenIDDiscoveryServer, expectedJwtPubkey string) {
 	t.Helper()
-
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
-	cases := []struct {
-		in                string
-		expectedJwtPubkey string
-	}{
-		{
-			in: mockCertURL,
-			// Mock server returns JwtPubKey1 for first call.
-			expectedJwtPubkey: test.JwtPubKey1,
-		},
+
+	pk, err := r.GetPublicKey(mockCertURL)
+	if err != nil {
+		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
 	}
-	for _, c := range cases {
-		pk, err := r.GetPublicKey(c.in)
-		if err != nil {
-			t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", c.in, err)
-		}
-		if c.expectedJwtPubkey != pk {
-			t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
-		}
+	// Mock server returns JwtPubKey1 for first call.
+	if test.JwtPubKey1 != pk {
+		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
 	}
 
 	// Wait until refresh job at least finished once.
@@ -292,48 +357,38 @@ func verifyPubkeyRefresh(t *testing.T, r *jwksResolver, ms *test.MockOpenIDDisco
 			break
 		}
 	}
-
 	if retries == 20 {
 		t.Fatalf("Refresher failed to run")
 	}
 
-	cases = []struct {
-		in                string
-		expectedJwtPubkey string
-	}{
-		{
-			in:                mockCertURL,
-			expectedJwtPubkey: expectedJwtPubkey,
-		},
+	pk, err = r.GetPublicKey(mockCertURL)
+	if err != nil {
+		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
 	}
-	for _, c := range cases {
-		pk, err := r.GetPublicKey(c.in)
-		if err != nil {
-			t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", c.in, err)
-		}
-		if c.expectedJwtPubkey != pk {
-			t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
-		}
+	if expectedJwtPubkey != pk {
+		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, expectedJwtPubkey, pk)
 	}
 }
 
-func verifyPubkeyEviction(t *testing.T, r *jwksResolver, ms *test.MockOpenIDDiscoveryServer) {
+func verifyKeyLastRefreshedTime(t *testing.T, r *jwksResolver, ms *test.MockOpenIDDiscoveryServer, wantChanged bool) {
 	t.Helper()
-
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
-	// Wait until unused keys are evicted.
-	retries := 0
-	for ; retries < 3; retries++ {
-		time.Sleep(time.Second)
-		if _, found := r.keyEntries.Load(mockCertURL); found {
-			// Retry after some sleep.
-			continue
-		}
 
-		break
+	e, found := r.keyEntries.Load(mockCertURL)
+	if !found {
+		t.Fatalf("No cached public key for %s", mockCertURL)
 	}
+	oldRefreshedTime := e.(jwtPubKeyEntry).lastRefreshedTime
 
-	if retries == 3 {
-		t.Errorf("Unused keys failed to be evicted")
+	time.Sleep(200 * time.Millisecond)
+
+	e, found = r.keyEntries.Load(mockCertURL)
+	if !found {
+		t.Fatalf("No cached public key for %s", mockCertURL)
+	}
+	newRefreshedTime := e.(jwtPubKeyEntry).lastRefreshedTime
+
+	if actualChanged := oldRefreshedTime != newRefreshedTime; actualChanged != wantChanged {
+		t.Errorf("Want changed: %t but got %t", wantChanged, actualChanged)
 	}
 }

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -195,18 +195,18 @@ func TestGetPublicKeyWithRetry(t *testing.T) {
 	ms := startMockServer(t)
 	defer ms.Stop()
 
-	// Configures the mock server to return error for the first 9 requests and return the successful
-	// results starting from the 10th request.
-	ms.ReturnErrorForFirstNumHits = 9
+	// Configures the mock server to return error for the first 3 requests and return the successful
+	// results starting from the 4th request.
+	ms.ReturnErrorForFirstNumHits = 3
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
 
-	// The first request should fail for all of its 5 retries.
+	// The first request should fail for all of its 2 fetches (1 retry).
 	pk, err := r.GetPublicKey(mockCertURL)
 	if err == nil || !strings.Contains(err.Error(), "unsuccessful response") {
 		t.Errorf("GetPublicKey(%+v) fails: expected error, got (%s)", mockCertURL, pk)
 	}
 
-	// The second request should succeed for the last of its 5 retries.
+	// The second request should succeed for the last of its 2 fetches (1 retry).
 	pk, err = r.GetPublicKey(mockCertURL)
 	if err != nil {
 		t.Errorf("GetPublicKey(%+v) fails: expected no error, got (%s)", mockCertURL, err)
@@ -214,8 +214,8 @@ func TestGetPublicKeyWithRetry(t *testing.T) {
 		t.Errorf("GetPublicKey(%+v) fails: expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
 	}
 
-	// Verify mock server http://localhost:9999/oauth2/v3/certs was called 10 times because of the retry.
-	if got, want := ms.PubKeyHitNum, uint64(10); got != want {
+	// Verify mock server http://localhost:9999/oauth2/v3/certs was called 4 times because of the retry.
+	if got, want := ms.PubKeyHitNum, uint64(4); got != want {
 		t.Errorf("Mock server Hit number => expected %d but got %d", want, got)
 	}
 }

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -187,38 +187,6 @@ func TestGetPublicKey(t *testing.T) {
 	}
 }
 
-func TestGetPublicKeyWithRetry(t *testing.T) {
-	r := newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
-	defer r.Close()
-
-	ms := startMockServer(t)
-	defer ms.Stop()
-
-	// Configures the mock server to return error for the first 3 requests and return the successful
-	// results starting from the 4th request.
-	ms.ReturnErrorForFirstNumHits = 3
-	mockCertURL := ms.URL + "/oauth2/v3/certs"
-
-	// The first call should fail for its 1st and 2nd request.
-	pk, err := r.GetPublicKey(mockCertURL)
-	if err == nil {
-		t.Errorf("GetPublicKey(%+v) fails: expected error, got (%s)", mockCertURL, pk)
-	}
-
-	// The second call should fail for its 1st request but succeed for its 2nd request.
-	pk, err = r.GetPublicKey(mockCertURL)
-	if err != nil {
-		t.Errorf("GetPublicKey(%+v) fails: expected no error, got (%s)", mockCertURL, err)
-	} else if pk != test.JwtPubKey1 {
-		t.Errorf("GetPublicKey(%+v) fails: expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
-	}
-
-	// Verify mock server http://localhost:9999/oauth2/v3/certs was called 4 times because of the retry.
-	if got, want := ms.PubKeyHitNum, uint64(4); got != want {
-		t.Errorf("Mock server Hit number => expected %d but got %d", want, got)
-	}
-}
-
 func TestJwtPubKeyEvictionForNotUsed(t *testing.T) {
 	r := newJwksResolver(100*time.Millisecond /*EvictionDuration*/, 2*time.Millisecond /*RefreshInterval*/)
 	defer r.Close()

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -48,11 +48,19 @@ type MockOpenIDDiscoveryServer struct {
 	URL    string
 	server *http.Server
 
-	// How many times openIDCfg is called, use this number to verfiy cache takes effect.
+	// How many times openIDCfg is called, use this number to verify cache takes effect.
 	OpenIDHitNum uint64
 
-	// How many times jwtPubKey is called, use this number to verfiy cache takes effect.
+	// How many times jwtPubKey is called, use this number to verify cache takes effect.
 	PubKeyHitNum uint64
+
+	// The mock server will return an error for the first number of hits for public key, this is used
+	// to simulate network errors and test the retry logic in jwks resolver for public key fetch.
+	ReturnErrorForFirstNumHits uint64
+
+	// The mock server will start to return an error after the first number of hits for public key,
+	// this is used to simulate network errors and test the refresh logic in jwks resolver.
+	ReturnErrorAfterFirstNumHits uint64
 }
 
 // StartNewServer creates a mock openID discovery server and starts it
@@ -60,7 +68,11 @@ func StartNewServer() (*MockOpenIDDiscoveryServer, error) {
 	serverMutex.Lock()
 	defer serverMutex.Unlock()
 
-	server := &MockOpenIDDiscoveryServer{}
+	server := &MockOpenIDDiscoveryServer{
+		// 0 means the mock server always return the success result.
+		ReturnErrorForFirstNumHits:   0,
+		ReturnErrorAfterFirstNumHits: 0,
+	}
 
 	return server, server.Start()
 }
@@ -134,8 +146,19 @@ func (ms *MockOpenIDDiscoveryServer) openIDCfg(w http.ResponseWriter, req *http.
 
 func (ms *MockOpenIDDiscoveryServer) jwtPubKey(w http.ResponseWriter, req *http.Request) {
 	atomic.AddUint64(&ms.PubKeyHitNum, 1)
+	if ms.ReturnErrorAfterFirstNumHits != 0 && atomic.LoadUint64(&ms.PubKeyHitNum) > ms.ReturnErrorAfterFirstNumHits {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprintf(w, "Mock server configured to return error after %d hits", ms.ReturnErrorForFirstNumHits)
+		return
+	}
 
-	if atomic.LoadUint64(&ms.PubKeyHitNum) == 1 {
+	if atomic.LoadUint64(&ms.PubKeyHitNum) <= ms.ReturnErrorForFirstNumHits {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprintf(w, "Mock server configured to return error until %d retries", ms.ReturnErrorForFirstNumHits)
+		return
+	}
+
+	if atomic.LoadUint64(&ms.PubKeyHitNum) == ms.ReturnErrorForFirstNumHits+1 {
 		fmt.Fprintf(w, "%v", JwtPubKey1)
 		return
 	}

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -148,7 +148,7 @@ func (ms *MockOpenIDDiscoveryServer) jwtPubKey(w http.ResponseWriter, req *http.
 	atomic.AddUint64(&ms.PubKeyHitNum, 1)
 	if ms.ReturnErrorAfterFirstNumHits != 0 && atomic.LoadUint64(&ms.PubKeyHitNum) > ms.ReturnErrorAfterFirstNumHits {
 		w.WriteHeader(http.StatusForbidden)
-		fmt.Fprintf(w, "Mock server configured to return error after %d hits", ms.ReturnErrorForFirstNumHits)
+		fmt.Fprintf(w, "Mock server configured to return error after %d hits", ms.ReturnErrorAfterFirstNumHits)
 		return
 	}
 


### PR DESCRIPTION
For https://github.com/istio/istio/issues/14638

1) add retry logic when getting the remote content from the network
2) remove the expire time and change the refresh job to always fetch the jwt public key

Note, a public key will still be deleted after not using for 1 week, so we won't store any public key forever.

/cc @duderino @wenchenglu @ellis-bigelow 

I created the PR for 1.1 branch first hoping to make it to the upcoming 1.1 release. Will later cherry-pick to 1.0 and master.