### PR TITLE
Test will not individually push image if it is not to gcr.io/istio-testing registry

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -46,7 +46,7 @@ export HUB=${HUB:-"gcr.io/istio-testing"}
 
 # shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
-if [[ $HUB != *"istio-release"* ]]; then
+if [[ $HUB == *"istio-testing"* ]]; then
   setup_and_export_git_sha
 fi
 setup_e2e_cluster
@@ -77,13 +77,13 @@ done
 
 export TAG="${TAG:-${GIT_SHA}}"
 
-if [[ $HUB != *"istio-release"* ]]; then
+if [[ $HUB == *"istio-testing"* ]]; then
   export TAG="${TAG:-${GIT_SHA}}"-"${SINGLE_TEST}"
 fi
 
 make init
 
-if [[ $HUB != *"istio-release"* ]]; then
+if [[ $HUB == *"istio-testing"* ]]; then
   # upload images
   time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"
 fi

--- a/prow/integ-suite-k8s.sh
+++ b/prow/integ-suite-k8s.sh
@@ -68,13 +68,13 @@ fi
 export HUB=${HUB:-"gcr.io/istio-testing"}
 export TAG="${TAG:-${GIT_SHA}}"
 
-if [[ $HUB != *"istio-release"* ]]; then
+if [[ $HUB == *"istio-testing"* ]]; then
   export TAG="${TAG:-${GIT_SHA}}"-"$*"
 fi
 
 make init
 
-if [[ $HUB != *"istio-release"* ]]; then
+if [[ $HUB == *"istio-testing"* ]]; then
   time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"
 fi
 


### PR DESCRIPTION
There are multiple possible for the HUB:
1. gcr.io/istio-testing ---> this is used for istio/istio presubmit&postsubmit testing.
2. gcr.io/istio-release --> this is used for daily releases
3. docker.io/istio --> this is used for monthly releases

Before this changes, monthly release will fail! because each test will try to upload images to docker.io and that's not right. Each test should only build and push images when they are working with gcr.io/istio-testing.