### PR TITLE
Add service type to kiali helm file

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/service.yaml
@@ -9,8 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  type: {{ .Values.service.type }}
   ports:
-  - name: http-kiali
+  - name: {{ .Values.service.name }}
     protocol: TCP
     port: 20001
   selector:

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -55,3 +55,7 @@ prometheusAddr: http://prometheus:9090
 
 # When true, a secret will be created with a default username and password. Useful for demos.
 createDemoSecret: false
+
+service:
+  name: http-kiali
+  type: ClusterIP


### PR DESCRIPTION
This patch allow user to set service type and name to kiali.
If you set kiali service configuration like following, you can run kiali as `type: NodePort`

```
kiali:
  enabled: true
  createDemoSecret: true
  service:
    name: http-kiali
    type: NodePort
```

Node: I used Grafana file as a reference.