### PR TITLE
 Set resolver to 'dns' to support client side load balancing between …

### DIFF
--- a/mixer/pkg/protobuf/yaml/dynamic/handler.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/handler.go
@@ -154,8 +154,9 @@ func (h *Handler) connect() (err error) {
 	if err != nil {
 		return err
 	}
-	opts = append(opts, grpc.WithBalancerName(roundrobin.Name))
-	if h.conn, err = grpc.Dial(h.connConfig.GetAddress(), opts...); err != nil {
+	dialTarget := "dns:///" + h.connConfig.GetAddress()
+	opts = append(opts, grpc.WithBalancerName(roundrobin.Name), grpc.WithDisableServiceConfig())
+	if h.conn, err = grpc.Dial(dialTarget, opts...); err != nil {
 		handlerLog.Errorf("Unable to connect to:%s %v", h.connConfig.GetAddress(), err)
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
…mixer and gRPC adapters

@kyessenov would you mind taking a look at this change?

This follows on from #11819 which is still a problem for us and builds on top of #11914

I created a headless service and added the keepalive params but load balancing still did not occur. I did a bit of digging and it seems the default resolver scheme is set to passthrough which needs to be dns to enable load balancing.

 The `grpc.WithDisableServiceConfig()` option was added to remove some errors in the logs in the format of `INFO: grpc: failed dns TXT record lookup due to lookup ....`. I can remove this if you prefer.

In fact, I just noticed in the original issue you alluded to prepending the address with `dns://` which likely achieves the same as this PR but wasn't added as far as I can see.

I've built mixer with this change and tested it and it load balances as expected.

As a side note: Adding the keepalive setting to the gRPC server creates lots of noise in both the mixer logs and the target adapter. For example, on the adapter side we see `2019-06-06T10:20:39.580191Z	info	transport: loopyWriter.run returning. connection error: desc = "transport is closing"` each time the `MaxConnectionAge` expires and we reconnect. Not a deal breaker but would be nice to be able to disable this in our logs. Do you know of a way?  