### PR TITLE
fix helm test issue for citadel.

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/tests/test-citadel-connection.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/tests/test-citadel-connection.yaml
@@ -21,7 +21,7 @@ spec:
     - name: "{{ template "security.fullname" . }}-test"
       image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
-      command: ['sh', '-c', 'for i in 1 2 3; do curl http://istio-citadel:8060/-/ready && exit 0 || sleep 15; done; exit 1']
+      command: ['sh', '-c', 'for i in 1 2 3; do curl http://istio-citadel:{{ .Values.global.monitoringPort }}/version && exit 0 || sleep 15; done; exit 1']
   restartPolicy: Never
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}


### PR DESCRIPTION
Change the `curl` destination from gRPC port(`8060`) to plain http monitoring port, to resolve `curl` issue with citadel image built with golang 1.12 
For more context, see: https://github.com/istio/istio/issues/14573