### PR TITLE
[1.2] Fix security vulnerabilities for istio components

### DIFF
--- a/docker/Dockerfile.bionic_debug
+++ b/docker/Dockerfile.bionic_debug
@@ -5,6 +5,7 @@ FROM ubuntu:bionic
 # Do not add more stuff to this list that isn't small or critically useful.
 # If you occasionally need something on the container do
 # sudo apt-get update && apt-get whichever
+
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       curl \
@@ -17,6 +18,7 @@ RUN apt-get update && \
       net-tools \
       lsof \
       sudo && \
+      apt-get upgrade -y && \
       apt-get clean -y && \
       rm -rf /var/cache/debconf/* /var/lib/apt/lists/* \
         /var/log/* /tmp/*  /var/tmp/*

--- a/docker/Dockerfile.xenial_debug
+++ b/docker/Dockerfile.xenial_debug
@@ -21,6 +21,7 @@ RUN apt-get update && \
       net-tools \
       lsof \
       linux-tools-generic \
-      sudo && apt-get upgrade -y && \
-      apt-get clean && \
-    rm -rf  /var/log/*log /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
+      sudo \
+   && apt-get upgrade -y \
+   && apt-get clean \
+   && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old


### PR DESCRIPTION
The following security vulnerability was discovered during our
image scanning - CVE-2016-7076, related to installing the 'sudo'
package (https://usn.ubuntu.com/3968-1/). This has been fixed
in the latest 1.2rc0 release by building new images with the
latest sudo packages for the xenial version

The fix in this PR includes minor updates to Dockerfile for xenial
and bionic versio:
- cleaning up the apt-cache folder after installing packages for
  docker/.Dockerfile.xenial_debug (already done in
  docker/Dockerfile.bionic_debug)
- upgrading the base packages using `apt-get upgrade` for
  docker/Dockerfile.bionic_debug (already done in
  docker/Dockerfile.bionic_debug). Without this step, the image was
  showing security vulnerabilities.

Fixes Bug:#14220

(cherry picked from commit 4348ec77ca260c9d2dc6523630bdd7b69dca2830)
Cherry pick from https://github.com/istio/istio/pull/14453