### PR TITLE
Consider ServiceEntry weight in EDS

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -948,7 +948,7 @@ func buildLocalityLbEndpointsFromShards(
 			weight += ep.LoadBalancingWeight.GetValue()
 		}
 		locLbEps.LoadBalancingWeight = &types.UInt32Value{
-			Value: uint32(weight),
+			Value: weight,
 		}
 		locEps = append(locEps, *locLbEps)
 	}

--- a/tests/testdata/config/static-weighted-se.yaml
+++ b/tests/testdata/config/static-weighted-se.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: httpbin
+spec:
+  hosts:
+    - weighted.static.svc.cluster.local
+  ports:
+    - number: 80
+      name: http
+      protocol: HTTP
+  resolution: STATIC
+  endpoints:
+    - address: 3.3.3.3
+      locality: a
+    - address: 2.2.2.2
+      locality: a
+      weight: 8
+    - address: 1.1.1.1
+      locality: b
+      weight: 3


### PR DESCRIPTION
ServiceEntry can specify a weight. When using DNS resolution (CDS) this
will be considered, but it was ignored for EDS.

Fixes https://github.com/istio/istio/issues/14466