### PR TITLE
[1.1] Modify `docker build` commands in the sample apps Dockerfile to use `…

### DIFF
--- a/docker/Dockerfile.bionic_debug
+++ b/docker/Dockerfile.bionic_debug
@@ -5,6 +5,7 @@ FROM ubuntu:bionic
 # Do not add more stuff to this list that isn't small or critically useful.
 # If you occasionally need something on the container do
 # sudo apt-get update && apt-get whichever
+
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       curl \
@@ -17,6 +18,7 @@ RUN apt-get update && \
       net-tools \
       lsof \
       sudo && \
+      apt-get upgrade -y && \
       apt-get clean -y && \
       rm -rf /var/cache/debconf/* /var/lib/apt/lists/* \
         /var/log/* /tmp/*  /var/tmp/*

--- a/docker/Dockerfile.xenial_debug
+++ b/docker/Dockerfile.xenial_debug
@@ -21,6 +21,7 @@ RUN apt-get update && \
       net-tools \
       lsof \
       linux-tools-generic \
-      sudo && apt-get upgrade -y && \
-      apt-get clean && \
-    rm -rf  /var/log/*log /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
+      sudo \
+   && apt-get upgrade -y \
+   && apt-get clean \
+   && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old

--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -26,14 +26,14 @@ VERSION=$1
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 pushd "$SCRIPTDIR/productpage"
-  docker build -t "istio/examples-bookinfo-productpage-v1:${VERSION}" -t istio/examples-bookinfo-productpage-v1:latest .
+  docker build --pull -t "istio/examples-bookinfo-productpage-v1:${VERSION}" -t istio/examples-bookinfo-productpage-v1:latest .
 popd
 
 pushd "$SCRIPTDIR/details"
   #plain build -- no calling external book service to fetch topics
-  docker build -t "istio/examples-bookinfo-details-v1:${VERSION}" -t istio/examples-bookinfo-details-v1:latest --build-arg service_version=v1 .
+  docker build --pull -t "istio/examples-bookinfo-details-v1:${VERSION}" -t istio/examples-bookinfo-details-v1:latest --build-arg service_version=v1 .
   #with calling external book service to fetch topic for the book
-  docker build -t "istio/examples-bookinfo-details-v2:${VERSION}" -t istio/examples-bookinfo-details-v2:latest --build-arg service_version=v2 \
+  docker build --pull -t "istio/examples-bookinfo-details-v2:${VERSION}" -t istio/examples-bookinfo-details-v2:latest --build-arg service_version=v2 \
 	 --build-arg enable_external_book_service=true .
 popd
 
@@ -42,25 +42,25 @@ pushd "$SCRIPTDIR/reviews"
   docker run --rm -v "$(pwd)":/home/gradle/project -w /home/gradle/project gradle:4.8.1 gradle clean build
   pushd reviews-wlpcfg
     #plain build -- no ratings
-    docker build -t "istio/examples-bookinfo-reviews-v1:${VERSION}" -t istio/examples-bookinfo-reviews-v1:latest --build-arg service_version=v1 .
+    docker build --pull -t "istio/examples-bookinfo-reviews-v1:${VERSION}" -t istio/examples-bookinfo-reviews-v1:latest --build-arg service_version=v1 .
     #with ratings black stars
-    docker build -t "istio/examples-bookinfo-reviews-v2:${VERSION}" -t istio/examples-bookinfo-reviews-v2:latest --build-arg service_version=v2 \
+    docker build --pull -t "istio/examples-bookinfo-reviews-v2:${VERSION}" -t istio/examples-bookinfo-reviews-v2:latest --build-arg service_version=v2 \
 	   --build-arg enable_ratings=true .
     #with ratings red stars
-    docker build -t "istio/examples-bookinfo-reviews-v3:${VERSION}" -t istio/examples-bookinfo-reviews-v3:latest --build-arg service_version=v3 \
+    docker build --pull -t "istio/examples-bookinfo-reviews-v3:${VERSION}" -t istio/examples-bookinfo-reviews-v3:latest --build-arg service_version=v3 \
 	   --build-arg enable_ratings=true --build-arg star_color=red .
   popd
 popd
 
 pushd "$SCRIPTDIR/ratings"
-  docker build -t "istio/examples-bookinfo-ratings-v1:${VERSION}" -t istio/examples-bookinfo-ratings-v1:latest --build-arg service_version=v1 .
-  docker build -t "istio/examples-bookinfo-ratings-v2:${VERSION}" -t istio/examples-bookinfo-ratings-v2:latest --build-arg service_version=v2 .
+  docker build --pull -t "istio/examples-bookinfo-ratings-v1:${VERSION}" -t istio/examples-bookinfo-ratings-v1:latest --build-arg service_version=v1 .
+  docker build --pull -t "istio/examples-bookinfo-ratings-v2:${VERSION}" -t istio/examples-bookinfo-ratings-v2:latest --build-arg service_version=v2 .
 popd
 
 pushd "$SCRIPTDIR/mysql"
-  docker build -t "istio/examples-bookinfo-mysqldb:${VERSION}" -t istio/examples-bookinfo-mysqldb:latest .
+  docker build --pull -t "istio/examples-bookinfo-mysqldb:${VERSION}" -t istio/examples-bookinfo-mysqldb:latest .
 popd
 
 pushd "$SCRIPTDIR/mongodb"
-  docker build -t "istio/examples-bookinfo-mongodb:${VERSION}" -t istio/examples-bookinfo-mongodb:latest .
+  docker build --pull -t "istio/examples-bookinfo-mongodb:${VERSION}" -t istio/examples-bookinfo-mongodb:latest .
 popd

--- a/samples/bookinfo/src/details/Dockerfile
+++ b/samples/bookinfo/src/details/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM ruby:2.3-slim
+FROM ruby:2.6.3-slim
 
 COPY details.rb /opt/microservices/
 

--- a/samples/bookinfo/src/mysql/Dockerfile
+++ b/samples/bookinfo/src/mysql/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM mysql:8.0.3
+FROM mysql:8.0.16
 # MYSQL_ROOT_PASSWORD must be supplied as an env var
 
 COPY ./mysqldb-init.sql /docker-entrypoint-initdb.d

--- a/samples/bookinfo/src/ratings/Dockerfile
+++ b/samples/bookinfo/src/ratings/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM node:4-slim
+FROM node:12-slim
 
 COPY package.json /opt/microservices/
 COPY ratings.js /opt/microservices/

--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM websphere-liberty:latest
+FROM websphere-liberty:19.0.0.4-javaee8
 
 ENV SERVERDIRNAME reviews
 


### PR DESCRIPTION
…--pull` tag

Update the docker build commands in the sample apps Dockerfile to always pull newer
version of images to get the latest security updates of base images. Without this
option, it uses the locally downloaded image with the same tag if one exists.

Fixes Bug: #13714

(cherry picked from commit 57cd509a7e89dceceb774fe127bf55ab8a826c2d)