### PR TITLE
[1.0] Update jwt resolver to mitigate network errors

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -24,7 +24,7 @@ import (
 )
 
 // JwtKeyResolver resolves JWT public key and JwksURI.
-var JwtKeyResolver = newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+var JwtKeyResolver = newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
 // GetConsolidateAuthenticationPolicy returns the authentication policy for
 // service specified by hostname and port, if defined.

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -61,9 +61,9 @@ const (
 	getRemoteContentRetryInSec = 1
 
 	// How many times should we retry the failed network fetch on main flow. The main flow
-	// means it's called when Pilot is pushing configs. We should retry more conservatively to make sure
-	// not to block Pilot too long.
-	networkFetchRetryCountOnMainFlow = 1
+	// means it's called when Pilot is pushing configs. Do not retry to make sure not to block Pilot
+	// too long.
+	networkFetchRetryCountOnMainFlow = 0
 
 	// How many times should we retry the failed network fetch on refresh flow. The refresh flow
 	// means it's called when the periodically refresh job is triggered. We can retry more aggressively

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -48,16 +48,27 @@ const (
 	// jwksURICacheEviction specifies the frequency at which eviction activities take place.
 	jwksURICacheEviction = time.Minute * 30
 
-	// JwtPubKeyExpireDuration is the expire duration for JWT public key in the cache.
-	// After this duration expire, refresher job will fetch key for the cached item again.
-	JwtPubKeyExpireDuration = time.Hour
-
 	// JwtPubKeyEvictionDuration is the life duration for cached item.
-	// Cached item will be removed from the cache if it hasn't been used longer than JwtPubKeyEvictionDuration.
+	// Cached item will be removed from the cache if it hasn't been used longer than JwtPubKeyEvictionDuration or if pilot
+	// has failed to refresh it for more than JwtPubKeyEvictionDuration.
 	JwtPubKeyEvictionDuration = 24 * 7 * time.Hour
 
 	// JwtPubKeyRefreshInterval is the running interval of JWT pubKey refresh job.
 	JwtPubKeyRefreshInterval = time.Minute * 20
+
+	// getRemoteContentRetryInSec is the retry interval between the attempt to retry getting the remote
+	// content from network.
+	getRemoteContentRetryInSec = 1
+
+	// How many times should we retry the failed network fetch on main flow. The main flow
+	// means it's called when Pilot is pushing configs. We should retry more conservatively to make sure
+	// not to block Pilot too long.
+	networkFetchRetryCountOnMainFlow = 1
+
+	// How many times should we retry the failed network fetch on refresh flow. The refresh flow
+	// means it's called when the periodically refresh job is triggered. We can retry more aggressively
+	// as it's running separately from the main flow.
+	networkFetchRetryCountOnRefreshFlow = 3
 )
 
 var (
@@ -72,8 +83,8 @@ var (
 type jwtPubKeyEntry struct {
 	pubKey string
 
-	// Cached item will be fetched again by refresher job if (time.now >= expireTime).
-	expireTime time.Time
+	// The last success refreshed time of the pubKey.
+	lastRefreshedTime time.Time
 
 	// Cached item's last used time, which is set in GetPublicKey.
 	lastUsedTime time.Time
@@ -95,23 +106,23 @@ type jwksResolver struct {
 	httpClient       *http.Client
 	refreshTicker    *time.Ticker
 
-	expireDuration time.Duration
-
 	// Cached key will be removed from cache if (time.now - cachedItem.lastUsedTime >= evictionDuration), this prevents key cache growing indefinitely.
 	evictionDuration time.Duration
 
 	// Refresher job running interval.
 	refreshInterval time.Duration
 
-	// How may times refresh job has detected JWT public key change happened, used in unit test.
-	keyChangedCount uint64
+	// How many times refresh job has detected JWT public key change happened, used in unit test.
+	refreshJobKeyChangedCount uint64
+
+	// How many times refresh job failed to fetch the public key from network, used in unit test.
+	refreshJobFetchFailedCount uint64
 }
 
 // newJwksResolver creates new instance of jwksResolver.
-func newJwksResolver(expireDuration, evictionDuration, refreshInterval time.Duration) *jwksResolver {
+func newJwksResolver(evictionDuration, refreshInterval time.Duration) *jwksResolver {
 	ret := &jwksResolver{
 		JwksURICache:     cache.NewTTL(jwksURICacheExpiration, jwksURICacheEviction),
-		expireDuration:   expireDuration,
 		evictionDuration: evictionDuration,
 		refreshInterval:  refreshInterval,
 		httpClient: &http.Client{
@@ -120,7 +131,8 @@ func newJwksResolver(expireDuration, evictionDuration, refreshInterval time.Dura
 			// TODO: pilot needs to include a collection of root CAs to make external
 			// https web request(https://github.com/istio/istio/issues/1419).
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				DisableKeepAlives: true,
+				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 			},
 		},
 	}
@@ -132,6 +144,7 @@ func newJwksResolver(expireDuration, evictionDuration, refreshInterval time.Dura
 		ret.secureHTTPClient = &http.Client{
 			Timeout: jwksHTTPTimeOutInSec * time.Second,
 			Transport: &http.Transport{
+				DisableKeepAlives: true,
 				TLSClientConfig: &tls.Config{
 					RootCAs: caCertPool,
 				},
@@ -139,7 +152,8 @@ func newJwksResolver(expireDuration, evictionDuration, refreshInterval time.Dura
 		}
 	}
 
-	atomic.StoreUint64(&ret.keyChangedCount, 0)
+	atomic.StoreUint64(&ret.refreshJobKeyChangedCount, 0)
+	atomic.StoreUint64(&ret.refreshJobFetchFailedCount, 0)
 	go ret.refresher()
 
 	return ret
@@ -186,28 +200,24 @@ func (r *jwksResolver) GetPublicKey(jwksURI string) (string, error) {
 	now := time.Now()
 	if val, found := r.keyEntries.Load(jwksURI); found {
 		e := val.(jwtPubKeyEntry)
-
-		// Return from cache if it's not expired.
-		if e.expireTime.After(now) {
-			// Update cached key's last used time.
-			e.lastUsedTime = now
-			r.keyEntries.Store(jwksURI, e)
-			return e.pubKey, nil
-		}
+		// Update cached key's last used time.
+		e.lastUsedTime = now
+		r.keyEntries.Store(jwksURI, e)
+		return e.pubKey, nil
 	}
 
-	// Fetch key if it's not cached, or cached item is expired.
-	resp, err := r.getRemoteContent(jwksURI)
+	// Fetch key if it's not cached.
+	resp, err := r.getRemoteContentWithRetry(jwksURI, networkFetchRetryCountOnMainFlow)
 	if err != nil {
-		log.Errorf("Failed to fetch pubkey from %q: %v", jwksURI, err)
+		log.Errorf("Failed to fetch public key from %q: %v", jwksURI, err)
 		return "", err
 	}
 
 	pubKey := string(resp)
 	r.keyEntries.Store(jwksURI, jwtPubKeyEntry{
-		pubKey:       pubKey,
-		expireTime:   now.Add(r.expireDuration),
-		lastUsedTime: now,
+		pubKey:            pubKey,
+		lastRefreshedTime: now,
+		lastUsedTime:      now,
 	})
 
 	return pubKey, nil
@@ -221,7 +231,7 @@ func (r *jwksResolver) resolveJwksURIUsingOpenID(issuer string) (string, error) 
 	}
 
 	// Try to get jwks_uri through OpenID Discovery.
-	body, err := r.getRemoteContent(issuer + openIDDiscoveryCfgURLSuffix)
+	body, err := r.getRemoteContentWithRetry(issuer+openIDDiscoveryCfgURLSuffix, networkFetchRetryCountOnMainFlow)
 	if err != nil {
 		log.Errorf("Failed to fetch jwks_uri from %q: %v", issuer+openIDDiscoveryCfgURLSuffix, err)
 		return "", err
@@ -242,7 +252,7 @@ func (r *jwksResolver) resolveJwksURIUsingOpenID(issuer string) (string, error) 
 	return jwksURI, nil
 }
 
-func (r *jwksResolver) getRemoteContent(uri string) ([]byte, error) {
+func (r *jwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		log.Errorf("Failed to parse %q", uri)
@@ -259,41 +269,55 @@ func (r *jwksResolver) getRemoteContent(uri string) ([]byte, error) {
 		client = r.secureHTTPClient
 	}
 
-	resp, err := client.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	getPublicKey := func() ([]byte, error) {
+		resp, err := client.Get(uri)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("unsuccessful response from %q", uri)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("status %d, %s", resp.StatusCode, string(body))
+		}
+
+		return body, nil
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+	for i := 0; i < retry; i++ {
+		body, err := getPublicKey()
+		if err == nil {
+			return body, nil
+		}
+		log.Warnf("Failed to GET from %q: %s. Retry in %d seconds", uri, err, getRemoteContentRetryInSec)
+		time.Sleep(getRemoteContentRetryInSec * time.Second)
 	}
 
-	return body, nil
+	// Return the last fetch directly, reaching here means we have tried `retry` times, this will be
+	// the last time for the retry.
+	return getPublicKey()
 }
 
 func (r *jwksResolver) refresher() {
 	// Wake up once in a while and refresh stale items.
-	//Write
 	r.refreshTicker = time.NewTicker(r.refreshInterval)
 	for {
 		select {
-		case now := <-r.refreshTicker.C:
-			r.refresh(now)
+		case <-r.refreshTicker.C:
+			r.refresh()
 		case <-close:
 			r.refreshTicker.Stop()
 		}
 	}
 }
 
-func (r *jwksResolver) refresh(t time.Time) {
+func (r *jwksResolver) refresh() {
 	var wg sync.WaitGroup
 	hasChange := false
 
@@ -302,42 +326,44 @@ func (r *jwksResolver) refresh(t time.Time) {
 		jwksURI := key.(string)
 		e := value.(jwtPubKeyEntry)
 
-		// Remove cached item if it hasn't been used for a while.
-		if now.Sub(e.lastUsedTime) >= r.evictionDuration {
+		// Remove cached item for either of the following 2 situations
+		// 1) it hasn't been used for a while
+		// 2) it hasn't been refreshed successfully for a while
+		// This makes sure 2 things, we don't grow the cache infinitely and also we don't reuse a cached public key
+		// with no success refresh for too much time.
+		if now.Sub(e.lastUsedTime) >= r.evictionDuration || now.Sub(e.lastRefreshedTime) >= r.evictionDuration {
+			log.Infof("Removed cached JWT public key (lastRefreshed: %s, lastUsed: %s) from %q",
+				e.lastRefreshedTime, e.lastUsedTime, jwksURI)
 			r.keyEntries.Delete(jwksURI)
 			return true
 		}
 
 		oldPubKey := e.pubKey
 
-		// key rotation: fetch JWT public key again if it's expired.
-		if e.expireTime.Before(t) {
-			// Increment the WaitGroup counter.
-			wg.Add(1)
+		// Increment the WaitGroup counter.
+		wg.Add(1)
 
-			go func() {
-				// Decrement the counter when the goroutine completes.
-				defer wg.Done()
+		go func() {
+			// Decrement the counter when the goroutine completes.
+			defer wg.Done()
 
-				resp, err := r.getRemoteContent(jwksURI)
-				if err != nil {
-					log.Errorf("Cannot fetch JWT public key from %q, %v", jwksURI, err)
-					r.keyEntries.Delete(jwksURI)
-					return
-				}
-				newPubKey := string(resp)
-
-				r.keyEntries.Store(jwksURI, jwtPubKeyEntry{
-					pubKey:       newPubKey,
-					expireTime:   now.Add(r.expireDuration), // Update expireTime even if prev/current keys are the same.
-					lastUsedTime: e.lastUsedTime,            // keep original lastUsedTime.
-				})
-
-				if oldPubKey != newPubKey {
-					hasChange = true
-				}
-			}()
-		}
+			resp, err := r.getRemoteContentWithRetry(jwksURI, networkFetchRetryCountOnRefreshFlow)
+			if err != nil {
+				log.Errorf("Failed to refresh JWT public key from %q: %v", jwksURI, err)
+				atomic.AddUint64(&r.refreshJobFetchFailedCount, 1)
+				return
+			}
+			newPubKey := string(resp)
+			r.keyEntries.Store(jwksURI, jwtPubKeyEntry{
+				pubKey:            newPubKey,
+				lastRefreshedTime: now,            // update the lastRefreshedTime if we get a success response from the network.
+				lastUsedTime:      e.lastUsedTime, // keep original lastUsedTime.
+			})
+			if oldPubKey != newPubKey {
+				hasChange = true
+				log.Infof("Updated cached JWT public key from %q", jwksURI)
+			}
+		}()
 
 		return true
 	})
@@ -346,7 +372,7 @@ func (r *jwksResolver) refresh(t time.Time) {
 	wg.Wait()
 
 	if hasChange {
-		atomic.AddUint64(&r.keyChangedCount, 1)
+		atomic.AddUint64(&r.refreshJobKeyChangedCount, 1)
 		// Push public key changes to sidecars.
 		if r.PushFunc != nil {
 			r.PushFunc()

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestResolveJwksURIUsingOpenID(t *testing.T) {
-	r := newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+	r := newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
 	ms, err := test.NewServer()
 	defer ms.Stop()
@@ -73,7 +73,7 @@ func TestResolveJwksURIUsingOpenID(t *testing.T) {
 }
 
 func TestSetAuthenticationPolicyJwksURIs(t *testing.T) {
-	r := newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+	r := newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
 	ms, err := test.NewServer()
 	defer ms.Stop()
@@ -153,7 +153,7 @@ func TestSetAuthenticationPolicyJwksURIs(t *testing.T) {
 }
 
 func TestGetPublicKey(t *testing.T) {
-	r := newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+	r := newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 	defer r.Close()
 
 	ms, err := test.NewServer()
@@ -196,95 +196,211 @@ func TestGetPublicKey(t *testing.T) {
 	}
 }
 
-func TestJwtPubKeyRefresh(t *testing.T) {
-	r := newJwksResolver(time.Millisecond /*ExpireDuration*/, 100*time.Millisecond /*EvictionDuration*/, 2*time.Millisecond /*RefreshInterval*/)
+func TestGetPublicKeyWithRetry(t *testing.T) {
+	r := newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 	defer r.Close()
 
-	ms, err := test.NewServer()
+	ms := startMockServer(t)
 	defer ms.Stop()
-	if err != nil {
-		t.Fatal("failed to create mock server")
-	}
-	if err := ms.Start(); err != nil {
-		t.Fatal("failed to start mock server")
+
+	// Configures the mock server to return error for the first 3 requests and return the successful
+	// results starting from the 4th request.
+	ms.ReturnErrorForFirstNumHits = 3
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+
+	// The first call should fail for its 1st and 2nd request.
+	pk, err := r.GetPublicKey(mockCertURL)
+	if err == nil {
+		t.Errorf("GetPublicKey(%+v) fails: expected error, got (%s)", mockCertURL, pk)
 	}
 
-	mockCertURL := ms.URL + "/oauth2/v3/certs"
-	cases := []struct {
-		in                string
-		expectedJwtPubkey string
-	}{
-		{
-			in: mockCertURL,
-			// Mock server returns JwtPubKey1 for first call.
-			expectedJwtPubkey: test.JwtPubKey1,
-		},
+	// The second call should fail for its 1st request but succeed for its 2nd request.
+	pk, err = r.GetPublicKey(mockCertURL)
+	if err != nil {
+		t.Errorf("GetPublicKey(%+v) fails: expected no error, got (%s)", mockCertURL, err)
+	} else if pk != test.JwtPubKey1 {
+		t.Errorf("GetPublicKey(%+v) fails: expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
 	}
-	for _, c := range cases {
-		pk, err := r.GetPublicKey(c.in)
-		if err != nil {
-			t.Errorf("GetPublicKey(%+v) fails: expected no error, got (%v)", c.in, err)
+
+	// Verify mock server http://localhost:9999/oauth2/v3/certs was called 4 times because of the retry.
+	if got, want := ms.PubKeyHitNum, uint64(4); got != want {
+		t.Errorf("Mock server Hit number => expected %d but got %d", want, got)
+	}
+}
+
+func TestJwtPubKeyEvictionForNotUsed(t *testing.T) {
+	r := newJwksResolver(100*time.Millisecond /*EvictionDuration*/, 2*time.Millisecond /*RefreshInterval*/)
+	defer r.Close()
+
+	ms := startMockServer(t)
+	defer ms.Stop()
+
+	// Mock server returns JwtPubKey2 for later calls.
+	// Verify the refresher has run and got new key from mock server.
+	verifyKeyRefresh(t, r, ms, test.JwtPubKey2)
+
+	// Wait until unused keys are evicted.
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+	retries := 0
+	for ; retries < 3; retries++ {
+		time.Sleep(time.Second)
+		// Verify the public key is evicted.
+		if _, found := r.keyEntries.Load(mockCertURL); found {
+			// Retry after some sleep.
+			continue
 		}
-		if c.expectedJwtPubkey != pk {
-			t.Errorf("GetPublicKey(%+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
+		break
+	}
+	if retries == 3 {
+		t.Errorf("Unused keys failed to be evicted")
+	}
+}
+
+func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
+	r := newJwksResolver(2*time.Second /*EvictionDuration*/, 100*time.Millisecond /*RefreshInterval*/)
+	defer r.Close()
+
+	ms := startMockServer(t)
+	defer ms.Stop()
+
+	// Configures the mock server to return error after the first request.
+	ms.ReturnErrorAfterFirstNumHits = 1
+
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+
+	// Keep getting the public key to change the lastUsedTime of the public key.
+	done := make(chan struct{})
+	go func() {
+		c := time.NewTicker(100 * time.Millisecond)
+		for {
+			select {
+			case <-done:
+				return
+			case <-c.C:
+				_, _ = r.GetPublicKey(mockCertURL)
+			}
 		}
+	}()
+	defer func() {
+		done <- struct{}{}
+	}()
+
+	pk, err := r.GetPublicKey(mockCertURL)
+	if err != nil {
+		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
+	}
+	// Mock server returns JwtPubKey1 for first call.
+	if test.JwtPubKey1 != pk {
+		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
+	}
+
+	// Verify the cached public key is removed after failed to refresh longer than the eviction duration.
+	time.Sleep(5 * time.Second)
+	_, err = r.GetPublicKey(mockCertURL)
+	if err == nil {
+		t.Errorf("GetPublicKey(%+v) fails: expected error, got no error", mockCertURL)
+	}
+}
+
+func TestJwtPubKeyLastRefreshedTime(t *testing.T) {
+	r := newJwksResolver(JwtPubKeyEvictionDuration, 2*time.Millisecond /*RefreshInterval*/)
+	defer r.Close()
+
+	ms := startMockServer(t)
+	defer ms.Stop()
+
+	// Mock server returns JwtPubKey2 for later calls.
+	// Verify the refresher has run and got new key from mock server.
+	verifyKeyRefresh(t, r, ms, test.JwtPubKey2)
+
+	// The lastRefreshedTime should change for each successful refresh.
+	verifyKeyLastRefreshedTime(t, r, ms, true /* wantChanged */)
+}
+
+func TestJwtPubKeyRefreshWithNetworkError(t *testing.T) {
+	r := newJwksResolver(JwtPubKeyEvictionDuration, time.Second /*RefreshInterval*/)
+	defer r.Close()
+
+	ms := startMockServer(t)
+	defer ms.Stop()
+
+	// Configures the mock server to return error after the first request.
+	ms.ReturnErrorAfterFirstNumHits = 1
+
+	// The refresh job should continue using the previously fetched public key (JwtPubKey1).
+	verifyKeyRefresh(t, r, ms, test.JwtPubKey1)
+
+	// The lastRefreshedTime should not change the refresh failed due to network error.
+	verifyKeyLastRefreshedTime(t, r, ms, false /* wantChanged */)
+}
+
+func startMockServer(t *testing.T) *test.MockOpenIDDiscoveryServer {
+	t.Helper()
+
+	ms, err := test.NewServer()
+	if err != nil {
+		t.Fatalf("failed to create mock server: %s", err)
+	}
+	if err := ms.Start(); err != nil {
+		t.Fatalf("failed to start mock server: %s", err)
+	}
+	return ms
+}
+
+func verifyKeyRefresh(t *testing.T, r *jwksResolver, ms *test.MockOpenIDDiscoveryServer, expectedJwtPubkey string) {
+	t.Helper()
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+
+	pk, err := r.GetPublicKey(mockCertURL)
+	if err != nil {
+		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
+	}
+	// Mock server returns JwtPubKey1 for first call.
+	if test.JwtPubKey1 != pk {
+		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
 	}
 
 	// Wait until refresh job at least finished once.
-	wait := time.Millisecond
 	retries := 0
-	for ; retries < 3; retries++ {
-		time.Sleep(wait)
-		// Make sure refresh job has run and detect change happened.
-		if atomic.LoadUint64(&r.keyChangedCount) == 0 {
-			// Retry after some sleep.
-			wait *= 2
-			continue
-		}
-
-		break
-	}
-
-	if retries == 3 {
-		t.Errorf("Refresher failed to run")
-	}
-
-	cases = []struct {
-		in                string
-		expectedJwtPubkey string
-	}{
-		{
-			in: mockCertURL,
-			// Mock server returns JwtPubKey2 for later calls.
-			// Verify the refresher has run and got new key from mock server.
-			expectedJwtPubkey: test.JwtPubKey2,
-		},
-	}
-	for _, c := range cases {
-		pk, err := r.GetPublicKey(c.in)
-		if err != nil {
-			t.Errorf("GetPublicKey(%+v) fails: expected no error, got (%v)", c.in, err)
-		}
-		if c.expectedJwtPubkey != pk {
-			t.Errorf("GetPublicKey(%+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
+	for ; retries < 20; retries++ {
+		time.Sleep(time.Second)
+		// Make sure refresh job has run and detect change or refresh happened.
+		if atomic.LoadUint64(&r.refreshJobKeyChangedCount) > 0 || atomic.LoadUint64(&r.refreshJobFetchFailedCount) > 0 {
+			break
 		}
 	}
-
-	// Wait until unused keys are evicted.
-	wait = 50 * time.Millisecond
-	retries = 0
-	for ; retries < 3; retries++ {
-		time.Sleep(wait)
-		if _, found := r.keyEntries.Load(mockCertURL); found {
-			// Retry after some sleep.
-			wait *= 2
-			continue
-		}
-
-		break
+	if retries == 20 {
+		t.Fatalf("Refresher failed to run")
 	}
 
-	if retries == 3 {
-		t.Errorf("Unused keys failed to be evicted")
+	pk, err = r.GetPublicKey(mockCertURL)
+	if err != nil {
+		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
+	}
+	if expectedJwtPubkey != pk {
+		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, expectedJwtPubkey, pk)
+	}
+}
+
+func verifyKeyLastRefreshedTime(t *testing.T, r *jwksResolver, ms *test.MockOpenIDDiscoveryServer, wantChanged bool) {
+	t.Helper()
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+
+	e, found := r.keyEntries.Load(mockCertURL)
+	if !found {
+		t.Fatalf("No cached public key for %s", mockCertURL)
+	}
+	oldRefreshedTime := e.(jwtPubKeyEntry).lastRefreshedTime
+
+	time.Sleep(200 * time.Millisecond)
+
+	e, found = r.keyEntries.Load(mockCertURL)
+	if !found {
+		t.Fatalf("No cached public key for %s", mockCertURL)
+	}
+	newRefreshedTime := e.(jwtPubKeyEntry).lastRefreshedTime
+
+	if actualChanged := oldRefreshedTime != newRefreshedTime; actualChanged != wantChanged {
+		t.Errorf("Want changed: %t but got %t", wantChanged, actualChanged)
 	}
 }

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -47,11 +47,19 @@ type MockOpenIDDiscoveryServer struct {
 	URL    string
 	server *http.Server
 
-	// How many times openIDCfg is called, use this number to verfiy cache takes effect.
+	// How many times openIDCfg is called, use this number to verify cache takes effect.
 	OpenIDHitNum uint64
 
-	// How many times jwtPubKey is called, use this number to verfiy cache takes effect.
+	// How many times jwtPubKey is called, use this number to verify cache takes effect.
 	PubKeyHitNum uint64
+
+	// The mock server will return an error for the first number of hits for public key, this is used
+	// to simulate network errors and test the retry logic in jwks resolver for public key fetch.
+	ReturnErrorForFirstNumHits uint64
+
+	// The mock server will start to return an error after the first number of hits for public key,
+	// this is used to simulate network errors and test the refresh logic in jwks resolver.
+	ReturnErrorAfterFirstNumHits uint64
 }
 
 // NewServer creates a mock openID discovery server.
@@ -65,6 +73,9 @@ func NewServer() (*MockOpenIDDiscoveryServer, error) {
 	return &MockOpenIDDiscoveryServer{
 		Port: port,
 		URL:  fmt.Sprintf("http://localhost:%d", port),
+		// 0 means the mock server always return the success result.
+		ReturnErrorForFirstNumHits:   0,
+		ReturnErrorAfterFirstNumHits: 0,
 	}, nil
 }
 
@@ -137,8 +148,19 @@ func (ms *MockOpenIDDiscoveryServer) openIDCfg(w http.ResponseWriter, req *http.
 
 func (ms *MockOpenIDDiscoveryServer) jwtPubKey(w http.ResponseWriter, req *http.Request) {
 	atomic.AddUint64(&ms.PubKeyHitNum, 1)
+	if ms.ReturnErrorAfterFirstNumHits != 0 && atomic.LoadUint64(&ms.PubKeyHitNum) > ms.ReturnErrorAfterFirstNumHits {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprintf(w, "Mock server configured to return error after %d hits", ms.ReturnErrorAfterFirstNumHits)
+		return
+	}
 
-	if atomic.LoadUint64(&ms.PubKeyHitNum) == 1 {
+	if atomic.LoadUint64(&ms.PubKeyHitNum) <= ms.ReturnErrorForFirstNumHits {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprintf(w, "Mock server configured to return error until %d retries", ms.ReturnErrorForFirstNumHits)
+		return
+	}
+
+	if atomic.LoadUint64(&ms.PubKeyHitNum) == ms.ReturnErrorForFirstNumHits+1 {
 		fmt.Fprintf(w, "%v", JwtPubKey1)
 		return
 	}


### PR DESCRIPTION
For #14638
Cherrypick #14577

The refresh job will retry the fetch if it failed, and we don't remove
the cached public key right after any network error until we failed all
the fetch for the past 1 week.

Note, we don't add any retry logic to the main push flow to make sure
we don't block pilot too long.

/cc @duderino @wenchenglu @ellis-bigelow 
