### PR TITLE
Optimize and test ParseSubsetKey

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -202,6 +202,11 @@ const (
 	TrafficDirectionInbound TrafficDirection = "inbound"
 	// TrafficDirectionOutbound indicates outbound traffic
 	TrafficDirectionOutbound TrafficDirection = "outbound"
+
+	// TrafficDirectionOutboundSrvPrefix the prefix for a DNS SRV type subset key
+	TrafficDirectionOutboundSrvPrefix string = string(TrafficDirectionOutbound) + "_"
+	// TrafficDirectionInboundSrvPrefix the prefix for a DNS SRV type subset key
+	TrafficDirectionInboundSrvPrefix string = string(TrafficDirectionInbound) + "_"
 )
 
 // Visibility defines whether a given config or service is exported to local namespace, all namespaces or none
@@ -944,8 +949,8 @@ func ParseSubsetKey(s string) (direction TrafficDirection, subsetName string, ho
 	// This could be the DNS srv form of the cluster that uses outbound_.port_.subset_.hostname
 	// Since we dont want every callsite to implement the logic to differentiate between the two forms
 	// we add an alternate parser here.
-	if strings.HasPrefix(s, string(TrafficDirectionOutbound)+"_") ||
-		strings.HasPrefix(s, string(TrafficDirectionInbound)+"_") {
+	if strings.HasPrefix(s, TrafficDirectionOutboundSrvPrefix) ||
+		strings.HasPrefix(s, TrafficDirectionInboundSrvPrefix) {
 		parts = strings.SplitN(s, ".", 4)
 		dnsSrvMode = true
 	} else {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -944,8 +944,8 @@ func ParseSubsetKey(s string) (direction TrafficDirection, subsetName string, ho
 	// This could be the DNS srv form of the cluster that uses outbound_.port_.subset_.hostname
 	// Since we dont want every callsite to implement the logic to differentiate between the two forms
 	// we add an alternate parser here.
-	if strings.HasPrefix(s, fmt.Sprintf("%s_", TrafficDirectionOutbound)) ||
-		strings.HasPrefix(s, fmt.Sprintf("%s_", TrafficDirectionInbound)) {
+	if strings.HasPrefix(s, string(TrafficDirectionOutbound)+"_") ||
+		strings.HasPrefix(s, string(TrafficDirectionInbound)+"_") {
 		parts = strings.SplitN(s, ".", 4)
 		dnsSrvMode = true
 	} else {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -203,10 +203,10 @@ const (
 	// TrafficDirectionOutbound indicates outbound traffic
 	TrafficDirectionOutbound TrafficDirection = "outbound"
 
-	// TrafficDirectionOutboundSrvPrefix the prefix for a DNS SRV type subset key
-	TrafficDirectionOutboundSrvPrefix string = string(TrafficDirectionOutbound) + "_"
-	// TrafficDirectionInboundSrvPrefix the prefix for a DNS SRV type subset key
-	TrafficDirectionInboundSrvPrefix string = string(TrafficDirectionInbound) + "_"
+	// trafficDirectionOutboundSrvPrefix the prefix for a DNS SRV type subset key
+	trafficDirectionOutboundSrvPrefix string = string(TrafficDirectionOutbound) + "_"
+	// trafficDirectionInboundSrvPrefix the prefix for a DNS SRV type subset key
+	trafficDirectionInboundSrvPrefix string = string(TrafficDirectionInbound) + "_"
 )
 
 // Visibility defines whether a given config or service is exported to local namespace, all namespaces or none
@@ -949,8 +949,8 @@ func ParseSubsetKey(s string) (direction TrafficDirection, subsetName string, ho
 	// This could be the DNS srv form of the cluster that uses outbound_.port_.subset_.hostname
 	// Since we dont want every callsite to implement the logic to differentiate between the two forms
 	// we add an alternate parser here.
-	if strings.HasPrefix(s, TrafficDirectionOutboundSrvPrefix) ||
-		strings.HasPrefix(s, TrafficDirectionInboundSrvPrefix) {
+	if strings.HasPrefix(s, trafficDirectionOutboundSrvPrefix) ||
+		strings.HasPrefix(s, trafficDirectionInboundSrvPrefix) {
 		parts = strings.SplitN(s, ".", 4)
 		dnsSrvMode = true
 	} else {

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -516,6 +516,13 @@ func TestHostnamesSortOrder(t *testing.T) {
 	}
 }
 
+func BenchmarkParseSubsetKey(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ParseSubsetKey("outbound|80|v1|example.com")
+		ParseSubsetKey("outbound_.8080_.v1_.foo.example.org")
+	}
+}
+
 func TestParseSubsetKey(t *testing.T) {
 	tests := []struct {
 		input      string

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -516,6 +516,40 @@ func TestHostnamesSortOrder(t *testing.T) {
 	}
 }
 
+func TestParseSubsetKey(t *testing.T) {
+	tests := []struct {
+		input      string
+		direction  TrafficDirection
+		subsetName string
+		hostname   Hostname
+		port       int
+	}{
+		{"outbound|80|v1|example.com", TrafficDirectionOutbound, "v1", "example.com", 80},
+		{"", "", "", "", 0},
+		{"|||", "", "", "", 0},
+		{"outbound_.8080_.v1_.foo.example.org", TrafficDirectionOutbound, "v1", "foo.example.org", 8080},
+		{"inbound_.8080_.v1_.foo.example.org", TrafficDirectionInbound, "v1", "foo.example.org", 8080},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			d, s, h, p := ParseSubsetKey(tt.input)
+			if d != tt.direction {
+				t.Errorf("Expected direction %v got %v", tt.direction, d)
+			}
+			if s != tt.subsetName {
+				t.Errorf("Expected subset %v got %v", tt.subsetName, s)
+			}
+			if h != tt.hostname {
+				t.Errorf("Expected hostname %v got %v", tt.hostname, h)
+			}
+			if p != tt.port {
+				t.Errorf("Expected direction %v got %v", tt.port, p)
+			}
+		})
+	}
+}
+
 func BenchmarkSort(b *testing.B) {
 	unsorted := Hostnames{"foo.com", "bar.com", "*.com", "*.foo.com", "*", "baz.bar.com"}
 


### PR DESCRIPTION
Profiling shows this function is using 3% of total Pilot CPU when under
heavy load, this is mostly due to Sprintf which is not needed. Adds
tests to verify no regression occurred.