### PR TITLE
Fix indentation of dnsConfig for certmanager deployment

### DIFF
--- a/install/kubernetes/helm/istio/charts/certmanager/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       {{- if .Values.podDnsConfig }}
       dnsConfig:
-      {{ toYaml .Values.podDnsConfig | indent 8 }}
+{{ toYaml .Values.podDnsConfig | indent 8 }}
       {{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}


### PR DESCRIPTION
This is a fix for: #14656

Indentation of dnsConfig in certmanager helm deployment is incorrect. This is a simple fix to put the correct indentation in.
