### PR TITLE
create_cluster_gke.sh preserves previous use_client_certificate value

### DIFF
--- a/tests/integration/create_cluster_gke.sh
+++ b/tests/integration/create_cluster_gke.sh
@@ -83,7 +83,7 @@ function cleanup {
   if [ -z "$OLD_USE_CLIENT_CERT" ]; then
     gcloud config unset container/use_client_certificate
   else
-    gcloud config set container/use_client_certificate $OLD_USE_CLIENT_CERT
+    gcloud config set container/use_client_certificate "$OLD_USE_CLIENT_CERT"
   fi
 }
 

--- a/tests/integration/create_cluster_gke.sh
+++ b/tests/integration/create_cluster_gke.sh
@@ -11,6 +11,8 @@ CLUSTER_NAME=${CLUSTER_NAME:-istio-e2e}
 CLUSTER_VERSION=${CLUSTER_VERSION}
 MACHINE_TYPE=${MACHINE_TYPE:-n1-standard-4}
 NUM_NODES=${NUM_NODES:-3}
+# Store the previous value (which may have been unset) so we can restore it on cleanup
+OLD_USE_CLIENT_CERT=$(gcloud config list 2>/dev/null | grep use_client_certificate | cut -d' ' -f3)
 
 function usage() {
   echo "${0} -p PROJECT [-z ZONE] [-c CLUSTER_NAME] [-v CLUSTER_VERSION] [-m MACHINE_TYPE] [-n NUM_NODES]"
@@ -77,8 +79,12 @@ set -o pipefail
 set -x # echo on
 
 function cleanup {
-  # Re-enable certificates.
-  gcloud config set container/use_client_certificate True
+  # Reset certificate config.
+  if [ -z "$OLD_USE_CLIENT_CERT" ]; then
+    gcloud config unset container/use_client_certificate
+  else
+    gcloud config set container/use_client_certificate $OLD_USE_CLIENT_CERT
+  fi
 }
 
 # Run cleanup before we exit.


### PR DESCRIPTION
The create_cluster_gke script assumed that use_client_certificate was
already true in the user's GKE config. If it was false or unset, this
resulted in a surprising change in the user's settings.

This fix ensures that the previous value (including if it was unset)
is restored correctly.

See https://github.com/istio/istio.io/issues/4269 for more context.