### PR TITLE
fix(pilot metrics): remove unbounded err strings in xDS metrics

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -140,10 +140,25 @@ var (
 		Help: "Pilot build and send errors for lds, rds, cds and eds.",
 	}, []string{"type"})
 
+	cdsPushes         = pushes.WithLabelValues("cds")
+	cdsBuildErrPushes = pushes.WithLabelValues("cds_builderr")
+	cdsSendErrPushes  = pushes.WithLabelValues("cds_senderr")
+	edsPushes         = pushes.WithLabelValues("eds")
+	edsSendErrPushes  = pushes.WithLabelValues("eds_senderr")
+	ldsPushes         = pushes.WithLabelValues("lds")
+	ldsBuildErrPushes = pushes.WithLabelValues("lds_builderr")
+	ldsSendErrPushes  = pushes.WithLabelValues("lds_senderr")
+	rdsPushes         = pushes.WithLabelValues("rds")
+	rdsBuildErrPushes = pushes.WithLabelValues("rds_builderr")
+	rdsSendErrPushes  = pushes.WithLabelValues("rds_senderr")
+
 	pushErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "pilot_xds_push_errors",
 		Help: "Number of errors (timeouts) pushing to sidecars.",
 	}, []string{"type"})
+
+	unrecoverablePushErrors = pushErrors.WithLabelValues("unrecoverable")
+	retryPushErrors         = pushErrors.WithLabelValues("retry")
 
 	proxiesConvergeDelay = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "pilot_proxy_convergence_time",
@@ -165,6 +180,11 @@ var (
 		Name: "pilot_inbound_updates",
 		Help: "Total number of updates received by pilot.",
 	}, []string{"type"})
+
+	inboundConfigUpdates   = inboundUpdates.WithLabelValues("config")
+	inboundEDSUpdates      = inboundUpdates.WithLabelValues("eds")
+	inboundServiceUpdates  = inboundUpdates.WithLabelValues("svc")
+	inboundWorkloadUpdates = inboundUpdates.WithLabelValues("workload")
 )
 
 func init() {
@@ -425,7 +445,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					// Already received a cluster watch request, this is an ACK
 					if discReq.ErrorDetail != nil {
 						adsLog.Warnf("ADS:CDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
-						cdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+						errCode := codes.Code(discReq.ErrorDetail.Code)
+						cdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
 						totalXDSRejects.Add(1)
 					} else if discReq.ResponseNonce != "" {
 						con.ClusterNonceAcked = discReq.ResponseNonce
@@ -448,7 +469,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					// Already received a cluster watch request, this is an ACK
 					if discReq.ErrorDetail != nil {
 						adsLog.Warnf("ADS:LDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
-						ldsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+						errCode := codes.Code(discReq.ErrorDetail.Code)
+						ldsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
 						totalXDSRejects.Add(1)
 					} else if discReq.ResponseNonce != "" {
 						con.ListenerNonceAcked = discReq.ResponseNonce
@@ -467,7 +489,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 			case RouteType:
 				if discReq.ErrorDetail != nil {
 					adsLog.Warnf("ADS:RDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
-					rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+					errCode := codes.Code(discReq.ErrorDetail.Code)
+					rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
 					totalXDSRejects.Add(1)
 					continue
 				}
@@ -498,7 +521,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 						// If versions mismatch then we should either have an error detail or no routes if a protocol error has occurred
 						if discReq.ErrorDetail != nil {
 							adsLog.Warnf("ADS:RDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
-							rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+							errCode := codes.Code(discReq.ErrorDetail.Code)
+							rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
 							totalXDSRejects.Add(1)
 						}
 						continue
@@ -524,7 +548,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 			case EndpointType:
 				if discReq.ErrorDetail != nil {
 					adsLog.Warnf("ADS:EDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
-					edsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+					errCode := codes.Code(discReq.ErrorDetail.Code)
+					edsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
 					totalXDSRejects.Add(1)
 					continue
 				}
@@ -912,13 +937,13 @@ func (s *DiscoveryServer) startPush(version string, push *model.PushContext, ful
 				if time.Since(lastPushFailure) > 10*time.Second {
 					adsLog.Warnf("Repeated failure to push %s", client.ConID)
 					// unfortunately grpc go doesn't allow closing (unblocking) the stream.
-					pushErrors.With(prometheus.Labels{"type": "unrecoverable"}).Add(1)
+					unrecoverablePushErrors.Add(1)
 					pushTimeoutFailures.Add(1)
 					return
 				}
 
 				adsLog.Warnf("Failed to push, client busy %s", client.ConID)
-				pushErrors.With(prometheus.Labels{"type": "retry"}).Add(1)
+				retryPushErrors.Add(1)
 
 				goto Retry
 			}

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -19,8 +19,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/google/uuid"
 	"go.uber.org/atomic"
@@ -372,7 +370,7 @@ func (s *DiscoveryServer) clearCache() {
 // ConfigUpdate implements ConfigUpdater interface, used to request pushes.
 // It replaces the 'clear cache' from v1.
 func (s *DiscoveryServer) ConfigUpdate(full bool) {
-	inboundUpdates.With(prometheus.Labels{"type": "config"}).Add(1)
+	inboundConfigUpdates.Add(1)
 	s.updateChannel <- &updateReq{full: full}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -354,7 +354,7 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 
 // SvcUpdate is a callback from service discovery when service info changes.
 func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, ports map[string]uint32, _ map[uint32]string) {
-	inboundUpdates.With(prometheus.Labels{"type": "svc"}).Add(1)
+	inboundServiceUpdates.Add(1)
 	pc := s.globalPushContext()
 	pl := model.PortList{}
 	for k, v := range ports {
@@ -418,7 +418,7 @@ func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext
 
 // WorkloadUpdate is called when workload labels/annotations are updated.
 func (s *DiscoveryServer) WorkloadUpdate(id string, labels map[string]string, _ map[string]string) {
-	inboundUpdates.With(prometheus.Labels{"type": "workload"}).Add(1)
+	inboundWorkloadUpdates.Add(1)
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	if labels == nil {
@@ -478,9 +478,8 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, labels map[string]string, _ 
 // It replaces InstancesByPort in model - instead of iterating over all endpoints it uses
 // the hostname-keyed map. And it avoids the conversion from Endpoint to ServiceEntry to envoy
 // on each step: instead the conversion happens once, when an endpoint is first discovered.
-func (s *DiscoveryServer) EDSUpdate(shard, serviceName string,
-	istioEndpoints []*model.IstioEndpoint) error {
-	inboundUpdates.With(prometheus.Labels{"type": "eds"}).Add(1)
+func (s *DiscoveryServer) EDSUpdate(shard, serviceName string, istioEndpoints []*model.IstioEndpoint) error {
+	inboundEDSUpdates.Add(1)
 	s.edsUpdate(shard, serviceName, istioEndpoints, false)
 	return nil
 }
@@ -745,10 +744,10 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 	err := con.send(response)
 	if err != nil {
 		adsLog.Warnf("EDS: Send failure %s: %v", con.ConID, err)
-		pushes.With(prometheus.Labels{"type": "eds_senderr"}).Add(1)
+		edsSendErrPushes.Add(1)
 		return err
 	}
-	pushes.With(prometheus.Labels{"type": "eds"}).Add(1)
+	edsPushes.Add(1)
 
 	if edsUpdatedServices == nil {
 		adsLog.Infof("EDS: PUSH for node:%s clusters:%d endpoints:%d empty:%v",

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -19,7 +19,6 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/gogo/protobuf/types"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"istio.io/istio/pilot/pkg/model"
 )
@@ -38,10 +37,10 @@ func (s *DiscoveryServer) pushLds(con *XdsConnection, push *model.PushContext, v
 	err = con.send(response)
 	if err != nil {
 		adsLog.Warnf("LDS: Send failure %s: %v", con.ConID, err)
-		pushes.With(prometheus.Labels{"type": "lds_senderr"}).Add(1)
+		ldsSendErrPushes.Add(1)
 		return err
 	}
-	pushes.With(prometheus.Labels{"type": "lds"}).Add(1)
+	ldsPushes.Add(1)
 
 	adsLog.Infof("LDS: PUSH for node:%s listeners:%d", con.modelNode.ID, len(rawListeners))
 	return nil
@@ -51,7 +50,7 @@ func (s *DiscoveryServer) generateRawListeners(con *XdsConnection, push *model.P
 	rawListeners, err := s.ConfigGenerator.BuildListeners(s.Env, con.modelNode, push)
 	if err != nil {
 		adsLog.Warnf("LDS: Failed to generate listeners for node:%s: %v", con.modelNode.ID, err)
-		pushes.With(prometheus.Labels{"type": "lds_builderr"}).Add(1)
+		ldsBuildErrPushes.Add(1)
 		return nil, err
 	}
 
@@ -59,7 +58,7 @@ func (s *DiscoveryServer) generateRawListeners(con *XdsConnection, push *model.P
 		if err = l.Validate(); err != nil {
 			retErr := fmt.Errorf("LDS: Generated invalid listener for node %v: %v", con.modelNode, err)
 			adsLog.Errorf("LDS: Generated invalid listener for node:%s: %v, %v", con.modelNode.ID, err, l)
-			pushes.With(prometheus.Labels{"type": "lds_builderr"}).Add(1)
+			ldsBuildErrPushes.Add(1)
 			// Generating invalid listeners is a bug.
 			// Panic instead of trying to recover from that, since we can't
 			// assume anything about the state.


### PR DESCRIPTION
This PR does a number of small things in an attempt to prevent issues around unbounded string size in pilot metrics:

1. changes all `*ds_reject` metric increments to use the grpc status code string as the value of the `err` label, instead of the grpc status message. This will prevent arbitrary-length error strings from appearing in these metrics.
1. for other unconstrained metrics in `ads.go`, it introduces a set of curried metrics with the known values of the strings. This should document what the acceptable values are for each label and reduce the urge to use ad-hoc string values over time.

This PR does **not** address the issues with `*ds_reject` metrics using envoy node IDs as the `node` label in metrics (this is a potential cardinality issue). Nor does it attempt to deal with the `cluster` label on the `pilot_xds_eds_instances` metric (same potential issue). Those potential issues will need to be addressed in subsequent PRs.

Fixes #14642 