### PR TITLE
Reject TCP/TLS VS without route

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1827,6 +1827,9 @@ func validateTLSRoute(tls *networking.TLSRoute, context *networking.VirtualServi
 	for _, match := range tls.Match {
 		errs = appendErrors(errs, validateTLSMatch(match, context))
 	}
+	if len(tls.Route) == 0 {
+		errs = appendErrors(errs, errors.New("TLS route is required"))
+	}
 	errs = appendErrors(errs, validateRouteDestinations(tls.Route))
 	return
 }
@@ -1878,6 +1881,9 @@ func validateTCPRoute(tcp *networking.TCPRoute) (errs error) {
 	}
 	for _, match := range tcp.Match {
 		errs = appendErrors(errs, validateTCPMatch(match))
+	}
+	if len(tcp.Route) == 0 {
+		errs = appendErrors(errs, errors.New("TCP route is required"))
 	}
 	errs = appendErrors(errs, validateRouteDestinations(tcp.Route))
 	return

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -2650,6 +2650,25 @@ func TestValidateVirtualService(t *testing.T) {
 				RemoveResponseHeaders: []string{"unwantedHeader", "secretStuff"},
 			}},
 		}, valid: true},
+		{name: "missing tcp route", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Tcp: []*networking.TCPRoute{{
+				Match: []*networking.L4MatchAttributes{
+					{Port: 999},
+				},
+			}},
+		}, valid: false},
+		{name: "missing tls route", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Tls: []*networking.TLSRoute{{
+				Match: []*networking.TLSMatchAttributes{
+					{
+						Port:     999,
+						SniHosts: []string{"foo.bar"},
+					},
+				},
+			}},
+		}, valid: false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
TCP ones missing route will cause invalid config to be generated which
Envoy will reject. In HTTP we already have logic to require one of route
or redirect, but similar logic was missing for TCP and TLS.

For #14414 