### PR TITLE
[cherry-pick to 1.1] fix(pilot metrics): remove unbounded err strings in metrics (#14671)

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -19,7 +19,6 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/gogo/protobuf/types"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"istio.io/istio/pilot/pkg/model"
 )
@@ -59,10 +58,10 @@ func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, v
 	err = con.send(response)
 	if err != nil {
 		adsLog.Warnf("CDS: Send failure %s: %v", con.ConID, err)
-		pushes.With(prometheus.Labels{"type": "cds_senderr"}).Add(1)
+		cdsSendErrPushes.Add(1)
 		return err
 	}
-	pushes.With(prometheus.Labels{"type": "cds"}).Add(1)
+	cdsPushes.Add(1)
 
 	// The response can't be easily read due to 'any' marshaling.
 	adsLog.Infof("CDS: PUSH %s for %s %q, Clusters: %d, Services %d", version,
@@ -73,16 +72,16 @@ func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, v
 func (s *DiscoveryServer) generateRawClusters(node *model.Proxy, push *model.PushContext) ([]*xdsapi.Cluster, error) {
 	rawClusters, err := s.ConfigGenerator.BuildClusters(s.Env, node, push)
 	if err != nil {
-		adsLog.Warnf("CDS: Failed to generate clusters for node %s: %v", node.ID, err)
-		pushes.With(prometheus.Labels{"type": "cds_builderr"}).Add(1)
+		adsLog.Warnf("CDS: Failed to generate clusters for node:%s: %v", node.ID, err)
+		cdsBuildErrPushes.Add(1)
 		return nil, err
 	}
 
 	for _, c := range rawClusters {
 		if err = c.Validate(); err != nil {
 			retErr := fmt.Errorf("CDS: Generated invalid cluster for node %v: %v", node, err)
-			adsLog.Errorf("CDS: Generated invalid cluster for node %s: %v, %v", node.ID, err, c)
-			pushes.With(prometheus.Labels{"type": "cds_builderr"}).Add(1)
+			adsLog.Errorf("CDS: Generated invalid cluster for node:%s: %v, %v", node.ID, err, c)
+			cdsBuildErrPushes.Add(1)
 			totalXDSInternalErrors.Add(1)
 			// Generating invalid clusters is a bug.
 			// Panic instead of trying to recover from that, since we can't

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -451,7 +451,7 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 }
 
 // SvcUpdate is a callback from service discovery when service info changes.
-func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, ports map[string]uint32, rports map[uint32]string) {
+func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, ports map[string]uint32, _ map[uint32]string) {
 	pc := s.globalPushContext()
 	// In 1.0 Services and configs are only from the 'primary' K8S cluster.
 	if cluster == string(serviceregistry.KubernetesRegistry) {
@@ -855,10 +855,10 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, e
 	err := con.send(response)
 	if err != nil {
 		adsLog.Warnf("EDS: Send failure %s: %v", con.ConID, err)
-		pushes.With(prometheus.Labels{"type": "eds_senderr"}).Add(1)
+		edsSendErrPushes.Add(1)
 		return err
 	}
-	pushes.With(prometheus.Labels{"type": "eds"}).Add(1)
+	edsPushes.Add(1)
 
 	if edsUpdatedServices == nil {
 		adsLog.Debugf("EDS: PUSH for %s clusters %d endpoints %d empty %d",


### PR DESCRIPTION
(cherry picked from commit af876f2c754bce9103946ca1597f1c907b5a7f16)

From fix for #14642 