### PR TITLE
[cherrypick to 1.2] fix(pilot metrics): remove unbounded err strings in metrics (#14671)

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -140,10 +140,25 @@ var (
 		Help: "Pilot build and send errors for lds, rds, cds and eds.",
 	}, []string{"type"})
 
+	cdsPushes         = pushes.WithLabelValues("cds")
+	cdsBuildErrPushes = pushes.WithLabelValues("cds_builderr")
+	cdsSendErrPushes  = pushes.WithLabelValues("cds_senderr")
+	edsPushes         = pushes.WithLabelValues("eds")
+	edsSendErrPushes  = pushes.WithLabelValues("eds_senderr")
+	ldsPushes         = pushes.WithLabelValues("lds")
+	ldsBuildErrPushes = pushes.WithLabelValues("lds_builderr")
+	ldsSendErrPushes  = pushes.WithLabelValues("lds_senderr")
+	rdsPushes         = pushes.WithLabelValues("rds")
+	rdsBuildErrPushes = pushes.WithLabelValues("rds_builderr")
+	rdsSendErrPushes  = pushes.WithLabelValues("rds_senderr")
+
 	pushErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "pilot_xds_push_errors",
 		Help: "Number of errors (timeouts) pushing to sidecars.",
 	}, []string{"type"})
+
+	unrecoverablePushErrors = pushErrors.WithLabelValues("unrecoverable")
+	retryPushErrors         = pushErrors.WithLabelValues("retry")
 
 	proxiesConvergeDelay = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "pilot_proxy_convergence_time",
@@ -160,6 +175,16 @@ var (
 		Name: "pilot_total_xds_internal_errors",
 		Help: "Total number of internal XDS errors in pilot (check logs).",
 	})
+
+	inboundUpdates = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pilot_inbound_updates",
+		Help: "Total number of updates received by pilot.",
+	}, []string{"type"})
+
+	inboundConfigUpdates   = inboundUpdates.WithLabelValues("config")
+	inboundEDSUpdates      = inboundUpdates.WithLabelValues("eds")
+	inboundServiceUpdates  = inboundUpdates.WithLabelValues("svc")
+	inboundWorkloadUpdates = inboundUpdates.WithLabelValues("workload")
 )
 
 func init() {
@@ -419,7 +444,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					// Already received a cluster watch request, this is an ACK
 					if discReq.ErrorDetail != nil {
 						adsLog.Warnf("ADS:CDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
-						cdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+						errCode := codes.Code(discReq.ErrorDetail.Code)
+						cdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
 						totalXDSRejects.Add(1)
 					} else if discReq.ResponseNonce != "" {
 						con.ClusterNonceAcked = discReq.ResponseNonce
@@ -442,7 +468,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					// Already received a cluster watch request, this is an ACK
 					if discReq.ErrorDetail != nil {
 						adsLog.Warnf("ADS:LDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
-						ldsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+						errCode := codes.Code(discReq.ErrorDetail.Code)
+						ldsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
 						totalXDSRejects.Add(1)
 					} else if discReq.ResponseNonce != "" {
 						con.ListenerNonceAcked = discReq.ResponseNonce
@@ -461,7 +488,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 			case RouteType:
 				if discReq.ErrorDetail != nil {
 					adsLog.Warnf("ADS:RDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
-					rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+					errCode := codes.Code(discReq.ErrorDetail.Code)
+					rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
 					totalXDSRejects.Add(1)
 					continue
 				}
@@ -492,7 +520,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 						// If versions mismatch then we should either have an error detail or no routes if a protocol error has occurred
 						if discReq.ErrorDetail != nil {
 							adsLog.Warnf("ADS:RDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
-							rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+							errCode := codes.Code(discReq.ErrorDetail.Code)
+							rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
 							totalXDSRejects.Add(1)
 						}
 						continue
@@ -518,7 +547,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 			case EndpointType:
 				if discReq.ErrorDetail != nil {
 					adsLog.Warnf("ADS:EDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
-					edsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+					errCode := codes.Code(discReq.ErrorDetail.Code)
+					edsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
 					totalXDSRejects.Add(1)
 					continue
 				}
@@ -906,13 +936,13 @@ func (s *DiscoveryServer) startPush(version string, push *model.PushContext, ful
 				if time.Since(lastPushFailure) > 10*time.Second {
 					adsLog.Warnf("Repeated failure to push %s", client.ConID)
 					// unfortunately grpc go doesn't allow closing (unblocking) the stream.
-					pushErrors.With(prometheus.Labels{"type": "unrecoverable"}).Add(1)
+					unrecoverablePushErrors.Add(1)
 					pushTimeoutFailures.Add(1)
 					return
 				}
 
 				adsLog.Warnf("Failed to push, client busy %s", client.ConID)
-				pushErrors.With(prometheus.Labels{"type": "retry"}).Add(1)
+				retryPushErrors.Add(1)
 
 				goto Retry
 			}

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -370,6 +370,7 @@ func (s *DiscoveryServer) clearCache() {
 // ConfigUpdate implements ConfigUpdater interface, used to request pushes.
 // It replaces the 'clear cache' from v1.
 func (s *DiscoveryServer) ConfigUpdate(full bool) {
+	inboundConfigUpdates.Add(1)
 	s.updateChannel <- &updateReq{full: full}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -353,7 +353,8 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 }
 
 // SvcUpdate is a callback from service discovery when service info changes.
-func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, ports map[string]uint32, rports map[uint32]string) {
+func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, ports map[string]uint32, _ map[uint32]string) {
+	inboundServiceUpdates.Add(1)
 	pc := s.globalPushContext()
 	// In 1.0 Services and configs are only from the 'primary' K8S cluster.
 	if cluster == string(serviceregistry.KubernetesRegistry) {
@@ -408,6 +409,7 @@ func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext
 
 // WorkloadUpdate is called when workload labels/annotations are updated.
 func (s *DiscoveryServer) WorkloadUpdate(id string, labels map[string]string, _ map[string]string) {
+	inboundWorkloadUpdates.Add(1)
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	if labels == nil {
@@ -467,8 +469,8 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, labels map[string]string, _ 
 // It replaces InstancesByPort in model - instead of iterating over all endpoints it uses
 // the hostname-keyed map. And it avoids the conversion from Endpoint to ServiceEntry to envoy
 // on each step: instead the conversion happens once, when an endpoint is first discovered.
-func (s *DiscoveryServer) EDSUpdate(shard, serviceName string,
-	istioEndpoints []*model.IstioEndpoint) error {
+func (s *DiscoveryServer) EDSUpdate(shard, serviceName string, istioEndpoints []*model.IstioEndpoint) error {
+	inboundEDSUpdates.Add(1)
 	s.edsUpdate(shard, serviceName, istioEndpoints, false)
 	return nil
 }
@@ -733,10 +735,10 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 	err := con.send(response)
 	if err != nil {
 		adsLog.Warnf("EDS: Send failure %s: %v", con.ConID, err)
-		pushes.With(prometheus.Labels{"type": "eds_senderr"}).Add(1)
+		edsSendErrPushes.Add(1)
 		return err
 	}
-	pushes.With(prometheus.Labels{"type": "eds"}).Add(1)
+	edsPushes.Add(1)
 
 	if edsUpdatedServices == nil {
 		adsLog.Infof("EDS: PUSH for node:%s clusters:%d endpoints:%d empty:%v",

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -19,7 +19,6 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/gogo/protobuf/types"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"istio.io/istio/pilot/pkg/model"
 )
@@ -38,10 +37,10 @@ func (s *DiscoveryServer) pushLds(con *XdsConnection, push *model.PushContext, v
 	err = con.send(response)
 	if err != nil {
 		adsLog.Warnf("LDS: Send failure %s: %v", con.ConID, err)
-		pushes.With(prometheus.Labels{"type": "lds_senderr"}).Add(1)
+		ldsSendErrPushes.Add(1)
 		return err
 	}
-	pushes.With(prometheus.Labels{"type": "lds"}).Add(1)
+	ldsPushes.Add(1)
 
 	adsLog.Infof("LDS: PUSH for node:%s listeners:%d", con.modelNode.ID, len(rawListeners))
 	return nil
@@ -51,7 +50,7 @@ func (s *DiscoveryServer) generateRawListeners(con *XdsConnection, push *model.P
 	rawListeners, err := s.ConfigGenerator.BuildListeners(s.Env, con.modelNode, push)
 	if err != nil {
 		adsLog.Warnf("LDS: Failed to generate listeners for node:%s: %v", con.modelNode.ID, err)
-		pushes.With(prometheus.Labels{"type": "lds_builderr"}).Add(1)
+		ldsBuildErrPushes.Add(1)
 		return nil, err
 	}
 
@@ -59,7 +58,7 @@ func (s *DiscoveryServer) generateRawListeners(con *XdsConnection, push *model.P
 		if err = l.Validate(); err != nil {
 			retErr := fmt.Errorf("LDS: Generated invalid listener for node %v: %v", con.modelNode, err)
 			adsLog.Errorf("LDS: Generated invalid listener for node:%s: %v, %v", con.modelNode.ID, err, l)
-			pushes.With(prometheus.Labels{"type": "lds_builderr"}).Add(1)
+			ldsBuildErrPushes.Add(1)
 			// Generating invalid listeners is a bug.
 			// Panic instead of trying to recover from that, since we can't
 			// assume anything about the state.


### PR DESCRIPTION
(cherry picked from commit af876f2c754bce9103946ca1597f1c907b5a7f16)

From fix for #14642 