### PR TITLE
Use default gopath when computing IstioRoot if GOPATH env var isn't set

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -79,7 +79,7 @@ var (
 	// TODO: Some of these values are overlapping. We should re-align them.
 
 	// IstioRoot is the root of the Istio source repository.
-	IstioRoot = path.Join(GOPATH.Value(), "/src/istio.io/istio")
+	IstioRoot = path.Join(GOPATH.ValueOrDefault(build.Default.GOPATH), "/src/istio.io/istio")
 
 	// ChartsDir is the Kubernetes Helm chart directory in the repository
 	ChartsDir = path.Join(IstioRoot, "install/kubernetes/helm")


### PR DESCRIPTION
This makes it so that if GOPATH isn't explicitly set, the default value is used. This matches the behavior lower down in the file used to compute IstioBin and IstioOut. 

So now this works: ```~/go/src/istio.io/istio/tests/integration$ go test ./...```
As well as this: ```~/go/src/istio.io/istio/tests/integration$ GOPATH=~/go go test ./...```