### PR TITLE
Add Makefile target to create and run dev Docker container

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,1 +1,1 @@
-perf_k8svcs_istio.yaml
+docker-dev/image-built

--- a/tools/docker-dev/Dockerfile
+++ b/tools/docker-dev/Dockerfile
@@ -1,0 +1,70 @@
+FROM docker:latest as docker
+
+FROM ubuntu:latest
+ARG goversion=1.12.5
+ARG user
+ARG group
+ARG uid=1000
+ARG gid=1000
+
+# Install development packages.
+RUN apt-get update && apt-get -qqy upgrade && apt-get -qqy install \
+autoconf \
+autotools-dev \
+build-essential \
+curl \
+git \
+libtool \
+lsb-release \
+make \
+sudo \
+bash-completion \
+jq \
+tmux \
+vim \
+&& rm -rf /var/lib/apt/lists/*
+
+# Create user and allow sudo without password.
+RUN addgroup --quiet --gid $gid $group \
+&& adduser --quiet --disabled-password --gecos ',,,,' --uid $uid --ingroup $group $user \
+&& echo "${user} ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/$user
+
+# Install Docker CLI.
+COPY --from=docker /usr/local/bin/docker /usr/local/bin/docker
+
+# Fix the Docker socket access rights at login time to allow non-root access.
+RUN echo 'sudo chmod o+rw /var/run/docker.sock' >> /home/${user}/.bashrc
+
+# Install Go.
+RUN curl -s -Lo - https://dl.google.com/go/go${goversion}.linux-amd64.tar.gz | tar -C /usr/local -xzf - \
+&& echo '# Go environment.' >> /home/${user}/.bashrc \
+&& echo 'export GOROOT=/usr/local/go' >> /home/${user}/.bashrc \
+&& echo 'export GOPATH=~/go' >> /home/${user}/.bashrc \
+&& echo 'export PATH=$GOROOT/bin:$GOPATH/out/linux_amd64/release:$GOPATH/bin:$PATH' >> /home/${user}/.bashrc \
+&& echo 'export GO111MODULE=on' >> /home/${user}/.bashrc \
+&& mkdir -p /home/${user}/go
+
+# Install KIND 0.3.0.
+# Cf. https://github.com/kubernetes-sigs/kind
+RUN GO111MODULE="on" GOROOT=/usr/local/go GOPATH=/home/${user}/go /usr/local/go/bin/go get sigs.k8s.io/kind@v0.3.0
+
+# Install Helm's latest release.
+RUN curl -s -Lo - https://git.io/get_helm.sh | /bin/bash
+
+# Install gcloud and kubectl.
+RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+&& curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+&& apt-get update && apt-get -qqy install \
+google-cloud-sdk \
+kubectl \
+&& rm -rf /var/lib/apt/lists/*
+
+# Install bash completion files.
+RUN /home/${user}/go/bin/kind completion bash > /etc/bash_completion.d/kind \
+&& /usr/local/bin/helm completion bash > /etc/bash_completion.d/helm \
+&& /usr/bin/kubectl completion bash > /etc/bash_completion.d/kubectl \
+&& curl -s -Lo - https://raw.githubusercontent.com/docker/cli/master/contrib/completion/bash/docker > /etc/bash_completion.d/docker
+
+USER $user
+WORKDIR /home/$user/go/src/istio.io/istio
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/tools/docker-dev/README.md
+++ b/tools/docker-dev/README.md
@@ -1,0 +1,67 @@
+# Istio Development Environment in Docker
+
+This `Dockerfile` creates an Ubuntu-based Docker image for developing on Istio.
+
+## Image Configuration
+
+* The base Istio development tools and the following additional tools are installed, with Bash completion configured:
+  * [Docker CLI](https://docs.docker.com/engine/reference/commandline/cli/)
+  * [Google Cloud SDK (gcloud)](https://cloud.google.com/sdk/gcloud/)
+  * [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/)
+  * [Kubernetes IN Docker (KIND)](https://github.com/kubernetes-sigs/kind)
+  * [Helm](https://helm.sh/)
+* A user with the same name as the local host user is created. That user has full sudo rights without password.
+* The following volumes are mounted from the host into the container to share development files and configuration:
+  * Go directory: `$(GOPATH)` → `/home/$(USER)/go`
+  * Google Cloud SDK config: `$(HOME)/.config/gcloud` → `/home/$(USER)/.config/gcloud`
+  * Kubernetes config: `$(HOME)/.kube` → `/home/$(USER)/.kube`
+  * Docker socket, to access Docker from within the container: `/var/run/docker.sock` → `/var/run/docker.sock`
+* The working directory is `/home/$user/go/src/istio.io/istio`.
+
+## Creating The Container
+
+To create your dev container, run:
+
+```
+make dev-shell
+```
+
+The first time this target it run, a Docker image named `istio/dev:USER` is created, where USER is your local username.
+Any subsequent run won't rebuild the image unless the `Dockerfile` is modified.
+
+The first time this target is run, a container named `istio-dev` is run with this image, and an interactive shell is executed in the container.
+Any subsequent run won't restart the container and will only start an additional interactive shell. 
+
+
+## Kubernetes Cluster Creation Using KIND
+
+A Kubernetes can be created using KIND. For instance, to create a cluster named `blah` with 2 workers, run the following command within the container:
+
+```
+export CLUSTER_NAME="blah"
+
+kind create cluster --name="$CLUSTER_NAME" --config=- <<EOF
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+EOF
+
+export KUBECONFIG=$(kind get kubeconfig-path --name="$CLUSTER_NAME")
+```
+
+KIND was originally intended to run from the host, so KIND rewrites the kubeconfig to redirect the port to kubeadmin.
+This rewriting must be undone to allow connecting directly from within the container:
+
+```
+docker exec "${CLUSTER_NAME}-control-plane" cat /etc/kubernetes/admin.conf > $KUBECONFIG
+```
+
+## Removing The Container
+
+```
+docker stop istio-dev
+docker rm istio-dev
+```

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -289,3 +289,40 @@ docker.basedebug_deb:
 # Job run from the nightly cron to publish an up-to-date xenial with the debug tools.
 docker.push.basedebug: docker.basedebug
 	docker push istionightly/base_debug:latest
+
+# Build a dev environment Docker image.
+DEV_IMAGE_NAME = istio/dev:$(USER)
+DEV_CONTAINER_NAME = istio-dev
+DEV_GO_VERSION = 1.12.5
+tools/docker-dev/image-built: tools/docker-dev/Dockerfile
+	@echo "building \"$(DEV_IMAGE_NAME)\" Docker image"
+	@docker build \
+		--build-arg goversion="$(DEV_GO_VERSION)" \
+		--build-arg user="${shell id -un}" \
+		--build-arg group="${shell id -gn}" \
+		--build-arg uid="${shell id -u}" \
+		--build-arg gid="${shell id -g}" \
+		--tag "$(DEV_IMAGE_NAME)" - < tools/docker-dev/Dockerfile
+	@touch $@
+
+# Start a dev environment Docker container.
+.PHONY = dev-shell clean-dev-shell
+dev-shell: tools/docker-dev/image-built
+	@if test -z "$(shell docker ps -a -q -f name=$(DEV_CONTAINER_NAME))"; then \
+	    echo "starting \"$(DEV_CONTAINER_NAME)\" Docker container"; \
+		docker run --detach \
+			--name "$(DEV_CONTAINER_NAME)" \
+			--volume "$(GOPATH):/home/$(USER)/go:consistent" \
+			--volume "$(HOME)/.config/gcloud:/home/$(USER)/.config/gcloud:cached" \
+			--volume "$(HOME)/.kube:/home/$(USER)/.kube:cached" \
+			--volume /var/run/docker.sock:/var/run/docker.sock \
+			"$(DEV_IMAGE_NAME)" \
+			'while true; do sleep 60; done';  fi
+	@echo "executing shell in \"$(DEV_CONTAINER_NAME)\" Docker container"
+	@docker exec --tty --interactive "$(DEV_CONTAINER_NAME)" /bin/bash
+
+clean-dev-shell:
+	docker rm -f "$(DEV_CONTAINER_NAME)" || true
+	if test -n "$(shell docker images -q $(DEV_IMAGE_NAME))"; then \
+		docker rmi -f "$(shell docker images -q $(DEV_IMAGE_NAME))" || true; fi
+	rm -f tools/docker-dev/image-built


### PR DESCRIPTION
Dockerfile for an Istio development environment on Docker. The image is built and the container is started with a single `make dev-shell` target. This is a more lightweight alternative to the Vagrant environment in `tools/vagrant`. The container image is setup to use KIND instead of Minikube.