### PR TITLE
add a unit test in sds service that trigger racing condition and fix

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -492,12 +492,15 @@ func receiveThread(con *sdsConnection, reqChannel chan *xdsapi.DiscoveryRequest,
 	for {
 		req, err := con.stream.Recv()
 		if err != nil {
+			con.mutex.RLock()
+			conID := con.conID
+			con.mutex.RUnlock()
 			if status.Code(err) == codes.Canceled || err == io.EOF {
-				log.Infof("SDS: connection with %q terminated %v", con.conID, err)
+				log.Infof("SDS: connection with %q terminated %v", conID, err)
 				return
 			}
 			*errP = err
-			log.Errorf("SDS: connection with %q terminated with errors %v", con.conID, err)
+			log.Errorf("SDS: connection with %q terminated with errors %v", conID, err)
 			return
 		}
 		reqChannel <- req

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -492,6 +492,7 @@ func receiveThread(con *sdsConnection, reqChannel chan *xdsapi.DiscoveryRequest,
 	for {
 		req, err := con.stream.Recv()
 		if err != nil {
+			// Add read lock to avoid race condition with set con.conID in StreamSecrets.
 			con.mutex.RLock()
 			conID := con.conID
 			con.mutex.RUnlock()


### PR DESCRIPTION
https://github.com/istio/istio/issues/14714, https://github.com/istio/istio/issues/13439

without adding read-lock in ```receiveThread```, the added unit test fail with below error 

```
Write at 0x00c4205d0d70 by goroutine 52:
  istio.io/istio/security/pkg/nodeagent/sds.(*sdsservice).StreamSecrets()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/sds/sdsservice.go:192 +0x147e
  istio.io/istio/vendor/github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2._SecretDiscoveryService_StreamSecrets_Handler()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2/sds.pb.go:175 +0xd2
  istio.io/istio/vendor/google.golang.org/grpc.(*Server).processStreamingRPC()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/server.go:1176 +0x157c
  istio.io/istio/vendor/google.golang.org/grpc.(*Server).handleStream()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/server.go:1256 +0x13f2
  istio.io/istio/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/server.go:691 +0xac

Previous read at 0x00c4205d0d70 by goroutine 59:
  runtime.convT2Estring()
      /usr/local/go/src/runtime/iface.go:346 +0x0
  istio.io/istio/security/pkg/nodeagent/sds.receiveThread()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/sds/sdsservice.go:499 +0x13a

Goroutine 52 (running) created at:
  istio.io/istio/vendor/google.golang.org/grpc.(*Server).serveStreams.func1()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/server.go:689 +0xb8
  istio.io/istio/vendor/google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/internal/transport/http2_server.go:421 +0x14d5
  istio.io/istio/vendor/google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/internal/transport/http2_server.go:461 +0x81e
  istio.io/istio/vendor/google.golang.org/grpc.(*Server).serveStreams()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/server.go:687 +0x16e
  istio.io/istio/vendor/google.golang.org/grpc.(*Server).handleRawConn.func1()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/server.go:649 +0x50

Goroutine 59 (running) created at:
  istio.io/istio/security/pkg/nodeagent/sds.(*sdsservice).StreamSecrets()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/sds/sdsservice.go:154 +0x193
  istio.io/istio/vendor/github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2._SecretDiscoveryService_StreamSecrets_Handler()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2/sds.pb.go:175 +0xd2
  istio.io/istio/vendor/google.golang.org/grpc.(*Server).processStreamingRPC()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/server.go:1176 +0x157c
  istio.io/istio/vendor/google.golang.org/grpc.(*Server).handleStream()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/server.go:1256 +0x13f2
  istio.io/istio/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/vendor/google.golang.org/grpc/server.go:691 +0xac

```