### PR TITLE
Add protoc to istio-testing image

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -66,3 +66,10 @@ RUN cd /tmp && \
     sudo mv linux-amd64/helm /usr/local/bin && \
     rm -rf helm.tgz linux-amd64
 
+# Install protoc
+RUN cd /tmp && \
+    curl -Lo /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v3.8.0/protoc-3.8.0-linux-x86_64.zip && \
+    unzip protoc.zip -d protoc3 && \
+    sudo mv protoc3/bin/* /usr/local/bin/ && \
+    sudo mv protoc3/include/* /usr/local/include/ && \
+    rm -rf protoc.zip protoc3


### PR DESCRIPTION
Adding protoc to circleci custom image for istio-testing.

This is to help with protoc-gen-* tools' tests so that we can write some automated tests for those.