### PR TITLE
make sure proxyv2 binaries are chmod 755 before the docker build step

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -91,7 +91,7 @@ docker.sidecar_injector:$(ISTIO_DOCKER)/sidecar-injector
 # BUILD_PRE tells $(DOCKER_RULE) to run the command specified before executing a docker build
 # BUILD_ARGS tells  $(DOCKER_RULE) to execute a docker build with the specified commands
 
-docker.proxy_debug: BUILD_PRE=$(if $(filter 1,${USE_LOCAL_PROXY}),,mv envoy-debug-${PROXY_REPO_SHA} envoy &&)
+docker.proxy_debug: BUILD_PRE=$(if $(filter 1,${USE_LOCAL_PROXY}),,mv envoy-debug-${PROXY_REPO_SHA} envoy &&) chmod 755 envoy pilot-agent &&
 docker.proxy_debug: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL}
 docker.proxy_debug: pilot/docker/Dockerfile.proxy_debug
 docker.proxy_debug: tools/packaging/common/envoy_bootstrap_v2.json
@@ -112,6 +112,7 @@ ${ISTIO_ENVOY_RELEASE_DIR}/envoy: ${ISTIO_ENVOY_RELEASE_PATH}
 	cp ${ISTIO_ENVOY_RELEASE_PATH} ${ISTIO_ENVOY_RELEASE_DIR}/envoy
 
 # Default proxy image.
+docker.proxyv2: BUILD_PRE=chmod 755 envoy pilot-agent &&
 docker.proxyv2: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL}
 docker.proxyv2: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxyv2: tools/packaging/common/envoy_bootstrap_drain.json


### PR DESCRIPTION
A chmod in the dockerfile for envoy and pilot-agent was removed in https://github.com/istio/istio/pull/13579. This is causing manually run tests to fail with a "permission denied" error (https://github.com/istio/istio/issues/14718).

The proposed fix is to restore the chmod 755 on those files but via Makefiles instead of the Dockerfile. 

Verified e2e_simple and integ tests now successfully run locally after the change:
```
make e2e_simple E2E_ARGS="--skip_cleanup"
TAG=$(git rev-parse --verify HEAD) HUB=gcr.io/google.com/crwilson-gcp-experimental/istio-test GOPATH=~/go go test ./... -p 1 --istio.test.env kube
```