### PR TITLE
Make boskos rental time shorter

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -49,11 +49,6 @@ source "${ROOT}/prow/lib.sh"
 if [[ $HUB == *"istio-testing"* ]]; then
   setup_and_export_git_sha
 fi
-setup_e2e_cluster
-
-if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
-   cni_run_daemon
-fi
 
 E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
 # e2e tests on prow use clusters borrowed from boskos, which cleans up the
@@ -86,6 +81,11 @@ make init
 if [[ $HUB == *"istio-testing"* ]]; then
   # upload images
   time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"
+fi
+
+setup_e2e_cluster
+if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
+   cni_run_daemon
 fi
 
 time ISTIO_DOCKER_HUB=$HUB \

--- a/prow/integ-suite-k8s.sh
+++ b/prow/integ-suite-k8s.sh
@@ -57,8 +57,6 @@ FILE_LOG="$(mktemp /tmp/XXXXX.boskos.log)"
 
 setup_and_export_git_sha
 
-get_resource "${RESOURCE_TYPE}" "${OWNER}" "${INFO_PATH}" "${FILE_LOG}"
-
 
 if [ "${CI:-}" == 'bootstrap' ]; then
   # bootsrap upload all artifacts in _artifacts to the log bucket.
@@ -78,6 +76,7 @@ if [[ $HUB == *"istio-testing"* ]]; then
   time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"
 fi
 
+get_resource "${RESOURCE_TYPE}" "${OWNER}" "${INFO_PATH}" "${FILE_LOG}"
 setup_cluster
 
 JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml" \


### PR DESCRIPTION
Each test in master will now BUILD the images and run the test. By re-arranging the code, we will only checkout a boskos resources only AFTER the build image is done. This will lessen the time boskos resources being checked out which hopefully help alleviate running-out of boskos resources issue.