### PR TITLE
Increase Bypass Adapter timeout value.

### DIFF
--- a/mixer/adapter/bypass/bypass.go
+++ b/mixer/adapter/bypass/bypass.go
@@ -155,7 +155,7 @@ func (b *builder) ensureConn() error {
 	if b.conn == nil {
 		bo := backoff.NewExponentialBackOff()
 		bo.InitialInterval = time.Millisecond * 10
-		bo.MaxElapsedTime = time.Minute
+		bo.MaxElapsedTime = time.Minute * 5
 
 		err := backoff.Retry(func() error {
 			var e error

--- a/pkg/test/framework/components/policybackend/policybackend.go
+++ b/pkg/test/framework/components/policybackend/policybackend.go
@@ -63,7 +63,7 @@ type Instance interface {
 	CreateConfigSnippet(name string, namespace string, am AdapterMode) string
 }
 
-// New returns a new instance of echo.
+// New returns a new instance of policybackend.Instance.
 func New(ctx resource.Context) (i Instance, err error) {
 	err = resource.UnsupportedEnvironment(ctx.Environment())
 	ctx.Environment().Case(environment.Native, func() {
@@ -75,6 +75,7 @@ func New(ctx resource.Context) (i Instance, err error) {
 	return
 }
 
+// NewOrFail calls New and fails test if it returns an error.
 func NewOrFail(t test.Failer, s resource.Context) Instance {
 	t.Helper()
 	i, err := New(s)

--- a/tests/integration/mixer/check_test.go
+++ b/tests/integration/mixer/check_test.go
@@ -25,15 +25,12 @@ import (
 	"istio.io/istio/pkg/test/framework/components/mixer"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/policybackend"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
 func TestCheck_Allow(t *testing.T) {
 	framework.
 		NewTest(t).
-		// TODO(https://github.com/istio/istio/issues/12750)
-		Label(label.Flaky).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			gal := galley.NewOrFail(t, ctx, galley.Config{})
@@ -78,8 +75,6 @@ func TestCheck_Allow(t *testing.T) {
 func TestCheck_Deny(t *testing.T) {
 	framework.
 		NewTest(t).
-		// TODO(https://github.com/istio/istio/issues/13155)
-		Label(label.Flaky).
 		Run(func(ctx framework.TestContext) {
 			gal := galley.NewOrFail(t, ctx, galley.Config{})
 			mxr := mixer.NewOrFail(t, ctx, mixer.Config{

--- a/tests/integration/mixer/check_test.go
+++ b/tests/integration/mixer/check_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/mixer"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -31,7 +30,6 @@ import (
 func TestCheck_Allow(t *testing.T) {
 	framework.
 		NewTest(t).
-		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			gal := galley.NewOrFail(t, ctx, galley.Config{})
 			mxr := mixer.NewOrFail(t, ctx, mixer.Config{

--- a/tests/integration/mixer/report_test.go
+++ b/tests/integration/mixer/report_test.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/mixer"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/policybackend"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 )
@@ -32,8 +31,6 @@ import (
 func TestMixer_Report_Direct(t *testing.T) {
 	framework.
 		NewTest(t).
-		// TODO(https://github.com/istio/istio/issues/13811)
-		Label(label.Flaky).
 		Run(func(ctx framework.TestContext) {
 
 			g := galley.NewOrFail(t, ctx, galley.Config{})


### PR DESCRIPTION
At least one problem seems to be connectivity between PolicyBackend and Mixer. This looks like it is due to delay of DNS update, as otherwise the service seems to be active.

This PR updates configuration generation to use the direct address of the PolicyBackend when generating Mixer configuration.