### PR TITLE
Fix sd adapter go rountine leak

### DIFF
--- a/mixer/adapter/stackdriver/metric/bufferedClient.go
+++ b/mixer/adapter/stackdriver/metric/bufferedClient.go
@@ -81,7 +81,7 @@ func batchTimeSeries(series []*monitoringpb.TimeSeries, tsLimit int) [][]*monito
 	return batches
 }
 
-func (b *buffered) start(env adapter.Env, ticker *time.Ticker, quit chan int) {
+func (b *buffered) start(env adapter.Env, ticker *time.Ticker, quit chan struct{}) {
 	env.ScheduleDaemon(func() {
 		select {
 		case <-ticker.C:

--- a/mixer/adapter/stackdriver/metric/bufferedClient.go
+++ b/mixer/adapter/stackdriver/metric/bufferedClient.go
@@ -81,11 +81,14 @@ func batchTimeSeries(series []*monitoringpb.TimeSeries, tsLimit int) [][]*monito
 	return batches
 }
 
-func (b *buffered) start(env adapter.Env, ticker *time.Ticker) {
+func (b *buffered) start(env adapter.Env, ticker *time.Ticker, quit chan int) {
 	env.ScheduleDaemon(func() {
-		for range ticker.C {
+		select {
+		case <-ticker.C:
 			b.mergeTimeSeries()
 			b.Send()
+		case <-quit:
+			return
 		}
 	})
 }

--- a/mixer/adapter/stackdriver/metric/metric.go
+++ b/mixer/adapter/stackdriver/metric/metric.go
@@ -74,7 +74,7 @@ type (
 		client     bufferedClient
 		// We hold a ref for cleanup during Close()
 		ticker *time.Ticker
-		quit   chan int
+		quit   chan struct{}
 	}
 )
 
@@ -170,7 +170,7 @@ func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, 
 	}
 
 	ticker := time.NewTicker(cfg.PushInterval)
-	quit := make(chan int)
+	quit := make(chan struct{})
 	var err error
 	var client *monitoring.MetricClient
 	if client, err = b.createClient(cfg); err != nil {
@@ -268,7 +268,7 @@ func (h *handler) HandleMetric(_ context.Context, vals []*metric.Instance) error
 
 func (h *handler) Close() error {
 	h.ticker.Stop()
-	h.quit <- 1
+	close(h.quit)
 	return h.client.Close()
 }
 

--- a/mixer/adapter/stackdriver/metric/metric.go
+++ b/mixer/adapter/stackdriver/metric/metric.go
@@ -74,6 +74,7 @@ type (
 		client     bufferedClient
 		// We hold a ref for cleanup during Close()
 		ticker *time.Ticker
+		quit   chan int
 	}
 )
 
@@ -169,7 +170,7 @@ func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, 
 	}
 
 	ticker := time.NewTicker(cfg.PushInterval)
-
+	quit := make(chan int)
 	var err error
 	var client *monitoring.MetricClient
 	if client, err = b.createClient(cfg); err != nil {
@@ -191,8 +192,8 @@ func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, 
 		pushInterval:        cfg.PushInterval,
 		env:                 env,
 	}
-	// We hold on to the ref to the ticker so we can stop it later
-	buffered.start(env, ticker)
+	// We hold on to the ref to the ticker so we can stop it later and quit channel to exit the daemon.
+	buffered.start(env, ticker, quit)
 	h := &handler{
 		l:          env.Logger(),
 		now:        time.Now,
@@ -200,6 +201,7 @@ func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, 
 		md:         md,
 		metricInfo: types,
 		ticker:     ticker,
+		quit:       quit,
 	}
 	return h, nil
 }
@@ -266,6 +268,7 @@ func (h *handler) HandleMetric(_ context.Context, vals []*metric.Instance) error
 
 func (h *handler) Close() error {
 	h.ticker.Stop()
+	h.quit <- 1
 	return h.client.Close()
 }
 


### PR DESCRIPTION
k8s addon manager exaggerates this behavior because of the reconciliation, which somehow triggers mixer config watch and keep rebuilding all handlers. I will cherry-pick this into master and 1.2.