### PR TITLE
[1.2] Remove lowered resource limits from demo (bp #14674)

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-demo-common.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo-common.yaml
@@ -25,9 +25,6 @@ pilot:
     requests:
       cpu: 10m
       memory: 100Mi
-    limits:
-      cpu: 100m
-      memory: 200Mi
 
 mixer:
   policy:
@@ -36,18 +33,12 @@ mixer:
       requests:
         cpu: 10m
         memory: 100Mi
-      limits:
-        cpu: 100m
-        memory: 100Mi
 
   telemetry:
     enabled: true
     resources:
       requests:
         cpu: 50m
-        memory: 100Mi
-      limits:
-        cpu: 100m
         memory: 100Mi
  
   adapters:
@@ -70,9 +61,6 @@ gateways:
       requests:
         cpu: 10m
         memory: 40Mi
-      limits:
-        cpu: 100m
-        memory: 128Mi
 
   istio-egressgateway:
     enabled: true
@@ -80,6 +68,3 @@ gateways:
       requests:
         cpu: 10m
         memory: 40Mi
-      limits:
-        cpu: 100m
-        memory: 128Mi


### PR DESCRIPTION
This is NOT removing the limits completely, the install will still use
the default limits.

This makes it so users that use the demo are less likely to get horrible
performance due to throttling or OOM kills decide not to use Istio.

(cherry picked from commit 69f92aec4c3c41388fc86e16244ed9ef7a8a9d7a)

https://github.com/istio/istio/pull/14704
 #14666