### PR TITLE
Re-arranging the code

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -50,11 +50,6 @@ if [[ $HUB == *"istio-testing"* ]]; then
   setup_and_export_git_sha
 fi
 
-E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
-# e2e tests on prow use clusters borrowed from boskos, which cleans up the
-# clusters. There is no need to cleanup in the test jobs.
-E2E_ARGS+=("--skip_cleanup")
-
 # getopts only handles single character flags
 for ((i=1; i<=$#; i++)); do
     case ${!i} in
@@ -87,6 +82,11 @@ setup_e2e_cluster
 if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
    cni_run_daemon
 fi
+
+E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
+# e2e tests on prow use clusters borrowed from boskos, which cleans up the
+# clusters. There is no need to cleanup in the test jobs.
+E2E_ARGS+=("--skip_cleanup")
 
 time ISTIO_DOCKER_HUB=$HUB \
   E2E_ARGS="${E2E_ARGS[*]}" \


### PR DESCRIPTION
${ARTIFACTS_DIR} is only setup during setup_and_export_git_sha. When the test doesn't use BUILD and run test mechanism that variable will only be set after setting up e2e clusters.