### PR TITLE
Add ctrlz

### DIFF
--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -16,10 +16,11 @@ package main
 
 import (
 	"fmt"
-	"istio.io/pkg/ctrlz"
 	"os"
 	"strings"
 	"time"
+
+	"istio.io/pkg/ctrlz"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -125,7 +126,7 @@ var (
 	serverOptions           sds.Options
 	gatewaySecretChan       chan struct{}
 	loggingOptions          = log.DefaultOptions()
-	ctrlzOptions   					= ctrlz.DefaultOptions()
+	ctrlzOptions            = ctrlz.DefaultOptions()
 
 	// rootCmd defines the command for node agent.
 	rootCmd = &cobra.Command{

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"istio.io/pkg/ctrlz"
 	"os"
 	"strings"
 	"time"
@@ -124,6 +125,7 @@ var (
 	serverOptions           sds.Options
 	gatewaySecretChan       chan struct{}
 	loggingOptions          = log.DefaultOptions()
+	ctrlzOptions   					= ctrlz.DefaultOptions()
 
 	// rootCmd defines the command for node agent.
 	rootCmd = &cobra.Command{
@@ -135,7 +137,7 @@ var (
 			}
 
 			applyEnvVars(c)
-
+			_, _ = ctrlz.Run(ctrlzOptions, nil)
 			gatewaySdsCacheOptions = workloadSdsCacheOptions
 
 			if err := validateOptions(); err != nil {
@@ -375,6 +377,8 @@ func main() {
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)
+	// Attach Ctrlz options to the command.
+	ctrlzOptions.AttachCobraFlags(rootCmd)
 
 	rootCmd.AddCommand(version.CobraCommand())
 	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{


### PR DESCRIPTION
Add Ctrlz support to Citadel Agent.

Below is from ingress gateway agent via $ kubectl port-forward -n istio-system istio-ingressgateway-668b85cb98-tblxp 9876:9876

Fixes: https://github.com/istio/istio/issues/14128

![citadel-agent-ctrlz-3](https://user-images.githubusercontent.com/28548492/59457696-cab23700-8dcd-11e9-862c-2a7357e0f81f.png)
![citadel-agent-ctrlz-2](https://user-images.githubusercontent.com/28548492/59457697-cab23700-8dcd-11e9-8051-308ecf9d06d3.png)
![citadel-agent-ctrlz-1](https://user-images.githubusercontent.com/28548492/59457698-cab23700-8dcd-11e9-96f4-e261b645e5f0.png)




