### PR TITLE
Fix tag name validation to match Kubernetes

### DIFF
--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -324,6 +324,16 @@ func TestLabelsValidate(t *testing.T) {
 			valid: true,
 		},
 		{
+			name:  "good tag - DNS prefix",
+			tags:  Labels{"k8s.io/key": "value"},
+			valid: true,
+		},
+		{
+			name:  "good tag - subdomain DNS prefix",
+			tags:  Labels{"app.kubernetes.io/name": "value"},
+			valid: true,
+		},
+		{
 			name: "bad tag - empty key",
 			tags: Labels{"": "value"},
 		},
@@ -338,6 +348,10 @@ func TestLabelsValidate(t *testing.T) {
 		{
 			name: "bad tag key 3",
 			tags: Labels{"key$": "value"},
+		},
+		{
+			name: "bad tag key - invalid DNS prefix",
+			tags: Labels{"istio./key": "value"},
 		},
 		{
 			name: "bad tag value 1",


### PR DESCRIPTION
In #12852, the validation of tag names was changed with the goal of [matching Kubernetes][format]. This introduced bug #14797, because the new validation format is stricter than Kubernetes: DNS-qualified labels like [`app.kubernetes.io/name`][common-labels] are now rejected by Istio. Qualified labels are a common practice in Kubernetes, and this bug is blocking our Istio 1.1 upgrade.

This PR updates validation tests to cover those labels, and fixes the rules so that the tests pass. It also adds a check for base label name length – I’m assuming the stated goal of #12852 was desirable and trying to fully implement validation that matches Kubernetes.

[format]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
[common-labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels