### PR TITLE
Reenable mixer test (Fix #12750)

### DIFF
--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -34,7 +34,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 	"istio.io/istio/pkg/test/framework/components/redis"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	util "istio.io/istio/tests/integration/mixer"
 )
@@ -59,8 +58,6 @@ func TestRateLimiting_RedisQuotaRollingWindow(t *testing.T) {
 func TestRateLimiting_DefaultLessThanOverride(t *testing.T) {
 	framework.
 		NewTest(t).
-		// TODO(https://github.com/istio/istio/issues/12750)
-		Label(label.Flaky).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			destinationService := "productpage"

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -17,7 +17,6 @@ package metrics
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/bookinfo"
@@ -48,7 +47,7 @@ var (
 func TestIngessToPrometheus_ServiceMetric(t *testing.T) {
 	framework.
 		NewTest(t).
-		// TODO(https://github.com/istio/istio/issues/12750)
+		// TODO(https://github.com/istio/istio/issues/14819)
 		Label(label.Flaky).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
@@ -62,8 +61,6 @@ func TestIngessToPrometheus_ServiceMetric(t *testing.T) {
 func TestIngessToPrometheus_IngressMetric(t *testing.T) {
 	framework.
 		NewTest(t).
-		// TODO(https://github.com/istio/istio/issues/12750)
-		Label(label.Flaky).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			label := "destination_service"
@@ -88,9 +85,10 @@ func testMetric(t *testing.T, ctx framework.TestContext, label string, labelValu
 	util.AllowRuleSync(t)
 
 	// Warm up
-	err := util.VisitProductPage(ing, 30*time.Second, 200, t)
-	if err != nil {
-		t.Fatalf("unable to retrieve 200 from product page: %v", err)
+	url := fmt.Sprintf("%s/productpage", ing.HTTPAddress())
+	res := util.SendTraffic(ing, t, "Sending traffic", url,10)
+	if res.RetCodes[200] < 1 {
+		t.Fatalf("unable to retrieve 200 from product page: %v", res.RetCodes)
 	}
 
 	label = tmpl.EvaluateOrFail(t, label, map[string]string{"TestNamespace": bookinfoNs.Name()})
@@ -103,9 +101,9 @@ func testMetric(t *testing.T, ctx framework.TestContext, label string, labelValu
 	}
 	t.Logf("Baseline established: initial = %v", initial)
 
-	err = util.VisitProductPage(ing, 30*time.Second, 200, t)
-	if err != nil {
-		t.Fatalf("unable to retrieve 200 from product page: %v", err)
+	res = util.SendTraffic(ing, t, "Sending traffic", url, 10)
+	if res.RetCodes[200] < 1 {
+		t.Fatalf("unable to retrieve 200 from product page: %v", res.RetCodes)
 	}
 
 	final, err := prom.WaitForQuiesce(`istio_requests_total{%s=%q,response_code="200"}`, label, labelValue)
@@ -127,8 +125,9 @@ func testMetric(t *testing.T, ctx framework.TestContext, label string, labelValu
 		t.Fatal(err)
 	}
 
-	if (f - i) < float64(1) {
-		t.Errorf("Bad metric value: got %f, want at least 1", f-i)
+	// We shold see 10 requests but giving an error of 1, to make test less flaky.
+	if (f - i) < float64(9) {
+		t.Errorf("Bad metric value: got %f, want at least 9", f-i)
 	}
 }
 
@@ -166,8 +165,6 @@ func TestStateMetrics(t *testing.T) {
 func TestTcpMetric(t *testing.T) {
 	framework.
 		NewTest(t).
-		// TODO(https://github.com/istio/istio/issues/12750)
-		Label(label.Flaky).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			_ = bookinfo.DeployOrFail(t, ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookinfoRatingsv2})
@@ -188,9 +185,10 @@ func TestTcpMetric(t *testing.T) {
 
 			util.AllowRuleSync(t)
 
-			err := util.VisitProductPage(ing, 30*time.Second, 200, t)
-			if err != nil {
-				t.Fatalf("unable to retrieve 200 from product page: %v", err)
+			url := fmt.Sprintf("%s/productpage", ing.HTTPAddress())
+			res := util.SendTraffic(ing, t, "Sending traffic", url, 10)
+			if res.RetCodes[200] < 1 {
+				t.Fatalf("unable to retrieve 200 from product page: %v", res.RetCodes)
 			}
 
 			query := fmt.Sprintf("sum(istio_tcp_sent_bytes_total{destination_app=\"%s\"})", "mongodb")

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -86,7 +86,7 @@ func testMetric(t *testing.T, ctx framework.TestContext, label string, labelValu
 
 	// Warm up
 	url := fmt.Sprintf("%s/productpage", ing.HTTPAddress())
-	res := util.SendTraffic(ing, t, "Sending traffic", url,10)
+	res := util.SendTraffic(ing, t, "Sending traffic", url, "", 10)
 	if res.RetCodes[200] < 1 {
 		t.Fatalf("unable to retrieve 200 from product page: %v", res.RetCodes)
 	}
@@ -101,7 +101,7 @@ func testMetric(t *testing.T, ctx framework.TestContext, label string, labelValu
 	}
 	t.Logf("Baseline established: initial = %v", initial)
 
-	res = util.SendTraffic(ing, t, "Sending traffic", url, 10)
+	res = util.SendTraffic(ing, t, "Sending traffic", url, "", 10)
 	if res.RetCodes[200] < 1 {
 		t.Fatalf("unable to retrieve 200 from product page: %v", res.RetCodes)
 	}
@@ -186,7 +186,7 @@ func TestTcpMetric(t *testing.T) {
 			util.AllowRuleSync(t)
 
 			url := fmt.Sprintf("%s/productpage", ing.HTTPAddress())
-			res := util.SendTraffic(ing, t, "Sending traffic", url, 10)
+			res := util.SendTraffic(ing, t, "Sending traffic", url, "", 10)
 			if res.RetCodes[200] < 1 {
 				t.Fatalf("unable to retrieve 200 from product page: %v", res.RetCodes)
 			}


### PR DESCRIPTION
Ref: https://github.com/istio/istio/issues/12750

Based on https://testgrid.k8s.io/istio-postsubmits-master#integ-mixer-k8s-postsubmit-tests&sort-by-flakiness=
1) TestIngessToPrometheus_ServiceMetric is flaky and should get fixed by refactoring in https://github.com/istio/istio/pull/14111/files#diff-be14bf3bcea83ca5db20fe06f8e4a019. Opened a separate bug to https://github.com/istio/istio/issues/14819 to track flakiness of tests in this file.
2) TestCheck_Deny will be fixed by https://github.com/istio/istio/commit/427ae7c9fbcae3a914af2d7254e24041fe49870b
