### PR TITLE
fix pilot panic

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -484,6 +484,9 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(env *model.Environmen
 			} else {
 				// parse the ip, port. Validation guarantees presence of :
 				parts := strings.Split(ingressListener.DefaultEndpoint, ":")
+				if len(parts) < 2 {
+					continue
+				}
 				if port, err = strconv.Atoi(parts[1]); err != nil {
 					continue
 				}


### PR DESCRIPTION
#14836 
If users create invalid sidecars without galley validate, it will cause pilot panic.

TODO: cherry-pick to 1.2 and 1.1