### PR TITLE
Fix missing separators in CRD files

### DIFF
--- a/install/kubernetes/helm/istio-init/files/crd-certmanager-10.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-certmanager-10.yaml
@@ -79,3 +79,4 @@ spec:
     shortNames:
       - cert
       - certs
+---

--- a/install/kubernetes/helm/istio-init/files/crd-certmanager-11.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-certmanager-11.yaml
@@ -71,3 +71,4 @@ spec:
     kind: Challenge
     plural: challenges
   scope: Namespaced
+---


### PR DESCRIPTION
Some of the workflows people use include `cat` of the CRD files.
While this is not recommended by the devs (instead we should be
recommending kubectl apply -f install/kubernetes/helm/istio-init/files/)
these two CRDs are improperly formatted which could lead to field
failure when operators use workflows not defined in the documentaiton.

Unfortunately our documentation also recommends this workflow here:
https://istio.io/docs/setup/kubernetes/install/multicluster/gateways/

which needs to be addressed separately.