### PR TITLE
Hide istioctl upgrade command for RBAC

### DIFF
--- a/istioctl/cmd/auth.go
+++ b/istioctl/cmd/auth.go
@@ -92,8 +92,9 @@ THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 	}
 
 	upgradeCmd = &cobra.Command{
-		Use:   "upgrade",
-		Short: "Upgrade Istio Authorization Policy from version v1 to v2",
+		Hidden: true,
+		Use:    "upgrade",
+		Short:  "Upgrade Istio Authorization Policy from version v1 to v2",
 		Long: `Upgrade converts Istio authorization policy from version v1 to v2. It requires access to Kubernetes
 service definition in order to translate the service name specified in the ServiceRole to the corresponding
 workload labels in the AuthorizationPolicy. The service definition could be provided either from the current


### PR DESCRIPTION
This PR is to hide the upgrade command for RBAC in release-1.2 (for the Istio Commands page), since in this release, we're still using RBAC alpha1. I tested it locally. 



