### PR TITLE
Add pkg/config/schema for Galley config metadata

### DIFF
--- a/galley/pkg/config/schema/ast/ast.go
+++ b/galley/pkg/config/schema/ast/ast.go
@@ -76,6 +76,9 @@ type DirectTransform struct {
 	Mapping map[string]string `json:"mapping"`
 }
 
+// for testing purposes
+var jsonUnmarshal = json.Unmarshal
+
 // UnmarshalJSON implements json.Unmarshaler
 func (s *Metadata) UnmarshalJSON(data []byte) error {
 	var in struct {
@@ -85,7 +88,7 @@ func (s *Metadata) UnmarshalJSON(data []byte) error {
 		Transforms  []json.RawMessage `json:"transforms"`
 	}
 
-	if err := json.Unmarshal(data, &in); err != nil {
+	if err := jsonUnmarshal(data, &in); err != nil {
 		return err
 	}
 
@@ -94,13 +97,13 @@ func (s *Metadata) UnmarshalJSON(data []byte) error {
 
 	for _, src := range in.Sources {
 		m := make(map[string]interface{})
-		if err := json.Unmarshal(src, &m); err != nil {
+		if err := jsonUnmarshal(src, &m); err != nil {
 			return err
 		}
 
 		if m["type"] == "kubernetes" {
 			ks := &KubeSource{}
-			if err := json.Unmarshal(src, &ks); err != nil {
+			if err := jsonUnmarshal(src, &ks); err != nil {
 				return err
 			}
 			s.Sources = append(s.Sources, ks)
@@ -111,13 +114,13 @@ func (s *Metadata) UnmarshalJSON(data []byte) error {
 
 	for _, xform := range in.Transforms {
 		m := make(map[string]interface{})
-		if err := json.Unmarshal(xform, &m); err != nil {
+		if err := jsonUnmarshal(xform, &m); err != nil {
 			return err
 		}
 
 		if m["type"] == "direct" {
 			dt := &DirectTransform{}
-			if err := json.Unmarshal(xform, &dt); err != nil {
+			if err := jsonUnmarshal(xform, &dt); err != nil {
 				return err
 			}
 			s.Transforms = append(s.Transforms, dt)

--- a/galley/pkg/config/schema/ast/ast.go
+++ b/galley/pkg/config/schema/ast/ast.go
@@ -1,0 +1,140 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+)
+
+// Metadata is the top-level container.
+type Metadata struct {
+	Collections []*Collection `json:"collections"`
+	Snapshots   []*Snapshot   `json:"snapshots"`
+	Sources     []Source      `json:"sources"`
+	Transforms  []Transform   `json:"transforms"`
+}
+
+var _ json.Unmarshaler = &Metadata{}
+
+// Collection metadata. Describes basic structure of collections.
+type Collection struct {
+	Name         string `json:"name"`
+	Proto        string `json:"proto"`
+	ProtoPackage string `json:"protoPackage"`
+}
+
+// Snapshot metadata. Describes the snapshots that should be produced.
+type Snapshot struct {
+	Name        string   `json:"name"`
+	Strategy    string   `json:"strategy"`
+	Collections []string `json:"collections"`
+}
+
+// Source configuration metadata.
+type Source interface {
+}
+
+// Transform configuration metadata.
+type Transform interface {
+}
+
+// KubeSource is configuration for K8s based input sources.
+type KubeSource struct {
+	Resources []*Resource `json:"resources"`
+}
+
+var _ Source = &KubeSource{}
+
+// Resource metadata for a Kubernetes Resource.
+type Resource struct {
+	Collection string `json:"collection"`
+	Group      string `json:"group"`
+	Version    string `json:"version"`
+	Kind       string `json:"kind"`
+	Plural     string `json:"plural"`
+	Optional   bool   `json:"optional"` // TODO: Reconsider this
+	Disabled   bool   `json:"disabled"`
+}
+
+// DirectTransform configuration
+type DirectTransform struct {
+	Mapping map[string]string `json:"mapping"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (s *Metadata) UnmarshalJSON(data []byte) error {
+	var in struct {
+		Collections []*Collection     `json:"collections"`
+		Snapshots   []*Snapshot       `json:"snapshots"`
+		Sources     []json.RawMessage `json:"sources"`
+		Transforms  []json.RawMessage `json:"transforms"`
+	}
+
+	if err := json.Unmarshal(data, &in); err != nil {
+		return err
+	}
+
+	s.Collections = in.Collections
+	s.Snapshots = in.Snapshots
+
+	for _, src := range in.Sources {
+		m := make(map[string]interface{})
+		if err := json.Unmarshal(src, &m); err != nil {
+			return err
+		}
+
+		if m["type"] == "kubernetes" {
+			ks := &KubeSource{}
+			if err := json.Unmarshal(src, &ks); err != nil {
+				return err
+			}
+			s.Sources = append(s.Sources, ks)
+		} else {
+			return fmt.Errorf("unable to parse source: %v", string([]byte(src)))
+		}
+	}
+
+	for _, xform := range in.Transforms {
+		m := make(map[string]interface{})
+		if err := json.Unmarshal(xform, &m); err != nil {
+			return err
+		}
+
+		if m["type"] == "direct" {
+			dt := &DirectTransform{}
+			if err := json.Unmarshal(xform, &dt); err != nil {
+				return err
+			}
+			s.Transforms = append(s.Transforms, dt)
+		} else {
+			return fmt.Errorf("unable to parse transform: %v", string([]byte(xform)))
+		}
+	}
+
+	return nil
+}
+
+// Parse and return a yaml representation of Metadata
+func Parse(yamlText string) (*Metadata, error) {
+	var s Metadata
+	err := yaml.Unmarshal([]byte(yamlText), &s)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/galley/pkg/config/schema/ast/ast_test.go
+++ b/galley/pkg/config/schema/ast/ast_test.go
@@ -1,0 +1,106 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+var cases = []struct {
+	input    string
+	expected *Metadata
+}{
+	{
+		input:    ``,
+		expected: &Metadata{},
+	},
+	{
+		input: `
+collections:
+  - name:         "istio/meshconfig"
+    proto:        "istio.mesh.v1alpha1.MeshConfig"
+    protoPackage: "istio.io/api/mesh/v1alpha1"
+
+snapshots:
+  - name: "default"
+    collections:
+      - "istio/meshconfig"
+
+sources:
+  - type: kubernetes
+    resources:
+    - collection:   "k8s/networking.istio.io/v1alpha3/virtualservices"
+      kind:         "VirtualService"
+      group:        "networking.istio.io"
+      version:      "v1alpha3"
+  
+transforms:
+  - type: direct
+    mapping:
+      "k8s/networking.istio.io/v1alpha3/destinationrules": "istio/networking/v1alpha3/destinationrules"
+`,
+		expected: &Metadata{
+			Collections: []*Collection{
+				{
+					Name:         "istio/meshconfig",
+					Proto:        "istio.mesh.v1alpha1.MeshConfig",
+					ProtoPackage: "istio.io/api/mesh/v1alpha1",
+				},
+			},
+			Snapshots: []*Snapshot{
+				{
+					Name: "default",
+					Collections: []string{
+						"istio/meshconfig",
+					},
+				},
+			},
+			Sources: []Source{
+				&KubeSource{
+					Resources: []*Resource{
+						{
+							Collection: "k8s/networking.istio.io/v1alpha3/virtualservices",
+							Kind:       "VirtualService",
+							Group:      "networking.istio.io",
+							Version:    "v1alpha3",
+						},
+					},
+				},
+			},
+			Transforms: []Transform{
+				&DirectTransform{
+					Mapping: map[string]string{
+						"k8s/networking.istio.io/v1alpha3/destinationrules": "istio/networking/v1alpha3/destinationrules",
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestParse(t *testing.T) {
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			actual, err := Parse(c.input)
+			if err != nil {
+				t.Fatalf("Error parsing: %v", err)
+			}
+			g.Expect(actual).To(Equal(c.expected))
+		})
+	}
+}

--- a/galley/pkg/config/schema/ast/ast_test.go
+++ b/galley/pkg/config/schema/ast/ast_test.go
@@ -155,7 +155,6 @@ transforms:
     mapping:
       "k8s/networking.istio.io/v1alpha3/destinationrules": "istio/networking/v1alpha3/destinationrules"
 `,
-
 	}
 
 	for _, c := range cases {

--- a/galley/pkg/config/schema/codegen/collections.go
+++ b/galley/pkg/config/schema/codegen/collections.go
@@ -1,0 +1,135 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codegen
+
+import (
+	"sort"
+	"strings"
+)
+
+const staticCollectionsTemplate = `
+// GENERATED FILE -- DO NOT EDIT
+//
+
+package {{.PackageName}}
+
+import (
+	"istio.io/istio/galley/pkg/config/collection"
+)
+
+var (
+{{range .Entries}}
+	// {{.VarName}} is the name of collection {{.Name}}
+	{{.VarName}} = collection.NewName("{{.Name}}")
+{{end}}
+)
+
+// CollectionNames returns the collection names declared in this package.
+func CollectionNames() []collection.Name {
+	return []collection.Name {
+		{{range .Entries}}{{.VarName}},
+		{{end}}
+	}
+}
+`
+
+type entry struct {
+	Name    string
+	VarName string
+}
+
+// StaticCollections generates a Go file for static-importing Proto packages, so that they get registered statically.
+func StaticCollections(packageName string, collections []string) (string, error) {
+	var entries []entry
+
+	for _, col := range collections {
+		entries = append(entries, entry{Name: col, VarName: asColVarName(col)})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return strings.Compare(entries[i].Name, entries[j].Name) < 0
+	})
+
+	context := struct {
+		Entries     []entry
+		PackageName string
+	}{Entries: entries, PackageName: packageName}
+
+	// Calculate the Go packages that needs to be imported for the proto types to be registered.
+	return applyTemplate(staticCollectionsTemplate, context)
+}
+
+func asColVarName(n string) string {
+	n = camelCase(n, "/")
+	n = camelCase(n, ".")
+	return n
+}
+
+// CamelCase converts the string into camel case string
+func CamelCase(s string) string {
+	if s == "" {
+		return ""
+	}
+	t := make([]byte, 0, 32)
+	i := 0
+	if s[0] == '_' {
+		// Need a capital letter; drop the '_'.
+		t = append(t, 'X')
+		i++
+	}
+	// Invariant: if the next letter is lower case, it must be converted
+	// to upper case.
+	// That is, we process a word at a time, where words are marked by _ or
+	// upper case letter. Digits are treated as words.
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c == '_' && i+1 < len(s) && isASCIILower(s[i+1]) {
+			continue // Skip the underscore in s.
+		}
+		if isASCIIDigit(c) {
+			t = append(t, c)
+			continue
+		}
+		// Assume we have a letter now - if not, it's a bogus identifier.
+		// The next word is a sequence of characters that must start upper case.
+		if isASCIILower(c) {
+			c ^= ' ' // Make it a capital letter.
+		}
+		t = append(t, c) // Guaranteed not lower case.
+		// Accept lower case sequence that follows.
+		for i+1 < len(s) && isASCIILower(s[i+1]) {
+			i++
+			t = append(t, s[i])
+		}
+	}
+	return string(t)
+}
+
+func camelCase(n string, sep string) string {
+	p := strings.Split(n, sep)
+	for i := 0; i < len(p); i++ {
+		p[i] = CamelCase(p[i])
+	}
+	return strings.Join(p, "")
+}
+
+// Is c an ASCII lower-case letter?
+func isASCIILower(c byte) bool {
+	return 'a' <= c && c <= 'z'
+}
+
+// Is c an ASCII digit?
+func isASCIIDigit(c byte) bool {
+	return '0' <= c && c <= '9'
+}

--- a/galley/pkg/config/schema/codegen/collections_test.go
+++ b/galley/pkg/config/schema/codegen/collections_test.go
@@ -1,0 +1,103 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestStaticCollections(t *testing.T) {
+	var cases = []struct {
+		packageName string
+		collections []string
+		err         string
+		output      string
+	}{
+		{
+			packageName: "pkg",
+			collections: []string{"foo", "bar"},
+			output: `
+// GENERATED FILE -- DO NOT EDIT
+//
+
+package pkg
+
+import (
+	"istio.io/istio/galley/pkg/config/collection"
+)
+
+var (
+
+	// Bar is the name of collection bar
+	Bar = collection.NewName("bar")
+
+	// Foo is the name of collection foo
+	Foo = collection.NewName("foo")
+
+)
+
+// CollectionNames returns the collection names declared in this package.
+func CollectionNames() []collection.Name {
+	return []collection.Name {
+		Bar,
+		Foo,
+		
+	}
+}`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			s, err := StaticCollections(c.packageName, c.collections)
+			if c.err != "" {
+				g.Expect(err).NotTo(BeNil())
+				g.Expect(err.Error()).To(Equal(s))
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(strings.TrimSpace(s)).To(Equal(strings.TrimSpace(c.output)))
+			}
+		})
+	}
+}
+
+func TestCamelCase(t *testing.T) {
+	cases := map[string]string{
+		"":        "",
+		"foo":     "Foo",
+		"foobar":  "Foobar",
+		"fooBar":  "FooBar",
+		"foo_bar": "FooBar",
+		"foo_Bar": "Foo_Bar", // TODO: This seems like a bug.
+		"foo9bar": "Foo9Bar",
+		"_foo":    "XFoo",
+		"_Foo":    "XFoo",
+	}
+
+	for k, v := range cases {
+		t.Run(k, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			a := CamelCase(k)
+			g.Expect(a).To(Equal(v))
+		})
+	}
+
+}

--- a/galley/pkg/config/schema/codegen/staticinit.go
+++ b/galley/pkg/config/schema/codegen/staticinit.go
@@ -1,0 +1,75 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codegen
+
+import (
+	"bytes"
+	"sort"
+	"text/template"
+)
+
+const importInitTemplate = `
+// GENERATED FILE -- DO NOT EDIT
+//
+
+package {{.PackageName}}
+
+import (
+	// Pull in all the known proto types to ensure we get their types registered.
+
+{{range .Packages}}
+	// Register protos in "{{.}}"
+	_ "{{.}}"
+{{end}}
+)
+`
+
+// StaticInit generates a Go file for static-importing Proto packages, so that they get registered statically.
+func StaticInit(packageName string, packages []string) (string, error) {
+	// Single instance and sort names
+	names := make(map[string]struct{})
+
+	for _, p := range packages {
+		if p != "" {
+			names[p] = struct{}{}
+		}
+	}
+
+	sorted := make([]string, 0, len(names))
+	for p := range names {
+		sorted = append(sorted, p)
+	}
+	sort.Strings(sorted)
+
+	context := struct {
+		Packages    []string
+		PackageName string
+	}{Packages: sorted, PackageName: packageName}
+
+	return applyTemplate(importInitTemplate, context)
+}
+
+func applyTemplate(tmpl string, i interface{}) (string, error) {
+	t := template.New("tmpl")
+
+	t2 := template.Must(t.Parse(tmpl))
+
+	var b bytes.Buffer
+	if err := t2.Execute(&b, i); err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}

--- a/galley/pkg/config/schema/codegen/staticinit_test.go
+++ b/galley/pkg/config/schema/codegen/staticinit_test.go
@@ -1,0 +1,75 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestStaticInit(t *testing.T) {
+	var cases = []struct {
+		packageName string
+		packages    []string
+		err         string
+		output      string
+	}{
+		{
+			packageName: "pkg",
+			packages:    []string{"foo", "bar"},
+			output: `
+// GENERATED FILE -- DO NOT EDIT
+//
+
+package pkg
+
+import (
+	// Pull in all the known proto types to ensure we get their types registered.
+
+
+	// Register protos in "bar"
+	_ "bar"
+
+	// Register protos in "foo"
+	_ "foo"
+
+)`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			s, err := StaticInit(c.packageName, c.packages)
+			if c.err != "" {
+				g.Expect(err).NotTo(BeNil())
+				g.Expect(err.Error()).To(Equal(s))
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(strings.TrimSpace(s)).To(Equal(strings.TrimSpace(c.output)))
+			}
+		})
+	}
+}
+
+func TestApplyTemplate_Error(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	_, err := applyTemplate(staticCollectionsTemplate, struct{}{})
+	g.Expect(err).ToNot(BeNil())
+}

--- a/galley/pkg/config/schema/codegen/tools/collections.main.go
+++ b/galley/pkg/config/schema/codegen/tools/collections.main.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"istio.io/istio/galley/pkg/config/schema"
+	"istio.io/istio/galley/pkg/config/schema/codegen"
+)
+
+// Utility for generating collections.gen.go. Called from gen.go
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Printf("Invalid args: %v", os.Args)
+		os.Exit(-1)
+	}
+
+	pkg := os.Args[1]
+	input := os.Args[2]
+	output := os.Args[3]
+
+	c, err := readMetadata(input)
+	if err != nil {
+		fmt.Printf("Error reading metadata: %v", err)
+		os.Exit(-2)
+	}
+
+	var names []string
+	for _, r := range c.Collections().All() {
+		names = append(names, r.Name.String())
+	}
+	contents, err := codegen.StaticCollections(pkg, names)
+	if err != nil {
+		fmt.Printf("Error applying static init template: %v", err)
+		os.Exit(-3)
+	}
+
+	if err = ioutil.WriteFile(output, []byte(contents), os.ModePerm); err != nil {
+		fmt.Printf("Error writing output file: %v", err)
+		os.Exit(-4)
+	}
+}
+
+func readMetadata(path string) (*schema.Metadata, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read input file: %v", err)
+	}
+
+	return schema.ParseAndBuild(string(b))
+}

--- a/galley/pkg/config/schema/codegen/tools/staticinit.main.go
+++ b/galley/pkg/config/schema/codegen/tools/staticinit.main.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"istio.io/istio/galley/pkg/config/schema"
+	"istio.io/istio/galley/pkg/config/schema/codegen"
+)
+
+// Utility for generating staticinit.gen.go. Called from gen.go
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Printf("Invalid args: %v", os.Args)
+		os.Exit(-1)
+	}
+
+	pkg := os.Args[1]
+	input := os.Args[2]
+	output := os.Args[3]
+
+	c, err := readMetadata(input)
+	if err != nil {
+		fmt.Printf("Error reading metadata: %v", err)
+		os.Exit(-2)
+	}
+
+	var packages []string
+	for _, r := range c.Collections().All() {
+		packages = append(packages, r.ProtoPackage)
+	}
+	contents, err := codegen.StaticInit(pkg, packages)
+	if err != nil {
+		fmt.Printf("Error applying static init template: %v", err)
+		os.Exit(-3)
+	}
+
+	if err = ioutil.WriteFile(output, []byte(contents), os.ModePerm); err != nil {
+		fmt.Printf("Error writing output file: %v", err)
+		os.Exit(-4)
+	}
+}
+
+func readMetadata(path string) (*schema.Metadata, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read input file: %v", err)
+	}
+
+	return schema.ParseAndBuild(string(b))
+}

--- a/galley/pkg/config/schema/schema.go
+++ b/galley/pkg/config/schema/schema.go
@@ -263,9 +263,6 @@ func Build(astm *ast.Metadata) (*Metadata, error) {
 				if !ok {
 					return nil, fmt.Errorf("collection not found: %v", v)
 				}
-				if _, found := mapping[from.Name]; found {
-					return nil, fmt.Errorf("mapping already exists: %v", v)
-				}
 				mapping[from.Name] = to.Name
 			}
 			tr := &DirectTransform{

--- a/galley/pkg/config/schema/schema.go
+++ b/galley/pkg/config/schema/schema.go
@@ -1,0 +1,287 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"fmt"
+	"reflect"
+
+	"istio.io/istio/galley/pkg/config/collection"
+	"istio.io/istio/galley/pkg/config/schema/ast"
+)
+
+// Metadata is the top-level container.
+type Metadata struct {
+	collections collection.Specs
+	snapshots   map[string]*Snapshot
+	sources     []Source
+	transforms  []Transform
+}
+
+// Collections is all known collections
+func (m *Metadata) Collections() collection.Specs { return m.collections }
+
+// Snapshots returns all known snapshots
+func (m *Metadata) Snapshots() []*Snapshot {
+	result := make([]*Snapshot, 0, len(m.snapshots))
+	for _, s := range m.snapshots {
+		result = append(result, s)
+	}
+	return result
+}
+
+// Sources is all known sources
+func (m *Metadata) Sources() []Source {
+	result := make([]Source, len(m.sources))
+	copy(result, m.sources)
+	return result
+}
+
+// KubeSource is a temporary convenience function for getting the Kubernetes Source. As the infrastructure
+// is generified, then this method should disappear.
+func (m *Metadata) KubeSource() *KubeSource {
+	for _, s := range m.sources {
+		if ks, ok := s.(*KubeSource); ok {
+			return ks
+		}
+	}
+
+	panic("Metadata.KubeSource: KubeSource not found")
+}
+
+// Transforms is all known transforms
+func (m *Metadata) Transforms() []Transform {
+	result := make([]Transform, len(m.transforms))
+	copy(result, m.transforms)
+	return result
+}
+
+// DirectTransform is a temporary convenience function for getting the Direct Transform config. As the
+// infrastructure is generified, then this method should disappear.
+func (m *Metadata) DirectTransform() *DirectTransform {
+	for _, s := range m.transforms {
+		if ks, ok := s.(*DirectTransform); ok {
+			return ks
+		}
+	}
+
+	panic("Metadata.DirectTransform: DirectTransform not found")
+}
+
+// Snapshot metadata. Describes the snapshots that should be produced.
+type Snapshot struct {
+	Name        string
+	Collections []collection.Name
+	Strategy    string
+}
+
+// Source configuration metadata.
+type Source interface {
+}
+
+// Transform configuration metadata.
+type Transform interface {
+}
+
+// KubeSource is configuration for K8s based input sources.
+type KubeSource struct {
+	resources []*KubeResource
+}
+
+// KubeResources is all known resources
+func (k *KubeSource) Resources() KubeResources {
+	result := make([]KubeResource, len(k.resources))
+	for i, r := range k.resources {
+		result[i] = *r
+	}
+	return result
+}
+
+var _ Source = &KubeSource{}
+
+// KubeResource metadata for a Kubernetes KubeResource.
+type KubeResource struct {
+	Collection collection.Spec
+	Group      string
+	Version    string
+	Kind       string
+	Plural     string
+	Disabled   bool
+	Optional   bool
+}
+
+// KubeResources is an array of resources
+type KubeResources []KubeResource
+
+// CanonicalResourceName of the resource.
+func (i KubeResource) CanonicalResourceName() string {
+	return fmt.Sprintf("%s.%s/%s", i.Group, i.Version, i.Kind)
+}
+
+// Collections returns the name of collections for this set of resources
+func (k KubeResources) Collections() []collection.Name {
+	result := make([]collection.Name, 0, len(k))
+	for _, res := range k {
+		result = append(result, res.Collection.Name)
+	}
+
+	return result
+}
+
+// Find searches and returns the resource spec with the given group/kind
+func (k KubeResources) Find(group, kind string) (KubeResource, bool) {
+	for _, rs := range k {
+		if rs.Group == group && rs.Kind == kind {
+			return rs, true
+		}
+	}
+
+	return KubeResource{}, false
+}
+
+// MustFind calls Find and panics if not found.
+func (k KubeResources) MustFind(group, kind string) KubeResource {
+	r, found := k.Find(group, kind)
+	if !found {
+		panic(fmt.Sprintf("KubeSource.MustFind: unable to find %s/%s", group, kind))
+	}
+	return r
+}
+
+// DirectTransform configuration
+type DirectTransform struct {
+	mapping map[collection.Name]collection.Name
+}
+
+// Mapping from source to destination
+func (d *DirectTransform) Mapping() map[collection.Name]collection.Name {
+	m := make(map[collection.Name]collection.Name)
+	for k, v := range d.mapping {
+		m[k] = v
+	}
+
+	return m
+}
+
+// ParseAndBuild parses the given metadata file and returns the strongly typed schema.
+func ParseAndBuild(yamlText string) (*Metadata, error) {
+	mast, err := ast.Parse(yamlText)
+	if err != nil {
+		return nil, err
+	}
+
+	return Build(mast)
+}
+
+// Build strongly-typed Metadata from parsed AST.
+func Build(astm *ast.Metadata) (*Metadata, error) {
+	b := collection.NewSpecsBuilder()
+	for _, c := range astm.Collections {
+		s, err := collection.NewSpec(c.Name, c.ProtoPackage, c.Proto)
+		if err != nil {
+			return nil, err
+		}
+
+		if err = b.Add(s); err != nil {
+			return nil, err
+		}
+	}
+	collections := b.Build()
+
+	snapshots := make(map[string]*Snapshot)
+	for _, s := range astm.Snapshots {
+		sn := &Snapshot{
+			Name:     s.Name,
+			Strategy: s.Strategy,
+		}
+
+		for _, c := range s.Collections {
+			col, found := collections.Lookup(c)
+			if !found {
+				return nil, fmt.Errorf("collection not found: %v", c)
+			}
+			sn.Collections = append(sn.Collections, col.Name)
+		}
+		snapshots[sn.Name] = sn
+	}
+
+	var sources []Source
+	for _, s := range astm.Sources {
+		switch v := s.(type) {
+		case *ast.KubeSource:
+			var resources []*KubeResource
+			for _, r := range v.Resources {
+				col, ok := collections.Lookup(r.Collection)
+				if !ok {
+					return nil, fmt.Errorf("collection not found: %v", r.Collection)
+				}
+				res := &KubeResource{
+					Collection: col,
+					Kind:       r.Kind,
+					Plural:     r.Plural,
+					Version:    r.Version,
+					Group:      r.Group,
+					Optional:   r.Optional,
+					Disabled:   r.Disabled,
+				}
+
+				resources = append(resources, res)
+			}
+			src := &KubeSource{
+				resources: resources,
+			}
+			sources = append(sources, src)
+
+		default:
+			return nil, fmt.Errorf("unrecognized source type: %v", reflect.TypeOf(s))
+		}
+	}
+
+	var transforms []Transform
+	for _, t := range astm.Transforms {
+		switch v := t.(type) {
+		case *ast.DirectTransform:
+			mapping := make(map[collection.Name]collection.Name)
+			for k, v := range v.Mapping {
+				from, ok := collections.Lookup(k)
+				if !ok {
+					return nil, fmt.Errorf("collection not found: %v", k)
+				}
+				to, ok := collections.Lookup(v)
+				if !ok {
+					return nil, fmt.Errorf("collection not found: %v", v)
+				}
+				if _, found := mapping[from.Name]; found {
+					return nil, fmt.Errorf("mapping already exists: %v", v)
+				}
+				mapping[from.Name] = to.Name
+			}
+			tr := &DirectTransform{
+				mapping: mapping,
+			}
+			transforms = append(transforms, tr)
+
+		default:
+			return nil, fmt.Errorf("unrecognized transform type: %v", reflect.TypeOf(t))
+		}
+	}
+
+	return &Metadata{
+		collections: collections,
+		snapshots:   snapshots,
+		sources:     sources,
+		transforms:  transforms,
+	}, nil
+}

--- a/galley/pkg/config/schema/schema_test.go
+++ b/galley/pkg/config/schema/schema_test.go
@@ -340,7 +340,7 @@ func TestSchema_Find(t *testing.T) {
 		Kind:    "VirtualService",
 	}))
 
-	k, b = s.KubeSource().Resources().Find("foo", "bar")
+	_, b = s.KubeSource().Resources().Find("foo", "bar")
 	g.Expect(b).To(BeFalse())
 }
 

--- a/galley/pkg/config/schema/schema_test.go
+++ b/galley/pkg/config/schema/schema_test.go
@@ -1,0 +1,435 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/galley/pkg/config/collection"
+	"istio.io/istio/galley/pkg/config/schema/ast"
+)
+
+func TestSchema_ParseAndBuild(t *testing.T) {
+	var cases = []struct {
+		Input    string
+		Expected *Metadata
+	}{
+		{
+			Input: ``,
+			Expected: &Metadata{
+				collections: collection.NewSpecsBuilder().Build(),
+				snapshots:   map[string]*Snapshot{},
+			},
+		},
+		{
+			Input: `
+collections:
+  - name:         "k8s/networking.istio.io/v1alpha3/virtualservices"
+    proto:        "istio.networking.v1alpha3.VirtualService"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+
+  - name:         "istio/networking.istio.io/v1alpha3/virtualservices"
+    proto:        "istio.networking.v1alpha3.VirtualService"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+
+snapshots:
+  - name: "default"
+    strategy: debounce
+    collections:
+      - "istio/networking.istio.io/v1alpha3/virtualservices"
+
+
+sources:
+  - type: kubernetes
+    resources:
+    - collection:   "k8s/networking.istio.io/v1alpha3/virtualservices"
+      kind:         "VirtualService"
+      group:        "networking.istio.io"
+      version:      "v1alpha3"
+  
+transforms:
+  - type: direct
+    mapping:
+      "k8s/networking.istio.io/v1alpha3/virtualservices": "istio/networking.istio.io/v1alpha3/virtualservices"
+`,
+			Expected: &Metadata{
+				collections: func() collection.Specs {
+					b := collection.NewSpecsBuilder()
+					b.MustAdd(
+						collection.MustNewSpec(
+							"k8s/networking.istio.io/v1alpha3/virtualservices",
+							"istio.io/api/networking/v1alpha3",
+							"istio.networking.v1alpha3.VirtualService"),
+					)
+					b.MustAdd(
+						collection.MustNewSpec(
+							"istio/networking.istio.io/v1alpha3/virtualservices",
+							"istio.io/api/networking/v1alpha3",
+							"istio.networking.v1alpha3.VirtualService"),
+					)
+					return b.Build()
+				}(),
+				snapshots: map[string]*Snapshot{
+					"default": {
+						Name:     "default",
+						Strategy: "debounce",
+						Collections: []collection.Name{
+							collection.NewName("istio/networking.istio.io/v1alpha3/virtualservices"),
+						},
+					},
+				},
+				sources: []Source{
+					&KubeSource{
+						resources: []*KubeResource{
+							{
+								Collection: collection.MustNewSpec(
+									"k8s/networking.istio.io/v1alpha3/virtualservices",
+									"istio.io/api/networking/v1alpha3",
+									"istio.networking.v1alpha3.VirtualService"),
+								Version: "v1alpha3",
+								Kind:    "VirtualService",
+								Group:   "networking.istio.io",
+							},
+						},
+					},
+				},
+				transforms: []Transform{
+					&DirectTransform{
+						mapping: map[collection.Name]collection.Name{
+							collection.NewName("k8s/networking.istio.io/v1alpha3/virtualservices"): collection.NewName("istio/networking.istio.io/v1alpha3/virtualservices"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			actual, err := ParseAndBuild(c.Input)
+			g.Expect(err).To(BeNil())
+			g.Expect(actual).To(Equal(c.Expected))
+		})
+	}
+}
+
+func TestSchema_ParseAndBuild_Error(t *testing.T) {
+	var cases = []string{
+		`
+	$$$
+`,
+
+		`
+collections:
+  - name:         "$$$"
+    proto:        "istio.networking.v1alpha3.VirtualService"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+`,
+		`
+collections:
+  - name:         "k8s/networking.istio.io/v1alpha3/virtualservices"
+    proto:        "istio.networking.v1alpha3.VirtualService"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+  - name:         "k8s/networking.istio.io/v1alpha3/virtualservices"
+    proto:        "istio.networking.v1alpha3.VirtualService"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+`,
+
+		`
+collections:
+  - name:         "k8s/networking.istio.io/v1alpha3/virtualservices"
+    proto:        "istio.networking.v1alpha3.VirtualService"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+snapshots:
+- name: "default"
+  strategy: debounce
+  collections:
+  - "istio/networking.istio.io/v1alpha3/virtualservices"
+`,
+		`
+collections:
+sources:
+  - type: kubernetes
+    resources:
+    - collection:   "k8s/networking.istio.io/v1alpha3/virtualservices"
+      kind:         "VirtualService"
+      group:        "networking.istio.io"
+      version:      "v1alpha3"
+`,
+		`
+collections:
+  - name:         "k8s/networking.istio.io/v1alpha3/virtualservices"
+    proto:        "istio.networking.v1alpha3.VirtualService"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+transforms:
+  - type: direct
+    mapping:
+      "k8s/networking.istio.io/v1alpha3/virtualservices": "istio/networking.istio.io/v1alpha3/virtualservices"
+`,
+		`
+collections:
+  - name:         "istio/networking.istio.io/v1alpha3/virtualservices"
+    proto:        "istio.networking.v1alpha3.VirtualService"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+transforms:
+  - type: direct
+    mapping:
+      "k8s/networking.istio.io/v1alpha3/virtualservices": "istio/networking.istio.io/v1alpha3/virtualservices"
+`,
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			_, err := ParseAndBuild(c)
+			g.Expect(err).NotTo(BeNil())
+		})
+	}
+}
+
+var input = `
+collections:
+  - name:         "k8s/networking.istio.io/v1alpha3/virtualservices"
+    proto:        "istio.networking.v1alpha3.VirtualService"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+
+  - name:         "istio/networking.istio.io/v1alpha3/virtualservices"
+    proto:        "istio.networking.v1alpha3.VirtualService"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+
+snapshots:
+  - name: "default"
+    strategy: debounce
+    collections:
+      - "istio/networking.istio.io/v1alpha3/virtualservices"
+
+
+sources:
+  - type: kubernetes
+    resources:
+    - collection:   "k8s/networking.istio.io/v1alpha3/virtualservices"
+      kind:         "VirtualService"
+      group:        "networking.istio.io"
+      version:      "v1alpha3"
+  
+transforms:
+  - type: direct
+    mapping:
+      "k8s/networking.istio.io/v1alpha3/virtualservices": "istio/networking.istio.io/v1alpha3/virtualservices"
+`
+
+func TestSchemaBasic(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s, err := ParseAndBuild(input)
+	g.Expect(err).To(BeNil())
+
+	b := collection.NewSpecsBuilder()
+	b.MustAdd(collection.MustNewSpec("k8s/networking.istio.io/v1alpha3/virtualservices",
+		"istio.io/api/networking/v1alpha3",
+		"istio.networking.v1alpha3.VirtualService"))
+	b.MustAdd(collection.MustNewSpec("istio/networking.istio.io/v1alpha3/virtualservices",
+		"istio.io/api/networking/v1alpha3",
+		"istio.networking.v1alpha3.VirtualService"))
+	g.Expect(s.Collections()).To(Equal(b.Build()))
+
+	g.Expect(s.Transforms()).To(HaveLen(1))
+	g.Expect(s.Transforms()[0]).To(Equal(
+		&DirectTransform{
+			mapping: map[collection.Name]collection.Name{
+				collection.NewName("k8s/networking.istio.io/v1alpha3/virtualservices"): collection.NewName("istio/networking.istio.io/v1alpha3/virtualservices"),
+			},
+		}))
+	g.Expect(s.DirectTransform()).To(Equal(
+		&DirectTransform{
+			mapping: map[collection.Name]collection.Name{
+				collection.NewName("k8s/networking.istio.io/v1alpha3/virtualservices"): collection.NewName("istio/networking.istio.io/v1alpha3/virtualservices"),
+			},
+		}))
+
+	g.Expect(s.DirectTransform().Mapping()).To(Equal(
+		map[collection.Name]collection.Name{
+			collection.NewName("k8s/networking.istio.io/v1alpha3/virtualservices"): collection.NewName("istio/networking.istio.io/v1alpha3/virtualservices"),
+		}))
+
+	g.Expect(s.Sources()).To(HaveLen(1))
+	g.Expect(s.Sources()[0]).To(Equal(
+		&KubeSource{
+			resources: []*KubeResource{
+				{
+					Collection: collection.MustNewSpec("k8s/networking.istio.io/v1alpha3/virtualservices",
+						"istio.io/api/networking/v1alpha3",
+						"istio.networking.v1alpha3.VirtualService"),
+					Group:   "networking.istio.io",
+					Version: "v1alpha3",
+					Kind:    "VirtualService",
+				},
+			},
+		}))
+
+	g.Expect(s.Snapshots()).To(HaveLen(1))
+	g.Expect(s.Snapshots()[0]).To(Equal(
+		&Snapshot{
+			Name:        "default",
+			Strategy:    "debounce",
+			Collections: []collection.Name{collection.NewName("istio/networking.istio.io/v1alpha3/virtualservices")},
+		}))
+
+	g.Expect(s.KubeSource()).To(Equal(&KubeSource{
+		resources: []*KubeResource{
+			{
+				Collection: collection.MustNewSpec("k8s/networking.istio.io/v1alpha3/virtualservices",
+					"istio.io/api/networking/v1alpha3",
+					"istio.networking.v1alpha3.VirtualService"),
+				Group:   "networking.istio.io",
+				Version: "v1alpha3",
+				Kind:    "VirtualService",
+			},
+		},
+	}))
+
+	g.Expect(s.KubeSource().Resources()).To(Equal(KubeResources{
+		{
+			Collection: collection.MustNewSpec("k8s/networking.istio.io/v1alpha3/virtualservices",
+				"istio.io/api/networking/v1alpha3",
+				"istio.networking.v1alpha3.VirtualService"),
+			Group:   "networking.istio.io",
+			Version: "v1alpha3",
+			Kind:    "VirtualService",
+		},
+	}))
+
+	g.Expect(s.KubeSource().Resources().Collections()).To(Equal([]collection.Name{
+		collection.NewName("k8s/networking.istio.io/v1alpha3/virtualservices"),
+	}))
+
+	g.Expect(s.KubeSource().Resources()[0].CanonicalResourceName()).To(Equal("networking.istio.io.v1alpha3/VirtualService"))
+}
+
+func TestSchema_Find(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s, err := ParseAndBuild(input)
+	g.Expect(err).To(BeNil())
+
+	k, b := s.KubeSource().Resources().Find("networking.istio.io", "VirtualService")
+	g.Expect(b).To(BeTrue())
+	g.Expect(k).To(Equal(KubeResource{
+		Collection: collection.MustNewSpec("k8s/networking.istio.io/v1alpha3/virtualservices",
+			"istio.io/api/networking/v1alpha3",
+			"istio.networking.v1alpha3.VirtualService"),
+		Group:   "networking.istio.io",
+		Version: "v1alpha3",
+		Kind:    "VirtualService",
+	}))
+
+	k, b = s.KubeSource().Resources().Find("foo", "bar")
+	g.Expect(b).To(BeFalse())
+}
+
+func TestSchema_MustFind(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	defer func() {
+		r := recover()
+		g.Expect(r).To(BeNil())
+	}()
+
+	s, err := ParseAndBuild(input)
+	g.Expect(err).To(BeNil())
+
+	k := s.KubeSource().Resources().MustFind("networking.istio.io", "VirtualService")
+	g.Expect(k).To(Equal(KubeResource{
+		Collection: collection.MustNewSpec("k8s/networking.istio.io/v1alpha3/virtualservices",
+			"istio.io/api/networking/v1alpha3",
+			"istio.networking.v1alpha3.VirtualService"),
+		Group:   "networking.istio.io",
+		Version: "v1alpha3",
+		Kind:    "VirtualService",
+	}))
+}
+
+func TestSchema_MustFind_Panic(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	defer func() {
+		r := recover()
+		g.Expect(r).NotTo(BeNil())
+	}()
+
+	s, err := ParseAndBuild(input)
+	g.Expect(err).To(BeNil())
+
+	_ = s.KubeSource().Resources().MustFind("foo.istio.io", "bar")
+}
+
+func TestSchema_KubeResource_Panic(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	defer func() {
+		r := recover()
+		g.Expect(r).NotTo(BeNil())
+	}()
+
+	s, err := ParseAndBuild(``)
+	g.Expect(err).To(BeNil())
+
+	_ = s.KubeSource()
+}
+
+func TestSchema_DirectTransform_Panic(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	defer func() {
+		r := recover()
+		g.Expect(r).NotTo(BeNil())
+	}()
+
+	s, err := ParseAndBuild(``)
+	g.Expect(err).To(BeNil())
+
+	_ = s.DirectTransform()
+}
+
+func TestBuild_UnknownSource(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	a := &ast.Metadata{
+		Sources: []ast.Source{
+			&struct{}{},
+		},
+	}
+
+	_, err := Build(a)
+	g.Expect(err).NotTo(BeNil())
+}
+
+func TestBuild_UnknownTransform(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	a := &ast.Metadata{
+		Transforms: []ast.Transform{
+			&struct{}{},
+		},
+	}
+
+	_, err := Build(a)
+	g.Expect(err).NotTo(BeNil())
+}


### PR DESCRIPTION
pkg/config/schema contains the main metadata parser/data model for Galley.

+ Adds the ast, model, parser & validator for the metadata model.
+ Adds code generation tools for generating code artifacts: mainly for pulling in proto types, and having well-defined collection names.

Here is an input format sample: https://github.com/ozevren/istio/blob/nwo-2-single/galley/pkg/config/processor/metadata/metadata.yaml
