### PR TITLE
refactor(pilot metrics): convert to OpenCensus from Prometheus

### DIFF
--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -57,12 +57,14 @@ var (
 
 	// experiment on getting some monitoring on config errors.
 	k8sEvents = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_k8s_cfg_events", "Events from k8s config."},
+		"pilot_k8s_cfg_events",
+		"Events from k8s config.",
 		typeTag, eventTag,
 	)
 
 	k8sErrors = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_k8s_object_errors", "Errors converting k8s CRDs"},
+		"pilot_k8s_object_errors",
+		"Errors converting k8s CRDs",
 		typeTag, eventTag,
 	)
 

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -64,7 +64,7 @@ var (
 	k8sErrors = monitoring.NewGauge(
 		"pilot_k8s_object_errors",
 		"Errors converting k8s CRDs",
-		typeTag, eventTag,
+		nameTag,
 	)
 
 	// InvalidCRDs contains a sync.Map keyed by the namespace/name of the entry, and has the error as value.

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -334,5 +334,5 @@ func (c *controller) List(typ, namespace string) ([]model.Config, error) {
 
 func setErrorGauge(name string, value int64) {
 	ctx, _ := tag.New(context.Background(), tag.Upsert(nameTag, name))
-	stats.Record(ctx, k8sErrors.M(1))
+	stats.Record(ctx, k8sErrors.M(value))
 }

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -182,7 +182,7 @@ func (c *controller) createInformer(
 }
 
 func incrementEvent(kind, event string) {
-	k8sEvents.WithTags(typeTag.Value(kind), eventTag.Value(event)).Increment()
+	k8sEvents.With(typeTag.Value(kind), eventTag.Value(event)).Increment()
 }
 
 func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model.Event)) {
@@ -288,7 +288,7 @@ func (c *controller) List(typ, namespace string) ([]model.Config, error) {
 	oldMap := InvalidCRDs.Load()
 	if oldMap != nil {
 		oldMap.(*sync.Map).Range(func(key, value interface{}) bool {
-			k8sErrors.WithTags(nameTag.Value(key.(string))).Record(1)
+			k8sErrors.With(nameTag.Value(key.(string))).Record(1)
 			return true
 		})
 	}
@@ -310,7 +310,7 @@ func (c *controller) List(typ, namespace string) ([]model.Config, error) {
 			// the rest should still be processed.
 			// TODO: find a way to reset and represent the error !!
 			newErrors.Store(key, err)
-			k8sErrors.WithTags(nameTag.Value(key)).Record(1)
+			k8sErrors.With(nameTag.Value(key)).Record(1)
 		} else {
 			out = append(out, *config)
 		}

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"go.opencensus.io/tag"
-
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/monitoring"
 )
@@ -47,8 +45,8 @@ type MergedGateway struct {
 }
 
 var (
-	typeTag = monitoring.MustCreateTagKey("type")
-	nameTag = monitoring.MustCreateTagKey("name")
+	typeTag = monitoring.MustCreateTag("type")
+	nameTag = monitoring.MustCreateTag("name")
 
 	totalRejectedConfigs = monitoring.NewSum(
 		"pilot_total_rejected_configs",
@@ -62,7 +60,7 @@ func init() {
 }
 
 func recordRejectedConfig(gateway string) {
-	totalRejectedConfigs.WithTags(tag.Upsert(typeTag, "gateway"), tag.Upsert(nameTag, gateway)).Increment()
+	totalRejectedConfigs.WithTags(typeTag.Value("gateway"), nameTag.Value(gateway)).Increment()
 }
 
 // MergeGateways combines multiple gateways targeting the same workload into a single logical Gateway.

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -51,7 +51,8 @@ var (
 	nameTag = monitoring.MustCreateTagKey("name")
 
 	totalRejectedConfigs = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_total_rejected_configs", "Total number of configs that Pilot had to reject or ignore."},
+		"pilot_total_rejected_configs",
+		"Total number of configs that Pilot had to reject or ignore.",
 		typeTag, nameTag,
 	)
 )

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -48,29 +47,17 @@ type MergedGateway struct {
 }
 
 var (
-	typeTag, typeTagErr = tag.NewKey("type")
-	nameTag, nameTagErr = tag.NewKey("name")
+	typeTag = monitoring.MustCreateTagKey("type")
+	nameTag = monitoring.MustCreateTagKey("name")
 
-	totalRejectedConfigs, totalRejectedConfigsView = monitoring.NewInt64AndView(
-		"pilot_total_rejected_configs",
-		"Total number of configs that Pilot had to reject or ignore.",
-		view.Sum(),
+	totalRejectedConfigs = monitoring.NewSum(
+		monitoring.MetricOpts{"pilot_total_rejected_configs", "Total number of configs that Pilot had to reject or ignore."},
 		typeTag, nameTag,
 	)
 )
 
 func init() {
-	if typeTagErr != nil {
-		panic(typeTagErr)
-	}
-
-	if nameTagErr != nil {
-		panic(nameTagErr)
-	}
-
-	if err := view.Register(totalRejectedConfigsView); err != nil {
-		panic(err)
-	}
+	monitoring.MustRegisterViews(totalRejectedConfigs)
 }
 
 func recordRejectedConfig(gateway string) {

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -60,7 +60,7 @@ func init() {
 }
 
 func recordRejectedConfig(gateway string) {
-	totalRejectedConfigs.WithTags(typeTag.Value("gateway"), nameTag.Value(gateway)).Increment()
+	totalRejectedConfigs.With(typeTag.Value("gateway"), nameTag.Value(gateway)).Increment()
 }
 
 // MergeGateways combines multiple gateways targeting the same workload into a single logical Gateway.

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -184,7 +184,8 @@ var (
 	// we can't figure out the labels. It may be a transient problem, if endpoint is processed before
 	// pod.
 	EndpointNoPod = monitoring.NewGauge(
-		monitoring.MetricOpts{"endpoint_no_pod", "Endpoints without an associated pod."},
+		"endpoint_no_pod",
+		"Endpoints without an associated pod.",
 	)
 
 	// ProxyStatusNoService represents proxies not selected by any service
@@ -193,82 +194,68 @@ var (
 	// the sidecar calls.
 	// Updated by GetProxyServiceInstances
 	ProxyStatusNoService = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_no_ip", "Pods not found in the endpoint table, possibly invalid."},
+		"pilot_no_ip",
+		"Pods not found in the endpoint table, possibly invalid.",
 	)
 
 	// ProxyStatusEndpointNotReady represents proxies found not be ready.
 	// Updated by GetProxyServiceInstances. Normal condition when starting
 	// an app with readiness, error if it doesn't change to 0.
 	ProxyStatusEndpointNotReady = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_endpoint_not_ready", "Endpoint found in unready state."},
+		"pilot_endpoint_not_ready",
+		"Endpoint found in unready state.",
 	)
 
 	// ProxyStatusConflictOutboundListenerTCPOverHTTP metric tracks number of
 	// wildcard TCP listeners that conflicted with existing wildcard HTTP listener on same port
 	ProxyStatusConflictOutboundListenerTCPOverHTTP = monitoring.NewGauge(
-		monitoring.MetricOpts{
-			"pilot_conflict_outbound_listener_tcp_over_current_http",
-			"Number of conflicting wildcard tcp listeners with current wildcard http listener.",
-		},
+		"pilot_conflict_outbound_listener_tcp_over_current_http",
+		"Number of conflicting wildcard tcp listeners with current wildcard http listener.",
 	)
 
 	// ProxyStatusConflictOutboundListenerTCPOverTCP metric tracks number of
 	// TCP listeners that conflicted with existing TCP listeners on same port
 	ProxyStatusConflictOutboundListenerTCPOverTCP = monitoring.NewGauge(
-		monitoring.MetricOpts{
-			"pilot_conflict_outbound_listener_tcp_over_current_tcp",
-			"Number of conflicting tcp listeners with current tcp listener.",
-		},
+		"pilot_conflict_outbound_listener_tcp_over_current_tcp",
+		"Number of conflicting tcp listeners with current tcp listener.",
 	)
 
 	// ProxyStatusConflictOutboundListenerHTTPOverTCP metric tracks number of
 	// wildcard HTTP listeners that conflicted with existing wildcard TCP listener on same port
 	ProxyStatusConflictOutboundListenerHTTPOverTCP = monitoring.NewGauge(
-		monitoring.MetricOpts{
-			"pilot_conflict_outbound_listener_http_over_current_tcp",
-			"Number of conflicting wildcard http listeners with current wildcard tcp listener.",
-		},
+		"pilot_conflict_outbound_listener_http_over_current_tcp",
+		"Number of conflicting wildcard http listeners with current wildcard tcp listener.",
 	)
 
 	// ProxyStatusConflictInboundListener tracks cases of multiple inbound
 	// listeners - 2 services selecting the same port of the pod.
 	ProxyStatusConflictInboundListener = monitoring.NewGauge(
-		monitoring.MetricOpts{
-			"pilot_conflict_inbound_listener",
-			"Number of conflicting inbound listeners.",
-		},
+		"pilot_conflict_inbound_listener",
+		"Number of conflicting inbound listeners.",
 	)
 
 	// DuplicatedClusters tracks duplicate clusters seen while computing CDS
 	DuplicatedClusters = monitoring.NewGauge(
-		monitoring.MetricOpts{
-			"pilot_duplicate_envoy_clusters",
-			"Duplicate envoy clusters caused by service entries with same hostname",
-		},
+		"pilot_duplicate_envoy_clusters",
+		"Duplicate envoy clusters caused by service entries with same hostname",
 	)
 
 	// ProxyStatusClusterNoInstances tracks clusters (services) without workloads.
 	ProxyStatusClusterNoInstances = monitoring.NewGauge(
-		monitoring.MetricOpts{
-			"pilot_eds_no_instances",
-			"Number of clusters without instances.",
-		},
+		"pilot_eds_no_instances",
+		"Number of clusters without instances.",
 	)
 
 	// DuplicatedDomains tracks rejected VirtualServices due to duplicated hostname.
 	DuplicatedDomains = monitoring.NewGauge(
-		monitoring.MetricOpts{
-			"pilot_vservice_dup_domain",
-			"Virtual services with dup domains.",
-		},
+		"pilot_vservice_dup_domain",
+		"Virtual services with dup domains.",
 	)
 
 	// DuplicatedSubsets tracks duplicate subsets that we rejected while merging multiple destination rules for same host
 	DuplicatedSubsets = monitoring.NewGauge(
-		monitoring.MetricOpts{
-			"pilot_destrule_subsets",
-			"Duplicate subsets across destination rules for same host",
-		},
+		"pilot_destrule_subsets",
+		"Duplicate subsets across destination rules for same host",
 	)
 
 	// LastPushStatus preserves the metrics and data collected during lasts global push.

--- a/pilot/pkg/monitoring/monitoring.go
+++ b/pilot/pkg/monitoring/monitoring.go
@@ -1,0 +1,59 @@
+package monitoring
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// Int64...
+type Int64 struct {
+	*stats.Int64Measure
+
+	tags []tag.Mutator
+}
+
+func (m *Int64) WithTags(tags ...tag.Mutator) *Int64 {
+	return &Int64{m.Int64Measure, append(m.tags, tags...)}
+}
+
+func (m *Int64) Increment() {
+	stats.RecordWithTags(context.Background(), m.tags, m.M(1))
+}
+
+func (m *Int64) Record(value int64) {
+	stats.RecordWithTags(context.Background(), m.tags, m.M(value))
+}
+
+func NewInt64AndView(name, description string, aggregation *view.Aggregation, tagKeys ...tag.Key) (*Int64, *view.View) {
+	i := &Int64{stats.Int64(name, description, stats.UnitDimensionless), make([]tag.Mutator, 0, len(tagKeys))}
+	v := &view.View{Measure: i.Int64Measure, TagKeys: tagKeys, Aggregation: aggregation}
+	return i, v
+}
+
+// Float64...
+type Float64 struct {
+	*stats.Float64Measure
+
+	tags []tag.Mutator
+}
+
+func NewFloat64AndView(name, description string, aggregation *view.Aggregation, tagKeys ...tag.Key) (*Float64, *view.View) {
+	f := &Float64{stats.Float64(name, description, stats.UnitDimensionless), make([]tag.Mutator, 0, len(tagKeys))}
+	v := &view.View{Measure: f.Float64Measure, TagKeys: tagKeys, Aggregation: aggregation}
+	return f, v
+}
+
+func (m *Float64) WithTags(tags ...tag.Mutator) *Float64 {
+	return &Float64{m.Float64Measure, append(m.tags, tags...)}
+}
+
+func (m *Float64) Increment() {
+	stats.RecordWithTags(context.Background(), m.tags, m.M(1))
+}
+
+func (m *Float64) Record(value float64) {
+	stats.RecordWithTags(context.Background(), m.tags, m.M(value))
+}

--- a/pilot/pkg/monitoring/monitoring.go
+++ b/pilot/pkg/monitoring/monitoring.go
@@ -45,17 +45,6 @@ type (
 		// View returns the OpenCensus view structure to which this Metric is being exported.
 		View() *view.View
 	}
-
-	// MetricOpts provides the basic options for a Metric.
-	MetricOpts struct {
-
-		// Name is the canonical name of the metric.
-		Name string
-
-		// Description provides a summary of the value being tracked by the Metric. It is used
-		// to generate documentation of the metric.
-		Description string
-	}
 )
 
 // MustCreateTagKey will attempt to create a new OpenCensus tag key. If
@@ -81,24 +70,24 @@ func MustRegisterViews(metrics ...Metric) {
 
 // NewSum creates a new Metric with an aggregation type of Sum. That means that data collected
 // by the new Metric will be summed before export.
-func NewSum(opts MetricOpts, tagKeys ...tag.Key) Metric {
-	return newMetric(opts, view.Sum(), tagKeys...)
+func NewSum(name, description string, tagKeys ...tag.Key) Metric {
+	return newMetric(name, description, view.Sum(), tagKeys...)
 }
 
 // NewGauge creates a new Metric with an aggregation type of LastValue. That means that data collected
 // by the new Metric will export only the last recorded value.
-func NewGauge(opts MetricOpts, tagKeys ...tag.Key) Metric {
-	return newMetric(opts, view.LastValue(), tagKeys...)
+func NewGauge(name, description string, tagKeys ...tag.Key) Metric {
+	return newMetric(name, description, view.LastValue(), tagKeys...)
 }
 
 // NewDistribution creates a new Metric with an aggregration type of Distribution. This means that the
 // data collected by the Metric will be collected and exported as a histogram, with the specified bounds.
-func NewDistribution(opts MetricOpts, bounds []float64, tagKeys ...tag.Key) Metric {
-	return newMetric(opts, view.Distribution(bounds...), tagKeys...)
+func NewDistribution(name, description string, bounds []float64, tagKeys ...tag.Key) Metric {
+	return newMetric(name, description, view.Distribution(bounds...), tagKeys...)
 }
 
-func newMetric(opts MetricOpts, aggregation *view.Aggregation, tagKeys ...tag.Key) Metric {
-	return newFloat64Metric(opts, aggregation, tagKeys...)
+func newMetric(name, description string, aggregation *view.Aggregation, tagKeys ...tag.Key) Metric {
+	return newFloat64Metric(name, description, aggregation, tagKeys...)
 }
 
 type float64Metric struct {
@@ -108,8 +97,8 @@ type float64Metric struct {
 	view *view.View
 }
 
-func newFloat64Metric(opts MetricOpts, aggregation *view.Aggregation, tagKeys ...tag.Key) *float64Metric {
-	measure := stats.Float64(opts.Name, opts.Description, stats.UnitDimensionless)
+func newFloat64Metric(name, description string, aggregation *view.Aggregation, tagKeys ...tag.Key) *float64Metric {
+	measure := stats.Float64(name, description, stats.UnitDimensionless)
 	return &float64Metric{
 		measure,
 		make([]tag.Mutator, 0, len(tagKeys)),
@@ -130,7 +119,9 @@ func (f *float64Metric) Record(value float64) {
 }
 
 func (f *float64Metric) WithTags(tags ...tag.Mutator) Metric {
-	return &float64Metric{f.Float64Measure, append(f.tags, tags...), f.view}
+	t := make([]tag.Mutator, 0, len(f.tags)+len(tags))
+	copy(t, f.tags)
+	return &float64Metric{f.Float64Measure, append(t, tags...), f.view}
 }
 
 func (f *float64Metric) View() *view.View {

--- a/pilot/pkg/monitoring/monitoring.go
+++ b/pilot/pkg/monitoring/monitoring.go
@@ -37,9 +37,9 @@ type (
 		// Record makes an observation of the provided value for the given measure.
 		Record(value float64)
 
-		// WithTags creates a new Metric, with the TagValues provided. This allows creating
+		// With creates a new Metric, with the TagValues provided. This allows creating
 		// a set of pre-dimensioned data for recording and export purposes.
-		WithTags(tagValues ...TagValue) Metric
+		With(tagValues ...TagValue) Metric
 
 		// View returns the OpenCensus view to which this Metric is being exported.
 		View() *view.View
@@ -133,7 +133,7 @@ func (f *float64Metric) Record(value float64) {
 	stats.RecordWithTags(context.Background(), f.tags, f.M(value)) //nolint:errcheck
 }
 
-func (f *float64Metric) WithTags(tagValues ...TagValue) Metric {
+func (f *float64Metric) With(tagValues ...TagValue) Metric {
 	t := make([]tag.Mutator, 0, len(f.tags)+len(tagValues))
 	copy(t, f.tags)
 	for _, tagValue := range tagValues {

--- a/pilot/pkg/monitoring/monitoring.go
+++ b/pilot/pkg/monitoring/monitoring.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package monitoring
 
 import (
@@ -108,7 +122,7 @@ func (f *float64Metric) Increment() {
 }
 
 func (f *float64Metric) Name() string {
-	return f.Name()
+	return f.Float64Measure.Name()
 }
 
 func (f *float64Metric) Record(value float64) {

--- a/pilot/pkg/monitoring/monitoring.go
+++ b/pilot/pkg/monitoring/monitoring.go
@@ -2,58 +2,123 @@ package monitoring
 
 import (
 	"context"
+	"fmt"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 )
 
-// Int64...
-type Int64 struct {
-	*stats.Int64Measure
+type (
+	// Metric collects numerical observations. These observations are aggregated and exported
+	// to OpenCensus views.
+	Metric interface {
 
-	tags []tag.Mutator
+		// Increment records a value of 1 for the current measure. For view.Count and view.Sum
+		// aggregations, this is equivalent to adding 1 to the current value.
+		Increment()
+
+		// Name returns the name value of a Metric
+		Name() string
+
+		// Record makes an observation of the provided value for the given measure.
+		Record(value float64)
+
+		// WithTags creates a new Metric, with the tag mutations provided. This allows creating
+		// a set of pre-dimensioned data for recording and export purposes.
+		WithTags(tags ...tag.Mutator) Metric
+
+		// View returns the OpenCensus view structure to which this Metric is being exported.
+		View() *view.View
+	}
+
+	// MetricOpts provides the basic options for a Metric.
+	MetricOpts struct {
+
+		// Name is the canonical name of the metric.
+		Name string
+
+		// Description provides a summary of the value being tracked by the Metric. It is used
+		// to generate documentation of the metric.
+		Description string
+	}
+)
+
+// MustCreateTagKey will attempt to create a new OpenCensus tag key. If
+// creation fails, then this method will panic.
+func MustCreateTagKey(key string) tag.Key {
+	k, err := tag.NewKey(key)
+	if err != nil {
+		panic(fmt.Errorf("could not create tag key %q: %v", key, err))
+	}
+	return k
 }
 
-func (m *Int64) WithTags(tags ...tag.Mutator) *Int64 {
-	return &Int64{m.Int64Measure, append(m.tags, tags...)}
+// MustRegisterViews is a helper function that will ensure that the OpenCensus views created
+// for the provided Metrics are registered. If the view for a metric fails to register,
+// this method will panic.
+func MustRegisterViews(metrics ...Metric) {
+	for _, s := range metrics {
+		if err := view.Register(s.View()); err != nil {
+			panic(err)
+		}
+	}
 }
 
-func (m *Int64) Increment() {
-	stats.RecordWithTags(context.Background(), m.tags, m.M(1))
+// NewSum creates a new Metric with an aggregation type of Sum. That means that data collected
+// by the new Metric will be summed before export.
+func NewSum(opts MetricOpts, tagKeys ...tag.Key) Metric {
+	return newMetric(opts, view.Sum(), tagKeys...)
 }
 
-func (m *Int64) Record(value int64) {
-	stats.RecordWithTags(context.Background(), m.tags, m.M(value))
+// NewGauge creates a new Metric with an aggregation type of LastValue. That means that data collected
+// by the new Metric will export only the last recorded value.
+func NewGauge(opts MetricOpts, tagKeys ...tag.Key) Metric {
+	return newMetric(opts, view.LastValue(), tagKeys...)
 }
 
-func NewInt64AndView(name, description string, aggregation *view.Aggregation, tagKeys ...tag.Key) (*Int64, *view.View) {
-	i := &Int64{stats.Int64(name, description, stats.UnitDimensionless), make([]tag.Mutator, 0, len(tagKeys))}
-	v := &view.View{Measure: i.Int64Measure, TagKeys: tagKeys, Aggregation: aggregation}
-	return i, v
+// NewDistribution creates a new Metric with an aggregration type of Distribution. This means that the
+// data collected by the Metric will be collected and exported as a histogram, with the specified bounds.
+func NewDistribution(opts MetricOpts, bounds []float64, tagKeys ...tag.Key) Metric {
+	return newMetric(opts, view.Distribution(bounds...), tagKeys...)
 }
 
-// Float64...
-type Float64 struct {
+func newMetric(opts MetricOpts, aggregation *view.Aggregation, tagKeys ...tag.Key) Metric {
+	return newFloat64Metric(opts, aggregation, tagKeys...)
+}
+
+type float64Metric struct {
 	*stats.Float64Measure
 
 	tags []tag.Mutator
+	view *view.View
 }
 
-func NewFloat64AndView(name, description string, aggregation *view.Aggregation, tagKeys ...tag.Key) (*Float64, *view.View) {
-	f := &Float64{stats.Float64(name, description, stats.UnitDimensionless), make([]tag.Mutator, 0, len(tagKeys))}
-	v := &view.View{Measure: f.Float64Measure, TagKeys: tagKeys, Aggregation: aggregation}
-	return f, v
+func newFloat64Metric(opts MetricOpts, aggregation *view.Aggregation, tagKeys ...tag.Key) *float64Metric {
+	measure := stats.Float64(opts.Name, opts.Description, stats.UnitDimensionless)
+	return &float64Metric{
+		measure,
+		make([]tag.Mutator, 0, len(tagKeys)),
+		&view.View{Measure: measure, TagKeys: tagKeys, Aggregation: aggregation},
+	}
 }
 
-func (m *Float64) WithTags(tags ...tag.Mutator) *Float64 {
-	return &Float64{m.Float64Measure, append(m.tags, tags...)}
+func (f *float64Metric) Increment() {
+	f.Record(1)
 }
 
-func (m *Float64) Increment() {
-	stats.RecordWithTags(context.Background(), m.tags, m.M(1))
+func (f *float64Metric) Name() string {
+	return f.Name()
 }
 
-func (m *Float64) Record(value float64) {
-	stats.RecordWithTags(context.Background(), m.tags, m.M(value))
+func (f *float64Metric) Record(value float64) {
+	stats.RecordWithTags(context.Background(), f.tags, f.M(value)) //nolint:errcheck
+}
+
+func (f *float64Metric) WithTags(tags ...tag.Mutator) Metric {
+	return &float64Metric{f.Float64Measure, append(f.tags, tags...), f.view}
+}
+
+func (f *float64Metric) View() *view.View {
+	return f.view
 }

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -173,7 +173,8 @@ var (
 	// than nothing.
 	// TODO: add dimensions - namespace of rule, service, rule name
 	invalidOutboundListeners = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_invalid_out_listeners", "Number of invalid outbound listeners."},
+		"pilot_invalid_out_listeners",
+		"Number of invalid outbound listeners.",
 	)
 )
 

--- a/pilot/pkg/proxy/envoy/discovery.go
+++ b/pilot/pkg/proxy/envoy/discovery.go
@@ -36,17 +36,20 @@ var (
 	buildTag  = monitoring.MustCreateTagKey("build_version")
 
 	callCounter = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_discovery_calls", "Individual method calls in Pilot"},
+		"pilot_discovery_calls",
+		"Individual method calls in Pilot",
 		methodTag, buildTag,
 	)
 
 	errorCounter = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_discovery_errors", "Errors encountered during a given method call within Pilot"},
+		"pilot_discovery_errors",
+		"Errors encountered during a given method call within Pilot",
 		methodTag, buildTag,
 	)
 
 	resourceCounter = monitoring.NewDistribution(
-		monitoring.MetricOpts{"pilot_discovery_resources", "Returned resource counts per method by Pilot"},
+		"pilot_discovery_resources",
+		"Returned resource counts per method by Pilot",
 		[]float64{0, 10, 20, 30, 40, 50, 75, 100, 150, 250, 500, 1000, 10000},
 		methodTag, buildTag,
 	)
@@ -188,7 +191,7 @@ func (ds *DiscoveryService) ListAllEndpoints(_ *restful.Request, response *restf
 		incErrors(methodName)
 		log.Warna(err)
 	} else {
-		observeResources(methodName, uint32(len(services)))
+		observeResources(methodName, float64(len(services)))
 	}
 }
 
@@ -200,8 +203,8 @@ func incErrors(methodName string) {
 	errorCounter.WithTags(tag.Upsert(buildTag, buildVersion), tag.Upsert(methodTag, methodName)).Increment()
 }
 
-func observeResources(methodName string, count uint32) {
-	resourceCounter.WithTags(tag.Upsert(buildTag, buildVersion), tag.Upsert(methodTag, methodName)).Increment()
+func observeResources(methodName string, count float64) {
+	resourceCounter.WithTags(tag.Upsert(buildTag, buildVersion), tag.Upsert(methodTag, methodName)).Record(count)
 }
 
 func errorResponse(methodName string, r *restful.Response, status int, msg string) {

--- a/pilot/pkg/proxy/envoy/discovery.go
+++ b/pilot/pkg/proxy/envoy/discovery.go
@@ -195,15 +195,15 @@ func (ds *DiscoveryService) ListAllEndpoints(_ *restful.Request, response *restf
 }
 
 func incCalls(methodName string) {
-	callCounter.WithTags(buildTag.Value(buildVersion), methodTag.Value(methodName)).Increment()
+	callCounter.With(buildTag.Value(buildVersion), methodTag.Value(methodName)).Increment()
 }
 
 func incErrors(methodName string) {
-	errorCounter.WithTags(buildTag.Value(buildVersion), methodTag.Value(methodName)).Increment()
+	errorCounter.With(buildTag.Value(buildVersion), methodTag.Value(methodName)).Increment()
 }
 
 func observeResources(methodName string, count float64) {
-	resourceCounter.WithTags(buildTag.Value(buildVersion), methodTag.Value(methodName)).Record(count)
+	resourceCounter.With(buildTag.Value(buildVersion), methodTag.Value(methodName)).Record(count)
 }
 
 func errorResponse(methodName string, r *restful.Response, status int, msg string) {

--- a/pilot/pkg/proxy/envoy/discovery.go
+++ b/pilot/pkg/proxy/envoy/discovery.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 
 	restful "github.com/emicklei/go-restful"
-	"go.opencensus.io/tag"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/monitoring"
@@ -32,8 +31,8 @@ var (
 	// Save the build version information.
 	buildVersion = version.Info.String()
 
-	methodTag = monitoring.MustCreateTagKey("method")
-	buildTag  = monitoring.MustCreateTagKey("build_version")
+	methodTag = monitoring.MustCreateTag("method")
+	buildTag  = monitoring.MustCreateTag("build_version")
 
 	callCounter = monitoring.NewSum(
 		"pilot_discovery_calls",
@@ -196,15 +195,15 @@ func (ds *DiscoveryService) ListAllEndpoints(_ *restful.Request, response *restf
 }
 
 func incCalls(methodName string) {
-	callCounter.WithTags(tag.Upsert(buildTag, buildVersion), tag.Upsert(methodTag, methodName)).Increment()
+	callCounter.WithTags(buildTag.Value(buildVersion), methodTag.Value(methodName)).Increment()
 }
 
 func incErrors(methodName string) {
-	errorCounter.WithTags(tag.Upsert(buildTag, buildVersion), tag.Upsert(methodTag, methodName)).Increment()
+	errorCounter.WithTags(buildTag.Value(buildVersion), methodTag.Value(methodName)).Increment()
 }
 
 func observeResources(methodName string, count float64) {
-	resourceCounter.WithTags(tag.Upsert(buildTag, buildVersion), tag.Upsert(methodTag, methodName)).Record(count)
+	resourceCounter.WithTags(buildTag.Value(buildVersion), methodTag.Value(methodName)).Record(count)
 }
 
 func errorResponse(methodName string, r *restful.Response, status int, msg string) {

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -28,7 +28,6 @@ import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/gogo/protobuf/types"
-	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
@@ -64,150 +63,6 @@ var (
 var (
 	timeZero time.Time
 )
-
-var (
-	// experiment on getting some monitoring on config errors.
-	cdsReject = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pilot_xds_cds_reject",
-		Help: "Pilot rejected CSD configs.",
-	}, []string{"node", "err"})
-
-	edsReject = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pilot_xds_eds_reject",
-		Help: "Pilot rejected EDS.",
-	}, []string{"node", "err"})
-
-	edsInstances = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pilot_xds_eds_instances",
-		Help: "Instances for each cluster, as of last push. Zero instances is an error.",
-	}, []string{"cluster"})
-
-	ldsReject = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pilot_xds_lds_reject",
-		Help: "Pilot rejected LDS.",
-	}, []string{"node", "err"})
-
-	rdsReject = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pilot_xds_rds_reject",
-		Help: "Pilot rejected RDS.",
-	}, []string{"node", "err"})
-
-	rdsExpiredNonce = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pilot_rds_expired_nonce",
-		Help: "Total number of RDS messages with an expired nonce.",
-	})
-
-	totalXDSRejects = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pilot_total_xds_rejects",
-		Help: "Total number of XDS responses from pilot rejected by proxy.",
-	})
-
-	monServices = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "pilot_services",
-		Help: "Total services known to pilot.",
-	})
-
-	// TODO: Update all the resource stats in separate routine
-	// virtual services, destination rules, gateways, etc.
-	monVServices = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "pilot_virt_services",
-		Help: "Total virtual services known to pilot.",
-	})
-
-	xdsClients = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "pilot_xds",
-		Help: "Number of endpoints connected to this pilot using XDS.",
-	})
-
-	xdsResponseWriteTimeouts = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pilot_xds_write_timeout",
-		Help: "Pilot XDS response write timeouts.",
-	})
-
-	pushTimeouts = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pilot_xds_push_timeout",
-		Help: "Pilot push timeout, will retry.",
-	})
-
-	pushTimeoutFailures = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pilot_xds_push_timeout_failures",
-		Help: "Pilot push timeout failures after repeated attempts.",
-	})
-
-	// Covers xds_builderr and xds_senderr for xds in {lds, rds, cds, eds}.
-	pushes = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "pilot_xds_pushes",
-		Help: "Pilot build and send errors for lds, rds, cds and eds.",
-	}, []string{"type"})
-
-	cdsPushes         = pushes.WithLabelValues("cds")
-	cdsBuildErrPushes = pushes.WithLabelValues("cds_builderr")
-	cdsSendErrPushes  = pushes.WithLabelValues("cds_senderr")
-	edsPushes         = pushes.WithLabelValues("eds")
-	edsSendErrPushes  = pushes.WithLabelValues("eds_senderr")
-	ldsPushes         = pushes.WithLabelValues("lds")
-	ldsBuildErrPushes = pushes.WithLabelValues("lds_builderr")
-	ldsSendErrPushes  = pushes.WithLabelValues("lds_senderr")
-	rdsPushes         = pushes.WithLabelValues("rds")
-	rdsBuildErrPushes = pushes.WithLabelValues("rds_builderr")
-	rdsSendErrPushes  = pushes.WithLabelValues("rds_senderr")
-
-	pushErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "pilot_xds_push_errors",
-		Help: "Number of errors (timeouts) pushing to sidecars.",
-	}, []string{"type"})
-
-	unrecoverablePushErrors = pushErrors.WithLabelValues("unrecoverable")
-	retryPushErrors         = pushErrors.WithLabelValues("retry")
-
-	proxiesConvergeDelay = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "pilot_proxy_convergence_time",
-		Help:    "Delay between config change and all proxies converging.",
-		Buckets: []float64{1, 3, 5, 10, 20, 30, 50, 100},
-	})
-
-	pushContextErrors = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pilot_xds_push_context_errors",
-		Help: "Number of errors (timeouts) initiating push context.",
-	})
-
-	totalXDSInternalErrors = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pilot_total_xds_internal_errors",
-		Help: "Total number of internal XDS errors in pilot (check logs).",
-	})
-
-	inboundUpdates = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "pilot_inbound_updates",
-		Help: "Total number of updates received by pilot.",
-	}, []string{"type"})
-
-	inboundConfigUpdates   = inboundUpdates.WithLabelValues("config")
-	inboundEDSUpdates      = inboundUpdates.WithLabelValues("eds")
-	inboundServiceUpdates  = inboundUpdates.WithLabelValues("svc")
-	inboundWorkloadUpdates = inboundUpdates.WithLabelValues("workload")
-)
-
-func init() {
-	prometheus.MustRegister(cdsReject)
-	prometheus.MustRegister(edsReject)
-	prometheus.MustRegister(ldsReject)
-	prometheus.MustRegister(rdsReject)
-	prometheus.MustRegister(rdsExpiredNonce)
-	prometheus.MustRegister(totalXDSRejects)
-	prometheus.MustRegister(edsInstances)
-	prometheus.MustRegister(monServices)
-	prometheus.MustRegister(monVServices)
-	prometheus.MustRegister(xdsClients)
-	prometheus.MustRegister(xdsResponseWriteTimeouts)
-	prometheus.MustRegister(pushTimeouts)
-	prometheus.MustRegister(pushTimeoutFailures)
-	prometheus.MustRegister(pushes)
-	prometheus.MustRegister(pushErrors)
-	prometheus.MustRegister(proxiesConvergeDelay)
-	prometheus.MustRegister(pushContextErrors)
-	prometheus.MustRegister(totalXDSInternalErrors)
-	prometheus.MustRegister(inboundUpdates)
-}
 
 // DiscoveryStream is a common interface for EDS and ADS. It also has a
 // shorter name.
@@ -372,7 +227,7 @@ func receiveThread(con *XdsConnection, reqChannel chan *xdsapi.DiscoveryRequest,
 			}
 			*errP = err
 			adsLog.Errorf("ADS: %q %s terminated with error: %v", con.PeerAddr, con.ConID, err)
-			totalXDSInternalErrors.Add(1)
+			increment(totalXDSInternalErrors)
 			return
 		}
 		select {
@@ -446,8 +301,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					if discReq.ErrorDetail != nil {
 						adsLog.Warnf("ADS:CDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
 						errCode := codes.Code(discReq.ErrorDetail.Code)
-						cdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
-						totalXDSRejects.Add(1)
+						incrementXDSRejects(cdsReject, discReq.Node.Id, errCode.String())
 					} else if discReq.ResponseNonce != "" {
 						con.ClusterNonceAcked = discReq.ResponseNonce
 					}
@@ -470,8 +324,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					if discReq.ErrorDetail != nil {
 						adsLog.Warnf("ADS:LDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
 						errCode := codes.Code(discReq.ErrorDetail.Code)
-						ldsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
-						totalXDSRejects.Add(1)
+						incrementXDSRejects(ldsReject, discReq.Node.Id, errCode.String())
 					} else if discReq.ResponseNonce != "" {
 						con.ListenerNonceAcked = discReq.ResponseNonce
 					}
@@ -490,8 +343,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				if discReq.ErrorDetail != nil {
 					adsLog.Warnf("ADS:RDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
 					errCode := codes.Code(discReq.ErrorDetail.Code)
-					rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
-					totalXDSRejects.Add(1)
+					incrementXDSRejects(rdsReject, discReq.Node.Id, errCode.String())
 					continue
 				}
 				routes := discReq.GetResourceNames()
@@ -504,7 +356,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					if routeNonceSent != "" && routeNonceSent != discReq.ResponseNonce {
 						adsLog.Debugf("ADS:RDS: Expired nonce received %s %s (%v), sent %s, received %s",
 							peerAddr, con.ConID, con.modelNode, routeNonceSent, discReq.ResponseNonce)
-						rdsExpiredNonce.Inc()
+						increment(rdsExpiredNonce)
 						continue
 					}
 					if discReq.VersionInfo == routeVersionInfoSent {
@@ -522,8 +374,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 						if discReq.ErrorDetail != nil {
 							adsLog.Warnf("ADS:RDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
 							errCode := codes.Code(discReq.ErrorDetail.Code)
-							rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
-							totalXDSRejects.Add(1)
+							incrementXDSRejects(rdsReject, discReq.Node.Id, errCode.String())
 						}
 						continue
 					} else if len(routes) == 0 {
@@ -549,8 +400,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				if discReq.ErrorDetail != nil {
 					adsLog.Warnf("ADS:EDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode.ID, discReq.String())
 					errCode := codes.Code(discReq.ErrorDetail.Code)
-					edsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": errCode.String()}).Add(1)
-					totalXDSRejects.Add(1)
+					incrementXDSRejects(edsReject, discReq.Node.Id, errCode.String())
 					continue
 				}
 				clusters := discReq.GetResourceNames()
@@ -755,7 +605,7 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 			pushEv.push.Mutex.Lock()
 			pushEv.push.End = time.Now()
 			pushEv.push.Mutex.Unlock()
-			proxiesConvergeDelay.Observe(time.Since(pushEv.push.Start).Seconds())
+			recordFloat(proxiesConvergeDelay, time.Since(pushEv.push.Start).Seconds())
 			out, _ := pushEv.push.JSON()
 			adsLog.Infof("Push finished: %v %s",
 				time.Since(pushEv.push.Start), string(out))
@@ -821,7 +671,7 @@ func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext,
 
 	adsLog.Infof("XDS: Pushing:%s Services:%d ConnectedEndpoints:%d",
 		version, len(push.Services(nil)), adsClientCount())
-	monServices.Set(float64(len(push.Services(nil))))
+	record(monServices, int64(len(push.Services(nil))))
 
 	t0 := time.Now()
 
@@ -841,7 +691,7 @@ func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext,
 	for clusterName, edsCluster := range cMap {
 		if err := s.updateCluster(push, clusterName, edsCluster); err != nil {
 			adsLog.Errorf("updateCluster failed with clusterName %s", clusterName)
-			totalXDSInternalErrors.Add(1)
+			increment(totalXDSInternalErrors)
 		}
 	}
 	adsLog.Infof("Cluster init time %v %s", time.Since(t0), version)
@@ -929,7 +779,7 @@ func (s *DiscoveryServer) startPush(version string, push *model.PushContext, ful
 			case <-timer.C:
 				// This may happen to some clients if the other side is in a bad state and can't receive.
 				// The tests were catching this - one of the client was not reading.
-				pushTimeouts.Add(1)
+				increment(pushTimeouts)
 				if lastPushFailure.IsZero() {
 					lastPushFailure = time.Now()
 
@@ -937,13 +787,12 @@ func (s *DiscoveryServer) startPush(version string, push *model.PushContext, ful
 				if time.Since(lastPushFailure) > 10*time.Second {
 					adsLog.Warnf("Repeated failure to push %s", client.ConID)
 					// unfortunately grpc go doesn't allow closing (unblocking) the stream.
-					unrecoverablePushErrors.Add(1)
-					pushTimeoutFailures.Add(1)
+					incrementWith(unrecoverableCtx, pushErrors, pushTimeoutFailures)
 					return
 				}
 
 				adsLog.Warnf("Failed to push, client busy %s", client.ConID)
-				retryPushErrors.Add(1)
+				incrementWith(retryCtx, pushErrors)
 
 				goto Retry
 			}
@@ -958,7 +807,7 @@ func (s *DiscoveryServer) addCon(conID string, con *XdsConnection) {
 	adsClientsMutex.Lock()
 	defer adsClientsMutex.Unlock()
 	adsClients[conID] = con
-	xdsClients.Set(float64(len(adsClients)))
+	record(xdsClients, int64(len(adsClients)))
 	if con.modelNode != nil {
 		if _, ok := adsSidecarIDConnectionsMap[con.modelNode.ID]; !ok {
 			adsSidecarIDConnectionsMap[con.modelNode.ID] = map[string]*XdsConnection{conID: con}
@@ -978,12 +827,12 @@ func (s *DiscoveryServer) removeCon(conID string, con *XdsConnection) {
 
 	if _, exist := adsClients[conID]; !exist {
 		adsLog.Errorf("ADS: Removing connection for non-existing node:%v.", conID)
-		totalXDSInternalErrors.Add(1)
+		increment(totalXDSInternalErrors)
 	} else {
 		delete(adsClients, conID)
 	}
 
-	xdsClients.Set(float64(len(adsClients)))
+	record(xdsClients, int64(len(adsClients)))
 	if con.modelNode != nil {
 		delete(adsSidecarIDConnectionsMap[con.modelNode.ID], conID)
 		if len(adsSidecarIDConnectionsMap[con.modelNode.ID]) == 0 {
@@ -1022,7 +871,7 @@ func (conn *XdsConnection) send(res *xdsapi.DiscoveryResponse) error {
 	case <-t.C:
 		// TODO: wait for ACK
 		adsLog.Infof("Timeout writing %s", conn.ConID)
-		xdsResponseWriteTimeouts.Add(1)
+		increment(xdsResponseWriteTimeouts)
 		return errors.New("timeout sending")
 	case err := <-done:
 		t.Stop()

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -671,7 +671,7 @@ func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext,
 
 	adsLog.Infof("XDS: Pushing:%s Services:%d ConnectedEndpoints:%d",
 		version, len(push.Services(nil)), adsClientCount())
-	monServices.Record(int64(len(push.Services(nil))))
+	monServices.Record(float64(len(push.Services(nil))))
 
 	t0 := time.Now()
 
@@ -807,7 +807,7 @@ func (s *DiscoveryServer) addCon(conID string, con *XdsConnection) {
 	adsClientsMutex.Lock()
 	defer adsClientsMutex.Unlock()
 	adsClients[conID] = con
-	xdsClients.Record(int64(len(adsClients)))
+	xdsClients.Record(float64(len(adsClients)))
 	if con.modelNode != nil {
 		if _, ok := adsSidecarIDConnectionsMap[con.modelNode.ID]; !ok {
 			adsSidecarIDConnectionsMap[con.modelNode.ID] = map[string]*XdsConnection{conID: con}
@@ -832,7 +832,7 @@ func (s *DiscoveryServer) removeCon(conID string, con *XdsConnection) {
 		delete(adsClients, conID)
 	}
 
-	xdsClients.Record(int64(len(adsClients)))
+	xdsClients.Record(float64(len(adsClients)))
 	if con.modelNode != nil {
 		delete(adsSidecarIDConnectionsMap[con.modelNode.ID], conID)
 		if len(adsSidecarIDConnectionsMap[con.modelNode.ID]) == 0 {

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -300,7 +300,7 @@ func (s *DiscoveryServer) Push(full bool, edsUpdates map[string]struct{}) {
 	if err != nil {
 		adsLog.Errorf("XDS: Failed to update services: %v", err)
 		// We can't push if we can't read the data - stick with previous version.
-		pushContextErrors.Inc()
+		increment(pushContextErrors)
 		return
 	}
 
@@ -371,7 +371,7 @@ func (s *DiscoveryServer) clearCache() {
 // ConfigUpdate implements ConfigUpdater interface, used to request pushes.
 // It replaces the 'clear cache' from v1.
 func (s *DiscoveryServer) ConfigUpdate(full bool) {
-	inboundConfigUpdates.Add(1)
+	incrementWith(configUpdatesCtx, inboundUpdates)
 	s.updateChannel <- &updateReq{full: full}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -300,7 +300,7 @@ func (s *DiscoveryServer) Push(full bool, edsUpdates map[string]struct{}) {
 	if err != nil {
 		adsLog.Errorf("XDS: Failed to update services: %v", err)
 		// We can't push if we can't read the data - stick with previous version.
-		increment(pushContextErrors)
+		pushContextErrors.Increment()
 		return
 	}
 
@@ -371,7 +371,7 @@ func (s *DiscoveryServer) clearCache() {
 // ConfigUpdate implements ConfigUpdater interface, used to request pushes.
 // It replaces the 'clear cache' from v1.
 func (s *DiscoveryServer) ConfigUpdate(full bool) {
-	incrementWith(configUpdatesCtx, inboundUpdates)
+	inboundConfigUpdates.Increment()
 	s.updateChannel <- &updateReq{full: full}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -341,7 +341,7 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 			push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
 			adsLog.Debugf("EDS: Cluster %q (host:%s ports:%v labels:%v) has no instances", clusterName, hostname, port, labels)
 		}
-		edsInstances.WithTags(tag.Upsert(clusterTag, clusterName)).Record(int64(len(instances)))
+		edsInstances.WithTags(tag.Upsert(clusterTag, clusterName)).Record(float64(len(instances)))
 		locEps = localityLbEndpointsFromInstances(instances)
 	}
 
@@ -965,7 +965,7 @@ func buildLocalityLbEndpointsFromShards(
 	if len(locEps) == 0 {
 		push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
 	}
-	edsInstances.WithTags(tag.Upsert(clusterTag, clusterName)).Record(int64(len(locEps)))
+	edsInstances.WithTags(tag.Upsert(clusterTag, clusterName)).Record(float64(len(locEps)))
 
 	return locEps
 }

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -25,7 +25,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/gogo/protobuf/types"
-	"go.opencensus.io/tag"
 
 	networkingapi "istio.io/api/networking/v1alpha3"
 	networking "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
@@ -341,7 +340,7 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 			push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
 			adsLog.Debugf("EDS: Cluster %q (host:%s ports:%v labels:%v) has no instances", clusterName, hostname, port, labels)
 		}
-		edsInstances.WithTags(tag.Upsert(clusterTag, clusterName)).Record(float64(len(instances)))
+		edsInstances.WithTags(clusterTag.Value(clusterName)).Record(float64(len(instances)))
 		locEps = localityLbEndpointsFromInstances(instances)
 	}
 
@@ -965,7 +964,7 @@ func buildLocalityLbEndpointsFromShards(
 	if len(locEps) == 0 {
 		push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
 	}
-	edsInstances.WithTags(tag.Upsert(clusterTag, clusterName)).Record(float64(len(locEps)))
+	edsInstances.WithTags(clusterTag.Value(clusterName)).Record(float64(len(locEps)))
 
 	return locEps
 }

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -340,7 +340,7 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 			push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
 			adsLog.Debugf("EDS: Cluster %q (host:%s ports:%v labels:%v) has no instances", clusterName, hostname, port, labels)
 		}
-		edsInstances.WithTags(clusterTag.Value(clusterName)).Record(float64(len(instances)))
+		edsInstances.With(clusterTag.Value(clusterName)).Record(float64(len(instances)))
 		locEps = localityLbEndpointsFromInstances(instances)
 	}
 
@@ -964,7 +964,7 @@ func buildLocalityLbEndpointsFromShards(
 	if len(locEps) == 0 {
 		push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
 	}
-	edsInstances.WithTags(clusterTag.Value(clusterName)).Record(float64(len(locEps)))
+	edsInstances.With(clusterTag.Value(clusterName)).Record(float64(len(locEps)))
 
 	return locEps
 }

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -37,10 +37,10 @@ func (s *DiscoveryServer) pushLds(con *XdsConnection, push *model.PushContext, v
 	err = con.send(response)
 	if err != nil {
 		adsLog.Warnf("LDS: Send failure %s: %v", con.ConID, err)
-		ldsSendErrPushes.Add(1)
+		incrementWith(ldsSendErrPushCtx, pushes)
 		return err
 	}
-	ldsPushes.Add(1)
+	incrementWith(ldsPushCtx, pushes)
 
 	adsLog.Infof("LDS: PUSH for node:%s listeners:%d", con.modelNode.ID, len(rawListeners))
 	return nil
@@ -50,7 +50,7 @@ func (s *DiscoveryServer) generateRawListeners(con *XdsConnection, push *model.P
 	rawListeners, err := s.ConfigGenerator.BuildListeners(s.Env, con.modelNode, push)
 	if err != nil {
 		adsLog.Warnf("LDS: Failed to generate listeners for node:%s: %v", con.modelNode.ID, err)
-		ldsBuildErrPushes.Add(1)
+		incrementWith(ldsBuildErrPushCtx, pushes)
 		return nil, err
 	}
 
@@ -58,7 +58,7 @@ func (s *DiscoveryServer) generateRawListeners(con *XdsConnection, push *model.P
 		if err = l.Validate(); err != nil {
 			retErr := fmt.Errorf("LDS: Generated invalid listener for node %v: %v", con.modelNode, err)
 			adsLog.Errorf("LDS: Generated invalid listener for node:%s: %v, %v", con.modelNode.ID, err, l)
-			ldsBuildErrPushes.Add(1)
+			incrementWith(ldsBuildErrPushCtx, pushes)
 			// Generating invalid listeners is a bug.
 			// Panic instead of trying to recover from that, since we can't
 			// assume anything about the state.
@@ -78,7 +78,7 @@ func ldsDiscoveryResponse(ls []*xdsapi.Listener, version string) *xdsapi.Discove
 	for _, ll := range ls {
 		if ll == nil {
 			adsLog.Errora("Nil listener ", ll)
-			totalXDSInternalErrors.Add(1)
+			increment(totalXDSInternalErrors)
 			continue
 		}
 		lr, _ := types.MarshalAny(ll)

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -14,16 +14,14 @@
 package v2
 
 import (
-	"go.opencensus.io/tag"
-
 	"istio.io/istio/pilot/pkg/monitoring"
 )
 
 var (
-	errTag     = monitoring.MustCreateTagKey("err")
-	clusterTag = monitoring.MustCreateTagKey("cluster")
-	nodeTag    = monitoring.MustCreateTagKey("node")
-	typeTag    = monitoring.MustCreateTagKey("type")
+	errTag     = monitoring.MustCreateTag("err")
+	clusterTag = monitoring.MustCreateTag("cluster")
+	nodeTag    = monitoring.MustCreateTag("node")
+	typeTag    = monitoring.MustCreateTag("type")
 
 	cdsReject = monitoring.NewGauge(
 		"pilot_xds_cds_reject",
@@ -104,17 +102,17 @@ var (
 		typeTag,
 	)
 
-	cdsPushes         = pushes.WithTags(tag.Upsert(typeTag, "cds"))
-	cdsSendErrPushes  = pushes.WithTags(tag.Upsert(typeTag, "cds_senderr"))
-	cdsBuildErrPushes = pushes.WithTags(tag.Upsert(typeTag, "cds_builderr"))
-	edsPushes         = pushes.WithTags(tag.Upsert(typeTag, "eds"))
-	edsSendErrPushes  = pushes.WithTags(tag.Upsert(typeTag, "eds_senderr"))
-	ldsPushes         = pushes.WithTags(tag.Upsert(typeTag, "lds"))
-	ldsSendErrPushes  = pushes.WithTags(tag.Upsert(typeTag, "lds_senderr"))
-	ldsBuildErrPushes = pushes.WithTags(tag.Upsert(typeTag, "lds_builderr"))
-	rdsPushes         = pushes.WithTags(tag.Upsert(typeTag, "rds"))
-	rdsSendErrPushes  = pushes.WithTags(tag.Upsert(typeTag, "rds_senderr"))
-	rdsBuildErrPushes = pushes.WithTags(tag.Upsert(typeTag, "rds_builderr"))
+	cdsPushes         = pushes.WithTags(typeTag.Value("cds"))
+	cdsSendErrPushes  = pushes.WithTags(typeTag.Value("cds_senderr"))
+	cdsBuildErrPushes = pushes.WithTags(typeTag.Value("cds_builderr"))
+	edsPushes         = pushes.WithTags(typeTag.Value("eds"))
+	edsSendErrPushes  = pushes.WithTags(typeTag.Value("eds_senderr"))
+	ldsPushes         = pushes.WithTags(typeTag.Value("lds"))
+	ldsSendErrPushes  = pushes.WithTags(typeTag.Value("lds_senderr"))
+	ldsBuildErrPushes = pushes.WithTags(typeTag.Value("lds_builderr"))
+	rdsPushes         = pushes.WithTags(typeTag.Value("rds"))
+	rdsSendErrPushes  = pushes.WithTags(typeTag.Value("rds_senderr"))
+	rdsBuildErrPushes = pushes.WithTags(typeTag.Value("rds_builderr"))
 
 	pushErrors = monitoring.NewSum(
 		"pilot_xds_push_errors",
@@ -122,8 +120,8 @@ var (
 		typeTag,
 	)
 
-	unrecoverableErrs = pushErrors.WithTags(tag.Upsert(typeTag, "unrecoverable"))
-	retryErrs         = pushErrors.WithTags(tag.Upsert(typeTag, "retry"))
+	unrecoverableErrs = pushErrors.WithTags(typeTag.Value("unrecoverable"))
+	retryErrs         = pushErrors.WithTags(typeTag.Value("retry"))
 
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesConvergeDelay = monitoring.NewDistribution(
@@ -148,14 +146,14 @@ var (
 		typeTag,
 	)
 
-	inboundConfigUpdates   = inboundUpdates.WithTags(tag.Upsert(typeTag, "config"))
-	inboundEDSUpdates      = inboundUpdates.WithTags(tag.Upsert(typeTag, "eds"))
-	inboundServiceUpdates  = inboundUpdates.WithTags(tag.Upsert(typeTag, "svc"))
-	inboundWorkloadUpdates = inboundUpdates.WithTags(tag.Upsert(typeTag, "workload"))
+	inboundConfigUpdates   = inboundUpdates.WithTags(typeTag.Value("config"))
+	inboundEDSUpdates      = inboundUpdates.WithTags(typeTag.Value("eds"))
+	inboundServiceUpdates  = inboundUpdates.WithTags(typeTag.Value("svc"))
+	inboundWorkloadUpdates = inboundUpdates.WithTags(typeTag.Value("workload"))
 )
 
 func incrementXDSRejects(metric monitoring.Metric, node, errCode string) {
-	metric.WithTags(tag.Upsert(nodeTag, node), tag.Upsert(errTag, errCode)).Increment()
+	metric.WithTags(nodeTag.Value(node), errTag.Value(errCode)).Increment()
 	totalXDSRejects.Increment()
 }
 

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -46,22 +46,16 @@ var (
 	pushTimeoutFailures      = stats.Int64("pilot_xds_push_timeout_failures", "Pilot push timeout failures after repeated attempts.", stats.UnitDimensionless)
 
 	// Covers xds_builderr and xds_senderr for xds in {lds, rds, cds, eds}.
-	pushes             = stats.Int64("pilot_xds_pushes", "Pilot build and send errors for lds, rds, cds and eds.", stats.UnitDimensionless)
-	cdsPushCtx         = typeContext("cds")
-	cdsSendErrPushCtx  = typeContext("cds_senderr")
-	cdsBuildErrPushCtx = typeContext("cds_builderr")
-	edsPushCtx         = typeContext("eds")
-	edsSendErrPushCtx  = typeContext("eds_senderr")
-	ldsPushCtx         = typeContext("lds")
-	ldsSendErrPushCtx  = typeContext("lds_senderr")
-	ldsBuildErrPushCtx = typeContext("lds_builderr")
-	rdsPushCtx         = typeContext("rds")
-	rdsSendErrPushCtx  = typeContext("rds_senderr")
-	rdsBuildErrPushCtx = typeContext("rds_builderr")
+	pushes = stats.Int64("pilot_xds_pushes", "Pilot build and send errors for lds, rds, cds and eds.", stats.UnitDimensionless)
+	// values for pushes
+	cdsPushCtx, cdsSendErrPushCtx, cdsBuildErrPushCtx context.Context
+	edsPushCtx, edsSendErrPushCtx                     context.Context
+	ldsPushCtx, ldsSendErrPushCtx, ldsBuildErrPushCtx context.Context
+	rdsPushCtx, rdsSendErrPushCtx, rdsBuildErrPushCtx context.Context
 
-	pushErrors       = stats.Int64("pilot_xds_push_errors", "Number of errors (timeouts) pushing to sidecars.", stats.UnitDimensionless)
-	unrecoverableCtx = typeContext("unrecoverable")
-	retryCtx         = typeContext("retry")
+	pushErrors = stats.Int64("pilot_xds_push_errors", "Number of errors (timeouts) pushing to sidecars.", stats.UnitDimensionless)
+	// values for pushErrors
+	unrecoverableCtx, retryCtx context.Context
 
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesConvergeDelay     = stats.Float64("pilot_proxy_convergence_time", "Delay between config change and all proxies converging.", stats.UnitDimensionless)
@@ -69,11 +63,9 @@ var (
 	pushContextErrors        = stats.Int64("pilot_xds_push_context_errors", "Number of errors (timeouts) initiating push context.", stats.UnitDimensionless)
 	totalXDSInternalErrors   = stats.Int64("pilot_total_xds_internal_errors", "Total number of internal XDS errors in pilot.", stats.UnitDimensionless)
 
-	inboundUpdates     = stats.Int64("pilot_inbound_updates", "Total number of updates received by pilot.", stats.UnitDimensionless)
-	configUpdatesCtx   = typeContext("config")
-	edsUpdatesCtx      = typeContext("eds")
-	svcUpdatesCtx      = typeContext("svc")
-	workloadUpdatesCtx = typeContext("workload")
+	inboundUpdates = stats.Int64("pilot_inbound_updates", "Total number of updates received by pilot.", stats.UnitDimensionless)
+	// values for inboundUpdates
+	configUpdatesCtx, edsUpdatesCtx, svcUpdatesCtx, workloadUpdatesCtx context.Context
 )
 
 func increment(measures ...stats.Measure) {
@@ -168,4 +160,25 @@ func init() {
 	); err != nil {
 		panic(err)
 	}
+
+	// contexts must be built after the tag keys have been created
+	cdsPushCtx = typeContext("cds")
+	cdsSendErrPushCtx = typeContext("cds_senderr")
+	cdsBuildErrPushCtx = typeContext("cds_builderr")
+	edsPushCtx = typeContext("eds")
+	edsSendErrPushCtx = typeContext("eds_senderr")
+	ldsPushCtx = typeContext("lds")
+	ldsSendErrPushCtx = typeContext("lds_senderr")
+	ldsBuildErrPushCtx = typeContext("lds_builderr")
+	rdsPushCtx = typeContext("rds")
+	rdsSendErrPushCtx = typeContext("rds_senderr")
+	rdsBuildErrPushCtx = typeContext("rds_builderr")
+
+	unrecoverableCtx = typeContext("unrecoverable")
+	retryCtx = typeContext("retry")
+
+	configUpdatesCtx = typeContext("config")
+	edsUpdatesCtx = typeContext("eds")
+	svcUpdatesCtx = typeContext("svc")
+	workloadUpdatesCtx = typeContext("workload")
 }

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -102,17 +102,17 @@ var (
 		typeTag,
 	)
 
-	cdsPushes         = pushes.WithTags(typeTag.Value("cds"))
-	cdsSendErrPushes  = pushes.WithTags(typeTag.Value("cds_senderr"))
-	cdsBuildErrPushes = pushes.WithTags(typeTag.Value("cds_builderr"))
-	edsPushes         = pushes.WithTags(typeTag.Value("eds"))
-	edsSendErrPushes  = pushes.WithTags(typeTag.Value("eds_senderr"))
-	ldsPushes         = pushes.WithTags(typeTag.Value("lds"))
-	ldsSendErrPushes  = pushes.WithTags(typeTag.Value("lds_senderr"))
-	ldsBuildErrPushes = pushes.WithTags(typeTag.Value("lds_builderr"))
-	rdsPushes         = pushes.WithTags(typeTag.Value("rds"))
-	rdsSendErrPushes  = pushes.WithTags(typeTag.Value("rds_senderr"))
-	rdsBuildErrPushes = pushes.WithTags(typeTag.Value("rds_builderr"))
+	cdsPushes         = pushes.With(typeTag.Value("cds"))
+	cdsSendErrPushes  = pushes.With(typeTag.Value("cds_senderr"))
+	cdsBuildErrPushes = pushes.With(typeTag.Value("cds_builderr"))
+	edsPushes         = pushes.With(typeTag.Value("eds"))
+	edsSendErrPushes  = pushes.With(typeTag.Value("eds_senderr"))
+	ldsPushes         = pushes.With(typeTag.Value("lds"))
+	ldsSendErrPushes  = pushes.With(typeTag.Value("lds_senderr"))
+	ldsBuildErrPushes = pushes.With(typeTag.Value("lds_builderr"))
+	rdsPushes         = pushes.With(typeTag.Value("rds"))
+	rdsSendErrPushes  = pushes.With(typeTag.Value("rds_senderr"))
+	rdsBuildErrPushes = pushes.With(typeTag.Value("rds_builderr"))
 
 	pushErrors = monitoring.NewSum(
 		"pilot_xds_push_errors",
@@ -120,8 +120,8 @@ var (
 		typeTag,
 	)
 
-	unrecoverableErrs = pushErrors.WithTags(typeTag.Value("unrecoverable"))
-	retryErrs         = pushErrors.WithTags(typeTag.Value("retry"))
+	unrecoverableErrs = pushErrors.With(typeTag.Value("unrecoverable"))
+	retryErrs         = pushErrors.With(typeTag.Value("retry"))
 
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesConvergeDelay = monitoring.NewDistribution(
@@ -146,14 +146,14 @@ var (
 		typeTag,
 	)
 
-	inboundConfigUpdates   = inboundUpdates.WithTags(typeTag.Value("config"))
-	inboundEDSUpdates      = inboundUpdates.WithTags(typeTag.Value("eds"))
-	inboundServiceUpdates  = inboundUpdates.WithTags(typeTag.Value("svc"))
-	inboundWorkloadUpdates = inboundUpdates.WithTags(typeTag.Value("workload"))
+	inboundConfigUpdates   = inboundUpdates.With(typeTag.Value("config"))
+	inboundEDSUpdates      = inboundUpdates.With(typeTag.Value("eds"))
+	inboundServiceUpdates  = inboundUpdates.With(typeTag.Value("svc"))
+	inboundWorkloadUpdates = inboundUpdates.With(typeTag.Value("workload"))
 )
 
 func incrementXDSRejects(metric monitoring.Metric, node, errCode string) {
-	metric.WithTags(nodeTag.Value(node), errTag.Value(errCode)).Increment()
+	metric.With(nodeTag.Value(node), errTag.Value(errCode)).Increment()
 	totalXDSRejects.Increment()
 }
 

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -1,0 +1,172 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package v2
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	nodeTag    tag.Key
+	errTag     tag.Key
+	clusterTag tag.Key
+	typeTag    tag.Key
+
+	// experiment on getting some monitoring on config errors.
+	cdsReject       = stats.Int64("pilot_xds_cds_reject", "Pilot rejected CSD configs.", stats.UnitDimensionless)
+	edsReject       = stats.Int64("pilot_xds_eds_reject", "Pilot rejected EDS.", stats.UnitDimensionless)
+	edsInstances    = stats.Int64("pilot_xds_eds_instances", "Instances for each cluster, as of last push. Zero instances is an error.", stats.UnitDimensionless)
+	ldsReject       = stats.Int64("pilot_xds_lds_reject", "Pilot rejected LDS.", stats.UnitDimensionless)
+	rdsReject       = stats.Int64("pilot_xds_rds_reject", "Pilot rejected RDS.", stats.UnitDimensionless)
+	rdsExpiredNonce = stats.Int64("pilot_rds_expired_nonce", "Total number of RDS messages with an expired nonce.", stats.UnitDimensionless)
+	totalXDSRejects = stats.Int64("pilot_total_xds_rejects", "Total number of XDS responses from pilot rejected by proxy.", stats.UnitDimensionless)
+	monServices     = stats.Int64("pilot_services", "Total services known to pilot.", stats.UnitDimensionless)
+
+	// TODO: Update all the resource stats in separate routine
+	// virtual services, destination rules, gateways, etc.
+	monVServices             = stats.Int64("pilot_virt_services", "Total virtual services known to pilot.", stats.UnitDimensionless)
+	xdsClients               = stats.Int64("pilot_xds", "Number of endpoints connected to this pilot using XDS.", stats.UnitDimensionless)
+	xdsResponseWriteTimeouts = stats.Int64("pilot_xds_write_timeout", "Pilot XDS response write timeouts.", stats.UnitDimensionless)
+	pushTimeouts             = stats.Int64("pilot_xds_push_timeout", "Pilot push timeout, will retry.", stats.UnitDimensionless)
+	pushTimeoutFailures      = stats.Int64("pilot_xds_push_timeout_failures", "Pilot push timeout failures after repeated attempts.", stats.UnitDimensionless)
+
+	// Covers xds_builderr and xds_senderr for xds in {lds, rds, cds, eds}.
+	pushes             = stats.Int64("pilot_xds_pushes", "Pilot build and send errors for lds, rds, cds and eds.", stats.UnitDimensionless)
+	cdsPushCtx         = typeContext("cds")
+	cdsSendErrPushCtx  = typeContext("cds_senderr")
+	cdsBuildErrPushCtx = typeContext("cds_builderr")
+	edsPushCtx         = typeContext("eds")
+	edsSendErrPushCtx  = typeContext("eds_senderr")
+	edsBuildErrPushCtx = typeContext("eds_builderr")
+	ldsPushCtx         = typeContext("lds")
+	ldsSendErrPushCtx  = typeContext("lds_senderr")
+	ldsBuildErrPushCtx = typeContext("lds_builderr")
+	rdsPushCtx         = typeContext("rds")
+	rdsSendErrPushCtx  = typeContext("rds_senderr")
+	rdsBuildErrPushCtx = typeContext("rds_builderr")
+
+	pushErrors       = stats.Int64("pilot_xds_push_errors", "Number of errors (timeouts) pushing to sidecars.", stats.UnitDimensionless)
+	unrecoverableCtx = typeContext("unrecoverable")
+	retryCtx         = typeContext("retry")
+
+	// only supported dimension is millis, unfortunately. default to unitdimensionless.
+	proxiesConvergeDelay     = stats.Float64("pilot_proxy_convergence_time", "Delay between config change and all proxies converging.", stats.UnitDimensionless)
+	proxiesConvergenceBounds = view.Distribution(1, 3, 5, 10, 20, 30, 50, 100)
+	pushContextErrors        = stats.Int64("pilot_xds_push_context_errors", "Number of errors (timeouts) initiating push context.", stats.UnitDimensionless)
+	totalXDSInternalErrors   = stats.Int64("pilot_total_xds_internal_errors", "Total number of internal XDS errors in pilot (check logs).", stats.UnitDimensionless)
+
+	inboundUpdates     = stats.Int64("pilot_inbound_updates", "Total number of updates received by pilot.", stats.UnitDimensionless)
+	configUpdatesCtx   = typeContext("config")
+	edsUpdatesCtx      = typeContext("eds")
+	svcUpdatesCtx      = typeContext("svc")
+	workloadUpdatesCtx = typeContext("workload")
+)
+
+func increment(measures ...stats.Measure) {
+	incrementWith(context.Background(), measures...)
+}
+
+func incrementWith(ctx context.Context, measures ...stats.Measure) {
+	for _, m := range measures {
+		switch v := m.(type) {
+		case *stats.Int64Measure:
+			recordWith(ctx, v, 1)
+		case *stats.Float64Measure:
+			recordFloatWith(ctx, v, 1)
+		}
+	}
+}
+
+func recordFloat(measure *stats.Float64Measure, value float64) {
+	recordFloatWith(context.Background(), measure, value)
+}
+
+func recordFloatWith(ctx context.Context, measure *stats.Float64Measure, value float64) {
+	stats.Record(ctx, measure.M(value))
+}
+
+func record(measure *stats.Int64Measure, value int64) {
+	recordWith(context.Background(), measure, value)
+}
+
+func recordWith(ctx context.Context, measure *stats.Int64Measure, value int64) {
+	stats.Record(ctx, measure.M(value))
+}
+
+func incrementXDSRejects(measure *stats.Int64Measure, node, errCode string) {
+	ctx, _ := tag.New(context.Background(), tag.Upsert(nodeTag, node), tag.Upsert(errTag, errCode))
+	incrementWith(ctx, measure, totalXDSRejects)
+}
+
+func typeContext(kind string) context.Context {
+	ctx, _ := tag.New(context.Background(), tag.Upsert(typeTag, kind))
+	return ctx
+}
+
+func clusterContext(cluster string) context.Context {
+	ctx, _ := tag.New(context.Background(), tag.Upsert(clusterTag, cluster))
+	return ctx
+}
+
+func init() {
+	var err error
+	if typeTag, err = tag.NewKey("type"); err != nil {
+		panic(err)
+	}
+	if errTag, err = tag.NewKey("err"); err != nil {
+		panic(err)
+	}
+	if clusterTag, err = tag.NewKey("cluster"); err != nil {
+		panic(err)
+	}
+	if nodeTag, err = tag.NewKey("node"); err != nil {
+		panic(err)
+	}
+	xdsTagKeys := []tag.Key{nodeTag, errTag}
+	clusterTagKeys := []tag.Key{clusterTag}
+	typeTagKeys := []tag.Key{typeTag}
+
+	if err := view.Register(
+		&view.View{Measure: cdsReject, TagKeys: xdsTagKeys, Aggregation: view.LastValue()},
+		&view.View{Measure: edsReject, TagKeys: xdsTagKeys, Aggregation: view.LastValue()},
+		&view.View{Measure: ldsReject, TagKeys: xdsTagKeys, Aggregation: view.LastValue()},
+		&view.View{Measure: rdsReject, TagKeys: xdsTagKeys, Aggregation: view.LastValue()},
+		&view.View{Measure: edsInstances, TagKeys: clusterTagKeys, Aggregation: view.LastValue()},
+
+		&view.View{Measure: rdsExpiredNonce, Aggregation: view.Sum()},
+		&view.View{Measure: totalXDSRejects, Aggregation: view.Sum()},
+
+		&view.View{Measure: monServices, Aggregation: view.LastValue()},
+		&view.View{Measure: monVServices, Aggregation: view.LastValue()},
+		&view.View{Measure: xdsClients, Aggregation: view.LastValue()},
+		&view.View{Measure: xdsResponseWriteTimeouts, Aggregation: view.Sum()},
+		&view.View{Measure: pushTimeouts, Aggregation: view.Sum()},
+		&view.View{Measure: pushTimeoutFailures, Aggregation: view.Sum()},
+
+		&view.View{Measure: pushes, TagKeys: typeTagKeys, Aggregation: view.Sum()},
+		&view.View{Measure: pushErrors, TagKeys: typeTagKeys, Aggregation: view.Sum()},
+		&view.View{Measure: inboundUpdates, TagKeys: typeTagKeys, Aggregation: view.Sum()},
+
+		&view.View{Measure: pushContextErrors, Aggregation: view.Sum()},
+		&view.View{Measure: totalXDSInternalErrors, Aggregation: view.Sum()},
+
+		&view.View{Measure: proxiesConvergeDelay, Aggregation: proxiesConvergenceBounds},
+	); err != nil {
+		panic(err)
+	}
+}

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -52,7 +52,6 @@ var (
 	cdsBuildErrPushCtx = typeContext("cds_builderr")
 	edsPushCtx         = typeContext("eds")
 	edsSendErrPushCtx  = typeContext("eds_senderr")
-	edsBuildErrPushCtx = typeContext("eds_builderr")
 	ldsPushCtx         = typeContext("lds")
 	ldsSendErrPushCtx  = typeContext("lds_senderr")
 	ldsBuildErrPushCtx = typeContext("lds_builderr")
@@ -68,7 +67,7 @@ var (
 	proxiesConvergeDelay     = stats.Float64("pilot_proxy_convergence_time", "Delay between config change and all proxies converging.", stats.UnitDimensionless)
 	proxiesConvergenceBounds = view.Distribution(1, 3, 5, 10, 20, 30, 50, 100)
 	pushContextErrors        = stats.Int64("pilot_xds_push_context_errors", "Number of errors (timeouts) initiating push context.", stats.UnitDimensionless)
-	totalXDSInternalErrors   = stats.Int64("pilot_total_xds_internal_errors", "Total number of internal XDS errors in pilot (check logs).", stats.UnitDimensionless)
+	totalXDSInternalErrors   = stats.Int64("pilot_total_xds_internal_errors", "Total number of internal XDS errors in pilot.", stats.UnitDimensionless)
 
 	inboundUpdates     = stats.Int64("pilot_inbound_updates", "Total number of updates received by pilot.", stats.UnitDimensionless)
 	configUpdatesCtx   = typeContext("config")
@@ -108,7 +107,7 @@ func recordWith(ctx context.Context, measure *stats.Int64Measure, value int64) {
 	stats.Record(ctx, measure.M(value))
 }
 
-func incrementXDSRejects(measure *stats.Int64Measure, node, errCode string) {
+func incrementXDSRejects(measure stats.Measure, node, errCode string) {
 	ctx, _ := tag.New(context.Background(), tag.Upsert(nodeTag, node), tag.Upsert(errTag, errCode))
 	incrementWith(ctx, measure, totalXDSRejects)
 }

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -26,66 +26,81 @@ var (
 	typeTag    = monitoring.MustCreateTagKey("type")
 
 	cdsReject = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_xds_cds_reject", "Pilot rejected CSD configs."},
+		"pilot_xds_cds_reject",
+		"Pilot rejected CSD configs.",
 		nodeTag, errTag,
 	)
 
 	edsReject = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_xds_eds_reject", "Pilot rejected EDS."},
+		"pilot_xds_eds_reject",
+		"Pilot rejected EDS.",
 		nodeTag, errTag,
 	)
 
 	edsInstances = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_xds_eds_instances", "Instances for each cluster, as of last push. Zero instances is an error."},
+		"pilot_xds_eds_instances",
+		"Instances for each cluster, as of last push. Zero instances is an error.",
 		clusterTag,
 	)
 
 	ldsReject = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_xds_lds_reject", "Pilot rejected LDS."},
+		"pilot_xds_lds_reject",
+		"Pilot rejected LDS.",
 		nodeTag, errTag,
 	)
 
 	rdsReject = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_xds_rds_reject", "Pilot rejected RDS."},
-		nodeTag, errTag)
+		"pilot_xds_rds_reject",
+		"Pilot rejected RDS.",
+		nodeTag, errTag,
+	)
 
 	rdsExpiredNonce = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_rds_expired_nonce", "Total number of RDS messages with an expired nonce."},
+		"pilot_rds_expired_nonce",
+		"Total number of RDS messages with an expired nonce.",
 	)
 
 	totalXDSRejects = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_total_xds_rejects", "Total number of XDS responses from pilot rejected by proxy."},
+		"pilot_total_xds_rejects",
+		"Total number of XDS responses from pilot rejected by proxy.",
 	)
 
 	monServices = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_services", "Total services known to pilot."},
+		"pilot_services",
+		"Total services known to pilot.",
 	)
 
 	// TODO: Update all the resource stats in separate routine
 	// virtual services, destination rules, gateways, etc.
 	monVServices = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_virt_services", "Total virtual services known to pilot."},
+		"pilot_virt_services",
+		"Total virtual services known to pilot.",
 	)
 
 	xdsClients = monitoring.NewGauge(
-		monitoring.MetricOpts{"pilot_xds", "Number of endpoints connected to this pilot using XDS."},
+		"pilot_xds",
+		"Number of endpoints connected to this pilot using XDS.",
 	)
 
 	xdsResponseWriteTimeouts = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_xds_write_timeout", "Pilot XDS response write timeouts."},
+		"pilot_xds_write_timeout",
+		"Pilot XDS response write timeouts.",
 	)
 
 	pushTimeouts = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_xds_push_timeout", "Pilot push timeout, will retry."},
+		"pilot_xds_push_timeout",
+		"Pilot push timeout, will retry.",
 	)
 
 	pushTimeoutFailures = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_xds_push_timeout_failures", "Pilot push timeout failures after repeated attempts."},
+		"pilot_xds_push_timeout_failures",
+		"Pilot push timeout failures after repeated attempts.",
 	)
 
 	// Covers xds_builderr and xds_senderr for xds in {lds, rds, cds, eds}.
 	pushes = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_xds_pushes", "Pilot build and send errors for lds, rds, cds and eds."},
+		"pilot_xds_pushes",
+		"Pilot build and send errors for lds, rds, cds and eds.",
 		typeTag,
 	)
 
@@ -102,7 +117,8 @@ var (
 	rdsBuildErrPushes = pushes.WithTags(tag.Upsert(typeTag, "rds_builderr"))
 
 	pushErrors = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_xds_push_errors", "Number of errors (timeouts) pushing to sidecars."},
+		"pilot_xds_push_errors",
+		"Number of errors (timeouts) pushing to sidecars.",
 		typeTag,
 	)
 
@@ -111,20 +127,24 @@ var (
 
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesConvergeDelay = monitoring.NewDistribution(
-		monitoring.MetricOpts{"pilot_proxy_convergence_time", "Delay between config change and all proxies converging."},
+		"pilot_proxy_convergence_time",
+		"Delay between config change and all proxies converging.",
 		[]float64{1, 3, 5, 10, 20, 30, 50, 100},
 	)
 
 	pushContextErrors = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_xds_push_context_errors", "Number of errors (timeouts) initiating push context."},
+		"pilot_xds_push_context_errors",
+		"Number of errors (timeouts) initiating push context.",
 	)
 
 	totalXDSInternalErrors = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_total_xds_internal_errors", "Total number of internal XDS errors in pilot."},
+		"pilot_total_xds_internal_errors",
+		"Total number of internal XDS errors in pilot.",
 	)
 
 	inboundUpdates = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_inbound_updates", "Total number of updates received by pilot."},
+		"pilot_inbound_updates",
+		"Total number of updates received by pilot.",
 		typeTag,
 	)
 

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -45,10 +45,10 @@ func (s *DiscoveryServer) pushRoute(con *XdsConnection, push *model.PushContext,
 	err = con.send(response)
 	if err != nil {
 		adsLog.Warnf("RDS: Send failure for node:%v: %v", con.modelNode.ID, err)
-		incrementWith(rdsSendErrPushCtx, pushes)
+		rdsSendErrPushes.Increment()
 		return err
 	}
-	incrementWith(rdsPushCtx, pushes)
+	rdsPushes.Increment()
 
 	adsLog.Infof("RDS: PUSH for node:%s routes:%d", con.modelNode.ID, len(rawRoutes))
 	return nil
@@ -63,7 +63,7 @@ func (s *DiscoveryServer) generateRawRoutes(con *XdsConnection, push *model.Push
 		if err != nil {
 			retErr := fmt.Errorf("RDS: Failed to generate route %s for node %v: %v", routeName, con.modelNode, err)
 			adsLog.Warnf("RDS: Failed to generate routes for route:%s for node:%v: %v", routeName, con.modelNode.ID, err)
-			incrementWith(rdsBuildErrPushCtx, pushes)
+			rdsBuildErrPushes.Increment()
 			return nil, retErr
 		}
 
@@ -87,7 +87,7 @@ func (s *DiscoveryServer) generateRawRoutes(con *XdsConnection, push *model.Push
 		if err = r.Validate(); err != nil {
 			retErr := fmt.Errorf("RDS: Generated invalid route %s for node %v: %v", routeName, con.modelNode, err)
 			adsLog.Errorf("RDS: Generated invalid routes for route:%s for node:%v: %v, %v", routeName, con.modelNode.ID, err, r)
-			incrementWith(rdsBuildErrPushCtx, pushes)
+			rdsBuildErrPushes.Increment()
 			// Generating invalid routes is a bug.
 			// Panic instead of trying to recover from that, since we can't
 			// assume anything about the state.

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -45,10 +45,10 @@ func (s *DiscoveryServer) pushRoute(con *XdsConnection, push *model.PushContext,
 	err = con.send(response)
 	if err != nil {
 		adsLog.Warnf("RDS: Send failure for node:%v: %v", con.modelNode.ID, err)
-		rdsSendErrPushes.Add(1)
+		incrementWith(rdsSendErrPushCtx, pushes)
 		return err
 	}
-	rdsPushes.Add(1)
+	incrementWith(rdsPushCtx, pushes)
 
 	adsLog.Infof("RDS: PUSH for node:%s routes:%d", con.modelNode.ID, len(rawRoutes))
 	return nil
@@ -63,7 +63,7 @@ func (s *DiscoveryServer) generateRawRoutes(con *XdsConnection, push *model.Push
 		if err != nil {
 			retErr := fmt.Errorf("RDS: Failed to generate route %s for node %v: %v", routeName, con.modelNode, err)
 			adsLog.Warnf("RDS: Failed to generate routes for route:%s for node:%v: %v", routeName, con.modelNode.ID, err)
-			rdsBuildErrPushes.Add(1)
+			incrementWith(rdsBuildErrPushCtx, pushes)
 			return nil, retErr
 		}
 
@@ -87,7 +87,7 @@ func (s *DiscoveryServer) generateRawRoutes(con *XdsConnection, push *model.Push
 		if err = r.Validate(); err != nil {
 			retErr := fmt.Errorf("RDS: Generated invalid route %s for node %v: %v", routeName, con.modelNode, err)
 			adsLog.Errorf("RDS: Generated invalid routes for route:%s for node:%v: %v, %v", routeName, con.modelNode.ID, err, r)
-			rdsBuildErrPushes.Add(1)
+			incrementWith(rdsBuildErrPushCtx, pushes)
 			// Generating invalid routes is a bug.
 			// Panic instead of trying to recover from that, since we can't
 			// assume anything about the state.

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -76,7 +76,7 @@ func init() {
 }
 
 func incrementEvent(kind, event string) {
-	k8sEvents.WithTags(typeTag.Value(kind), eventTag.Value(event)).Increment()
+	k8sEvents.With(typeTag.Value(kind), eventTag.Value(event)).Increment()
 }
 
 // Options stores the configurable attributes of a Controller.

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/yl2chen/cidranger"
-	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -62,30 +61,18 @@ const (
 )
 
 var (
-	typeTag, typeTagErr   = tag.NewKey("type")
-	eventTag, eventTagErr = tag.NewKey("event")
+	typeTag  = monitoring.MustCreateTagKey("type")
+	eventTag = monitoring.MustCreateTagKey("event")
 
 	// experiment on getting some monitoring on config errors.
-	k8sEvents, k8sEventsView = monitoring.NewInt64AndView(
-		"pilot_k8s_reg_events",
-		"Events from k8s registry.",
-		view.Sum(),
+	k8sEvents = monitoring.NewSum(
+		monitoring.MetricOpts{"pilot_k8s_reg_events", "Events from k8s registry."},
 		typeTag, eventTag,
 	)
 )
 
 func init() {
-	if typeTagErr != nil {
-		panic(typeTagErr)
-	}
-
-	if eventTagErr != nil {
-		panic(eventTagErr)
-	}
-
-	if err := view.Register(k8sEventsView); err != nil {
-		panic(err)
-	}
+	monitoring.MustRegisterViews(k8sEvents)
 }
 
 func incrementEvent(kind, event string) {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -211,19 +211,19 @@ func (c *Controller) createCacheHandler(informer cache.SharedIndexInformer, otyp
 			// TODO: filtering functions to skip over un-referenced resources (perf)
 			AddFunc: func(obj interface{}) {
 				incrementEvent(otype, "add")
-				c.queue.Push(kube.Task{handler: handler.Apply, obj: obj, event: model.EventAdd})
+				c.queue.Push(kube.Task{Handler: handler.Apply, Obj: obj, Event: model.EventAdd})
 			},
 			UpdateFunc: func(old, cur interface{}) {
 				if !reflect.DeepEqual(old, cur) {
 					incrementEvent(otype, "update")
-					c.queue.Push(kube.Task{handler: handler.Apply, obj: cur, event: model.EventUpdate})
+					c.queue.Push(kube.Task{Handler: handler.Apply, Obj: cur, Event: model.EventUpdate})
 				} else {
 					incrementEvent(otype, "updatesame")
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				incrementEvent(otype, "delete")
-				c.queue.Push(kube.Task{handler: handler.Apply, obj: obj, event: model.EventDelete})
+				c.queue.Push(kube.Task{Handler: handler.Apply, Obj: obj, Event: model.EventDelete})
 			},
 		})
 
@@ -238,7 +238,7 @@ func (c *Controller) createEDSCacheHandler(informer cache.SharedIndexInformer, o
 			// TODO: filtering functions to skip over un-referenced resources (perf)
 			AddFunc: func(obj interface{}) {
 				incrementEvent(otype, "add")
-				c.queue.Push(kube.Task{handler: handler.Apply, obj: obj, event: model.EventAdd})
+				c.queue.Push(kube.Task{Handler: handler.Apply, Obj: obj, Event: model.EventAdd})
 			},
 			UpdateFunc: func(old, cur interface{}) {
 				// Avoid pushes if only resource version changed (kube-scheduller, cluster-autoscaller, etc)
@@ -247,7 +247,7 @@ func (c *Controller) createEDSCacheHandler(informer cache.SharedIndexInformer, o
 
 				if !reflect.DeepEqual(oldE.Subsets, curE.Subsets) {
 					incrementEvent(otype, "update")
-					c.queue.Push(kube.Task{handler: handler.Apply, obj: cur, event: model.EventUpdate})
+					c.queue.Push(kube.Task{Handler: handler.Apply, Obj: cur, Event: model.EventUpdate})
 				} else {
 					incrementEvent(otype, "updatesame")
 				}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/yl2chen/cidranger"
-	"go.opencensus.io/tag"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/informers"
@@ -61,8 +60,8 @@ const (
 )
 
 var (
-	typeTag  = monitoring.MustCreateTagKey("type")
-	eventTag = monitoring.MustCreateTagKey("event")
+	typeTag  = monitoring.MustCreateTag("type")
+	eventTag = monitoring.MustCreateTag("event")
 
 	// experiment on getting some monitoring on config errors.
 	k8sEvents = monitoring.NewSum(
@@ -77,7 +76,7 @@ func init() {
 }
 
 func incrementEvent(kind, event string) {
-	k8sEvents.WithTags(tag.Upsert(typeTag, kind), tag.Upsert(eventTag, event)).Increment()
+	k8sEvents.WithTags(typeTag.Value(kind), eventTag.Value(event)).Increment()
 }
 
 // Options stores the configurable attributes of a Controller.

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -66,7 +66,8 @@ var (
 
 	// experiment on getting some monitoring on config errors.
 	k8sEvents = monitoring.NewSum(
-		monitoring.MetricOpts{"pilot_k8s_reg_events", "Events from k8s registry."},
+		"pilot_k8s_reg_events",
+		"Events from k8s registry.",
 		typeTag, eventTag,
 	)
 )

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -305,6 +305,12 @@ func pilotQueryFilterFn(queries []string) []string {
 		if strings.Contains(query, "_reject") {
 			continue
 		}
+		if strings.Contains(query, "_timeout") {
+			continue
+		}
+		if strings.Contains(query, "_virt_services") {
+			continue
+		}
 		filtered = append(filtered, query)
 	}
 	return filtered


### PR DESCRIPTION
This PR converts Pilot's self-monitoring metrics to use the OpenCensus libraries instead of the Prometheus libraries.

Motivation:
1. We recently added packages to istio/pkg repo to enable automated generation of collateral, _including documentation of metrics_. The prometheus libraries prevent gathering of this information in this manner (gather() doesn't report on metrics without a value, etc.).
1. Brings Pilot up-to-date with the other Istio components (galley, mixer, citadel). Providing a more consistent developer experience.

note: i do not have a firm understanding of the performance impact of this change. as a result, I am *not* targeting this change for backport to 1.1 or 1.2.
