### PR TITLE
mount directory instead of file to detect file change

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -245,7 +245,7 @@ spec:
           volumeMounts:
           {{- if $.Values.global.sds.enabled }}
           - name: sdsudspath
-            mountPath: /var/run/sds/uds_path
+            mountPath: /var/run/sds
             readOnly: true
           {{- if $.Values.global.sds.useTrustworthyJwt }}
           - name: istio-token
@@ -279,8 +279,7 @@ spec:
       {{- if $.Values.global.sds.enabled }}
       - name: sdsudspath
         hostPath:
-          path: /var/run/sds/uds_path
-          type: Socket
+          path: /var/run/sds
       {{- if $.Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
         projected:

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -11,8 +11,7 @@
           optional: true
       {{- if $.Values.global.sds.enabled }}
       - hostPath:
-          path: /var/run/sds/uds_path
-          type: Socket
+          path: /var/run/sds
         name: sds-uds-path
       {{- if $.Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
@@ -167,7 +166,7 @@
           readOnly: true
         {{- if $.Values.global.sds.enabled }}
         - name: sds-uds-path
-          mountPath: /var/run/sds/uds_path
+          mountPath: /var/run/sds
           readOnly: true
         {{- if $.Values.global.sds.useTrustworthyJwt }}
         - name: istio-token
@@ -191,8 +190,7 @@
           optional: true
       {{- if $.Values.global.sds.enabled }}
       - hostPath:
-          path: /var/run/sds/uds_path
-          type: Socket
+          path: /var/run/sds
         name: sds-uds-path
       {{- if $.Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
@@ -353,7 +351,7 @@
           readOnly: true
         {{- if $.Values.global.sds.enabled }}
         - name: sds-uds-path
-          mountPath: /var/run/sds/uds_path
+          mountPath: /var/run/sds
           readOnly: true
         {{- if $.Values.global.sds.useTrustworthyJwt }}
         - name: istio-token

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -183,7 +183,7 @@ spec:
             readOnly: true
           {{- if $.Values.global.sds.enabled }}
           - name: sds-uds-path
-            mountPath: /var/run/sds/uds_path
+            mountPath: /var/run/sds
             readOnly: true
           {{- if $.Values.global.sds.useTrustworthyJwt }}
           - name: istio-token
@@ -194,8 +194,7 @@ spec:
       volumes:
       {{- if $.Values.global.sds.enabled }}
       - hostPath:
-          path: /var/run/sds/uds_path
-          type: Socket
+          path: /var/run/sds
         name: sds-uds-path
       {{- if $.Values.global.sds.useTrustworthyJwt }}
       - name: istio-token

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -265,7 +265,7 @@ containers:
   - mountPath: /etc/istio/proxy
     name: istio-envoy
   {{- if .Values.global.sds.enabled }}
-  - mountPath: /var/run/sds/uds_path
+  - mountPath: /var/run/sds
     name: sds-uds-path
     readOnly: true
   {{- if .Values.global.sds.useTrustworthyJwt }}
@@ -305,8 +305,7 @@ volumes:
 {{- if .Values.global.sds.enabled }}
 - name: sds-uds-path
   hostPath:
-    path: /var/run/sds/uds_path
-    type: Socket
+    path: /var/run/sds
 {{- if .Values.global.sds.customTokenDirectory }}
 - name: custom-sds-token
   secret:


### PR DESCRIPTION
**Issue**:
https://github.com/istio/istio/issues/14853

**Fix**:
(by consulting k8s storage team)
if reference a file in the hostpath, that file itself gets bind mounted into the container,
so if you change the contents, you will see the update; when rm/recreate the file, you won't see it
in order to see file updates, you need to mount the parent directory and not the file directly 

