### PR TITLE
Add a Base Infrastructure area

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,6 @@ about: Report a bug to help us improve Istio
 
 **Affected product area (please put an X in all that apply)**
 
-[ ] Base Infrastructure
 [ ] Configuration Infrastructure
 [ ] Docs
 [ ] Installation
@@ -21,6 +20,7 @@ about: Report a bug to help us improve Istio
 [ ] Security
 [ ] Test and Release
 [ ] User Experience
+[ ] Developer Infrastrcture
 
 **Expected behavior**
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,7 @@ about: Report a bug to help us improve Istio
 
 **Affected product area (please put an X in all that apply)**
 
+[ ] Base Infrastructure
 [ ] Configuration Infrastructure
 [ ] Docs
 [ ] Installation

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,5 +20,6 @@ about: Suggest an idea to improve Istio
 [ ] Security
 [ ] Test and Release
 [ ] User Experience
+[ ] Developer Infrastructure
 
 **Additional context**


### PR DESCRIPTION
Triagers can quickly determine when base infrastructure is the root
cause of a problem vs the actual test cases.

See: https://github.com/istio/istio/issues/14848#issuecomment-502295108

Needs to be added to github and the triager bot if we proceed :)