### PR TITLE
configure redis latency stat to emit in micro seconds

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -262,7 +262,8 @@ func buildOutboundAutoPassthroughFilterStack(env *model.Environment, node *model
 // configuring the Redis proxy.
 func buildRedisFilter(statPrefix, clusterName string, isXDSMarshalingToAnyEnabled bool) listener.Filter {
 	config := &redis_proxy.RedisProxy{
-		StatPrefix: statPrefix, // redis stats are prefixed with redis.<statPrefix> by Envoy
+		LatencyInMicros: true,       // redis latency stats are captured in micro seconds which is typically the case.
+		StatPrefix:      statPrefix, // redis stats are prefixed with redis.<statPrefix> by Envoy
 		Settings: &redis_proxy.RedisProxy_ConnPoolSettings{
 			OpTimeout: &redisOpTimeout, // TODO: Make this user configurable
 		},

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -36,6 +36,9 @@ func TestBuildRedisFilter(t *testing.T) {
 		if redisProxy.StatPrefix != "redis" {
 			t.Errorf("redis proxy statPrefix is %s", redisProxy.StatPrefix)
 		}
+		if !redisProxy.LatencyInMicros {
+			t.Errorf("redis proxy latency stat is not configured for microseconds")
+		}
 		if redisProxy.PrefixRoutes.CatchAllCluster != "redis-cluster" {
 			t.Errorf("redis proxy's PrefixRoutes.CatchAllCluster is %s", redisProxy.PrefixRoutes.CatchAllCluster)
 		}


### PR DESCRIPTION
Typically redis latencies are captured in micro seconds. This PR configures redis proxy to emit latency stats in micros.