### PR TITLE
Wait for Kubernetes before running test cases

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -85,8 +85,8 @@ const (
 	// RemoteCluster identifies the remote cluster
 	RemoteCluster = "remote"
 
-	kubernetesResponsiveTimeout       = time.SecondMinute * 180
-	kubernetesResponsiveFreq          = 100 * time.Millisecond
+	kubernetesResponsiveTimeout       = time.Second * 180
+	kubernetesResponsiveFreq          = 200 * time.Millisecond
 	validationWebhookReadinessTimeout = time.Minute
 	validationWebhookReadinessFreq    = 100 * time.Millisecond
 )
@@ -380,7 +380,7 @@ func (k *KubeInfo) Setup() error {
 		return err
 	}
 
-	if err = waitForKubernetes(); err != nil {
+	if err = k.waitForKubernetes(); err != nil {
 		return err
 	}
 
@@ -913,7 +913,7 @@ func (k *KubeInfo) waitForKubernetes() error {
 	timeout := time.Now().Add(kubernetesResponsiveTimeout)
 	for {
 		if time.Now().After(timeout) {
-			return errors.New("Timeout waiting for Kubernetes to become active")
+			return errors.New("timeout waiting for Kubernetes to become active")
 		}
 
 		out, err := util.ShellSilent(cmd)

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -35,7 +35,6 @@ import (
 	testKube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/tests/util"
-
 	"istio.io/pkg/log"
 )
 

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -912,7 +912,7 @@ spec:
 func (k *KubeInfo) waitForKubernetes() error {
 	log.Info("Waiting for Kubernetes to become responsive")
 	return retry.UntilSuccess(func() error {
-		pods, err := k.KubeAccessor.GetPods("kube-system")
+		_, err := k.KubeAccessor.GetPods("kube-system")
 		if err != nil {
 			return err
 		}

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -912,10 +912,7 @@ func (k *KubeInfo) waitForKubernetes() error {
 	log.Info("Waiting for Kubernetes to become responsive")
 	return retry.UntilSuccess(func() error {
 		_, err := k.KubeAccessor.GetPods("kube-system")
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	}, retry.Delay(kubernetesReadinessInterval), retry.Timeout(kubernetesReadinessTimeout))
 }
 


### PR DESCRIPTION
Without this wait, the test cases assume Kubernetes is ready to run.
This assumption is racy.  In some occasions, the machine may not be
ready from a K8s perspective, and the tests will then crater.

Fixes: #14848