### PR TITLE
Use describe tags so that soft tags are used

### DIFF
--- a/bin/get_workspace_status.sh
+++ b/bin/get_workspace_status.sh
@@ -40,7 +40,7 @@ if [[ -n ${ISTIO_DOCKER_HUB} ]]; then
   DOCKER_HUB="${ISTIO_DOCKER_HUB}"
 fi
 
-GIT_DESCRIBE_TAG=$(git describe)
+GIT_DESCRIBE_TAG=$(git describe --tags)
 
 # used by bin/gobuild.sh
 echo "istio.io/istio/vendor/istio.io/pkg/version.buildVersion=${VERSION}"


### PR DESCRIPTION
`git describe` only uses annotated tags.
It therefore prints incorrect version when new soft tags are created.
`--tags` arg fixes the problem.

```
✔ ~/GOHOME/src/istio.io/istio [fix_version L|…57⚑ 42]
20:50 $ git describe
1.1.6-936-g4a03ec440
✔ ~/GOHOME/src/istio.io/istio [fix_version L|…57⚑ 42]
20:50 $ git describe --tags
1.2.0-rc.1-19-g4a03ec440
```