### PR TITLE
Remove unused value 'istioNamespace' when fill app template

### DIFF
--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -388,7 +388,6 @@ func getApp(deploymentName, serviceName string, replicas, port1, port2, port3, p
 			"port5":           strconv.Itoa(port5),
 			"port6":           strconv.Itoa(port6),
 			"version":         version,
-			"istioNamespace":  tc.Kube.Namespace,
 			"injectProxy":     strconv.FormatBool(injectProxy),
 			"headless":        strconv.FormatBool(headless),
 			"serviceAccount":  strconv.FormatBool(serviceAccount),


### PR DESCRIPTION
When run e2e pilot_test, the template value 'istioNamespace' is unused in the step of filling app template