### PR TITLE
Fix pilot validation seg faults

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1239,6 +1239,10 @@ func ValidateMixerAttributes(msg proto.Message) error {
 	}
 	var errs error
 	for k, v := range in.Attributes {
+		if v == nil {
+			errs = multierror.Append(errs, errors.New("an attribute cannot be empty"))
+			continue
+		}
 		switch val := v.Value.(type) {
 		case *mpb.Attributes_AttributeValue_StringValue:
 			if val.StringValue == "" {
@@ -1371,6 +1375,10 @@ func ValidateQuotaSpec(_, _ string, msg proto.Message) error {
 	for _, rule := range in.Rules {
 		for _, match := range rule.Match {
 			for name, clause := range match.Clause {
+				if clause == nil {
+					errs = multierror.Append(errs, errors.New("a clause cannot be empty"))
+					continue
+				}
 				switch matchType := clause.MatchType.(type) {
 				case *mccpb.StringMatch_Exact:
 					if matchType.Exact == "" {
@@ -1477,6 +1485,14 @@ func ValidateAuthenticationPolicy(name, namespace string, msg proto.Message) err
 		}
 	}
 	for _, method := range in.Origins {
+		if method == nil {
+			errs = multierror.Append(errs, errors.New("origin cannot be empty"))
+			continue
+		}
+		if method.Jwt == nil {
+			errs = multierror.Append(errs, errors.New("jwt cannot be empty"))
+			continue
+		}
 		if _, jwtExist := jwtIssuers[method.Jwt.Issuer]; jwtExist {
 			errs = appendErrors(errs, fmt.Errorf("jwt with issuer %q already defined", method.Jwt.Issuer))
 		} else {

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -1170,6 +1170,15 @@ func TestValidateHTTPAPISpec(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			name: "invalid attribute (nil)",
+			in: &mccpb.HTTPAPISpec{
+				Attributes: &mpb.Attributes{
+					Attributes: map[string]*mpb.Attributes_AttributeValue{"": nil},
+				},
+			},
+			valid: false,
+		},
 	}
 	for _, c := range cases {
 		if got := ValidateHTTPAPISpec(someName, someNamespace, c.in); (got == nil) != c.valid {
@@ -1331,6 +1340,19 @@ func TestValidateQuotaSpec(t *testing.T) {
 				}},
 			},
 			valid: true,
+		},
+		{
+			name: "regression test - nil clause",
+			in: &mccpb.QuotaSpec{
+				Rules: []*mccpb.QuotaRule{{
+					Match: []*mccpb.AttributeMatch{{
+						Clause: map[string]*mccpb.StringMatch{
+							"": nil,
+						},
+					}},
+				}},
+			},
+			valid: false,
 		},
 	}
 	for _, c := range cases {
@@ -3755,6 +3777,22 @@ func TestValidateAuthenticationMeshPolicy(t *testing.T) {
 				}},
 			},
 			valid: true,
+		},
+		{
+			name:       "empty origin",
+			configName: DefaultAuthenticationPolicyName,
+			in: &authn.Policy{
+				Origins: []*authn.OriginAuthenticationMethod{{}},
+			},
+			valid: false,
+		},
+		{
+			name:       "nil origin",
+			configName: DefaultAuthenticationPolicyName,
+			in: &authn.Policy{
+				Origins: []*authn.OriginAuthenticationMethod{nil},
+			},
+			valid: false,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
These three config types can cause crashes. This isn't that bad when
used from Galley, as Galley will recover from the panics, but it could
cause other issues and is worse UX for users if they do happen to pass
one of these invalid configs.

Note: I believe there are other states that can crash our validation that are possible to create in the go structs, but Kubernetes will never actually have these created in this way. These are all possible to create via Kubernetes, see examples:

```
kubectl apply -f - <<EOF
apiVersion: "authentication.istio.io/v1alpha1"
kind: "MeshPolicy"
metadata:
  name: "default"
spec:
  origins: [{}]
EOF
```
```
kubectl apply -f - <<EOF
apiVersion: config.istio.io/v1alpha2
kind: HTTPAPISpec
metadata:
  name: default
spec:
  "attributes": {
    "attributes": {
      "": null,
    }
  }
EOF
```

```
kubectl apply -f - <<EOF
apiVersion: config.istio.io/v1alpha2
kind: QuotaSpec
metadata:
  name: default
spec:
  "rules": [
    {
      "match": [
        {
          "clause": {
            "": null
          }
        },
      ],
      "quotas": [
        {},
      ]
    }
  ]
EOF
```