### PR TITLE
[Testing] New utility for downloading Envoy binary

### DIFF
--- a/pkg/test/deps/istio.go
+++ b/pkg/test/deps/istio.go
@@ -1,0 +1,50 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package deps
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"istio.io/istio/pkg/test/env"
+)
+
+var (
+	Istio []IstioDep
+)
+
+func init() {
+	content, err := ioutil.ReadFile(filepath.Join(env.IstioSrc, "istio.deps"))
+	assert(err)
+
+	Istio = make([]IstioDep, 0)
+	assert(json.Unmarshal(content, &Istio))
+}
+
+// IstioDep identifies a external dependency of Istio.
+type IstioDep struct {
+	Comment       string `json:"_comment,omitempty"`
+	Name          string `json:"name,omitempty"`
+	RepoName      string `json:"repoName,omitempty"`
+	LastStableSHA string `json:"lastStableSHA,omitempty"`
+}
+
+func assert(err error) {
+	if err != nil {
+		panic(fmt.Errorf("failed retrieving Envoy SHA: %v", err))
+	}
+}

--- a/pkg/test/envoy/download.go
+++ b/pkg/test/envoy/download.go
@@ -1,0 +1,51 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package envoy
+
+import (
+	"fmt"
+	"net/http"
+
+	"istio.io/istio/pkg/test/deps"
+	"istio.io/istio/pkg/test/util"
+)
+
+var (
+	LatestStableSHA string
+	LinuxReleaseURL string
+)
+
+func init() {
+	for _, dep := range deps.Istio {
+		if dep.Name == "PROXY_REPO_SHA" {
+			LatestStableSHA = dep.LastStableSHA
+			LinuxReleaseURL = fmt.Sprintf("https://storage.googleapis.com/istio-build/proxy/envoy-alpha-%s.tar.gz", LatestStableSHA)
+			return
+		}
+	}
+
+	panic(fmt.Errorf("envoy SHA not found in: \n%v", deps.Istio))
+}
+
+// DownloadLinuxRelease downloads the release linux binary to the given directory.
+func DownloadLinuxRelease(dir string) error {
+	resp, err := http.Get(LinuxReleaseURL)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return util.ExtractTarGz(resp.Body, dir)
+}

--- a/pkg/test/envoy/download_test.go
+++ b/pkg/test/envoy/download_test.go
@@ -1,0 +1,41 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package envoy_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"istio.io/istio/pkg/test/envoy"
+)
+
+func TestDownload(t *testing.T) {
+	dir, err := ioutil.TempDir("", "envoy-download")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	if err := envoy.DownloadLinuxRelease(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(filepath.Join(dir, "usr/local/bin/envoy"))
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/test/util/download.go
+++ b/pkg/test/util/download.go
@@ -1,0 +1,58 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"istio.io/pkg/log"
+)
+
+// HTTPDownload download from src(url) and store into dst(local file)
+func HTTPDownload(dst string, src string) error {
+	log.Infof("Start downloading from %s to %s ...\n", src, dst)
+	var err error
+	var out *os.File
+	var resp *http.Response
+	out, err = os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err = out.Close(); err != nil {
+			log.Errorf("Error: close file %s, %s", dst, err)
+		}
+	}()
+	resp, err = http.Get(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err = resp.Body.Close(); err != nil {
+			log.Errorf("Error: close downloaded file from %s, %s", src, err)
+		}
+	}()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("http get request, received unexpected response status: %s", resp.Status)
+	}
+	if _, err = io.Copy(out, resp.Body); err != nil {
+		return err
+	}
+	log.Info("Download successfully!")
+	return err
+}

--- a/pkg/test/util/extract.go
+++ b/pkg/test/util/extract.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// ExtractTarGz extracts a .tar.gz file into current dir.
+func ExtractTarGz(gzippedStream io.Reader, dir string) error {
+	uncompressedStream, err := gzip.NewReader(gzippedStream)
+	if err != nil {
+		return errors.Wrap(err, "Fail to uncompress")
+	}
+	tarReader := tar.NewReader(uncompressedStream)
+
+	for {
+		header, err := tarReader.Next()
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return errors.Wrap(err, "ExtractTarGz: Next() failed")
+		}
+
+		rel := filepath.FromSlash(header.Name)
+		abs := filepath.Join(dir, rel)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(abs, 0755); err != nil {
+				return errors.Wrap(err, "ExtractTarGz: Mkdir() failed")
+			}
+		case tar.TypeReg:
+			outFile, err := os.Create(abs)
+			if err != nil {
+				return errors.Wrap(err, "ExtractTarGz: Create() failed")
+			}
+			defer func() { _ = outFile.Close() }()
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				return errors.Wrap(err, "ExtractTarGz: Copy() failed")
+			}
+		default:
+			return fmt.Errorf("unknown type: %s in %s",
+				string(header.Typeflag), header.Name)
+		}
+	}
+	return nil
+}

--- a/tests/e2e/framework/istioctl.go
+++ b/tests/e2e/framework/istioctl.go
@@ -23,7 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"istio.io/istio/tests/util"
+	testUtil "istio.io/istio/pkg/test/util"
+	testsUtil "istio.io/istio/tests/util"
 	"istio.io/pkg/log"
 )
 
@@ -101,11 +102,11 @@ func (i *Istioctl) Install() error {
 		}
 		homeDir := usr.HomeDir
 
-		istioctlSuffix, err := util.GetOsExt()
+		istioctlSuffix, err := testsUtil.GetOsExt()
 		if err != nil {
 			return err
 		}
-		if err = util.HTTPDownload(i.binaryPath, i.remotePath+"/istioctl-"+istioctlSuffix); err != nil {
+		if err = testUtil.HTTPDownload(i.binaryPath, i.remotePath+"/istioctl-"+istioctlSuffix); err != nil {
 			log.Error("Failed to download istioctl")
 			return err
 		}
@@ -123,7 +124,7 @@ func (i *Istioctl) Install() error {
 
 func (i *Istioctl) run(format string, args ...interface{}) (res string, err error) {
 	format = i.binaryPath + " " + format
-	if res, err = util.ShellMuteOutput(format, args...); err != nil {
+	if res, err = testsUtil.ShellMuteOutput(format, args...); err != nil {
 		log.Errorf("istioctl %s failed", args)
 		return "", err
 	}

--- a/tests/util/common_utils.go
+++ b/tests/util/common_utils.go
@@ -15,13 +15,10 @@
 package util
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,9 +27,9 @@ import (
 	"time"
 
 	"github.com/google/go-github/github"
-	"github.com/pkg/errors"
 
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/util"
 	"istio.io/pkg/log"
 )
 
@@ -195,40 +192,6 @@ func Record(command, record string) error {
 	return err
 }
 
-// HTTPDownload download from src(url) and store into dst(local file)
-func HTTPDownload(dst string, src string) error {
-	log.Infof("Start downloading from %s to %s ...\n", src, dst)
-	var err error
-	var out *os.File
-	var resp *http.Response
-	out, err = os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err = out.Close(); err != nil {
-			log.Errorf("Error: close file %s, %s", dst, err)
-		}
-	}()
-	resp, err = http.Get(src)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err = resp.Body.Close(); err != nil {
-			log.Errorf("Error: close downloaded file from %s, %s", src, err)
-		}
-	}()
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("http get request, received unexpected response status: %s", resp.Status)
-	}
-	if _, err = io.Copy(out, resp.Body); err != nil {
-		return err
-	}
-	log.Info("Download successfully!")
-	return err
-}
-
 // GetOsExt returns the current OS tag.
 func GetOsExt() (string, error) {
 	var osExt string
@@ -290,7 +253,7 @@ func DownloadRelease(version, tmpDir string) (string, error) {
 	url := fmt.Sprintf(releaseURL, version, version, osExt)
 	fname := fmt.Sprintf("istio-%s.tar.gz", version)
 	tgz := filepath.Join(tmpDir, fname)
-	err = HTTPDownload(tgz, url)
+	err = util.HTTPDownload(tgz, url)
 	if err != nil {
 		return "", err
 	}
@@ -298,51 +261,10 @@ func DownloadRelease(version, tmpDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	err = ExtractTarGz(f)
+	err = util.ExtractTarGz(f, tmpDir)
 	if err != nil {
 		return "", err
 	}
 	subdir := "istio-" + version
 	return filepath.Join(tmpDir, subdir), nil
-}
-
-// ExtractTarGz extracts a .tar.gz file into current dir.
-func ExtractTarGz(gzipStream io.Reader) error {
-	uncompressedStream, err := gzip.NewReader(gzipStream)
-	if err != nil {
-		return errors.Wrap(err, "Fail to uncompress")
-	}
-	tarReader := tar.NewReader(uncompressedStream)
-
-	for {
-		header, err := tarReader.Next()
-
-		if err == io.EOF {
-			break
-		}
-
-		if err != nil {
-			return errors.Wrap(err, "ExtractTarGz: Next() failed")
-		}
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := os.Mkdir(header.Name, 0755); err != nil {
-				return errors.Wrap(err, "ExtractTarGz: Mkdir() failed")
-			}
-		case tar.TypeReg:
-			outFile, err := os.Create(header.Name)
-			if err != nil {
-				return errors.Wrap(err, "ExtractTarGz: Create() failed")
-			}
-			defer outFile.Close() // nolint: errcheck
-			if _, err := io.Copy(outFile, tarReader); err != nil {
-				return errors.Wrap(err, "ExtractTarGz: Copy() failed")
-			}
-		default:
-			return fmt.Errorf("unknown type: %s in %s",
-				string(header.Typeflag), header.Name)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
This is split out from #14614 and is needed for dynamically building docker images for the Echo component.

Overview:

- Added parsing for istio.deps
- Moved test utilities for downloading and extracting tar.gz files to pkg/test/util
- Added utility for downloading the current release of the envoy linux binary.