### PR TITLE
allow users to disable istio default retries by setting retries to 0

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -2268,9 +2268,14 @@ func validateHTTPRetry(retries *networking.HTTPRetry) (errs error) {
 		return
 	}
 
-	if retries.Attempts <= 0 {
-		errs = multierror.Append(errs, errors.New("attempts must be positive"))
+	if retries.Attempts < 0 {
+		errs = multierror.Append(errs, errors.New("attempts cannot be negative"))
 	}
+
+	if retries.Attempts == 0 && (retries.PerTryTimeout != nil || retries.RetryOn != "") {
+		errs = appendErrors(errs, errors.New("http retry policy configured when attempts are set to 0 (disabled)"))
+	}
+
 	if retries.PerTryTimeout != nil {
 		errs = appendErrors(errs, ValidateDurationGogo(retries.PerTryTimeout))
 	}

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -2040,6 +2040,14 @@ func TestValidateHTTPRetry(t *testing.T) {
 			PerTryTimeout: &types.Duration{Seconds: 2},
 			RetryOn:       "5xx,gateway-error",
 		}, valid: true},
+		{name: "disable retries", in: &networking.HTTPRetry{
+			Attempts: 0,
+		}, valid: true},
+		{name: "invalid, retry policy configured but attempts set to zero", in: &networking.HTTPRetry{
+			Attempts:      0,
+			PerTryTimeout: &types.Duration{Seconds: 2},
+			RetryOn:       "5xx,gateway-error",
+		}, valid: false},
 		{name: "valid default", in: &networking.HTTPRetry{
 			Attempts: 10,
 		}, valid: true},


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/14900

This appears to be a disconnect in our validation logic for the webhook and how pilot generates the envoy config. Specifically in the validation webhook:
https://github.com/istio/istio/blob/master/pilot/pkg/model/validation.go#L2272
and how we attempt to detect whether to disable the default retries istio appends for each Route:
https://github.com/istio/istio/blob/master/pilot/pkg/networking/core/v1alpha3/route/retry/retry.go#L69

Istio applies default retries (2) to resolve 503's.  Pilot expects a user to be able to disable the default retries by setting `HTTPRetry.Attempts<=0`, but validation webhook only accepts values greater than 0