### PR TITLE
Add readiness probe to proxy to check Envoy status

### DIFF
--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -21,6 +21,8 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 
+	admin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
+
 	"istio.io/istio/pilot/cmd/pilot-agent/status/util"
 )
 
@@ -42,7 +44,11 @@ func (p *Probe) Check() error {
 
 	// Envoy has received some configuration, make sure that configuration has been received for
 	// all inbound ports.
-	return p.checkInboundConfigured()
+	if err := p.checkInboundConfigured(); err != nil {
+		return err
+	}
+
+	return p.checkServerInfo()
 }
 
 // checkApplicationPorts verifies that Envoy has received configuration for all ports exposed by the application container.
@@ -93,4 +99,18 @@ func (p *Probe) checkUpdated() error {
 	}
 
 	return fmt.Errorf("config not received from Pilot (is Pilot running?): %s", s.String())
+}
+
+// checkServerInfo checks to ensure that Envoy is in the READY state
+func (p *Probe) checkServerInfo() error {
+	info, err := util.GetServerInfo(p.LocalHostAddr, p.AdminPort)
+	if err != nil {
+		return fmt.Errorf("failed to get server info: %v", err)
+	}
+
+	if info.GetState() != admin.ServerInfo_LIVE {
+		return fmt.Errorf("server is not live, current state is: %v", info.GetState().String())
+	}
+
+	return nil
 }

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -22,6 +22,7 @@ import (
 
 	admin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
 	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
 	. "github.com/onsi/gomega"
 )
 
@@ -163,7 +164,7 @@ func TestEnvoyInitializing(t *testing.T) {
 	g.Expect(err).To(HaveOccurred())
 }
 
-func createAndStartServer(statsToReturn string, serverInfo *admin.ServerInfo) *httptest.Server {
+func createAndStartServer(statsToReturn string, serverInfo proto.Message) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/stats", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Send response to be tested
@@ -171,10 +172,10 @@ func createAndStartServer(statsToReturn string, serverInfo *admin.ServerInfo) *h
 	}))
 	mux.HandleFunc("/server_info", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		jsonm := &jsonpb.Marshaler{Indent: "  "}
-		infoJson, _ := jsonm.MarshalToString(serverInfo)
+		infoJSON, _ := jsonm.MarshalToString(serverInfo)
 
 		// Send response to be tested
-		rw.Write([]byte(infoJson))
+		rw.Write([]byte(infoJSON))
 	}))
 
 	// Start a local HTTP server

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -20,18 +20,24 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	admin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
+	"github.com/gogo/protobuf/jsonpb"
 	. "github.com/onsi/gomega"
 )
 
-var probe Probe
+var (
+	goodStats      = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1"
+	liveServerInfo = &admin.ServerInfo{State: admin.ServerInfo_LIVE}
+	initServerInfo = &admin.ServerInfo{State: admin.ServerInfo_INITIALIZING}
+)
 
 func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {
 	g := NewGomegaWithT(t)
-	stats := "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1"
+	stats := goodStats
 
-	server := createAndStartServer(stats)
+	server := createAndStartServer(stats, liveServerInfo)
 	defer server.Close()
-	probe = Probe{AdminPort: 1234}
+	probe := Probe{AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -42,9 +48,9 @@ func TestEnvoyStatsIncompleteCDS(t *testing.T) {
 	g := NewGomegaWithT(t)
 	stats := "listener_manager.lds.update_success: 1"
 
-	server := createAndStartServer(stats)
+	server := createAndStartServer(stats, liveServerInfo)
 	defer server.Close()
-	probe = Probe{AdminPort: 1234}
+	probe := Probe{AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -56,9 +62,9 @@ func TestEnvoyStatsIncompleteLDS(t *testing.T) {
 	g := NewGomegaWithT(t)
 	stats := "cluster_manager.cds.update_success: 1"
 
-	server := createAndStartServer(stats)
+	server := createAndStartServer(stats, liveServerInfo)
 	defer server.Close()
-	probe = Probe{AdminPort: 1234}
+	probe := Probe{AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -70,9 +76,9 @@ func TestEnvoyStatsCompleteAndRejectedCDS(t *testing.T) {
 	g := NewGomegaWithT(t)
 	stats := "cluster_manager.cds.update_rejected: 1\nlistener_manager.lds.update_success: 1"
 
-	server := createAndStartServer(stats)
+	server := createAndStartServer(stats, liveServerInfo)
 	defer server.Close()
-	probe = Probe{AdminPort: 1234}
+	probe := Probe{AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -83,9 +89,9 @@ func TestEnvoyStatsCompleteAndRejectedLDS(t *testing.T) {
 	g := NewGomegaWithT(t)
 	stats := "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_rejected: 1"
 
-	server := createAndStartServer(stats)
+	server := createAndStartServer(stats, liveServerInfo)
 	defer server.Close()
-	probe = Probe{AdminPort: 1234}
+	probe := Probe{AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -96,9 +102,9 @@ func TestEnvoyCheckFailsIfStatsUnparsableNoSeparator(t *testing.T) {
 	g := NewGomegaWithT(t)
 	stats := "cluster_manager.cds.update_success; 1\nlistener_manager.lds.update_success: 1"
 
-	server := createAndStartServer(stats)
+	server := createAndStartServer(stats, liveServerInfo)
 	defer server.Close()
-	probe = Probe{AdminPort: 1234}
+	probe := Probe{AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -110,9 +116,9 @@ func TestEnvoyCheckFailsIfStatsUnparsableNoNumber(t *testing.T) {
 	g := NewGomegaWithT(t)
 	stats := "cluster_manager.cds.update_success: a\nlistener_manager.lds.update_success: 1"
 
-	server := createAndStartServer(stats)
+	server := createAndStartServer(stats, liveServerInfo)
 	defer server.Close()
-	probe = Probe{AdminPort: 1234}
+	probe := Probe{AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -122,35 +128,58 @@ func TestEnvoyCheckFailsIfStatsUnparsableNoNumber(t *testing.T) {
 
 func TestEnvoyCheckSucceedsIfStatsCleared(t *testing.T) {
 	g := NewGomegaWithT(t)
-	probe = Probe{AdminPort: 1234}
+	probe := Probe{AdminPort: 1234}
 
 	// Verify bad stats trigger an error
 	badStats := "cluster_manager.cds.update_success: 0\nlistener_manager.lds.update_success: 0"
-	server := createAndStartServer(badStats)
+	server := createAndStartServer(badStats, liveServerInfo)
 	err := probe.Check()
 	server.Close()
 	g.Expect(err).To(HaveOccurred())
 
 	// trigger the state change
-	goodStats := "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1"
-	server = createAndStartServer(goodStats)
+	server = createAndStartServer(goodStats, liveServerInfo)
 	err = probe.Check()
 	server.Close()
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// verify empty stats no longer break probe
-	server = createAndStartServer(badStats)
+	server = createAndStartServer(badStats, liveServerInfo)
 	err = probe.Check()
 	server.Close()
 	g.Expect(err).ToNot(HaveOccurred())
 }
 
-func createAndStartServer(statsToReturn string) *httptest.Server {
-	// Start a local HTTP server
-	server := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+func TestEnvoyInitializing(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := goodStats
+
+	server := createAndStartServer(stats, initServerInfo)
+	defer server.Close()
+	probe := Probe{AdminPort: 1234}
+
+	err := probe.Check()
+
+	g.Expect(err).To(HaveOccurred())
+}
+
+func createAndStartServer(statsToReturn string, serverInfo *admin.ServerInfo) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/stats", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Send response to be tested
 		rw.Write([]byte(statsToReturn))
 	}))
+	mux.HandleFunc("/server_info", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		jsonm := &jsonpb.Marshaler{Indent: "  "}
+		infoJson, _ := jsonm.MarshalToString(serverInfo)
+
+		// Send response to be tested
+		rw.Write([]byte(infoJson))
+	}))
+
+	// Start a local HTTP server
+	server := httptest.NewUnstartedServer(mux)
+
 	l, err := net.Listen("tcp", "127.0.0.1:1234")
 	if err != nil {
 		panic("Could not create listener for test: " + err.Error())

--- a/pilot/cmd/pilot-agent/status/util/server_info.go
+++ b/pilot/cmd/pilot-agent/status/util/server_info.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/pilot/cmd/pilot-agent/status/util/server_info.go
+++ b/pilot/cmd/pilot-agent/status/util/server_info.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"fmt"
+
+	admin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/hashicorp/go-multierror"
+)
+
+func GetServerInfo(localHostAddr string, adminPort uint16) (*admin.ServerInfo, error) {
+	input, err := doHTTPGet(fmt.Sprintf("http://%s:%d/server_info", localHostAddr, adminPort))
+	if err != nil {
+		return nil, multierror.Prefix(err, "failed retrieving Envoy stats:")
+	}
+	info := &admin.ServerInfo{}
+	if err := jsonpb.Unmarshal(input, info); err != nil {
+		return &admin.ServerInfo{}, err
+	}
+
+	return info, nil
+}


### PR DESCRIPTION
Currently we just check that a LDS and CDS response was received and
that there is correct inbound listeners. However, there are a lot of
cases where this is not sufficient, and Envoy is still not ready. For
instance, if the listeners are waiting on RDS or SDS response. In this
case, Envoy will not actually accept traffic as expected.

Envoy exposes its current state in the /server_info endpoint, so we can
read that and ensure we don't mark it as ready until it has completed
initialization.

Fixes https://github.com/istio/istio/issues/14560