### PR TITLE
Update pilot service registry aggregate controller to use rlock

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -87,8 +87,8 @@ func (c *Controller) DeleteRegistry(clusterID string) {
 
 // GetRegistries returns a copy of all registries
 func (c *Controller) GetRegistries() []Registry {
-	c.storeLock.Lock()
-	defer c.storeLock.Unlock()
+	c.storeLock.RLock()
+	defer c.storeLock.RUnlock()
 
 	return c.registries
 }


### PR DESCRIPTION
Update pilot service registry aggregate controller to use `RLock` and `RUnlock`for `getRegistries().