### PR TITLE
Adding the build&test logic to release-1.2

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -42,24 +42,13 @@ export OWNER="${OWNER:-e2e-suite}"
 export PILOT_CLUSTER="${PILOT_CLUSTER:-}"
 export USE_MASON_RESOURCE="${USE_MASON_RESOURCE:-True}"
 export CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
+export HUB=${HUB:-"gcr.io/istio-testing"}
 
 # shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
-setup_e2e_cluster
-
-if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
-   cni_run_daemon
+if [[ $HUB == *"istio-testing"* ]]; then
+  setup_and_export_git_sha
 fi
-
-E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
-# e2e tests on prow use clusters borrowed from boskos, which cleans up the
-# clusters. There is no need to cleanup in the test jobs.
-E2E_ARGS+=("--skip_cleanup")
-
-export HUB=${HUB:-"gcr.io/istio-testing"}
-export TAG="${TAG:-${GIT_SHA}}"
-
-make init
 
 # getopts only handles single character flags
 for ((i=1; i<=$#; i++)); do
@@ -75,6 +64,29 @@ for ((i=1; i<=$#; i++)); do
     esac
     E2E_ARGS+=( "${!i}" )
 done
+
+export TAG="${TAG:-${GIT_SHA}}"
+
+if [[ $HUB == *"istio-testing"* ]]; then
+  export TAG="${TAG:-${GIT_SHA}}"-"${SINGLE_TEST}"
+fi
+
+make init
+
+if [[ $HUB == *"istio-testing"* ]]; then
+  # upload images
+  time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"
+fi
+
+setup_e2e_cluster
+if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
+   cni_run_daemon
+fi
+
+E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
+# e2e tests on prow use clusters borrowed from boskos, which cleans up the
+# clusters. There is no need to cleanup in the test jobs.
+E2E_ARGS+=("--skip_cleanup")
 
 time ISTIO_DOCKER_HUB=$HUB \
   E2E_ARGS="${E2E_ARGS[*]}" \

--- a/prow/integ-suite-k8s.sh
+++ b/prow/integ-suite-k8s.sh
@@ -57,9 +57,6 @@ FILE_LOG="$(mktemp /tmp/XXXXX.boskos.log)"
 
 setup_and_export_git_sha
 
-get_resource "${RESOURCE_TYPE}" "${OWNER}" "${INFO_PATH}" "${FILE_LOG}"
-
-
 if [ "${CI:-}" == 'bootstrap' ]; then
   # bootsrap upload all artifacts in _artifacts to the log bucket.
   ARTIFACTS_DIR=${ARTIFACTS_DIR:-"${GOPATH}/src/istio.io/istio/_artifacts"}
@@ -68,8 +65,17 @@ fi
 export HUB=${HUB:-"gcr.io/istio-testing"}
 export TAG="${TAG:-${GIT_SHA}}"
 
+if [[ $HUB == *"istio-testing"* ]]; then
+  export TAG="${TAG:-${GIT_SHA}}"-"$*"
+fi
+
 make init
 
+if [[ $HUB == *"istio-testing"* ]]; then
+  time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"
+fi
+
+get_resource "${RESOURCE_TYPE}" "${OWNER}" "${INFO_PATH}" "${FILE_LOG}"
 setup_cluster
 
 JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml" \


### PR DESCRIPTION
We need this to get check-in before we are able to turn off run_after_success in the yaml file (run_after_success if blocker to move prow to head binary)

These changes is already in master for at least a couple weeks. We need this changes in release-1.2, release-1.1, release-1.0, and release-0.8.