### PR TITLE
Adding the build&test logic to release-1.0

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -49,16 +49,14 @@ export OWNER="${OWNER:-e2e-suite}"
 export PILOT_CLUSTER="${PILOT_CLUSTER:-}"
 export USE_MASON_RESOURCE="${USE_MASON_RESOURCE:-True}"
 export CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
+export HUB=${HUB:-"gcr.io/istio-testing"}
 
 source "${ROOT}/prow/lib.sh"
-setup_e2e_cluster
+if [[ $HUB == *"istio-testing"* ]]; then
+  setup_and_export_git_sha
+fi
 
 ISTIO_GO=$(cd $(dirname $0)/..; pwd)
-
-export HUB=${HUB:-"gcr.io/istio-testing"}
-export TAG="${TAG:-${GIT_SHA}}"
-
-make init
 
 # getopts only handles single character flags
 for ((i=1; i<=$#; i++)); do
@@ -74,6 +72,21 @@ for ((i=1; i<=$#; i++)); do
     esac
     E2E_ARGS+=( ${!i} )
 done
+
+export TAG="${TAG:-${GIT_SHA}}"
+
+if [[ ${SINGLE_MODE} && $HUB == *"istio-testing"* ]]; then
+  export TAG="${TAG:-${GIT_SHA}}"-"${SINGLE_TEST}"
+fi
+
+make init
+
+if [[ $HUB == *"istio-testing"* ]]; then
+  # upload images
+  time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"
+fi
+
+setup_e2e_cluster
 
 echo 'Running ISTIO E2E Test(s)'
 if ${SINGLE_MODE}; then


### PR DESCRIPTION
We need this to get check-in before we are able to turn off run_after_success in the yaml file (run_after_success if blocker to move prow to head binary)

These changes is already in master for at least a couple weeks. We need this changes in release-1.2, release-1.1, release-1.0, and release-0.8.