### PR TITLE
add unit test that trigger race in nodeagent cache

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -205,7 +206,12 @@ func TestWorkloadAgentRefreshSecret(t *testing.T) {
 	testConnID := "proxy1-id"
 	_, err := sc.GenerateSecret(context.Background(), testConnID, testResourceName, "jwtToken1")
 	if err != nil {
-		t.Fatalf("Failed to get secrets: %v", err)
+		t.Fatalf("Failed to get secrets for %q: %v", testConnID, err)
+	}
+
+	for i := 0; i < 10; i++ {
+		id := "proxy-id" + strconv.Itoa(i)
+		sc.GenerateSecret(context.Background(), id, testResourceName, "jwtToken1")
 	}
 
 	// Wait until key rotation job run to update cached secret.


### PR DESCRIPTION
https://github.com/istio/istio/issues/14714

add unit test for previous racing condition fix(https://github.com/istio/istio/pull/13333), without the fix, new added unit test fail with - 
```
WARNING: DATA RACE
Write at 0x00c4203c21b0 by goroutine 29:
  runtime.mapassign()
      /usr/local/go/src/runtime/hashmap.go:505 +0x0
  istio.io/istio/security/pkg/nodeagent/cache.(*SecretCache).rotate.func1.1()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/cache/secretcache.go:515 +0x491

Previous write at 0x00c4203c21b0 by goroutine 28:
  runtime.mapassign()
      /usr/local/go/src/runtime/hashmap.go:505 +0x0
  istio.io/istio/security/pkg/nodeagent/cache.(*SecretCache).rotate.func1.1()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/cache/secretcache.go:515 +0x491

Goroutine 29 (running) created at:
  istio.io/istio/security/pkg/nodeagent/cache.(*SecretCache).rotate.func1()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/cache/secretcache.go:501 +0x8b8
  sync.(*Map).Range()
      /usr/local/go/src/sync/map.go:337 +0x13b
  istio.io/istio/security/pkg/nodeagent/cache.(*SecretCache).rotate()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/cache/secretcache.go:444 +0x1e0
  istio.io/istio/security/pkg/nodeagent/cache.(*SecretCache).keyCertRotationJob()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/cache/secretcache.go:345 +0x20c

Goroutine 28 (finished) created at:
  istio.io/istio/security/pkg/nodeagent/cache.(*SecretCache).rotate.func1()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/cache/secretcache.go:501 +0x8b8
  sync.(*Map).Range()
      /usr/local/go/src/sync/map.go:337 +0x13b
  istio.io/istio/security/pkg/nodeagent/cache.(*SecretCache).rotate()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/cache/secretcache.go:444 +0x1e0
  istio.io/istio/security/pkg/nodeagent/cache.(*SecretCache).keyCertRotationJob()
      /usr/local/google/home/quanlin/go/src/istio.io/istio/security/pkg/nodeagent/cache/secretcache.go:345 +0x20c

```
