### PR TITLE
Handle some errors

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -104,7 +104,10 @@ var (
 
 func getDefaultIstioTop() string {
 	// Assume it is run inside istio.io/istio
-	current, _ := os.Getwd()
+	current, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
 	idx := strings.Index(current, "/src/istio.io/istio")
 	if idx > 0 {
 		return current[0:idx]

--- a/pkg/test/framework/components/echo/native/util.go
+++ b/pkg/test/framework/components/echo/native/util.go
@@ -31,7 +31,9 @@ const (
 
 func randomBase64String(length int) string {
 	buff := make([]byte, length)
-	_, _ = rand.Read(buff)
+	if _, err := rand.Read(buff); err != nil {
+		panic(err)
+	}
 	str := base64.URLEncoding.EncodeToString(buff)
 	return str[:length]
 }
@@ -58,6 +60,9 @@ func pb2Json(pb proto.Message) string {
 	m := jsonpb.Marshaler{
 		Indent: "  ",
 	}
-	str, _ := m.MarshalToString(pb)
+	str, err := m.MarshalToString(pb)
+	if err != nil {
+		panic(err)
+	}
 	return str
 }


### PR DESCRIPTION
I ran a test which ended up crashing with nil dereference due to unhandled error. So fix some of many places we cheerfully ignore errors.