### PR TITLE
Have SD adapter use default app credentials if the provided credentials are non-existent

### DIFF
--- a/mixer/adapter/stackdriver/contextgraph/contextgraph_test.go
+++ b/mixer/adapter/stackdriver/contextgraph/contextgraph_test.go
@@ -102,6 +102,7 @@ func TestBuild(t *testing.T) {
 		projectID: "myid",
 		zone:      "myzone",
 		cluster:   "mycluster",
+		cfg:       &config.Params{ProjectId: "myid"},
 	}
 
 	mEnv := env.NewEnv(t)

--- a/mixer/adapter/stackdriver/helper/common.go
+++ b/mixer/adapter/stackdriver/helper/common.go
@@ -96,7 +96,7 @@ func ToOpts(cfg *config.Params) (opts []gapiopts.ClientOption) {
 	switch cfg.Creds.(type) {
 	case *config.Params_ApiKey:
 		if key := cfg.GetApiKey(); key != "" {
-			opts = append(opts, gapiopts.WithAPIKey(cfg.GetApiKey()))
+			opts = append(opts, gapiopts.WithAPIKey(key))
 		}
 	case *config.Params_ServiceAccountPath:
 		path := cfg.GetServiceAccountPath()

--- a/mixer/adapter/stackdriver/helper/common.go
+++ b/mixer/adapter/stackdriver/helper/common.go
@@ -15,6 +15,8 @@
 package helper
 
 import (
+	"os"
+
 	gapiopts "google.golang.org/api/option"
 
 	"istio.io/istio/mixer/adapter/stackdriver/config"
@@ -93,9 +95,14 @@ func (md *Metadata) FillProjectMetadata(in map[string]string) {
 func ToOpts(cfg *config.Params) (opts []gapiopts.ClientOption) {
 	switch cfg.Creds.(type) {
 	case *config.Params_ApiKey:
-		opts = append(opts, gapiopts.WithAPIKey(cfg.GetApiKey()))
+		if key := cfg.GetApiKey(); key != "" {
+			opts = append(opts, gapiopts.WithAPIKey(cfg.GetApiKey()))
+		}
 	case *config.Params_ServiceAccountPath:
-		opts = append(opts, gapiopts.WithCredentialsFile(cfg.GetServiceAccountPath()))
+		path := cfg.GetServiceAccountPath()
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			opts = append(opts, gapiopts.WithCredentialsFile(path))
+		}
 	case *config.Params_AppCredentials:
 		// When using default app credentials the SDK handles everything for us.
 	}

--- a/mixer/adapter/stackdriver/helper/common.go
+++ b/mixer/adapter/stackdriver/helper/common.go
@@ -95,11 +95,7 @@ func (md *Metadata) FillProjectMetadata(in map[string]string) {
 func ToOpts(cfg *config.Params, logger adapter.Logger) (opts []gapiopts.ClientOption) {
 	switch cfg.Creds.(type) {
 	case *config.Params_ApiKey:
-		if key := cfg.GetApiKey(); key != "" {
-			opts = append(opts, gapiopts.WithAPIKey(key))
-		} else {
-			logger.Warningf("received an empty API key, using Application Default Credentials instead")
-		}
+		opts = append(opts, gapiopts.WithAPIKey(cfg.GetApiKey()))
 	case *config.Params_ServiceAccountPath:
 		path := cfg.GetServiceAccountPath()
 		if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/mixer/adapter/stackdriver/helper/common.go
+++ b/mixer/adapter/stackdriver/helper/common.go
@@ -92,16 +92,20 @@ func (md *Metadata) FillProjectMetadata(in map[string]string) {
 }
 
 // ToOpts converts the Stackdriver config params to options for configuring Stackdriver clients.
-func ToOpts(cfg *config.Params) (opts []gapiopts.ClientOption) {
+func ToOpts(cfg *config.Params, logger adapter.Logger) (opts []gapiopts.ClientOption) {
 	switch cfg.Creds.(type) {
 	case *config.Params_ApiKey:
 		if key := cfg.GetApiKey(); key != "" {
 			opts = append(opts, gapiopts.WithAPIKey(key))
+		} else {
+			logger.Warningf("received an empty API key, using Application Default Credentials instead")
 		}
 	case *config.Params_ServiceAccountPath:
 		path := cfg.GetServiceAccountPath()
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			opts = append(opts, gapiopts.WithCredentialsFile(path))
+		} else {
+			logger.Warningf("could not find %v, using Application Default Credentials instead", path)
 		}
 	case *config.Params_AppCredentials:
 		// When using default app credentials the SDK handles everything for us.

--- a/mixer/adapter/stackdriver/helper/common_test.go
+++ b/mixer/adapter/stackdriver/helper/common_test.go
@@ -41,8 +41,7 @@ func TestToOpts(t *testing.T) {
 		out  []gapiopts.ClientOption // we only assert that the types match, so contents of the option don't matter
 	}{
 		{"empty", &config.Params{}, []gapiopts.ClientOption{}},
-		{"api key", &config.Params{Creds: &config.Params_ApiKey{ApiKey: "test-api-key"}}, []gapiopts.ClientOption{gapiopts.WithAPIKey("test-api-key")}},
-		{"api key empty", &config.Params{Creds: &config.Params_ApiKey{}}, []gapiopts.ClientOption{}},
+		{"api key", &config.Params{Creds: &config.Params_ApiKey{}}, []gapiopts.ClientOption{gapiopts.WithAPIKey("")}},
 		{"app creds", &config.Params{Creds: &config.Params_AppCredentials{}}, []gapiopts.ClientOption{}},
 		{"service account",
 			&config.Params{Creds: &config.Params_ServiceAccountPath{ServiceAccountPath: svcAcctFilePath}},

--- a/mixer/adapter/stackdriver/helper/common_test.go
+++ b/mixer/adapter/stackdriver/helper/common_test.go
@@ -25,6 +25,7 @@ import (
 	gapiopts "google.golang.org/api/option"
 
 	"istio.io/istio/mixer/adapter/stackdriver/config"
+	testenv "istio.io/istio/mixer/pkg/adapter/test"
 )
 
 func TestToOpts(t *testing.T) {
@@ -46,6 +47,9 @@ func TestToOpts(t *testing.T) {
 		{"service account",
 			&config.Params{Creds: &config.Params_ServiceAccountPath{ServiceAccountPath: svcAcctFilePath}},
 			[]gapiopts.ClientOption{gapiopts.WithCredentialsFile(svcAcctFilePath)}},
+		{"service account file not found",
+			&config.Params{Creds: &config.Params_ServiceAccountPath{ServiceAccountPath: "/some/non/existent/path"}},
+			[]gapiopts.ClientOption{}},
 		{"service account empty",
 			&config.Params{Creds: &config.Params_ServiceAccountPath{}},
 			[]gapiopts.ClientOption{}},
@@ -58,7 +62,7 @@ func TestToOpts(t *testing.T) {
 	}
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			opts := ToOpts(tt.cfg)
+			opts := ToOpts(tt.cfg, testenv.NewEnv(t).Logger())
 			if len(opts) != len(tt.out) {
 				t.Errorf("len(toOpts(%v)) = %d, expected %d", tt.cfg, len(opts), len(tt.out))
 			}

--- a/mixer/adapter/stackdriver/log/log.go
+++ b/mixer/adapter/stackdriver/log/log.go
@@ -102,7 +102,7 @@ func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, 
 		// Try to fill project id with Metadata if it is not provided.
 		cfg.ProjectId = md.ProjectID
 	}
-	client, err := b.makeClient(context.Background(), cfg.ProjectId, helper.ToOpts(cfg)...)
+	client, err := b.makeClient(context.Background(), cfg.ProjectId, helper.ToOpts(cfg, env.Logger())...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create stackdriver logging client: %v", err)
 	}
@@ -110,7 +110,7 @@ func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, 
 		_ = logger.Errorf("Stackdriver logger failed with: %v", err)
 	}
 
-	syncClient, err := b.makeSyncClient(context.Background(), cfg.ProjectId, helper.ToOpts(cfg)...)
+	syncClient, err := b.makeSyncClient(context.Background(), cfg.ProjectId, helper.ToOpts(cfg, env.Logger())...)
 	if err != nil {
 		_ = logger.Errorf("failed to create stackdriver sink logging client: %v", err)
 		syncClient = nil

--- a/mixer/adapter/stackdriver/metric/metric_test.go
+++ b/mixer/adapter/stackdriver/metric/metric_test.go
@@ -32,6 +32,7 @@ import (
 	descriptor "istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/adapter/stackdriver/config"
 	"istio.io/istio/mixer/adapter/stackdriver/helper"
+	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/adapter/test"
 	metrict "istio.io/istio/mixer/template/metric"
 )
@@ -47,7 +48,7 @@ func (f *fakebuf) Record(in []*monitoringpb.TimeSeries) {
 func (*fakebuf) Close() error { return nil }
 
 var clientFunc = func(err error) createClientFunc {
-	return func(cfg *config.Params) (*monitoring.MetricClient, error) {
+	return func(cfg *config.Params, logger adapter.Logger) (*monitoring.MetricClient, error) {
 		return nil, err
 	}
 }
@@ -411,7 +412,7 @@ func TestRecord(t *testing.T) {
 
 func TestProjectID(t *testing.T) {
 	createClientFn := func(pid string) createClientFunc {
-		return func(cfg *config.Params) (*monitoring.MetricClient, error) {
+		return func(cfg *config.Params, logger adapter.Logger) (*monitoring.MetricClient, error) {
 			if cfg.ProjectId != pid {
 				return nil, fmt.Errorf("wanted %v got %v", pid, cfg.ProjectId)
 			}

--- a/mixer/adapter/stackdriver/trace/exporter.go
+++ b/mixer/adapter/stackdriver/trace/exporter.go
@@ -38,8 +38,8 @@ var (
 
 func getStackdriverExporter(_ context.Context, env adapter.Env, params *config.Params) (trace.Exporter, error) {
 	opts := ocstackdriver.Options{
-		MonitoringClientOptions: helper.ToOpts(params), // not used, but causes errors if invalid
-		TraceClientOptions:      helper.ToOpts(params),
+		MonitoringClientOptions: helper.ToOpts(params, env.Logger()), // not used, but causes errors if invalid
+		TraceClientOptions:      helper.ToOpts(params, env.Logger()),
 		ProjectID:               params.ProjectId,
 		OnError: func(err error) {
 			_ = env.Logger().Errorf("Stackdriver trace: %s", err.Error())

--- a/mixer/adapter/stackdriver/trace/exporter_test.go
+++ b/mixer/adapter/stackdriver/trace/exporter_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"istio.io/istio/mixer/adapter/stackdriver/config"
-	"istio.io/istio/mixer/pkg/runtime/testing/data"
+	testenv "istio.io/istio/mixer/pkg/adapter/test"
 )
 
 func TestGetStackdriverExporter(t *testing.T) {
@@ -30,18 +30,14 @@ func TestGetStackdriverExporter(t *testing.T) {
 	params.Creds = &config.Params_ServiceAccountPath{
 		ServiceAccountPath: "testdata/serviceaccount.json",
 	}
-	_, err := getStackdriverExporter(ctx, &testEnv{}, &params)
+	_, err := getStackdriverExporter(ctx, testenv.NewEnv(t), &params)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to call getStackdriverExporter again with the same project ID: this should work.
-	_, err = getStackdriverExporter(ctx, &testEnv{}, &params)
+	_, err = getStackdriverExporter(ctx, testenv.NewEnv(t), &params)
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-type testEnv struct {
-	data.FakeEnv
 }


### PR DESCRIPTION
To avoid the SD adapter failing to call the SD API when the credential is not available.