### PR TITLE
Correct the nodeport for 80

### DIFF
--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -80,14 +80,14 @@ func getHTTPAddressInner(env *kube.Environment, ns string) (interface{}, bool, e
 			return nil, false, fmt.Errorf("no ports found in service: %s/%s", ns, "istio-ingressgateway")
 		}
 
-		var port int32 = 1
+		var nodePort int32
 		for _, svcPort := range svc.Spec.Ports {
 			if svcPort.Protocol == "TCP" && svcPort.Port == 80 {
-				port = svcPort.NodePort
+				nodePort = svcPort.NodePort
 				break
 			}
 		}
-		if nodePort == 1 {
+		if nodePort == 0 {
 			return nil, false, fmt.Errorf("no port 80 found in service: %s/%s", ns, "istio-ingressgateway")
 		}
 

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -80,11 +80,15 @@ func getHTTPAddressInner(env *kube.Environment, ns string) (interface{}, bool, e
 			return nil, false, fmt.Errorf("no ports found in service: %s/%s", ns, "istio-ingressgateway")
 		}
 
-		var nodePort int32
-		for _, port := range svc.Spec.Ports {
-			if port.Name == "http2" {
-				nodePort = port.NodePort
+		var port int32 = 1
+		for _, svcPort := range svc.Spec.Ports {
+			if svcPort.Protocol == "TCP" && svcPort.Port == 80 {
+				port = svcPort.NodePort
+				break
 			}
+		}
+		if nodePort == 1 {
+			return nil, false, fmt.Errorf("no port 80 found in service: %s/%s", ns, "istio-ingressgateway")
 		}
 
 		return fmt.Sprintf("http://%s:%d", ip, nodePort), true, nil


### PR DESCRIPTION
We have added the status-port as the first one of Ports for ingressgateway.
```
istio-ingressgateway   LoadBalancer   10.101.41.194   <pending>     15020:30620/TCP,80:31432/TCP,443:30782/TCP,15029:32277/TCP,15030:30281/TCP,15031:30842/TCP,15032:31532/TCP,15443:31002/TCP   125m
```

so `port := svc.Spec.Ports[0].NodePort` cannot get the right value.

Signed-off-by: clyang82 <clyang@cn.ibm.com>