### PR TITLE
Overwrite istio-system namespace

### DIFF
--- a/pkg/test/framework/components/galley/kube.go
+++ b/pkg/test/framework/components/galley/kube.go
@@ -184,6 +184,13 @@ func (c *kubeComponent) DeleteConfig(ns namespace.Instance, yamlText ...string) 
 	}
 
 	for _, txt := range yamlText {
+
+		if nsName != "" {
+			if txt, err = yml.ApplyNamespace(txt, nsName); err != nil {
+				return err
+			}
+		}
+
 		err := c.environment.Accessor.DeleteContents(nsName, txt)
 		if err != nil {
 			return err

--- a/samples/bookinfo/telemetry/log-entry.yaml
+++ b/samples/bookinfo/telemetry/log-entry.yaml
@@ -3,7 +3,6 @@ apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
   name: newlog
-  namespace: istio-system
 spec:
   compiledTemplate: logentry
   params:
@@ -23,7 +22,6 @@ apiVersion: config.istio.io/v1alpha2
 kind: handler
 metadata:
   name: newloghandler
-  namespace: istio-system
 spec:
   compiledAdapter: stdio
   params:
@@ -36,7 +34,6 @@ apiVersion: config.istio.io/v1alpha2
 kind: rule
 metadata:
   name: newlogstdio
-  namespace: istio-system
 spec:
   match: "true" # match for all requests
   actions:

--- a/samples/bookinfo/telemetry/log-entry.yaml
+++ b/samples/bookinfo/telemetry/log-entry.yaml
@@ -3,6 +3,7 @@ apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
   name: newlog
+  namespace: istio-system
 spec:
   compiledTemplate: logentry
   params:
@@ -22,6 +23,7 @@ apiVersion: config.istio.io/v1alpha2
 kind: handler
 metadata:
   name: newloghandler
+  namespace: istio-system
 spec:
   compiledAdapter: stdio
   params:
@@ -34,6 +36,7 @@ apiVersion: config.istio.io/v1alpha2
 kind: rule
 metadata:
   name: newlogstdio
+  namespace: istio-system
 spec:
   match: "true" # match for all requests
   actions:


### PR DESCRIPTION
It throws the following error when run the circle ci integration test
```
	asm_amd64.s:574: Galley.DeleteConfigOrFail: 1 error occurred:
			* exit status 1: the namespace from the provided object "istio-system" does not match the namespace "istio-control". You must pass '--namespace=istio-system' to perform this operation.
		the namespace from the provided object "istio-system" does not match the namespace "istio-control". You must pass '--namespace=istio-system' to perform this operation.
		the namespace from the provided object "istio-system" does not match the namespace "istio-control". You must pass '--namespace=istio-system' to perform this operation.

```

Signed-off-by: clyang82 <clyang@cn.ibm.com>