### PR TITLE
Use rsync instead of cp for gsutil 

### DIFF
--- a/release/gcb/run_monthly_release.sh
+++ b/release/gcb/run_monthly_release.sh
@@ -19,7 +19,7 @@ set -x
 gsutil -q rm -rf "gs://$CB_GCS_FULL_STAGING_PATH" || echo "Staging path does not exist."
 
 #copy files over to final destination
-gsutil -m cp -r "gs://$CB_GCS_BUILD_PATH" "gs://$CB_GCS_FULL_STAGING_PATH"
+gsutil -m rsync -d -r "gs://$CB_GCS_BUILD_PATH" "gs://$CB_GCS_FULL_STAGING_PATH"
 
 
 cd /workspace || exit 1


### PR DESCRIPTION
We encountered the problem with cp when the folder already created (even though it was deleted)
Looks like rsync might be better option for this.