### PR TITLE
Migrate codecov, racetest, shellcheck to prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,10 @@ lint: $(JUNIT_REPORT) buildcache
 	SKIP_INIT=1 bin/linters.sh \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_LINT_TEST_XML))
 
+
+shellcheck:
+	bin/check_shell_scripts.sh
+
 # @todo gometalinter targets?
 
 #-----------------------------------------------------------------------------

--- a/bin/codecov_diff.sh
+++ b/bin/codecov_diff.sh
@@ -70,6 +70,6 @@ if [[ -n "${CIRCLE_PR_NUMBER:-}" ]]; then
     | tee >(go-junit-report > "${GOPATH}"/out/tests/junit.xml)
 else
   # Upload to codecov.io in post submit only for visualization
-  bash <(curl -s https://codecov.io/bash) -f /go/out/codecov/pr/coverage.cov
+  bash <(curl -s https://codecov.io/bash) -f "${GOPATH}/out/codecov/pr/coverage.cov"
 fi
 

--- a/prow/codecov.sh
+++ b/prow/codecov.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
+# No unset vars, print commands as they're executed, and exit on any non-zero
+# return code
+set -u
+set -x
+set -e
+
+# shellcheck source=prow/lib.sh
+source "${ROOT}/prow/lib.sh"
+setup_and_export_git_sha
+
+cd "${ROOT}"
+
+make localTestEnv build
+MAXPROCS=6 bin/codecov_diff.sh

--- a/prow/racetest.sh
+++ b/prow/racetest.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
+# No unset vars, print commands as they're executed, and exit on any non-zero
+# return code
+set -u
+set -x
+set -e
+
+# shellcheck source=prow/lib.sh
+source "${ROOT}/prow/lib.sh"
+setup_and_export_git_sha
+
+cd "${ROOT}"
+
+mkdir -p /go/out/tests
+trap "go-junit-report </go/out/tests/build-log.txt > /go/out/tests/junit.xml" EXIT
+make localTestEnv
+set -o pipefail
+make -k pilot-racetest mixer-racetest security-racetest T=-v | tee -a /go/out/tests/build-log.txt

--- a/prow/shellcheck.sh
+++ b/prow/shellcheck.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
+# No unset vars, print commands as they're executed, and exit on any non-zero
+# return code
+set -u
+set -x
+set -e
+
+# shellcheck source=prow/lib.sh
+source "${ROOT}/prow/lib.sh"
+setup_and_export_git_sha
+
+cd "${ROOT}"
+
+make localTestEnv shellcheck


### PR DESCRIPTION
Steps:
* Merge this. Tests won't run here, but passed in #14993
* Merge https://github.com/istio/test-infra/pull/1356

wait

* Make prow required, circle optional
* Delete circle tests