### PR TITLE
Unify log format for SDS server and SDS cache manager

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -189,7 +189,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			con.mutex.Unlock()
 
 			conIDresourceNamePrefix := sdsLogPrefix(conID, resourceName)
-			if !s.skipToken && token == "" {
+			if !s.skipToken {
 				ctx = stream.Context()
 				t, err := getCredentialToken(ctx)
 				if err != nil {


### PR DESCRIPTION
Currently, the logs in sdsservice.go and secretcache.go are verbose, and not presented in the same format. Some logs only show proxy ID but do not show secret name, while others only show secret name but no proxy ID. Which makes it hard to trace a particular secret push and rotate.
1. Use a unified prefix for all the logs to trace the events in SDS server and cache manager. Make the log message shorter.
1. Add some debug logs for tracing secret rotation.
1. Move ingress gateway secret generator into a separate function.

An example of the log 
```
2019-06-19T19:29:29.979987Z	info	sdsServiceLog	CONNECTION ID: sidecar~10.60.5.8~a-v1-746c94f4b4-59tgm.sds-citadel-flow-1-86762~sds-citadel-flow-1-86762.svc.cluster.local-1, RESOURCE NAME: default, EVENT: pushed key/cert pair to proxy

2019-06-19T19:29:29.993967Z	info	sdsServiceLog	CONNECTION ID: sidecar~10.60.5.8~a-v1-746c94f4b4-59tgm.sds-citadel-flow-1-86762~sds-citadel-flow-1-86762.svc.cluster.local-3, RESOURCE NAME: ROOTCA, EVENT: pushed root cert to proxy

2019-06-19T19:29:29.993983Z	info	sdsServiceLog	CONNECTION ID: sidecar~10.60.5.8~a-v1-746c94f4b4-59tgm.sds-citadel-flow-1-86762~sds-citadel-flow-1-86762.svc.cluster.local-4, RESOURCE NAME: ROOTCA, EVENT: pushed root cert to proxy

2019-06-19T19:29:30.444567Z	info	sdsServiceLog	CONNECTION ID: sidecar~10.60.5.8~a-v1-746c94f4b4-59tgm.sds-citadel-flow-1-86762~sds-citadel-flow-1-86762.svc.cluster.local-2, RESOURCE NAME: default, EVENT: pushed key/cert pair to proxy

2019-06-19T19:29:31.009517Z	info	sdsServiceLog	CONNECTION ID: sidecar~10.60.5.9~b-v1-7755f486df-xh6f8.sds-citadel-flow-1-86762~sds-citadel-flow-1-86762.svc.cluster.local-6, RESOURCE NAME: ROOTCA, EVENT: pushed root cert to proxy

2019-06-19T19:29:31.012520Z	info	sdsServiceLog	CONNECTION ID: sidecar~10.60.5.9~b-v1-7755f486df-xh6f8.sds-citadel-flow-1-86762~sds-citadel-flow-1-86762.svc.cluster.local-8, RESOURCE NAME: ROOTCA, EVENT: pushed root cert to proxy

2019-06-19T19:29:31.167542Z	info	sdsServiceLog	CONNECTION ID: sidecar~10.60.5.9~b-v1-7755f486df-xh6f8.sds-citadel-flow-1-86762~sds-citadel-flow-1-86762.svc.cluster.local-5, RESOURCE NAME: default, EVENT: pushed key/cert pair to proxy

2019-06-19T19:29:31.421042Z	info	sdsServiceLog	CONNECTION ID: sidecar~10.60.5.9~b-v1-7755f486df-xh6f8.sds-citadel-flow-1-86762~sds-citadel-flow-1-86762.svc.cluster.local-7, RESOURCE NAME: default, EVENT: pushed key/cert pair to proxy

```

https://github.com/istio/istio/issues/14942
#13439