### PR TITLE
Better support for Go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,10 @@ security/cmd/node_agent/na/cert_file
 security/cmd/node_agent/na/pkey
 # Test artifacts
 tests/e2e/local/minikube/docker-machine-driver-hyperkit
+/istio_bin/
+/istio_out/
+# In case of symlinks
+/istio_bin
+/istio_out
 # istioctl bash completion file
 tools/istioctl.bash

--- a/.gitignore
+++ b/.gitignore
@@ -78,10 +78,5 @@ security/cmd/node_agent/na/cert_file
 security/cmd/node_agent/na/pkey
 # Test artifacts
 tests/e2e/local/minikube/docker-machine-driver-hyperkit
-/istio_bin/
-/istio_out/
-# In case of symlinks
-/istio_bin
-/istio_out
 # istioctl bash completion file
 tools/istioctl.bash

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -447,12 +448,8 @@ func loadProxyConfig(base, out string, _ *testing.T) (*meshconfig.ProxyConfig, e
 	}
 
 	// Exported from makefile or env
-	cfg.ConfigPath = out + "/bootstrap/" + base
-	gobase := os.Getenv("ISTIO_GO")
-	if gobase == "" {
-		gobase = "../.."
-	}
-	cfg.CustomConfigFile = gobase + "/tools/packaging/common/envoy_bootstrap_v2.json"
+	cfg.ConfigPath = filepath.Join(out, "bootstrap", base)
+	cfg.CustomConfigFile = filepath.Join(env.IstioSrc, "tools", "packaging", "common", "envoy_bootstrap_v2.json")
 	return cfg, nil
 }
 

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -258,7 +258,7 @@ func DeployBookinfo(t *testing.T, ctx framework.TestContext, g galley.Instance, 
 
 	// Backup the original bookinfo root.
 	originBookInfoRoot := env.BookInfoRoot
-	env.BookInfoRoot = path.Join(env.IstioRoot, "tests/integration/security/sds_ingress/")
+	env.BookInfoRoot = path.Join(env.IstioSrc, "tests/integration/security/sds_ingress/")
 	var gatewayPath, virtualSvcPath, destRulePath bookinfo.ConfigFile
 	switch gatewayType {
 	case SingleTLSGateway:


### PR DESCRIPTION
- GOPATH has no meaning with Go modules, but the code looks for a bunch of things there. Instead use current directory to find the root of the Istio repo (which we can assuming the code is run with go test).
- Remove some unused vars, since it wasn't obvious what they were supposed to mean with modules
- Fail hard on non-existent directories, debugging failures like <" " does not exist> is not a good use of someone's time
- When running outside GOPATH, use bin and out dirs within the repo so that multiple checkouts of Istio don't collide with each other
- Do not silence unexpected errors in CheckFileExists, a failure to stat a file does not mean it exists..

This does not make things just work (TM) yet, a module based checkout has to run make init and then symlink bin and out directories for new integration tests to succeed. We need to fix Makefile(s) separately for that, if nothing else.

In particular, when running integration tests (`go test ./tests/integration/...`), code looks for YAML files under $GOPATH/src/istio.io/istio (which may not exist, be broken or out of sync) and some binaries under $GOPATH/out (which seems to be Istio invention so shouldn't be there, and either way it's not per-module so chances of conflict arise if one has multiple Istio checkouts). This PR fixes the former, and partially the latter: it looks in local module directory for `bin` and `out` directories, but `out` needs to be initialized with Makefile (because Envoy binary and maybe something else), and the Makefile change is not here (Go code will read <module_root>/out/ but Makefile will write to $GOPATH/out/, symlinking can make the two kinda work together for now).