### PR TITLE
Allow same port numbers with different protocols for ServiceEntry validation

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -2355,17 +2355,21 @@ func ValidateServiceEntry(_, _ string, config proto.Message) (errs error) {
 		}
 	}
 
-	servicePortNumbers := make(map[uint32]bool)
+	servicePortNumbers := make(map[uint32]string)
 	servicePorts := make(map[string]bool, len(serviceEntry.Ports))
 	for _, port := range serviceEntry.Ports {
 		if servicePorts[port.Name] {
 			errs = appendErrors(errs, fmt.Errorf("service entry port name %q already defined", port.Name))
 		}
 		servicePorts[port.Name] = true
-		if servicePortNumbers[port.Number] {
-			errs = appendErrors(errs, fmt.Errorf("service entry port %d already defined", port.Number))
+
+		if protocol, ok := servicePortNumbers[port.Number]; ok {
+			if protocol == port.Protocol {
+				errs = appendErrors(errs, fmt.Errorf("service entry port number & protocol %d already defined", port.Number))
+			}
+		} else {
+			servicePortNumbers[port.Number] = port.Protocol
 		}
-		servicePortNumbers[port.Number] = true
 	}
 
 	switch serviceEntry.Resolution {

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -3335,6 +3335,15 @@ func TestValidateServiceEntries(t *testing.T) {
 			Resolution: networking.ServiceEntry_DNS,
 		},
 			valid: false},
+		{name: "same port numbers different protocols", in: networking.ServiceEntry{
+			Hosts: []string{"google.com"},
+			Ports: []*networking.Port{
+				{Number: 80, Protocol: "http", Name: "http-valid"},
+				{Number: 80, Protocol: "tcp", Name: "tcp-valid"},
+			},
+			Resolution: networking.ServiceEntry_DNS,
+		},
+			valid: true},
 
 		{name: "discovery type DNS, non-FQDN endpoint", in: networking.ServiceEntry{
 			Hosts: []string{"*.google.com"},


### PR DESCRIPTION
The current validation on ServiceEntries do not allow same port number with different protocols. This PR enables support for the following [case](https://github.com/istio/istio/blob/ba59f1ebd9f219d5532d58c1a9a68be7e9b56958/galley/testdata/conversion/dataset/networking.istio.io/v1alpha3/synthetic/serviceEntry.yaml#L982-L990).

```
apiVersion: v1
kind: Service
metadata:
spec:
  clusterIP: 1.1.1.1
  ports:
    - name: http-valid
      port: 80
      protocol: http
      targetPort: 80
    - name: tcp-valid
      port: 80
      protocol: tcp
      targetPort: 80
```