### PR TITLE
[Kiali]Allow auth strategy configuration in Helm chart

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   config.yaml: |
     istio_namespace: {{ .Release.Namespace }}
     auth:
-      strategy: "login"
+      strategy: {{ .Values.dashboard.auth.strategy }}
     server:
       port: 20001
 {{- if .Values.contextPath }}

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -45,6 +45,8 @@ ingress:
     #     - kiali.local
 
 dashboard:
+  auth:
+    strategy: login # Can be anonymous, login, or openshift
   secretName: kiali # You must create a secret with this name - one is not provided out-of-box.
   viewOnlyMode: false # Bind the service account to a role with only read access
   grafanaURL:  # If you have Grafana installed and it is accessible to client browsers, then set this to its external URL. Kiali will redirect users to this URL when Grafana metrics are to be shown.


### PR DESCRIPTION
This is a trivial patch to allow configuration of auth strategy in Kiali through the Helm chart values. Default behavior using 'login' strategy does not change.