### PR TITLE
support dry run in galley validation webhook

### DIFF
--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -187,6 +187,10 @@ func rebuildWebhookConfigHelper(
 		if webhookConfig.Webhooks[i].NamespaceSelector == nil {
 			webhookConfig.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{}
 		}
+		if webhookConfig.Webhooks[i].SideEffects == nil {
+			sideEffects := v1beta1.SideEffectClassNoneOnDryRun
+			webhookConfig.Webhooks[i].SideEffects = &sideEffects
+		}
 	}
 
 	// the webhook name is fixed at startup time

--- a/galley/pkg/crd/validation/config_test.go
+++ b/galley/pkg/crd/validation/config_test.go
@@ -36,6 +36,8 @@ import (
 var (
 	failurePolicyFailVal = admissionregistrationv1beta1.Fail
 	failurePolicyFail    = &failurePolicyFailVal
+	sideEffectsVal       = admissionregistrationv1beta1.SideEffectClassNoneOnDryRun
+	sideEffects          = &sideEffectsVal
 )
 
 func TestValidatingWebhookConfig(t *testing.T) {
@@ -85,6 +87,7 @@ func TestValidatingWebhookConfig(t *testing.T) {
 				},
 				FailurePolicy:     failurePolicyFail,
 				NamespaceSelector: &metav1.LabelSelector{},
+				SideEffects:       sideEffects,
 			},
 			{
 				Name: "hook-bar",
@@ -121,6 +124,7 @@ func TestValidatingWebhookConfig(t *testing.T) {
 				},
 				FailurePolicy:     failurePolicyFail,
 				NamespaceSelector: &metav1.LabelSelector{},
+				SideEffects:       sideEffects,
 			},
 		},
 	}
@@ -128,6 +132,7 @@ func TestValidatingWebhookConfig(t *testing.T) {
 	missingDefaults := want.DeepCopyObject().(*admissionregistrationv1beta1.ValidatingWebhookConfiguration)
 	missingDefaults.Webhooks[0].NamespaceSelector = nil
 	missingDefaults.Webhooks[0].FailurePolicy = nil
+	missingDefaults.Webhooks[0].SideEffects = nil
 
 	ts := []struct {
 		name    string

--- a/install/kubernetes/helm/istio/charts/galley/templates/validatingwebhookconfiguration.yaml.tpl
+++ b/install/kubernetes/helm/istio/charts/galley/templates/validatingwebhookconfiguration.yaml.tpl
@@ -64,7 +64,7 @@ webhooks:
         - sidecars
         - virtualservices
     failurePolicy: Fail
-    sideEffects: None
+    sideEffects: NoneOnDryRun
   - name: mixer.validation.istio.io
     clientConfig:
       service:
@@ -115,6 +115,6 @@ webhooks:
         - templates
         - zipkins
     failurePolicy: Fail
-    sideEffects: None
+    sideEffects: NoneOnDryRun
 {{- end }}
 {{- end }}


### PR DESCRIPTION
when run command: kubectl diff -f gateway.yaml
```
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: my-gateway
  namespace: some-config-namespace
spec:
  selector:
    app: my-gateway-controller
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - "ns2/foo.bar.com"
```
a error raised:
```
Error from server (BadRequest): admission webhook "pilot.validation.istio.io" does not support dry run
```
After [PR](https://github.com/kubernetes/kubernetes/pull/66936) merged, if sideEffects set Unknown in webhook pilot.validation.istio.io, the command will be blocked. Now we can  set default value 'NoneOnDryRun' to solve it.