### PR TITLE
fix the hard coded port for ingress.

### DIFF
--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -80,9 +80,14 @@ func getHTTPAddressInner(env *kube.Environment, ns string) (interface{}, bool, e
 			return nil, false, fmt.Errorf("no ports found in service: %s/%s", ns, "istio-ingressgateway")
 		}
 
-		port := svc.Spec.Ports[0].NodePort
+		var nodePort int32
+		for _, port := range svc.Spec.Ports {
+			if port.Name == "http2" {
+				nodePort = port.NodePort
+			}
+		}
 
-		return fmt.Sprintf("http://%s:%d", ip, port), true, nil
+		return fmt.Sprintf("http://%s:%d", ip, nodePort), true, nil
 	}
 
 	// Otherwise, get the load balancer IP.


### PR DESCRIPTION
The port list for ingressgateway has been changed since: https://github.com/istio/istio/pull/12668, resulting in wrong port in integration test(mainly for new installer), need to replace the hard code port with the correct one by port name.