### PR TITLE
Remove percentage output from EDS reporting

### DIFF
--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -99,8 +99,8 @@ func statusPrintln(w io.Writer, status *writerStatus) error {
 		// but it is better than not providing any information.
 		version = status.ProxyVersion + "*"
 	}
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v (%v%%)\t%v\t%v\t%v\n",
-		status.ProxyID, clusterSynced, listenerSynced, endpointSynced, status.EndpointPercent, routeSynced, status.pilot, version)
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+		status.ProxyID, clusterSynced, listenerSynced, endpointSynced, routeSynced, status.pilot, version)
 	return nil
 }
 

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
@@ -1,4 +1,4 @@
-NAME       CDS                            LDS          EDS                                 RDS          PILOT      VERSION
-proxy1     STALE (1h0m0s)                 SYNCED       SYNCED (100%)                       NOT SENT     pilot1     1.1
-proxy2     STALE (1h0m0s)                 SYNCED       STALE (1h0m0s) (0%)                 SYNCED       pilot2     1.1
-proxy3     STALE (Never Acknowledged)     NOT SENT     STALE (Never Acknowledged) (0%)     SYNCED       pilot3     1.1
+NAME       CDS                            LDS          EDS                            RDS          PILOT      VERSION
+proxy1     STALE (1h0m0s)                 SYNCED       SYNCED                         NOT SENT     pilot1     1.1
+proxy2     STALE (1h0m0s)                 SYNCED       STALE (1h0m0s)                 SYNCED       pilot2     1.1
+proxy3     STALE (Never Acknowledged)     NOT SENT     STALE (Never Acknowledged)     SYNCED       pilot3     1.1

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
@@ -1,3 +1,3 @@
-NAME       CDS                LDS        EDS                     RDS          PILOT      VERSION
-proxy1     STALE (1h0m0s)     SYNCED     SYNCED (100%)           NOT SENT     pilot1     1.1
-proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED       pilot1     1.1
+NAME       CDS                LDS        EDS                RDS          PILOT      VERSION
+proxy1     STALE (1h0m0s)     SYNCED     SYNCED             NOT SENT     pilot1     1.1
+proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s)     SYNCED       pilot1     1.1

--- a/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
@@ -1,2 +1,2 @@
-NAME       CDS                LDS        EDS                     RDS        PILOT      VERSION
-proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED     pilot2     1.1
+NAME       CDS                LDS        EDS                RDS        PILOT      VERSION
+proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s)     SYNCED     pilot2     1.1

--- a/istioctl/pkg/writer/pilot/testdata/singleStatusFallback.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatusFallback.txt
@@ -1,2 +1,2 @@
-NAME       CDS                LDS        EDS                     RDS        PILOT      VERSION
-proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED     pilot2     1.1*
+NAME       CDS                LDS        EDS                RDS        PILOT      VERSION
+proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s)     SYNCED     pilot2     1.1*


### PR DESCRIPTION
Mitigates https://github.com/istio/istio.io/issues/3853 by removing the inexplicable "(50%)" from output.

A follow-up will be needed to address the documentation in https://istio.io/docs/ops/traffic-management/proxy-cmd/