### PR TITLE
[WIP] Add support for the new install to test framework

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -89,6 +89,9 @@ var (
 
 	CrdsFilesDir = path.Join(ChartsDir, "istio-init/files")
 
+	// IstioAlphaInstallDir specifies the base directory for the alpha installer
+	IstioAlphaInstallDir = path.Join(GOPATH.ValueOrDefault(build.Default.GOPATH), "/src/istio.io/installer")
+
 	// BookInfoRoot is the root folder for the bookinfo samples
 	BookInfoRoot = path.Join(IstioRoot, "samples/bookinfo")
 

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -72,12 +72,38 @@ var (
 		IngressNamespace:   DefaultSystemNamespace,
 		EgressNamespace:    DefaultSystemNamespace,
 		DeployIstio:        true,
+		AlphaInstaller:     false,
 		DeployTimeout:      0,
 		UndeployTimeout:    0,
+		InstallComponents:  []InstallComponent{Base},
 		ChartDir:           env.IstioChartDir,
 		CrdsFilesDir:       env.CrdsFilesDir,
 		ValuesFile:         E2EValuesFile,
 	}
+)
+
+// InstallComponent represents a component, or set of components, to be installed
+// This is only used for the alpha installer
+type InstallComponent int
+
+const (
+	// Base will install citadel, galley, pilot, and autoinjector
+	Base InstallComponent = iota
+
+	// Ingress will install an ingressgateway
+	Ingress
+
+	// Ingress will install an egressgateway
+	Egress
+
+	// Telemetry will install Mixer policy
+	Telemetry
+
+	// Policy will install Mixer policy
+	Policy
+
+	// Tracing will install zipkins
+	Tracing
 )
 
 // Config provide kube-specific Config from flags.
@@ -105,6 +131,12 @@ type Config struct {
 
 	// Indicates that the test should deploy Istio into the target Kubernetes cluster before running tests.
 	DeployIstio bool
+
+	// Indicates that the test should deploy Istio using the alpha installer.
+	AlphaInstaller bool
+
+	// Indicates which components to install for the test. Use only if AlphaInstaller=true.
+	InstallComponents []InstallComponent
 
 	// DeployTimeout the timeout for deploying Istio.
 	DeployTimeout time.Duration
@@ -274,6 +306,7 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("IngressNamespace:   %s\n", c.IngressNamespace)
 	result += fmt.Sprintf("EgressNamespace:    %s\n", c.EgressNamespace)
 	result += fmt.Sprintf("DeployIstio:        %v\n", c.DeployIstio)
+	result += fmt.Sprintf("AlphaInstaller:     %v\n", c.AlphaInstaller)
 	result += fmt.Sprintf("DeployTimeout:      %s\n", c.DeployTimeout.String())
 	result += fmt.Sprintf("UndeployTimeout:    %s\n", c.UndeployTimeout.String())
 	result += fmt.Sprintf("Values:             %v\n", c.Values)

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -36,6 +36,8 @@ func init() {
 		"Specifies the namespace in which istio egressgateway is deployed.")
 	flag.BoolVar(&settingsFromCommandline.DeployIstio, "istio.test.kube.deploy", settingsFromCommandline.DeployIstio,
 		"Deploy Istio into the target Kubernetes environment.")
+	flag.BoolVar(&settingsFromCommandline.AlphaInstaller, "istio.test.kube.deploy.alpha", settingsFromCommandline.AlphaInstaller,
+		"Deploy Istio into the target Kubernetes environment using the alpha installer.")
 	flag.DurationVar(&settingsFromCommandline.DeployTimeout, "istio.test.kube.deployTimeout", 0,
 		"Timeout applied to deploying Istio into the target Kubernetes environment. Only applies if DeployIstio=true.")
 	flag.DurationVar(&settingsFromCommandline.UndeployTimeout, "istio.test.kube.undeployTimeout", 0,

--- a/pkg/test/framework/components/istio/kubealpha.go
+++ b/pkg/test/framework/components/istio/kubealpha.go
@@ -1,0 +1,220 @@
+package istio
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"sync"
+
+	"istio.io/istio/pkg/test/deployment"
+	ienv "istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/scopes"
+)
+
+func getNamespaces(cfg Config) []string {
+	allNamespace := []string{}
+	for _, c := range cfg.InstallComponents {
+		switch c {
+		case Base:
+			allNamespace = append(allNamespace, cfg.IstioNamespace, cfg.ConfigNamespace)
+		case Ingress:
+			allNamespace = append(allNamespace, cfg.IngressNamespace)
+		case Egress:
+			allNamespace = append(allNamespace, cfg.EgressNamespace)
+		case Telemetry:
+			allNamespace = append(allNamespace, cfg.TelemetryNamespace)
+		case Policy:
+			allNamespace = append(allNamespace, cfg.PolicyNamespace)
+		}
+	}
+	return allNamespace
+}
+
+type installerComponent struct {
+	id          resource.ID
+	settings    Config
+	ctx         resource.Context
+	environment *kube.Environment
+	deployment  *deployment.Instance
+}
+
+var _ io.Closer = &installerComponent{}
+var _ Instance = &installerComponent{}
+var _ resource.Dumper = &installerComponent{}
+
+// ID implements resource.Instance
+func (i *installerComponent) ID() resource.ID {
+	return i.id
+}
+
+func (i *installerComponent) Settings() Config {
+	return i.settings
+}
+
+func (i *installerComponent) Close() error {
+
+	if !i.settings.DeployIstio {
+		return nil
+	}
+	wg := &sync.WaitGroup{}
+	for _, ns := range getNamespaces(i.settings) {
+		ns := ns
+		wg.Add(1)
+		go func() {
+			err := i.environment.Accessor.DeleteNamespace(ns)
+			if err == nil {
+				err = i.environment.Accessor.WaitForNamespaceDeletion(ns)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	return nil
+}
+
+func (i *installerComponent) Dump() {
+	scopes.CI.Errorf("=== Dumping Istio Deployment State...")
+
+	d, err := i.ctx.CreateTmpDirectory("istio-state")
+	if err != nil {
+		scopes.CI.Errorf("Unable to create directory for dumping Istio contents: %v", err)
+		return
+	}
+	for _, ns := range getNamespaces(i.settings) {
+		deployment.DumpPodState(d, ns, i.environment.Accessor)
+		deployment.DumpPodEvents(d, ns, i.environment.Accessor)
+
+		pods, err := i.environment.Accessor.GetPods(ns)
+		if err != nil {
+			scopes.CI.Errorf("Unable to get pods from the system namespace: %v", err)
+			return
+		}
+
+		for _, pod := range pods {
+			for _, container := range pod.Spec.Containers {
+				l, err := i.environment.Logs(pod.Namespace, pod.Name, container.Name, false /* previousLog */)
+				if err != nil {
+					scopes.CI.Errorf("Unable to get logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
+					continue
+				}
+
+				fname := path.Join(d, fmt.Sprintf("%s-%s.log", pod.Name, container.Name))
+				if err = ioutil.WriteFile(fname, []byte(l), os.ModePerm); err != nil {
+					scopes.CI.Errorf("Unable to write logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
+				}
+			}
+		}
+	}
+}
+
+func deployAlphaInstall(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, error) {
+	scopes.CI.Infof("=== Istio Component Config ===")
+	scopes.CI.Infof("\n%s", cfg.String())
+	scopes.CI.Infof("================================")
+
+	i := &installerComponent{
+		environment: env,
+		settings:    cfg,
+		ctx:         ctx,
+	}
+	i.id = ctx.TrackResource(i)
+
+	if !cfg.DeployIstio {
+		scopes.Framework.Info("skipping deployment due to Config")
+		return i, nil
+	}
+
+	// Top-level work dir for Istio deployment.
+	workDir, err := ctx.CreateTmpDirectory("istio-deployment")
+	if err != nil {
+		return nil, err
+	}
+
+	// Create helm working dir
+	helmWorkDir := path.Join(workDir, "helm")
+	if err := os.MkdirAll(helmWorkDir, os.ModePerm); err != nil {
+		return nil, err
+	}
+
+	// First, generate CRDs.
+	crdYaml, err := generateCRDYaml(path.Join(ienv.IstioAlphaInstallDir, "crds/files"))
+	if err != nil {
+		return nil, err
+	}
+
+	scopes.CI.Infof("Applying CRDs: %v", workDir)
+
+	// Apply CRDs first.
+	if _, err = env.Accessor.ApplyContents("", crdYaml); err != nil {
+		return nil, err
+	}
+
+	// Restructure components for easier lookup
+	components := map[InstallComponent]struct{}{}
+	for _, c := range cfg.InstallComponents {
+		components[c] = struct{}{}
+	}
+
+	if _, f := components[Base]; f {
+		// Generate rendered yaml file for Istio, including namespace.
+		if err := applyAlphaInstall(env.Accessor, helmWorkDir, cfg.IstioNamespace, "security/citadel", cfg); err != nil {
+			return nil, err
+		}
+
+		if err := applyAlphaInstall(env.Accessor, helmWorkDir, cfg.ConfigNamespace, "istio-control/istio-config", cfg); err != nil {
+			return nil, err
+		}
+
+		// Wait for Galley & the validation webhook to come online before applying Istio configurations.
+		if _, _, err = env.WaitUntilServiceEndpointsAreReady(cfg.ConfigNamespace, "istio-galley"); err != nil {
+			err = fmt.Errorf("error waiting %s/istio-galley service endpoints: %v", cfg.SystemNamespace, err)
+			scopes.CI.Info(err.Error())
+			return nil, err
+		}
+
+		// Wait for webhook to come online. The only reliable way to do that is to see if we can submit invalid config.
+		err = waitForValidationWebhook(env.Accessor)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := applyAlphaInstall(env.Accessor, helmWorkDir, cfg.ConfigNamespace, "istio-control/istio-discovery", cfg); err != nil {
+			return nil, err
+		}
+		if err := applyAlphaInstall(env.Accessor, helmWorkDir, cfg.ConfigNamespace, "istio-control/istio-autoinject", cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, f := components[Ingress]; f {
+		if err := applyAlphaInstall(env.Accessor, helmWorkDir, cfg.IngressNamespace, "gateways/istio-ingress", cfg); err != nil {
+			return nil, err
+		}
+	}
+	if _, f := components[Egress]; f {
+		if err := applyAlphaInstall(env.Accessor, helmWorkDir, cfg.IngressNamespace, "gateways/istio-egress", cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, f := components[Telemetry]; f {
+		if err := applyAlphaInstall(env.Accessor, helmWorkDir, cfg.TelemetryNamespace, "istio-telemetry/prometheus", cfg); err != nil {
+			return nil, err
+		}
+		if err := applyAlphaInstall(env.Accessor, helmWorkDir, cfg.TelemetryNamespace, "istio-telemetry/mixer-telemetry", cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, f := components[Policy]; f {
+		if err := applyAlphaInstall(env.Accessor, helmWorkDir, cfg.PolicyNamespace, "istio-policy", cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	return i, nil
+}

--- a/pkg/test/helm/helm.go
+++ b/pkg/test/helm/helm.go
@@ -38,9 +38,9 @@ func Init(homeDir string, clientOnly bool) error {
 	return err
 }
 
-func Template(homeDir, template, name, namespace string, valuesFile string, values map[string]string) (string, error) {
+func Template(homeDir, template, name, namespace string, valuesFiles []string, values map[string]string) (string, error) {
 	p := []string{"helm", "--home", homeDir, "template", template, "--name", name, "--namespace", namespace}
-	if valuesFile != "" {
+	for _, valuesFile := range valuesFiles {
 		p = append(p, "--values", valuesFile)
 	}
 

--- a/tests/integration/istioctl/istioctl_test.go
+++ b/tests/integration/istioctl/istioctl_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 		RequireEnvironment(environment.Kube).
 
 		// Deploy Istio
-		SetupOnEnv(environment.Kube, istio.Setup(&i, nil)).
+		SetupOnEnv(environment.Kube, istio.Setup(&i, nil, istio.Ingress, istio.Egress, istio.Telemetry, istio.Policy)).
 		SetupOnEnv(environment.Kube, func(ctx resource.Context) error {
 			env = ctx.Environment().(*kube.Environment)
 			return nil

--- a/tests/integration/mixer/main_test.go
+++ b/tests/integration/mixer/main_test.go
@@ -28,6 +28,6 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.NewSuite("mixer_test", m).
-		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil, istio.Telemetry, istio.Policy)).
 		Run()
 }

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -289,13 +289,13 @@ func setupConfigOrFail(t *testing.T, config bookinfo.ConfigFile, bookInfoNameSpa
 	con = strings.Replace(con, "namespace: default",
 		"namespace: "+bookInfoNameSpaceStr, -1)
 
-	ns := namespace.ClaimOrFail(t, ctx, ist.Settings().SystemNamespace)
+	ns := namespace.ClaimOrFail(t, ctx, ist.Settings().PolicyNamespace)
 	g.ApplyConfigOrFail(t, ns, con)
 	return con
 }
 
 func deleteConfigOrFail(t *testing.T, config string, g galley.Instance, ctx resource.Context) {
-	ns := namespace.ClaimOrFail(t, ctx, ist.Settings().SystemNamespace)
+	ns := namespace.ClaimOrFail(t, ctx, ist.Settings().PolicyNamespace)
 	g.DeleteConfigOrFail(t, ns, config)
 }
 
@@ -303,7 +303,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("mixer_policy_ratelimit", m).
 		RequireEnvironment(environment.Kube).
-		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil, istio.Telemetry, istio.Policy)).
 		Setup(testsetup).
 		Run()
 }

--- a/tests/integration/mixer/telemetry/logs/accesslog_test.go
+++ b/tests/integration/mixer/telemetry/logs/accesslog_test.go
@@ -72,7 +72,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("mixer_telemetry_logs", m).
 		RequireEnvironment(environment.Kube).
-		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil, istio.Telemetry, istio.Policy)).
 		Setup(testsetup).
 		Run()
 }

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -195,6 +195,6 @@ func TestTcpMetric(t *testing.T) {
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite("mixer_telemetry_metrics", m).
-		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil, istio.Telemetry, istio.Policy)).
 		Run()
 }

--- a/tests/integration/pilot/outboundtrafficpolicy/allowany/traffic_allow_any_test.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/allowany/traffic_allow_any_test.go
@@ -38,6 +38,7 @@ func setupConfig(cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}
+
 	cfg.Values["global.outboundTrafficPolicy.mode"] = "ALLOW_ANY"
 	cfg.Values["pilot.env.PILOT_ENABLE_FALLTHROUGH_ROUTE"] = "true"
 }

--- a/tests/integration/qualification/main_test.go
+++ b/tests/integration/qualification/main_test.go
@@ -29,6 +29,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite("qualification", m).
-		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil, istio.Ingress, istio.Telemetry)).
 		Run()
 }

--- a/tests/integration/telemetry/tracing/tracing_test.go
+++ b/tests/integration/telemetry/tracing/tracing_test.go
@@ -78,7 +78,7 @@ func TestProxyTracing(t *testing.T) {
 func TestMain(m *testing.M) {
 	framework.NewSuite("tracing_test", m).
 		RequireEnvironment(environment.Kube).
-		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig, istio.Tracing)).
 		Setup(testSetup).
 		Run()
 }


### PR DESCRIPTION
This is passing all tests (with some modifications to the installer that
need to be merged), other than Mixer (still debugging) and Istioctl
(because istioctl doesn't support the split namespace for its version
command.

TODO:
* Get fixes to installer merged
* Get CI working - need both the actual job to run it and a way to handle the dependency on the installer yamls
* Get mixer tests working 
* Find a better name than `AlphaInstaller`?