### PR TITLE
Do not overwrite Citadel storage namespace with env var

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -274,6 +274,8 @@ var (
 )
 
 func runCA() {
+	verifyCommandLineOptions()
+
 	if err := log.Configure(opts.loggingOptions); err != nil {
 		fatalf("Failed to configure logging (%v)", err)
 	}
@@ -285,13 +287,9 @@ func runCA() {
 		if opts.listenedNamespaces == "" {
 			opts.listenedNamespaces = value
 		}
-		// Use environment variable for istioCaStorageNamespace if it exists
-		opts.istioCaStorageNamespace = value
 	}
 
 	listenedNamespaces := strings.Split(opts.listenedNamespaces, ",")
-
-	verifyCommandLineOptions()
 
 	var webhooks map[string]*controller.DNSNameEntry
 	if opts.appendDNSNames {

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -65,7 +65,7 @@ const (
 
 // DNSNameEntry stores the service name and namespace to construct the DNS id.
 // Service accounts matching the ServiceName and Namespace will have additional DNS SANs:
-// ServiceName.Namespace.svc, ServiceName.Namespace and optionall CustomDomain.
+// ServiceName.Namespace.svc, ServiceName.Namespace and optional CustomDomain.
 // This is intended for control plane and trusted services.
 type DNSNameEntry struct {
 	// ServiceName is the name of the service account to match


### PR DESCRIPTION
https://istio.io/docs/reference/commands/istio_ca/.
The `NAMESPACE` env var is used for listened namespaces and overwrites Citadel storage namespace (istio-system), which is not what we wanted, since NAMESPACE is a list of namespaces. Plus, we did not document this overwriting feature in Citadel storage namespace, which can cause problems. 
