### PR TITLE
Remove specific nodePort mappings for ingress gateway

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -61,14 +61,11 @@ istio-ingressgateway:
   - port: 80
     targetPort: 80
     name: http2
-    nodePort: 31380
   - port: 443
     name: https
-    nodePort: 31390
   # Example of a port to add. Remove if not needed
   - port: 31400
     name: tcp
-    nodePort: 31400
   ### PORTS FOR UI/metrics #####
   ## Disable if not needed
   - port: 15029


### PR DESCRIPTION
This should fix https://github.com/istio/istio/issues/14190. We get occasional nodeport conflicts against these hard-coded port values, but (as far as I have been able to determine) there is no need for these values to be hardcoded in the first place. The external port values remain the same, just the internal port used is now automatically chosen from what's available. 