### PR TITLE
[collab-galley] Add pkg/config/meshcfg 

### DIFF
--- a/galley/pkg/config/meshcfg/const.go
+++ b/galley/pkg/config/meshcfg/const.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meshcfg
+
+import (
+	"istio.io/istio/galley/pkg/config/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+)
+
+// IstioMeshconfig is the name of collection istio/meshconfig
+// It is captured here explicitly, as some of the core pieces of code need to reference this.
+var IstioMeshconfig = collection.NewName("istio/mesh/v1alpha1/MeshConfig")
+
+// ResourceName for the Istio Mesh Config resource
+var ResourceName = resource.NewName("istio-system", "meshconfig")

--- a/galley/pkg/config/meshcfg/defaults.go
+++ b/galley/pkg/config/meshcfg/defaults.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meshcfg
+
+import (
+	"time"
+
+	"github.com/gogo/protobuf/types"
+
+	"istio.io/api/mesh/v1alpha1"
+)
+
+// Default mesh configuration
+func Default() *v1alpha1.MeshConfig {
+	return &v1alpha1.MeshConfig{
+		MixerCheckServer:      "",
+		MixerReportServer:     "",
+		DisablePolicyChecks:   false,
+		PolicyCheckFailOpen:   false,
+		ProxyListenPort:       15001,
+		ConnectTimeout:        types.DurationProto(1 * time.Second),
+		IngressClass:          "istio",
+		IngressControllerMode: v1alpha1.MeshConfig_STRICT,
+		EnableTracing:         true,
+		AccessLogFile:         "/dev/stdout",
+		SdsUdsPath:            "",
+		OutboundTrafficPolicy: &v1alpha1.MeshConfig_OutboundTrafficPolicy{Mode: v1alpha1.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY},
+	}
+}

--- a/galley/pkg/config/meshcfg/defaults_test.go
+++ b/galley/pkg/config/meshcfg/defaults_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meshcfg
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/api/mesh/v1alpha1"
+)
+
+func TestDefaults(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	m := Default()
+
+	// A couple of point-wise checks.
+	g.Expect(m.IngressClass).To(Equal("istio"))
+	g.Expect(m.IngressControllerMode).To(Equal(v1alpha1.MeshConfig_STRICT))
+}

--- a/galley/pkg/config/meshcfg/fs.go
+++ b/galley/pkg/config/meshcfg/fs.go
@@ -1,0 +1,115 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meshcfg
+
+import (
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+	"github.com/gogo/protobuf/jsonpb"
+
+	"istio.io/pkg/filewatcher"
+
+	"istio.io/istio/galley/pkg/config/event"
+)
+
+// For overriding in tests
+var yamlToJSON = yaml.YAMLToJSON
+
+// FsSource is a event.InMemorySource implementation that reads mesh from file.
+type FsSource struct {
+	path string
+	fw   filewatcher.FileWatcher
+
+	inmemory *InMemorySource
+}
+
+var _ event.Source = &FsSource{}
+
+// NewFS returns a new mesh cache, based on watching a file.
+func NewFS(path string) (*FsSource, error) {
+	fw := filewatcher.NewWatcher()
+
+	err := fw.Add(path)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &FsSource{
+		path:     path,
+		fw:       fw,
+		inmemory: NewInmemory(),
+	}
+
+	c.reload()
+	// If we were not able to load mesh config, start with the default.
+	if !c.inmemory.IsSynced() {
+		scope.Infof("Unable to load up mesh config, using default...")
+		c.inmemory.Set(Default())
+	}
+
+	go func() {
+		for range fw.Events(path) {
+			c.reload()
+		}
+	}()
+
+	return c, nil
+}
+
+// Start implements event.Source
+func (c *FsSource) Start() {
+	c.inmemory.Start()
+}
+
+// Stop implements event.Source
+func (c *FsSource) Stop() {
+	scope.Debugf("meshcfg.FsSource.Stop >>>")
+	c.inmemory.Stop()
+	scope.Debugf("meshcfg.FsSource.Stop <<<")
+}
+
+// Dispatch implements event.Source
+func (c *FsSource) Dispatch(h event.Handler) {
+	c.inmemory.Dispatch(h)
+}
+
+func (c *FsSource) reload() {
+	by, err := ioutil.ReadFile(c.path)
+	if err != nil {
+		scope.Errorf("Error loading mesh config (path: %s): %v", c.path, err)
+		return
+	}
+
+	js, err := yamlToJSON(by)
+	if err != nil {
+		scope.Errorf("Error converting mesh config Yaml to JSON: %v", err)
+		return
+	}
+
+	cfg := Default()
+	if err = jsonpb.UnmarshalString(string(js), cfg); err != nil {
+		scope.Errorf("Error reading mesh config as json: %v", err)
+		return
+	}
+
+	c.inmemory.Set(cfg)
+	scope.Infof("Reloaded mesh config: \n%s\n", string(by))
+}
+
+// Close closes this cache.
+func (c *FsSource) Close() error {
+	return c.fw.Close()
+}

--- a/galley/pkg/config/meshcfg/fs_test.go
+++ b/galley/pkg/config/meshcfg/fs_test.go
@@ -1,0 +1,407 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meshcfg
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/jsonpb"
+	. "github.com/onsi/gomega"
+
+	"istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/testing/fixtures"
+)
+
+func TestFsSource_NoInitialFile(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	file := setupDir(t, nil)
+
+	fs, err := NewFS(file)
+	g.Expect(err).To(BeNil())
+	defer func() {
+		err = fs.Close()
+		g.Expect(err).To(BeNil())
+	}()
+	acc := &fixtures.Accumulator{}
+	fs.Dispatch(acc)
+
+	fs.Start()
+
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: resource.NewName("istio-system", "meshconfig"),
+				},
+				Item: Default(),
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+}
+
+func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	file := setupDir(t, nil)
+
+	fs, err := NewFS(file)
+	g.Expect(err).To(BeNil())
+	defer func() {
+		err = fs.Close()
+		g.Expect(err).To(BeNil())
+	}()
+	acc := &fixtures.Accumulator{}
+	fs.Dispatch(acc)
+
+	fs.Start()
+
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: resource.NewName("istio-system", "meshconfig"),
+				},
+				Item: Default(),
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+
+	acc.Clear()
+	mcfg := Default()
+	mcfg.IngressClass = "foo"
+	writeMeshCfg(t, file, mcfg)
+
+	expected = []event.Event{
+		{
+			Kind:   event.Reset,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+}
+
+func TestFsSource_InitialFile_UpdateAfterStart(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	mcfg := Default()
+	mcfg.IngressClass = "foo"
+	file := setupDir(t, mcfg)
+
+	fs, err := NewFS(file)
+	g.Expect(err).To(BeNil())
+	defer func() {
+		err = fs.Close()
+		g.Expect(err).To(BeNil())
+	}()
+	acc := &fixtures.Accumulator{}
+	fs.Dispatch(acc)
+
+	fs.Start()
+
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: resource.NewName("istio-system", "meshconfig"),
+				},
+				Item: mcfg,
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+
+	acc.Clear()
+	mcfg2 := Default()
+	mcfg2.IngressClass = "bar"
+	writeMeshCfg(t, file, mcfg2)
+
+	expected = []event.Event{
+		{
+			Kind:   event.Reset,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+}
+
+func TestFsSource_InitialFile(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	mcfg := Default()
+	mcfg.IngressClass = "foo"
+	file := setupDir(t, mcfg)
+
+	fs, err := NewFS(file)
+	g.Expect(err).To(BeNil())
+	defer func() {
+		err = fs.Close()
+		g.Expect(err).To(BeNil())
+	}()
+	acc := &fixtures.Accumulator{}
+	fs.Dispatch(acc)
+
+	fs.Start()
+
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: resource.NewName("istio-system", "meshconfig"),
+				},
+				Item: mcfg,
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+}
+
+func TestFsSource_StartStopStart(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	mcfg := Default()
+	mcfg.IngressClass = "foo"
+	file := setupDir(t, mcfg)
+
+	fs, err := NewFS(file)
+	g.Expect(err).To(BeNil())
+	defer func() {
+		err = fs.Close()
+		g.Expect(err).To(BeNil())
+	}()
+	acc := &fixtures.Accumulator{}
+	fs.Dispatch(acc)
+
+	fs.Start()
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: resource.NewName("istio-system", "meshconfig"),
+				},
+				Item: mcfg,
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+
+	acc.Clear()
+	fs.Stop()
+	g.Consistently(acc.Events()).Should(HaveLen(0))
+
+	fs.Start()
+	g.Eventually(acc.Events).Should(Equal(expected))
+}
+
+func TestFsSource_FileRemoved_NoChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	mcfg := Default()
+	mcfg.IngressClass = "foo"
+	file := setupDir(t, mcfg)
+
+	fs, err := NewFS(file)
+	g.Expect(err).To(BeNil())
+	defer func() {
+		err = fs.Close()
+		g.Expect(err).To(BeNil())
+	}()
+	acc := &fixtures.Accumulator{}
+	fs.Dispatch(acc)
+
+	fs.Start()
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: resource.NewName("istio-system", "meshconfig"),
+				},
+				Item: mcfg,
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+	acc.Clear()
+
+	err = os.Remove(file)
+	g.Expect(err).To(BeNil())
+	time.Sleep(time.Millisecond * 100)
+	g.Consistently(acc.Events()).Should(HaveLen(0))
+}
+
+func TestFsSource_BogusFile_NoChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	mcfg := Default()
+	mcfg.IngressClass = "foo"
+	file := setupDir(t, mcfg)
+
+	fs, err := NewFS(file)
+	g.Expect(err).To(BeNil())
+	defer func() {
+		err = fs.Close()
+		g.Expect(err).To(BeNil())
+	}()
+	acc := &fixtures.Accumulator{}
+	fs.Dispatch(acc)
+
+	fs.Start()
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: resource.NewName("istio-system", "meshconfig"),
+				},
+				Item: mcfg,
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+	acc.Clear()
+
+	err = ioutil.WriteFile(file, []byte(":@#Hallo!"), os.ModePerm)
+	g.Expect(err).To(BeNil())
+
+	time.Sleep(time.Millisecond * 100)
+	g.Consistently(acc.Events()).Should(HaveLen(0))
+}
+
+func setupDir(t *testing.T, m *v1alpha1.MeshConfig) string {
+	g := NewGomegaWithT(t)
+
+	p, err := ioutil.TempDir(os.TempDir(), t.Name())
+	g.Expect(err).To(BeNil())
+	file := path.Join(p, "meshconfig.yaml")
+
+	if m != nil {
+		writeMeshCfg(t, file, m)
+	}
+
+	return file
+}
+
+func writeMeshCfg(t *testing.T, file string, m *v1alpha1.MeshConfig) { // nolint:interfacer
+	g := NewGomegaWithT(t)
+	s, err := (&jsonpb.Marshaler{Indent: "  "}).MarshalToString(m)
+	g.Expect(err).To(BeNil())
+	err = ioutil.WriteFile(file, []byte(s), os.ModePerm)
+	g.Expect(err).To(BeNil())
+}
+
+func TestFsSource_InvalidPath(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	file := setupDir(t, nil)
+	file = path.Join(file, "bogus")
+
+	_, err := NewFS(file)
+	g.Expect(err).NotTo(BeNil())
+}
+
+func TestFsSource_YamlToJSONError(t *testing.T) {
+	g := NewGomegaWithT(t)
+	old := yamlToJSON
+	yamlToJSON = func([]byte) ([]byte, error) {
+		return nil, fmt.Errorf("horror")
+	}
+	defer func() {
+		yamlToJSON = old
+	}()
+
+	mcfg := Default()
+	mcfg.IngressClass = "foo"
+	file := setupDir(t, mcfg)
+
+	fs, err := NewFS(file)
+	g.Expect(err).To(BeNil())
+	defer func() {
+		err = fs.Close()
+		g.Expect(err).To(BeNil())
+	}()
+	acc := &fixtures.Accumulator{}
+	fs.Dispatch(acc)
+
+	fs.Start()
+
+	// Expect default config
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: resource.NewName("istio-system", "meshconfig"),
+				},
+				Item: Default(),
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+}

--- a/galley/pkg/config/meshcfg/inmemory.go
+++ b/galley/pkg/config/meshcfg/inmemory.go
@@ -1,0 +1,136 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meshcfg
+
+import (
+	"sync"
+
+	"github.com/gogo/protobuf/proto"
+
+	"istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/resource"
+)
+
+// InMemorySource is an event.InMemorySource implementation for meshconfig. When the mesh config is first set, add & fullsync events
+// will be published. Otherwise a reset event will be sent.
+type InMemorySource struct {
+	mu      sync.Mutex
+	current *v1alpha1.MeshConfig
+
+	handlers event.Handler
+
+	synced  bool
+	started bool
+}
+
+var _ event.Source = &InMemorySource{}
+
+// NewInmemory returns a new meshconfig.InMemorySource.
+func NewInmemory() *InMemorySource {
+	return &InMemorySource{
+		current: Default(),
+	}
+}
+
+// Dispatch implements event.Dispatcher
+func (s *InMemorySource) Dispatch(handler event.Handler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.handlers = event.CombineHandlers(s.handlers, handler)
+}
+
+// Start implements event.InMemorySource
+func (s *InMemorySource) Start() {
+	s.mu.Lock()
+
+	if s.started {
+		// Already started
+		s.mu.Unlock()
+		return
+	}
+	s.started = true
+
+	if s.synced {
+		go s.sendInitialEvents()
+	} else {
+		s.mu.Unlock()
+	}
+}
+
+func (s *InMemorySource) sendInitialEvents() {
+	// Lock must be held when entering this go routine
+	s.send(event.Added)
+	s.send(event.FullSync)
+	s.mu.Unlock()
+}
+
+// Stop implements event.InMemorySource
+func (s *InMemorySource) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.started = false
+}
+
+// Set new meshconfig
+func (s *InMemorySource) Set(cfg *v1alpha1.MeshConfig) {
+	s.mu.Lock()
+
+	cfg = proto.Clone(cfg).(*v1alpha1.MeshConfig)
+	s.current = cfg
+
+	if s.started {
+		go func() {
+			if !s.synced {
+				s.send(event.Added)
+				s.send(event.FullSync)
+			} else {
+				s.send(event.Reset)
+			}
+			s.synced = true
+			s.mu.Unlock()
+		}()
+	} else {
+		s.synced = true
+		s.mu.Unlock()
+	}
+}
+
+// IsSynced indicates that the InMemorySource has been given a Mesh config at least once.
+func (s *InMemorySource) IsSynced() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.synced
+}
+
+func (s *InMemorySource) send(k event.Kind) {
+	// must be called under lock
+	e := event.Event{
+		Kind:   k,
+		Source: IstioMeshconfig,
+	}
+
+	switch k {
+	case event.Added, event.Updated:
+		e.Entry = &resource.Entry{
+			Metadata: resource.Metadata{
+				Name: ResourceName,
+			},
+			Item: proto.Clone(s.current),
+		}
+	}
+
+	s.handlers.Handle(e)
+}

--- a/galley/pkg/config/meshcfg/inmemory_test.go
+++ b/galley/pkg/config/meshcfg/inmemory_test.go
@@ -1,0 +1,207 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meshcfg
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/testing/fixtures"
+)
+
+func TestInMemorySource_Empty(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := NewInmemory()
+
+	acc := &fixtures.Accumulator{}
+	s.Dispatch(acc)
+
+	g.Expect(s.IsSynced()).To(BeFalse())
+
+	s.Start()
+
+	g.Consistently(s.IsSynced).Should(BeFalse())
+	g.Consistently(acc.Events).Should(HaveLen(0))
+}
+
+func TestInMemorySource_SetBeforeStart(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := NewInmemory()
+
+	acc := &fixtures.Accumulator{}
+	s.Dispatch(acc)
+
+	s.Set(Default())
+	g.Expect(s.IsSynced()).To(BeTrue())
+
+	s.Start()
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: ResourceName,
+				},
+				Item: Default(),
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+}
+
+func TestInMemorySource_SetAfterStart(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := NewInmemory()
+
+	acc := &fixtures.Accumulator{}
+	s.Dispatch(acc)
+
+	s.Start()
+	s.Set(Default())
+	g.Expect(s.IsSynced()).To(BeTrue())
+
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: ResourceName,
+				},
+				Item: Default(),
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+}
+
+func TestInMemorySource_DoubleStart(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := NewInmemory()
+
+	acc := &fixtures.Accumulator{}
+	s.Dispatch(acc)
+
+	s.Set(Default())
+	s.Start()
+	s.Start()
+	g.Expect(s.IsSynced()).To(BeTrue())
+
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: ResourceName,
+				},
+				Item: Default(),
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+}
+
+func TestInMemorySource_StartStop(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := NewInmemory()
+
+	acc := &fixtures.Accumulator{}
+	s.Dispatch(acc)
+
+	s.Start()
+	s.Set(Default())
+	s.Stop()
+	acc.Clear()
+
+	s.Start()
+	g.Expect(s.IsSynced()).To(BeTrue())
+
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: ResourceName,
+				},
+				Item: Default(),
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+}
+
+func TestInMemorySource_ResetOnUpdate(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := NewInmemory()
+
+	acc := &fixtures.Accumulator{}
+	s.Dispatch(acc)
+
+	s.Start()
+	s.Set(Default())
+	m := Default()
+	m.IngressClass = "foo"
+	s.Set(m)
+
+	expected := []event.Event{
+		{
+			Kind:   event.Added,
+			Source: IstioMeshconfig,
+			Entry: &resource.Entry{
+				Metadata: resource.Metadata{
+					Name: ResourceName,
+				},
+				Item: Default(),
+			},
+		},
+		{
+			Kind:   event.FullSync,
+			Source: IstioMeshconfig,
+		},
+		{
+			Kind:   event.Reset,
+			Source: IstioMeshconfig,
+		},
+	}
+	g.Eventually(acc.Events).Should(Equal(expected))
+}

--- a/galley/pkg/config/meshcfg/scope.go
+++ b/galley/pkg/config/meshcfg/scope.go
@@ -1,0 +1,21 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meshcfg
+
+import (
+	"istio.io/pkg/log"
+)
+
+var scope = log.RegisterScope("processing", "", 0)

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -33,18 +33,19 @@ import (
 	"github.com/spf13/cobra/doc"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/collateral"
+	"istio.io/pkg/env"
+	"istio.io/pkg/log"
+	"istio.io/pkg/version"
+
 	"istio.io/istio/pilot/cmd/pilot-agent/status"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/proxy"
 	"istio.io/istio/pilot/pkg/proxy/envoy"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/cmd"
-	"istio.io/istio/pkg/features/pilot"
 	"istio.io/istio/pkg/spiffe"
-	"istio.io/pkg/collateral"
-	"istio.io/pkg/env"
-	"istio.io/pkg/log"
-	"istio.io/pkg/version"
 )
 
 var (
@@ -371,7 +372,7 @@ var (
 			log.Infof("PilotSAN %#v", pilotSAN)
 
 			envoyProxy := envoy.NewProxy(proxyConfig, role.ServiceNode(), proxyLogLevel, proxyComponentLogLevel, pilotSAN, role.IPAddresses, dnsRefreshRate)
-			agent := proxy.NewAgent(envoyProxy, proxy.DefaultRetry, pilot.TerminationDrainDuration())
+			agent := proxy.NewAgent(envoyProxy, proxy.DefaultRetry, features.TerminationDrainDuration())
 			watcher := envoy.NewWatcher(tlsCertsToWatch, agent.ConfigCh())
 
 			go waitForCompletion(ctx, agent.Run)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -48,6 +48,12 @@ import (
 	mcpapi "istio.io/api/mcp/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	istio_networking_v1alpha3 "istio.io/api/networking/v1alpha3"
+	"istio.io/pkg/ctrlz"
+	"istio.io/pkg/env"
+	"istio.io/pkg/filewatcher"
+	"istio.io/pkg/log"
+	"istio.io/pkg/version"
+
 	"istio.io/istio/pilot/cmd"
 	configaggregate "istio.io/istio/pilot/pkg/config/aggregate"
 	"istio.io/istio/pilot/pkg/config/clusterregistry"
@@ -56,6 +62,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/kube/ingress"
 	"istio.io/istio/pilot/pkg/config/memory"
 	configmonitor "istio.io/istio/pilot/pkg/config/monitor"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	istio_networking "istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pilot/pkg/networking/plugin"
@@ -68,18 +75,12 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/external"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	srmemory "istio.io/istio/pilot/pkg/serviceregistry/memory"
-	"istio.io/istio/pkg/features/pilot"
 	istiokeepalive "istio.io/istio/pkg/keepalive"
 	kubelib "istio.io/istio/pkg/kube"
 	configz "istio.io/istio/pkg/mcp/configz/client"
 	"istio.io/istio/pkg/mcp/creds"
 	"istio.io/istio/pkg/mcp/monitoring"
 	"istio.io/istio/pkg/mcp/sink"
-	"istio.io/pkg/ctrlz"
-	"istio.io/pkg/env"
-	"istio.io/pkg/filewatcher"
-	"istio.io/pkg/log"
-	"istio.io/pkg/version"
 )
 
 const (
@@ -940,7 +941,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go func() {
-			if pilot.EnableWaitCacheSync && !s.waitForCacheSync(stop) {
+			if features.EnableWaitCacheSync && !s.waitForCacheSync(stop) {
 				return
 			}
 
@@ -992,7 +993,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			go func() {
-				if pilot.EnableWaitCacheSync && !s.waitForCacheSync(stop) {
+				if features.EnableWaitCacheSync && !s.waitForCacheSync(stop) {
 					return
 				}
 
@@ -1054,7 +1055,7 @@ func (s *Server) initGrpcServer(options *istiokeepalive.Options) {
 
 // initialize secureGRPCServer
 func (s *Server) initSecureGrpcServer(options *istiokeepalive.Options) error {
-	certDir := pilot.CertDir
+	certDir := features.CertDir
 	if certDir == "" {
 		certDir = PilotCertDir
 	}
@@ -1119,7 +1120,7 @@ func (s *Server) grpcServerOptions(options *istiokeepalive.Options) []grpc.Serve
 
 	// Temp setting, default should be enough for most supported environments. Can be used for testing
 	// envoy with lower values.
-	maxStreams := pilot.MaxConcurrentStreams
+	maxStreams := features.MaxConcurrentStreams
 
 	grpcOptions := []grpc.ServerOption{
 		grpc.UnaryInterceptor(middleware.ChainUnaryServer(interceptors...)),

--- a/pilot/pkg/config/kube/crd/controller.go
+++ b/pilot/pkg/config/kube/crd/controller.go
@@ -28,10 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
+	"istio.io/pkg/log"
+
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
-	"istio.io/istio/pkg/features/pilot"
-	"istio.io/pkg/log"
 )
 
 // controller is a collection of synchronized resource watchers.
@@ -205,7 +206,7 @@ func (c *controller) HasSynced() bool {
 
 func (c *controller) Run(stop <-chan struct{}) {
 	go func() {
-		if pilot.EnableWaitCacheSync {
+		if features.EnableWaitCacheSync {
 			cache.WaitForCacheSync(stop, c.HasSynced)
 		}
 		c.queue.Run(stop)

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -27,11 +27,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/serviceregistry/kube"
-	"istio.io/istio/pkg/features/pilot"
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
+
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 )
 
 // In 1.0, the Gateway is defined in the namespace where the actual controller runs, and needs to be managed by
@@ -163,7 +164,7 @@ func (c *controller) HasSynced() bool {
 
 func (c *controller) Run(stop <-chan struct{}) {
 	go func() {
-		if pilot.EnableWaitCacheSync {
+		if features.EnableWaitCacheSync {
 			cache.WaitForCacheSync(stop, c.HasSynced)
 		}
 		c.queue.Run(stop)

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -1,4 +1,4 @@
-//  Copyright 2018 Istio Authors
+// Copyright 2019 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pilot
+package features
 
 import (
 	"os"

--- a/pilot/pkg/features/pilot_test.go
+++ b/pilot/pkg/features/pilot_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pilot
+package features
 
 import (
 	"os"

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -25,9 +25,9 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/config/grpc_credential/v2alpha"
 	"github.com/gogo/protobuf/types"
 
-	"istio.io/istio/pkg/features/pilot"
-
 	authn "istio.io/api/authentication/v1alpha1"
+
+	"istio.io/istio/pilot/pkg/features"
 )
 
 const (
@@ -108,7 +108,7 @@ func ConstructSdsSecretConfigForGatewayListener(name, sdsUdsPath string) *auth.S
 					},
 				},
 			},
-			InitialFetchTimeout: pilot.InitialFetchTimeout,
+			InitialFetchTimeout: features.InitialFetchTimeout,
 		},
 	}
 }
@@ -168,7 +168,7 @@ func ConstructSdsSecretConfig(name, sdsUdsPath string, useK8sSATrustworthyJwt, u
 					},
 				},
 			},
-			InitialFetchTimeout: pilot.InitialFetchTimeout,
+			InitialFetchTimeout: features.InitialFetchTimeout,
 		},
 	}
 }

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/config/grpc_credential/v2alpha"
 	"github.com/gogo/protobuf/types"
 
-	"istio.io/istio/pkg/features/pilot"
+	"istio.io/istio/pilot/pkg/features"
 )
 
 func TestParseJwksURI(t *testing.T) {
@@ -123,7 +123,7 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 			expected: &auth.SdsSecretConfig{
 				Name: "spiffe://cluster.local/ns/bar/sa/foo",
 				SdsConfig: &core.ConfigSource{
-					InitialFetchTimeout: pilot.InitialFetchTimeout,
+					InitialFetchTimeout: features.InitialFetchTimeout,
 					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 						ApiConfigSource: &core.ApiConfigSource{
 							ApiType: core.ApiConfigSource_GRPC,
@@ -196,7 +196,7 @@ func TestConstructSdsSecretConfigForGatewayListener(t *testing.T) {
 			expected: &auth.SdsSecretConfig{
 				Name: "spiffe://cluster.local/ns/bar/sa/foo",
 				SdsConfig: &core.ConfigSource{
-					InitialFetchTimeout: pilot.InitialFetchTimeout,
+					InitialFetchTimeout: features.InitialFetchTimeout,
 					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 						ApiConfigSource: &core.ApiConfigSource{
 							ApiType: core.ApiConfigSource_GRPC,
@@ -254,7 +254,7 @@ func constructGCECallCredConfig() *core.GrpcService_GoogleGrpc_CallCredentials {
 func constructsdsconfighelper(tokenFileName, headerKey string, metaConfig *v2alpha.FileBasedMetadataConfig) *core.ConfigSource {
 	any := findOrMarshalFileBasedMetadataConfig(tokenFileName, headerKey, metaConfig)
 	return &core.ConfigSource{
-		InitialFetchTimeout: pilot.InitialFetchTimeout,
+		InitialFetchTimeout: features.InitialFetchTimeout,
 		ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 			ApiConfigSource: &core.ApiConfigSource{
 				ApiType: core.ApiConfigSource_GRPC,

--- a/pilot/pkg/model/trace.go
+++ b/pilot/pkg/model/trace.go
@@ -15,7 +15,7 @@
 package model
 
 import (
-	"istio.io/istio/pkg/features/pilot"
+	"istio.io/istio/pilot/pkg/features"
 )
 
 // Default trace sampling, if not provided in env var.
@@ -27,7 +27,7 @@ var (
 
 // Return trace sampling if set correctly, or default if not.
 func getTraceSampling() float64 {
-	f := pilot.TraceSampling
+	f := features.TraceSampling
 	if f < 0.0 || f > 100.0 {
 		log.Warnf("PILOT_TRACE_SAMPLING out of range: %v", f)
 		return traceSamplingDefault

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -27,15 +27,16 @@ import (
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
 
-	"istio.io/istio/pkg/features/pilot"
-
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/pkg/log"
+
+	"istio.io/istio/pilot/pkg/features"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
-	"istio.io/pkg/log"
 )
 
 const (
@@ -330,7 +331,7 @@ func updateEds(cluster *apiv2.Cluster) {
 			ConfigSourceSpecifier: &core.ConfigSource_Ads{
 				Ads: &core.AggregatedConfigSource{},
 			},
-			InitialFetchTimeout: pilot.InitialFetchTimeout,
+			InitialFetchTimeout: features.InitialFetchTimeout,
 		},
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -19,23 +19,24 @@ import (
 	"strconv"
 	"strings"
 
-	"istio.io/istio/pkg/features/pilot"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
+
+	"istio.io/istio/pilot/pkg/features"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/pkg/log"
+
 	"istio.io/istio/pilot/pkg/model"
 	istio_route "istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/proto"
-	"istio.io/pkg/log"
 )
 
 func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env *model.Environment, node *model.Proxy, push *model.PushContext) ([]*xdsapi.Listener, error) {
@@ -218,7 +219,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(env *model.Env
 
 		// If the flag is set, send Envoy an error, blocking all routes from being sent. This flag
 		// is intended only to support legacy behavior and should be removed in the future.
-		if pilot.DisablePartialRouteResponse {
+		if features.DisablePartialRouteResponse {
 			return nil, fmt.Errorf("buildGatewayRoutes: could not find server for routeName %s, have %v", routeName, merged.ServersByRouteName)
 		}
 
@@ -330,7 +331,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 
 	httpProtoOpts := &core.Http1ProtocolOptions{}
 
-	if pilot.HTTP10 || node.Metadata[model.NodeMetadataHTTP10] == "1" {
+	if features.HTTP10 || node.Metadata[model.NodeMetadataHTTP10] == "1" {
 		httpProtoOpts.AcceptHttp_10 = true
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/fakes"
 	"istio.io/istio/pilot/pkg/networking/plugin"
-	"istio.io/istio/pkg/features/pilot"
 	"istio.io/istio/pkg/proto"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -85,7 +85,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 						{
 							Name: "ingress-sds-resource-name",
 							SdsConfig: &core.ConfigSource{
-								InitialFetchTimeout: pilot.InitialFetchTimeout,
+								InitialFetchTimeout: features.InitialFetchTimeout,
 								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 									ApiConfigSource: &core.ApiConfigSource{
 										ApiType: core.ApiConfigSource_GRPC,
@@ -127,7 +127,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 						{
 							Name: "ingress-sds-resource-name",
 							SdsConfig: &core.ConfigSource{
-								InitialFetchTimeout: pilot.InitialFetchTimeout,
+								InitialFetchTimeout: features.InitialFetchTimeout,
 								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 									ApiConfigSource: &core.ApiConfigSource{
 										ApiType: core.ApiConfigSource_GRPC,
@@ -240,7 +240,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 						{
 							Name: "ingress-sds-resource-name",
 							SdsConfig: &core.ConfigSource{
-								InitialFetchTimeout: pilot.InitialFetchTimeout,
+								InitialFetchTimeout: features.InitialFetchTimeout,
 								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 									ApiConfigSource: &core.ApiConfigSource{
 										ApiType: core.ApiConfigSource_GRPC,
@@ -267,7 +267,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
 								Name: "ingress-sds-resource-name-cacert",
 								SdsConfig: &core.ConfigSource{
-									InitialFetchTimeout: pilot.InitialFetchTimeout,
+									InitialFetchTimeout: features.InitialFetchTimeout,
 									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 										ApiConfigSource: &core.ApiConfigSource{
 											ApiType: core.ApiConfigSource_GRPC,

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -23,13 +23,14 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/log"
+
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	istio_route "istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
-	"istio.io/istio/pkg/features/pilot"
 	"istio.io/istio/pkg/proto"
-	"istio.io/pkg/log"
 )
 
 // BuildHTTPRoutes produces a list of routes for the proxy
@@ -210,7 +211,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 
 	util.SortVirtualHosts(virtualHosts)
 
-	if pilot.EnableFallthroughRoute() {
+	if features.EnableFallthroughRoute() {
 		// This needs to be the last virtual host, as routes are evaluated in order.
 		if env.Mesh.OutboundTrafficPolicy.Mode == meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY {
 			virtualHosts = append(virtualHosts, route.VirtualHost{

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
-	"istio.io/istio/pkg/features/pilot"
-
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	accesslogconfig "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
@@ -29,6 +27,8 @@ import (
 	mysql_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/mysql_proxy/v1alpha1"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+
+	"istio.io/istio/pilot/pkg/features"
 
 	networking "istio.io/api/networking/v1alpha3"
 
@@ -181,7 +181,7 @@ func buildNetworkFiltersStack(node *model.Proxy, port *model.Port, tcpFilter *li
 	case model.ProtocolMongo:
 		filterstack = append(filterstack, buildMongoFilter(statPrefix, util.IsProxyVersionGE11(node)), *tcpFilter)
 	case model.ProtocolMySQL:
-		if util.IsProxyVersionGE11(node) && pilot.EnableMysqlFilter() {
+		if util.IsProxyVersionGE11(node) && features.EnableMysqlFilter() {
 			filterstack = append(filterstack, buildMySQLFilter(statPrefix, util.IsProxyVersionGE11(node)))
 		}
 		filterstack = append(filterstack, *tcpFilter)

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -34,9 +34,10 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/features/pilot"
 	"istio.io/pkg/log"
+
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
 )
 
 const (
@@ -249,7 +250,7 @@ func IsProxyVersionGE11(node *model.Proxy) bool {
 
 // IsXDSMarshalingToAnyEnabled controls whether "marshaling to Any" feature is enabled.
 func IsXDSMarshalingToAnyEnabled(node *model.Proxy) bool {
-	return IsProxyVersionGE11(node) && !pilot.DisableXDSMarshalingToAny()
+	return IsProxyVersionGE11(node) && !features.DisableXDSMarshalingToAny()
 }
 
 // ResolveHostsInNetworksConfig will go through the Gateways addresses for all

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -25,10 +25,10 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
-	"istio.io/istio/pkg/features/pilot"
 )
 
 var (
@@ -70,8 +70,8 @@ const (
 )
 
 func init() {
-	DebounceAfter = pilot.DebounceAfter
-	DebounceMax = pilot.DebounceMax
+	DebounceAfter = features.DebounceAfter
+	DebounceMax = features.DebounceMax
 }
 
 // DiscoveryServer is Pilot's gRPC implementation for Envoy's v2 xds APIs
@@ -211,10 +211,10 @@ func NewDiscoveryServer(
 		}
 	}
 
-	out.DebugConfigs = pilot.DebugConfigs
+	out.DebugConfigs = features.DebugConfigs
 
-	pushThrottle := pilot.PushThrottle
-	pushBurst := pilot.PushBurst
+	pushThrottle := features.PushThrottle
+	pushBurst := features.PushBurst
 
 	adsLog.Infof("Starting ADS server with rateLimiter=%d burst=%d", pushThrottle, pushBurst)
 	out.rateLimiter = rate.NewLimiter(rate.Limit(pushThrottle), pushBurst)
@@ -240,7 +240,7 @@ func (s *DiscoveryServer) Start(stopCh <-chan struct{}) {
 // ( will be removed after change detection is implemented, to double check all changes are
 // captured)
 func (s *DiscoveryServer) periodicRefresh(stopCh <-chan struct{}) {
-	periodicRefreshDuration := pilot.RefreshDuration
+	periodicRefreshDuration := features.RefreshDuration
 	if periodicRefreshDuration == 0 {
 		return
 	}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -28,6 +28,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	networkingapi "istio.io/api/networking/v1alpha3"
+
+	"istio.io/istio/pilot/pkg/features"
 	networking "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -35,7 +37,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
-	"istio.io/istio/pkg/features/pilot"
 )
 
 // EDS returns the list of endpoints (IP:port and in future labels) associated with a real
@@ -698,7 +699,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 
 		var l *xdsapi.ClusterLoadAssignment
 		// decide which to use based on presence of Sidecar.
-		if sidecarScope == nil || sidecarScope.Config == nil || len(pilot.DisableEDSIsolation) != 0 {
+		if sidecarScope == nil || sidecarScope.Config == nil || len(features.DisableEDSIsolation) != 0 {
 			l = s.loadAssignmentsForClusterLegacy(push, clusterName)
 		} else {
 			l = s.loadAssignmentsForClusterIsolated(con.modelNode, push, clusterName)
@@ -722,7 +723,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 		}
 
 		// If location prioritized load balancing is enabled, prioritize endpoints.
-		if pilot.EnableLocalityLoadBalancing() {
+		if features.EnableLocalityLoadBalancing() {
 			// Make a shallow copy of the cla as we are mutating the endpoints with priorities/weights relative to the calling proxy
 			clonedCLA := util.CloneClusterLoadAssignment(l)
 			l = &clonedCLA

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -21,8 +21,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/features/pilot"
 	"istio.io/istio/pkg/proto"
 )
 
@@ -72,7 +72,7 @@ func (s *DiscoveryServer) generateRawRoutes(con *XdsConnection, push *model.Push
 
 			// Don't send an empty route, instead ignore the request. This may cause Envoy to block
 			// listeners waiting for this route
-			if pilot.DisableEmptyRouteResponse {
+			if features.DisableEmptyRouteResponse {
 				continue
 			}
 

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -28,13 +28,14 @@ import (
 	authn_v1alpha1 "istio.io/api/authentication/v1alpha1"
 	authn_filter "istio.io/api/envoy/config/filter/http/authn/v2alpha1"
 	jwtfilter "istio.io/api/envoy/config/filter/http/jwt_auth/v2alpha1"
+	"istio.io/pkg/log"
+
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/security/authn"
-	"istio.io/istio/pkg/features/pilot"
 	protovalue "istio.io/istio/pkg/proto"
-	"istio.io/pkg/log"
 )
 
 const (
@@ -253,7 +254,7 @@ func (a v1alpha1PolicyApplier) InboundFilterChain(sdsUdsPath string, sdsUseTrust
 		RequireClientCertificate: protovalue.BoolTrue,
 	}
 	if sdsUdsPath == "" {
-		base := meta[pilot.BaseDir] + model.AuthCertsPath
+		base := meta[features.BaseDir] + model.AuthCertsPath
 		tlsServerRootCert := model.GetOrDefaultFromMap(meta, model.NodeMetadataTLSServerRootCert, base+model.RootCertFilename)
 
 		tls.CommonTlsContext.ValidationContextType = model.ConstructValidationContext(tlsServerRootCert, []string{} /*subjectAltNames*/)

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -18,17 +18,18 @@ import (
 	"reflect"
 	"testing"
 
-	"istio.io/istio/pkg/features/pilot"
-
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/gogo/protobuf/types"
 
+	"istio.io/istio/pilot/pkg/features"
+
 	authn "istio.io/api/authentication/v1alpha1"
 	authn_filter "istio.io/api/envoy/config/filter/http/authn/v2alpha1"
 	jwtfilter "istio.io/api/envoy/config/filter/http/jwt_auth/v2alpha1"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pilot/pkg/networking/plugin"
@@ -729,7 +730,7 @@ func constructSDSConfig(name, sdsudspath string) *auth.SdsSecretConfig {
 	return &auth.SdsSecretConfig{
 		Name: name,
 		SdsConfig: &core.ConfigSource{
-			InitialFetchTimeout: pilot.InitialFetchTimeout,
+			InitialFetchTimeout: features.InitialFetchTimeout,
 			ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 				ApiConfigSource: &core.ApiConfigSource{
 					ApiType: core.ApiConfigSource_GRPC,

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -34,9 +34,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/features/pilot"
 	"istio.io/pkg/log"
+
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
 )
 
 const (
@@ -257,7 +258,7 @@ func (c *Controller) HasSynced() bool {
 // Run all controllers until a signal is received
 func (c *Controller) Run(stop <-chan struct{}) {
 	go func() {
-		if pilot.EnableWaitCacheSync {
+		if features.EnableWaitCacheSync {
 			cache.WaitForCacheSync(stop, c.HasSynced)
 		}
 		c.queue.Run(stop)


### PR DESCRIPTION
Adds an event source for publishing mesh config. The file-based meshconfig handling is modeled as a regular event source.