### PR TITLE
Cleanup management of Envoy binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,8 +168,8 @@ export ISTIO_ENVOY_LINUX_RELEASE_DIR ?= ${OUT_DIR}/linux_amd64/release
 export ISTIO_ENVOY_LINUX_RELEASE_NAME ?= envoy-${ISTIO_ENVOY_VERSION}
 export ISTIO_ENVOY_LINUX_RELEASE_PATH ?= ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${ISTIO_ENVOY_LINUX_RELEASE_NAME}
 
-# Envoy mac/darwin vars.
-# TODO Change url when official envoy release for MAC is available
+# Envoy macOS vars.
+# TODO Change url when official envoy release for macOS is available
 export ISTIO_ENVOY_MACOS_VERSION ?= 1.0.2
 export ISTIO_ENVOY_MACOS_RELEASE_URL ?= https://github.com/istio/proxy/releases/download/${ISTIO_ENVOY_MACOS_VERSION}/istio-proxy-${ISTIO_ENVOY_MACOS_VERSION}-macos.tar.gz
 # Variables for the extracted debug/release Envoy artifacts.

--- a/Makefile
+++ b/Makefile
@@ -150,25 +150,48 @@ ifeq ($(PROXY_REPO_SHA),)
 endif
 
 # Envoy binary variables Keep the default URLs up-to-date with the latest push from istio/proxy.
-ISTIO_ENVOY_VERSION ?= ${PROXY_REPO_SHA}
+
+# OS-neutral vars. These currently only work for linux.
+export ISTIO_ENVOY_VERSION ?= ${PROXY_REPO_SHA}
 export ISTIO_ENVOY_DEBUG_URL ?= https://storage.googleapis.com/istio-build/proxy/envoy-debug-$(ISTIO_ENVOY_VERSION).tar.gz
 export ISTIO_ENVOY_RELEASE_URL ?= https://storage.googleapis.com/istio-build/proxy/envoy-alpha-$(ISTIO_ENVOY_VERSION).tar.gz
 
-# Use envoy build from local workspace
+# Envoy Linux vars.
+export ISTIO_ENVOY_LINUX_VERSION ?= ${ISTIO_ENVOY_VERSION}
+export ISTIO_ENVOY_LINUX_DEBUG_URL ?= ${ISTIO_ENVOY_DEBUG_URL}
+export ISTIO_ENVOY_LINUX_RELEASE_URL ?= ${ISTIO_ENVOY_RELEASE_URL}
+# Variables for the extracted debug/release Envoy artifacts.
+export ISTIO_ENVOY_LINUX_DEBUG_DIR ?= ${OUT_DIR}/linux_amd64/debug
+export ISTIO_ENVOY_LINUX_DEBUG_NAME ?= envoy-debug-${ISTIO_ENVOY_LINUX_VERSION}
+export ISTIO_ENVOY_LINUX_DEBUG_PATH ?= ${ISTIO_ENVOY_LINUX_DEBUG_DIR}/${ISTIO_ENVOY_LINUX_DEBUG_NAME}
+export ISTIO_ENVOY_LINUX_RELEASE_DIR ?= ${OUT_DIR}/linux_amd64/release
+export ISTIO_ENVOY_LINUX_RELEASE_NAME ?= envoy-${ISTIO_ENVOY_VERSION}
+export ISTIO_ENVOY_LINUX_RELEASE_PATH ?= ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${ISTIO_ENVOY_LINUX_RELEASE_NAME}
+
+# Envoy mac/darwin vars.
+# TODO Change url when official envoy release for MAC is available
+export ISTIO_ENVOY_MACOS_VERSION ?= 1.0.2
+export ISTIO_ENVOY_MACOS_RELEASE_URL ?= https://github.com/istio/proxy/releases/download/${ISTIO_ENVOY_MACOS_VERSION}/istio-proxy-${ISTIO_ENVOY_MACOS_VERSION}-macos.tar.gz
+# Variables for the extracted debug/release Envoy artifacts.
+export ISTIO_ENVOY_MACOS_RELEASE_DIR ?= ${OUT_DIR}/darwin_amd64/release
+export ISTIO_ENVOY_MACOS_RELEASE_NAME ?= envoy-${ISTIO_ENVOY_MACOS_VERSION}
+export ISTIO_ENVOY_MACOS_RELEASE_PATH ?= ${ISTIO_ENVOY_MACOS_RELEASE_DIR}/${ISTIO_ENVOY_MACOS_RELEASE_NAME}
+
+# Allow user-override for a local Envoy build.
 export USE_LOCAL_PROXY ?= 0
 ifeq ($(USE_LOCAL_PROXY),1)
-  $(info "Using istio-proxy image from local workspace")
-  export ISTIO_ENVOY_DEBUG_PATH:=$(realpath $(ISTIO_GO)/../proxy/bazel-bin/src/envoy/envoy)
-  export ISTIO_ENVOY_RELEASE_PATH:=$(realpath $(ISTIO_GO)/../proxy/bazel-bin/src/envoy/envoy)
+  export ISTIO_ENVOY_LOCAL ?= $(realpath ${ISTIO_GO}/../proxy/bazel-bin/src/envoy/envoy)
+  # Point the native paths to the local envoy build.
+  ifeq ($(GOOS_LOCAL), Darwin)
+    export ISTIO_ENVOY_MACOS_RELEASE_DIR = $(dirname ${ISTIO_ENVOY_LOCAL})
+    export ISTIO_ENVOY_MACOS_RELEASE_PATH = ${ISTIO_ENVOY_LOCAL}
+  else
+    export ISTIO_ENVOY_LINUX_DEBUG_DIR = $(dirname ${ISTIO_ENVOY_LOCAL})
+    export ISTIO_ENVOY_LINUX_RELEASE_DIR = $(dirname ${ISTIO_ENVOY_LOCAL})
+    export ISTIO_ENVOY_LINUX_DEBUG_PATH = ${ISTIO_ENVOY_LOCAL}
+    export ISTIO_ENVOY_LINUX_RELEASE_PATH = ${ISTIO_ENVOY_LOCAL}
+  endif
 endif
-
-# Variables for the extracted debug/release Envoy artifacts.
-export ISTIO_ENVOY_DEBUG_DIR ?= ${OUT_DIR}/${GOOS}_${GOARCH}/debug
-export ISTIO_ENVOY_DEBUG_NAME ?= envoy-debug-${ISTIO_ENVOY_VERSION}
-export ISTIO_ENVOY_DEBUG_PATH ?= ${ISTIO_ENVOY_DEBUG_DIR}/${ISTIO_ENVOY_DEBUG_NAME}
-export ISTIO_ENVOY_RELEASE_DIR ?= ${OUT_DIR}/${GOOS}_${GOARCH}/release
-export ISTIO_ENVOY_RELEASE_NAME ?= envoy-${ISTIO_ENVOY_VERSION}
-export ISTIO_ENVOY_RELEASE_PATH ?= ${ISTIO_ENVOY_RELEASE_DIR}/${ISTIO_ENVOY_RELEASE_NAME}
 
 GO_VERSION_REQUIRED:=1.10
 
@@ -248,8 +271,9 @@ $(ISTIO_OUT)/istio_is_init: bin/init.sh istio.deps | ${ISTIO_OUT}
 
 # init.sh downloads envoy
 ${ISTIO_OUT}/envoy: init
-${ISTIO_ENVOY_DEBUG_PATH}: init
-${ISTIO_ENVOY_RELEASE_PATH}: init
+${ISTIO_ENVOY_LINUX_DEBUG_PATH}: init
+${ISTIO_ENVOY_LINUX_RELEASE_PATH}: init
+${ISTIO_ENVOY_MACOS_RELEASE_PATH}: init
 
 # Pull dependencies, based on the checked in Gopkg.lock file.
 # Developers must manually run `dep ensure` if adding new deps

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -111,7 +111,7 @@ function download_envoy_if_necessary () {
   fi
 }
 
-# Included for support on mac.
+# Included for support on macOS.
 function realpath () {
   python -c "import os; print(os.path.realpath('$1'))"
 }
@@ -139,8 +139,8 @@ ISTIO_ENVOY_LINUX_RELEASE_DIR=${ISTIO_ENVOY_LINUX_RELEASE_DIR:-"${OUT_DIR}/linux
 ISTIO_ENVOY_LINUX_RELEASE_NAME=${ISTIO_ENVOY_LINUX_RELEASE_NAME:-"envoy-${ISTIO_ENVOY_LINUX_VERSION}"}
 ISTIO_ENVOY_LINUX_RELEASE_PATH=${ISTIO_ENVOY_LINUX_RELEASE_PATH:-"${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${ISTIO_ENVOY_LINUX_RELEASE_NAME}"}
 
-# Envoy mac/darwin vars. Normally set by the makefile.
-# TODO Change url when official envoy release for MAC is available
+# Envoy macOS vars. Normally set by the makefile.
+# TODO Change url when official envoy release for macOS is available
 ISTIO_ENVOY_MACOS_VERSION=${ISTIO_ENVOY_MACOS_VERSION:-1.0.2}
 ISTIO_ENVOY_MACOS_RELEASE_URL=${ISTIO_ENVOY_MACOS_RELEASE_URL:-https://github.com/istio/proxy/releases/download/${ISTIO_ENVOY_MACOS_VERSION}/istio-proxy-${ISTIO_ENVOY_MACOS_VERSION}-macos.tar.gz}
 # Variables for the extracted debug/release Envoy artifacts.
@@ -167,7 +167,7 @@ if [[ ${USE_LOCAL_PROXY} == 1 ]] ; then
       ISTIO_ENVOY_LINUX_DEBUG_PATH=${ISTIO_ENVOY_LINUX_LOCAL_PATH}
       ISTIO_ENVOY_LINUX_RELEASE_PATH=${ISTIO_ENVOY_LINUX_LOCAL_PATH}
     else
-      echo "Warning: The specified local OSX Envoy will not be included by Docker images. Set ISTIO_ENVOY_LINUX_LOCAL_PATH to specify a custom Linux build."
+      echo "Warning: The specified local macOS Envoy will not be included by Docker images. Set ISTIO_ENVOY_LINUX_LOCAL_PATH to specify a custom Linux build."
     fi
   else
     ISTIO_ENVOY_LINUX_DEBUG_PATH=${ISTIO_ENVOY_LOCAL_PATH}
@@ -188,7 +188,7 @@ download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_DEBUG_URL}" "$ISTIO_ENVOY_LINUX
 download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_RELEASE_URL}" "$ISTIO_ENVOY_LINUX_RELEASE_PATH"
 
 if [[ "$LOCAL_OS" == "Darwin" ]]; then
-  # Download and extract the Envoy mac release binary
+  # Download and extract the Envoy macOS release binary
   download_envoy_if_necessary "${ISTIO_ENVOY_MACOS_RELEASE_URL}" "$ISTIO_ENVOY_MACOS_RELEASE_PATH"
   ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_MACOS_RELEASE_PATH}
 else

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -39,7 +39,7 @@ export GOARCH=${GOARCH:-'amd64'}
 
 # Determine the OS. Matches logic in the Makefile.
 LOCAL_OS=${LOCAL_OS:-"$(uname)"}
-case $LOCAL_OS in
+case ${LOCAL_OS} in
   'Linux')
     export GOOS=${GOOS:-"linux"}
     ;;
@@ -61,104 +61,149 @@ export ISTIO_OUT=${ISTIO_OUT:-${ISTIO_BIN}}
 # Gets the download command supported by the system (currently either curl or wget)
 DOWNLOAD_COMMAND=""
 function set_download_command () {
-    # Try curl.
-    if command -v curl > /dev/null; then
-        if curl --version | grep Protocols  | grep https > /dev/null; then
-	       DOWNLOAD_COMMAND='curl -fLSs'
-	       return
-        fi
-        echo curl does not support https, will try wget for downloading files.
-    else
-        echo curl is not installed, will try wget for downloading files.
+  # Try curl.
+  if command -v curl > /dev/null; then
+    if curl --version | grep Protocols  | grep https > /dev/null; then
+      DOWNLOAD_COMMAND='curl -fLSs'
+      return
     fi
+    echo curl does not support https, will try wget for downloading files.
+  else
+    echo curl is not installed, will try wget for downloading files.
+  fi
 
-    # Try wget.
-    if command -v wget > /dev/null; then
-        DOWNLOAD_COMMAND='wget -qO -'
-        return
-    fi
-    echo wget is not installed.
+  # Try wget.
+  if command -v wget > /dev/null; then
+    DOWNLOAD_COMMAND='wget -qO -'
+    return
+  fi
+  echo wget is not installed.
 
-    echo Error: curl is not installed or does not support https, wget is not installed. \
-         Cannot download envoy. Please install wget or add support of https to curl.
-    exit 1
+  echo Error: curl is not installed or does not support https, wget is not installed. \
+       Cannot download envoy. Please install wget or add support of https to curl.
+  exit 1
 }
 
-if [ -z "${PROXY_REPO_SHA:-}" ] ; then
+# Downloads and extract an Envoy binary if the artifact doesn't already exist.
+# Params:
+#   $1: The URL of the Envoy tar.gz to be downloaded.
+#   $2: The full path of the output binary.
+function download_envoy_if_necessary () {
+  if [[ ! -f "$2" ]] ; then
+    # Enter the output directory.
+    mkdir -p "$(dirname "$2")"
+    pushd "$(dirname "$2")"
+
+    # Download and extract the binary to the output directory.
+    echo "Downloading Envoy: ${DOWNLOAD_COMMAND} $1 to $2"
+    time ${DOWNLOAD_COMMAND} "$1" | tar xz
+
+    # Copy the extracted binary to the output location
+    cp usr/local/bin/envoy "$2"
+
+    # Remove the extracted binary.
+    rm -rf usr
+
+    # Make a copy named just "envoy" in the same directory (overwrite if necessary).
+    echo "Copying $2 to $(dirname "$2")/envoy"
+    cp -f "$2" "$(dirname "$2")/envoy"
+    popd
+  fi
+}
+
+# Included for support on mac.
+function realpath () {
+  python -c "import os; print(os.path.realpath('$1'))"
+}
+
+if [[ -z "${PROXY_REPO_SHA:-}" ]] ; then
   PROXY_REPO_SHA=$(grep PROXY_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')
   export PROXY_REPO_SHA
 fi
 
-# Normally set by the Makefile.
+# These variables are normally set by the Makefile.
+# OS-neutral vars. These currently only work for linux.
 ISTIO_ENVOY_VERSION=${ISTIO_ENVOY_VERSION:-${PROXY_REPO_SHA}}
-ISTIO_ENVOY_DEBUG_URL=${ISTIO_ENVOY_DEBUG_URL:-https://storage.googleapis.com/istio-build/proxy/envoy-debug-${ISTIO_ENVOY_VERSION}.tar.gz}
-ISTIO_ENVOY_RELEASE_URL=${ISTIO_ENVOY_RELEASE_URL:-https://storage.googleapis.com/istio-build/proxy/envoy-alpha-${ISTIO_ENVOY_VERSION}.tar.gz}
-# TODO Change url when official envoy release for MAC is available
-ISTIO_ENVOY_MAC_RELEASE_URL=${ISTIO_ENVOY_MAC_RELEASE_URL:-https://github.com/istio/proxy/releases/download/1.0.2/istio-proxy-1.0.2-macos.tar.gz}
+ISTIO_ENVOY_DEBUG_URL=${ISTIO_ENVOY_DEBUG_URL:-https://storage.googleapis.com/istio-build/proxy/envoy-debug-${ISTIO_ENVOY_LINUX_VERSION}.tar.gz}
+ISTIO_ENVOY_RELEASE_URL=${ISTIO_ENVOY_RELEASE_URL:-https://storage.googleapis.com/istio-build/proxy/envoy-alpha-${ISTIO_ENVOY_LINUX_VERSION}.tar.gz}
 
-# Normally set by the Makefile.
+# Envoy Linux vars. Normally set by the Makefile.
+ISTIO_ENVOY_LINUX_VERSION=${ISTIO_ENVOY_LINUX_VERSION:-${ISTIO_ENVOY_VERSION}}
+ISTIO_ENVOY_LINUX_DEBUG_URL=${ISTIO_ENVOY_LINUX_DEBUG_URL:-${ISTIO_ENVOY_DEBUG_URL}}
+ISTIO_ENVOY_LINUX_RELEASE_URL=${ISTIO_ENVOY_LINUX_RELEASE_URL:-${ISTIO_ENVOY_RELEASE_URL}}
 # Variables for the extracted debug/release Envoy artifacts.
-ISTIO_ENVOY_DEBUG_DIR=${ISTIO_ENVOY_DEBUG_DIR:-"${OUT_DIR}/${GOOS}_${GOARCH}/debug"}
-ISTIO_ENVOY_DEBUG_NAME=${ISTIO_ENVOY_DEBUG_NAME:-"envoy-debug-$ISTIO_ENVOY_VERSION"}
-ISTIO_ENVOY_DEBUG_PATH=${ISTIO_ENVOY_DEBUG_PATH:-"$ISTIO_ENVOY_DEBUG_DIR/$ISTIO_ENVOY_DEBUG_NAME"}
-ISTIO_ENVOY_RELEASE_DIR=${ISTIO_ENVOY_RELEASE_DIR:-"${OUT_DIR}/${GOOS}_${GOARCH}/release"}
-ISTIO_ENVOY_RELEASE_NAME=${ISTIO_ENVOY_RELEASE_NAME:-"envoy-$ISTIO_ENVOY_VERSION"}
-ISTIO_ENVOY_RELEASE_PATH=${ISTIO_ENVOY_RELEASE_PATH:-"$ISTIO_ENVOY_RELEASE_DIR/$ISTIO_ENVOY_RELEASE_NAME"}
+ISTIO_ENVOY_LINUX_DEBUG_DIR=${ISTIO_ENVOY_LINUX_DEBUG_DIR:-"${OUT_DIR}/linux_amd64/debug"}
+ISTIO_ENVOY_LINUX_DEBUG_NAME=${ISTIO_ENVOY_LINUX_DEBUG_NAME:-"envoy-debug-${ISTIO_ENVOY_LINUX_VERSION}"}
+ISTIO_ENVOY_LINUX_DEBUG_PATH=${ISTIO_ENVOY_LINUX_DEBUG_PATH:-"${ISTIO_ENVOY_LINUX_DEBUG_DIR}/${ISTIO_ENVOY_LINUX_DEBUG_NAME}"}
+ISTIO_ENVOY_LINUX_RELEASE_DIR=${ISTIO_ENVOY_LINUX_RELEASE_DIR:-"${OUT_DIR}/linux_amd64/release"}
+ISTIO_ENVOY_LINUX_RELEASE_NAME=${ISTIO_ENVOY_LINUX_RELEASE_NAME:-"envoy-${ISTIO_ENVOY_LINUX_VERSION}"}
+ISTIO_ENVOY_LINUX_RELEASE_PATH=${ISTIO_ENVOY_LINUX_RELEASE_PATH:-"${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${ISTIO_ENVOY_LINUX_RELEASE_NAME}"}
 
-# Set the value of DOWNLOAD_COMMAND (either curl or wget)
-set_download_command
+# Envoy mac/darwin vars. Normally set by the makefile.
+# TODO Change url when official envoy release for MAC is available
+ISTIO_ENVOY_MACOS_VERSION=${ISTIO_ENVOY_MACOS_VERSION:-1.0.2}
+ISTIO_ENVOY_MACOS_RELEASE_URL=${ISTIO_ENVOY_MACOS_RELEASE_URL:-https://github.com/istio/proxy/releases/download/${ISTIO_ENVOY_MACOS_VERSION}/istio-proxy-${ISTIO_ENVOY_MACOS_VERSION}-macos.tar.gz}
+# Variables for the extracted debug/release Envoy artifacts.
+ISTIO_ENVOY_MACOS_RELEASE_DIR=${ISTIO_ENVOY_MACOS_RELEASE_DIR:-"${OUT_DIR}/darwin_amd64/release"}
+ISTIO_ENVOY_MACOS_RELEASE_NAME=${ISTIO_ENVOY_MACOS_RELEASE_NAME:-"envoy-${ISTIO_ENVOY_MACOS_VERSION}"}
+ISTIO_ENVOY_MACOS_RELEASE_PATH=${ISTIO_ENVOY_MACOS_RELEASE_PATH:-"${ISTIO_ENVOY_MACOS_RELEASE_DIR}/${ISTIO_ENVOY_MACOS_RELEASE_NAME}"}
 
-# Save envoy in $ISTIO_ENVOY_DIR
-if [ ! -f "$ISTIO_ENVOY_DEBUG_PATH" ] || [ ! -f "$ISTIO_ENVOY_RELEASE_PATH" ] ; then
-    # Clear out any old versions of Envoy.
-    rm -f "${ISTIO_OUT}/envoy" "${ROOTDIR}/pilot/pkg/proxy/envoy/envoy" "${ISTIO_BIN}/envoy"
+# Allow override with a local build of Envoy
+USE_LOCAL_PROXY=${USE_LOCAL_PROXY:-0}
+if [[ ${USE_LOCAL_PROXY} == 1 ]] ; then
+  ISTIO_ENVOY_LOCAL_PATH=${ISTIO_ENVOY_LOCAL_PATH:-$(realpath "${ISTIO_GO}/../proxy/bazel-bin/src/envoy/envoy")}
+  echo "Using istio-proxy image from local workspace: ${ISTIO_ENVOY_LOCAL_PATH}"
+  if [[ ! -f "${ISTIO_ENVOY_LOCAL_PATH}" ]]; then
+    echo "Error: missing istio-proxy from local workspace: ${ISTIO_ENVOY_LOCAL_PATH}. Check your build path."
+    exit 1
+  fi
 
-    # Download debug envoy binary.
-    mkdir -p "$ISTIO_ENVOY_DEBUG_DIR"
-    pushd "$ISTIO_ENVOY_DEBUG_DIR"
-    if [ "$LOCAL_OS" == "Darwin" ] && [ "$GOOS" != "linux" ]; then
-       ISTIO_ENVOY_DEBUG_URL=${ISTIO_ENVOY_MAC_RELEASE_URL}
+  # Point the native paths to the local envoy build.
+  if [[ "$LOCAL_OS" == "Darwin" ]]; then
+    ISTIO_ENVOY_MACOS_RELEASE_PATH=${ISTIO_ENVOY_LOCAL_PATH}
+
+    ISTIO_ENVOY_LINUX_LOCAL_PATH=${ISTIO_ENVOY_LINUX_LOCAL_PATH:-}
+    if [[ -f "${ISTIO_ENVOY_LINUX_LOCAL_PATH}" ]] ; then
+      ISTIO_ENVOY_LINUX_DEBUG_PATH=${ISTIO_ENVOY_LINUX_LOCAL_PATH}
+      ISTIO_ENVOY_LINUX_RELEASE_PATH=${ISTIO_ENVOY_LINUX_LOCAL_PATH}
+    else
+      echo "Warning: The specified local OSX Envoy will not be included by Docker images. Set ISTIO_ENVOY_LINUX_LOCAL_PATH to specify a custom Linux build."
     fi
-    echo "Downloading envoy debug artifact: ${DOWNLOAD_COMMAND} ${ISTIO_ENVOY_DEBUG_URL}"
-    time ${DOWNLOAD_COMMAND} "${ISTIO_ENVOY_DEBUG_URL}" | tar xz
-    cp usr/local/bin/envoy "$ISTIO_ENVOY_DEBUG_PATH"
-    rm -rf usr
-    popd
-
-    # Download release envoy binary.
-    mkdir -p "$ISTIO_ENVOY_RELEASE_DIR"
-    pushd "$ISTIO_ENVOY_RELEASE_DIR"
-    if [ "$LOCAL_OS" == "Darwin" ] && [ "$GOOS" != "linux" ]; then
-       ISTIO_ENVOY_RELEASE_URL=${ISTIO_ENVOY_MAC_RELEASE_URL}
-    fi
-    echo "Downloading envoy release artifact: ${DOWNLOAD_COMMAND} ${ISTIO_ENVOY_RELEASE_URL}"
-    time ${DOWNLOAD_COMMAND} "${ISTIO_ENVOY_RELEASE_URL}" | tar xz
-    cp usr/local/bin/envoy "$ISTIO_ENVOY_RELEASE_PATH"
-    rm -rf usr
-    popd
+  else
+    ISTIO_ENVOY_LINUX_DEBUG_PATH=${ISTIO_ENVOY_LOCAL_PATH}
+    ISTIO_ENVOY_LINUX_RELEASE_PATH=${ISTIO_ENVOY_LOCAL_PATH}
+  fi
 fi
 
 mkdir -p "${ISTIO_OUT}"
 mkdir -p "${ISTIO_BIN}"
 
-# copy debug envoy binary used for local tests such as ones in mixer/test/clients
-if [ "$LOCAL_OS" == "Darwin" ]; then
-    # Download darwin envoy binary.
-    DARWIN_ENVOY_DIR=$(mktemp -d)
-    pushd "$DARWIN_ENVOY_DIR"
-    echo "Downloading envoy darwin binary: ${DOWNLOAD_COMMAND} ${ISTIO_ENVOY_MAC_RELEASE_URL}"
-    time ${DOWNLOAD_COMMAND} "${ISTIO_ENVOY_MAC_RELEASE_URL}" | tar xz
-    cp usr/local/bin/envoy "${ISTIO_OUT}/envoy"
-    cp usr/local/bin/envoy "${ISTIO_BIN}/envoy"
-    popd
-    rm -rf "$DARWIN_ENVOY_DIR"
+# Set the value of DOWNLOAD_COMMAND (either curl or wget)
+set_download_command
+
+# Download and extract the Envoy linux debug binary.
+download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_DEBUG_URL}" "$ISTIO_ENVOY_LINUX_DEBUG_PATH"
+
+# Download and extract the Envoy linux release binary.
+download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_RELEASE_URL}" "$ISTIO_ENVOY_LINUX_RELEASE_PATH"
+
+if [[ "$LOCAL_OS" == "Darwin" ]]; then
+  # Download and extract the Envoy mac release binary
+  download_envoy_if_necessary "${ISTIO_ENVOY_MACOS_RELEASE_URL}" "$ISTIO_ENVOY_MACOS_RELEASE_PATH"
+  ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_MACOS_RELEASE_PATH}
 else
-    cp -f "${ISTIO_ENVOY_DEBUG_PATH}" "${ISTIO_OUT}/envoy"
-    # TODO(nmittler): Remove once tests no longer use the envoy binary directly.
-    # circleCI expects this in the bin directory
-    # Make sure the envoy binary exists. This is only used for tests, so use the debug binary.
-    cp "${ISTIO_ENVOY_DEBUG_PATH}" "${ISTIO_BIN}/envoy"
+  ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_LINUX_DEBUG_PATH}
 fi
+
+# Copy native envoy binary to ISTIO_OUT
+echo "Copying ${ISTIO_ENVOY_NATIVE_PATH} to ${ISTIO_OUT}/envoy"
+cp -f "${ISTIO_ENVOY_NATIVE_PATH}" "${ISTIO_OUT}/envoy"
+
+# TODO(nmittler): Remove once tests no longer use the envoy binary directly.
+# circleCI expects this in the bin directory
+# Make sure the envoy binary exists. This is only used for tests, so use the debug binary.
+echo "Copying ${ISTIO_OUT}/envoy to ${ISTIO_BIN}/envoy"
+cp -f "${ISTIO_OUT}/envoy" "${ISTIO_BIN}/envoy"
 
 # Download istio.deps from the istio/proxy repository so it can be referenced, if needed
 ISTIO_PROXY_DEPS_URL="https://raw.githubusercontent.com/istio/proxy/${PROXY_REPO_SHA}/istio.deps"

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -98,7 +98,7 @@ docker.proxy_debug: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxy_debug: tools/packaging/common/envoy_bootstrap_drain.json
 docker.proxy_debug: install/gcp/bootstrap/gcp_envoy_bootstrap.json
 docker.proxy_debug: $(ISTIO_DOCKER)/ca-certificates.tgz
-docker.proxy_debug: ${ISTIO_ENVOY_DEBUG_PATH}
+docker.proxy_debug: ${ISTIO_ENVOY_LINUX_DEBUG_PATH}
 docker.proxy_debug: $(ISTIO_OUT)/pilot-agent
 docker.proxy_debug: pilot/docker/Dockerfile.proxyv2
 docker.proxy_debug: pilot/docker/envoy_pilot.yaml.tmpl
@@ -107,9 +107,9 @@ docker.proxy_debug: pilot/docker/envoy_telemetry.yaml.tmpl
 	$(DOCKER_RULE)
 
 # The file must be named 'envoy', depends on the release.
-${ISTIO_ENVOY_RELEASE_DIR}/envoy: ${ISTIO_ENVOY_RELEASE_PATH}
+${ISTIO_ENVOY_LINUX_RELEASE_DIR}/envoy: ${ISTIO_ENVOY_LINUX_RELEASE_PATH}
 	mkdir -p $(DOCKER_BUILD_TOP)/proxyv2
-	cp ${ISTIO_ENVOY_RELEASE_PATH} ${ISTIO_ENVOY_RELEASE_DIR}/envoy
+	cp ${ISTIO_ENVOY_LINUX_RELEASE_PATH} ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/envoy
 
 # Default proxy image.
 docker.proxyv2: BUILD_PRE=chmod 755 envoy pilot-agent &&
@@ -118,7 +118,7 @@ docker.proxyv2: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxyv2: tools/packaging/common/envoy_bootstrap_drain.json
 docker.proxyv2: install/gcp/bootstrap/gcp_envoy_bootstrap.json
 docker.proxyv2: $(ISTIO_DOCKER)/ca-certificates.tgz
-docker.proxyv2: $(ISTIO_ENVOY_RELEASE_DIR)/envoy
+docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/envoy
 docker.proxyv2: $(ISTIO_OUT)/pilot-agent
 docker.proxyv2: pilot/docker/Dockerfile.proxyv2
 docker.proxyv2: pilot/docker/envoy_pilot.yaml.tmpl
@@ -133,7 +133,7 @@ docker.proxytproxy: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxytproxy: tools/packaging/common/envoy_bootstrap_drain.json
 docker.proxytproxy: install/gcp/bootstrap/gcp_envoy_bootstrap.json
 docker.proxytproxy: $(ISTIO_DOCKER)/ca-certificates.tgz
-docker.proxytproxy: $(ISTIO_ENVOY_RELEASE_DIR)/envoy
+docker.proxytproxy: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/envoy
 docker.proxytproxy: $(ISTIO_OUT)/pilot-agent
 docker.proxytproxy: pilot/docker/Dockerfile.proxytproxy
 docker.proxytproxy: pilot/docker/envoy_pilot.yaml.tmpl


### PR DESCRIPTION
The logic flow for linux vs mac is not currently obvious
and without setting GOOS beforehand, you'll end up with
mac binaries in your dockerfiles.

This PR makes more clear where binaries are used. Docker always uses linux, where tests will use the appropriate binary for the os.