### PR TITLE
copy code coverage to artifacts directory

### DIFF
--- a/bin/codecov_diff.sh
+++ b/bin/codecov_diff.sh
@@ -74,5 +74,5 @@ else
 fi
 
 if [[ -n "${ARTIFACTS_DIR:-}" ]]; then
-  cp ${REPORT_PATH}/coverage.cov ${ARTIFACTS_DIR}
+  cp "${REPORT_PATH}/coverage.cov" "${ARTIFACTS_DIR}"
 fi

--- a/bin/codecov_diff.sh
+++ b/bin/codecov_diff.sh
@@ -70,6 +70,9 @@ if [[ -n "${CIRCLE_PR_NUMBER:-}" ]]; then
     | tee >(go-junit-report > "${GOPATH}"/out/tests/junit.xml)
 else
   # Upload to codecov.io in post submit only for visualization
-  bash <(curl -s https://codecov.io/bash) -f "${GOPATH}/out/codecov/pr/coverage.cov"
+  bash <(curl -s https://codecov.io/bash) -f "${REPORT_PATH}/coverage.cov"
 fi
 
+if [[ -n "${ARTIFACTS_DIR:-}" ]]; then
+  cp ${REPORT_PATH}/coverage.cov ${ARTIFACTS_DIR}
+fi


### PR DESCRIPTION
For the eng dashboard, we want to be able to scrape code coverage from
GCS. This change adds the coverage file to the artifacts directory,
which in turn should automatically be uploaded to GCS.