### PR TITLE
set nodeagent updateStrategy to RollingUpdate

### DIFF
--- a/install/kubernetes/helm/istio/charts/nodeagent/templates/daemonset.yaml
+++ b/install/kubernetes/helm/istio/charts/nodeagent/templates/daemonset.yaml
@@ -62,3 +62,5 @@ spec:
       tolerations:
 {{ toYaml .Values.global.defaultTolerations | indent 6 }}
       {{- end }}
+  updateStrategy:
+    type: RollingUpdate


### PR DESCRIPTION
https://github.com/istio/istio/issues/15020

https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy

looks like current updateStrategy defaut mode is ```OnDelete```, which means upgrade didn't happen without delete daemonset explicitly. 

```
kubectl get ds/istio-nodeagent -o go-template='{{.spec.updateStrategy.type}}{{"\n"}}' -n istio-system
OnDelete
```