### PR TITLE
disable redundant circleci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,16 +249,7 @@ workflows:
   version: 2
   all:
     jobs:
-      - shellcheck
       - build
-      - test
-      - codecov
-      - racetest:
-          requires:
-            - test
-      - e2e-pilot-noauth-v1alpha3-v2: # noauth+v1alpha3+v2
-          requires:
-            - build
       - e2e-pilot-cloudfoundry-v1alpha3-v2:
           requires:
             - build


### PR DESCRIPTION
@rosenhouse / @utako / @Nino-K / @zachgersh et al, if you can help migrate this cf test to prow, then we can disable circleci fully.