### PR TITLE
Change CA client test name

### DIFF
--- a/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
@@ -46,7 +46,7 @@ func (ca *mockCAServer) CreateCertificate(ctx context.Context, in *pb.IstioCerti
 	return nil, ca.Err
 }
 
-func TestGoogleCAClient(t *testing.T) {
+func TestCitadelClient(t *testing.T) {
 	testCases := map[string]struct {
 		server       mockCAServer
 		expectedCert []string


### PR DESCRIPTION
The code lives under Citadel client directory and tests Citadel client, not GoogleCA client. 

#13439 