### PR TITLE
 Grant k8s namespace read permissions to Citadel [Issue 15115]

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/clusterrole.yaml
@@ -15,7 +15,7 @@ rules:
   resources: ["secrets"]
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 - apiGroups: [""]
-  resources: ["serviceaccounts", "services"]
+  resources: ["serviceaccounts", "services", "namespaces"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]


### PR DESCRIPTION
---
name: Grant k8s namespace read permissions to Citadel
about: Citadel's controller loop requires namespace read permissions, but does not have them
---

[Relevant issue
](https://github.com/istio/istio/issues/15115)
To determine whether or not a given namespace should be Citadel-managed, if the `listened-namespaces` flag is not used and `explicit-opt-in` is enabled, [we must check the namespace's labels](https://github.com/istio/istio/blob/5fcdb826dd8e4e08757c52a4587d0c499c1cafc5/security/pkg/k8s/controller/workloadsecret.go#L222) for `istio-managed`. However, Citadel [does not currently have the privileges](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/security/templates/clusterrole.yaml#L18) to read cluster namespace resources. This patch is a one-liner which grants the correct permission.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastrcture
