### PR TITLE
Implement /quitquitquit in pilot-agent to support k8s job exit

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -183,7 +183,7 @@ func (s *Server) handleQuit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 	log.Infof("handling %s, and notify pilot-agent to exit", quitPath)
 	notifyExit()
 }

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -41,6 +41,8 @@ import (
 const (
 	// readyPath is for the pilot agent readiness itself.
 	readyPath = "/healthz/ready"
+	// quitPath is to notify the pilot agent to quit.
+	quitPath = "/quitquitquit"
 	// KubeAppProberEnvName is the name of the command line flag for pilot agent to pass app prober config.
 	// The json encoded string to pass app HTTP probe information from injector(istioctl or webhook).
 	// For example, ISTIO_KUBE_APP_PROBERS='{"/app-health/httpbin/livez":{"path": "/hello", "port": 8080}.
@@ -123,6 +125,7 @@ func (s *Server) Run(ctx context.Context) {
 
 	// Add the handler for ready probes.
 	mux.HandleFunc(readyPath, s.handleReadyProbe)
+	mux.HandleFunc(quitPath, s.handleQuit)
 	mux.HandleFunc("/app-health/", s.handleAppProbe)
 
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", s.statusPort))
@@ -145,11 +148,7 @@ func (s *Server) Run(ctx context.Context) {
 			log.Errora(err)
 			// If the server errors then pilot-agent can never pass readiness or liveness probes
 			// Therefore, trigger graceful termination by sending SIGTERM to the binary pid
-			p, err := os.FindProcess(os.Getpid())
-			if err != nil {
-				log.Errora(err)
-			}
-			log.Errora(p.Signal(syscall.SIGTERM))
+			notifyExit()
 		}
 	}()
 
@@ -176,6 +175,17 @@ func (s *Server) handleReadyProbe(w http.ResponseWriter, _ *http.Request) {
 		s.lastProbeSuccessful = true
 	}
 	s.mutex.Unlock()
+}
+
+func (s *Server) handleQuit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+	log.Infof("handling %s, and notify pilot-agent to exit", quitPath)
+	notifyExit()
 }
 
 func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
@@ -233,4 +243,13 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 
 	// We only write the status code to the response.
 	w.WriteHeader(response.StatusCode)
+}
+
+// notifyExit sends SIGTERM to itself
+func notifyExit() {
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		log.Errora(err)
+	}
+	log.Errora(p.Signal(syscall.SIGTERM))
 }

--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -46,7 +46,6 @@ type envoy struct {
 	extraArgs      []string
 	pilotSAN       []string
 	opts           map[string]interface{}
-	errChan        chan error
 	nodeIPs        []string
 	dnsRefreshRate string
 }
@@ -141,17 +140,6 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
-
-	// Set if the caller is monitoring envoy, for example in tests or if envoy runs in same
-	// container with the app.
-	if e.errChan != nil {
-		// Caller passed a channel, will wait itself for termination
-		go func() {
-			e.errChan <- cmd.Wait()
-		}()
-		return nil
-	}
-
 	done := make(chan error, 1)
 	go func() {
 		done <- cmd.Wait()

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -637,6 +638,33 @@ func (k *KubeInfo) GetAppPods(cluster string) map[string][]string {
 		}
 	}
 	return newMap
+}
+
+// CheckJobSucceeded checks whether the job succeeded.
+func (k *KubeInfo) CheckJobSucceeded(cluster, jobName string) error {
+	retry := util.Retrier{
+		BaseDelay: 5 * time.Second,
+		MaxDelay:  5 * time.Second,
+		Retries:   5,
+	}
+
+	retryFn := func(_ context.Context, i int) error {
+		ret, err := util.IsJobSucceeded(k.Namespace, jobName, k.Clusters[cluster])
+		if err != nil {
+			log.Errorf("Failed to get retrieve the app pods for namespace %s", k.Namespace)
+			return err
+		}
+		if !ret {
+			return fmt.Errorf("Job %s not succeeded", jobName)
+		}
+		return nil
+	}
+	ctx := context.Background()
+	_, err := retry.Retry(ctx, retryFn)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // GetRoutes gets routes from the pod or returns error

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -655,7 +655,7 @@ func (k *KubeInfo) CheckJobSucceeded(cluster, jobName string) error {
 			return err
 		}
 		if !ret {
-			return fmt.Errorf("Job %s not succeeded", jobName)
+			return fmt.Errorf("job %s not succeeded", jobName)
 		}
 		return nil
 	}

--- a/tests/e2e/tests/pilot/pilot_agent_test.go
+++ b/tests/e2e/tests/pilot/pilot_agent_test.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pilot
+
+import (
+	"testing"
+)
+
+func TestJobComplete(t *testing.T) {
+	jobName := "test-job"
+
+	for cluster := range tc.Kube.Clusters {
+		if err := tc.Kube.CheckJobSucceeded(cluster, jobName); err != nil {
+			t.Errorf("Job %s not completed successfully", jobName)
+		}
+	}
+}

--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -364,6 +364,8 @@ func getApps() []framework.App {
 		getApp("d", "d", 1, 80, 8080, 90, 9090, 70, 7070, "per-svc-auth", true, false, true, true),
 		getApp("headless", "headless", 1, 80, 8080, 10090, 19090, 70, 7070, "unversioned", true, true, true, true),
 		getStatefulSet("statefulset", 19090, true),
+
+		getJob("test-job", true),
 	}
 }
 
@@ -412,6 +414,18 @@ func getStatefulSet(service string, port int, injectProxy bool) framework.App {
 			"istioNamespace":  tc.Kube.Namespace,
 			"injectProxy":     strconv.FormatBool(injectProxy),
 			"ImagePullPolicy": tc.Kube.ImagePullPolicy(),
+		},
+		KubeInject: injectProxy,
+	}
+}
+
+func getJob(jobName string, injectProxy bool) framework.App {
+
+	// Return the config.
+	return framework.App{
+		AppYamlTemplate: "testdata/job.yaml",
+		Template: map[string]string{
+			"name": jobName,
 		},
 		KubeInject: injectProxy,
 	}

--- a/tests/e2e/tests/pilot/testdata/job.yaml
+++ b/tests/e2e/tests/pilot/testdata/job.yaml
@@ -1,0 +1,25 @@
+# Copyright 2019 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.name}}
+spec:
+  template:
+    spec:
+      containers:
+        - name: test
+          image: pstauffer/curl
+          command: ["sh", "-c", "sleep 5;curl -X POST http://127.0.0.1:15020/quitquitquit"]
+      restartPolicy: Never

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -461,6 +461,20 @@ func GetAppPods(n string, kubeconfig string) (map[string][]string, error) {
 	return m, nil
 }
 
+// IsJobSucceeded checks whether a job for the given namespace succeeded
+func IsJobSucceeded(n, name string, kubeconfig string) (bool, error) {
+	succeed, err := Shell("kubectl -n %s get job  %s -o jsonpath='{.status.succeeded}' --kubeconfig=%s", n, name, kubeconfig)
+	if err != nil {
+		log.Warnf("could not get %s job: %v", name, err)
+		return false, err
+	}
+
+	if len(succeed) != 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
 // GetPodLabelValues gets a map of pod name to label value for the given label and namespace
 func GetPodLabelValues(n, label string, kubeconfig string) (map[string]string, error) {
 	// This will return a table where c0=pod_name and c1=label_value.


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Added a `/quitquitquit` to handle quit request from client, which mainly provide a way for k8s jobs to exit.

It only handles  http POST method,  by default pilot-agent listens on 15020 port.


fixes: #https://github.com/istio/istio/issues/15041