### PR TITLE
Test Framework: Add target for simple new installer tests, and minor fixes

### DIFF
--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -395,7 +395,6 @@ func (a *Accessor) CreateNamespaceWithInjectionEnabled(ns string, istioTestingAn
 	n := a.newNamespace(ns, istioTestingAnnotation)
 
 	n.ObjectMeta.Labels["istio-injection"] = "enabled"
-	n.ObjectMeta.Labels["istio-env"] = configNamespace
 
 	_, err := a.set.CoreV1().Namespaces().Create(&n)
 	return err

--- a/tests/integration/galley/validation_test.go
+++ b/tests/integration/galley/validation_test.go
@@ -100,6 +100,7 @@ func TestValidation(t *testing.T) {
 					env := ctx.Environment().(*kube.Environment)
 					ns := namespace.NewOrFail(t, ctx, "validation", false)
 					err = env.ApplyContents(ns.Name(), yml)
+					defer env.DeleteContents(ns.Name(), yml)
 
 					switch {
 					case err != nil && d.isValid():

--- a/tests/integration/security/citadel/bootstrap_writesecret_test.go
+++ b/tests/integration/security/citadel/bootstrap_writesecret_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pkg/test/framework/label"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test/framework"
@@ -42,7 +43,9 @@ const (
 // it should not generate a new cert and overwrite the existing secret. Instead, the Citadel pod should
 // immediately exit with error.
 func TestCitadelBootstrapKubernetes(t *testing.T) {
-	framework.NewTest(t).Run(func(ctx framework.TestContext) {
+	framework.NewTest(t).
+		Label(label.CustomSetup). // test depends on the clusterrole name being "istio-citadel-istio-system"
+		Run(func(ctx framework.TestContext) {
 		ns := namespace.ClaimOrFail(t, ctx, ist.Settings().IstioNamespace)
 		namespaceTmpl := map[string]string{
 			"Namespace": ns.Name(),

--- a/tests/integration/security/citadel/bootstrap_writesecret_test.go
+++ b/tests/integration/security/citadel/bootstrap_writesecret_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/framework/label"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pkg/test/framework/label"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
@@ -46,80 +47,80 @@ func TestCitadelBootstrapKubernetes(t *testing.T) {
 	framework.NewTest(t).
 		Label(label.CustomSetup). // test depends on the clusterrole name being "istio-citadel-istio-system"
 		Run(func(ctx framework.TestContext) {
-		ns := namespace.ClaimOrFail(t, ctx, ist.Settings().IstioNamespace)
-		namespaceTmpl := map[string]string{
-			"Namespace": ns.Name(),
-		}
+			ns := namespace.ClaimOrFail(t, ctx, ist.Settings().IstioNamespace)
+			namespaceTmpl := map[string]string{
+				"Namespace": ns.Name(),
+			}
 
-		// Apply the RBAC policy to prevent Citadel from reading the CA-root secret.
-		policies := tmpl.EvaluateAllOrFail(t, namespaceTmpl,
-			file.AsStringOrFail(t, noReadRBACConfigTmpl))
+			// Apply the RBAC policy to prevent Citadel from reading the CA-root secret.
+			policies := tmpl.EvaluateAllOrFail(t, namespaceTmpl,
+				file.AsStringOrFail(t, noReadRBACConfigTmpl))
 
-		g.ApplyConfigOrFail(t, ns, policies...)
+			g.ApplyConfigOrFail(t, ns, policies...)
 
-		// Sleep 10 seconds for the policy to take effect.
-		time.Sleep(10 * time.Second)
+			// Sleep 10 seconds for the policy to take effect.
+			time.Sleep(10 * time.Second)
 
-		// Retrieve Citadel CA-root secret. Keep it for later comparison.
-		env := ctx.Environment().(*kube.Environment)
-		secrets := env.GetSecret(ns.Name())
-		citadelSecret, err := secrets.Get(ca.CASecret, metav1.GetOptions{})
-		if err != nil {
-			t.Fatal("Failed to retrieve Citadel CA-root secret.")
-		}
+			// Retrieve Citadel CA-root secret. Keep it for later comparison.
+			env := ctx.Environment().(*kube.Environment)
+			secrets := env.GetSecret(ns.Name())
+			citadelSecret, err := secrets.Get(ca.CASecret, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal("Failed to retrieve Citadel CA-root secret.")
+			}
 
-		// Delete Citadel pod, a new pod will be started.
-		pods, err := env.GetPods(ns.Name(), "istio=citadel")
-		if err != nil {
-			t.Fatal("Failed to get Citadel pods.")
-		}
-		env.DeletePod(ns.Name(), pods[0].GetName())
+			// Delete Citadel pod, a new pod will be started.
+			pods, err := env.GetPods(ns.Name(), "istio=citadel")
+			if err != nil {
+				t.Fatal("Failed to get Citadel pods.")
+			}
+			env.DeletePod(ns.Name(), pods[0].GetName())
 
-		// Sleep 60 seconds for the recreated Citadel to detect the write error and exit.
-		time.Sleep(60 * time.Second)
+			// Sleep 60 seconds for the recreated Citadel to detect the write error and exit.
+			time.Sleep(60 * time.Second)
 
-		pods, err = env.GetPods(ns.Name(), "istio=citadel")
-		if err != nil {
-			t.Fatalf("failed to get Citadel pod")
-		}
-		cl, cErr := env.Logs(ns.Name(), pods[0].Name, "citadel", false /* previousLog */)
-		pl, pErr := env.Logs(ns.Name(), pods[0].Name, "citadel", true /* previousLog */)
-		expectedErr := []string{"Failed to write secret to CA", "Failed to create a self-signed Citadel"}
-		if cl != "" && cErr == nil && strings.Contains(cl, expectedErr[0]) && strings.Contains(cl, expectedErr[1]) {
-			// Found the strings in the current log.
-		} else if pl != "" && pErr == nil && strings.Contains(pl, expectedErr[0]) && strings.Contains(pl, expectedErr[1]) {
-			// Found the strings in the previous log.
-		} else {
-			t.Errorf("log does not match, expected strings %s and %s not found in logs. Current log: %s, previous log: %s",
-				expectedErr[0], expectedErr[1], cl, pl)
-		}
+			pods, err = env.GetPods(ns.Name(), "istio=citadel")
+			if err != nil {
+				t.Fatalf("failed to get Citadel pod")
+			}
+			cl, cErr := env.Logs(ns.Name(), pods[0].Name, "citadel", false /* previousLog */)
+			pl, pErr := env.Logs(ns.Name(), pods[0].Name, "citadel", true /* previousLog */)
+			expectedErr := []string{"Failed to write secret to CA", "Failed to create a self-signed Citadel"}
+			if cl != "" && cErr == nil && strings.Contains(cl, expectedErr[0]) && strings.Contains(cl, expectedErr[1]) {
+				// Found the strings in the current log.
+			} else if pl != "" && pErr == nil && strings.Contains(pl, expectedErr[0]) && strings.Contains(pl, expectedErr[1]) {
+				// Found the strings in the previous log.
+			} else {
+				t.Errorf("log does not match, expected strings %s and %s not found in logs. Current log: %s, previous log: %s",
+					expectedErr[0], expectedErr[1], cl, pl)
+			}
 
-		// Verify that the CA-root secret remains intact.
-		currentSecret, err := secrets.Get(ca.CASecret, metav1.GetOptions{})
-		if err != nil {
-			t.Fatal("Failed to retrieve Citadel CA-root secret.")
-		}
-		if !reflect.DeepEqual(citadelSecret, currentSecret) {
-			t.Fatal("Citadel CA-root secret is changed!")
-		}
+			// Verify that the CA-root secret remains intact.
+			currentSecret, err := secrets.Get(ca.CASecret, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal("Failed to retrieve Citadel CA-root secret.")
+			}
+			if !reflect.DeepEqual(citadelSecret, currentSecret) {
+				t.Fatal("Citadel CA-root secret is changed!")
+			}
 
-		// Recover the normal setup for other tests.
-		// Recover the normal RBAC policy.
-		policies = tmpl.EvaluateAllOrFail(t, namespaceTmpl,
-			file.AsStringOrFail(t, normalRBACConfigTmpl))
+			// Recover the normal setup for other tests.
+			// Recover the normal RBAC policy.
+			policies = tmpl.EvaluateAllOrFail(t, namespaceTmpl,
+				file.AsStringOrFail(t, normalRBACConfigTmpl))
 
-		g.ApplyConfigOrFail(t, ns, policies...)
+			g.ApplyConfigOrFail(t, ns, policies...)
 
-		// Sleep 10 seconds for the policy to take effect.
-		time.Sleep(10 * time.Second)
+			// Sleep 10 seconds for the policy to take effect.
+			time.Sleep(10 * time.Second)
 
-		// Delete Citadel pod, a new pod will be started.
-		pods, err = env.GetPods(ns.Name(), "istio=citadel")
-		if err != nil {
-			t.Fatal("Failed to get Citadel pods.")
-		}
-		env.DeletePod(ns.Name(), pods[0].GetName())
-		// Sleep 10 seconds for the Citadel pod to recreate.
-		time.Sleep(10 * time.Second)
-	})
+			// Delete Citadel pod, a new pod will be started.
+			pods, err = env.GetPods(ns.Name(), "istio=citadel")
+			if err != nil {
+				t.Fatal("Failed to get Citadel pods.")
+			}
+			env.DeletePod(ns.Name(), pods[0].GetName())
+			// Sleep 10 seconds for the Citadel pod to recreate.
+			time.Sleep(10 * time.Second)
+		})
 }

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -55,6 +55,29 @@ test.integration.%.kube: | $(JUNIT_REPORT)
 	${_INTEGRATION_TEST_INGRESS_FLAG} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))
 
+# Test targets to run with the new installer. Some targets are filtered now as they are not yet working
+NEW_INSTALLER_TARGETS = $(shell GOPATH=${GOPATH} go list ../istio/tests/integration/... | grep -v "/mixer\|telemetry/tracing\|/istioctl")
+
+# Runs tests using the new installer. Istio is deployed before the test and setup and cleanup are disabled.
+# For this to work, the -customsetup selector is used.
+test.integration.new.installer: | $(JUNIT_REPORT)
+	KUBECONFIG=${INTEGRATION_TEST_KUBECONFIG} kubectl apply -k github.com/istio/installer/crds
+	KUBECONFIG=${INTEGRATION_TEST_KUBECONFIG} kubectl apply -k github.com/istio/installer/test/demo
+	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
+	set -o pipefail; \
+	$(GO) test -p 1 ${T} ${NEW_INSTALLER_TARGETS} ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
+	--istio.test.nocleanup \
+	--istio.test.kube.deploy=false \
+	--istio.test.select -postsubmit,-flaky,-customsetup \
+	--istio.test.kube.minikube \
+	--istio.test.env kube \
+	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
+	--istio.test.hub=${HUB} \
+	--istio.test.tag=${TAG} \
+	--istio.test.pullpolicy=${_INTEGRATION_TEST_PULL_POLICY} \
+	${_INTEGRATION_TEST_INGRESS_FLAG} \
+	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))
+
 # Generate integration test targets for local environment.
 test.integration.%.local: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))


### PR DESCRIPTION
This PR accomplishes two things:
* Gets the same tests running on istio/installer running on istio/istio
so changes in istio/istio are less likely to come in that break the
installer repo
* Makes some minor modifications to get the tests passing

In the long term, we will have the test framework actually do the
installer, but there are still some open questions on how that will be
done. In the short term getting this test enabled will help the
installer progress.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
