### PR TITLE
Use docker.push instead of push in prow tests

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -77,7 +77,7 @@ make init
 
 if [[ $HUB == *"istio-testing"* ]]; then
   # upload images
-  time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}" DOCKER_BUILD_VARIANTS="${VARIANT:-default}"
+  time ISTIO_DOCKER_HUB="${HUB}" make docker.push HUB="${HUB}" TAG="${TAG}" DOCKER_BUILD_VARIANTS="${VARIANT:-default}"
 fi
 
 setup_e2e_cluster

--- a/prow/integ-suite-k8s.sh
+++ b/prow/integ-suite-k8s.sh
@@ -73,7 +73,7 @@ fi
 make init
 
 if [[ $HUB == *"istio-testing"* ]]; then
-  time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"
+  time ISTIO_DOCKER_HUB="${HUB}" make docker.push HUB="${HUB}" TAG="${TAG}"
 fi
 
 get_resource "${RESOURCE_TYPE}" "${OWNER}" "${INFO_PATH}" "${FILE_LOG}"


### PR DESCRIPTION

The push command also does some installgen stuff which wastes 5+
minutes.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
