### PR TITLE
Relax keepalive enforcement policy to avoid dropping connections under load

### DIFF
--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -173,6 +173,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 			MaxConnectionAge:      a.KeepAlive.MaxServerConnectionAge,
 			MaxConnectionAgeGrace: a.KeepAlive.MaxServerConnectionAgeGrace,
 		}),
+		// Relax keepalive enforcement policy requirements to avoid dropping connections due to too many pings.
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             time.Minute,
 			PermitWithoutStream: true,

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -174,10 +174,10 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 			MaxConnectionAgeGrace: a.KeepAlive.MaxServerConnectionAgeGrace,
 		}),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime: time.Minute,
+			MinTime:             time.Minute,
 			PermitWithoutStream: true,
 		}),
-		)
+	)
 
 	s.stopCh = make(chan struct{})
 	var checker source.AuthChecker = server.NewAllowAllChecker()

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -172,7 +172,12 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 			Time:                  a.KeepAlive.Time,
 			MaxConnectionAge:      a.KeepAlive.MaxServerConnectionAge,
 			MaxConnectionAgeGrace: a.KeepAlive.MaxServerConnectionAgeGrace,
-		}))
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime: time.Minute,
+			PermitWithoutStream: true,
+		}),
+		)
 
 	s.stopCh = make(chan struct{})
 	var checker source.AuthChecker = server.NewAllowAllChecker()


### PR DESCRIPTION

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
