### PR TITLE
feat(proxy metadata): introduce istio.io/metadata in proxy node metadata

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -392,19 +392,20 @@ type ServiceInstance struct {
 //
 // This is used by CDS/EDS to group the endpoints by locality.
 func (si *ServiceInstance) GetLocality() string {
-	return GetLocalityOrDefault(si.Endpoint.Locality, si.Labels)
+	return GetLocalityOrDefault(si.Labels[LocalityLabel], si.Endpoint.Locality)
 }
 
-// Gets the locality from the labels, or falls back to to a default locality if not found
-// Because Kubernetes labels don't support `/`, we replace "." with "/" as a workaround
-func GetLocalityOrDefault(defaultLocality string, labels map[string]string) string {
-	if labels != nil && labels[LocalityLabel] != "" {
+// GetLocalityOrDefault returns the locality from the supplied label, or falls back to
+// the supplied default locality if the supplied label is empty. Because Kubernetes
+// labels don't support `/`, we replace "." with "/" in the supplied label as a workaround.
+func GetLocalityOrDefault(label, defaultLocality string) string {
+	if len(label) > 0 {
 		// if there are /'s present we don't need to replace
-		if strings.Contains(labels[LocalityLabel], "/") {
-			return labels[LocalityLabel]
+		if strings.Contains(label, "/") {
+			return label
 		}
 		// replace "." with "/"
-		return strings.Replace(labels[LocalityLabel], k8sSeparator, "/", -1)
+		return strings.Replace(label, k8sSeparator, "/", -1)
 	}
 	return defaultLocality
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -330,7 +330,7 @@ func (c *Controller) GetPodLocality(pod *v1.Pod) string {
 		return ""
 	}
 	locality := fmt.Sprintf("%v/%v", region, zone)
-	return model.GetLocalityOrDefault(locality, pod.Labels)
+	return model.GetLocalityOrDefault(pod.Labels[model.LocalityLabel], locality)
 }
 
 // ManagementPorts implements a service catalog operation

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -236,18 +236,20 @@ func extractMetadata(envs []string, prefix string, set setMetaFunc, meta map[str
 }
 
 type istioMetadata struct {
-	CanonicalService string            `json:"canonical_service,omitempty"`
-	IP               string            `json:"ip,omitempty"`
-	Labels           map[string]string `json:"labels,omitempty"`
-	Name             string            `json:"name,omitempty"`
-	Namespace        string            `json:"namespace,omitempty"`
-	ServiceAccount   string            `json:"service_account,omitempty"`
+	CanonicalTelemetryService string            `json:"canonical_telemetry_service,omitempty"`
+	IP                        string            `json:"ip,omitempty"`
+	Labels                    map[string]string `json:"labels,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Namespace                 string            `json:"namespace,omitempty"`
+	ServiceAccount            string            `json:"service_account,omitempty"`
 }
 
 func shouldExtract(envVar, prefix string) bool {
-	if strings.HasPrefix(envVar, "ISTIO_METAJSON_LABELS") {
-		return false
-	}
+	// this will allow transition from current method of exposition in the future
+	// Example:
+	// if strings.HasPrefix(envVar, "ISTIO_METAJSON_LABELS") {
+	// 	return false
+	// }
 	return strings.HasPrefix(envVar, prefix)
 }
 
@@ -281,8 +283,8 @@ func extractIstioMetadata(envVars []string) istioMetadata {
 		case "ISTIO_METAJSON_LABELS":
 			m := jsonStringToMap(val)
 			im.Labels = m
-			if svc, found := m["istioService"]; found {
-				im.CanonicalService = svc
+			if svc, found := m["istioTelemetryService"]; found {
+				im.CanonicalTelemetryService = svc
 			}
 		case "POD_NAME":
 			im.Name = val

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -319,16 +319,6 @@ func getNodeMetaData(envs []string) map[string]interface{} {
 	return meta
 }
 
-func stringMap(in map[string]interface{}) map[string]string {
-	out := make(map[string]string, len(in))
-	for k, v := range in {
-		if s, ok := v.(string); ok {
-			out[k] = s
-		}
-	}
-	return out
-}
-
 var overrideVar = env.RegisterStringVar("ISTIO_BOOTSTRAP", "", "")
 
 // WriteBootstrap generates an envoy config based on config and epoch, and returns the filename.
@@ -382,7 +372,10 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	// Support passing extra info from node environment as metadata
 	meta := getNodeMetaData(localEnv)
 
-	localityOverride := model.GetLocalityOrDefault("", stringMap(meta))
+	localityOverride := ""
+	if locality, ok := meta[model.LocalityLabel].(string); ok {
+		localityOverride = model.GetLocalityOrDefault(locality, localityOverride)
+	}
 	l := util.ConvertLocality(localityOverride)
 	if l == nil {
 		// Populate the platform locality if available.

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -283,9 +283,7 @@ func extractIstioMetadata(envVars []string) istioMetadata {
 		case "ISTIO_METAJSON_LABELS":
 			m := jsonStringToMap(val)
 			im.Labels = m
-			if svc, found := m["istioTelemetryService"]; found {
-				im.CanonicalTelemetryService = svc
-			}
+			im.CanonicalTelemetryService = m["istioTelemetryService"]
 		case "POD_NAME":
 			im.Name = val
 		case "POD_NAMESPACE":
@@ -373,8 +371,8 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	meta := getNodeMetaData(localEnv)
 
 	localityOverride := ""
-	if locality, ok := meta[model.LocalityLabel].(string); ok {
-		localityOverride = model.GetLocalityOrDefault(locality, localityOverride)
+	if locality, ok := meta[model.LocalityLabel]; ok {
+		localityOverride = model.GetLocalityOrDefault(locality.(string), localityOverride)
 	}
 	l := util.ConvertLocality(localityOverride)
 	if l == nil {

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -102,9 +102,8 @@ func TestGolden(t *testing.T) {
 				"ISTIO_META_POD_NAME":            "svc-0-0-0-6944fb884d-4pgx8",
 				"POD_NAME":                       "svc-0-0-0-6944fb884d-4pgx8",
 				"POD_NAMESPACE":                  "test",
-				"ISTIO_META_istio-locality":      "region.zone.sub_zone",
 				"INSTANCE_IP":                    "10.10.10.1",
-				"ISTIO_METAJSON_LABELS":          `{"version": "v1alpha1", "app": "test"}`,
+				"ISTIO_METAJSON_LABELS":          `{"version": "v1alpha1", "app": "test", "istio-locality":"regionA.zoneB.sub_zoneC"}`,
 			},
 			annotations: map[string]string{
 				"istio.io/insecurepath": "{\"paths\":[\"/metrics\",\"/live\"]}",

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -100,7 +100,11 @@ func TestGolden(t *testing.T) {
 				"ISTIO_META_ISTIO_PROXY_VERSION": "istio-proxy:version",
 				"ISTIO_META_ISTIO_VERSION":       "release-3.1",
 				"ISTIO_META_POD_NAME":            "svc-0-0-0-6944fb884d-4pgx8",
+				"POD_NAME":                       "svc-0-0-0-6944fb884d-4pgx8",
+				"POD_NAMESPACE":                  "test",
 				"ISTIO_META_istio-locality":      "region.zone.sub_zone",
+				"INSTANCE_IP":                    "10.10.10.1",
+				"ISTIO_METAJSON_LABELS":          `{"version": "v1alpha1", "app": "test"}`,
 			},
 			annotations: map[string]string{
 				"istio.io/insecurepath": "{\"paths\":[\"/metrics\",\"/live\"]}",

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -623,6 +623,8 @@ func TestNodeMetadata(t *testing.T) {
 		"istio.io/metadata": istioMetadata{
 			Labels: labels,
 		},
+		"l1": "v1",
+		"l2": "v2",
 	}
 
 	_, envs := createEnv(t, labels, nil)

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar"}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar"}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar", "istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar"}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -8,6 +8,8 @@
       "sub_zone": "sub_zone"
     },
     "metadata": {
+      "app": "test",
+      "version": "v1alpha1",
       "INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6",
       "INTERCEPTION_MODE":"REDIRECT",
       "ISTIO_PROXY_SHA":"istio-proxy:sha",
@@ -17,7 +19,15 @@
       "istio":"sidecar",
       "istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}",
       "istio-locality": "region.zone.sub_zone",
-      "istio.io/metadata": {}
+      "istio.io/metadata": {
+        "ip": "10.10.10.1",
+        "name" : "svc-0-0-0-6944fb884d-4pgx8",
+        "namespace": "test",
+        "labels": {
+          "version": "v1alpha1",
+          "app": "test"
+        }
+      }
     }
   },
   "stats_config": {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -3,9 +3,9 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      "region": "region",
-      "zone": "zone",
-      "sub_zone": "sub_zone"
+      "region": "regionA",
+      "zone": "zoneB",
+      "sub_zone": "sub_zoneC"
     },
     "metadata": {
       "app": "test",
@@ -18,14 +18,15 @@
       "POD_NAME":"svc-0-0-0-6944fb884d-4pgx8",
       "istio":"sidecar",
       "istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}",
-      "istio-locality": "region.zone.sub_zone",
+      "istio-locality": "regionA.zoneB.sub_zoneC",
       "istio.io/metadata": {
         "ip": "10.10.10.1",
         "name" : "svc-0-0-0-6944fb884d-4pgx8",
         "namespace": "test",
         "labels": {
           "version": "v1alpha1",
-          "app": "test"
+          "app": "test",
+          "istio-locality": "regionA.zoneB.sub_zoneC"
         }
       }
     }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -16,7 +16,8 @@
       "POD_NAME":"svc-0-0-0-6944fb884d-4pgx8",
       "istio":"sidecar",
       "istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}",
-      "istio-locality": "region.zone.sub_zone"
+      "istio-locality": "region.zone.sub_zone",
+      "istio.io/metadata": {}
     }
   },
   "stats_config": {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","sidecar.istio.io/statsInclusionPrefixes":"cluster_manager,cluster.xds-grpc,listener."}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{},"sidecar.istio.io/statsInclusionPrefixes":"cluster_manager,cluster.xds-grpc,listener."}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -7,7 +7,7 @@
       
       
     },
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar"}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar"}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar"}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar"}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,


### PR DESCRIPTION
This PR introduces functionality to add a field named `"istio.io/metadata"` to the envoy node metadata struct. The new field will host environmental metadata, roughly equivalent to the current Istio attributes, for a given proxy.

This PR is a building block towards a v2 architecture. It represents the first step towards realizing the design approved in https://tinyurl.com/yxablanu.

The `"istio.io/metadata"` field is populated with a struct containing values taken from existing environment variables. Follow-on PRs will add additional fields, once the base functionality has been established and agreed upon.

Here is the node metadata generated by a proxy running with this PR:

```json
    {
  	"node": {
    		"metadata": {
  			"POD_NAME": "ratings-v1-6699485fc9-4g6p9",
  			"istio": "sidecar",
  			"ISTIO_PROXY_VERSION": "1.1.3",
  			"ISTIO_PROXY_SHA": "istio-proxy:542b4fda35046fc9dad5014dbe81f3d5969e63f7",
  			"app": "ratings",
  			"INSTANCE_IPS": "10.44.2.18,fe80::242e:9eff:fea8:9864",
  			"istioTelemetryService": "istio-ratings-v1",
  			"pod-template-hash": "6699485fc9",
  			"istio.io/metadata": {
  				"namespace": "default",
  				"labels": {
  					"istioTelemetryService": "istio-ratings-v1",
  					"pod-template-hash": "6699485fc9",
  					"app": "ratings",
  					"version": "v1"
  				},
  				"ip": "10.44.2.18",
  				"name": "ratings-v1-6699485fc9-4g6p9",
  				"canonical_telemetry_service": "istio-ratings-v1"
  			},
  			"INTERCEPTION_MODE": "REDIRECT",
  			"CONFIG_NAMESPACE": "default",
  			"version": "v1",
  			"ISTIO_VERSION": "1.0-dev",
  			"kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container ratings"
  		},
   	}
  }
```

Dev-level support is added for a preliminary escape hatch feature for labeling proxies with the canonical service to use in telemetry reporting. The `istioTelemetryService` label is given special value, resulting in a metadata field of `canonical_telemetry_service`. This is EXPERIMENTAL and will not be documented for use at this time. No dependencies should be developed around the presence of that metadata field or the mechanism for its population.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
