### PR TITLE
[Node agent] Add retry for token exchange + improve tests

### DIFF
--- a/security/pkg/nodeagent/cache/helper.go
+++ b/security/pkg/nodeagent/cache/helper.go
@@ -15,116 +15,16 @@
 package cache
 
 import (
-	"context"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"math/rand"
 	"strings"
-	"sync/atomic"
 	"time"
 
-	"github.com/gogo/status"
 	"google.golang.org/grpc/codes"
-
-	"istio.io/istio/security/pkg/nodeagent/model"
 )
-
-// SecretExist checks if secret already existed.
-// This API is used for sds server to check if coming request is ack request.
-func (sc *SecretCache) SecretExist(connectionID, resourceName, token, version string) bool {
-	key := ConnKey{
-		ConnectionID: connectionID,
-		ResourceName: resourceName,
-	}
-	val, exist := sc.secrets.Load(key)
-	if !exist {
-		return false
-	}
-
-	e := val.(model.SecretItem)
-	return e.ResourceName == resourceName && e.Token == token && e.Version == version
-}
-
-func (sc *SecretCache) callbackWithTimeout(connectionID string, secretName string, secret *model.SecretItem) {
-	c := make(chan struct{})
-	conIDresourceNamePrefix := cacheLogPrefix(connectionID, secretName)
-	go func() {
-		defer close(c)
-		if sc.notifyCallback != nil {
-			if err := sc.notifyCallback(connectionID, secretName, secret); err != nil {
-				cacheLog.Errorf("%s failed to notify secret change for proxy: %v",
-					conIDresourceNamePrefix, err)
-			}
-		} else {
-			cacheLog.Warnf("%s secret cache notify callback isn't set", conIDresourceNamePrefix)
-		}
-	}()
-	select {
-	case <-c:
-		return // completed normally
-	case <-time.After(notifyK8sSecretTimeout):
-		cacheLog.Warnf("%s notify secret change for proxy got timeout", conIDresourceNamePrefix)
-	}
-}
-
-func (sc *SecretCache) keyCertRotationJob() {
-	// Wake up once in a while and refresh stale items.
-	sc.rotationTicker = time.NewTicker(sc.configOptions.RotationInterval)
-	for {
-		select {
-		case <-sc.rotationTicker.C:
-			sc.rotate(false /*updateRootFlag*/)
-		case <-sc.closing:
-			if sc.rotationTicker != nil {
-				sc.rotationTicker.Stop()
-			}
-		}
-	}
-}
-
-// IsIngressGatewaySecretReady returns true if node agent is working in ingress gateway agent mode
-// and needs to wait for ingress gateway secret to be ready.
-func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string) bool {
-	// If node agent works as workload agent, node agent does not expect any ingress gateway secret.
-	if sc.fetcher.UseCaClient {
-		return false
-	}
-
-	key := ConnKey{
-		ConnectionID: connectionID,
-		ResourceName: resourceName,
-	}
-	// Add an entry into cache, so that when ingress gateway secret is ready, gateway agent is able to
-	// notify the ingress gateway and push the secret to via connect ID.
-	if _, found := sc.secrets.Load(key); !found {
-		t := time.Now()
-		dummySecret := &model.SecretItem{
-			ResourceName: resourceName,
-			Token:        token,
-			CreatedTime:  t,
-			Version:      t.String(),
-		}
-		sc.secrets.Store(key, *dummySecret)
-	}
-
-	conIDresourceNamePrefix := cacheLogPrefix(connectionID, resourceName)
-	// If node agent works as ingress gateway agent, searches for kubernetes secret and verify secret
-	// is not empty.
-	cacheLog.Debugf("%s calling SecretFetcher to search for secret %s",
-		conIDresourceNamePrefix, resourceName)
-	_, exist := sc.fetcher.FindIngressGatewaySecret(resourceName)
-	// If kubernetes secret does not exist, need to wait for secret.
-	if !exist {
-		cacheLog.Warnf("%s SecretFetcher cannot find secret %s from cache",
-			conIDresourceNamePrefix, resourceName)
-		return true
-	}
-
-	return false
-}
 
 // parseCertAndGetExpiryTimestamp parses certificate and returns cert expire time, or return error
 // if fails to parse certificate.
@@ -140,24 +40,6 @@ func parseCertAndGetExpiryTimestamp(certByte []byte) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("failed to parse certificate: %v", err)
 	}
 	return cert.NotAfter, nil
-}
-
-func (sc *SecretCache) shouldRefresh(s *model.SecretItem) bool {
-	// secret should be refreshed before it expired, SecretRefreshGraceDuration is the grace period;
-	return time.Now().After(s.ExpireTime.Add(-sc.configOptions.SecretRefreshGraceDuration))
-}
-
-func (sc *SecretCache) isTokenExpired() bool {
-	// skip check if the token passed from envoy is always valid (ex, normal k8s sa JWT).
-	if sc.configOptions.AlwaysValidTokenFlag {
-		return false
-	}
-
-	if atomic.LoadUint32(&sc.skipTokenExpireCheck) == 1 {
-		return true
-	}
-	// TODO(quanlin), check if token has expired.
-	return false
 }
 
 func constructCSRHostName(trustDomain, token string) (string, error) {
@@ -197,16 +79,15 @@ func constructCSRHostName(trustDomain, token string) (string, error) {
 	return fmt.Sprintf(identityTemplate, domain, ns, sa), nil
 }
 
+// isRetryableErr checks if a failed request should be retry based on gRPC resp code or http status code.
 func isRetryableErr(c codes.Code, httpRespCode int, isGrpc bool) bool {
 	if isGrpc {
 		switch c {
 		case codes.Canceled, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Internal, codes.Unavailable:
 			return true
 		}
-	} else {
-		if httpRespCode >= 500 && !(httpRespCode == 501 || httpRespCode == 505 || httpRespCode == 511) {
-			return true
-		}
+	} else if httpRespCode >= 500 && !(httpRespCode == 501 || httpRespCode == 505 || httpRespCode == 511) {
+		return true
 	}
 	return false
 }
@@ -215,80 +96,4 @@ func isRetryableErr(c codes.Code, httpRespCode int, isGrpc bool) bool {
 func cacheLogPrefix(conID, resourceName string) string {
 	lPrefix := fmt.Sprintf("CONNECTION ID: %s, RESOURCE NAME: %s, EVENT:", conID, resourceName)
 	return lPrefix
-}
-
-// sendRetriableRequest sends retriable requests for either CSR or ExchangeToken.
-// Prior to sending the request, it also sleep random millisecond to avoid thundering herd problem.
-func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte, providedExchangedToken, resourceName string, isCSR bool) ([]string, error) {
-	backOffInMilliSec := rand.Int63n(sc.configOptions.InitialBackoff)
-	cacheLog.Debugf("Wait for %d millisec for initial CSR", backOffInMilliSec)
-	// Add a jitter to initial CSR to avoid thundering herd problem.
-	time.Sleep(time.Duration(backOffInMilliSec) * time.Millisecond)
-
-	startTime := time.Now()
-	var retry int64
-	var certChainPEM []string
-	exchangedToken := providedExchangedToken
-	var requestErrorString string
-	var err error
-
-	// Keep trying until no error or timeout.
-	for {
-		var httpRespCode int
-		if isCSR {
-			requestErrorString = fmt.Sprintf("CSR for %q", resourceName)
-			certChainPEM, err = sc.fetcher.CaClient.CSRSign(
-				ctx, csrPEM, exchangedToken, int64(sc.configOptions.SecretTTL.Seconds()))
-		} else {
-			requestErrorString = "Token exchange"
-			p := sc.configOptions.Plugins[0]
-			exchangedToken, _, httpRespCode, err = p.ExchangeToken(ctx, sc.configOptions.TrustDomain, exchangedToken)
-		}
-
-		if err == nil {
-			break
-		}
-
-		// If non-retryable error, fail the request by returning err
-		if !isRetryableErr(status.Code(err), httpRespCode, isCSR) {
-			cacheLog.Errorf("%s hit non-retryable error %v", requestErrorString, err)
-			return nil, err
-		}
-
-		// If reach envoy timeout, fail the request by returning err
-		if startTime.Add(time.Millisecond * envoyDefaultTimeoutInMilliSec).Before(time.Now()) {
-			cacheLog.Errorf("%s retry timed out %v", requestErrorString, err)
-			return nil, err
-		}
-
-		retry++
-		backOffInMilliSec = rand.Int63n(retry * initialBackOffIntervalInMilliSec)
-		time.Sleep(time.Duration(backOffInMilliSec) * time.Millisecond)
-		cacheLog.Warnf("%s failed with error: %v, retry in %d millisec", requestErrorString, err, backOffInMilliSec)
-	}
-
-	if isCSR {
-		return certChainPEM, nil
-	}
-	return []string{exchangedToken}, nil
-}
-
-// getExchangedToken gets the exchanged token for the CSR. The token is either the k8s jwt token of the
-// workload or another token from a plug in provider.
-func (sc *SecretCache) getExchangedToken(ctx context.Context, k8sJwtToken string) (string, error) {
-	exchangedTokens := []string{k8sJwtToken}
-	var err error
-	if sc.configOptions.Plugins != nil && len(sc.configOptions.Plugins) > 0 {
-		// Currently the only plugin is GoogleTokenExchange, so we only extract the first possible plugin.
-		if len(sc.configOptions.Plugins) > 1 {
-			cacheLog.Error("found more than one plugin")
-			return "", err
-		}
-		exchangedTokens, err = sc.sendRetriableRequest(ctx, nil, k8sJwtToken, "", false)
-		if err != nil || len(exchangedTokens) == 0 {
-			cacheLog.Errorf("failed to exchange token: %v", err)
-			return "", err
-		}
-	}
-	return exchangedTokens[0], nil
 }

--- a/security/pkg/nodeagent/cache/helper.go
+++ b/security/pkg/nodeagent/cache/helper.go
@@ -1,0 +1,294 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/gogo/status"
+	"google.golang.org/grpc/codes"
+
+	"istio.io/istio/security/pkg/nodeagent/model"
+)
+
+// SecretExist checks if secret already existed.
+// This API is used for sds server to check if coming request is ack request.
+func (sc *SecretCache) SecretExist(connectionID, resourceName, token, version string) bool {
+	key := ConnKey{
+		ConnectionID: connectionID,
+		ResourceName: resourceName,
+	}
+	val, exist := sc.secrets.Load(key)
+	if !exist {
+		return false
+	}
+
+	e := val.(model.SecretItem)
+	return e.ResourceName == resourceName && e.Token == token && e.Version == version
+}
+
+func (sc *SecretCache) callbackWithTimeout(connectionID string, secretName string, secret *model.SecretItem) {
+	c := make(chan struct{})
+	conIDresourceNamePrefix := cacheLogPrefix(connectionID, secretName)
+	go func() {
+		defer close(c)
+		if sc.notifyCallback != nil {
+			if err := sc.notifyCallback(connectionID, secretName, secret); err != nil {
+				cacheLog.Errorf("%s failed to notify secret change for proxy: %v",
+					conIDresourceNamePrefix, err)
+			}
+		} else {
+			cacheLog.Warnf("%s secret cache notify callback isn't set", conIDresourceNamePrefix)
+		}
+	}()
+	select {
+	case <-c:
+		return // completed normally
+	case <-time.After(notifyK8sSecretTimeout):
+		cacheLog.Warnf("%s notify secret change for proxy got timeout", conIDresourceNamePrefix)
+	}
+}
+
+func (sc *SecretCache) keyCertRotationJob() {
+	// Wake up once in a while and refresh stale items.
+	sc.rotationTicker = time.NewTicker(sc.configOptions.RotationInterval)
+	for {
+		select {
+		case <-sc.rotationTicker.C:
+			sc.rotate(false /*updateRootFlag*/)
+		case <-sc.closing:
+			if sc.rotationTicker != nil {
+				sc.rotationTicker.Stop()
+			}
+		}
+	}
+}
+
+// IsIngressGatewaySecretReady returns true if node agent is working in ingress gateway agent mode
+// and needs to wait for ingress gateway secret to be ready.
+func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string) bool {
+	// If node agent works as workload agent, node agent does not expect any ingress gateway secret.
+	if sc.fetcher.UseCaClient {
+		return false
+	}
+
+	key := ConnKey{
+		ConnectionID: connectionID,
+		ResourceName: resourceName,
+	}
+	// Add an entry into cache, so that when ingress gateway secret is ready, gateway agent is able to
+	// notify the ingress gateway and push the secret to via connect ID.
+	if _, found := sc.secrets.Load(key); !found {
+		t := time.Now()
+		dummySecret := &model.SecretItem{
+			ResourceName: resourceName,
+			Token:        token,
+			CreatedTime:  t,
+			Version:      t.String(),
+		}
+		sc.secrets.Store(key, *dummySecret)
+	}
+
+	conIDresourceNamePrefix := cacheLogPrefix(connectionID, resourceName)
+	// If node agent works as ingress gateway agent, searches for kubernetes secret and verify secret
+	// is not empty.
+	cacheLog.Debugf("%s calling SecretFetcher to search for secret %s",
+		conIDresourceNamePrefix, resourceName)
+	_, exist := sc.fetcher.FindIngressGatewaySecret(resourceName)
+	// If kubernetes secret does not exist, need to wait for secret.
+	if !exist {
+		cacheLog.Warnf("%s SecretFetcher cannot find secret %s from cache",
+			conIDresourceNamePrefix, resourceName)
+		return true
+	}
+
+	return false
+}
+
+// parseCertAndGetExpiryTimestamp parses certificate and returns cert expire time, or return error
+// if fails to parse certificate.
+func parseCertAndGetExpiryTimestamp(certByte []byte) (time.Time, error) {
+	block, _ := pem.Decode(certByte)
+	if block == nil {
+		cacheLog.Errorf("Failed to decode certificate")
+		return time.Time{}, fmt.Errorf("failed to decode certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		cacheLog.Errorf("Failed to parse certificate: %v", err)
+		return time.Time{}, fmt.Errorf("failed to parse certificate: %v", err)
+	}
+	return cert.NotAfter, nil
+}
+
+func (sc *SecretCache) shouldRefresh(s *model.SecretItem) bool {
+	// secret should be refreshed before it expired, SecretRefreshGraceDuration is the grace period;
+	return time.Now().After(s.ExpireTime.Add(-sc.configOptions.SecretRefreshGraceDuration))
+}
+
+func (sc *SecretCache) isTokenExpired() bool {
+	// skip check if the token passed from envoy is always valid (ex, normal k8s sa JWT).
+	if sc.configOptions.AlwaysValidTokenFlag {
+		return false
+	}
+
+	if atomic.LoadUint32(&sc.skipTokenExpireCheck) == 1 {
+		return true
+	}
+	// TODO(quanlin), check if token has expired.
+	return false
+}
+
+func constructCSRHostName(trustDomain, token string) (string, error) {
+	// If token is jwt format, construct host name from jwt with format like spiffe://cluster.local/ns/foo/sa/sleep,
+	strs := strings.Split(token, ".")
+	if len(strs) != 3 {
+		return "", fmt.Errorf("invalid k8s jwt token")
+	}
+
+	payload := strs[1]
+	if l := len(payload) % 4; l > 0 {
+		payload += strings.Repeat("=", 4-l)
+	}
+	dp, err := base64.URLEncoding.DecodeString(payload)
+	if err != nil {
+		return "", fmt.Errorf("invalid k8s jwt token: %v", err)
+	}
+
+	var jp k8sJwtPayload
+	if err = json.Unmarshal(dp, &jp); err != nil {
+		return "", fmt.Errorf("invalid k8s jwt token: %v", err)
+	}
+
+	// sub field in jwt should be in format like: system:serviceaccount:foo:bar
+	ss := strings.Split(jp.Sub, ":")
+	if len(ss) != 4 {
+		return "", fmt.Errorf("invalid sub field in k8s jwt token")
+	}
+	ns := ss[2] //namespace
+	sa := ss[3] //service account
+
+	domain := "cluster.local"
+	if trustDomain != "" {
+		domain = trustDomain
+	}
+
+	return fmt.Sprintf(identityTemplate, domain, ns, sa), nil
+}
+
+func isRetryableErr(c codes.Code, httpRespCode int, isGrpc bool) bool {
+	if isGrpc {
+		switch c {
+		case codes.Canceled, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Internal, codes.Unavailable:
+			return true
+		}
+	} else {
+		if httpRespCode >= 500 && !(httpRespCode == 501 || httpRespCode == 505 || httpRespCode == 511) {
+			return true
+		}
+	}
+	return false
+}
+
+// cacheLogPrefix returns a unified log prefix.
+func cacheLogPrefix(conID, resourceName string) string {
+	lPrefix := fmt.Sprintf("CONNECTION ID: %s, RESOURCE NAME: %s, EVENT:", conID, resourceName)
+	return lPrefix
+}
+
+// sendRetriableRequest sends retriable requests for either CSR or ExchangeToken.
+// Prior to sending the request, it also sleep random millisecond to avoid thundering herd problem.
+func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte, providedExchangedToken, resourceName string, isCSR bool) ([]string, error) {
+	backOffInMilliSec := rand.Int63n(sc.configOptions.InitialBackoff)
+	cacheLog.Debugf("Wait for %d millisec for initial CSR", backOffInMilliSec)
+	// Add a jitter to initial CSR to avoid thundering herd problem.
+	time.Sleep(time.Duration(backOffInMilliSec) * time.Millisecond)
+
+	startTime := time.Now()
+	var retry int64
+	var certChainPEM []string
+	exchangedToken := providedExchangedToken
+	var requestErrorString string
+	var err error
+
+	// Keep trying until no error or timeout.
+	for {
+		var httpRespCode int
+		if isCSR {
+			requestErrorString = fmt.Sprintf("CSR for %q", resourceName)
+			certChainPEM, err = sc.fetcher.CaClient.CSRSign(
+				ctx, csrPEM, exchangedToken, int64(sc.configOptions.SecretTTL.Seconds()))
+		} else {
+			requestErrorString = "Token exchange"
+			p := sc.configOptions.Plugins[0]
+			exchangedToken, _, httpRespCode, err = p.ExchangeToken(ctx, sc.configOptions.TrustDomain, exchangedToken)
+		}
+
+		if err == nil {
+			break
+		}
+
+		// If non-retryable error, fail the request by returning err
+		if !isRetryableErr(status.Code(err), httpRespCode, isCSR) {
+			cacheLog.Errorf("%s hit non-retryable error %v", requestErrorString, err)
+			return nil, err
+		}
+
+		// If reach envoy timeout, fail the request by returning err
+		if startTime.Add(time.Millisecond * envoyDefaultTimeoutInMilliSec).Before(time.Now()) {
+			cacheLog.Errorf("%s retry timed out %v", requestErrorString, err)
+			return nil, err
+		}
+
+		retry++
+		backOffInMilliSec = rand.Int63n(retry * initialBackOffIntervalInMilliSec)
+		time.Sleep(time.Duration(backOffInMilliSec) * time.Millisecond)
+		cacheLog.Warnf("%s failed with error: %v, retry in %d millisec", requestErrorString, err, backOffInMilliSec)
+	}
+
+	if isCSR {
+		return certChainPEM, nil
+	}
+	return []string{exchangedToken}, nil
+}
+
+// getExchangedToken gets the exchanged token for the CSR. The token is either the k8s jwt token of the
+// workload or another token from a plug in provider.
+func (sc *SecretCache) getExchangedToken(ctx context.Context, k8sJwtToken string) (string, error) {
+	exchangedTokens := []string{k8sJwtToken}
+	var err error
+	if sc.configOptions.Plugins != nil && len(sc.configOptions.Plugins) > 0 {
+		// Currently the only plugin is GoogleTokenExchange, so we only extract the first possible plugin.
+		if len(sc.configOptions.Plugins) > 1 {
+			cacheLog.Error("found more than one plugin")
+			return "", err
+		}
+		exchangedTokens, err = sc.sendRetriableRequest(ctx, nil, k8sJwtToken, "", false)
+		if err != nil || len(exchangedTokens) == 0 {
+			cacheLog.Errorf("failed to exchange token: %v", err)
+			return "", err
+		}
+	}
+	return exchangedTokens[0], nil
+}

--- a/security/pkg/nodeagent/cache/mock/secretcache_mock.go
+++ b/security/pkg/nodeagent/cache/mock/secretcache_mock.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+	"fmt"
+	"github.com/gogo/status"
+	"google.golang.org/grpc/codes"
+	"math/rand"
+	"sync/atomic"
+	"time"
+)
+
+type MockCAClient struct {
+	signInvokeCount uint64
+	mockCertChain1st []string
+	mockCertChainRemain []string
+}
+
+func NewMockCAClient(mockCertChain1st, mockCertChainRemain []string) *MockCAClient {
+	cl := MockCAClient{
+		mockCertChain1st:mockCertChain1st,
+		mockCertChainRemain: mockCertChainRemain,
+	}
+	atomic.StoreUint64(&cl.signInvokeCount, 0)
+	return &cl
+}
+
+func (c *MockCAClient) CSRSign(ctx context.Context, csrPEM []byte, exchangedToken string,
+		certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
+	// Mock CSRSign failure errors to force Citadel agent to retry.
+	// 50% chance of failure.
+	if rand.Intn(2) != 0 {
+		return nil, status.Error(codes.Unavailable, "CA is unavailable")
+	}
+
+	if atomic.LoadUint64(&c.signInvokeCount) == 0 {
+		atomic.AddUint64(&c.signInvokeCount, 1)
+		return nil, status.Error(codes.Internal, "some internal error")
+	}
+
+	if atomic.LoadUint64(&c.signInvokeCount) == 1 {
+		atomic.AddUint64(&c.signInvokeCount, 1)
+		return c.mockCertChain1st, nil
+	}
+
+	return c.mockCertChainRemain, nil
+}
+
+type MockTokenExchangeServer struct {
+}
+
+func NewMockTokenExchangeServer() *MockTokenExchangeServer {
+	return &MockTokenExchangeServer{}
+}
+
+func (s *MockTokenExchangeServer) ExchangeToken(context.Context, string, string) (string, time.Time, int, error) {
+	// Mock ExchangeToken failure errors to force Citadel agent to retry.
+	// 50% chance of failure.
+	if rand.Intn(2) != 0 {
+		return "", time.Time{}, 503, fmt.Errorf("service unavailable")
+	}
+	// Since the secret cache uses the k8s token in the stored secret, we can just return anything here.
+	return "some-token", time.Now(), 200, nil
+}

--- a/security/pkg/nodeagent/cache/mock/secretcache_mock.go
+++ b/security/pkg/nodeagent/cache/mock/secretcache_mock.go
@@ -24,14 +24,14 @@ import (
 	"time"
 )
 
-type MockCAClient struct {
+type CAClient struct {
 	signInvokeCount uint64
 	mockCertChain1st []string
 	mockCertChainRemain []string
 }
 
-func NewMockCAClient(mockCertChain1st, mockCertChainRemain []string) *MockCAClient {
-	cl := MockCAClient{
+func NewMockCAClient(mockCertChain1st, mockCertChainRemain []string) *CAClient {
+	cl := CAClient{
 		mockCertChain1st:mockCertChain1st,
 		mockCertChainRemain: mockCertChainRemain,
 	}
@@ -39,7 +39,7 @@ func NewMockCAClient(mockCertChain1st, mockCertChainRemain []string) *MockCAClie
 	return &cl
 }
 
-func (c *MockCAClient) CSRSign(ctx context.Context, csrPEM []byte, exchangedToken string,
+func (c *CAClient) CSRSign(ctx context.Context, csrPEM []byte, exchangedToken string,
 		certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
 	// Mock CSRSign failure errors to force Citadel agent to retry.
 	// 50% chance of failure.
@@ -60,14 +60,14 @@ func (c *MockCAClient) CSRSign(ctx context.Context, csrPEM []byte, exchangedToke
 	return c.mockCertChainRemain, nil
 }
 
-type MockTokenExchangeServer struct {
+type TokenExchangeServer struct {
 }
 
-func NewMockTokenExchangeServer() *MockTokenExchangeServer {
-	return &MockTokenExchangeServer{}
+func NewMockTokenExchangeServer() *TokenExchangeServer {
+	return &TokenExchangeServer{}
 }
 
-func (s *MockTokenExchangeServer) ExchangeToken(context.Context, string, string) (string, time.Time, int, error) {
+func (s *TokenExchangeServer) ExchangeToken(context.Context, string, string) (string, time.Time, int, error) {
 	// Mock ExchangeToken failure errors to force Citadel agent to retry.
 	// 50% chance of failure.
 	if rand.Intn(2) != 0 {

--- a/security/pkg/nodeagent/cache/mock/secretcache_mock.go
+++ b/security/pkg/nodeagent/cache/mock/secretcache_mock.go
@@ -17,22 +17,24 @@ package mock
 import (
 	"context"
 	"fmt"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
 	"math/rand"
 	"sync/atomic"
 	"time"
 )
 
 type CAClient struct {
-	signInvokeCount uint64
-	mockCertChain1st []string
+	signInvokeCount     uint64
+	mockCertChain1st    []string
 	mockCertChainRemain []string
 }
 
 func NewMockCAClient(mockCertChain1st, mockCertChainRemain []string) *CAClient {
 	cl := CAClient{
-		mockCertChain1st:mockCertChain1st,
+		mockCertChain1st:    mockCertChain1st,
 		mockCertChainRemain: mockCertChainRemain,
 	}
 	atomic.StoreUint64(&cl.signInvokeCount, 0)

--- a/security/pkg/nodeagent/cache/mock/secretcache_mock.go
+++ b/security/pkg/nodeagent/cache/mock/secretcache_mock.go
@@ -17,8 +17,8 @@ package mock
 import (
 	"context"
 	"fmt"
-	"github.com/gogo/status"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"math/rand"
 	"sync/atomic"
 	"time"

--- a/security/pkg/nodeagent/cache/mock/secretcache_mock.go
+++ b/security/pkg/nodeagent/cache/mock/secretcache_mock.go
@@ -42,7 +42,7 @@ func NewMockCAClient(mockCertChain1st, mockCertChainRemain []string) *CAClient {
 }
 
 func (c *CAClient) CSRSign(ctx context.Context, csrPEM []byte, exchangedToken string,
-		certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
+	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
 	// Mock CSRSign failure errors to force Citadel agent to retry.
 	// 50% chance of failure.
 	if rand.Intn(2) != 0 {

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Istio Authors
+// Copyright 2019 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,20 +18,12 @@ package cache
 import (
 	"bytes"
 	"context"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"math/rand"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/gogo/status"
-	"google.golang.org/grpc/codes"
 
 	"istio.io/istio/security/pkg/nodeagent/model"
 	"istio.io/istio/security/pkg/nodeagent/plugin"
@@ -253,63 +245,6 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 	return ns, nil
 }
 
-// SecretExist checks if secret already existed.
-// This API is used for sds server to check if coming request is ack request.
-func (sc *SecretCache) SecretExist(connectionID, resourceName, token, version string) bool {
-	key := ConnKey{
-		ConnectionID: connectionID,
-		ResourceName: resourceName,
-	}
-	val, exist := sc.secrets.Load(key)
-	if !exist {
-		return false
-	}
-
-	e := val.(model.SecretItem)
-	return e.ResourceName == resourceName && e.Token == token && e.Version == version
-}
-
-// IsIngressGatewaySecretReady returns true if node agent is working in ingress gateway agent mode
-// and needs to wait for ingress gateway secret to be ready.
-func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string) bool {
-	// If node agent works as workload agent, node agent does not expect any ingress gateway secret.
-	if sc.fetcher.UseCaClient {
-		return false
-	}
-
-	key := ConnKey{
-		ConnectionID: connectionID,
-		ResourceName: resourceName,
-	}
-	// Add an entry into cache, so that when ingress gateway secret is ready, gateway agent is able to
-	// notify the ingress gateway and push the secret to via connect ID.
-	if _, found := sc.secrets.Load(key); !found {
-		t := time.Now()
-		dummySecret := &model.SecretItem{
-			ResourceName: resourceName,
-			Token:        token,
-			CreatedTime:  t,
-			Version:      t.String(),
-		}
-		sc.secrets.Store(key, *dummySecret)
-	}
-
-	conIDresourceNamePrefix := cacheLogPrefix(connectionID, resourceName)
-	// If node agent works as ingress gateway agent, searches for kubernetes secret and verify secret
-	// is not empty.
-	cacheLog.Debugf("%s calling SecretFetcher to search for secret %s",
-		conIDresourceNamePrefix, resourceName)
-	_, exist := sc.fetcher.FindIngressGatewaySecret(resourceName)
-	// If kubernetes secret does not exist, need to wait for secret.
-	if !exist {
-		cacheLog.Warnf("%s SecretFetcher cannot find secret %s from cache",
-			conIDresourceNamePrefix, resourceName)
-		return true
-	}
-
-	return false
-}
-
 // DeleteSecret deletes a secret by its key from cache.
 func (sc *SecretCache) DeleteSecret(connectionID, resourceName string) {
 	key := ConnKey{
@@ -319,46 +254,9 @@ func (sc *SecretCache) DeleteSecret(connectionID, resourceName string) {
 	sc.secrets.Delete(key)
 }
 
-func (sc *SecretCache) callbackWithTimeout(connectionID string, secretName string, secret *model.SecretItem) {
-	c := make(chan struct{})
-	conIDresourceNamePrefix := cacheLogPrefix(connectionID, secretName)
-	go func() {
-		defer close(c)
-		if sc.notifyCallback != nil {
-			if err := sc.notifyCallback(connectionID, secretName, secret); err != nil {
-				cacheLog.Errorf("%s failed to notify secret change for proxy: %v",
-					conIDresourceNamePrefix, err)
-			}
-		} else {
-			cacheLog.Warnf("%s secret cache notify callback isn't set", conIDresourceNamePrefix)
-		}
-	}()
-	select {
-	case <-c:
-		return // completed normally
-	case <-time.After(notifyK8sSecretTimeout):
-		cacheLog.Warnf("%s notify secret change for proxy got timeout", conIDresourceNamePrefix)
-	}
-}
-
 // Close shuts down the secret cache.
 func (sc *SecretCache) Close() {
 	sc.closing <- true
-}
-
-func (sc *SecretCache) keyCertRotationJob() {
-	// Wake up once in a while and refresh stale items.
-	sc.rotationTicker = time.NewTicker(sc.configOptions.RotationInterval)
-	for {
-		select {
-		case <-sc.rotationTicker.C:
-			sc.rotate(false /*updateRootFlag*/)
-		case <-sc.closing:
-			if sc.rotationTicker != nil {
-				sc.rotationTicker.Stop()
-			}
-		}
-	}
 }
 
 // DeleteK8sSecret deletes all entries that match secretName. This is called when a K8s secret
@@ -588,16 +486,9 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token, resourceName s
 	}
 
 	// call authentication provider specific plugins to exchange token if necessary.
-	exchangedToken := token
-	var err error
-	if sc.configOptions.Plugins != nil && len(sc.configOptions.Plugins) > 0 {
-		for _, p := range sc.configOptions.Plugins {
-			exchangedToken, _, err = p.ExchangeToken(ctx, sc.configOptions.TrustDomain, exchangedToken)
-			if err != nil {
-				cacheLog.Errorf("failed to exchange token: %v", err)
-				return nil, err
-			}
-		}
+	exchangedToken, err := sc.getExchangedToken(ctx, token)
+	if err != nil {
+		return nil, err
 	}
 
 	// If token is jwt format, construct host name from jwt with format like spiffe://cluster.local/ns/foo/sa/sleep
@@ -619,36 +510,9 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token, resourceName s
 		return nil, err
 	}
 
-	backOffInMilliSec := rand.Int63n(sc.configOptions.InitialBackoff)
-	cacheLog.Debugf("Wait for %d millisec for initial CSR", backOffInMilliSec)
-	// Add a jitter to initial CSR to avoid thundering herd problem.
-	time.Sleep(time.Duration(backOffInMilliSec) * time.Millisecond)
-	startTime := time.Now()
-	var retry int64
-	var certChainPEM []string
-	for {
-		certChainPEM, err = sc.fetcher.CaClient.CSRSign(
-			ctx, csrPEM, exchangedToken, int64(sc.configOptions.SecretTTL.Seconds()))
-		if err == nil {
-			break
-		}
-
-		// If non-retryable error, fail the request by returning err
-		if !isRetryableErr(status.Code(err)) {
-			cacheLog.Errorf("CSR for %q hit non-retryable error %v", resourceName, err)
-			return nil, err
-		}
-
-		// If reach envoy timeout, fail the request by returning err
-		if startTime.Add(time.Millisecond * envoyDefaultTimeoutInMilliSec).Before(time.Now()) {
-			cacheLog.Errorf("CSR retry timeout for %q: %v", resourceName, err)
-			return nil, err
-		}
-
-		retry++
-		backOffInMilliSec = rand.Int63n(retry * initialBackOffIntervalInMilliSec)
-		time.Sleep(time.Duration(backOffInMilliSec) * time.Millisecond)
-		cacheLog.Warnf("CSR failed for %q: %v, retry in %d millisec", resourceName, err, backOffInMilliSec)
+	certChainPEM, err := sc.sendRetriableRequest(ctx, csrPEM, exchangedToken, resourceName, true)
+	if err != nil {
+		return nil, err
 	}
 
 	cacheLog.Debugf("CSR response certificate chain %+v \n", certChainPEM)
@@ -700,89 +564,4 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token, resourceName s
 		ExpireTime:       expireTime,
 		Version:          t.String(),
 	}, nil
-}
-
-// parseCertAndGetExpiryTimestamp parses certificate and returns cert expire time, or return error
-// if fails to parse certificate.
-func parseCertAndGetExpiryTimestamp(certByte []byte) (time.Time, error) {
-	block, _ := pem.Decode(certByte)
-	if block == nil {
-		cacheLog.Errorf("Failed to decode certificate")
-		return time.Time{}, fmt.Errorf("failed to decode certificate")
-	}
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		cacheLog.Errorf("Failed to parse certificate: %v", err)
-		return time.Time{}, fmt.Errorf("failed to parse certificate: %v", err)
-	}
-	return cert.NotAfter, nil
-}
-
-func (sc *SecretCache) shouldRefresh(s *model.SecretItem) bool {
-	// secret should be refreshed before it expired, SecretRefreshGraceDuration is the grace period;
-	return time.Now().After(s.ExpireTime.Add(-sc.configOptions.SecretRefreshGraceDuration))
-}
-
-func (sc *SecretCache) isTokenExpired() bool {
-	// skip check if the token passed from envoy is always valid (ex, normal k8s sa JWT).
-	if sc.configOptions.AlwaysValidTokenFlag {
-		return false
-	}
-
-	if atomic.LoadUint32(&sc.skipTokenExpireCheck) == 1 {
-		return true
-	}
-	// TODO(quanlin), check if token has expired.
-	return false
-}
-
-func constructCSRHostName(trustDomain, token string) (string, error) {
-	// If token is jwt format, construct host name from jwt with format like spiffe://cluster.local/ns/foo/sa/sleep,
-	strs := strings.Split(token, ".")
-	if len(strs) != 3 {
-		return "", fmt.Errorf("invalid k8s jwt token")
-	}
-
-	payload := strs[1]
-	if l := len(payload) % 4; l > 0 {
-		payload += strings.Repeat("=", 4-l)
-	}
-	dp, err := base64.URLEncoding.DecodeString(payload)
-	if err != nil {
-		return "", fmt.Errorf("invalid k8s jwt token: %v", err)
-	}
-
-	var jp k8sJwtPayload
-	if err = json.Unmarshal(dp, &jp); err != nil {
-		return "", fmt.Errorf("invalid k8s jwt token: %v", err)
-	}
-
-	// sub field in jwt should be in format like: system:serviceaccount:foo:bar
-	ss := strings.Split(jp.Sub, ":")
-	if len(ss) != 4 {
-		return "", fmt.Errorf("invalid sub field in k8s jwt token")
-	}
-	ns := ss[2] //namespace
-	sa := ss[3] //service account
-
-	domain := "cluster.local"
-	if trustDomain != "" {
-		domain = trustDomain
-	}
-
-	return fmt.Sprintf(identityTemplate, domain, ns, sa), nil
-}
-
-func isRetryableErr(c codes.Code) bool {
-	switch c {
-	case codes.Canceled, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Internal, codes.Unavailable:
-		return true
-	}
-	return false
-}
-
-// cacheLogPrefix returns a unified log prefix.
-func cacheLogPrefix(conID, resourceName string) string {
-	lPrefix := fmt.Sprintf("CONNECTION ID: %s, RESOURCE NAME: %s, EVENT:", conID, resourceName)
-	return lPrefix
 }

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -20,10 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/gogo/status"
 
 	"istio.io/istio/security/pkg/nodeagent/model"
 	"istio.io/istio/security/pkg/nodeagent/plugin"
@@ -245,6 +248,63 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 	return ns, nil
 }
 
+// SecretExist checks if secret already existed.
+// This API is used for sds server to check if coming request is ack request.
+func (sc *SecretCache) SecretExist(connectionID, resourceName, token, version string) bool {
+	key := ConnKey{
+		ConnectionID: connectionID,
+		ResourceName: resourceName,
+	}
+	val, exist := sc.secrets.Load(key)
+	if !exist {
+		return false
+	}
+
+	e := val.(model.SecretItem)
+	return e.ResourceName == resourceName && e.Token == token && e.Version == version
+}
+
+// IsIngressGatewaySecretReady returns true if node agent is working in ingress gateway agent mode
+// and needs to wait for ingress gateway secret to be ready.
+func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string) bool {
+	// If node agent works as workload agent, node agent does not expect any ingress gateway secret.
+	if sc.fetcher.UseCaClient {
+		return false
+	}
+
+	key := ConnKey{
+		ConnectionID: connectionID,
+		ResourceName: resourceName,
+	}
+	// Add an entry into cache, so that when ingress gateway secret is ready, gateway agent is able to
+	// notify the ingress gateway and push the secret to via connect ID.
+	if _, found := sc.secrets.Load(key); !found {
+		t := time.Now()
+		dummySecret := &model.SecretItem{
+			ResourceName: resourceName,
+			Token:        token,
+			CreatedTime:  t,
+			Version:      t.String(),
+		}
+		sc.secrets.Store(key, *dummySecret)
+	}
+
+	conIDresourceNamePrefix := cacheLogPrefix(connectionID, resourceName)
+	// If node agent works as ingress gateway agent, searches for kubernetes secret and verify secret
+	// is not empty.
+	cacheLog.Debugf("%s calling SecretFetcher to search for secret %s",
+		conIDresourceNamePrefix, resourceName)
+	_, exist := sc.fetcher.FindIngressGatewaySecret(resourceName)
+	// If kubernetes secret does not exist, need to wait for secret.
+	if !exist {
+		cacheLog.Warnf("%s SecretFetcher cannot find secret %s from cache",
+			conIDresourceNamePrefix, resourceName)
+		return true
+	}
+
+	return false
+}
+
 // DeleteSecret deletes a secret by its key from cache.
 func (sc *SecretCache) DeleteSecret(connectionID, resourceName string) {
 	key := ConnKey{
@@ -254,9 +314,46 @@ func (sc *SecretCache) DeleteSecret(connectionID, resourceName string) {
 	sc.secrets.Delete(key)
 }
 
+func (sc *SecretCache) callbackWithTimeout(connectionID string, secretName string, secret *model.SecretItem) {
+	c := make(chan struct{})
+	conIDresourceNamePrefix := cacheLogPrefix(connectionID, secretName)
+	go func() {
+		defer close(c)
+		if sc.notifyCallback != nil {
+			if err := sc.notifyCallback(connectionID, secretName, secret); err != nil {
+				cacheLog.Errorf("%s failed to notify secret change for proxy: %v",
+					conIDresourceNamePrefix, err)
+			}
+		} else {
+			cacheLog.Warnf("%s secret cache notify callback isn't set", conIDresourceNamePrefix)
+		}
+	}()
+	select {
+	case <-c:
+		return // completed normally
+	case <-time.After(notifyK8sSecretTimeout):
+		cacheLog.Warnf("%s notify secret change for proxy got timeout", conIDresourceNamePrefix)
+	}
+}
+
 // Close shuts down the secret cache.
 func (sc *SecretCache) Close() {
 	sc.closing <- true
+}
+
+func (sc *SecretCache) keyCertRotationJob() {
+	// Wake up once in a while and refresh stale items.
+	sc.rotationTicker = time.NewTicker(sc.configOptions.RotationInterval)
+	for {
+		select {
+		case <-sc.rotationTicker.C:
+			sc.rotate(false /*updateRootFlag*/)
+		case <-sc.closing:
+			if sc.rotationTicker != nil {
+				sc.rotationTicker.Stop()
+			}
+		}
+	}
 }
 
 // DeleteK8sSecret deletes all entries that match secretName. This is called when a K8s secret
@@ -564,4 +661,98 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token, resourceName s
 		ExpireTime:       expireTime,
 		Version:          t.String(),
 	}, nil
+}
+
+func (sc *SecretCache) shouldRefresh(s *model.SecretItem) bool {
+	// secret should be refreshed before it expired, SecretRefreshGraceDuration is the grace period;
+	return time.Now().After(s.ExpireTime.Add(-sc.configOptions.SecretRefreshGraceDuration))
+}
+
+func (sc *SecretCache) isTokenExpired() bool {
+	// skip check if the token passed from envoy is always valid (ex, normal k8s sa JWT).
+	if sc.configOptions.AlwaysValidTokenFlag {
+		return false
+	}
+
+	if atomic.LoadUint32(&sc.skipTokenExpireCheck) == 1 {
+		return true
+	}
+	// TODO(quanlin), check if token has expired.
+	return false
+}
+
+// sendRetriableRequest sends retriable requests for either CSR or ExchangeToken.
+// Prior to sending the request, it also sleep random millisecond to avoid thundering herd problem.
+func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte, providedExchangedToken, resourceName string, isCSR bool) ([]string, error) {
+	backOffInMilliSec := rand.Int63n(sc.configOptions.InitialBackoff)
+	cacheLog.Debugf("Wait for %d millisec for initial CSR", backOffInMilliSec)
+	// Add a jitter to initial CSR to avoid thundering herd problem.
+	time.Sleep(time.Duration(backOffInMilliSec) * time.Millisecond)
+
+	startTime := time.Now()
+	var retry int64
+	var certChainPEM []string
+	exchangedToken := providedExchangedToken
+	var requestErrorString string
+	var err error
+
+	// Keep trying until no error or timeout.
+	for {
+		var httpRespCode int
+		if isCSR {
+			requestErrorString = fmt.Sprintf("CSR for %q", resourceName)
+			certChainPEM, err = sc.fetcher.CaClient.CSRSign(
+				ctx, csrPEM, exchangedToken, int64(sc.configOptions.SecretTTL.Seconds()))
+		} else {
+			requestErrorString = "Token exchange"
+			p := sc.configOptions.Plugins[0]
+			exchangedToken, _, httpRespCode, err = p.ExchangeToken(ctx, sc.configOptions.TrustDomain, exchangedToken)
+		}
+
+		if err == nil {
+			break
+		}
+
+		// If non-retryable error, fail the request by returning err
+		if !isRetryableErr(status.Code(err), httpRespCode, isCSR) {
+			cacheLog.Errorf("%s hit non-retryable error %v", requestErrorString, err)
+			return nil, err
+		}
+
+		// If reach envoy timeout, fail the request by returning err
+		if startTime.Add(time.Millisecond * envoyDefaultTimeoutInMilliSec).Before(time.Now()) {
+			cacheLog.Errorf("%s retry timed out %v", requestErrorString, err)
+			return nil, err
+		}
+
+		retry++
+		backOffInMilliSec = rand.Int63n(retry * initialBackOffIntervalInMilliSec)
+		time.Sleep(time.Duration(backOffInMilliSec) * time.Millisecond)
+		cacheLog.Warnf("%s failed with error: %v, retry in %d millisec", requestErrorString, err, backOffInMilliSec)
+	}
+
+	if isCSR {
+		return certChainPEM, nil
+	}
+	return []string{exchangedToken}, nil
+}
+
+// getExchangedToken gets the exchanged token for the CSR. The token is either the k8s jwt token of the
+// workload or another token from a plug in provider.
+func (sc *SecretCache) getExchangedToken(ctx context.Context, k8sJwtToken string) (string, error) {
+	exchangedTokens := []string{k8sJwtToken}
+	var err error
+	if sc.configOptions.Plugins != nil && len(sc.configOptions.Plugins) > 0 {
+		// Currently the only plugin is GoogleTokenExchange, so we only extract the first possible plugin.
+		if len(sc.configOptions.Plugins) > 1 {
+			cacheLog.Error("found more than one plugin")
+			return "", err
+		}
+		exchangedTokens, err = sc.sendRetriableRequest(ctx, nil, k8sJwtToken, "", false)
+		if err != nil || len(exchangedTokens) == 0 {
+			cacheLog.Errorf("failed to exchange token: %v", err)
+			return "", err
+		}
+	}
+	return exchangedTokens[0], nil
 }

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -32,7 +32,7 @@ import (
 	"istio.io/istio/security/pkg/nodeagent/model"
 	"istio.io/istio/security/pkg/nodeagent/secretfetcher"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/api/core/v1"
 	"os"
 	"reflect"
 	"strconv"
@@ -33,6 +32,7 @@ import (
 	"istio.io/istio/security/pkg/nodeagent/model"
 	"istio.io/istio/security/pkg/nodeagent/secretfetcher"
 
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/api/core/v1"
 	"os"
 	"reflect"
 	"strconv"
@@ -26,13 +27,12 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"istio.io/istio/security/pkg/nodeagent/cache/mock"
+	"istio.io/istio/security/pkg/nodeagent/plugin"
 
 	"istio.io/istio/security/pkg/nodeagent/model"
 	"istio.io/istio/security/pkg/nodeagent/secretfetcher"
 
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -88,7 +88,15 @@ var (
 )
 
 func TestWorkloadAgentGenerateSecret(t *testing.T) {
-	fakeCACli := newMockCAClient()
+	testWorkloadAgentGenerateSecret(t, false)
+}
+
+func TestWorkloadAgentGenerateSecretWithPluginProvider(t *testing.T) {
+	testWorkloadAgentGenerateSecret(t, true)
+}
+
+func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
+	fakeCACli := mock.NewMockCAClient(mockCertChain1st, mockCertChainRemain)
 	opt := Options{
 		SecretTTL:        time.Minute,
 		RotationInterval: 300 * time.Microsecond,
@@ -96,6 +104,12 @@ func TestWorkloadAgentGenerateSecret(t *testing.T) {
 		InitialBackoff:   10,
 		SkipValidateCert: true,
 	}
+
+	if isUsingPluginProvider {
+		fakePlugin := mock.NewMockTokenExchangeServer()
+		opt.Plugins = []plugin.Plugin{fakePlugin}
+	}
+
 	fetcher := &secretfetcher.SecretFetcher{
 		UseCaClient: true,
 		CaClient:    fakeCACli,
@@ -184,7 +198,7 @@ func TestWorkloadAgentGenerateSecret(t *testing.T) {
 }
 
 func TestWorkloadAgentRefreshSecret(t *testing.T) {
-	fakeCACli := newMockCAClient()
+	fakeCACli := mock.NewMockCAClient(mockCertChain1st, mockCertChainRemain)
 	opt := Options{
 		SecretTTL:        200 * time.Microsecond,
 		RotationInterval: 200 * time.Microsecond,
@@ -716,7 +730,7 @@ func checkBool(t *testing.T, name string, got bool, want bool) {
 }
 
 func TestSetAlwaysValidTokenFlag(t *testing.T) {
-	fakeCACli := newMockCAClient()
+	fakeCACli := mock.NewMockCAClient(mockCertChain1st, mockCertChainRemain)
 	opt := Options{
 		SecretTTL:            200 * time.Microsecond,
 		RotationInterval:     200 * time.Microsecond,
@@ -776,31 +790,6 @@ func verifySecret(gotSecret *model.SecretItem, expectedSecret *model.SecretItem)
 
 func notifyCb(_ string, _ string, _ *model.SecretItem) error {
 	return nil
-}
-
-type mockCAClient struct {
-	signInvokeCount uint64
-}
-
-func newMockCAClient() *mockCAClient {
-	cl := mockCAClient{}
-	atomic.StoreUint64(&cl.signInvokeCount, 0)
-	return &cl
-}
-
-func (c *mockCAClient) CSRSign(ctx context.Context, csrPEM []byte, subjectID string,
-	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
-	if atomic.LoadUint64(&c.signInvokeCount) == 0 {
-		atomic.AddUint64(&c.signInvokeCount, 1)
-		return nil, status.Error(codes.Internal, "some internal error")
-	}
-
-	if atomic.LoadUint64(&c.signInvokeCount) == 1 {
-		atomic.AddUint64(&c.signInvokeCount, 1)
-		return mockCertChain1st, nil
-	}
-
-	return mockCertChainRemain, nil
 }
 
 func convertToBytes(ss []string) []byte {

--- a/security/pkg/nodeagent/plugin/plugin.go
+++ b/security/pkg/nodeagent/plugin/plugin.go
@@ -26,5 +26,5 @@ const (
 
 // Plugin provides common interfaces so that authentication providers could choose to implement their specific logic.
 type Plugin interface {
-	ExchangeToken(context.Context, string, string) (string, time.Time, error)
+	ExchangeToken(context.Context, string, string) (string, time.Time, int, error)
 }

--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient_test.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient_test.go
@@ -40,7 +40,7 @@ func TestGetFederatedToken(t *testing.T) {
 		t.Fatalf("failed to start a mock server %v", err)
 	}
 
-	token, _, err := r.ExchangeToken(context.Background(), "", "")
+	token, _, _, err := r.ExchangeToken(context.Background(), "", "")
 	if err != nil {
 		t.Fatalf("failed to call exchange token %v", err)
 	}


### PR DESCRIPTION
* Use similar logic from CSR for token exchange (sleep to reduce request spike, retry)
* Move mock CA client to another file and create a mock token exchange server.
* Add new test + refine mock services to test for resilience.
* Move helper functions from `secretcache.go` to its own function. `secretcache.go` now only contains core functionalities, e.g. generate secret, update secret, etc. 
* Instead of getting the last token from token exchange, check if the number of plugin is one.

I also manually tested with GoogleCA. 

Besides the new feature, it's somewhat related to #13439. 


