### PR TITLE
Add helm value for configuring auth strategy of kiali

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   config.yaml: |
     istio_namespace: {{ .Release.Namespace }}
     auth:
-      strategy: "login"
+      strategy: {{ .Values.authStrategy }}
     server:
       port: 20001
 {{- if .Values.contextPath }}

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 hub: quay.io/kiali
 tag: v0.20
 contextPath: /kiali # The root context path to access the Kiali UI.
+authStrategy: login # authentication mechanism for accessing Kiali, options include login, anonymous and openshift.
 nodeSelector: {}
 tolerations: []
 


### PR DESCRIPTION
We have our own in house authentication proxy and do not wish to use the default "login" option hardcoded in this new kiali installation process (earlier we simply added the relevant env var but looks like config.yaml has a higher priority than env vars). With this PR I can easily override the login option and use anonymous in my own values.yaml

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
