### PR TITLE
guard use remote address fort sidecar outbound listeners by feature flag

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1006,7 +1006,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(l
 			// Set useRemoteAddress to true for side car outbound listeners so that it picks up the localhost address of the sender,
 			// which is an internal address, so that trusted headers are not sanitized. This helps to retain the timeout headers
 			// such as "x-envoy-upstream-rq-timeout-ms" set by the calling application.
-			useRemoteAddress: true,
+			useRemoteAddress: pilot.UseRemoteAddress(),
 			direction:        http_conn.EGRESS,
 			rds:              rdsName,
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -460,9 +460,9 @@ func testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t *testing.T, ser
 	}
 
 	// enable use remote address to true
-	os.Setenv("PILOT_USE_REMOTE_ADDRESS", "true")
+	os.Setenv("PILOT_SIDECAR_USE_REMOTE_ADDRESS", "true")
 
-	defer os.Unsetenv("PILOT_USE_REMOTE_ADDRESS")
+	defer os.Unsetenv("PILOT_SIDECAR_USE_REMOTE_ADDRESS")
 
 	listeners := buildOutboundListeners(p, sidecarConfig, nil, services...)
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -212,6 +212,7 @@ func TestOutboundListenerConfig_WithSidecar(t *testing.T) {
 		buildService("test3.com", wildcardIP, model.ProtocolHTTP, tnow.Add(2*time.Second))}
 	testOutboundListenerConfigWithSidecar(t, services...)
 	testOutboundListenerConfigWithSidecarWithCaptureModeNone(t, services...)
+	testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t, services...)
 }
 
 func TestGetActualWildcardAndLocalHost(t *testing.T) {
@@ -424,6 +425,57 @@ func testOutboundListenerConfigWithSidecar(t *testing.T, services ...*model.Serv
 
 	if listener := findListenerByPort(listeners, 9000); !isHTTPListener(listener) {
 		t.Fatalf("expected HTTP listener on port 9000, found TCP\n%v", listener)
+	} else {
+		f := listener.FilterChains[0].Filters[0]
+		config, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+		if useRemoteAddress, exists := config.Fields["use_remote_address"]; exists {
+			if exists && useRemoteAddress.GetBoolValue() {
+				t.Fatalf("expected useRemoteAddress false, found true %v", listener)
+			}
+		}
+	}
+}
+
+func testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t *testing.T, services ...*model.Service) {
+	t.Helper()
+	p := &fakePlugin{}
+	sidecarConfig := &model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Name:      "foo",
+			Namespace: "not-default",
+		},
+		Spec: &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Port: &networking.Port{
+						Number:   9000,
+						Protocol: "HTTP",
+						Name:     "uds",
+					},
+					Bind:  "1.1.1.1",
+					Hosts: []string{"*/*"},
+				},
+			},
+		},
+	}
+
+	// enable use remote address to true
+	os.Setenv("PILOT_USE_REMOTE_ADDRESS", "true")
+
+	defer os.Unsetenv("PILOT_USE_REMOTE_ADDRESS")
+
+	listeners := buildOutboundListeners(p, sidecarConfig, nil, services...)
+
+	if listener := findListenerByPort(listeners, 9000); !isHTTPListener(listener) {
+		t.Fatalf("expected HTTP listener on port 9000, found TCP\n%v", listener)
+	} else {
+		f := listener.FilterChains[0].Filters[0]
+		config, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+		if useRemoteAddress, exists := config.Fields["use_remote_address"]; exists {
+			if !exists || !useRemoteAddress.GetBoolValue() {
+				t.Fatalf("expected useRemoteAddress true, found false %v", listener)
+			}
+		}
 	}
 }
 

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -172,6 +172,14 @@ var (
 		"PILOT_ENABLE_REDIS_FILTER",
 		false,
 		"EnableRedisFilter enables injection of `envoy.filters.network.redis_proxy` in the filter chain.")
+
+	// UseRemoteAddress sets useRemoteAddress to true for side car outbound listeners so that it picks up the localhost
+	// address of the sender, which is an internal address, so that trusted headers are not sanitized.
+	UseRemoteAddress = useRemoteAddress.Get
+	useRemoteAddress = env.RegisterBoolVar(
+		"PILOT_USE_REMOTE_ADDRESS",
+		false,
+		"seRemoteAddress sets useRemoteAddress to true for side car outbound listeners.")
 )
 
 var (

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -179,7 +179,7 @@ var (
 	useRemoteAddress = env.RegisterBoolVar(
 		"PILOT_USE_REMOTE_ADDRESS",
 		false,
-		"seRemoteAddress sets useRemoteAddress to true for side car outbound listeners.")
+		"UseRemoteAddress sets useRemoteAddress to true for side car outbound listeners.")
 )
 
 var (

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -177,7 +177,7 @@ var (
 	// address of the sender, which is an internal address, so that trusted headers are not sanitized.
 	UseRemoteAddress = useRemoteAddress.Get
 	useRemoteAddress = env.RegisterBoolVar(
-		"PILOT_USE_REMOTE_ADDRESS",
+		"PILOT_SIDECAR_USE_REMOTE_ADDRESS",
 		false,
 		"UseRemoteAddress sets useRemoteAddress to true for side car outbound listeners.")
 )


### PR DESCRIPTION
Signed-off-by: Rama Chavali <rama.rao@salesforce.com>

This PR adds a feature flag to configure `useRemoteAddress` for side car outbound listeners. By default it is set to false - retaining the old behaviour. See issue https://github.com/istio/istio/issues/15124 for more details.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

