### PR TITLE
handle envoy exit when killed by accident

### DIFF
--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -151,7 +151,7 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 		e.processNum.Dec()
 		if err == nil {
 			if e.processNum.Load() == 0 {
-				err = fmt.Errorf("Envoy process was killed unexpectedly by something other than pilot-agent")
+				err = fmt.Errorf("envoy process was killed unexpectedly by something other than pilot-agent")
 			}
 		}
 		done <- err

--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -148,9 +148,9 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 	done := make(chan error, 1)
 	go func() {
 		err := cmd.Wait()
-		e.processNum.Dec()
+		processNum := e.processNum.Dec()
 		if err == nil {
-			if e.processNum.Load() == 0 {
+			if processNum == 0 {
 				err = fmt.Errorf("envoy process was killed unexpectedly by something other than pilot-agent")
 			}
 		}

--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -151,7 +151,7 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 		e.processNum.Dec()
 		if err == nil {
 			if e.processNum.Load() == 0 {
-				err = fmt.Errorf("envoy process is killed, maybe by SIGTERM")
+				err = fmt.Errorf("envoy process is killed, maybe by SIGTERM from outside")
 			}
 		}
 		done <- err

--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -151,7 +151,7 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 		e.processNum.Dec()
 		if err == nil {
 			if e.processNum.Load() == 0 {
-				err = fmt.Errorf("envoy process is killed, maybe by SIGTERM from outside")
+				err = fmt.Errorf("Envoy process was killed unexpectedly by something other than pilot-agent")
 			}
 		}
 		done <- err

--- a/pilot/pkg/proxy/envoy/proxy_test.go
+++ b/pilot/pkg/proxy/envoy/proxy_test.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 	"testing"
 
+	"go.uber.org/atomic"
+
 	"istio.io/istio/pilot/pkg/model"
 )
 
@@ -33,6 +35,7 @@ func TestEnvoyArgs(t *testing.T) {
 		extraArgs:      []string{"-l", "trace", "--component-log-level", "misc:error"},
 		nodeIPs:        []string{"10.75.2.9", "192.168.11.18"},
 		dnsRefreshRate: "60s",
+		processNum:     atomic.NewInt32(0),
 	}
 	testProxy := NewProxy(
 		config,


### PR DESCRIPTION
Please provide a description for what this PR is for.

When we exec kill pidof envoy. pilot-agent can not start a new envoy process, this is not reliable to users.
This pr will restart a envoy process in this case, even envoy exit without error in this case.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure
