### PR TITLE
warn only if remote cluster is unavailable

### DIFF
--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/transport/spdy"
 
 	"istio.io/istio/pkg/kube"
+	"istio.io/pkg/log"
 	"istio.io/pkg/version"
 )
 
@@ -248,10 +249,12 @@ func (client *Client) GetIstioVersions(namespace string) (*version.MeshInfo, err
 		"fieldSelector": "status.phase=Running",
 	})
 	if err != nil {
-		return nil, err
+		log.Warnf("will use `--remote=false` to retrieve version info due to %q", err)
+		return nil, nil
 	}
 	if len(pods) == 0 {
-		return nil, fmt.Errorf("unable to determine control plane version - no Istio pods in namespace %q", namespace)
+		log.Warnf("will use `--remote=false` to retrieve version info due to `no Istio pods in namespace %q`", namespace)
+		return nil, nil
 	}
 
 	labelToPodDetail := map[string]podDetail{


### PR DESCRIPTION
To address part of https://github.com/istio/istio/issues/15061 :
when there is no cluster available, will print client version only and warn user about this:
```
warn    will use `--remote=false` to retrieve version info due to "unable to retrieve Pods: Get https://xxxx:6443/api/v1/namespaces/istio-system/pods?fieldSelector=status.phase%3DRunning&labelSelector=istio: dial tcp xxxx:6443: connect: connection refused"
2b86b6665dd6eb4f7d2d47d20e692cedee2f1825
```