### PR TITLE
Fully qualifies images names for Istio samples.

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v2:1.15.0
+        image: docker.io/istio/examples-bookinfo-details-v2:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.15.0
+        image: docker.io/istio/examples-bookinfo-details-v1:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: istio/examples-bookinfo-mysqldb:1.15.0
+        image: docker.io/istio/examples-bookinfo-mysqldb:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.15.0
+        image: docker.io/istio/examples-bookinfo-ratings-v2:1.15.0
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.15.0
+        image: docker.io/istio/examples-bookinfo-ratings-v2:1.15.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: bookinfo-ratings-v2
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.15.0
+        image: docker.io/istio/examples-bookinfo-ratings-v2:1.15.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.15.0
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.15.0
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.15.0
+        image: docker.io/istio/examples-bookinfo-details-v1:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -105,7 +105,7 @@ spec:
       serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.15.0
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -154,7 +154,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1:1.15.0
+        image: docker.io/istio/examples-bookinfo-reviews-v1:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -181,7 +181,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.15.0
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -208,7 +208,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v3:1.15.0
+        image: docker.io/istio/examples-bookinfo-reviews-v3:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -257,7 +257,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:1.15.0
+        image: docker.io/istio/examples-bookinfo-productpage-v1:1.15.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/custom-bootstrap/example-app.yaml
+++ b/samples/custom-bootstrap/example-app.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: helloworld
-          image: istio/examples-helloworld-v1
+          image: docker.io/istio/examples-helloworld-v1
           resources:
             requests:
               cpu: "100m"

--- a/samples/helloworld/helloworld.yaml
+++ b/samples/helloworld/helloworld.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: istio/examples-helloworld-v1
+        image: docker.io/istio/examples-helloworld-v1
         resources:
           requests:
             cpu: "100m"
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: istio/examples-helloworld-v2
+        image: docker.io/istio/examples-helloworld-v2
         resources:
           requests:
             cpu: "100m"

--- a/samples/kubernetes-blog/bookinfo-ratings.yaml
+++ b/samples/kubernetes-blog/bookinfo-ratings.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:0.2.3
+        image: docker.io/istio/examples-bookinfo-ratings-v1:0.2.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/kubernetes-blog/bookinfo-reviews-v2.yaml
+++ b/samples/kubernetes-blog/bookinfo-reviews-v2.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:0.2.3
+        image: docker.io/istio/examples-bookinfo-reviews-v2:0.2.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/kubernetes-blog/bookinfo-v1.yaml
+++ b/samples/kubernetes-blog/bookinfo-v1.yaml
@@ -85,7 +85,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1:0.2.3
+        image: docker.io/istio/examples-bookinfo-reviews-v1:0.2.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -124,7 +124,7 @@ spec:
     spec:
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:0.2.3
+        image: docker.io/istio/examples-bookinfo-productpage-v1:0.2.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/tcp-echo/tcp-echo-services.yaml
+++ b/samples/tcp-echo/tcp-echo-services.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: istio/tcp-echo-server:1.1
+        image: docker.io/istio/tcp-echo-server:1.1
         imagePullPolicy: IfNotPresent
         args: [ "9000", "one" ]
         ports:
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: istio/tcp-echo-server:1.1
+        image: docker.io/istio/tcp-echo-server:1.1
         imagePullPolicy: IfNotPresent
         args: [ "9000", "two" ]
         ports:

--- a/samples/tcp-echo/tcp-echo.yaml
+++ b/samples/tcp-echo/tcp-echo.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: istio/tcp-echo-server:1.1
+        image: docker.io/istio/tcp-echo-server:1.1
         imagePullPolicy: IfNotPresent
         args: [ "9000", "hello" ]
         ports:


### PR DESCRIPTION
Fixes: #14237.

Signed-off-by: Jason Clark <jason.clark@ibm.com>

This PR provides fully qualified `image:` fields for ~the bookinfo~ all Istio samples.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
