### PR TITLE
More detailed errors when kube-inject fails

### DIFF
--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -271,7 +271,7 @@ istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo.yaml \
 				}
 				var config inject.Config
 				if err := yaml.Unmarshal(injectionConfig, &config); err != nil {
-					return err
+					return multierr.Append(fmt.Errorf("loading --injectConfigFile"), err)
 				}
 				sidecarTemplate = config.Template
 			} else if sidecarTemplate, err = getInjectConfigFromConfigMap(kubeconfig); err != nil {


### PR DESCRIPTION
A small PR for improved error messages when kube-inject fails.

Inspired by https://github.com/istio/istio/issues/15152

The old error messages were things like "error converting YAML to JSON" which are confusing to users who were not trying to convert any JSON to YAML when they used the CLI or auto-inject.