### PR TITLE
Add a process package to galley/pkg/server for tracking sub-components

### DIFF
--- a/galley/pkg/server/process/component.go
+++ b/galley/pkg/server/process/component.go
@@ -27,7 +27,7 @@ type Component interface {
 
 type component struct {
 	startFn func() error
-	stopFn func()
+	stopFn  func()
 }
 
 // Start implements Component
@@ -42,8 +42,8 @@ func (c *component) Stop() {
 
 // ComponentFromFns creates a component from functions.
 func ComponentFromFns(startFn func() error, stopFn func()) Component {
-	return &component {
+	return &component{
 		startFn: startFn,
-		stopFn: stopFn,
+		stopFn:  stopFn,
 	}
 }

--- a/galley/pkg/server/process/component.go
+++ b/galley/pkg/server/process/component.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+// Component of a running process.
+type Component interface {
+	// Start the component. If the component succeeds in starting, then it should complete its initialization by the
+	// time Start returns.
+	Start() error
+
+	// Stop the component. When called multiple times, Stop should stop the component idempotently. By the time Stop()
+	// returns control, the Component should cease all background operations.
+	Stop()
+}
+
+type component struct {
+	startFn func() error
+	stopFn func()
+}
+
+// Start implements Component
+func (c *component) Start() error {
+	return c.startFn()
+}
+
+// Stop implements Component
+func (c *component) Stop() {
+	c.stopFn()
+}
+
+// ComponentFromFns creates a component from functions.
+func ComponentFromFns(startFn func() error, stopFn func()) Component {
+	return &component {
+		startFn: startFn,
+		stopFn: stopFn,
+	}
+}

--- a/galley/pkg/server/process/component_test.go
+++ b/galley/pkg/server/process/component_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestComponentFromFns(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var started bool
+	var stopped bool
+	var startErr error
+	c := ComponentFromFns(
+		func() error {
+			started = true
+			return startErr
+		},
+		func() {
+			stopped = true
+		})
+
+	err := c.Start()
+	g.Expect(err).To(BeNil())
+	g.Expect(started).To(BeTrue())
+
+	c.Stop()
+	g.Expect(stopped).To(BeTrue())
+
+	startErr = errors.New("some error")
+	err = c.Start()
+	g.Expect(err).NotTo(BeNil())
+}

--- a/galley/pkg/server/process/host.go
+++ b/galley/pkg/server/process/host.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+import (
+	"errors"
+	"sync"
+)
+
+// Host is a process host that takes care of start/stop of sub-components.
+type Host struct {
+	mu         sync.Mutex
+	started    bool
+	components []Component
+}
+
+// Add a new component to this host. It panics if the host is already started.
+func (h *Host) Add(c Component) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.started {
+		panic("Host.Add: host is already started")
+	}
+	h.components = append(h.components, c)
+}
+
+// Start the process.Host. If any of the components starts to fail, then an error is returned. If there is an error
+// then all successfully started components will be stopped before control is returned.
+func (h *Host) Start() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.started {
+		return errors.New("process.Host: already started")
+	}
+
+	for i := 0; i < len(h.components); i++ {
+		c := h.components[i]
+		if err := c.Start(); err != nil {
+			// Component startup failed. Stop already started components.
+			for j := i - 1; j >= 0; j-- {
+				h.components[j].Stop()
+			}
+			return err
+		}
+	}
+	h.started = true
+
+	return nil
+}
+
+// Stop the Host. All components will be stopped, before the control is returned.
+func (h *Host) Stop() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for j := len(h.components) - 1; j >= 0; j-- {
+		h.components[j].Stop()
+	}
+}

--- a/galley/pkg/server/process/host.go
+++ b/galley/pkg/server/process/host.go
@@ -45,8 +45,7 @@ func (h *Host) Start() error {
 		return errors.New("process.Host: already started")
 	}
 
-	for i := 0; i < len(h.components); i++ {
-		c := h.components[i]
+	for i, c := range h.components {
 		if err := c.Start(); err != nil {
 			// Component startup failed. Stop already started components.
 			for j := i - 1; j >= 0; j-- {

--- a/galley/pkg/server/process/host_test.go
+++ b/galley/pkg/server/process/host_test.go
@@ -1,0 +1,109 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHost_Basic(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	c1 := &fakeComponent{}
+	var h Host
+	h.Add(c1)
+
+	err := h.Start()
+	g.Expect(err).To(BeNil())
+	g.Expect(c1.started).To(BeTrue())
+
+	h.Stop()
+	g.Expect(c1.started).To(BeFalse())
+}
+
+func TestHost_AddAfterStart(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var h Host
+	err := h.Start()
+	g.Expect(err).To(BeNil())
+	defer h.Stop()
+
+	defer func() {
+		r := recover()
+		g.Expect(r).NotTo(BeNil())
+	}()
+
+	c1 := &fakeComponent{}
+	h.Add(c1)
+}
+
+func TestHost_DoubleStart(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	c1 := &fakeComponent{}
+	var h Host
+	h.Add(c1)
+
+	err := h.Start()
+	g.Expect(err).To(BeNil())
+	g.Expect(c1.started).To(BeTrue())
+
+	defer h.Stop()
+
+	err = h.Start()
+	g.Expect(err).NotTo(BeNil())
+}
+
+func TestHost_StartFailure(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	c1 := &fakeComponent{}
+	c2 := &fakeComponent{startErr: errors.New("some err")}
+	c3 := &fakeComponent{}
+	var h Host
+	h.Add(c1)
+	h.Add(c2)
+	h.Add(c3)
+
+	err := h.Start()
+	g.Expect(err).NotTo(BeNil())
+	g.Expect(c1.started).To(BeFalse())
+	g.Expect(c2.started).To(BeFalse())
+	g.Expect(c2.started).To(BeFalse())
+}
+
+type fakeComponent struct {
+	started  bool
+	startErr error
+}
+
+var _ Component = &fakeComponent{}
+
+func (f *fakeComponent) Start() error {
+	if f.startErr != nil {
+		return f.startErr
+	}
+
+	f.started = true
+	return nil
+}
+
+func (f *fakeComponent) Stop() {
+	f.started = false
+}


### PR DESCRIPTION
- process.Host is a basic container of multiple sub-components.
- process.Component is an interface to be implemented by sub-components.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
