### PR TITLE
[Fix] retain CommonLbConfig for HealthyPanicThreshold (#13682)

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -854,11 +854,12 @@ func applyOutlierDetection(cluster *apiv2.Cluster, outlier *networking.OutlierDe
 
 func applyLoadBalancer(cluster *apiv2.Cluster, lb *networking.LoadBalancerSettings, port *model.Port) {
 	if cluster.OutlierDetection != nil {
+		if cluster.CommonLbConfig == nil {
+			cluster.CommonLbConfig = &apiv2.Cluster_CommonLbConfig{}
+		}
 		// Locality weighted load balancing
-		cluster.CommonLbConfig = &apiv2.Cluster_CommonLbConfig{
-			LocalityConfigSpecifier: &apiv2.Cluster_CommonLbConfig_LocalityWeightedLbConfig_{
-				LocalityWeightedLbConfig: &apiv2.Cluster_CommonLbConfig_LocalityWeightedLbConfig{},
-			},
+		cluster.CommonLbConfig.LocalityConfigSpecifier = &apiv2.Cluster_CommonLbConfig_LocalityWeightedLbConfig_{
+			LocalityWeightedLbConfig: &apiv2.Cluster_CommonLbConfig_LocalityWeightedLbConfig{},
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -739,8 +739,8 @@ func TestLocalityLB(t *testing.T) {
 			Host: "*.example.org",
 			TrafficPolicy: &networking.TrafficPolicy{
 				OutlierDetection: &networking.OutlierDetection{
-					ConsecutiveErrors:  5,
-					MinHealthPercent:   10,
+					ConsecutiveErrors: 5,
+					MinHealthPercent:  10,
 				},
 			},
 		})

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -739,7 +739,8 @@ func TestLocalityLB(t *testing.T) {
 			Host: "*.example.org",
 			TrafficPolicy: &networking.TrafficPolicy{
 				OutlierDetection: &networking.OutlierDetection{
-					ConsecutiveErrors: 5,
+					ConsecutiveErrors:  5,
+					MinHealthPercent:   10,
 				},
 			},
 		})
@@ -748,6 +749,7 @@ func TestLocalityLB(t *testing.T) {
 	if clusters[0].CommonLbConfig == nil {
 		t.Errorf("CommonLbConfig should be set for cluster %+v", clusters[0])
 	}
+	g.Expect(clusters[0].CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
 
 	g.Expect(len(clusters[0].LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range clusters[0].LoadAssignment.Endpoints {


### PR DESCRIPTION
Please provide a description for what this PR is for.

#13682

* when `DestinationRule` with `outlierDetection.minHealthPercent` created

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: DestinationRule
metadata:
  annotations:
    name: orders
    namespace: sock-shop
spec:
  host: orders
  trafficPolicy:
    outlierDetection:
      minHealthPercent: 10
```

* a releated sidecar got configuration without `"common_lb_config.healthy_panic_threshold`

```json
{
  "cluster": {
    "common_lb_config": {
      "locality_weighted_lb_config": {}
    }
```

* pilot should convert `minHealthPercent` to `healthy_panic_threshold`, and retain it

```json
{
  "cluster": {
    "common_lb_config": {
      "healthy_panic_threshold": {
        "value": 10
      },
      "locality_weighted_lb_config": {}
    }
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[X ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
