### PR TITLE
Migrate Citadel secret controller metrics from prometheus to open census

### DIFF
--- a/security/pkg/k8s/controller/monitoring.go
+++ b/security/pkg/k8s/controller/monitoring.go
@@ -15,7 +15,7 @@
 package controller
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
+	"istio.io/pkg/monitoring"
 )
 
 const (
@@ -23,70 +23,65 @@ const (
 )
 
 var (
-	serviceAccountCreationCounts = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "citadel",
-		Subsystem: "secret_controller",
-		Name:      "svc_acc_created_cert_count",
-		Help:      "The number of certificates created due to service account creation.",
-	}, []string{})
+	errorTag = monitoring.MustCreateLabel(errorlabel)
 
-	serviceAccountDeletionCounts = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "citadel",
-		Subsystem: "secret_controller",
-		Name:      "svc_acc_deleted_cert_count",
-		Help:      "The number of certificates deleted due to service account deletion.",
-	}, []string{})
+	serviceAccountCreationCounts = monitoring.NewSum(
+		"svc_acc_created_cert_count",
+		"The number of certificates created due to service account creation.",
+	)
 
-	secretDeletionCounts = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "citadel",
-		Subsystem: "secret_controller",
-		Name:      "secret_deleted_cert_count",
-		Help:      "The number of certificates recreated due to secret deletion (service account still exists).",
-	}, []string{})
+	serviceAccountDeletionCounts = monitoring.NewSum(
+		"svc_acc_deleted_cert_count",
+		"The number of certificates deleted due to service account deletion.",
+	)
 
-	csrErrorCounts = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "citadel",
-		Subsystem: "secret_controller",
-		Name:      "csr_err_count",
-		Help:      "The number of errors occurred when creating the CSR.",
-	}, []string{})
+	secretDeletionCounts = monitoring.NewSum(
+		"secret_deleted_cert_count",
+		"The number of certificates recreated due to secret deletion (service account still exists).",
+	)
 
-	certSignErrorCounts = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "citadel",
-		Subsystem: "secret_controller",
-		Name:      "csr_sign_err_count",
-		Help:      "The number of errors occurred when signing the CSR.",
-	}, []string{errorlabel})
+	csrErrorCounts = monitoring.NewSum(
+		"csr_err_count",
+		"The number of errors occurred when creating the CSR.",
+	)
+
+	certSignErrorCounts = monitoring.NewSum(
+		"csr_sign_err_count",
+		"The number of errors occurred when signing the CSR.",
+		monitoring.WithLabels(errorTag),
+	)
 )
 
 func init() {
-	prometheus.MustRegister(serviceAccountCreationCounts)
-	prometheus.MustRegister(serviceAccountDeletionCounts)
-	prometheus.MustRegister(secretDeletionCounts)
-	prometheus.MustRegister(csrErrorCounts)
-	prometheus.MustRegister(certSignErrorCounts)
+	monitoring.MustRegister(
+		serviceAccountCreationCounts,
+		serviceAccountDeletionCounts,
+		secretDeletionCounts,
+		csrErrorCounts,
+		certSignErrorCounts,
+	)
 }
 
 // monitoringMetrics are counters for secret controller operations.
 type monitoringMetrics struct {
-	ServiceAccountCreation prometheus.Counter
-	ServiceAccountDeletion prometheus.Counter
-	SecretDeletion         prometheus.Counter
-	CSRError               prometheus.Counter
-	certSignErrors         *prometheus.CounterVec
+	ServiceAccountCreation monitoring.Metric
+	ServiceAccountDeletion monitoring.Metric
+	SecretDeletion         monitoring.Metric
+	CSRError               monitoring.Metric
+	certSignErrors         monitoring.Metric
 }
 
 // newMonitoringMetrics creates a new monitoringMetrics.
 func newMonitoringMetrics() monitoringMetrics {
 	return monitoringMetrics{
-		ServiceAccountCreation: serviceAccountCreationCounts.With(prometheus.Labels{}),
-		ServiceAccountDeletion: serviceAccountDeletionCounts.With(prometheus.Labels{}),
-		SecretDeletion:         secretDeletionCounts.With(prometheus.Labels{}),
-		CSRError:               csrErrorCounts.With(prometheus.Labels{}),
+		ServiceAccountCreation: serviceAccountCreationCounts,
+		ServiceAccountDeletion: serviceAccountDeletionCounts,
+		SecretDeletion:         secretDeletionCounts,
+		CSRError:               csrErrorCounts,
 		certSignErrors:         certSignErrorCounts,
 	}
 }
 
-func (m *monitoringMetrics) GetCertSignError(err string) prometheus.Counter {
-	return m.certSignErrors.With(prometheus.Labels{errorlabel: err})
+func (m *monitoringMetrics) GetCertSignError(err string) monitoring.Metric {
+	return m.certSignErrors.With(errorTag.Value(err))
 }

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -245,14 +245,14 @@ func (sc *SecretController) saAdded(obj interface{}) {
 	if sc.istioEnabledObject(acct.GetObjectMeta()) {
 		sc.upsertSecret(acct.GetName(), acct.GetNamespace())
 	}
-	sc.monitoring.ServiceAccountCreation.Inc()
+	sc.monitoring.ServiceAccountCreation.Increment()
 }
 
 // Handles the event where a service account is deleted.
 func (sc *SecretController) saDeleted(obj interface{}) {
 	acct := obj.(*v1.ServiceAccount)
 	sc.deleteSecret(acct.GetName(), acct.GetNamespace())
-	sc.monitoring.ServiceAccountDeletion.Inc()
+	sc.monitoring.ServiceAccountDeletion.Increment()
 }
 
 func (sc *SecretController) upsertSecret(saName, saNamespace string) {
@@ -324,7 +324,7 @@ func (sc *SecretController) scrtDeleted(obj interface{}) {
 		if sc.istioEnabledObject(sa.GetObjectMeta()) {
 			sc.upsertSecret(saName, scrt.GetNamespace())
 		}
-		sc.monitoring.SecretDeletion.Inc()
+		sc.monitoring.SecretDeletion.Increment()
 	}
 }
 
@@ -357,7 +357,7 @@ func (sc *SecretController) generateKeyAndCert(saName string, saNamespace string
 	csrPEM, keyPEM, err := util.GenCSR(options)
 	if err != nil {
 		log.Errorf("CSR generation error (%v)", err)
-		sc.monitoring.CSRError.Inc()
+		sc.monitoring.CSRError.Increment()
 		return nil, nil, err
 	}
 
@@ -365,7 +365,7 @@ func (sc *SecretController) generateKeyAndCert(saName string, saNamespace string
 	certPEM, signErr := sc.ca.Sign(csrPEM, strings.Split(id, ","), sc.certTTL, sc.forCA)
 	if signErr != nil {
 		log.Errorf("CSR signing error (%v)", signErr.Error())
-		sc.monitoring.GetCertSignError(signErr.(*ca.Error).ErrorType()).Inc()
+		sc.monitoring.GetCertSignError(signErr.(*ca.Error).ErrorType()).Increment()
 		return nil, nil, fmt.Errorf("CSR signing error (%v)", signErr.(*ca.Error))
 	}
 	certPEM = append(certPEM, certChainPEM...)


### PR DESCRIPTION
This PR migrates the metrics in the Citadel secret controller from prometheus to open census. [Related issue](https://github.com/istio/istio/issues/14362) which calls for open census metrics in Citadel agent.

I followed the general migration pattern from [this PR](https://github.com/istio/istio/pull/14854). For helpers, I dropped in the [monitoring util file from here](https://github.com/douglas-reid/istio/blob/f17fc3c0d6f584da956c4342c696a4d570852f53/pilot/pkg/monitoring/monitoring.go), which from the surrounding discussion, seems like it might become standard across all packages in the future (for the purposes of this PR though, not sure if we should abstract it out now or keep a copy).

I wasn't sure how to all the relevant fields from the prometheus metrics should translate over to open census (subsystem, namespace, etc), so I attached labels where it seemed appropriate.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
