### PR TITLE
Fixes #15250. Add support for HTTP1.0 for sidecar inbound listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -391,7 +391,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 				Bind:             bind,
 			}
 
-			if l := configgen.buildSidecarInboundListenerForPortOrUDS(listenerOpts, pluginParams, listenerMap); l != nil {
+			if l := configgen.buildSidecarInboundListenerForPortOrUDS(node, listenerOpts, pluginParams, listenerMap); l != nil {
 				listeners = append(listeners, l)
 			}
 		}
@@ -474,7 +474,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 				Bind:             bind,
 			}
 
-			if l := configgen.buildSidecarInboundListenerForPortOrUDS(listenerOpts, pluginParams, listenerMap); l != nil {
+			if l := configgen.buildSidecarInboundListenerForPortOrUDS(node, listenerOpts, pluginParams, listenerMap); l != nil {
 				listeners = append(listeners, l)
 			}
 		}
@@ -485,7 +485,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 
 // buildSidecarInboundListenerForPortOrUDS creates a single listener on the server-side (inbound)
 // for a given port or unix domain socket
-func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(listenerOpts buildListenerOpts,
+func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(node *model.Proxy, listenerOpts buildListenerOpts,
 	pluginParams *plugin.InputParams, listenerMap map[string]*inboundListenerEntry) *xdsapi.Listener {
 
 	// Local service instances can be accessed through one of four addresses:
@@ -554,6 +554,12 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(li
 				httpOpts.connectionManager.Http2ProtocolOptions = &core.Http2ProtocolOptions{}
 				if pluginParams.ServiceInstance.Endpoint.ServicePort.Protocol == model.ProtocolGRPCWeb {
 					httpOpts.addGRPCWebFilter = true
+				}
+			}
+
+			if pilot.HTTP10 || node.Metadata[model.NodeMetadataHTTP10] == "1" {
+				httpOpts.connectionManager.HttpProtocolOptions = &core.Http1ProtocolOptions{
+					AcceptHttp_10: true,
 				}
 			}
 


### PR DESCRIPTION
This PR should be a fix for #15250.
The problem reported there is that even when pilot is started with support for HTTP 1.0 or the node explicitly asks for HTTP 1.0 support with its metadata, Pilot does not configure the HTTP connection manager to accept HTTP 1.0 on the inbound listeners for sidecars.
This results in HTTP 1.0 not being supported for calls from clients in the local cluster that don't have a sidecar.

The logic is pretty much the same as for the gateway and the sidecar outbound listeners.
It might make sense to only support HTTP 1.0 for the "plain" filter chain and keep it unsupported for the Istio mTLS filter chain as the consumer seems to already upgrade to HTTP 1.1, but that would require more changes to the existing logic.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
