### PR TITLE
make keepalive EnforcementPolicy.MinTime equals keepalive interval

### DIFF
--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -175,7 +175,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 		}),
 		// Relax keepalive enforcement policy requirements to avoid dropping connections due to too many pings.
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime:             time.Minute,
+			MinTime:             30 * time.Second,
 			PermitWithoutStream: true,
 		}),
 	)


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
