### PR TITLE
Fixes #15250. Add support for HTTP1.0 for sidecar inbound listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -566,7 +566,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(no
 				}
 			}
 
-			if pilot.HTTP10 || node.Metadata[model.NodeMetadataHTTP10] == "1" {
+			if features.HTTP10 || node.Metadata[model.NodeMetadataHTTP10] == "1" {
 				httpOpts.connectionManager.HttpProtocolOptions = &core.Http1ProtocolOptions{
 					AcceptHttp_10: true,
 				}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -400,7 +400,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 				Bind:             bind,
 			}
 
-			if l := configgen.buildSidecarInboundListenerForPortOrUDS(listenerOpts, pluginParams, listenerMap); l != nil {
+			if l := configgen.buildSidecarInboundListenerForPortOrUDS(node, listenerOpts, pluginParams, listenerMap); l != nil {
 				listeners = append(listeners, l)
 			}
 		}
@@ -483,7 +483,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 				Bind:             bind,
 			}
 
-			if l := configgen.buildSidecarInboundListenerForPortOrUDS(listenerOpts, pluginParams, listenerMap); l != nil {
+			if l := configgen.buildSidecarInboundListenerForPortOrUDS(node, listenerOpts, pluginParams, listenerMap); l != nil {
 				listeners = append(listeners, l)
 			}
 		}
@@ -494,7 +494,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 
 // buildSidecarInboundListenerForPortOrUDS creates a single listener on the server-side (inbound)
 // for a given port or unix domain socket
-func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(listenerOpts buildListenerOpts,
+func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(node *model.Proxy, listenerOpts buildListenerOpts,
 	pluginParams *plugin.InputParams, listenerMap map[string]*inboundListenerEntry) *xdsapi.Listener {
 
 	// Local service instances can be accessed through one of four addresses:
@@ -563,6 +563,12 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(li
 				httpOpts.connectionManager.Http2ProtocolOptions = &core.Http2ProtocolOptions{}
 				if pluginParams.ServiceInstance.Endpoint.ServicePort.Protocol == model.ProtocolGRPCWeb {
 					httpOpts.addGRPCWebFilter = true
+				}
+			}
+
+			if pilot.HTTP10 || node.Metadata[model.NodeMetadataHTTP10] == "1" {
+				httpOpts.connectionManager.HttpProtocolOptions = &core.Http1ProtocolOptions{
+					AcceptHttp_10: true,
 				}
 			}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -53,6 +53,18 @@ var (
 		},
 		ConfigNamespace: "not-default",
 	}
+	proxyHTTP10 = model.Proxy{
+		Type:        model.SidecarProxy,
+		IPAddresses: []string{"1.1.1.1"},
+		ID:          "v0.default",
+		DNSDomain:   "default.example.org",
+		Metadata: map[string]string{
+			model.NodeMetadataConfigNamespace: "not-default",
+			"ISTIO_PROXY_VERSION":             "1.1",
+			model.NodeMetadataHTTP10:          "1",
+		},
+		ConfigNamespace: "not-default",
+	}
 	proxyInstances = []*model.ServiceInstance{
 		{
 			Service: &model.Service{
@@ -195,13 +207,15 @@ func TestOutboundListenerTCPWithVS(t *testing.T) {
 	}
 }
 func TestInboundListenerConfig_HTTP(t *testing.T) {
-	// Add a service and verify it's config
-	testInboundListenerConfig(t,
-		buildService("test.com", wildcardIP, model.ProtocolHTTP, tnow))
-	testInboundListenerConfigWithoutServices(t)
-	testInboundListenerConfigWithSidecar(t,
-		buildService("test.com", wildcardIP, model.ProtocolHTTP, tnow))
-	testInboundListenerConfigWithSidecarWithoutServices(t)
+	for _, p := range []*model.Proxy{&proxy, &proxyHTTP10} {
+		// Add a service and verify it's config
+		testInboundListenerConfig(t, p,
+			buildService("test.com", wildcardIP, model.ProtocolHTTP, tnow))
+		testInboundListenerConfigWithoutServices(t, p)
+		testInboundListenerConfigWithSidecar(t, p,
+			buildService("test.com", wildcardIP, model.ProtocolHTTP, tnow))
+		testInboundListenerConfigWithSidecarWithoutServices(t, p)
+	}
 }
 
 func TestOutboundListenerConfig_WithSidecar(t *testing.T) {
@@ -278,11 +292,11 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 	}
 }
 
-func testInboundListenerConfig(t *testing.T, services ...*model.Service) {
+func testInboundListenerConfig(t *testing.T, proxy *model.Proxy, services ...*model.Service) {
 	t.Helper()
 	oldestService := getOldestService(services...)
 	p := &fakePlugin{}
-	listeners := buildInboundListeners(p, nil, services...)
+	listeners := buildInboundListeners(p, proxy, nil, services...)
 	if len(listeners) != 1 {
 		t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
 	}
@@ -297,20 +311,23 @@ func testInboundListenerConfig(t *testing.T, services ...*model.Service) {
 		verifyInboundHTTPListenerCertDetails(t, listeners[0])
 		verifyInboundHTTPListenerNormalizePath(t, listeners[0])
 	}
+	for _, listener := range listeners {
+		verifyInboundHTTP10(t, isNodeHTTP10(proxy), listener)
+	}
 
 	verifyInboundEnvoyListenerNumber(t, listeners[0])
 }
 
-func testInboundListenerConfigWithoutServices(t *testing.T) {
+func testInboundListenerConfigWithoutServices(t *testing.T, proxy *model.Proxy) {
 	t.Helper()
 	p := &fakePlugin{}
-	listeners := buildInboundListeners(p, nil)
+	listeners := buildInboundListeners(p, proxy, nil)
 	if expected := 0; len(listeners) != expected {
 		t.Fatalf("expected %d listeners, found %d", expected, len(listeners))
 	}
 }
 
-func testInboundListenerConfigWithSidecar(t *testing.T, services ...*model.Service) {
+func testInboundListenerConfigWithSidecar(t *testing.T, proxy *model.Proxy, services ...*model.Service) {
 	t.Helper()
 	p := &fakePlugin{}
 	sidecarConfig := &model.Config{
@@ -332,7 +349,7 @@ func testInboundListenerConfigWithSidecar(t *testing.T, services ...*model.Servi
 			},
 		},
 	}
-	listeners := buildInboundListeners(p, sidecarConfig, services...)
+	listeners := buildInboundListeners(p, proxy, sidecarConfig, services...)
 	if len(listeners) != 1 {
 		t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
 	}
@@ -340,9 +357,12 @@ func testInboundListenerConfigWithSidecar(t *testing.T, services ...*model.Servi
 	if !isHTTPListener(listeners[0]) {
 		t.Fatal("expected HTTP listener, found TCP")
 	}
+	for _, listener := range listeners {
+		verifyInboundHTTP10(t, isNodeHTTP10(proxy), listener)
+	}
 }
 
-func testInboundListenerConfigWithSidecarWithoutServices(t *testing.T) {
+func testInboundListenerConfigWithSidecarWithoutServices(t *testing.T, proxy *model.Proxy) {
 	t.Helper()
 	p := &fakePlugin{}
 	sidecarConfig := &model.Config{
@@ -364,7 +384,7 @@ func testInboundListenerConfigWithSidecarWithoutServices(t *testing.T) {
 			},
 		},
 	}
-	listeners := buildInboundListeners(p, sidecarConfig)
+	listeners := buildInboundListeners(p, proxy, sidecarConfig)
 	if expected := 0; len(listeners) != expected {
 		t.Fatalf("expected %d listeners, found %d", expected, len(listeners))
 	}
@@ -671,6 +691,34 @@ func verifyInboundHTTPListenerNormalizePath(t *testing.T, l *xdsapi.Listener) {
 	}
 }
 
+func verifyInboundHTTP10(t *testing.T, http10Expected bool, l *xdsapi.Listener) {
+	t.Helper()
+	for _, fc := range l.FilterChains {
+		for _, f := range fc.Filters {
+			if f.Name == "envoy.http_connection_manager" {
+				config, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+				httpProtocolOptionsField := config.Fields["http_protocol_options"]
+				if http10Expected && httpProtocolOptionsField == nil {
+					t.Error("expected http_protocol_options for http_connection_manager, found nil")
+					return
+				}
+				if !http10Expected && httpProtocolOptionsField == nil {
+					continue
+				}
+				httpProtocolOptions := httpProtocolOptionsField.GetStructValue()
+				acceptHTTP10Field := httpProtocolOptions.Fields["accept_http_10"]
+				if http10Expected && acceptHTTP10Field == nil {
+					t.Error("expected http protocol option accept_http_10, found nil")
+					return
+				}
+				if http10Expected && acceptHTTP10Field.GetBoolValue() != http10Expected {
+					t.Errorf("expected accepting HTTP 1.0: %v, found: %v", http10Expected, acceptHTTP10Field.GetBoolValue())
+				}
+			}
+		}
+	}
+}
+
 func getOldestService(services ...*model.Service) *model.Service {
 	var oldestService *model.Service
 	for _, s := range services {
@@ -741,7 +789,7 @@ func buildOutboundListeners(p plugin.Plugin, sidecarConfig *model.Config,
 	return configgen.buildSidecarOutboundListeners(&env, &proxy, env.PushContext, proxyInstances)
 }
 
-func buildInboundListeners(p plugin.Plugin, sidecarConfig *model.Config, services ...*model.Service) []*xdsapi.Listener {
+func buildInboundListeners(p plugin.Plugin, proxy *model.Proxy, sidecarConfig *model.Config, services ...*model.Service) []*xdsapi.Listener {
 	configgen := NewConfigGenerator([]plugin.Plugin{p})
 	env := buildListenerEnv(services)
 	if err := env.PushContext.InitContext(&env); err != nil {
@@ -759,7 +807,7 @@ func buildInboundListeners(p plugin.Plugin, sidecarConfig *model.Config, service
 	} else {
 		proxy.SidecarScope = model.ConvertToSidecarScope(env.PushContext, sidecarConfig, sidecarConfig.Namespace)
 	}
-	return configgen.buildSidecarInboundListeners(&env, &proxy, env.PushContext, instances)
+	return configgen.buildSidecarInboundListeners(&env, proxy, env.PushContext, instances)
 }
 
 type fakePlugin struct {
@@ -807,6 +855,10 @@ func isMysqlListener(listener *xdsapi.Listener) bool {
 		return listener.FilterChains[0].Filters[0].Name == xdsutil.MySQLProxy
 	}
 	return false
+}
+
+func isNodeHTTP10(proxy *model.Proxy) bool {
+	return proxy.Metadata[model.NodeMetadataHTTP10] == "1"
 }
 
 func findListenerByPort(listeners []*xdsapi.Listener, port uint32) *xdsapi.Listener {


### PR DESCRIPTION
This PR is the same as #15253, just for master.

This PR should be a fix for #15250.
The problem reported there is that even when pilot is started with support for HTTP 1.0 or the node explicitly asks for HTTP 1.0 support with its metadata, Pilot does not configure the HTTP connection manager to accept HTTP 1.0 on the inbound listeners for sidecars.
This results in HTTP 1.0 not being supported for calls from clients in the local cluster that don't have a sidecar.

The logic is pretty much the same as for the gateway and the sidecar outbound listeners.
It might make sense to only support HTTP 1.0 for the "plain" filter chain and keep it unsupported for the Istio mTLS filter chain as the consumer seems to already upgrade to HTTP 1.1, but that would require more changes to the existing logic.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure