### PR TITLE
Stop skipping cleanup on new installer tests

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -66,7 +66,6 @@ test.integration.new.installer: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
 	set -o pipefail; \
 	$(GO) test -p 1 ${T} ${NEW_INSTALLER_TARGETS} ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
-	--istio.test.nocleanup \
 	--istio.test.kube.deploy=false \
 	--istio.test.select -postsubmit,-flaky,-customsetup \
 	--istio.test.kube.minikube \


### PR DESCRIPTION
I think this will still work and will prevent tests failing due to other tests leaving around config

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
