### PR TITLE
Fix testMTlsWithAuthNPolicy by not using --export in kubectl

### DIFF
--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -195,7 +195,7 @@ func KubeGetYaml(namespace, resource, name string, kubeconfig string) (string, e
 	if namespace == "" {
 		namespace = "default"
 	}
-	cmd := fmt.Sprintf("kubectl get %s %s -n %s -o yaml --kubeconfig=%s --export", resource, name, namespace, kubeconfig)
+	cmd := fmt.Sprintf("kubectl get %s %s -n %s -o yaml --kubeconfig=%s", resource, name, namespace, kubeconfig)
 
 	return Shell(cmd)
 }


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

`--export` being deprecated in kubectl: https://github.com/kubernetes/kubernetes/pull/73787
This potentially fixes https://github.com/istio/istio/issues/15276