### PR TITLE
Allow setting EnableNamespacesByDefault from command line

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -63,21 +63,21 @@ var (
 	helmValues string
 
 	settingsFromCommandline = &Config{
-		ChartRepo:                 DefaultIstioChartRepo,
-		SystemNamespace:           DefaultSystemNamespace,
-		IstioNamespace:            DefaultSystemNamespace,
-		ConfigNamespace:           DefaultSystemNamespace,
-		TelemetryNamespace:        DefaultSystemNamespace,
-		PolicyNamespace:           DefaultSystemNamespace,
-		IngressNamespace:          DefaultSystemNamespace,
-		EgressNamespace:           DefaultSystemNamespace,
-		DeployIstio:               true,
-		DeployTimeout:             0,
-		UndeployTimeout:           0,
-		ChartDir:                  env.IstioChartDir,
-		CrdsFilesDir:              env.CrdsFilesDir,
-		ValuesFile:                E2EValuesFile,
-		EnableNamespacesByDefault: false,
+		ChartRepo:                DefaultIstioChartRepo,
+		SystemNamespace:          DefaultSystemNamespace,
+		IstioNamespace:           DefaultSystemNamespace,
+		ConfigNamespace:          DefaultSystemNamespace,
+		TelemetryNamespace:       DefaultSystemNamespace,
+		PolicyNamespace:          DefaultSystemNamespace,
+		IngressNamespace:         DefaultSystemNamespace,
+		EgressNamespace:          DefaultSystemNamespace,
+		DeployIstio:              true,
+		DeployTimeout:            0,
+		UndeployTimeout:          0,
+		ChartDir:                 env.IstioChartDir,
+		CrdsFilesDir:             env.CrdsFilesDir,
+		ValuesFile:               E2EValuesFile,
+		UseCustomSidecarInjector: false,
 	}
 )
 
@@ -131,8 +131,9 @@ type Config struct {
 	// doing deployments without Galley.
 	SkipWaitForValidationWebhook bool
 
-	// EnableNamespacesByDefault enables injection of sidecar in all namespaces if it is true
-	EnableNamespacesByDefault bool
+	// UseCustomSidecarInjector allows injecting the sidecar from the specified namespace.
+	// if the value is false, use the default sidecar injection instead.
+	UseCustomSidecarInjector bool
 }
 
 // Is mtls enabled. Check in Values flag and Values file.
@@ -290,7 +291,7 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("CrdsFilesDir:                 %s\n", c.CrdsFilesDir)
 	result += fmt.Sprintf("ValuesFile:                   %s\n", c.ValuesFile)
 	result += fmt.Sprintf("SkipWaitForValidationWebhook: %v\n", c.SkipWaitForValidationWebhook)
-	result += fmt.Sprintf("EnableNamespacesByDefault:    %v\n", c.EnableNamespacesByDefault)
+	result += fmt.Sprintf("UseCustomSidecarInjector:     %v\n", c.UseCustomSidecarInjector)
 
 	return result
 }

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -63,21 +63,21 @@ var (
 	helmValues string
 
 	settingsFromCommandline = &Config{
-		ChartRepo:                DefaultIstioChartRepo,
-		SystemNamespace:          DefaultSystemNamespace,
-		IstioNamespace:           DefaultSystemNamespace,
-		ConfigNamespace:          DefaultSystemNamespace,
-		TelemetryNamespace:       DefaultSystemNamespace,
-		PolicyNamespace:          DefaultSystemNamespace,
-		IngressNamespace:         DefaultSystemNamespace,
-		EgressNamespace:          DefaultSystemNamespace,
-		DeployIstio:              true,
-		DeployTimeout:            0,
-		UndeployTimeout:          0,
-		ChartDir:                 env.IstioChartDir,
-		CrdsFilesDir:             env.CrdsFilesDir,
-		ValuesFile:               E2EValuesFile,
-		UseCustomSidecarInjector: false,
+		ChartRepo:                      DefaultIstioChartRepo,
+		SystemNamespace:                DefaultSystemNamespace,
+		IstioNamespace:                 DefaultSystemNamespace,
+		ConfigNamespace:                DefaultSystemNamespace,
+		TelemetryNamespace:             DefaultSystemNamespace,
+		PolicyNamespace:                DefaultSystemNamespace,
+		IngressNamespace:               DefaultSystemNamespace,
+		EgressNamespace:                DefaultSystemNamespace,
+		DeployIstio:                    true,
+		DeployTimeout:                  0,
+		UndeployTimeout:                0,
+		ChartDir:                       env.IstioChartDir,
+		CrdsFilesDir:                   env.CrdsFilesDir,
+		ValuesFile:                     E2EValuesFile,
+		CustomSidecarInjectorNamespace: "",
 	}
 )
 
@@ -131,9 +131,9 @@ type Config struct {
 	// doing deployments without Galley.
 	SkipWaitForValidationWebhook bool
 
-	// UseCustomSidecarInjector allows injecting the sidecar from the specified namespace.
-	// if the value is false, use the default sidecar injection instead.
-	UseCustomSidecarInjector bool
+	// CustomSidecarInjectorNamespace allows injecting the sidecar from the specified namespace.
+	// if the value is "", use the default sidecar injection instead.
+	CustomSidecarInjectorNamespace string
 }
 
 // Is mtls enabled. Check in Values flag and Values file.
@@ -275,23 +275,23 @@ func parseHelmValues() (map[string]string, error) {
 func (c *Config) String() string {
 	result := ""
 
-	result += fmt.Sprintf("SystemNamespace:              %s\n", c.SystemNamespace)
-	result += fmt.Sprintf("IstioNamespace:               %s\n", c.IstioNamespace)
-	result += fmt.Sprintf("ConfigNamespace:              %s\n", c.ConfigNamespace)
-	result += fmt.Sprintf("TelemetryNamespace:           %s\n", c.TelemetryNamespace)
-	result += fmt.Sprintf("PolicyNamespace:              %s\n", c.PolicyNamespace)
-	result += fmt.Sprintf("IngressNamespace:             %s\n", c.IngressNamespace)
-	result += fmt.Sprintf("EgressNamespace:              %s\n", c.EgressNamespace)
-	result += fmt.Sprintf("DeployIstio:                  %v\n", c.DeployIstio)
-	result += fmt.Sprintf("DeployTimeout:                %s\n", c.DeployTimeout.String())
-	result += fmt.Sprintf("UndeployTimeout:              %s\n", c.UndeployTimeout.String())
-	result += fmt.Sprintf("Values:                       %v\n", c.Values)
-	result += fmt.Sprintf("ChartRepo:                    %s\n", c.ChartRepo)
-	result += fmt.Sprintf("ChartDir:                     %s\n", c.ChartDir)
-	result += fmt.Sprintf("CrdsFilesDir:                 %s\n", c.CrdsFilesDir)
-	result += fmt.Sprintf("ValuesFile:                   %s\n", c.ValuesFile)
-	result += fmt.Sprintf("SkipWaitForValidationWebhook: %v\n", c.SkipWaitForValidationWebhook)
-	result += fmt.Sprintf("UseCustomSidecarInjector:     %v\n", c.UseCustomSidecarInjector)
+	result += fmt.Sprintf("SystemNamespace:                %s\n", c.SystemNamespace)
+	result += fmt.Sprintf("IstioNamespace:                 %s\n", c.IstioNamespace)
+	result += fmt.Sprintf("ConfigNamespace:                %s\n", c.ConfigNamespace)
+	result += fmt.Sprintf("TelemetryNamespace:             %s\n", c.TelemetryNamespace)
+	result += fmt.Sprintf("PolicyNamespace:                %s\n", c.PolicyNamespace)
+	result += fmt.Sprintf("IngressNamespace:               %s\n", c.IngressNamespace)
+	result += fmt.Sprintf("EgressNamespace:                %s\n", c.EgressNamespace)
+	result += fmt.Sprintf("DeployIstio:                    %v\n", c.DeployIstio)
+	result += fmt.Sprintf("DeployTimeout:                  %s\n", c.DeployTimeout.String())
+	result += fmt.Sprintf("UndeployTimeout:                %s\n", c.UndeployTimeout.String())
+	result += fmt.Sprintf("Values:                         %v\n", c.Values)
+	result += fmt.Sprintf("ChartRepo:                      %s\n", c.ChartRepo)
+	result += fmt.Sprintf("ChartDir:                       %s\n", c.ChartDir)
+	result += fmt.Sprintf("CrdsFilesDir:                   %s\n", c.CrdsFilesDir)
+	result += fmt.Sprintf("ValuesFile:                     %s\n", c.ValuesFile)
+	result += fmt.Sprintf("SkipWaitForValidationWebhook:   %v\n", c.SkipWaitForValidationWebhook)
+	result += fmt.Sprintf("CustomSidecarInjectorNamespace: %s\n", c.CustomSidecarInjectorNamespace)
 
 	return result
 }

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -63,20 +63,21 @@ var (
 	helmValues string
 
 	settingsFromCommandline = &Config{
-		ChartRepo:          DefaultIstioChartRepo,
-		SystemNamespace:    DefaultSystemNamespace,
-		IstioNamespace:     DefaultSystemNamespace,
-		ConfigNamespace:    DefaultSystemNamespace,
-		TelemetryNamespace: DefaultSystemNamespace,
-		PolicyNamespace:    DefaultSystemNamespace,
-		IngressNamespace:   DefaultSystemNamespace,
-		EgressNamespace:    DefaultSystemNamespace,
-		DeployIstio:        true,
-		DeployTimeout:      0,
-		UndeployTimeout:    0,
-		ChartDir:           env.IstioChartDir,
-		CrdsFilesDir:       env.CrdsFilesDir,
-		ValuesFile:         E2EValuesFile,
+		ChartRepo:                 DefaultIstioChartRepo,
+		SystemNamespace:           DefaultSystemNamespace,
+		IstioNamespace:            DefaultSystemNamespace,
+		ConfigNamespace:           DefaultSystemNamespace,
+		TelemetryNamespace:        DefaultSystemNamespace,
+		PolicyNamespace:           DefaultSystemNamespace,
+		IngressNamespace:          DefaultSystemNamespace,
+		EgressNamespace:           DefaultSystemNamespace,
+		DeployIstio:               true,
+		DeployTimeout:             0,
+		UndeployTimeout:           0,
+		ChartDir:                  env.IstioChartDir,
+		CrdsFilesDir:              env.CrdsFilesDir,
+		ValuesFile:                E2EValuesFile,
+		EnableNamespacesByDefault: false,
 	}
 )
 
@@ -129,6 +130,9 @@ type Config struct {
 	// Do not wait for the validation webhook before completing the deployment. This is useful for
 	// doing deployments without Galley.
 	SkipWaitForValidationWebhook bool
+
+	// EnableNamespacesByDefault enables injection of sidecar in all namespaces if it is true
+	EnableNamespacesByDefault bool
 }
 
 // Is mtls enabled. Check in Values flag and Values file.
@@ -270,17 +274,23 @@ func parseHelmValues() (map[string]string, error) {
 func (c *Config) String() string {
 	result := ""
 
-	result += fmt.Sprintf("SystemNamespace:    %s\n", c.SystemNamespace)
-	result += fmt.Sprintf("IstioNamespace:     %s\n", c.IstioNamespace)
-	result += fmt.Sprintf("ConfigNamespace:    %s\n", c.ConfigNamespace)
-	result += fmt.Sprintf("TelemetryNamespace: %s\n", c.TelemetryNamespace)
-	result += fmt.Sprintf("PolicyNamespace:    %s\n", c.PolicyNamespace)
-	result += fmt.Sprintf("IngressNamespace:   %s\n", c.IngressNamespace)
-	result += fmt.Sprintf("EgressNamespace:    %s\n", c.EgressNamespace)
-	result += fmt.Sprintf("DeployIstio:        %v\n", c.DeployIstio)
-	result += fmt.Sprintf("DeployTimeout:      %s\n", c.DeployTimeout.String())
-	result += fmt.Sprintf("UndeployTimeout:    %s\n", c.UndeployTimeout.String())
-	result += fmt.Sprintf("Values:             %v\n", c.Values)
+	result += fmt.Sprintf("SystemNamespace:              %s\n", c.SystemNamespace)
+	result += fmt.Sprintf("IstioNamespace:               %s\n", c.IstioNamespace)
+	result += fmt.Sprintf("ConfigNamespace:              %s\n", c.ConfigNamespace)
+	result += fmt.Sprintf("TelemetryNamespace:           %s\n", c.TelemetryNamespace)
+	result += fmt.Sprintf("PolicyNamespace:              %s\n", c.PolicyNamespace)
+	result += fmt.Sprintf("IngressNamespace:             %s\n", c.IngressNamespace)
+	result += fmt.Sprintf("EgressNamespace:              %s\n", c.EgressNamespace)
+	result += fmt.Sprintf("DeployIstio:                  %v\n", c.DeployIstio)
+	result += fmt.Sprintf("DeployTimeout:                %s\n", c.DeployTimeout.String())
+	result += fmt.Sprintf("UndeployTimeout:              %s\n", c.UndeployTimeout.String())
+	result += fmt.Sprintf("Values:                       %v\n", c.Values)
+	result += fmt.Sprintf("ChartRepo:                    %s\n", c.ChartRepo)
+	result += fmt.Sprintf("ChartDir:                     %s\n", c.ChartDir)
+	result += fmt.Sprintf("CrdsFilesDir:                 %s\n", c.CrdsFilesDir)
+	result += fmt.Sprintf("ValuesFile:                   %s\n", c.ValuesFile)
+	result += fmt.Sprintf("SkipWaitForValidationWebhook: %v\n", c.SkipWaitForValidationWebhook)
+	result += fmt.Sprintf("EnableNamespacesByDefault:    %v\n", c.EnableNamespacesByDefault)
 
 	return result
 }

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -46,8 +46,7 @@ func init() {
 		"Helm values file. This can be an absolute path or relative to chartDir. Only valid when deploying Istio.")
 	flag.StringVar(&helmValues, "istio.test.kube.helm.values", helmValues,
 		"Manual overrides for Helm values file. Only valid when deploying Istio.")
-	flag.BoolVar(&settingsFromCommandline.EnableNamespacesByDefault, "istio.test.kube.enableNamespacesByDefault",
-		settingsFromCommandline.EnableNamespacesByDefault, "Specifies sidecar injection for all namespaces "+
-			"with the exception of namespaces with istio-injection:disabled annotation")
+	flag.BoolVar(&settingsFromCommandline.UseCustomSidecarInjector, "istio.test.kube.useCustomSidecarInjector",
+		settingsFromCommandline.UseCustomSidecarInjector, "Inject the sidecar from the specified namespace with label istio-env: namespace.")
 
 }

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -46,4 +46,8 @@ func init() {
 		"Helm values file. This can be an absolute path or relative to chartDir. Only valid when deploying Istio.")
 	flag.StringVar(&helmValues, "istio.test.kube.helm.values", helmValues,
 		"Manual overrides for Helm values file. Only valid when deploying Istio.")
+	flag.BoolVar(&settingsFromCommandline.EnableNamespacesByDefault, "istio.test.kube.enableNamespacesByDefault",
+		settingsFromCommandline.EnableNamespacesByDefault, "Specifies sidecar injection for all namespaces "+
+			"with the exception of namespaces with istio-injection:disabled annotation")
+
 }

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -46,7 +46,7 @@ func init() {
 		"Helm values file. This can be an absolute path or relative to chartDir. Only valid when deploying Istio.")
 	flag.StringVar(&helmValues, "istio.test.kube.helm.values", helmValues,
 		"Manual overrides for Helm values file. Only valid when deploying Istio.")
-	flag.BoolVar(&settingsFromCommandline.UseCustomSidecarInjector, "istio.test.kube.useCustomSidecarInjector",
-		settingsFromCommandline.UseCustomSidecarInjector, "Inject the sidecar from the specified namespace with label istio-env: namespace.")
+	flag.StringVar(&settingsFromCommandline.CustomSidecarInjectorNamespace, "istio.test.kube.customSidecarInjectorNamespace",
+		settingsFromCommandline.CustomSidecarInjectorNamespace, "Inject the sidecar from the specified namespace")
 
 }

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -75,7 +75,7 @@ func claimKube(ctx resource.Context, name string) (Instance, error) {
 
 	if !env.Accessor.NamespaceExists(name) {
 		if err := env.CreateNamespaceWithInjectionEnabled(name, "istio-test",
-			cfg.ConfigNamespace, cfg.EnableNamespacesByDefault); err != nil {
+			cfg.ConfigNamespace, cfg.UseCustomSidecarInjector); err != nil {
 			return nil, err
 		}
 
@@ -100,7 +100,7 @@ func newKube(ctx resource.Context, prefix string, inject bool) (Instance, error)
 			return nil, err
 		}
 		err = env.CreateNamespaceWithInjectionEnabled(ns, "istio-test",
-			cfg.ConfigNamespace, cfg.EnableNamespacesByDefault)
+			cfg.ConfigNamespace, cfg.UseCustomSidecarInjector)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -75,7 +75,7 @@ func claimKube(ctx resource.Context, name string) (Instance, error) {
 
 	if !env.Accessor.NamespaceExists(name) {
 		if err := env.CreateNamespaceWithInjectionEnabled(name, "istio-test",
-			cfg.ConfigNamespace, cfg.UseCustomSidecarInjector); err != nil {
+			cfg.CustomSidecarInjectorNamespace); err != nil {
 			return nil, err
 		}
 
@@ -100,7 +100,7 @@ func newKube(ctx resource.Context, prefix string, inject bool) (Instance, error)
 			return nil, err
 		}
 		err = env.CreateNamespaceWithInjectionEnabled(ns, "istio-test",
-			cfg.ConfigNamespace, cfg.UseCustomSidecarInjector)
+			cfg.CustomSidecarInjectorNamespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -74,7 +74,8 @@ func claimKube(ctx resource.Context, name string) (Instance, error) {
 	}
 
 	if !env.Accessor.NamespaceExists(name) {
-		if err := env.CreateNamespaceWithInjectionEnabled(name, "istio-test", cfg.ConfigNamespace); err != nil {
+		if err := env.CreateNamespaceWithInjectionEnabled(name, "istio-test",
+			cfg.ConfigNamespace, cfg.EnableNamespacesByDefault); err != nil {
 			return nil, err
 		}
 
@@ -98,7 +99,8 @@ func newKube(ctx resource.Context, prefix string, inject bool) (Instance, error)
 		if err != nil {
 			return nil, err
 		}
-		err = env.CreateNamespaceWithInjectionEnabled(ns, "istio-test", cfg.ConfigNamespace)
+		err = env.CreateNamespaceWithInjectionEnabled(ns, "istio-test",
+			cfg.ConfigNamespace, cfg.EnableNamespacesByDefault)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -391,14 +391,14 @@ func (a *Accessor) CreateNamespace(ns string, istioTestingAnnotation string) err
 
 // CreateNamespaceWithInjectionEnabled with the given name and have sidecar-injection enabled.
 func (a *Accessor) CreateNamespaceWithInjectionEnabled(ns string, istioTestingAnnotation string,
-	configNamespace string, enableNamespacesByDefault bool) error {
+	configNamespace string, useCustomSidecarInjector bool) error {
 	scopes.Framework.Debugf("Creating namespace with injection enabled: %s", ns)
 
 	n := a.newNamespace(ns, istioTestingAnnotation)
 
 	n.ObjectMeta.Labels["istio-injection"] = "enabled"
 
-	if !enableNamespacesByDefault {
+	if useCustomSidecarInjector {
 		n.ObjectMeta.Labels["istio-env"] = configNamespace
 	}
 

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -389,12 +389,18 @@ func (a *Accessor) CreateNamespace(ns string, istioTestingAnnotation string) err
 	return err
 }
 
-func (a *Accessor) CreateNamespaceWithInjectionEnabled(ns string, istioTestingAnnotation string, configNamespace string) error {
+// CreateNamespaceWithInjectionEnabled with the given name and have sidecar-injection enabled.
+func (a *Accessor) CreateNamespaceWithInjectionEnabled(ns string, istioTestingAnnotation string,
+	configNamespace string, enableNamespacesByDefault bool) error {
 	scopes.Framework.Debugf("Creating namespace with injection enabled: %s", ns)
 
 	n := a.newNamespace(ns, istioTestingAnnotation)
 
 	n.ObjectMeta.Labels["istio-injection"] = "enabled"
+
+	if !enableNamespacesByDefault {
+		n.ObjectMeta.Labels["istio-env"] = configNamespace
+	}
 
 	_, err := a.set.CoreV1().Namespaces().Create(&n)
 	return err

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -391,15 +391,15 @@ func (a *Accessor) CreateNamespace(ns string, istioTestingAnnotation string) err
 
 // CreateNamespaceWithInjectionEnabled with the given name and have sidecar-injection enabled.
 func (a *Accessor) CreateNamespaceWithInjectionEnabled(ns string, istioTestingAnnotation string,
-	configNamespace string, useCustomSidecarInjector bool) error {
+	customSidecarInjectorNamespace string) error {
 	scopes.Framework.Debugf("Creating namespace with injection enabled: %s", ns)
 
 	n := a.newNamespace(ns, istioTestingAnnotation)
 
 	n.ObjectMeta.Labels["istio-injection"] = "enabled"
 
-	if useCustomSidecarInjector {
-		n.ObjectMeta.Labels["istio-env"] = configNamespace
+	if customSidecarInjectorNamespace != "" {
+		n.ObjectMeta.Labels["istio-env"] = customSidecarInjectorNamespace
 	}
 
 	_, err := a.set.CoreV1().Namespaces().Create(&n)


### PR DESCRIPTION
for the new installer, `istio-env` is used to inject the specific sidecar. 

- if the `enableNamespacesByDefault` is true, it will use default injector so there should not have `istio-env` label defined.

- if the `enableNamespacesByDefault` is false, need have `istio-env` label defined for sidecar injection.


Signed-off-by: clyang82 <clyang@cn.ibm.com>

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
