### PR TITLE
Update KinD e2e test suite

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -46,7 +46,7 @@ function setup_and_export_git_sha() {
     # Use the current commit.
     GIT_SHA="$(git rev-parse --verify HEAD)"
     export GIT_SHA
-    export ARTIFACTS_DIR="${ARTIFACTS_DIR:-`mktemp -d`}"
+    export ARTIFACTS_DIR="${ARTIFACTS_DIR:-$(mktemp -d)}"
   fi
   GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
   export GIT_BRANCH

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -46,6 +46,7 @@ function setup_and_export_git_sha() {
     # Use the current commit.
     GIT_SHA="$(git rev-parse --verify HEAD)"
     export GIT_SHA
+    export ARTIFACTS_DIR="${ARTIFACTS_DIR:-`mktemp -d`}"
   fi
   GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
   export GIT_BRANCH


### PR DESCRIPTION
* Set imagePullPolciy=Never per KinD docs
* Fix image loading -- before it was only loading the last image not all
of them
* Set ARTIFACTS_DIR so the script can be run locally

Fixes https://github.com/istio/test-infra/issues/1403

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
