### PR TITLE
Optimize yamllint to run in one process

### DIFF
--- a/bin/yaml_lint.sh
+++ b/bin/yaml_lint.sh
@@ -25,12 +25,7 @@ cd "$ROOTDIR"
 
 PKGS=${PKGS:-"."}
 if [[ -z ${YAML_FILES} ]];then
-    YAML_FILES=$(find "${PKGS}" -type f -name '*.yaml' | grep -v ./vendor | grep -v -E "\/templates\/" | grep -v -E "template")
+    find "${PKGS}" -type f -name '*.yaml' | grep -v ./vendor | grep -v -E "\/templates\/" | grep -v -E "template" | xargs yamllint -c ./bin/yamllintrules
 fi
- 
-for YAML_FILE in ${YAML_FILES}; do
-        echo "${YAML_FILE}"
-        yamllint -c ./bin/yamllintrules "${YAML_FILE}"
-done
 
 exit $?


### PR DESCRIPTION
Previously we ran a new process for every yaml file. yamllint can just
take in a list of files to run, and handles this much more efficiently.
On my machine, this broguht runtime from 75s to 15s.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
