### PR TITLE
Send test `kubectl describe` to files instead of stdout

### DIFF
--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -708,12 +708,21 @@ func FetchAndSaveClusterLogs(namespace string, tempDir string, kubeconfig string
 		// Log the description; if we fail to get the logs it may help
 		describeCmd := fmt.Sprintf("kubectl -n %s describe pod %s --kubeconfig=%s",
 			namespace, pod, kubeconfig)
-		describeOutput, errDescribe := Shell(describeCmd)
+		describeOutput, errDescribe := ShellMuteOutput(describeCmd)
 		if errDescribe != nil {
 			log.Warnf("Error getting description for pod %s: %v\n", pod, errDescribe)
 			// don't bail, keep going
 		} else {
-			log.Info(describeOutput)
+			filePath := filepath.Join(tempDir, fmt.Sprintf("%s_describe.log", pod))
+			f, err := os.Create(filePath)
+			if err != nil {
+				log.Warnf("Error creating %s for pod %s: %v\n", filePath, pod, err)
+				return err
+			}
+			if _, err = f.WriteString(fmt.Sprintf("%s\n", describeOutput)); err != nil {
+				log.Warnf("Error writing log dump to %s for pod %s/%s: %v\n", filePath, namespace, pod, err)
+				return err
+			}
 		}
 
 		cmd := fmt.Sprintf(


### PR DESCRIPTION
Our test output is very verbose, which makes it hard to find real failures. it also bloats our build logs - some are 4gb large. This kubectl describe output seems better suited as a file (can be found under artifacts) than stdout

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
https://github.com/istio/istio/issues/15332