### PR TITLE
Fix getServiceLoadBalancer

### DIFF
--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -371,13 +371,14 @@ func getServiceLoadBalancer(name, namespace, kubeconfig string) (string, error) 
 		if ip == "localhost" {
 			ip = "127.0.0.1"
 		}
-	} else {
-		ip = strings.Trim(ip, "'")
-		addr := net.ParseIP(ip)
-		if addr == nil {
-			return "", errors.New("ingress ip not available yet")
-		}
 	}
+
+	ip = strings.Trim(ip, "'")
+	addr := net.ParseIP(ip)
+	if addr == nil {
+		return "", errors.New("ingress ip not available yet")
+	}
+
 	return ip, nil
 }
 


### PR DESCRIPTION
A recent change (#14944) modified this logic which was causing it to no
longer actually poll for the ingress ip -- it would return "" and use
that rather than erroring properly.

With this change we will continue to retry if we don't get a valid IP.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
