### PR TITLE
Stackdriver tracer: part I, generate bootstrap given meshconfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -187,6 +187,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible // indirect
 	istio.io/api v0.0.0-20190708200418-70f6e4eada00
+	istio.io/gogo-genproto v0.0.0-20190614210408-e88dc8b0e4db
 	istio.io/pkg v0.0.0-20190624144336-268695a9d878
 	k8s.io/api v0.0.0-20190222213804-5cb15d344471
 	k8s.io/apiextensions-apiserver v0.0.0-20190221221350-bfb440be4b87

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -234,6 +234,9 @@ data:
         datadog:
           # Address of the Datadog Agent
           address: {{ .Values.global.tracer.datadog.address }}
+      {{- else if eq .Values.global.proxy.tracer "stackdriver" }}
+      tracing:
+        stackdriver: {}
       {{- end }}
 
     {{- if .Values.global.proxy.envoyStatsd.enabled }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -258,7 +258,8 @@ global:
       host: # example: metrics-service.istio-system
       port: # example: 15000
 
-    # Specify which tracer to use. One of: lightstep, zipkin, datadog
+    # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver.
+    # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
     tracer: "zipkin"
 
   proxy_init:

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -23,7 +23,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/envoyproxy/go-control-plane/pkg/util"
+
 	v2 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
+	tracev2 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2"
+
+	ocv1 "istio.io/gogo-genproto/opencensus/proto/trace/v1"
+
 	"github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
@@ -64,6 +70,11 @@ var (
 // cp $TOP/out/linux_amd64/release/bootstrap/tracing_lightstep/envoy-rev0.json pkg/bootstrap/testdata/tracing_lightstep_golden.json
 // cp $TOP/out/linux_amd64/release/bootstrap/tracing_zipkin/envoy-rev0.json pkg/bootstrap/testdata/tracing_zipkin_golden.json
 func TestGolden(t *testing.T) {
+	out := env.ISTIO_OUT.Value() // defined in the makefile
+	if out == "" {
+		out = "/tmp"
+	}
+
 	cases := []struct {
 		base                       string
 		labels                     map[string]string
@@ -71,6 +82,9 @@ func TestGolden(t *testing.T) {
 		expectLightstepAccessToken bool
 		stats                      stats
 		checkLocality              bool
+		setup                      func()
+		teardown                   func()
+		check                      func(got *v2.Bootstrap, t *testing.T)
 	}{
 		{
 			base: "auth",
@@ -102,6 +116,58 @@ func TestGolden(t *testing.T) {
 		},
 		{
 			base: "tracing_datadog",
+		},
+		{
+			base: "tracing_stackdriver",
+			setup: func() {
+				credPath := out + "/sd_cred.json"
+				if err := ioutil.WriteFile(credPath, []byte(`{"type": "service_account", "project_id": "my-sd-project"}`), os.ModePerm); err != nil {
+					t.Fatalf("unable write file: %v", err)
+				}
+				_ = os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credPath)
+			},
+			teardown: func() {
+				credPath := out + "/sd_cred.json"
+				_ = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+				_ = os.Remove(credPath)
+			},
+			check: func(got *v2.Bootstrap, t *testing.T) {
+				cfg := got.Tracing.Http.GetConfig()
+				sdMsg := tracev2.OpenCensusConfig{}
+				if err := util.StructToMessage(cfg, &sdMsg); err != nil {
+					t.Fatalf("unable to parse: %v %v", cfg, err)
+				}
+
+				want := tracev2.OpenCensusConfig{
+					TraceConfig: &ocv1.TraceConfig{
+						Sampler: &ocv1.TraceConfig_ConstantSampler{
+							ConstantSampler: &ocv1.ConstantSampler{
+								Decision: ocv1.ConstantSampler_ALWAYS_PARENT,
+							},
+						},
+						MaxNumberOfAttributes:    200,
+						MaxNumberOfAnnotations:   201,
+						MaxNumberOfMessageEvents: 201,
+						MaxNumberOfLinks:         200,
+					},
+					StackdriverExporterEnabled: true,
+					StdoutExporterEnabled:      true,
+					StackdriverProjectId:       "my-sd-project",
+					IncomingTraceContext: []tracev2.OpenCensusConfig_TraceContext{
+						tracev2.OpenCensusConfig_CLOUD_TRACE_CONTEXT,
+						tracev2.OpenCensusConfig_TRACE_CONTEXT,
+						tracev2.OpenCensusConfig_GRPC_TRACE_BIN},
+					OutgoingTraceContext: []tracev2.OpenCensusConfig_TraceContext{
+						tracev2.OpenCensusConfig_CLOUD_TRACE_CONTEXT,
+						tracev2.OpenCensusConfig_TRACE_CONTEXT,
+						tracev2.OpenCensusConfig_GRPC_TRACE_BIN},
+				}
+
+				p, equal := diff.PrettyDiff(sdMsg, want)
+				if !equal {
+					t.Fatalf("t diff: %v\ngot: %v\nwant: %v\n", p, sdMsg, want)
+				}
+			},
 		},
 		{
 			// Specify zipkin/statsd address, similar with the default config in v1 tests
@@ -141,16 +207,18 @@ func TestGolden(t *testing.T) {
 		},
 	}
 
-	out := env.ISTIO_OUT.Value() // defined in the makefile
-	if out == "" {
-		out = "/tmp"
-	}
-
 	for _, c := range cases {
 		t.Run("Bootstrap-"+c.base, func(t *testing.T) {
+			if c.setup != nil {
+				c.setup()
+			}
+			if c.teardown != nil {
+				defer c.teardown()
+			}
+
 			cfg, err := loadProxyConfig(c.base, out, t)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("unable to load proxy config: %s\n%v", c.base, err)
 			}
 
 			_, localEnv := createEnv(t, c.labels, c.annotations)
@@ -201,20 +269,30 @@ func TestGolden(t *testing.T) {
 			}
 
 			if err = goldenM.Validate(); err != nil {
-				t.Fatalf("invalid golder: %v", err)
+				t.Fatalf("invalid golden %s: %v", c.base, err)
 			}
 
 			jreal, err := yaml.YAMLToJSON(read)
 
 			if err != nil {
-				t.Fatalf("unable to convert: %v", err)
+				t.Fatalf("unable to convert: %s (%s) %v", c.base, fn, err)
 			}
 
 			if err = jsonpb.UnmarshalString(string(jreal), &realM); err != nil {
 				t.Fatalf("invalid json %v\n%s", err, string(read))
 			}
 
+			if err = realM.Validate(); err != nil {
+				t.Fatalf("invalid generated file %s: %v", c.base, err)
+			}
+
 			checkStatsMatcher(t, &realM, &goldenM, c.stats)
+
+			if c.check != nil {
+				c.check(&realM, t)
+			}
+
+			checkOpencensusConfig(t, &realM, &goldenM)
 
 			if !reflect.DeepEqual(realM, goldenM) {
 				s, _ := diff.PrettyDiff(realM, goldenM)
@@ -239,7 +317,6 @@ func TestGolden(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func checkListStringMatcher(t *testing.T, got *matcher.ListStringMatcher, want string, typ string) {
@@ -265,6 +342,21 @@ func checkListStringMatcher(t *testing.T, got *matcher.ListStringMatcher, want s
 	}
 }
 
+func checkOpencensusConfig(t *testing.T, got, want *v2.Bootstrap) {
+	if want.Tracing == nil {
+		return
+	}
+
+	if want.Tracing.Http.Name != "envoy.tracers.opencensus" {
+		return
+	}
+
+	if !reflect.DeepEqual(got.Tracing.Http, want.Tracing.Http) {
+		p, _ := diff.PrettyDiff(got.Tracing.Http, want.Tracing.Http)
+		t.Fatalf("t diff: %v\ngot:\n %v\nwant:\n %v\n", p, got.Tracing.Http, want.Tracing.Http)
+	}
+}
+
 func checkStatsMatcher(t *testing.T, got, want *v2.Bootstrap, stats stats) {
 	gsm := got.GetStatsConfig().GetStatsMatcher()
 
@@ -273,6 +365,7 @@ func checkStatsMatcher(t *testing.T, got, want *v2.Bootstrap, stats stats) {
 	} else {
 		stats.prefixes += "," + requiredEnvoyStatsMatcherInclusionPrefixes
 	}
+
 	if stats.suffixes == "" {
 		stats.suffixes = requiredEnvoyStatsMatcherInclusionSuffix
 	} else {

--- a/pkg/bootstrap/testdata/tracing_stackdriver.proto
+++ b/pkg/bootstrap/testdata/tracing_stackdriver.proto
@@ -1,0 +1,12 @@
+config_path:               "/etc/istio/proxy"
+binary_path:               "/usr/local/bin/envoy"
+service_cluster:           "istio-proxy"
+drain_duration:            {seconds: 2}
+parent_shutdown_duration:  {seconds: 3}
+discovery_address:         "istio-pilot:15010"
+connect_timeout:           {seconds: 1}
+proxy_admin_port:          15000
+control_plane_auth_policy: NONE
+tracing:                   { stackdriver: { debug: true, max_number_of_annotations: {value: 201}, max_number_of_message_events: {value:201}} }
+
+# Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -1,0 +1,219 @@
+{
+  "node": {
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
+    "locality": {},
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar"}
+  },
+  "stats_config": {
+    "use_all_default_tags": false,
+    "stats_tags": [
+      {
+        "tag_name": "cluster_name",
+        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+      },
+      {
+        "tag_name": "tcp_prefix",
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+      },
+      {
+        "tag_name": "response_code",
+        "regex": "_rq(_(\\d{3}))$"
+      },
+      {
+        "tag_name": "response_code_class",
+        "regex": "_rq(_(\\dxx))$"
+      },
+      {
+        "tag_name": "http_conn_manager_listener_prefix",
+        "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "http_conn_manager_prefix",
+        "regex": "^http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "listener_address",
+        "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "mongo_prefix",
+        "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
+      }
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [{
+            "prefix": "cluster_manager"
+          },
+          {
+            "prefix": "listener_manager"
+          },
+          {
+            "prefix": "http_mixer_filter"
+          },
+          {
+            "prefix": "tcp_mixer_filter"
+          },
+          {
+            "prefix": "server"
+          },
+          {
+            "prefix": "cluster.xds-grpc"
+          }
+        ]
+      }
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 15000
+      }
+    }
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {}
+    },
+    "cds_config": {
+      "ads": {}
+    },
+    "ads_config": {
+      "api_type": "GRPC",
+      "grpc_services": [
+        {
+          "envoy_grpc": {
+            "cluster_name": "xds-grpc"
+          }
+        }
+      ]
+    }
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "prometheus_stats",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "hosts": [
+          {
+            "socket_address": {
+              "protocol": "TCP",
+              "address": "127.0.0.1",
+              "port_value": 15000
+            }
+          }
+        ]
+      },
+      {
+        "name": "xds-grpc",
+        "type": "STRICT_DNS",
+        "dns_refresh_rate": "60s",
+        "dns_lookup_family": "V4_ONLY",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        
+        "hosts": [
+          {
+            "socket_address": {"address": "istio-pilot", "port_value": 15010}
+          }
+        ],
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "DEFAULT",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            },
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            }
+          ]
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_time": 300
+          }
+        },
+        "http2_protocol_options": { }
+      }
+    ],
+    "listeners":[
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15090
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "config": {
+                  "codec_type": "AUTO",
+                  "stat_prefix": "stats",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/stats/prometheus"
+                            },
+                            "route": {
+                              "cluster": "prometheus_stats"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": {
+                    "name": "envoy.router"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  ,
+  "tracing": {
+    "http": {
+      "name": "envoy.tracers.opencensus",
+      "config": {
+        "stackdriver_exporter_enabled": true,
+        "stackdriver_project_id": "my-sd-project",
+        "stdout_exporter_enabled": true,
+        "incoming_trace_context": ["CLOUD_TRACE_CONTEXT", "TRACE_CONTEXT", "GRPC_TRACE_BIN"],
+        "outgoing_trace_context": ["CLOUD_TRACE_CONTEXT", "TRACE_CONTEXT", "GRPC_TRACE_BIN"],
+        "trace_config":{
+          "constant_sampler":{
+            "decision": "ALWAYS_PARENT"
+          },
+          "max_number_of_annotations": 201,
+          "max_number_of_attributes": 200,
+          "max_number_of_message_events": 201,
+          "max_number_of_links": 200,
+        }
+      }
+    }
+  }
+}

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -360,6 +360,28 @@
       }
     }
   }
+  {{ else if .stackdriver }}
+  ,
+  "tracing": {
+    "http": {
+      "name": "envoy.tracers.opencensus",
+      "config": {
+      "stackdriver_exporter_enabled": true,
+      "stackdriver_project_id": "{{ .stackdriverProjectID }}",
+      "stdout_exporter_enabled": {{ .stackdriverDebug }},
+      "incoming_trace_context": ["CLOUD_TRACE_CONTEXT", "TRACE_CONTEXT", "GRPC_TRACE_BIN"],
+      "outgoing_trace_context": ["CLOUD_TRACE_CONTEXT", "TRACE_CONTEXT", "GRPC_TRACE_BIN"],
+      "trace_config":{
+        "constant_sampler":{
+          "decision": "ALWAYS_PARENT"
+        },
+        "max_number_of_annotations": {{ .stackdriverMaxAnnotations }},
+        "max_number_of_attributes": {{ .stackdriverMaxAttributes }},
+        "max_number_of_message_events": {{ .stackdriverMaxEvents }},
+        "max_number_of_links": 200,
+       }
+     }
+  }}
   {{ end }}
   {{ if or .envoy_metrics_service .statsd }}
   ,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -170,9 +170,9 @@ github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2
 github.com/envoyproxy/go-control-plane/envoy/service/tap/v2alpha
 github.com/envoyproxy/go-control-plane/pkg/cache
 github.com/envoyproxy/go-control-plane/pkg/server
+github.com/envoyproxy/go-control-plane/envoy/config/trace/v2
 github.com/envoyproxy/go-control-plane/envoy/config/metrics/v2
 github.com/envoyproxy/go-control-plane/envoy/config/overload/v2alpha
-github.com/envoyproxy/go-control-plane/envoy/config/trace/v2
 github.com/envoyproxy/go-control-plane/envoy/data/tap/v2alpha
 github.com/envoyproxy/go-control-plane/pkg/log
 # github.com/envoyproxy/protoc-gen-validate v0.0.0-20190405222122-d6164de49109


### PR DESCRIPTION
1. Enable stackdriver tracer with shallow unit tests.
2. Add `global.proxy.tracer=stackdriver` values.yaml option.
3. Update to next version of go-control-plane and run `go mod tidy`

This PR produces the correct bootstrap config given meshconfig is made available to the pilot-agent.
There will be a follow up PR that adds a generic way to get all meshconfig / values data into Pilot-agent. As it stands right now, meshconfig propagation is not present.  