### PR TITLE
Turn off HPA on demo profile

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-demo-common.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo-common.yaml
@@ -20,6 +20,7 @@ sidecarInjectorWebhook:
   rewriteAppHTTPProbe: false
 
 pilot:
+  autoscaleEnabled: false
   traceSampling: 100.0
   resources:
     requests:
@@ -29,6 +30,7 @@ pilot:
 mixer:
   policy:
     enabled: true
+    autoscaleEnabled: false
     resources:
       requests:
         cpu: 10m
@@ -36,6 +38,7 @@ mixer:
 
   telemetry:
     enabled: true
+    autoscaleEnabled: false
     resources:
       requests:
         cpu: 50m
@@ -57,6 +60,7 @@ kiali:
 
 gateways:
   istio-ingressgateway:
+    autoscaleEnabled: false
     resources:
       requests:
         cpu: 10m
@@ -64,6 +68,7 @@ gateways:
 
   istio-egressgateway:
     enabled: true
+    autoscaleEnabled: false
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
Currently each component has 10m cpu requests and an HPA that scales at
80% CPU usage meaning they will immediately scale up.

This turns off the HPA for the demo.

Fixes https://github.com/istio/istio/issues/15338

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
