### PR TITLE
Add back test target to circleci nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,27 @@ jobs:
           path: /go/out/logs
       - store_artifacts:
           path: /tmp
+  test:
+    <<: *defaults
+    environment:
+      KUBECONFIG: /go/src/istio.io/istio/.circleci/config
+    resource_class: xlarge
+    steps:
+      - checkout
+      - <<: *markJobStartsOnGCS
+      - run: make sync
+      - run:
+          command: |
+            mkdir -p /go/out/tests
+            export PATH=$GOPATH/bin:$PATH
+            make localTestEnv
+            set -o pipefail
+            make test T=-v | tee -a /go/out/tests/build-log.txt
+      - <<: *recordZeroExitCodeIfTestPassed
+      - <<: *recordNonzeroExitCodeIfTestFailed
+      - <<: *markJobFinishesOnGCS
+      - store_test_results:
+          path: /go/out/tests
 
   build:
     <<: *defaults


### PR DESCRIPTION
We previously added back some targets to run on circleci nightly so we
can compare to prow, but the test target was deleted so the tests are
failing. This just adds the same test target back.

Fixes https://github.com/istio/istio/issues/15374

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
