### PR TITLE
Fix accesslog integration tests

### DIFF
--- a/tests/integration/mixer/telemetry/logs/accesslog_test.go
+++ b/tests/integration/mixer/telemetry/logs/accesslog_test.go
@@ -135,10 +135,10 @@ func validateLog(content string) error {
 	if !strings.Contains(content, "\"level\":\"warn\"") {
 		return fmt.Errorf("accesslog doesnt contain warning level. Log %v", content)
 	}
-	if !strings.Contains(content, "\"destination\":\"details\"") || !strings.Contains(content,
-		"\"destination\":\"reviews\"") || !strings.Contains(content, "\"destination\":\"productpage\"") {
-		return fmt.Errorf(
-			"accesslog doesnt contain either details or reviews or productpage destination. Log %v", content)
+	for _, expected := range []string{"details", "reviews", "productpage"} {
+		if !strings.Contains(content, fmt.Sprintf("\"destination\":\"%s\"", expected)) {
+			return fmt.Errorf("accesslog doesnt contain %s destination. Log %v", expected, content)
+		}
 	}
 	if !strings.Contains(content, "\"responseCode\":") {
 		return fmt.Errorf("accesslog doesnt contain response code. Log %v", content)

--- a/tests/integration/mixer/util.go
+++ b/tests/integration/mixer/util.go
@@ -188,7 +188,7 @@ func GetAndValidateAccessLog(ns namespace.Instance, t *testing.T, labelSelector,
 	}
 
 	retryFn := func(_ context.Context, i int) error {
-		content, err := shell.Execute(false, "kubectl logs -n %s -l %s -c %s --tail=1000",
+		content, err := shell.Execute(false, "kubectl logs -n %s -l %s -c %s --tail=-1",
 			ns.Name(), labelSelector, container)
 		if err != nil {
 			return fmt.Errorf("unable to get access logs from mixer: %v , content %v", err, content)

--- a/tests/integration/mixer/util.go
+++ b/tests/integration/mixer/util.go
@@ -188,7 +188,7 @@ func GetAndValidateAccessLog(ns namespace.Instance, t *testing.T, labelSelector,
 	}
 
 	retryFn := func(_ context.Context, i int) error {
-		content, err := shell.Execute(false, "kubectl logs -n %s -l %s -c %s ",
+		content, err := shell.Execute(false, "kubectl logs -n %s -l %s -c %s --tail=1000",
 			ns.Name(), labelSelector, container)
 		if err != nil {
 			return fmt.Errorf("unable to get access logs from mixer: %v , content %v", err, content)


### PR DESCRIPTION
The log command was only getting the last 10 results, so it was missing
the logs it was looking for. Additionally, cleaned up the error message
to expose what log was actually missing rather than "one of these 3 logs
was missing"

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
