### PR TITLE
Add status when returning QuotaResult from RedisQuota Adapter

### DIFF
--- a/mixer/adapter/redisquota/redisquota.go
+++ b/mixer/adapter/redisquota/redisquota.go
@@ -321,7 +321,9 @@ func (h *handler) HandleQuota(context context.Context, instance *quota.Instance,
 			key, maxAmount, err := h.getKeyAndQuotaAmount(instance, limit)
 			if err != nil {
 				_ = h.logger.Errorf("%v", err.Error())
-				return adapter.QuotaResult{}, nil
+				return adapter.QuotaResult{
+					Status: status.WithInternal("redisquota: Internal Error"),
+				}, nil
 			}
 
 			h.logger.Debugf("key: %v maxAmount: %v", key, maxAmount)
@@ -344,13 +346,17 @@ func (h *handler) HandleQuota(context context.Context, instance *quota.Instance,
 
 			if err != nil {
 				_ = h.logger.Errorf("failed to run quota script: %v", err)
-				return adapter.QuotaResult{}, nil
+				return adapter.QuotaResult{
+					Status: status.WithUnavailable("redisquota: Service Unavailable"),
+				}, nil
 			}
 
 			allocated, expiration, err := getAllocatedTokenFromResult(&result)
 			if err != nil {
 				_ = h.logger.Errorf("%v", err)
-				return adapter.QuotaResult{}, nil
+				return adapter.QuotaResult{
+					Status: status.WithInternal("redisquota: Internal Error"),
+				}, nil
 			}
 
 			if allocated <= 0 {
@@ -365,7 +371,9 @@ func (h *handler) HandleQuota(context context.Context, instance *quota.Instance,
 		}
 	}
 
-	return adapter.QuotaResult{}, nil
+	return adapter.QuotaResult{
+		Status: status.OK,
+	}, nil
 }
 
 func (h handler) Close() error {

--- a/mixer/adapter/redisquota/redisquota_integration_test.go
+++ b/mixer/adapter/redisquota/redisquota_integration_test.go
@@ -151,6 +151,10 @@ func runServerWithSelectedAlgorithm(t *testing.T, algorithm string) {
 			  {
 			   "Quota": {
 			    "requestCount": {
+                 "Status": {
+                  "code": 8,
+                  "message": "handler.redisquota.istio-system:redisquota: Resource exhausted"
+                 },
 			     "ValidDuration": 0,
 			     "Amount": 0
 			    }
@@ -228,4 +232,78 @@ func TestFixedWindowAlgorithm(t *testing.T) {
 
 func TestRollingWindowAlgorithm(t *testing.T) {
 	runServerWithSelectedAlgorithm(t, "FIXED_WINDOW")
+}
+
+func TestErrorFromRedis(t *testing.T) {
+	cases := map[string]struct {
+		attrs  map[string]interface{}
+		quotas map[string]istio_mixer_v1.CheckRequest_QuotaParams
+		want   string
+	}{
+		"Request 30 when 50 is available": {
+			attrs: map[string]interface{}{},
+			quotas: map[string]istio_mixer_v1.CheckRequest_QuotaParams{
+				"requestCount": {
+					Amount:     30,
+					BestEffort: true,
+				},
+			},
+			want: `
+			 {
+			  "AdapterState": null,
+			  "Returns": [
+			   {
+			    "Quota": {
+			 	"requestCount": {
+                 "Status": {
+                  "code": 14,
+                  "message": "handler.redisquota.istio-system:redisquota: Service Unavailable"
+                 },
+			 	 "ValidDuration": 0,
+			 	 "Amount": 0
+			 	}
+			    }
+			   }
+			  ]
+			 }
+			`,
+		},
+	}
+	// start mock redis server
+	for id, c := range cases {
+		mockRedis, err := miniredis.Run()
+		if err != nil {
+			t.Fatalf("Unable to start mock redis server: %v", err)
+		}
+
+		serviceCfg := adapterConfig
+		serviceCfg = strings.Replace(serviceCfg, "__RATE_LIMIT_ALGORITHM__", "ROLLING_WINDOW", -1)
+		serviceCfg = strings.Replace(serviceCfg, "__REDIS_SERVER_ADDRESS__", mockRedis.Addr(), -1)
+
+		t.Logf("Executing test case '%s'", id)
+		adapter_integration.RunTest(
+			t,
+			GetInfo,
+			adapter_integration.Scenario{
+				ParallelCalls: []adapter_integration.Call{
+					{
+						CallKind: adapter_integration.CHECK,
+						Attrs:    c.attrs,
+						Quotas:   c.quotas,
+					},
+				},
+				Configs: []string{
+					serviceCfg,
+				},
+				SetError: func(ctx interface{}) error {
+					mockRedis.Close()
+					return nil
+				},
+				Want: c.want,
+			},
+		)
+
+		mockRedis.Close()
+	}
+
 }

--- a/mixer/adapter/redisquota/redisquota_test.go
+++ b/mixer/adapter/redisquota/redisquota_test.go
@@ -25,9 +25,12 @@ import (
 	"github.com/alicebob/miniredis"
 	"github.com/alicebob/miniredis/server"
 
+	"github.com/gogo/googleapis/google/rpc"
+
 	"istio.io/istio/mixer/adapter/redisquota/config"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/adapter/test"
+	"istio.io/istio/mixer/pkg/status"
 	"istio.io/istio/mixer/template/quota"
 )
 
@@ -469,6 +472,7 @@ func TestHandleQuota(t *testing.T) {
 	}
 
 	for id, c := range cases {
+		t.Logf("Executing test case '%s'", id)
 		b := info.NewBuilder().(*builder)
 
 		b.SetAdapterConfig(&config.Params{
@@ -519,6 +523,7 @@ func TestHandleQuotaErrorMsg(t *testing.T) {
 		instance    quota.Instance
 		req         RequestInfo
 		errMsg      []string
+		status      rpc.Status
 	}{
 		"Failed to run the script": {
 			mockRedis: map[string]server.Cmd{
@@ -557,6 +562,7 @@ func TestHandleQuotaErrorMsg(t *testing.T) {
 				"key: fixed-window maxAmount: 10",
 				"failed to run quota script: Error",
 			},
+			status: status.WithUnavailable("failed to run quota script: Error"),
 		},
 		"Invalid response from the script": {
 			mockRedis: map[string]server.Cmd{
@@ -596,6 +602,7 @@ func TestHandleQuotaErrorMsg(t *testing.T) {
 				"key: fixed-window maxAmount: 10",
 				"invalid response from the redis server: [10]",
 			},
+			status: status.WithInternal("invalid response from the redis server: [10]"),
 		},
 	}
 
@@ -629,13 +636,18 @@ func TestHandleQuotaErrorMsg(t *testing.T) {
 
 		quotaHandler := adapterHandler.(*handler)
 
-		_, err = quotaHandler.HandleQuota(context.Background(), &c.instance, adapter.QuotaArgs{
+		quotaResult, err := quotaHandler.HandleQuota(context.Background(), &c.instance, adapter.QuotaArgs{
 			QuotaAmount: c.req.token,
 			BestEffort:  c.req.bestEffort,
 		})
 
 		if err != nil {
 			t.Errorf("%v: unexpected error: %v", id, err.Error())
+			continue
+		}
+
+		if c.status.GetCode() != quotaResult.Status.GetCode() {
+			t.Errorf("%v: unexpected error code: %v, expected: %v", id, quotaResult.Status.GetCode(), c.status.GetCode())
 			continue
 		}
 

--- a/mixer/pkg/adapter/test/integration.go
+++ b/mixer/pkg/adapter/test/integration.go
@@ -87,6 +87,8 @@ type (
 		// New test can start of with an empty "{}" string and then
 		// get the baseline from the failure logs upon execution.
 		Want string
+
+		SetError SetErrorFn
 	}
 	// Call represents the input to make a call to Mixer
 	Call struct {
@@ -139,6 +141,9 @@ type (
 	GetStateFn func(ctx interface{}) (interface{}, error)
 	// GetConfigFn returns configuration that is generated
 	GetConfigFn func(ctx interface{}) ([]string, error)
+	// SetErrorFn function will be called just before test begins and setup and config is done. This can be used to
+	// introduce errors in the test
+	SetErrorFn func(ctx interface{}) error
 )
 
 // RunTest performs a Mixer adapter integration test using in-memory Mixer and config store.
@@ -213,6 +218,13 @@ func RunTest(
 	}
 	client := istio_mixer_v1.NewMixerClient(conn)
 	defer closeHelper(conn)
+
+	if scenario.SetError != nil {
+		err = scenario.SetError(ctx)
+		if err != nil {
+			t.Fatalf("calling SetError Failed: %v", err)
+		}
+	}
 
 	// Invoke calls async
 	var wg sync.WaitGroup
@@ -301,6 +313,7 @@ func execute(c Call, client istio_mixer_v1.MixerClient, returns []Return, i int,
 			for k := range c.Quotas {
 				ret.Quota[k] = adapter.QuotaResult{
 					Amount: result.Quotas[k].GrantedAmount, ValidDuration: result.Quotas[k].ValidDuration,
+					Status: result.Quotas[k].Status,
 				}
 			}
 		} else {

--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -214,6 +214,7 @@ func (s *grpcServer) check(ctx context.Context, req *mixerpb.CheckRequest,
 				if !status.IsOK(qr.Status) {
 					lg.Debugf("Quota denied: %v", qr.Status)
 				}
+				crqr.Status = qr.Status
 				crqr.ValidDuration = qr.ValidDuration
 				crqr.GrantedAmount = qr.Amount
 			}


### PR DESCRIPTION
Adding Status value when returning quota result from redisquota adapter as well as in Check Quota Response.
Status in Check Quota Response will be used in proxy to determine fail/pass the check response too.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[x ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Ref: Previous closed PR: https://github.com/istio/istio/pull/12507
Ref Issue: https://github.com/istio/istio/issues/12115