### PR TITLE
Set tail to high number for access log test

### DIFF
--- a/tests/integration/mixer/util.go
+++ b/tests/integration/mixer/util.go
@@ -188,7 +188,8 @@ func GetAndValidateAccessLog(ns namespace.Instance, t *testing.T, labelSelector,
 	}
 
 	retryFn := func(_ context.Context, i int) error {
-		content, err := shell.Execute(false, "kubectl logs -n %s -l %s -c %s --tail=-1",
+		// Different kubectl versions seem to return different amounts of logs. To ensure we get them all, set tail to a large number
+		content, err := shell.Execute(false, "kubectl logs -n %s -l %s -c %s --tail=10000000",
 			ns.Name(), labelSelector, container)
 		if err != nil {
 			return fmt.Errorf("unable to get access logs from mixer: %v , content %v", err, content)


### PR DESCRIPTION
A prior commit was settting this to -1, which apparently doesn't work on
all versions of kubectl and wasn't caught because the test is not
required. Setting this to a high number will work on all versions.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
