### PR TITLE
Adapt e2e-suite.sh to allow execution with existing cluster

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -79,17 +79,27 @@ if [[ $HUB == *"istio-testing"* ]]; then
   # upload images
   time ISTIO_DOCKER_HUB="${HUB}" make docker.push HUB="${HUB}" TAG="${TAG}" DOCKER_BUILD_VARIANTS="${VARIANT:-default}"
 fi
-echo "Setup cluster."
-date
-setup_e2e_cluster
+
+if [[ "${SETUP_CLUSTER:-true}" == true ]]; then
+  echo "Setup cluster."
+  date
+  setup_e2e_cluster
+  # e2e tests on prow use clusters borrowed from boskos, which cleans up the
+  # clusters. There is no need to cleanup in the test jobs.
+  E2E_ARGS+=("--skip_cleanup")
+else
+  if [[ -z $KUBECONFIG ]]; then
+    echo "Please specify a KUBECONFIG to run the tests."
+    exit 1
+  fi
+  ARTIFACTS_DIR=${ARTIFACTS_DIR:-/tmp}
+fi
+
 if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
    cni_run_daemon
 fi
 
 E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
-# e2e tests on prow use clusters borrowed from boskos, which cleans up the
-# clusters. There is no need to cleanup in the test jobs.
-E2E_ARGS+=("--skip_cleanup")
 
 echo "Run test."
 date


### PR DESCRIPTION
This change allows developers to run prow-tests independently of google infrastructure, e.g. via:
```
export KUBECONFIG=/my-kubeconfig.yaml
SETUP_CLUSTER=false ./prow/e2e-pilot-no_auth.sh
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[X] Developer Infrastructure
