### PR TITLE
Fix misleading error message in pilot-agent

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -251,5 +251,7 @@ func notifyExit() {
 	if err != nil {
 		log.Errora(err)
 	}
-	log.Errora(p.Signal(syscall.SIGTERM))
+	if err := p.Signal(syscall.SIGTERM); err != nil {
+		log.Errorf("failed to send SIGTERM to self: %v", err)
+	}
 }


### PR DESCRIPTION
Previously this would log `error: <nil>` every time an exit was
triggered which was confusing. This makes it so it is only logged when
an error actually occurs.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
