### PR TITLE
add backward compatability support for pilot-agent

### DIFF
--- a/pilot/cmd/pilot-agent/status/util/listeners_test.go
+++ b/pilot/cmd/pilot-agent/status/util/listeners_test.go
@@ -76,6 +76,29 @@ func TestGetInboundListeningPorts(t *testing.T) {
 		wantPorts  map[uint16]bool
 	}{
 		{
+			name:       "SidecarProxy with non-Json output",
+			nodeType:   model.SidecarProxy,
+			ipPrefixes: []string{"10.0.0.1", "10.0.0.2", "1004:"},
+			listeners: `["10.0.0.1:1001","10.0.0.1:1002","10.0.0.2:2001","10.0.0.2:2002","10.0.0.3:3001","[1004::ffff]:4001"]`,
+			wantPorts: map[uint16]bool{
+				1001: true,
+				1002: true,
+				2001: true,
+				2002: true,
+				4001: true,
+			},
+		},
+		{
+			name:       "Router with non-Json output",
+			nodeType:   model.Router,
+			ipPrefixes: []string{"10.0.0.1", "10.0.0.2"},
+			listeners: `["10.0.0.1:1001","10.0.0.2:2001","0.0.0.0:80","0.0.0.0:90"`,
+			wantPorts: map[uint16]bool{
+				80: true,
+				90: true,
+			},
+		},
+		{
 			name:       "SidecarProxy",
 			nodeType:   model.SidecarProxy,
 			ipPrefixes: []string{"10.0.0.1", "10.0.0.2", "1004:"},


### PR DESCRIPTION
I'm not sure if this PR is needed but just opened for some discussion. I updated the code to parse the `/listeners` in json format in https://github.com/istio/istio/pull/15342. However the code could fail if there is any version mismatch between the pilot-agent and Envoy binary.

I assume the pilot-agent and Envoy binary should always have the compatible version with each other as they're packed in the same proxyv2 Docker image. If that's always the case, we don't need this PR at all. @howardjohn @kyessenov 

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
