### PR TITLE
Publishes istioctl binaries to GCS for separate download.

### DIFF
--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -89,7 +89,12 @@ function create_linux_archive() {
 
   env GZIP=-9 "${TAR}" --owner releng --group releng -czf \
     "${OUTPUT_PATH}/istio-${VER_STRING}-linux.tar.gz" "istio-${VER_STRING}" \
-    || error_exit 'Could not create linux archive'
+    || error_exit 'Could not create istio linux archive'
+  
+  env GZIP=-9 "${TAR}" --owner releng --group releng -czf \
+    "${OUTPUT_PATH}/istioctl-${VER_STRING}-linux.tar.gz" "${OUTPUT_PATH}/${ISTIOCTL_SUBDIR}"/istioctl-linux \
+    || error_exit 'Could not create istioctl linux archive'
+
   rm "${istioctl_path}"
 }
 
@@ -101,7 +106,12 @@ function create_osx_archive() {
 
   env GZIP=-9 "${TAR}" --owner releng --group releng -czf \
     "${OUTPUT_PATH}/istio-${VER_STRING}-osx.tar.gz" "istio-${VER_STRING}" \
-    || error_exit 'Could not create osx archive'
+    || error_exit 'Could not create istio osx archive'
+
+  env GZIP=-9 "${TAR}" --owner releng --group releng -czf \
+    "${OUTPUT_PATH}/istioctl-${VER_STRING}-osx.tar.gz" "${OUTPUT_PATH}/${ISTIOCTL_SUBDIR}"/istioctl-osx \
+    || error_exit 'Could not create istioctl osx archive'
+
   rm "${istioctl_path}"
 }
 
@@ -111,7 +121,11 @@ function create_windows_archive() {
   ${CP} "${OUTPUT_PATH}/${ISTIOCTL_SUBDIR}/istioctl-win.exe" "${istioctl_path}"
 
   zip -r -q "${OUTPUT_PATH}/istio-${VER_STRING}-win.zip" "istio-${VER_STRING}" \
-    || error_exit 'Could not create windows archive'
+    || error_exit 'Could not create istio windows archive'
+  
+  zip -r -q "${OUTPUT_PATH}/istioctl-${VER_STRING}-win.zip" "${OUTPUT_PATH}/${ISTIOCTL_SUBDIR}"/istioctl-win.exe \
+    || error_exit 'Could not create istioctl windows archive'
+  
   rm "${istioctl_path}"
 }
 

--- a/release/gcb/gcb_lib.sh
+++ b/release/gcb/gcb_lib.sh
@@ -95,7 +95,9 @@ function make_istio() {
   sha256sum "${ISTIO_OUT}/istio-sidecar.deb" > "${OUTPUT_PATH}/deb/istio-sidecar.deb.sha256"
   cp        "${ISTIO_OUT}/istio-sidecar.deb"   "${OUTPUT_PATH}/deb/"
   cp        "${ISTIO_OUT}"/archive/istio-*z*   "${OUTPUT_PATH}/"
-  
+  cp        "${ISTIO_OUT}"/archive/istioctl*.tar.gz "${OUTPUT_PATH}/"
+  cp        "${ISTIO_OUT}"/archive/istioctl*.zip "${OUTPUT_PATH}/"
+
   rm -r "${ISTIO_OUT}/docker" || true
   BUILD_DOCKER_TARGETS=(docker.save)
 


### PR DESCRIPTION
Addresses #11527.

Signed-off-by: Jason Clark <jason.clark@ibm.com>

This PR adds additional steps to the create_release_archives.sh script that preps the istioctl binaries to be stored on GCS for separate download.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure
