### PR TITLE
Helm tests fail on distroless.

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
 {{- if contains "/" $.Values.global.proxy_init.image }}
           image: "{{ $.Values.global.proxy_init.image }}"
 {{- else }}
-          image: "{{ $.Values.global.hub }}/{{ $.Values.global.proxy_init.image }}:{{ $.Values.global.tag }}"
+          image: ubuntu:xenial
 {{- end }}
           imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
           command:

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
 {{- if contains "/" $.Values.global.proxy_init.image }}
           image: "{{ $.Values.global.proxy_init.image }}"
 {{- else }}
-          image: ubuntu:xenial
+          image: {{ $.Values.global.proxy.enableCoreDumpImage }}
 {{- end }}
           imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
           command:

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -48,11 +48,7 @@ spec:
 {{- if $.Values.global.proxy.enableCoreDump }}
       initContainers:
         - name: enable-core-dump
-{{- if contains "/" $.Values.global.proxy_init.image }}
-          image: "{{ $.Values.global.proxy_init.image }}"
-{{- else }}
           image: {{ $.Values.global.proxy.enableCoreDumpImage }}
-{{- end }}
           imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
           command:
             - /bin/sh

--- a/install/kubernetes/helm/istio/charts/grafana/templates/tests/test-grafana-connection.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/tests/test-grafana-connection.yaml
@@ -19,7 +19,7 @@ spec:
 {{- end }}
   containers:
     - name: "{{ template "grafana.fullname" . }}-test"
-      image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
+      image: pstauffer/curl:v1.0.3
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
       command: ['curl']
       args: ['http://grafana:{{ .Values.grafana.service.externalPort }}']

--- a/install/kubernetes/helm/istio/charts/kiali/templates/tests/test-kiali-connection.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/tests/test-kiali-connection.yaml
@@ -19,7 +19,7 @@ spec:
 {{- end }}
   containers:
     - name: "{{ template "kiali.fullname" . }}-test"
-      image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
+      image: pstauffer/curl:v1.0.3
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
       command: ['curl']
       args: ['http://kiali:20001']

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/tests/test-prometheus-connection.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/tests/test-prometheus-connection.yaml
@@ -19,7 +19,7 @@ spec:
 {{- end }}
   containers:
     - name: "{{ template "prometheus.fullname" . }}-test"
-      image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
+      image: pstauffer/curl:v1.0.3
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
       command: ['sh', '-c', 'for i in 1 2 3; do curl http://prometheus:9090/-/ready && exit 0 || sleep 15; done; exit 1']
   restartPolicy: Never

--- a/install/kubernetes/helm/istio/charts/security/templates/tests/test-citadel-connection.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/tests/test-citadel-connection.yaml
@@ -19,7 +19,7 @@ spec:
 {{- end }}
   containers:
     - name: "{{ template "security.fullname" . }}-test"
-      image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
+      image: pstauffer/curl:v1.0.3
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
       command: ['sh', '-c', 'for i in 1 2 3; do curl http://istio-citadel:{{ .Values.global.monitoringPort }}/version && exit 0 || sleep 15; done; exit 1']
   restartPolicy: Never

--- a/install/kubernetes/helm/istio/charts/tracing/templates/tests/test-tracing-connection.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/tests/test-tracing-connection.yaml
@@ -18,7 +18,7 @@ spec:
 {{- end }}
   containers:
     - name: "{{ .Values.provider }}-test"
-      image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
+      image: pstauffer/curl:v1.0.3
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
       command: ['curl']
       {{- if eq .Values.provider "jaeger" }}

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -66,7 +66,7 @@ initContainers:
 {{- if contains "/" .Values.global.proxy_init.image }}
   image: "{{ .Values.global.proxy_init.image }}"
 {{- else }}
-  image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
+  image: ubuntu:xenial
 {{- end }}
   imagePullPolicy: IfNotPresent
   resources: {}

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -63,11 +63,7 @@ initContainers:
   - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
   command:
     - /bin/sh
-{{- if contains "/" .Values.global.proxy_init.image }}
-  image: "{{ .Values.global.proxy_init.image }}"
-{{- else }}
   image: {{ $.Values.global.proxy.enableCoreDumpImage }}
-{{- end }}
   imagePullPolicy: IfNotPresent
   resources: {}
   securityContext:

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -66,7 +66,7 @@ initContainers:
 {{- if contains "/" .Values.global.proxy_init.image }}
   image: "{{ .Values.global.proxy_init.image }}"
 {{- else }}
-  image: ubuntu:xenial
+  image: {{ $.Values.global.proxy.enableCoreDumpImage }}
 {{- end }}
   imagePullPolicy: IfNotPresent
   resources: {}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -199,6 +199,9 @@ global:
     # If set, newly injected sidecars will have core dumps enabled.
     enableCoreDump: false
 
+    # Image used to enable core dumps. This is only used, when "enableCoreDump" is set to true.
+    enableCoreDumpImage: ubuntu:xenial
+
     # Default port for Pilot agent health checks. A value of 0 will disable health checking.
     statusPort: 15020
 

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -157,7 +157,7 @@ spec:
         - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
         command:
         - /bin/sh
-        image: docker.io/istio/proxy_init:unittest
+        image: ubuntu:xenial
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}

--- a/tests/e2e/tests/pilot/testdata/job.yaml
+++ b/tests/e2e/tests/pilot/testdata/job.yaml
@@ -20,6 +20,6 @@ spec:
     spec:
       containers:
         - name: test
-          image: pstauffer/curl
+          image: pstauffer/curl:v1.0.3
           command: ["sh", "-c", "while :; do sleep 1s; ret=`curl -o /dev/null -s -w %{http_code} -X POST http://127.0.0.1:15020/quitquitquit`; if  [ $ret -eq 200 ]; then break; fi; done"]
       restartPolicy: Never


### PR DESCRIPTION
This PR fixes the issue #15414. The new distroless images no longer contain the `curl` command. Therefore, I changed the images, which are used to run `curl` test commands from `proxy` to `pstauffer/curl:v1.0.3`

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
