### PR TITLE
Revert "Use envoy with symbol and add gdb, strace, pstack to docker image"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ endif
 # OS-neutral vars. These currently only work for linux.
 export ISTIO_ENVOY_VERSION ?= ${PROXY_REPO_SHA}
 export ISTIO_ENVOY_DEBUG_URL ?= https://storage.googleapis.com/istio-build/proxy/envoy-debug-$(ISTIO_ENVOY_VERSION).tar.gz
-export ISTIO_ENVOY_RELEASE_URL ?= https://storage.googleapis.com/istio-build/proxy/envoy-symbol-$(ISTIO_ENVOY_VERSION).tar.gz
+export ISTIO_ENVOY_RELEASE_URL ?= https://storage.googleapis.com/istio-build/proxy/envoy-alpha-$(ISTIO_ENVOY_VERSION).tar.gz
 
 # Envoy Linux vars.
 export ISTIO_ENVOY_LINUX_VERSION ?= ${ISTIO_ENVOY_VERSION}

--- a/docker/Dockerfile.bionic_debug
+++ b/docker/Dockerfile.bionic_debug
@@ -9,14 +9,11 @@ FROM ubuntu:bionic
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       curl \
-      gdb \
       iptables \
       iproute2 \
       iputils-ping \
       knot-dnsutils \
       netcat \
-      pstack \
-      strace \
       tcpdump \
       net-tools \
       lsof \
@@ -37,8 +34,5 @@ RUN apt-get update && \
 # net-tools (0.7M): netstat
 # lsof (0.5M): for debugging open socket, file descriptors
 # knot-dnsutils (4.5M): dig/nslookup
-# gdb: for debugging envoy
-# pstack: display a stack trace for each process
-# strace: monitor and tamper with interactions between processes and the Linux kernel
 
 # Alternative: dnsutils(44M) for dig/nslookup

--- a/docker/Dockerfile.deb_debug
+++ b/docker/Dockerfile.deb_debug
@@ -9,14 +9,11 @@ FROM debian:9-slim
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       curl \
-      gdb \
       iptables \
       iproute2 \
       iputils-ping \
       knot-dnsutils \
       netcat \
-      pstack \
-      strace \
       tcpdump \
       net-tools \
       lsof \
@@ -36,8 +33,5 @@ RUN apt-get update && \
 # net-tools (0.7M): netstat
 # lsof (0.5M): for debugging open socket, file descriptors
 # knot-dnsutils (4.5M): dig/nslookup
-# gdb: for debugging envoy
-# pstack: display a stack trace for each process
-# strace: monitor and tamper with interactions between processes and the Linux kernel
 
 # Alternative: dnsutils(44M) for dig/nslookup

--- a/docker/Dockerfile.xenial_debug
+++ b/docker/Dockerfile.xenial_debug
@@ -12,14 +12,11 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
       curl \
-      gdb \
       iptables \
       iproute2 \
       iputils-ping \
       knot-dnsutils \
       netcat \
-      pstack \
-      strace \
       tcpdump \
       net-tools \
       lsof \


### PR DESCRIPTION
Reverts istio/istio#14483

@crazyxy I think I merged this too quickly.  @howardjohn reports it made the Envoy images 3x bigger.  We still may want to do this, but let's discuss whether the overhead is worth the troubleshooting improvements.