### PR TITLE
Skip/reject k8s jwt authentication if SDS is disabled

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
 {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
+          {{- if .Values.global.sds.enabled }}
+            - --sds-enabled=true
+          {{- end }}
             - --append-dns-names=true
             - --grpc-port=8060
             - --citadel-storage-namespace={{ .Release.Namespace }}

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -110,6 +110,9 @@ type cliOptions struct { // nolint: maligned
 
 	// Enable dual-use certs - SPIFFE in SAN and in CommonName
 	dualUse bool
+
+	// Whether SDS is enabled on.
+	sdsEnabled bool
 }
 
 var (
@@ -241,6 +244,8 @@ func init() {
 	flags.BoolVar(&opts.dualUse, "experimental-dual-use",
 		false, "Enable dual-use mode. Generates certificates with a CommonName identical to the SAN.")
 
+	flags.BoolVar(&opts.sdsEnabled, "sds-enabled", false, "Whether SDS is enabled.")
+
 	rootCmd.AddCommand(version.CobraCommand())
 
 	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
@@ -345,7 +350,8 @@ func runCA() {
 
 		// The CA API uses cert with the max workload cert TTL.
 		hostnames := append(strings.Split(opts.grpcHosts, ","), fqdn())
-		caServer, startErr := caserver.New(ca, opts.maxWorkloadCertTTL, opts.signCACerts, hostnames, opts.grpcPort, spiffe.GetTrustDomain())
+		caServer, startErr := caserver.New(ca, opts.maxWorkloadCertTTL, opts.signCACerts, hostnames,
+			opts.grpcPort, spiffe.GetTrustDomain(), opts.sdsEnabled)
 		if startErr != nil {
 			fatalf("Failed to create istio ca server: %v", startErr)
 		}

--- a/security/pkg/server/ca/authenticate/authenticator.go
+++ b/security/pkg/server/ca/authenticate/authenticator.go
@@ -31,6 +31,9 @@ const (
 	bearerTokenPrefix = "Bearer "
 	httpAuthHeader    = "authorization"
 	idTokenIssuer     = "https://accounts.google.com"
+
+	ClientCertAuthenticatorType = "ClientCertAuthenticator"
+	IDTokenAuthenticatorType    = "IDTokenAuthenticator"
 )
 
 // AuthSource represents where authentication result is derived from.
@@ -49,6 +52,10 @@ type Caller struct {
 
 // ClientCertAuthenticator extracts identities from client certificate.
 type ClientCertAuthenticator struct{}
+
+func (cca *ClientCertAuthenticator) AuthenticatorType() string {
+	return ClientCertAuthenticatorType
+}
 
 // Authenticate extracts identities from presented client certificates. This
 // method assumes that certificate chain has been properly validated before
@@ -96,6 +103,10 @@ func NewIDTokenAuthenticator(aud string) (*IDTokenAuthenticator, error) {
 
 	verifier := provider.Verifier(&oidc.Config{ClientID: aud})
 	return &IDTokenAuthenticator{verifier}, nil
+}
+
+func (a *IDTokenAuthenticator) AuthenticatorType() string {
+	return IDTokenAuthenticatorType
 }
 
 // Authenticate authenticates a caller using the JWT in the context.

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -21,7 +21,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -46,8 +46,8 @@ const (
 )
 
 type authenticator interface {
-	AuthenticatorType() string
 	Authenticate(ctx context.Context) (*authenticate.Caller, error)
+	AuthenticatorType() string
 }
 
 // Server implements IstioCAService and IstioCertificateService and provides the services on the

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -53,15 +53,15 @@ type authenticator interface {
 // Server implements IstioCAService and IstioCertificateService and provides the services on the
 // specified port.
 type Server struct {
-	authenticators []authenticator
-	authorizer     authorizer
-	serverCertTTL  time.Duration
-	ca             ca.CertificateAuthority
-	certificate    *tls.Certificate
-	hostnames      []string
-	forCA          bool
-	port           int
 	monitoring     monitoringMetrics
+	authenticators []authenticator
+	hostnames      []string
+	authorizer     authorizer
+	ca             ca.CertificateAuthority
+	serverCertTTL  time.Duration
+	certificate    *tls.Certificate
+	port           int
+	forCA          bool
 	sdsEnabled     bool
 }
 

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -71,6 +71,10 @@ type mockAuthenticator struct {
 	errMsg     string
 }
 
+func (authn *mockAuthenticator) AuthenticatorType() string {
+	return "mockAuthenticator"
+}
+
 func (authn *mockAuthenticator) Authenticate(ctx context.Context) (*authenticate.Caller, error) {
 	if len(authn.errMsg) > 0 {
 		return nil, fmt.Errorf("%v", authn.errMsg)
@@ -449,7 +453,7 @@ func TestRun(t *testing.T) {
 			// K8s JWT authenticator is added in k8s env.
 			tc.expectedAuthenticatorsLen++
 		}
-		server, err := New(tc.ca, time.Hour, false, tc.hostname, tc.port, "testdomain.com")
+		server, err := New(tc.ca, time.Hour, false, tc.hostname, tc.port, "testdomain.com", true)
 		if err == nil {
 			err = server.Run()
 		}


### PR DESCRIPTION
When SDS is not used, skip k8s jwt authentication to mitigate the risk of compromised (untrustworthy) jwts being used. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


https://github.com/istio/istio/issues/15269