### PR TITLE
Make invalid test configs valid k8s configs

### DIFF
--- a/galley/testdata/validation/dataset.gen.go
+++ b/galley/testdata/validation/dataset.gen.go
@@ -260,6 +260,7 @@ kind: HTTPAPISpecBinding
 metadata:
   name: invalid-http-api-spec-binding
 spec:
+  services:
 `)
 
 func datasetConfigV1alpha2HttpapispecbindingInvalidYamlBytes() ([]byte, error) {
@@ -310,6 +311,7 @@ kind: QuotaSpec
 metadata:
   name: invalid-quota-spec
 spec:
+  quota:
 `)
 
 func datasetConfigV1alpha2QuotaspecInvalidYamlBytes() ([]byte, error) {
@@ -362,7 +364,7 @@ kind: QuotaSpecBinding
 metadata:
   name: valid-quota-spec-binding
 spec:
-`)
+  services:`)
 
 func datasetConfigV1alpha2QuotaspecbindingInvalidYamlBytes() ([]byte, error) {
 	return _datasetConfigV1alpha2QuotaspecbindingInvalidYaml, nil

--- a/galley/testdata/validation/dataset/config-v1alpha2-HTTPAPISpecBinding-invalid.yaml
+++ b/galley/testdata/validation/dataset/config-v1alpha2-HTTPAPISpecBinding-invalid.yaml
@@ -3,3 +3,4 @@ kind: HTTPAPISpecBinding
 metadata:
   name: invalid-http-api-spec-binding
 spec:
+  services:

--- a/galley/testdata/validation/dataset/config-v1alpha2-QuotaSpec-invalid.yaml
+++ b/galley/testdata/validation/dataset/config-v1alpha2-QuotaSpec-invalid.yaml
@@ -3,3 +3,4 @@ kind: QuotaSpec
 metadata:
   name: invalid-quota-spec
 spec:
+  quota:

--- a/galley/testdata/validation/dataset/config-v1alpha2-QuotaSpecBinding-invalid.yaml
+++ b/galley/testdata/validation/dataset/config-v1alpha2-QuotaSpecBinding-invalid.yaml
@@ -3,3 +3,4 @@ kind: QuotaSpecBinding
 metadata:
   name: valid-quota-spec-binding
 spec:
+  services:


### PR DESCRIPTION
Right now these configs were rejected by kubernetes before even reaching
Galley validation on Kubernetes 1.15+. This change makes them valid from
a kubernetes perspective, but still invalid from Galley perspective.

Fixes https://github.com/istio/istio/issues/15432

This PR won't really be fully tested in the presubmit here as we don't have a 1.15 cluster but i tested locally and it will be tested in the installer repo

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
