### PR TITLE
Makes the release grab the actual latest version

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -22,8 +22,9 @@ else
 fi
 
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
-  ISTIO_VERSION=$(curl -L -s https://api.github.com/repos/istio/istio/releases/latest | \
-                  grep tag_name | sed "s/ *\"tag_name\": *\"\\(.*\\)\",*/\\1/")
+  ISTIO_VERSION=$(curl -L -s https://api.github.com/repos/istio/istio/releases | \
+                  grep tag_name | sed "s/ *\"tag_name\": *\"\\(.*\\)\",*/\\1/" | \
+                  sort -t"." -k 1,1 -k 2,2 -k 3,3 -k 4,4 | tail -n 1)
 fi
 
 if [ "x${ISTIO_VERSION}" = "x" ] ; then


### PR DESCRIPTION
Please provide a description for what this PR is for.
This prevents https://git.io/getLatestIstio to access the latest released (as per creation time of the tag) version of Istio, even if it is not on the most recent branch. (For example, we released 1.1.11 after 1.2.2 and 1.1.11 was returned by the script, which is not the intent of that tool). 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
