### PR TITLE
Fix checkDeploymentsReady.

### DIFF
--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -848,10 +848,10 @@ func CheckDeploymentsReady(ns string, kubeconfig string) (int, error) {
 	notReady := 0
 	for _, line := range strings.Split(out, "\n") {
 		flds := strings.Fields(line)
-		if len(flds) < 2 {
+		if len(flds) < 1 {
 			continue
 		}
-		if flds[1] == "0" { // no replicas ready
+		if len(flds) == 1 || flds[1] == "0" { // no replicas ready
 			notReady++
 		}
 	}


### PR DESCRIPTION
Fix checkDeploymentsReady so that deployments with 0 ready pods are correctly treated as 'not ready' (e.g. istio-egressgateway):
```
Running command kubectl -n istio-system get deployments -o jsonpath='{range .items[*]}{@.metadata.name}{" "}{@.status.availableReplicas}{"\n"}{end}'
istio-citadel 1
istio-egressgateway
istio-galley
istio-ingressgateway
istio-pilot
istio-policy 2
istio-sidecar-injector
istio-telemetry 1
prometheus 1
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
