### PR TITLE
Fix invalid kubernetes yaml in tests

### DIFF
--- a/tests/integration/security/reachability/testdata/global-mtls-off.yaml
+++ b/tests/integration/security/reachability/testdata/global-mtls-off.yaml
@@ -2,7 +2,7 @@ apiVersion: authentication.istio.io/v1alpha1
 kind: MeshPolicy
 metadata:
   name: "default"
-spec:
+spec: {}
 ---
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"


### PR DESCRIPTION
Before:
```
$ kaf ./tests/integration/security/reachability/testdata/global-mtls-off.yaml
error: error validating "./tests/integration/security/reachability/testdata/global-mtls-off.yaml": error validating data: unknown object type "nil" in MeshPolicy.spec; if you choose to ignore these errors, turn validation off with --validate=false
```

After: 
```
$ kaf ./tests/integration/security/reachability/testdata/global-mtls-off.yaml
meshpolicy.authentication.istio.io/default created
destinationrule.networking.istio.io/default created
```
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
