### PR TITLE
Remove unneeded build steps in prow

### DIFF
--- a/prow/codecov.sh
+++ b/prow/codecov.sh
@@ -30,5 +30,5 @@ setup_and_export_git_sha
 
 cd "${ROOT}"
 
-make localTestEnv build
+make localTestEnv
 MAXPROCS=6 bin/codecov_diff.sh

--- a/prow/istio-unit-tests.sh
+++ b/prow/istio-unit-tests.sh
@@ -34,4 +34,4 @@ cd "${ROOT}"
 # Integration/e2e tests in the other scripts are run against GKE or real clusters.
 JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml" \
 T="-v" \
-make build localTestEnv test version-test
+make localTestEnv test version-test


### PR DESCRIPTION
The builds add about 2 min to our tests. Not that big of a deal but it
is not needed to build the binaries here as they are not used.

Part of https://github.com/istio/test-infra/issues/1461

Note -- our circleci ones never built, so this is not a new change really

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
