### PR TITLE
Remove unused circleci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,28 +70,6 @@ markJobFinishesOnGCS: &markJobFinishesOnGCS
       make dumpsys || true
 
 jobs:
-  e2e-pilot-cloudfoundry-v1alpha3-v2:
-    <<: *integrationDefaults
-    steps:
-      - <<: *initWorkingDir
-      - checkout
-      - attach_workspace:
-          at: /go
-      - run: make sync
-      - run:
-          no_output_timeout: 20m
-          command: |
-            export PATH=$GOPATH/bin:$PATH
-            make localTestEnv
-            make test/local/cloudfoundry/e2e_pilotv2
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
-      - store_artifacts:
-          path: /go/out/logs
-      - store_artifacts:
-          path: /tmp
-
   e2e-pilot-auth-v1alpha3-v2:
     <<: *integrationDefaults
     steps:
@@ -165,11 +143,6 @@ jobs:
 
 workflows:
   version: 2
-  all:
-    jobs:
-      # The cloudfoundry test is not yet migrated to prow yet
-      - e2e-pilot-cloudfoundry-v1alpha3-v2
-
   # Ran nightly to check against prow tests
   nightly:
     triggers:
@@ -183,10 +156,6 @@ workflows:
     jobs:
       - test
       - build
-      - e2e-simple:
-          requires:
-            - test
-            - build
       - e2e-pilot-auth-v1alpha3-v2:
           requires:
             - test


### PR DESCRIPTION
The cloudfoundry test has been migrated to circleci

e2e-simple test does not exist, throwing errors. We agreed to have
build+test+one e2e test so I think its ok to remove.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
