### PR TITLE
Make only one target build docker images

### DIFF
--- a/prow/e2e-simpleTests-non-mcp.sh
+++ b/prow/e2e-simpleTests-non-mcp.sh
@@ -28,5 +28,7 @@ set -u
 # Print commands
 set -x
 
-echo 'Running Simple test with rbac, auth Tests'
-./prow/e2e-suite.sh --auth_enable --use_mcp=false --single_test e2e_simple --installer helm "$@"
+# Hijack unit test -- just to avoid needing changes to test-infra for this experiment
+
+# Upload images - needed by the subsequent tests
+time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"

--- a/prow/e2e-simpleTests-non-mcp.sh
+++ b/prow/e2e-simpleTests-non-mcp.sh
@@ -27,8 +27,3 @@ set -e
 set -u
 # Print commands
 set -x
-
-# Hijack unit test -- just to avoid needing changes to test-infra for this experiment
-
-# Upload images - needed by the subsequent tests
-time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -76,8 +76,8 @@ fi
 make init
 
 function check_images_exist() {
-  for image in pilot node-agent-k8s foo; do
-    DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$HUB/$image:$TAG" > /dev/null
+  for image in pilot node-agent-k8s; do
+    DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$HUB/$image:$TAG" > /dev/null || return 1
    done
 }
 

--- a/prow/e2e_pilotv2_auth_sds.sh
+++ b/prow/e2e_pilotv2_auth_sds.sh
@@ -27,6 +27,7 @@ set -u
 # Print commands
 set -x
 
-# Run tests with auth enabled through SDS
-#echo 'Running pilot e2e tests (v1alpha3, auth through sds)'
-./prow/e2e-suite.sh --single_test e2e_pilotv2_auth_sds
+# Hijack unit test -- just to avoid needing changes to test-infra for this experiment
+
+# Upload images - needed by the subsequent tests
+time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"

--- a/prow/e2e_pilotv2_auth_sds.sh
+++ b/prow/e2e_pilotv2_auth_sds.sh
@@ -19,6 +19,9 @@
 #        e2e_pilotv2_auth_sds         #
 #                                     #
 #######################################
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
 
 # Exit immediately for non zero status
 set -e
@@ -32,6 +35,8 @@ source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
 
 # Hijack unit test -- just to avoid needing changes to test-infra for this experiment
+
+make init
 
 # Upload images - needed by the subsequent tests
 time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"

--- a/prow/e2e_pilotv2_auth_sds.sh
+++ b/prow/e2e_pilotv2_auth_sds.sh
@@ -27,6 +27,10 @@ set -u
 # Print commands
 set -x
 
+# shellcheck source=prow/lib.sh
+source "${ROOT}/prow/lib.sh"
+setup_and_export_git_sha
+
 # Hijack unit test -- just to avoid needing changes to test-infra for this experiment
 
 # Upload images - needed by the subsequent tests

--- a/prow/istio-unit-tests.sh
+++ b/prow/istio-unit-tests.sh
@@ -30,8 +30,7 @@ setup_and_export_git_sha
 
 cd "${ROOT}"
 
-# Unit tests are run against a local apiserver and etcd.
-# Integration/e2e tests in the other scripts are run against GKE or real clusters.
-JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml" \
-T="-v" \
-make build localTestEnv test version-test
+# Hijack unit test -- just to avoid needing changes to test-infra for this experiment
+
+# Upload images - needed by the subsequent tests
+time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"

--- a/prow/istio-unit-tests.sh
+++ b/prow/istio-unit-tests.sh
@@ -30,7 +30,3 @@ setup_and_export_git_sha
 
 cd "${ROOT}"
 
-# Hijack unit test -- just to avoid needing changes to test-infra for this experiment
-
-# Upload images - needed by the subsequent tests
-time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"


### PR DESCRIPTION
This is an experimental PR. It is probably not a good idea.
