### PR TITLE
Use imagePullSecrets in istio-init serviceaccount

### DIFF
--- a/install/kubernetes/helm/istio-init/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio-init/templates/serviceaccount.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
 kind: ServiceAccount
+{{- if $.Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range $.Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 metadata:
   name: istio-init-service-account
   namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/helm/istio-init/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio-init/templates/serviceaccount.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
-{{- if $.Values.global.imagePullSecrets }}
+{{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
-{{- range $.Values.global.imagePullSecrets }}
+{{- range .Values.global.imagePullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR adds `imagePullSecrets` to the istio-init service account in the helm install. We have a need to pull the images from a registry that needed the `imagePullSecrets` set. It looks like this was done with the other Istio charts e.g https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/gateways/templates/serviceaccount.yaml#L6-L11. So this follows the same pattern for the serviceaccount in istio-init. If the imagePullSecrets is not specified in the helm values then it will not be added, but if it is specified it will be added.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
