### PR TITLE
Update base image version for bookinfo-reviews sample app

### DIFF
--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM websphere-liberty:19.0.0.4-javaee8
+FROM websphere-liberty:19.0.0.5-javaee8
 
 ENV SERVERDIRNAME reviews
 


### PR DESCRIPTION
Update the base image version from websphere-liberty version 19.0.0.4-javaee8 to
19.0.0.5-javaee8.

Fixes: #15477