### PR TITLE
Extend ListenerBuilder to include Gateway listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter.go
@@ -343,7 +343,8 @@ func buildClusterFromEnvoyConfig(value *types.Value) (*xdsapi.Cluster, error) {
 	return &cluster, nil
 }
 
-func applyListenerConfigPatches(listeners []*xdsapi.Listener, env *model.Environment, labels model.LabelsCollection) []*xdsapi.Listener {
+func applyListenerConfigPatches(builder *ListenerBuilder, env *model.Environment, labels model.LabelsCollection) []*xdsapi.Listener {
+	listeners := builder.getListeners()
 	filterCRD := getUserFiltersForWorkload(env, labels)
 	if filterCRD == nil {
 		return listeners

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter_test.go
@@ -193,8 +193,10 @@ func TestApplyListenerConfigPatches(t *testing.T) {
 	for _, tc := range testCases {
 		serviceDiscovery := &fakes.ServiceDiscovery{}
 		env := newTestEnvironment(serviceDiscovery, testMesh, buildEnvoyFilterConfigStore(tc.patches))
+		builder := NewListenerBuilder(&model.Proxy{Type: model.SidecarProxy})
+		builder.inboundListeners = tc.listeners
 
-		ret := applyListenerConfigPatches(tc.listeners, env, tc.labels)
+		ret := applyListenerConfigPatches(builder, env, tc.labels)
 		if !reflect.DeepEqual(tc.result, ret) {
 			t.Errorf("test case %s: expecting %v but got %v", tc.name, tc.result, ret)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -191,22 +191,23 @@ func (configgen *ConfigGeneratorImpl) BuildListeners(env *model.Environment, nod
 	push *model.PushContext) ([]*xdsapi.Listener, error) {
 	var listeners []*xdsapi.Listener
 	var err error
+	var builder *ListenerBuilder
 
 	switch node.Type {
 	case model.SidecarProxy:
-		listeners = configgen.buildSidecarListeners(env, node, push)
+		builder = configgen.buildSidecarListeners(env, node, push)
 	case model.Router:
-		listeners = configgen.buildGatewayListeners(env, node, push)
+		builder = configgen.buildGatewayListeners(env, node, push)
 	}
 
-	listeners = applyListenerConfigPatches(listeners, env, node.WorkloadLabels)
+	listeners = applyListenerConfigPatches(builder, env, node.WorkloadLabels)
 
 	return listeners, err
 }
 
 // buildSidecarListeners produces a list of listeners for sidecar proxies
 func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environment, node *model.Proxy,
-	push *model.PushContext) []*xdsapi.Listener {
+	push *model.PushContext) *ListenerBuilder {
 	mesh := env.Mesh
 
 	proxyInstances := node.ServiceInstances
@@ -338,7 +339,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 		// TODO: need inbound listeners in HTTP_PROXY case, with dedicated ingress listener.
 	}
 
-	return builder.getListeners()
+	return builder
 }
 
 // buildSidecarInboundListeners creates listeners for the server-side (inbound)

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -215,6 +215,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 
 	actualWildcard, actualLocalHostAddress := getActualWildcardAndLocalHost(node)
 
+	builder := NewListenerBuilder(node)
 	if mesh.ProxyListenPort > 0 {
 		// Notes that the the else branch works for both split and non-split cases.
 		// TODO(silentdai): remove `if` branch once split behavior is well verified
@@ -222,10 +223,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 			inbound := configgen.buildSidecarInboundListeners(env, node, push, proxyInstances)
 			outbound := configgen.buildSidecarOutboundListeners(env, node, push, proxyInstances)
 
-			listeners = append(listeners, inbound...)
-			listeners = append(listeners, outbound...)
-
-			listeners = configgen.generateManagementListeners(node, noneMode, env, listeners)
+			builder.inboundListeners = inbound
+			builder.outboundListeners = outbound
+			builder.managementListeners = configgen.generateManagementListeners(node, noneMode, env, listeners)
 
 			tcpProxy := &tcp_proxy.TcpProxy{
 				StatPrefix:       util.BlackHoleCluster,
@@ -258,7 +258,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 			}
 
 			// add an extra listener that binds to the port that is the recipient of the iptables redirect
-			listeners = append(listeners, &xdsapi.Listener{
+			builder.virtualListener = &xdsapi.Listener{
 				Name:           VirtualListenerName,
 				Address:        util.BuildAddress(actualWildcard, uint32(mesh.ProxyListenPort)),
 				Transparent:    transparent,
@@ -268,16 +268,15 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 						Filters: []listener.Filter{filter},
 					},
 				},
-			})
+			}
 		} else {
 			// Any build order change need a careful code review
-			listeners = NewListenerBuilder(node).
+			builder = NewListenerBuilder(node).
 				buildSidecarInboundListeners(configgen, env, node, push, proxyInstances).
 				buildSidecarOutboundListeners(configgen, env, node, push, proxyInstances).
 				buildManagementListeners(configgen, env, node, push, proxyInstances).
 				buildVirtualListener(env, node).
-				buildVirtualInboundListener(env, node).
-				getListeners()
+				buildVirtualInboundListener(env, node)
 		}
 	}
 
@@ -334,12 +333,12 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 		if err := buildCompleteFilterChain(pluginParams, mutable, opts); err != nil {
 			log.Warna("buildSidecarListeners ", err.Error())
 		} else {
-			listeners = append(listeners, l)
+			builder.outboundListeners = append(builder.outboundListeners, l)
 		}
 		// TODO: need inbound listeners in HTTP_PROXY case, with dedicated ingress listener.
 	}
 
-	return listeners
+	return builder.getListeners()
 }
 
 // buildSidecarInboundListeners creates listeners for the server-side (inbound)

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -744,7 +744,7 @@ func buildAllListeners(p plugin.Plugin, sidecarConfig *model.Config, services ..
 		proxy.SidecarScope = model.ConvertToSidecarScope(env.PushContext, sidecarConfig, sidecarConfig.Namespace)
 	}
 
-	return configgen.buildSidecarListeners(&env, &proxy, env.PushContext)
+	return configgen.buildSidecarListeners(&env, &proxy, env.PushContext).getListeners()
 }
 
 func getFilterConfig(filter listener.Filter, out proto.Message) error {


### PR DESCRIPTION
In preparation for adding support for listener matching for Envoy Filters, we need to extend the ListenerBuilder to include Gateway listeners and use the builder for both code paths.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
