### PR TITLE
Improve how citadel decides which set of namespaces to operate on [Issue #14828]

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
             - --liveness-probe-interval=60s # interval for health check file update
             - --probe-check-interval=15s    # interval for health status check
           {{- end }}
+          env:
+            - name: CITADEL_ENABLE_NAMESPACES_BY_DEFAULT
+              value: "{{ .Values.enableNamespacesByDefault }}"
           {{- if .Values.citadelHealthCheck }}
           livenessProbe:
             exec:

--- a/install/kubernetes/helm/istio/charts/security/values.yaml
+++ b/install/kubernetes/helm/istio/charts/security/values.yaml
@@ -14,6 +14,16 @@ citadelHealthCheck: false
 # 90*24hour = 2160h
 workloadCertTtl: 2160h
 
+# Determines Citadel default behavior if the ca.istio.io/env or ca.istio.io/override
+# labels are not found on a given namespace.
+#
+# For example: consider a namespace called "target", which has neither the "ca.istio.io/env"
+# nor the "ca.istio.io/override" namespace labels. To decide whether or not to generate secrets
+# for service accounts created in this "target" namespace, Citadel will defer to this option. If the value
+# of this option is "true" in this case, secrets will be generated for the "target" namespace.
+# If the value of this option is "false" Citadel will not generate secrets upon service account creation.
+enableNamespacesByDefault: true
+
 # Specify the pod anti-affinity that allows you to constrain which nodes
 # your pod is eligible to be scheduled based on labels on pods that are
 # already running on the node rather than based on labels on nodes.

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -41,6 +41,15 @@ const (
 	// The Istio secret annotation type
 	IstioSecretType = "istio.io/key-and-cert"
 
+	// NamespaceManagedLabel (string, with namespace as value) and NamespaceOverrideLabel (boolean) contribute to determining
+	// whether or not a given Citadel instance should operate on a namespace. The behavior is as follows:
+	// 1) If NamespaceOverrideLabel exists and is valid, follow what this label tells us
+	// 2) If not, check NamespaceManagedLabel. If the value matches the Citadel instance's NS, then it should be active
+	// 3) If NamespaceManagedLabel nonexistent or invalid, follow enableNamespacesByDefault, set from "CITADEL_ENABLE_NAMESPACES_BY_DEFAULT" envvar
+	// 4) If enableNamespacesByDefault is "true", the Citadel instance should operate on unlabeled namespaces, otherwise should not
+	NamespaceManagedLabel  = "ca.istio.io/env"
+	NamespaceOverrideLabel = "ca.istio.io/override"
+
 	// The ID/name for the certificate chain file.
 	CertChainID = "cert-chain.pem"
 	// The ID/name for the private key file.
@@ -50,8 +59,9 @@ const (
 	// The key to specify corresponding service account in the annotation of K8s secrets.
 	ServiceAccountNameAnnotationKey = "istio.io/service-account.name"
 
-	secretNamePrefix   = "istio."
-	secretResyncPeriod = time.Minute
+	secretNamePrefix      = "istio."
+	secretResyncPeriod    = time.Minute
+	namespaceResyncPeriod = time.Second * 5
 
 	recommendedMinGracePeriodRatio = 0.2
 	recommendedMaxGracePeriodRatio = 0.8
@@ -87,6 +97,9 @@ type SecretController struct {
 	// Length of the grace period for the certificate rotation.
 	gracePeriodRatio float32
 
+	// Whether controller loop should target namespaces without the NamespaceManagedLabel
+	enableNamespacesByDefault bool
+
 	// Whether the certificates are for dual-use clients (SAN+CN).
 	dualUse bool
 
@@ -95,12 +108,6 @@ type SecretController struct {
 
 	// If true, generate a PKCS#8 private key.
 	pkcs8Key bool
-
-	// whether ServiceAccount objects must explicitly opt-in for secrets.
-	// Object explicit opt-in is based on "istio-inject" NS label value.
-	// The default value should be read from a configmap and applied consistently
-	// to all control plane operations
-	explicitOptIn bool
 
 	// The set of namespaces explicitly set for monitoring via commandline (an entry could be metav1.NamespaceAll)
 	namespaces map[string]struct{}
@@ -116,14 +123,20 @@ type SecretController struct {
 	scrtController cache.Controller
 	scrtStore      cache.Store
 
-	monitoring monitoringMetrics
+	// Controller and store for namespace objects
+	namespaceController cache.Controller
+	namespaceStore      cache.Store
+
+	// Used to coordinate with label and check if this instance of Citadel should create secret
+	istioCaStorageNamespace string
+	monitoring              monitoringMetrics
 }
 
 // NewSecretController returns a pointer to a newly constructed SecretController instance.
-func NewSecretController(ca ca.CertificateAuthority, requireOptIn bool, certTTL time.Duration,
+func NewSecretController(ca ca.CertificateAuthority, enableNamespacesByDefault bool, certTTL time.Duration,
 	gracePeriodRatio float32, minGracePeriod time.Duration, dualUse bool,
 	core corev1.CoreV1Interface, forCA bool, pkcs8Key bool, namespaces []string,
-	dnsNames map[string]*DNSNameEntry) (*SecretController, error) {
+	dnsNames map[string]*DNSNameEntry, istioCaStorageNamespace string) (*SecretController, error) {
 
 	if gracePeriodRatio < 0 || gracePeriodRatio > 1 {
 		return nil, fmt.Errorf("grace period ratio %f should be within [0, 1]", gracePeriodRatio)
@@ -134,24 +147,26 @@ func NewSecretController(ca ca.CertificateAuthority, requireOptIn bool, certTTL 
 	}
 
 	c := &SecretController{
-		ca:               ca,
-		certTTL:          certTTL,
-		gracePeriodRatio: gracePeriodRatio,
-		minGracePeriod:   minGracePeriod,
-		dualUse:          dualUse,
-		core:             core,
-		forCA:            forCA,
-		pkcs8Key:         pkcs8Key,
-		explicitOptIn:    requireOptIn,
-		namespaces:       make(map[string]struct{}),
-		dnsNames:         dnsNames,
-		monitoring:       newMonitoringMetrics(),
+		ca:                        ca,
+		certTTL:                   certTTL,
+		istioCaStorageNamespace:   istioCaStorageNamespace,
+		gracePeriodRatio:          gracePeriodRatio,
+		enableNamespacesByDefault: enableNamespacesByDefault,
+		minGracePeriod:            minGracePeriod,
+		dualUse:                   dualUse,
+		core:                      core,
+		forCA:                     forCA,
+		pkcs8Key:                  pkcs8Key,
+		namespaces:                make(map[string]struct{}),
+		dnsNames:                  dnsNames,
+		monitoring:                newMonitoringMetrics(),
 	}
 
 	for _, ns := range namespaces {
 		c.namespaces[ns] = struct{}{}
 	}
 
+	// listen for service account creation across all listened namespaces, filter out which should be ignored upon receipt
 	saLW := listwatch.MultiNamespaceListerWatcher(namespaces, func(namespace string) cache.ListerWatcher {
 		return &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -162,12 +177,11 @@ func NewSecretController(ca ca.CertificateAuthority, requireOptIn bool, certTTL 
 			},
 		}
 	})
-
-	rehf := cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.saAdded,
-		DeleteFunc: c.saDeleted,
-	}
-	c.saStore, c.saController = cache.NewInformer(saLW, &v1.ServiceAccount{}, time.Minute, rehf)
+	c.saStore, c.saController =
+		cache.NewInformer(saLW, &v1.ServiceAccount{}, time.Minute, cache.ResourceEventHandlerFuncs{
+			AddFunc:    c.saAdded,
+			DeleteFunc: c.saDeleted,
+		})
 
 	istioSecretSelector := fields.SelectorFromSet(map[string]string{"type": IstioSecretType}).String()
 	scrtLW := listwatch.MultiNamespaceListerWatcher(namespaces, func(namespace string) cache.ListerWatcher {
@@ -188,6 +202,20 @@ func NewSecretController(ca ca.CertificateAuthority, requireOptIn bool, certTTL 
 			UpdateFunc: c.scrtUpdated,
 		})
 
+	namespaceLW := listwatch.MultiNamespaceListerWatcher(namespaces, func(namespace string) cache.ListerWatcher {
+		return &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return core.Namespaces().List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return core.Namespaces().Watch(options)
+			}}
+	})
+	c.namespaceStore, c.namespaceController =
+		cache.NewInformer(namespaceLW, &v1.Namespace{}, namespaceResyncPeriod, cache.ResourceEventHandlerFuncs{
+			UpdateFunc: c.namespaceUpdated,
+		})
+
 	return c, nil
 }
 
@@ -200,6 +228,7 @@ func (sc *SecretController) Run(stopCh chan struct{}) {
 	cache.WaitForCacheSync(stopCh, sc.scrtController.HasSynced)
 
 	go sc.saController.Run(stopCh)
+	go sc.namespaceController.Run(stopCh)
 }
 
 // GetSecretName returns the secret name for a given service account name.
@@ -207,42 +236,29 @@ func GetSecretName(saName string) string {
 	return secretNamePrefix + saName
 }
 
-// Determine if the object is "enabled" for Istio.
+// Determine if the object is "enabled" for Citadel.
 // Currently this looks at the list of watched namespaces and the object's namespace annotation
-func (sc *SecretController) istioEnabledObject(obj metav1.Object) bool {
-	if _, watched := sc.namespaces[obj.GetNamespace()]; watched || !sc.explicitOptIn {
+func (sc *SecretController) citadelManagedObject(obj metav1.Object) bool {
+
+	// todo(incfly)
+	// should be removed once listened namespaces flag phased out
+	if _, watched := sc.namespaces[obj.GetNamespace()]; watched {
 		return true
 	}
 
-	const label = "istio-managed"
-	enabled := !sc.explicitOptIn // for backward compatibility, Citadel always creates secrets
-	// @todo this should be changed to false once we communicate behavior change and ensure customers
-	// correctly mark their namespaces. Currently controlled via command line
-
 	ns, err := sc.core.Namespaces().Get(obj.GetNamespace(), metav1.GetOptions{})
-	if err != nil || ns == nil { // @todo handle errors? Unit tests mocks don't create NS, only secrets
-		return enabled
+	if err != nil || ns == nil { // if we can't retrieve namespace details, fall back on default value
+		log.Errorf("could not retrieve namespace resource for object %s", obj.GetName())
+		return sc.enableNamespacesByDefault
 	}
 
-	if ns.Labels != nil {
-		if v, ok := ns.Labels[label]; ok {
-			switch strings.ToLower(v) {
-			case "enabled", "enable", "true", "yes", "y":
-				enabled = true
-			case "disabled", "disable", "false", "no", "n":
-				enabled = false
-			default: // leave default unchanged
-				break
-			}
-		}
-	}
-	return enabled
+	return sc.namespaceIsManaged(ns)
 }
 
 // Handles the event where a service account is added.
 func (sc *SecretController) saAdded(obj interface{}) {
 	acct := obj.(*v1.ServiceAccount)
-	if sc.istioEnabledObject(acct.GetObjectMeta()) {
+	if sc.citadelManagedObject(acct.GetObjectMeta()) {
 		sc.upsertSecret(acct.GetName(), acct.GetNamespace())
 	}
 	sc.monitoring.ServiceAccountCreation.Inc()
@@ -321,11 +337,67 @@ func (sc *SecretController) scrtDeleted(obj interface{}) {
 	saName := scrt.Annotations[ServiceAccountNameAnnotationKey]
 	if sa, err := sc.core.ServiceAccounts(scrt.GetNamespace()).Get(saName, metav1.GetOptions{}); err == nil {
 		log.Infof("Re-creating deleted secret %s/%s.", scrt.GetNamespace(), GetSecretName(saName))
-		if sc.istioEnabledObject(sa.GetObjectMeta()) {
+		if sc.citadelManagedObject(sa.GetObjectMeta()) {
 			sc.upsertSecret(saName, scrt.GetNamespace())
 		}
 		sc.monitoring.SecretDeletion.Inc()
 	}
+}
+
+func (sc *SecretController) namespaceUpdated(oldObj, newObj interface{}) {
+	oldNs := oldObj.(*v1.Namespace)
+	newNs := newObj.(*v1.Namespace)
+
+	oldManaged := sc.namespaceIsManaged(oldNs)
+	newManaged := sc.namespaceIsManaged(newNs)
+
+	if !oldManaged && newManaged {
+		sc.enableNamespaceRetroactive(newNs.GetName())
+		return
+	}
+}
+
+// namespaceIsManaged returns whether a given namespace object should be managed by Citadel
+func (sc *SecretController) namespaceIsManaged(ns *v1.Namespace) bool {
+	nsLabels := ns.GetLabels()
+
+	override, exists := nsLabels[NamespaceOverrideLabel]
+	if exists {
+		switch override {
+		case "true":
+			return true
+		case "false":
+			return false
+		} // if exists but not valid, should fall through to check for NamespaceManagedLabel
+	}
+
+	targetNamespace, exists := nsLabels[NamespaceManagedLabel]
+	if !exists {
+		return sc.enableNamespacesByDefault
+	}
+
+	if targetNamespace != sc.istioCaStorageNamespace {
+		return false // this instance is not the intended CA
+	}
+
+	return true
+}
+
+// enableNamespaceRetroactive generates secrets for all service accounts in a newly enabled namespace
+// for instance: if a namespace had its {NamespaceOverrideLabel: false} label removed, and its namespace is targeted
+// in NamespaceManagedLabel, then we should generate secrets for its ServiceAccounts
+func (sc *SecretController) enableNamespaceRetroactive(namespace string) {
+
+	serviceAccounts, err := sc.core.ServiceAccounts(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("could not retrieve service account resources from namespace %s", namespace)
+		return
+	}
+
+	for _, sa := range serviceAccounts.Items {
+		sc.upsertSecret(sa.GetName(), sa.GetNamespace()) // idempotent, since does not gen duplicate secrets
+	}
+
 }
 
 func (sc *SecretController) generateKeyAndCert(saName string, saNamespace string) ([]byte, []byte, error) {
@@ -410,6 +482,17 @@ func (sc *SecretController) scrtUpdated(oldObj, newObj interface{}) {
 	// one held by the ca (this may happen when the CA is restarted and
 	// a new self-signed CA cert is generated).
 	if certLifeTimeLeft < gracePeriod || !bytes.Equal(rootCertificate, scrt.Data[RootCertID]) {
+		// if the namespace is not managed, don't refresh the expired secret, delete it
+		secretNamespace, err := sc.core.Namespaces().Get(namespace, metav1.GetOptions{})
+		if err == nil {
+			if !sc.namespaceIsManaged(secretNamespace) { // delete the expiring secret if namespace not Citadel managed
+				sc.deleteSecret(name, namespace)
+				return
+			}
+		} else { // in the case we couldn't retrieve namespace, we should proceed with cert refresh
+			log.Errorf("Failed to retrieve details for namespace %s, err %v", namespace, err)
+		}
+
 		if certLifeTimeLeft < gracePeriod {
 			log.Infof("Refreshing about to expire secret %s/%s", namespace, GetSecretName(name))
 		} else {


### PR DESCRIPTION
---
name: Improve how Istio citadel decides which set of namespaces to operate on [Issue #14828]
about: Removed explicit-opt-in flag and introduced new targeting mechanism, based on labeling namespaces with the namespace of the desired Citadel instance
---

[Relevant issue](https://github.com/istio/istio/issues/14828)
[Relevant design document](https://docs.google.com/document/d/1FRO_Cso_Q7FbJ5-TIXt1kIDirEurWRIAIZN8glr-5vc/edit#heading=h.7ubp6he6anu6)
[PR and comments from personal fork](https://github.com/Monkeyanator/istio/pull/2)
[Recorded Security WG Meeting Discussion on this](https://youtu.be/LD7ascGbcT8?t=1998)

This PR introduces two new labels, `ca.istio.io/env`, which allows users to designate which namespaces (if any) Citadel should operate on, and `ca.istio.io/override`, which allows users to force Citadel to target or ignore a namespace (supersedes other activation rules). This PR also introduces a new environment variable, `enableNamespacesByDefault`, which determines the default behavior when the designated label is not found (i.e. whether or not Citadel instance should create secret for added `ServiceAccount`).

Retroactive secret creation and deletion are also included in this PR (i.e. enabling a namespace will create secrets in the namespace for existing SAs).

Note: this is a hefty PR, and I'd be fine to chop it into multiple, smaller PRs if that seems more manageable/reviewable (separating retroactive secret creation into a different PR / discussion might make sense). Further note: the configuration options are operator facing and will have to be documented.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastrcture
