### PR TITLE
Only delete each staled connection key once

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -379,6 +379,9 @@ func recycleConnection(conID, resourceName string) {
 		ResourceName: resourceName,
 	}
 
+	sdsClientsMutex.Lock()
+	defer sdsClientsMutex.Unlock()
+
 	// Only add connection key to staledClientKeys if it's not there already.
 	// The recycleConnection function may be triggered more than once for each connection key.
 	// https://github.com/istio/istio/issues/15306#issuecomment-509783105
@@ -386,8 +389,6 @@ func recycleConnection(conID, resourceName string) {
 		return
 	}
 
-	sdsClientsMutex.Lock()
-	defer sdsClientsMutex.Unlock()
 	staledClientKeys[key] = true
 
 	metricLabelName := generateResourcePerConnLabel(resourceName, conID)


### PR DESCRIPTION
Only delete each staled connection key once. This is mostly for citadel agent to get the metrics correctly. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
