### PR TITLE
Print log on test failure

### DIFF
--- a/tests/integration/security/sds_ingress/multi_mtls_gateway_invalid_secret/multi_mtls_gateway_invalid_secret_test.go
+++ b/tests/integration/security/sds_ingress/multi_mtls_gateway_invalid_secret/multi_mtls_gateway_invalid_secret_test.go
@@ -133,5 +133,6 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 						c.name, c.expectedResponse.ResponseCode, c.hostName, err)
 				}
 			}
+			ingressutil.DumpGatewayLogOnTestFailure(t, ctx)
 		})
 }

--- a/tests/integration/security/sds_ingress/multi_tls_gateway_invalid_secret/multi_tls_gateway_invalid_secret_test.go
+++ b/tests/integration/security/sds_ingress/multi_tls_gateway_invalid_secret/multi_tls_gateway_invalid_secret_test.go
@@ -163,5 +163,6 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 						c.name, c.expectedResponse.ResponseCode, c.hostName, err)
 				}
 			}
+			ingressutil.DumpGatewayLogOnTestFailure(t, ctx)
 		})
 }

--- a/tests/integration/security/sds_ingress/multiple_mtls_gateway/multiple_mtls_gateway_test.go
+++ b/tests/integration/security/sds_ingress/multiple_mtls_gateway/multiple_mtls_gateway_test.go
@@ -70,6 +70,7 @@ func testMultiMtlsGateways(t *testing.T, ctx framework.TestContext) { // nolint:
 			t.Errorf("unable to retrieve 200 from product page at host %s: %v", h, err)
 		}
 	}
+	ingressutil.DumpGatewayLogOnTestFailure(t, ctx)
 }
 
 func TestMtlsGateways(t *testing.T) {

--- a/tests/integration/security/sds_ingress/multiple_tls_gateway/multiple_tls_gateways_test.go
+++ b/tests/integration/security/sds_ingress/multiple_tls_gateway/multiple_tls_gateways_test.go
@@ -65,6 +65,7 @@ func testMultiTLSGateways(t *testing.T, ctx framework.TestContext) { // nolint:i
 			t.Errorf("unable to retrieve 200 from product page at host %s: %v", h, err)
 		}
 	}
+	ingressutil.DumpGatewayLogOnTestFailure(t, ctx)
 }
 
 func TestTlsGateways(t *testing.T) {

--- a/tests/integration/security/sds_ingress/single_mtls_gateway/single_mtls_gateway_test.go
+++ b/tests/integration/security/sds_ingress/single_mtls_gateway/single_mtls_gateway_test.go
@@ -105,5 +105,6 @@ func TestSingleMTLSGateway_SecretRotation(t *testing.T) {
 			if err != nil {
 				t.Errorf("unable to retrieve 200 from product page at host %s: %v", host, err)
 			}
+			ingressutil.DumpGatewayLogOnTestFailure(t, ctx)
 		})
 }

--- a/tests/integration/security/sds_ingress/single_tls_gateway/single_tls_gateway_test.go
+++ b/tests/integration/security/sds_ingress/single_tls_gateway/single_tls_gateway_test.go
@@ -95,5 +95,6 @@ func TestSingleTlsGateway_SecretRotation(t *testing.T) {
 			if err != nil {
 				t.Errorf("unable to retrieve 200 from product page at host %s: %v", host, err)
 			}
+			ingressutil.DumpGatewayLogOnTestFailure(t, ctx)
 		})
 }

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -312,13 +312,13 @@ func DumpGatewayLogOnTestFailure(t *testing.T, ctx framework.TestContext) {
 		if err != nil {
 			t.Logf("failed to get ingress gateway proxy log: %v", err)
 		} else {
-			t.Log("Dump ingress gateway proxy log\n%s", proxyLog)
+			t.Logf("dump ingress gateway proxy log\n%s", proxyLog)
 		}
 		agentLog, err := GetGatewayLog(t, ctx, "ingress-sds")
 		if err != nil {
 			t.Logf("failed to get ingress gateway agent log: %v", err)
 		} else {
-			t.Logf("Dump ingress gateway agent log\n%s", agentLog)
+			t.Logf("dump ingress gateway agent log\n%s", agentLog)
 		}
 	}
 }


### PR DESCRIPTION
Please provide a description for what this PR is for.
When ingress SDS integration test fails, dump the ingress gateway proxy log and gateway agent log for debugging.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

https://github.com/istio/istio/issues/13439