### PR TITLE
Remove legacy non-isolation EDS code

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -71,13 +71,6 @@ var (
 	// Default is 10s, Example: "300ms", "10s" or "2h45m".
 	DebounceMax = env.RegisterDurationVar("PILOT_DEBOUNCE_MAX", 10*time.Second, "").Get()
 
-	// DisableEDSIsolation provides an option to disable the feature
-	// of EDS isolation which is enabled by default from Istio 1.1 and
-	// go back to the legacy behavior of previous releases.
-	// If not set, Pilot will return the endpoints for a proxy in an isolated namespace.
-	// Set the environment variable to any value to disable.
-	DisableEDSIsolation = env.RegisterStringVar("PILOT_DISABLE_EDS_ISOLATION", "", "").Get()
-
 	// BaseDir is the base directory for locating configs.
 	// File based certificates are located under $BaseDir/etc/certs/. If not set, the original 1.0 locations will
 	// be used, "/"

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -130,7 +130,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 		listenerPort = 0
 	}
 
-
 	nameToServiceMap := make(map[model.Hostname]*model.Service)
 	for _, svc := range services {
 		if listenerPort == 0 {

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -183,9 +183,6 @@ func verifySyncStatus(t *testing.T, nodeID string, wantSent, wantAcked bool) {
 				if (ss.EndpointAcked != "") != wantAcked {
 					errorHandler("wanted EndpointAcked set %v got %v for %v", wantAcked, ss.EndpointAcked, nodeID)
 				}
-				if (ss.EndpointPercent != 0) != wantAcked {
-					errorHandler("wanted EndpointPercent set %v got %v for %v", wantAcked, ss.EndpointPercent, nodeID)
-				}
 				return
 			}
 		}


### PR DESCRIPTION
All proxies will now be given a default `egress: */*` Sidecar config.
Because of this, we no longer need the legacy code to handle proxies
without a Sidecar scope. The only exception to this is Gateways.
However, we can also give gateways a */* scope, which simplifies the EDS
code.

[x] Networking
