### PR TITLE
Add log on connection close done by Citadel Agent

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -618,11 +618,11 @@ func receiveThread(con *sdsConnection, reqChannel chan *xdsapi.DiscoveryRequest,
 			conIDresourceNamePrefix := sdsLogPrefix(con.conID, con.ResourceName)
 			con.mutex.RUnlock()
 			if status.Code(err) == codes.Canceled || err == io.EOF {
-				sdsServiceLog.Infof("%s connection terminated: %v", conIDresourceNamePrefix, err)
+				sdsServiceLog.Infof("%s connection is terminated: %v", conIDresourceNamePrefix, err)
 				return
 			}
 			*errP = err
-			sdsServiceLog.Errorf("%s connection terminated with errors %v", conIDresourceNamePrefix, err)
+			sdsServiceLog.Errorf("%s connection is terminated with errors %v", conIDresourceNamePrefix, err)
 			return
 		}
 		reqChannel <- req


### PR DESCRIPTION
Please provide a description for what this PR is for.
Currently in Citadel Agent, StreamSecrets() closes connections without indication in logs. When a connection is closed in this case, StreamSecrets() returns and the goroutine where it runs is deleted. But receiveThread() is still running on another goroutine. Soon after that, Envoy closes the same connection accordingly, and receiveThread() prints log showing that connection is terminated by Envoy. This could be misleading as it indicates Envoy actively closes the connection. The PR complements/updates logs when StreamSecrets() returns, to differentiate a connection closed by Citadel Agent and a connection closed by Envoy.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

https://github.com/istio/istio/issues/13439