### PR TITLE
Get rid of Values.global.istioNamespace helm value

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -128,10 +128,8 @@ spec:
           - --zipkinAddress
         {{- if $.Values.global.tracer.zipkin.address }}
           - {{ $.Values.global.tracer.zipkin.address }}
-        {{- else if $.Values.global.istioNamespace }}
-          - zipkin.{{ $.Values.global.istioNamespace }}:9411
         {{- else }}
-          - zipkin:9411
+          - zipkin.{{ $.Release.Namespace }}:9411
         {{- end }}
         {{- if $.Values.global.proxy.envoyStatsd.enabled }}
           - --statsdUdpAddress
@@ -153,20 +151,12 @@ spec:
           - --controlPlaneAuthPolicy
           - MUTUAL_TLS
           - --discoveryAddress
-          {{- if $.Values.global.istioNamespace }}
-          - istio-pilot.{{ $.Values.global.istioNamespace }}:15011
-          {{- else }}
-          - istio-pilot:15011
-          {{- end }}
+          - istio-pilot.{{ $.Release.Namespace }}:15011
         {{- else }}
           - --controlPlaneAuthPolicy
           - NONE
           - --discoveryAddress
-          {{- if $.Values.global.istioNamespace }}
-          - istio-pilot.{{ $.Values.global.istioNamespace }}:15010
-          {{- else }}
-          - istio-pilot:15010
-          {{- end }}
+          - istio-pilot.{{ $.Release.Namespace }}:15010
           {{- if $spec.applicationPorts }}
           - --applicationPorts
           - "{{ $spec.applicationPorts }}"


### PR DESCRIPTION
Its only usage is in the gateway deployments.

If the user wants to deploy the gateway in another namespace, and forget
setting this value, they will end up with a broken gateway deployment, due
to unreachable pilot and zipkin.

Setting their domains to `$.Release.Namespace` fixes the problem. This variable
is replaced by the control plane namespace, which is what we want. The gateway
itself will be installed in `values.namespace` or, if not set, in the same namespace
as the control plane (`$.Release.Namespace`).
