### PR TITLE
Clean up legacy pilot flags

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -941,7 +941,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go func() {
-			if features.EnableWaitCacheSync && !s.waitForCacheSync(stop) {
+			if !s.waitForCacheSync(stop) {
 				return
 			}
 
@@ -993,7 +993,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			go func() {
-				if features.EnableWaitCacheSync && !s.waitForCacheSync(stop) {
+				if !s.waitForCacheSync(stop) {
 					return
 				}
 

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -30,7 +30,6 @@ import (
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/monitoring"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
@@ -217,9 +216,7 @@ func (c *controller) HasSynced() bool {
 
 func (c *controller) Run(stop <-chan struct{}) {
 	go func() {
-		if features.EnableWaitCacheSync {
-			cache.WaitForCacheSync(stop, c.HasSynced)
-		}
+		cache.WaitForCacheSync(stop, c.HasSynced)
 		c.queue.Run(stop)
 	}()
 

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -30,7 +30,6 @@ import (
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
@@ -165,9 +164,7 @@ func (c *controller) HasSynced() bool {
 
 func (c *controller) Run(stop <-chan struct{}) {
 	go func() {
-		if features.EnableWaitCacheSync {
-			cache.WaitForCacheSync(stop, c.HasSynced)
-		}
+		cache.WaitForCacheSync(stop, c.HasSynced)
 		c.queue.Run(stop)
 	}()
 	go c.informer.Run(stop)

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+
 	"istio.io/pkg/log"
 
 	"istio.io/pkg/env"

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+	"istio.io/pkg/log"
 
 	"istio.io/pkg/env"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -125,10 +125,6 @@ var (
 		return len(enableLocalityLoadBalancingVar.Get()) != 0
 	}
 
-	// EnableWaitCacheSync provides an option to specify whether it should wait
-	// for cache sync before Pilot bootstrap. Set env PILOT_ENABLE_WAIT_CACHE_SYNC = 0 to disable it.
-	EnableWaitCacheSync = env.RegisterStringVar("PILOT_ENABLE_WAIT_CACHE_SYNC", "", "").Get() != "0"
-
 	enableFallthroughRouteVar = env.RegisterBoolVar(
 		"PILOT_ENABLE_FALLTHROUGH_ROUTE",
 		true,
@@ -137,30 +133,6 @@ var (
 			"When REGISTRY_ONLY traffic policy is used, a 502 error is returned.",
 	)
 	EnableFallthroughRoute = enableFallthroughRouteVar.Get
-
-	// DisablePartialRouteResponse provides an option to disable a partial route response. This
-	// will cause Pilot to send an error if any routes are invalid. The default behavior (without
-	// this flag) is to just skip the invalid route.
-	DisablePartialRouteResponse = env.RegisterBoolVar(
-		"PILOT_DISABLE_PARTIAL_ROUTE_RESPONSE",
-		false,
-		"DisablePartialRouteResponse provides an option to disable a partial route response. This "+
-			"will cause Pilot to send an error if any routes are invalid. The default behavior (without "+
-			"this flag) is to just skip the invalid route.")
-
-	// DisableEmptyRouteResponse provides an option to disable a partial route response. This
-	// will cause Pilot to ignore a route request if Pilot generates a nil route (due to an error).
-	// This may cause Envoy to wait forever for the route, blocking listeners from receiving traffic.
-	// The default behavior (without this flag set) is to explicitly send an empty route. This
-	// will break routing for that particular route, but allow others on the same listener to work.
-	DisableEmptyRouteResponse = env.RegisterBoolVar(
-		"PILOT_DISABLE_EMPTY_ROUTE_RESPONSE",
-		false,
-		"DisableEmptyRouteResponse provides an option to disable a partial route response. This "+
-			"will cause Pilot to ignore a route request if Pilot generates a nil route (due to an error). "+
-			"This may cause Envoy to wait forever for the route, blocking listeners from receiving traffic. "+
-			"The default behavior (without this flag set) is to explicitly send an empty route. This "+
-			"will break routing for that particular route, but allow others on the same listener to work.")
 
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
 	disableXDSMarshalingToAnyVar = env.RegisterStringVar("PILOT_DISABLE_XDS_MARSHALING_TO_ANY", "", "")

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -220,12 +220,6 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(env *model.Env
 	if _, ok := merged.ServersByRouteName[routeName]; !ok {
 		log.Warnf("Gateway missing for route %s. This is normal if gateway was recently deleted. Have %v", routeName, merged.ServersByRouteName)
 
-		// If the flag is set, send Envoy an error, blocking all routes from being sent. This flag
-		// is intended only to support legacy behavior and should be removed in the future.
-		if features.DisablePartialRouteResponse.Get() {
-			return nil, fmt.Errorf("buildGatewayRoutes: could not find server for routeName %s, have %v", routeName, merged.ServersByRouteName)
-		}
-
 		// This can happen when a gateway has recently been deleted. Envoy will still request route
 		// information due to the draining of listeners, so we should not return an error.
 		return nil, nil

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -21,7 +21,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/proto"
 )
@@ -69,12 +68,6 @@ func (s *DiscoveryServer) generateRawRoutes(con *XdsConnection, push *model.Push
 
 		if r == nil {
 			adsLog.Warnf("RDS: Got nil value for route:%s for node:%v", routeName, con.modelNode)
-
-			// Don't send an empty route, instead ignore the request. This may cause Envoy to block
-			// listeners waiting for this route
-			if features.DisableEmptyRouteResponse.Get() {
-				continue
-			}
 
 			// Explicitly send an empty route configuration
 			r = &xdsapi.RouteConfiguration{

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -267,9 +267,7 @@ func (c *Controller) HasSynced() bool {
 // Run all controllers until a signal is received
 func (c *Controller) Run(stop <-chan struct{}) {
 	go func() {
-		if features.EnableWaitCacheSync {
-			cache.WaitForCacheSync(stop, c.HasSynced)
-		}
+		cache.WaitForCacheSync(stop, c.HasSynced)
 		c.queue.Run(stop)
 	}()
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -35,7 +35,6 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/pkg/log"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/monitoring"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"


### PR DESCRIPTION
These features flags were intended to introduce risky code in the 1.1
release. As there have been no cases of needing this in 1.1 or 1.2, it
should be safe to clean these up for the 1.3 release.

Fixes https://github.com/istio/istio/issues/15442

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
