### PR TITLE
feat(node metadata): add bits to extract metadata via sidecar injector

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -200,6 +200,17 @@ containers:
     value: |
            {{ toJSON .ObjectMeta.Labels }}
   {{ end }}
+  {{- if .DeploymentMeta.Name }}
+  - name: ISTIO_META_WORKLOAD_NAME
+    value: {{ .DeploymentMeta.Name }}
+  {{ end }}
+  {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
+  - name: ISTIO_META_OWNER
+    value: kubernetes://api/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}/{{ .DeploymentMeta.Name }}
+  {{- end}}
+  - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+    value: |
+           {{ toJson (portsToContainers .Spec) }}
   {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
   - name: ISTIO_BOOTSTRAP_OVERRIDE
     value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -204,13 +204,12 @@ containers:
   - name: ISTIO_META_WORKLOAD_NAME
     value: {{ .DeploymentMeta.Name }}
   {{ end }}
-  {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
-  - name: ISTIO_META_OWNER
-    value: kubernetes://api/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}/{{ .DeploymentMeta.Name }}
+  {{- if and .TypeMeta.APIVersion .TypeMeta.Kind }}
+  - name: ISTIO_META_WORKLOAD_API_VERSION
+    value: {{ .TypeMeta.APIVersion }}
+  - name: ISTIO_META_WORKLOAD_KIND
+    value: {{ toLower .TypeMeta.Kind }}
   {{- end}}
-  - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-    value: |
-           {{ toJson (portsToContainers .Spec) }}
   {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
   - name: ISTIO_BOOTSTRAP_OVERRIDE
     value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -168,6 +168,10 @@ containers:
     valueFrom:
       fieldRef:
         fieldPath: status.podIP
+  - name: SERVICE_ACCOUNT
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.serviceAccountName
 {{ if eq .Values.global.proxy.tracer "datadog" }}
   - name: HOST_IP
     valueFrom:
@@ -204,12 +208,10 @@ containers:
   - name: ISTIO_META_WORKLOAD_NAME
     value: {{ .DeploymentMeta.Name }}
   {{ end }}
-  {{- if and .TypeMeta.APIVersion .TypeMeta.Kind }}
-  - name: ISTIO_META_WORKLOAD_API_VERSION
-    value: {{ .TypeMeta.APIVersion }}
-  - name: ISTIO_META_WORKLOAD_KIND
-    value: {{ toLower .TypeMeta.Kind }}
-  {{- end}}
+  {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
+  - name: ISTIO_META_OWNER
+    value: kubernetes://api/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}/{{ .DeploymentMeta.Name }}
+   {{- end}}
   {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
   - name: ISTIO_BOOTSTRAP_OVERRIDE
     value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"

--- a/istioctl/cmd/testdata/uninject/cronjob-with-app.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/cronjob-with-app.yaml.injected
@@ -62,6 +62,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             - name: ISTIO_META_POD_NAME
               valueFrom:
                 fieldRef:

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -532,6 +532,16 @@ const (
 	// NodeMetadataIdleTimeout specifies the idle timeout for the proxy, in duration format (10s).
 	// If not set, no timeout is set.
 	NodeMetadataIdleTimeout = "IDLE_TIMEOUT"
+
+	NodeMetadataCanonicalTelemetryService = "CANONICAL_TELEMETRY_SERVICE"
+	NodeMetadataLabels                    = "LABELS"
+	NodeMetadataWorkloadName              = "WORKLOAD_NAME"
+	NodeMetadataWorkloadAPIVersion        = "WORKLOAD_API_VERSION"
+	NodeMetadataWorkloadKind              = "WORKLOAD_KIND"
+	NodeMetadataServiceAccount            = "SERVICE_ACCOUNT"
+	NodeMetadataPlatformMetadata          = "PLATFORM_METADATA"
+	NodeMetadataInstanceName              = "NAME"      // replaces POD_NAME
+	NodeMetadataNamespace                 = "NAMESPACE" // Possibly replaces CONFIG_NAMESPACE
 )
 
 // TrafficInterceptionMode indicates how traffic to/from the workload is captured and

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -533,15 +533,34 @@ const (
 	// If not set, no timeout is set.
 	NodeMetadataIdleTimeout = "IDLE_TIMEOUT"
 
+	// NodeMetadataCanonicalTelemetryService specifies the service name to use for all node telemetry.
 	NodeMetadataCanonicalTelemetryService = "CANONICAL_TELEMETRY_SERVICE"
-	NodeMetadataLabels                    = "LABELS"
-	NodeMetadataWorkloadName              = "WORKLOAD_NAME"
-	NodeMetadataWorkloadAPIVersion        = "WORKLOAD_API_VERSION"
-	NodeMetadataWorkloadKind              = "WORKLOAD_KIND"
-	NodeMetadataServiceAccount            = "SERVICE_ACCOUNT"
-	NodeMetadataPlatformMetadata          = "PLATFORM_METADATA"
-	NodeMetadataInstanceName              = "NAME"      // replaces POD_NAME
-	NodeMetadataNamespace                 = "NAMESPACE" // Possibly replaces CONFIG_NAMESPACE
+
+	// NodeMetadataLabels specifies the set of workload instance (ex: k8s pod) labels associated with this node.
+	NodeMetadataLabels = "LABELS"
+
+	// NodeMetadataWorkloadName specifies the name of the workload represented by this node.
+	NodeMetadataWorkloadName = "WORKLOAD_NAME"
+
+	// NodeMetadataOwner specifies the workload owner (opaque string). Typically, this is the owning controller of
+	// of the workload instance (ex: k8s deployment for a k8s pod).
+	NodeMetadataOwner = "OWNER"
+
+	// NodeMetadataServiceAccount specifies the service account which is running the workload.
+	NodeMetadataServiceAccount = "SERVICE_ACCOUNT"
+
+	// NodeMetadataPlatformMetadata contains any platform specific metadata
+	NodeMetadataPlatformMetadata = "PLATFORM_METADATA"
+
+	// NodeMetadataInstanceName is the short name for the workload instance (ex: pod name)
+	NodeMetadataInstanceName = "NAME" // replaces POD_NAME
+
+	// NodeMetadataNamespace is the namespace in which the workload instance is running.
+	NodeMetadataNamespace = "NAMESPACE" // replaces CONFIG_NAMESPACE
+
+	// NodeMetadataExchangeKeys specifies a list of metadata keys that should be used for Node Metadata Exchange.
+	// The list is comma-separated.
+	NodeMetadataExchangeKeys = "EXCHANGE_KEYS"
 )
 
 // TrafficInterceptionMode indicates how traffic to/from the workload is captured and

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -238,11 +238,8 @@ type istioMetadata struct {
 	Owner                     string            `json:"owner,omitempty"`
 	PortsToContainers         map[string]string `json:"ports_to_containers,omitempty"`
 	ServiceAccount            string            `json:"service_account,omitempty"`
-<<<<<<< HEAD
 	PlatformMetadata          map[string]string `json:"platform_metadata,omitempty"`
-=======
 	WorkloadName              string            `json:"workload_name,omitempty"`
->>>>>>> feat(node metadata): add bits to extract metadata via sidecar injector
 }
 
 func shouldExtract(envVar, prefix string) bool {

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -235,16 +235,22 @@ type istioMetadata struct {
 	Labels                    map[string]string `json:"labels,omitempty"`
 	Name                      string            `json:"name,omitempty"`
 	Namespace                 string            `json:"namespace,omitempty"`
+	Owner                     string            `json:"owner,omitempty"`
+	PortsToContainers         map[string]string `json:"ports_to_containers,omitempty"`
 	ServiceAccount            string            `json:"service_account,omitempty"`
+<<<<<<< HEAD
 	PlatformMetadata          map[string]string `json:"platform_metadata,omitempty"`
+=======
+	WorkloadName              string            `json:"workload_name,omitempty"`
+>>>>>>> feat(node metadata): add bits to extract metadata via sidecar injector
 }
 
 func shouldExtract(envVar, prefix string) bool {
-	// this will allow transition from current method of exposition in the future
-	// Example:
-	// if strings.HasPrefix(envVar, "ISTIO_METAJSON_LABELS") {
-	// 	return false
-	// }
+	if strings.HasPrefix(envVar, "ISTIO_META_OWNER") ||
+		strings.HasPrefix(envVar, "ISTIO_META_WORKLOAD") ||
+		strings.HasPrefix(envVar, "ISTIO_METAJSON_PORTS") {
+		return false
+	}
 	return strings.HasPrefix(envVar, prefix)
 }
 
@@ -283,6 +289,13 @@ func extractIstioMetadata(envVars []string, plat platform.Environment) istioMeta
 			im.Name = val
 		case "POD_NAMESPACE":
 			im.Namespace = val
+		case "ISTIO_META_OWNER":
+			im.Owner = val
+		case "ISTIO_META_WORKLOAD_NAME":
+			im.WorkloadName = val
+		case "ISTIO_METAJSON_PORTS_TO_CONTAINERS":
+			m := jsonStringToMap(val)
+			im.PortsToContainers = m
 		}
 	}
 	if plat != nil {

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	ocv1 "istio.io/gogo-genproto/opencensus/proto/trace/v1"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/bootstrap/platform"
 	"istio.io/istio/pkg/test/env"
 )
@@ -632,13 +633,11 @@ func TestNodeMetadata(t *testing.T) {
 	plat := &fakePlatform{meta: map[string]string{"some_env": "foo", "other_env": "bar"}}
 
 	wantMap := map[string]interface{}{
-		"istio": "sidecar",
-		"istio.io/metadata": istioMetadata{
-			Labels:           labels,
-			PlatformMetadata: map[string]string{"some_env": "foo", "other_env": "bar"},
-		},
-		"l1": "v1",
-		"l2": "v2",
+		"istio":                            "sidecar",
+		model.NodeMetadataLabels:           labels,
+		model.NodeMetadataPlatformMetadata: map[string]string{"some_env": "foo", "other_env": "bar"},
+		"l1":                               "v1",
+		"l2":                               "v2",
 	}
 
 	_, envs := createEnv(t, labels, nil)

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -634,6 +634,7 @@ func TestNodeMetadata(t *testing.T) {
 
 	wantMap := map[string]interface{}{
 		"istio":                            "sidecar",
+		model.NodeMetadataExchangeKeys:     metadataExchangeKeys,
 		model.NodeMetadataLabels:           labels,
 		model.NodeMetadataPlatformMetadata: map[string]string{"some_env": "foo", "other_env": "bar"},
 		"l1":                               "v1",

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -6,7 +6,7 @@
     "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6", "istio":"sidecar",
       "ISTIO_META_SDS": "1",
       "ISTIO_META_TRUSTJWT": "1",
-      "istio.io/metadata":{}}
+      "alpha.istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -6,7 +6,7 @@
     "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6", "istio":"sidecar",
       "ISTIO_META_SDS": "1",
       "ISTIO_META_TRUSTJWT": "1",
-      "alpha.istio.io/metadata":{}}
+      "EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -20,7 +20,7 @@
       "istio":"sidecar",
       "istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}",
       "istio-locality": "regionA.zoneB.sub_zoneC",
-      "istio.io/metadata": {
+      "alpha.istio.io/metadata": {
         "ip": "10.10.10.1",
         "name" : "svc-0-0-0-6944fb884d-4pgx8",
         "namespace": "test",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -20,15 +20,13 @@
       "istio":"sidecar",
       "istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}",
       "istio-locality": "regionA.zoneB.sub_zoneC",
-      "alpha.istio.io/metadata": {
-        "ip": "10.10.10.1",
-        "name" : "svc-0-0-0-6944fb884d-4pgx8",
-        "namespace": "test",
-        "labels": {
+      "EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT",
+      "NAME": "svc-0-0-0-6944fb884d-4pgx8",
+      "NAMESPACE": "test",
+      "LABELS": {
           "version": "v1alpha1",
           "app": "test",
           "istio-locality": "regionA.zoneB.sub_zoneC"
-        }
       }
     }
   },

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{},"sidecar.istio.io/statsInclusionPrefixes":"cluster_manager,cluster.xds-grpc,listener."}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","sidecar.istio.io/statsInclusionPrefixes":"cluster_manager,cluster.xds-grpc,listener.","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{},"sidecar.istio.io/statsInclusionPrefixes":"cluster_manager,cluster.xds-grpc,listener."}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{},"sidecar.istio.io/statsInclusionPrefixes":"cluster_manager,cluster.xds-grpc,listener."}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -7,7 +7,7 @@
       
       
     },
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -7,7 +7,7 @@
       
       
     },
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","alpha.istio.io/metadata":{}}
+    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -598,16 +598,6 @@ func InjectionData(sidecarTemplate, valuesConfig, version string, typeMetadata *
 		return bbuf.String()
 	}
 
-	funcMap["portsToContainers"] = func(podSpec *corev1.PodSpec) map[string]string {
-		out := map[string]string{}
-		for _, container := range podSpec.Containers {
-			for _, cPort := range container.Ports {
-				out[strconv.Itoa(int(cPort.ContainerPort))] = container.Name
-			}
-		}
-		return out
-	}
-
 	bbuf, err := parseTemplate(sidecarTemplate, funcMap, data)
 	if err != nil {
 		return nil, "", err

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/pkg/log"
 
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/batch/v2alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -767,6 +768,12 @@ func intoObject(sidecarTemplate string, valuesConfig string, meshconfig *meshcon
 		metadata = &pod.ObjectMeta
 		deploymentMetadata = &pod.ObjectMeta
 		podSpec = &pod.Spec
+	case *appsv1.Deployment: // Added to be explicit about the most expected case
+		deploy := v
+		typeMeta = &deploy.TypeMeta
+		deploymentMetadata = &deploy.ObjectMeta
+		metadata = &deploy.Spec.Template.ObjectMeta
+		podSpec = &deploy.Spec.Template.Spec
 	default:
 		// `in` is a pointer to an Object. Dereference it.
 		outValue := reflect.ValueOf(out).Elem()

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -99,6 +99,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -117,6 +117,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello","90":"world"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333},"/app-health/world/livez":{"port":90}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -121,9 +121,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello","90":"world"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333},"/app-health/world/livez":{"port":90}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -114,6 +114,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello","90":"world"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -118,9 +118,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello","90":"world"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -96,6 +96,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -98,6 +98,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -117,9 +117,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello","90":"world"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333},"/app-health/world/livez":{"port":90}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -113,6 +113,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello","90":"world"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333},"/app-health/world/livez":{"port":90}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -98,9 +98,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"path":"/ip","port":8000}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -79,6 +79,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -94,6 +94,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"path":"/ip","port":8000}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -99,6 +99,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -114,6 +114,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello","90":"world"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333,"scheme":"HTTPS"},"/app-health/world/livez":{"port":90}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -118,9 +118,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello","90":"world"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333,"scheme":"HTTPS"},"/app-health/world/livez":{"port":90}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -98,9 +98,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"port":80}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -94,6 +94,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"port":80}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -79,6 +79,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -102,9 +102,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -98,6 +98,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -83,6 +83,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -98,9 +98,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"port":3333}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -94,6 +94,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"port":3333}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -79,6 +79,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -89,6 +89,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -104,6 +104,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello","90":"world"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"path":"/ip","port":8000},"/app-health/world/readyz":{"path":"/ipv6","port":9000}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -108,9 +108,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello","90":"world"}
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"path":"/ip","port":8000},"/app-health/world/readyz":{"path":"/ipv6","port":9000}}'
         image: docker.io/istio/proxyv2:unittest

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -84,9 +84,6 @@ spec:
               value: hellocron
             - name: ISTIO_META_OWNER
               value: kubernetes://api/batch/v2alpha1/namespaces/default/cronjob/hellocron
-            - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-              value: |
-                {}
             image: docker.io/istio/proxyv2:unittest
             imagePullPolicy: IfNotPresent
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -69,6 +69,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             - name: ISTIO_META_POD_NAME
               valueFrom:
                 fieldRef:

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -80,6 +80,13 @@ spec:
             - name: ISTIO_META_INTERCEPTION_MODE
               value: REDIRECT
             - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+            - name: ISTIO_META_WORKLOAD_NAME
+              value: hellocron
+            - name: ISTIO_META_OWNER
+              value: kubernetes://api/batch/v2alpha1/namespaces/default/cronjob/hellocron
+            - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+              value: |
+                {}
             image: docker.io/istio/proxyv2:unittest
             imagePullPolicy: IfNotPresent
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -89,6 +89,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/daemonset/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -93,9 +93,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/daemonset/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -74,6 +74,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -104,6 +104,13 @@ items:
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"backend","track":"stable"}
+          - name: ISTIO_META_WORKLOAD_NAME
+            value: hello
+          - name: ISTIO_META_OWNER
+            value: kubernetes://api/apps.openshift.io/v1/namespaces/default/deploymentconfig/hello
+          - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+            value: |
+              {"80":"hello"}
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -89,6 +89,10 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -108,9 +108,6 @@ items:
             value: hello
           - name: ISTIO_META_OWNER
             value: kubernetes://api/apps.openshift.io/v1/namespaces/default/deploymentconfig/hello
-          - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-            value: |
-              {"80":"hello"}
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -74,6 +74,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -89,6 +89,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps.openshift.io/v1/namespaces/default/deploymentconfig/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -93,9 +93,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps.openshift.io/v1/namespaces/default/deploymentconfig/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -107,6 +107,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"frontend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: frontend
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/frontend
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -111,9 +111,6 @@ spec:
           value: frontend
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/frontend
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -93,6 +93,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: Always
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: Always
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -77,6 +77,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -99,9 +99,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -95,6 +95,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -78,6 +78,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -251,6 +255,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -97,9 +97,6 @@ spec:
           value: hello-v1
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello-v1
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -273,9 +270,6 @@ spec:
           value: hello-v2
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello-v2
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"81":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -93,6 +93,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable","version":"v1"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello-v1
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello-v1
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -262,6 +269,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable","version":"v2"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello-v2
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello-v2
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"81":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -92,6 +92,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/test/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -77,6 +77,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -96,9 +96,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/test/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: Never
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: Never
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -95,6 +95,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxy2_debug:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -77,6 +77,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -99,9 +99,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxy2_debug:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -70,6 +70,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -89,9 +89,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -85,6 +85,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -82,9 +82,6 @@ spec:
           value: pi
         - name: ISTIO_META_OWNER
           value: kubernetes://api/batch/v1/namespaces/default/job/pi
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -78,6 +78,13 @@ spec:
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: pi
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/batch/v1/namespaces/default/job/pi
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -67,6 +67,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -77,6 +77,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -99,9 +99,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -95,6 +95,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -77,6 +77,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -99,9 +99,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -95,6 +95,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -112,9 +112,6 @@ items:
             value: frontend
           - name: ISTIO_META_OWNER
             value: kubernetes://api/apps/v1/namespaces/default/deployment/frontend
-          - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-            value: |
-              {}
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -94,6 +94,10 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -108,6 +108,13 @@ items:
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"frontend","track":"stable"}
+          - name: ISTIO_META_WORKLOAD_NAME
+            value: frontend
+          - name: ISTIO_META_OWNER
+            value: kubernetes://api/apps/v1/namespaces/default/deployment/frontend
+          - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+            value: |
+              {}
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -99,9 +99,6 @@ items:
             value: hello-v1
           - name: ISTIO_META_OWNER
             value: kubernetes://api/apps/v1/namespaces/default/deployment/hello-v1
-          - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-            value: |
-              {"80":"hello"}
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
@@ -274,9 +271,6 @@ items:
             value: hello-v2
           - name: ISTIO_META_OWNER
             value: kubernetes://api/apps/v1/namespaces/default/deployment/hello-v2
-          - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-            value: |
-              {"81":"hello"}
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -95,6 +95,13 @@ items:
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"backend","track":"stable","version":"v1"}
+          - name: ISTIO_META_WORKLOAD_NAME
+            value: hello-v1
+          - name: ISTIO_META_OWNER
+            value: kubernetes://api/apps/v1/namespaces/default/deployment/hello-v1
+          - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+            value: |
+              {"80":"hello"}
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
@@ -263,6 +270,13 @@ items:
           - name: ISTIO_METAJSON_LABELS
             value: |
               {"app":"hello","tier":"backend","track":"stable","version":"v2"}
+          - name: ISTIO_META_WORKLOAD_NAME
+            value: hello-v2
+          - name: ISTIO_META_OWNER
+            value: kubernetes://api/apps/v1/namespaces/default/deployment/hello-v2
+          - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+            value: |
+              {"81":"hello"}
           image: docker.io/istio/proxyv2:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -80,6 +80,10 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:
@@ -252,6 +256,10 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/pod-with-app.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod-with-app.yaml.injected
@@ -54,6 +54,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SERVICE_ACCOUNT
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.serviceAccountName
     - name: ISTIO_META_POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -61,6 +61,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SERVICE_ACCOUNT
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.serviceAccountName
     - name: ISTIO_META_POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -77,9 +77,6 @@ spec:
       value: hellopod
     - name: ISTIO_META_OWNER
       value: kubernetes://api/v1/namespaces/default/pod/hellopod
-    - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-      value: |
-        {"80":"hello"}
     image: docker.io/istio/proxyv2:unittest
     imagePullPolicy: IfNotPresent
     name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -73,6 +73,13 @@ spec:
       value: REDIRECT
     - name: ISTIO_META_INCLUDE_INBOUND_PORTS
       value: "80"
+    - name: ISTIO_META_WORKLOAD_NAME
+      value: hellopod
+    - name: ISTIO_META_OWNER
+      value: kubernetes://api/v1/namespaces/default/pod/hellopod
+    - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+      value: |
+        {"80":"hello"}
     image: docker.io/istio/proxyv2:unittest
     imagePullPolicy: IfNotPresent
     name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -90,9 +90,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/replicaset/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -71,6 +71,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -86,6 +86,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/replicaset/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -85,6 +85,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"nginx"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: nginx
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/v1/namespaces/default/replicationcontroller/nginx
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"nginx"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -70,6 +70,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -89,9 +89,6 @@ spec:
           value: nginx
         - name: ISTIO_META_OWNER
           value: kubernetes://api/v1/namespaces/default/replicationcontroller/nginx
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"nginx"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -94,6 +94,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/statefulset/hello
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -79,6 +79,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -98,9 +98,6 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/statefulset/hello
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"hello"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -95,6 +95,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"status"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: statusPort
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/statusPort
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"status"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -99,9 +99,6 @@ spec:
           value: statusPort
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/statusPort
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"status"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -77,6 +77,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -87,6 +87,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"status"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: statusPort
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/statusPort
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"status"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -91,9 +91,6 @@ spec:
           value: statusPort
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/statusPort
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"status"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -72,6 +72,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -90,6 +90,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: traffic
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/traffic
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"traffic"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -94,9 +94,6 @@ spec:
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/traffic
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"traffic"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -73,6 +73,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -91,6 +91,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: traffic
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/traffic
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"traffic"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -73,6 +73,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -95,9 +95,6 @@ spec:
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/traffic
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"traffic"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -74,6 +74,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -92,6 +92,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: traffic
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/traffic
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"traffic"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -96,9 +96,6 @@ spec:
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/traffic
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"traffic"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -90,9 +90,6 @@ spec:
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/traffic
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"traffic"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -86,6 +86,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: traffic
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/traffic
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"traffic"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -71,6 +71,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -69,6 +69,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -84,6 +84,13 @@ spec:
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"traffic"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: traffic
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployment/traffic
+        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
+          value: |
+            {"80":"traffic"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -88,9 +88,6 @@ spec:
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://api/apps/v1/namespaces/default/deployment/traffic
-        - name: ISTIO_METAJSON_PORTS_TO_CONTAINERS
-          value: |
-            {"80":"traffic"}
         image: docker.io/istio/proxyv2:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -73,6 +73,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -72,6 +72,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -72,6 +72,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -78,6 +78,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -74,6 +74,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -241,6 +245,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -94,6 +94,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -68,6 +68,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -79,6 +79,10 @@ spec:
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: pi
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/v1/namespaces/default/pod/pi
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -78,6 +78,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -241,6 +245,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -68,6 +68,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -70,6 +70,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -80,6 +80,10 @@ spec:
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
           value: "80"
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: nginx
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/v1/namespaces/default/pod/nginx
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -68,6 +68,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -72,6 +72,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -77,6 +77,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -75,6 +75,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -74,6 +74,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -74,6 +74,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -75,6 +75,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -76,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -600,11 +600,10 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 
 	if len(pod.GenerateName) > 0 {
 		// if the pod name was generated (or is scheduled for generation), we can begin an investigation into the controlling reference for the pod.
-		// podPrefix := pod.GenerateName
 		var controllerRef metav1.OwnerReference
 		controllerFound := false
 		for _, ref := range pod.GetOwnerReferences() {
-			if *ref.Controller == true {
+			if *ref.Controller {
 				controllerRef = ref
 				controllerFound = true
 				break


### PR DESCRIPTION
This PR is a follow-on to #15143. 

It does a number of small items, based on feedback gathered during review:
1. removes `istio.io/metadata` and the associated nested struct. metadata is now flattened.
1. adds a `EXCHANGE_KEYS` metadata label to control which bits of metadata are used in peer exchange.
1. calculates `OWNER` information based on supplied config for manual injection and a heuristic for automatic.
1. adds `WORKLOAD_NAME` metadata
1. includes `SERVICE_ACCOUNT` metadata

This PR is a building block towards a v2 architecture. It represents a further step towards realizing the design approved in https://tinyurl.com/yxablanu.

Example output with webhook for bookinfo's `ratings-v1` running on GKE:

```json
     "metadata": {
      "NAMESPACE": "default",
      "INCLUDE_INBOUND_PORTS": "9080",
      "app": "ratings",
      "EXCHANGE_KEYS": "NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT",
      "INSTANCE_IPS": "10.52.0.34,fe80::a075:11ff:fe5e:f1cd",
      "pod-template-hash": "84975bc778",
      "INTERCEPTION_MODE": "REDIRECT",
      "SERVICE_ACCOUNT": "bookinfo-ratings",
      "CONFIG_NAMESPACE": "default",
      "version": "v1",
      "OWNER": "kubernetes://api/apps/v1/namespaces/default/deployment/ratings-v1",
      "WORKLOAD_NAME": "ratings-v1",
      "ISTIO_VERSION": "1.3-dev",
      "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container ratings",
      "POD_NAME": "ratings-v1-84975bc778-pxz2w",
      "istio": "sidecar",
      "PLATFORM_METADATA": {
       "gcp_cluster_name": "<redacted>",
       "gcp_project": "<redacted>",
       "gcp_cluster_location": "us-east4-b"
      },
      "LABELS": {
       "app": "ratings",
       "version": "v1",
       "pod-template-hash": "84975bc778"
      },
      "ISTIO_PROXY_SHA": "istio-proxy:47e4559b8e4f0d516c0d17b233d127a3deb3d7ce",
      "NAME": "ratings-v1-84975bc778-pxz2w"
     },
```

NOTE: There is some label duplication (`CONFIG_NAMESPACE`, `NAMESPACE`). This is done to maintain backwards compatibility during name standardization. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
