### PR TITLE
Fix spelling for 'expected' on test files.

### DIFF
--- a/mixer/adapter/redisquota/redisquota_test.go
+++ b/mixer/adapter/redisquota/redisquota_test.go
@@ -640,12 +640,12 @@ func TestHandleQuotaErrorMsg(t *testing.T) {
 		}
 
 		if len(env.GetLogs()) != len(c.errMsg) {
-			t.Errorf("%v: Invalid number of error messages. Exptected: %v Got %v",
+			t.Errorf("%v: Invalid number of error messages. Expected: %v Got %v",
 				id, len(c.errMsg), len(env.GetLogs()))
 		} else {
 			for idx, msg := range c.errMsg {
 				if msg != env.GetLogs()[idx] {
-					t.Errorf("%v: Unexpected error message. Exptected: %v Got %v",
+					t.Errorf("%v: Unexpected error message. Expected: %v Got %v",
 						id, msg, env.GetLogs()[idx])
 				}
 			}

--- a/security/pkg/platform/gcp_test.go
+++ b/security/pkg/platform/gcp_test.go
@@ -232,7 +232,7 @@ func TestGcpGetAgentCredentials(t *testing.T) {
 		expectedErr        string
 		expectedCredential []byte
 	}{
-		"Token abddef is exptected": {
+		"Token abddef is expected": {
 			token:              "abcdef",
 			tokenFetchErr:      "",
 			expectedErr:        "",

--- a/security/pkg/platform/onprem_test.go
+++ b/security/pkg/platform/onprem_test.go
@@ -190,9 +190,9 @@ func TestOnpremIsProperPlatform(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create OnPrem client %v", err)
 	}
-	exptected := onprem.IsProperPlatform()
-	if !exptected {
-		t.Errorf("Unexpected response: %v.", exptected)
+	expected := onprem.IsProperPlatform()
+	if !expected {
+		t.Errorf("Unexpected response: %v.", expected)
 	}
 }
 


### PR DESCRIPTION
Some test files had the word `expected` misspelled as `exptected`.

This PR fix the spelling.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
