### PR TITLE
Add e2e test for Citadel dashboard

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/dashboards/citadel-dashboard.json
+++ b/install/kubernetes/helm/istio/charts/grafana/dashboards/citadel-dashboard.json
@@ -726,7 +726,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "citadel_server_authentication_failure_count{job=\"citadel\"}\t",
+          "expr": "citadel_server_authentication_failure_count{job=\"citadel\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Authentication Failure Count",

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -49,6 +49,7 @@ const (
 	mixerDashboard       = "install/kubernetes/helm/istio/charts/grafana/dashboards/mixer-dashboard.json"
 	pilotDashboard       = "install/kubernetes/helm/istio/charts/grafana/dashboards/pilot-dashboard.json"
 	galleyDashboard      = "install/kubernetes/helm/istio/charts/grafana/dashboards/galley-dashboard.json"
+	citadelDashboard     = "install/kubernetes/helm/istio/charts/grafana/dashboards/citadel-dashboard.json"
 	fortioYaml           = "tests/e2e/tests/dashboard/fortio-rules.yaml"
 	netcatYaml           = "tests/e2e/tests/dashboard/netcat-rules.yaml"
 
@@ -136,6 +137,7 @@ func TestDashboards(t *testing.T) {
 		{"Istio", istioMeshDashboard, func(queries []string) []string { return queries }, nil, "istio-telemetry", 42422},
 		{"Service", serviceDashboard, func(queries []string) []string { return queries }, nil, "istio-telemetry", 42422},
 		{"Workload", workloadDashboard, func(queries []string) []string { return queries }, workloadReplacer, "istio-telemetry", 42422},
+		{"Citadel", citadelDashboard, citadelQueryFilterFn, nil, "istio-citadel", 15014},
 		{"Mixer", mixerDashboard, mixerQueryFilterFn, nil, "istio-telemetry", 15014},
 		{"Pilot", pilotDashboard, pilotQueryFilterFn, nil, "istio-pilot", 15014},
 		{"Galley", galleyDashboard, galleyQueryFilterFn, nil, "istio-galley", 15014},
@@ -348,6 +350,26 @@ func galleyQueryFilterFn(queries []string) []string {
 		}
 		// This is a frequent source of flakes in e2e-dashboard test. Remove from checked queries for now.
 		if strings.Contains(query, "runtime_strategy_timer_quiesce_reached_total") {
+			continue
+		}
+		filtered = append(filtered, query)
+	}
+	return filtered
+}
+
+func citadelQueryFilterFn(queries []string) []string {
+	filtered := make([]string, 0, len(queries))
+	for _, query := range queries {
+		if strings.Contains(query, "csr_err_count") {
+			continue
+		}
+		if strings.Contains(query, "svc_acc_created_cert_count") {
+			continue
+		}
+		if strings.Contains(query, "acc_deleted_cert_count") {
+			continue
+		}
+		if strings.Contains(query, "secret_deleted_cert_count") {
 			continue
 		}
 		filtered = append(filtered, query)


### PR DESCRIPTION
[This PR](https://github.com/istio/istio/pull/15297#event-2471264791) introduced a basic Grafana dashboard for Citadel. All the other dashboards have [e2e tests](https://github.com/istio/istio/blob/master/tests/e2e/tests/dashboard/dashboard_test.go) which make sure the metrics used in their dashboards exist and are accessible from Prometheus. This PR adds one such test for Citadel.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure