### PR TITLE
Make all proxies, even gateways, have SidecarScope

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -72,13 +72,6 @@ var (
 	// Default is 10s, Example: "300ms", "10s" or "2h45m".
 	DebounceMax = env.RegisterDurationVar("PILOT_DEBOUNCE_MAX", 10*time.Second, "").Get()
 
-	// DisableEDSIsolation provides an option to disable the feature
-	// of EDS isolation which is enabled by default from Istio 1.1 and
-	// go back to the legacy behavior of previous releases.
-	// If not set, Pilot will return the endpoints for a proxy in an isolated namespace.
-	// Set the environment variable to any value to disable.
-	DisableEDSIsolation = env.RegisterStringVar("PILOT_DISABLE_EDS_ISOLATION", "", "").Get()
-
 	// BaseDir is the base directory for locating configs.
 	// File based certificates are located under $BaseDir/etc/certs/. If not set, the original 1.0 locations will
 	// be used, "/"

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -205,8 +205,14 @@ func (node *Proxy) GetRouterMode() RouterMode {
 // Listener generation code will still use the SidecarScope object directly
 // as it needs the set of services for each listener port.
 func (node *Proxy) SetSidecarScope(ps *PushContext) {
-	labels := node.WorkloadLabels
-	node.SidecarScope = ps.getSidecarScope(node, labels)
+	if node.Type == SidecarProxy {
+		labels := node.WorkloadLabels
+		node.SidecarScope = ps.getSidecarScope(node, labels)
+	} else {
+		// Gateways should just have a default scope with egress: */*
+		node.SidecarScope = DefaultSidecarScopeForNamespace(ps, node.ConfigNamespace)
+	}
+
 }
 
 func (node *Proxy) SetServiceInstances(env *Environment) error {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -859,6 +859,7 @@ func (ps *PushContext) initDestinationRules(env *Environment) error {
 // SetDestinationRules is updates internal structures using a set of configs.
 // Split out of DestinationRule expensive conversions, computed once per push.
 // This also allows tests to inject a config without having the mock.
+// This will not work properly for Sidecars, which will precompute their destination rules on init
 func (ps *PushContext) SetDestinationRules(configs []Config) {
 	// Sort by time first. So if two destination rule have top level traffic policies
 	// we take the first one.

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -429,7 +429,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(env *model.Environmen
 
 	_, actualLocalHost := getActualWildcardAndLocalHost(proxy)
 
-	if sidecarScope == nil || !sidecarScope.HasCustomIngressListeners {
+	if !sidecarScope.HasCustomIngressListeners {
 		// No user supplied sidecar scope or the user supplied one has no ingress listeners
 
 		// We should not create inbound listeners in NONE mode based on the service instances

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -116,33 +116,24 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 	var virtualServices []model.Config
 	var services []*model.Service
 
-	// Get the list of services that correspond to this egressListener from the sidecarScope
-	sidecarScope := node.SidecarScope
-	// sidecarScope should never be nil
-	if sidecarScope != nil && sidecarScope.Config != nil {
-		// this is a user supplied sidecar scope. Get the services from the egress listener
-		egressListener := sidecarScope.GetEgressListenerForRDS(listenerPort, routeName)
-		// We should never be getting a nil egress listener because the code that setup this RDS
-		// call obviously saw an egress listener
-		if egressListener == nil {
-			return nil
-		}
+	// this is a user supplied sidecar scope. Get the services from the egress listener
+	egressListener := node.SidecarScope.GetEgressListenerForRDS(listenerPort, routeName)
+	// We should never be getting a nil egress listener because the code that setup this RDS
+	// call obviously saw an egress listener
+	if egressListener == nil {
+		return nil
+	}
 
-		services = egressListener.Services()
-		// To maintain correctness, we should only use the virtualservices for
-		// this listener and not all virtual services accessible to this proxy.
-		virtualServices = egressListener.VirtualServices()
+	services = egressListener.Services()
+	// To maintain correctness, we should only use the virtualservices for
+	// this listener and not all virtual services accessible to this proxy.
+	virtualServices = egressListener.VirtualServices()
 
-		// When generating RDS for ports created via the SidecarScope, we treat
-		// these ports as HTTP proxy style ports. All services attached to this listener
-		// must feature in this RDS route irrespective of the service port.
-		if egressListener.IstioListener != nil && egressListener.IstioListener.Port != nil {
-			listenerPort = 0
-		}
-	} else {
-		meshGateway := map[string]bool{model.IstioMeshGateway: true}
-		services = push.Services(node)
-		virtualServices = push.VirtualServices(node, meshGateway)
+	// When generating RDS for ports created via the SidecarScope, we treat
+	// these ports as HTTP proxy style ports. All services attached to this listener
+	// must feature in this RDS route irrespective of the service port.
+	if egressListener.IstioListener != nil && egressListener.IstioListener.Port != nil {
+		listenerPort = 0
 	}
 
 	nameToServiceMap := make(map[model.Hostname]*model.Service)

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -70,9 +70,7 @@ func (builder *ListenerBuilder) buildManagementListeners(_ *ConfigGeneratorImpl,
 	// Do not generate any management port listeners if the user has specified a SidecarScope object
 	// with ingress listeners. Specifying the ingress listener implies that the user wants
 	// to only have those specific listeners and nothing else, in the inbound path.
-	sidecarScope := node.SidecarScope
-	if sidecarScope != nil && sidecarScope.HasCustomIngressListeners ||
-		noneMode {
+	if node.SidecarScope.HasCustomIngressListeners || noneMode {
 		return builder
 	}
 	// Let ServiceDiscovery decide which IP and Port are used for management if

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -524,10 +524,8 @@ func (s *DiscoveryServer) initConnectionNode(discReq *xdsapi.DiscoveryRequest, c
 		return err
 	}
 
-	// Set the sidecarScope associated with this proxy if its a sidecar.
-	if nt.Type == model.SidecarProxy {
-		nt.SetSidecarScope(s.globalPushContext())
-	}
+	// Set the sidecarScope associated with this proxy
+	nt.SetSidecarScope(s.globalPushContext())
 
 	con.mu.Lock()
 	con.modelNode = nt
@@ -576,13 +574,11 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 		}
 	}
 
-	// Precompute the sidecar scope associated with this proxy if its a sidecar type.
+	// Precompute the sidecar scope associated with this proxy.
 	// Saves compute cycles in networking code. Though this might be redundant sometimes, we still
 	// have to compute this because as part of a config change, a new Sidecar could become
 	// applicable to this proxy
-	if con.modelNode.Type == model.SidecarProxy {
-		con.modelNode.SetSidecarScope(pushEv.push)
-	}
+	con.modelNode.SetSidecarScope(pushEv.push)
 
 	adsLog.Infof("Pushing %v", con.ConID)
 

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -508,14 +508,15 @@ func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
 	comma := false
 	if len(edsClusters) > 0 {
 		fmt.Fprintln(w, "[")
-		for _, eds := range edsClusters {
+		for cluster := range edsClusters {
 			if comma {
 				fmt.Fprint(w, ",\n")
 			} else {
 				comma = true
 			}
+			cla := s.loadAssignmentsForClusterLegacy(s.globalPushContext(), cluster)
 			jsonm := &jsonpb.Marshaler{Indent: "  "}
-			dbgString, _ := jsonm.MarshalToString(eds.LoadAssignment)
+			dbgString, _ := jsonm.MarshalToString(cla)
 			if _, err := w.Write([]byte(dbgString)); err != nil {
 				return
 			}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -677,7 +677,6 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 	loadAssignments := []*xdsapi.ClusterLoadAssignment{}
 	endpoints := 0
 	empty := []string{}
-	sidecarScope := con.modelNode.SidecarScope
 
 	// All clusters that this endpoint is watching. For 1.0 - it's typically all clusters in the mesh.
 	// For 1.1+Sidecar - it's the small set of explicitly imported clusters, using the isolated DestinationRules
@@ -692,13 +691,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 			}
 		}
 
-		var l *xdsapi.ClusterLoadAssignment
-		// decide which to use based on presence of Sidecar.
-		if sidecarScope == nil || sidecarScope.Config == nil || len(features.DisableEDSIsolation) != 0 {
-			l = s.loadAssignmentsForClusterLegacy(push, clusterName)
-		} else {
-			l = s.loadAssignmentsForClusterIsolated(con.modelNode, push, clusterName)
-		}
+		l := s.loadAssignmentsForClusterIsolated(con.modelNode, push, clusterName)
 
 		if l == nil {
 			continue

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -319,22 +319,9 @@ func testUdsEndpoints(_ *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 
 // Update
 func edsUpdates(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
-
 	// Old style (non-incremental)
-	server.EnvoyXdsServer.MemRegistry.AddInstance(edsIncSvc, &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: "127.0.0.3",
-			Port:    int(testEnv.Ports().BackendPort),
-			ServicePort: &model.Port{
-				Name:     "http-main",
-				Port:     8080,
-				Protocol: model.ProtocolHTTP,
-			},
-			Locality: "az",
-		},
-		ServiceAccount: "hello-sa",
-		Labels:         map[string]string{"version": "v1"},
-	})
+	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc,
+		newEndpointWithAccount("127.0.0.3", "hello-sa", "v1"))
 
 	v2.AdsPushAll(server.EnvoyXdsServer)
 	// will trigger recompute and push


### PR DESCRIPTION
By giving gateways a `egress: */*` we can simplify the code and use the
assumption that sidecarscope is never nil. This is a stepping stone to
removing the old EDS legacy code entirely

This code is essentially a subset of https://github.com/istio/istio/pull/15531. That PR tries to do two things at once which makes it hard to understand and debug.

[x] Networking