### PR TITLE
Add specific DestinationRule for SimpleIngress test

### DIFF
--- a/tests/e2e/tests/simple/testdata/v1alpha3/servicesToBeInjected.yaml
+++ b/tests/e2e/tests/simple/testdata/v1alpha3/servicesToBeInjected.yaml
@@ -27,6 +27,16 @@ spec:
     - "*"
 ---
 apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: echosrv
+spec:
+  host: 'echosrv.istio-system.svc.cluster.local'
+  trafficPolicy:
+    tls:
+      mode: DISABLE​
+---
+apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: echosrv

--- a/tests/e2e/tests/simple/testdata/v1alpha3/servicesToBeInjected.yaml
+++ b/tests/e2e/tests/simple/testdata/v1alpha3/servicesToBeInjected.yaml
@@ -34,7 +34,7 @@ spec:
   host: 'echosrv.istio-system.svc.cluster.local'
   trafficPolicy:
     tls:
-      mode: DISABLE​
+      mode: DISABLE
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService


### PR DESCRIPTION
This PR fixes: https://github.com/istio/istio/issues/15577 and allows the simple test to be run on an mTLS activated istio cluster e.g. if you want to run the e2e tests on an existing istio cluster.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
