### PR TITLE
 Make redis tests reliable

### DIFF
--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"testing"
 
+	"fortio.org/fortio/fhttp"
+
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/bookinfo"
@@ -34,18 +36,18 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 	"istio.io/istio/pkg/test/framework/components/redis"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	util "istio.io/istio/tests/integration/mixer"
 )
 
 var (
-	ist        istio.Instance
-	bookinfoNs namespace.Instance
-	g          galley.Instance
-	red        redis.Instance
-	ing        ingress.Instance
-	prom       prometheus.Instance
+	ist                                                  istio.Instance
+	bookinfoNs                                           namespace.Instance
+	g                                                    galley.Instance
+	red                                                  redis.Instance
+	ing                                                  ingress.Instance
+	prom                                                 prometheus.Instance
+	prior200s, prior429s, errorInRequestReportingAllowed float64
 )
 
 func TestRateLimiting_RedisQuotaFixedWindow(t *testing.T) {
@@ -59,8 +61,6 @@ func TestRateLimiting_RedisQuotaRollingWindow(t *testing.T) {
 func TestRateLimiting_DefaultLessThanOverride(t *testing.T) {
 	framework.
 		NewTest(t).
-		// TODO(https://github.com/istio/istio/issues/15686) deflake and remove label
-		Label(label.Flaky).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			destinationService := "productpage"
@@ -68,162 +68,211 @@ func TestRateLimiting_DefaultLessThanOverride(t *testing.T) {
 			config := setupConfigOrFail(t, bookinfo.ProductPageRedisRateLimit, bookInfoNameSpaceStr,
 				red, g, ctx)
 			defer deleteConfigOrFail(t, config, g, ctx)
+			defer func() {
+				deleteConfigOrFail(t, config, g, ctx)
+				util.AllowRuleSync(t)
+			}()
 			util.AllowRuleSync(t)
 
+			util.ValidateBookInfoGatewayIsSetup(t, prom, bookinfoNs)
 			res := util.SendTraffic(ing, t, "Sending traffic...", "", "", 300)
-			totalReqs := float64(res.DurationHistogram.Count)
-			succReqs := float64(res.RetCodes[http.StatusOK])
-			got429s := float64(res.RetCodes[http.StatusTooManyRequests])
-			actualDuration := res.ActualDuration.Seconds() // can be a bit more than requested
-
-			// Sending 600 requests at 10qps, and limit allowed is 50 for 30s, so we should see approx 100 requests go
-			// through.
-			want200s := 50.0
-			// everything in excess of 200s should be 429s (ideally)
-			want429s := totalReqs - want200s
-			t.Logf("Expected Totals: 200s: %f (%f rps), 429s: %f (%f rps)", want200s, want200s/actualDuration,
-				want429s, want429s/actualDuration)
-
-			// As rate limit is applied at ingressgateway itself, fortio should see the limits too.
-			want := math.Floor(want200s * 0.90)
-			if succReqs < want {
-				attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
-					util.Fqdn(destinationService, bookInfoNameSpaceStr)),
-					fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 200),
-					fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
-				t.Logf("prometheus values for istio_requests_total for 200's:\n%s",
-					util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
-				t.Errorf("Bad metric value for successful requests (200s): got %f, want at least %f", succReqs, want)
-			}
-
-			// check resource exhausted
-			// TODO: until https://github.com/istio/istio/issues/3028 is fixed, use 50% - should be only 5% or so
-			want429s = math.Floor(want429s * 0.50)
-			if got429s < want429s {
-				attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
-					util.Fqdn(destinationService, bookInfoNameSpaceStr)),
-					fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 429),
-					fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
-				t.Logf("prometheus values for istio_requests_total for 429's:\n%s",
-					util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
-				t.Errorf("Bad metric value for rate-limited requests (429s): got %f, want at least %f", got429s,
-					want429s)
+			err := validateDefaultLessThanOverride(res, t, destinationService, bookInfoNameSpaceStr)
+			if err != nil {
+				t.Logf("Got error, trying again. Err: %v", err)
+				res = util.SendTraffic(ing, t, "Sending traffic...", "", "", 300)
+				err = validateDefaultLessThanOverride(res, t, destinationService, bookInfoNameSpaceStr)
+				if err != nil {
+					// Fail now, as its still error'ing out.
+					t.Fatalf("Failed with err %v", err)
+				}
 			}
 		})
 }
 
 func testRedisQuota(t *testing.T, config bookinfo.ConfigFile, destinationService string) {
-	framework.NewTest(t).Label(label.Flaky).Run(func(ctx framework.TestContext) {
+	framework.Run(t, func(ctx framework.TestContext) {
 		g.ApplyConfigOrFail(
 			t,
 			bookinfoNs,
 			bookinfo.NetworkingReviewsV3Rule.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 		)
-		defer g.DeleteConfigOrFail(t,
-			bookinfoNs,
-			bookinfo.NetworkingReviewsV3Rule.LoadWithNamespaceOrFail(t, bookinfoNs.Name()))
 		bookInfoNameSpaceStr := bookinfoNs.Name()
 		config := setupConfigOrFail(t, config, bookInfoNameSpaceStr, red, g, ctx)
-		defer deleteConfigOrFail(t, config, g, ctx)
+		defer func() {
+			g.DeleteConfigOrFail(t,
+				bookinfoNs,
+				bookinfo.NetworkingReviewsV3Rule.LoadWithNamespaceOrFail(t, bookinfoNs.Name()))
+			deleteConfigOrFail(t, config, g, ctx)
+			util.AllowRuleSync(t)
+		}()
 		util.AllowRuleSync(t)
 
-		// This is the number of requests we allow to be missing to be reported, so as to make test stable.
-		errorInRequestReportingAllowed := 5.0
-		_ = util.SendTraffic(ing, t, "Sending traffic...", "", "", 300)
-		prior429s, prior200s := util.FetchRequestCount(t, prom, destinationService, "",
-			bookInfoNameSpaceStr, 300)
-
-		res := util.SendTraffic(ing, t, "Sending traffic...", "", "", 300)
-		totalReqs := res.DurationHistogram.Count
-		succReqs := float64(res.RetCodes[http.StatusOK])
-		badReqs := res.RetCodes[http.StatusBadRequest]
-		actualDuration := res.ActualDuration.Seconds() // can be a bit more than requested
-
-		t.Log("Successfully sent request(s) to /productpage; checking metrics...")
-		t.Logf("Fortio Summary: %d reqs (%f rps, %f 200s (%f rps), %d 400s - %+v)",
-			totalReqs, res.ActualQPS, succReqs, succReqs/actualDuration, badReqs, res.RetCodes)
-
-		// consider only successful requests (as recorded at productpage service)
-		callsToRatings := succReqs
-		want200s := 50.0
-		// everything in excess of 200s should be 429s (ideally)
-		want429s := callsToRatings - want200s
-		t.Logf("Expected Totals: 200s: %f (%f rps), 429s: %f (%f rps)", want200s, want200s/actualDuration,
-			want429s, want429s/actualDuration)
-		// if we received less traffic than the expected enforced limit to ratings
-		// then there is no way to determine if the rate limit was applied at all
-		// and for how much traffic. log all metrics and abort test.
-		if callsToRatings < want200s {
-			attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
-				util.Fqdn(destinationService, bookInfoNameSpaceStr))}
-			t.Logf("full set of prometheus metrics for ratings:\n%s",
-				util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
-			t.Fatalf("Not enough traffic generated to exercise rate limit: %s_reqs=%f, want200s=%f",
-				destinationService, callsToRatings, want200s)
-		}
-
-		got429s, got200s := util.FetchRequestCount(t, prom, destinationService, "", bookInfoNameSpaceStr,
-			prior429s+prior200s+300-errorInRequestReportingAllowed)
-		if got429s == 0 {
-			attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
-				util.Fqdn(destinationService, bookInfoNameSpaceStr)),
-				fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 429),
-				fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
-			t.Logf("prometheus values for istio_requests_total for 429's:\n%s",
-				util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
-			t.Errorf("Could not find 429s")
-		}
-		want429s = math.Floor(want429s * 0.90)
-		got429s -= prior429s
-		t.Logf("Actual 429s: %f (%f rps)", got429s, got429s/actualDuration)
-		// check resource exhausted
-		if got429s < want429s {
-			attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
-				util.Fqdn(destinationService, bookInfoNameSpaceStr)),
-				fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 429),
-				fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
-			t.Logf("prometheus values for istio_requests_total for 429's:\n%s",
-				util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
-			t.Errorf("Bad metric value for rate-limited requests (429s): got %f, want at least %f", got429s,
-				want429s)
-		}
-		if got200s == 0 {
-			attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
-				util.Fqdn(destinationService, bookInfoNameSpaceStr)),
-				fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 200),
-				fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
-			t.Logf("prometheus values for istio_requests_total for 200's:\n%s",
-				util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
-			t.Errorf("Could not find successes value")
-		}
-		got200s -= prior200s
-		t.Logf("Actual 200s: %f (%f rps), expecting ~1.666rps", got200s, got200s/actualDuration)
-		// establish some baseline to protect against flakiness due to randomness in routing
-		// and to allow for leniency in actual ceiling of enforcement (if 10 is the limit, but we allow slightly
-		// less than 10, don't fail this test).
-		want := math.Floor(want200s * 0.90)
-		// check successes
-		if got200s < want {
-			attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
-				util.Fqdn(destinationService, bookInfoNameSpaceStr)),
-				fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 200),
-				fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
-			t.Logf("prometheus values for istio_requests_total for 200's:\n%s",
-				util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
-			t.Errorf("Bad metric value for successful requests (200s): got %f, want at least %f", got200s, want)
-		}
-		want200s = math.Ceil(want200s * 1.05)
-		if got200s > want200s {
-			attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
-				util.Fqdn(destinationService, bookInfoNameSpaceStr)),
-				fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 200),
-				fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
-			t.Logf("prometheus values for istio_requests_total for 200's:\n%s",
-				util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
-			t.Errorf("Bad metric value for successful requests (200s): got %f, want at most %f", got200s,
-				want200s)
+		errorInRequestReportingAllowed = 5
+		util.ValidateBookInfoGatewayIsSetup(t, prom, bookinfoNs)
+		res := util.SendTrafficAndWaitForExpectedStatus(ing, t, "Sending traffic...", "", 300, http.StatusOK)
+		util.AllowPrometheusSync(t)
+		err := validate200sand429s(res, t, 0, destinationService, bookInfoNameSpaceStr)
+		if err != nil {
+			t.Logf("Got error, trying again. Err: %v", err)
+			// Try again as prometheus can take time to set up.
+			res = util.SendTrafficAndWaitForExpectedStatus(ing, t, "Sending traffic...", "", 300, http.StatusOK)
+			util.AllowPrometheusSync(t)
+			err = validate200sand429s(res, t, prior429s+prior200s+300-errorInRequestReportingAllowed, destinationService, bookInfoNameSpaceStr)
+			if err != nil {
+				// Fail now, as its still error'ing out.
+				t.Fatalf("Failed with err %v", err)
+			}
 		}
 	})
+}
+
+func validate200sand429s(res *fhttp.HTTPRunnerResults, t *testing.T, totalRequestExpected float64, destinationService,
+	bookInfoNameSpaceStr string) error {
+	// This is the number of requests we allow to be missing to be reported, so as to make test stable.
+	errorInRequestReportingAllowed := 5.0
+	totalReqs := res.DurationHistogram.Count
+	succReqs := float64(res.RetCodes[http.StatusOK])
+	badReqs := res.RetCodes[http.StatusBadRequest]
+	actualDuration := res.ActualDuration.Seconds() // can be a bit more than requested
+
+	t.Log("Successfully sent request(s) to /productpage; checking metrics...")
+	t.Logf("Fortio Summary: %d reqs (%f rps, %f 200s (%f rps), %d 400s - %+v)",
+		totalReqs, res.ActualQPS, succReqs, succReqs/actualDuration, badReqs, res.RetCodes)
+
+	// consider only successful requests (as recorded at productpage service)
+	callsToRatings := succReqs - errorInRequestReportingAllowed
+	want200s := 50.0 - errorInRequestReportingAllowed
+	// everything in excess of 200s should be 429s (ideally)
+	want429s := callsToRatings - want200s - errorInRequestReportingAllowed
+	t.Logf("Expected Totals: 200s: %f (%f rps), 429s: %f (%f rps)", want200s, want200s/actualDuration,
+		want429s, want429s/actualDuration)
+	// if we received less traffic than the expected enforced limit to ratings
+	// then there is no way to determine if the rate limit was applied at all
+	// and for how much traffic. log all metrics and abort test.
+	if callsToRatings < want200s {
+		attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
+			util.Fqdn(destinationService, bookInfoNameSpaceStr))}
+		t.Logf("full set of prometheus metrics for ratings:\n%s",
+			util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
+		return fmt.Errorf("not enough traffic generated to exercise rate limit: %s_reqs=%f, want200s=%f",
+			destinationService, callsToRatings, want200s)
+	}
+
+	got429s, got200s, err := util.FetchRequestCount(t, prom, destinationService, "", bookInfoNameSpaceStr,
+		totalRequestExpected)
+	if err != nil {
+		return fmt.Errorf("error getting request count err:%v", err)
+	}
+	if got429s == 0 {
+		attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
+			util.Fqdn(destinationService, bookInfoNameSpaceStr)),
+			fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 429),
+			fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "source")}
+		t.Logf("prometheus values for istio_requests_total for 429's:\n%s",
+			util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
+		return fmt.Errorf("could not find 429s")
+	}
+	want429s = math.Floor(want429s * 0.70)
+	// Store new 200's and 429's value in prior vars and subtract prior's values from one
+	// obtained from prometheus.
+	temp := got429s
+	got429s -= prior429s
+	prior429s = temp
+	temp = got200s
+	got200s -= prior200s
+	prior200s = temp
+	t.Logf("Actual 429s: %f (%f rps)", got429s, got429s/actualDuration)
+	// check resource exhausted
+	if got429s < want429s {
+		attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
+			util.Fqdn(destinationService, bookInfoNameSpaceStr)),
+			fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 429),
+			fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "source")}
+		t.Logf("prometheus values for istio_requests_total for 429's:\n%s",
+			util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
+		return fmt.Errorf("bad metric value for rate-limited requests (429s): got %f, want at least %f", got429s,
+			want429s)
+	}
+	if got200s == 0 {
+		attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
+			util.Fqdn(destinationService, bookInfoNameSpaceStr)),
+			fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 200),
+			fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "source")}
+		t.Logf("prometheus values for istio_requests_total for 200's:\n%s",
+			util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
+		return fmt.Errorf("could not find successes value")
+	}
+
+	t.Logf("Actual 200s: %f (%f rps), expecting ~1.666rps", got200s, got200s/actualDuration)
+	// establish some baseline to protect against flakiness due to randomness in routing
+	// and to allow for leniency in actual ceiling of enforcement (if 10 is the limit, but we allow slightly
+	// less than 10, don't fail this test).
+	want := math.Floor(want200s * 0.70)
+	// check successes
+	if got200s < want {
+		attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
+			util.Fqdn(destinationService, bookInfoNameSpaceStr)),
+			fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 200),
+			fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "source")}
+		t.Logf("prometheus values for istio_requests_total for 200's:\n%s",
+			util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
+		return fmt.Errorf("bad metric value for successful requests (200s): got %f, want at least %f", got200s, want)
+	}
+	// TODO: until https://github.com/istio/istio/issues/3028 is fixed, use 25% - should be only 5% or so
+	want200s = math.Ceil(want200s * 1.25)
+	if got200s > want200s {
+		attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
+			util.Fqdn(destinationService, bookInfoNameSpaceStr)),
+			fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 200),
+			fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "source")}
+		t.Logf("prometheus values for istio_requests_total for 200's:\n%s",
+			util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
+		return fmt.Errorf("bad metric value for successful requests (200s): got %f, want at most %f", got200s,
+			want200s)
+	}
+	return nil
+}
+
+func validateDefaultLessThanOverride(res *fhttp.HTTPRunnerResults, t *testing.T, destinationService,
+	bookInfoNameSpaceStr string) error {
+	totalReqs := float64(res.DurationHistogram.Count)
+	succReqs := float64(res.RetCodes[http.StatusOK])
+	got429s := float64(res.RetCodes[http.StatusTooManyRequests])
+	actualDuration := res.ActualDuration.Seconds() // can be a bit more than requested
+
+	// Sending 600 requests at 10qps, and limit allowed is 50 for 30s, so we should see approx 100 requests go
+	// through.
+	want200s := 50.0
+	// everything in excess of 200s should be 429s (ideally)
+	want429s := totalReqs - want200s
+	t.Logf("Expected Totals: 200s: %f (%f rps), 429s: %f (%f rps)", want200s, want200s/actualDuration,
+		want429s, want429s/actualDuration)
+
+	// As rate limit is applied at ingressgateway itself, fortio should see the limits too.
+	want := math.Floor(want200s * 0.70)
+	if succReqs < want {
+		attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
+			util.Fqdn(destinationService, bookInfoNameSpaceStr)),
+			fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 200),
+			fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
+		t.Logf("prometheus values for istio_requests_total for 200's:\n%s",
+			util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
+		return fmt.Errorf("bad metric value for successful requests (200s): got %f, want at least %f", succReqs, want)
+	}
+
+	// check resource exhausted
+	want429s = math.Floor(want429s * 0.70)
+	if got429s < want429s {
+		attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
+			util.Fqdn(destinationService, bookInfoNameSpaceStr)),
+			fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 429),
+			fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
+		t.Logf("prometheus values for istio_requests_total for 429's:\n%s",
+			util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
+		return fmt.Errorf("bad metric value for rate-limited requests (429s): got %f, want at least %f", got429s,
+			want429s)
+	}
+	return nil
 }
 
 func setupConfigOrFail(t *testing.T, config bookinfo.ConfigFile, bookInfoNameSpaceStr string,
@@ -313,6 +362,9 @@ func testsetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return
 	}
+
+	prior200s = 0
+	prior429s = 0
 
 	return nil
 }

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -175,6 +175,8 @@ func TestStateMetrics(t *testing.T) {
 func TestTcpMetric(t *testing.T) {
 	framework.
 		NewTest(t).
+		// TODO(https://github.com/istio/istio/issues/18105)
+		Label(label.Flaky).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			_ = bookinfo.DeployOrFail(t, ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookinfoRatingsv2})

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -175,8 +175,6 @@ func TestStateMetrics(t *testing.T) {
 func TestTcpMetric(t *testing.T) {
 	framework.
 		NewTest(t).
-		// TODO(https://github.com/istio/istio/issues/18105)
-		Label(label.Flaky).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			_ = bookinfo.DeployOrFail(t, ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookinfoRatingsv2})

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -49,7 +49,7 @@ endif
 # Generate integration test targets for kubernetes environment.
 test.integration.%.kube: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
-	$(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
+	$(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 60m \
 	--istio.test.env kube \
 	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
 	--istio.test.hub=${HUB} \
@@ -96,7 +96,7 @@ TEST_PACKAGES = $(shell go list ./tests/integration/... | grep -v /qualification
 # Generate presubmit integration test targets for each component in kubernetes environment
 test.integration.%.kube.presubmit: istioctl | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
-	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
+	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 60m \
     --istio.test.select -postsubmit,-flaky \
 	--istio.test.env kube \
 	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
@@ -134,7 +134,7 @@ test.integration.local.presubmit: | $(JUNIT_REPORT)
 .PHONY: test.integration.kube
 test.integration.kube: istioctl | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
-	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ${TEST_PACKAGES} ${_INTEGRATION_TEST_WORK_DIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
+	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ${TEST_PACKAGES} ${_INTEGRATION_TEST_WORK_DIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 60m \
 	--istio.test.env kube \
 	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
 	--istio.test.hub=${HUB} \
@@ -147,7 +147,7 @@ test.integration.kube: istioctl | $(JUNIT_REPORT)
 .PHONY: test.integration.kube.presubmit
 test.integration.kube.presubmit: istioctl | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
-	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ${TEST_PACKAGES} ${_INTEGRATION_TEST_WORK_DIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
+	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ${TEST_PACKAGES} ${_INTEGRATION_TEST_WORK_DIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 60m \
     --istio.test.select -postsubmit,-flaky \
  	--istio.test.env kube \
 	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \


### PR DESCRIPTION
 Make redis tests reliable: The limits are resumed to what was there in previous e2e tests at https://github.com/istio/istio/commit/2aa4a006bde94f5cfedd05d7094544c66d7dd59f which were quite reliable.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X ] Policies and Telemetry
[ ] Security
[X ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
