### PR TITLE
Override fixed nodePort values for testing

### DIFF
--- a/install/kubernetes/helm/istio/test-values/values-e2e.yaml
+++ b/install/kubernetes/helm/istio/test-values/values-e2e.yaml
@@ -28,6 +28,36 @@ gateways:
       limits:
         cpu: 100m
         memory: 128Mi
+    # Disable the specific nodePort mappings for testing
+    # These occasionally cause port conflict flakes (#14190)
+    # Lacking a good way to override just part of a list, this is copied from
+    # the prod values.yaml with nodePort omitted
+    ports:
+    - port: 15020
+      targetPort: 15020
+      name: status-port
+    - port: 80
+      targetPort: 80
+      name: http2
+    - port: 443
+      name: https
+    - port: 31400
+      name: tcp
+    - port: 15029
+      targetPort: 15029
+      name: https-kiali
+    - port: 15030
+      targetPort: 15030
+      name: https-prometheus
+    - port: 15031
+      targetPort: 15031
+      name: https-grafana
+    - port: 15032
+      targetPort: 15032
+      name: https-tracing
+    - port: 15443
+      targetPort: 15443
+      name: tls
 
   istio-egressgateway:
     enabled: true


### PR DESCRIPTION
Fix for https://github.com/istio/istio/issues/14190.
Also see https://github.com/istio/istio/pull/15042 for a discussion about why we don't just remove nodePort from the prod values.yaml. 

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
