### PR TITLE
Ignore envoy.admin.v2alpha.ScopedRoutesConfigDump

### DIFF
--- a/istioctl/pkg/util/configdump/route.go
+++ b/istioctl/pkg/util/configdump/route.go
@@ -69,12 +69,17 @@ func (w *Wrapper) GetDynamicRouteDump(stripVersions bool) (*adminapi.RoutesConfi
 
 // GetRouteConfigDump retrieves the route config dump from the ConfigDump
 func (w *Wrapper) GetRouteConfigDump() (*adminapi.RoutesConfigDump, error) {
-	// The route dump is the fourth one in the list.
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/admin/v2alpha/config_dump.proto
-	if len(w.Configs) < 4 {
+	// The route dump is no longer the 4th one;
+	// now envoy.admin.v2alpha.ScopedRoutesConfigDump may be 4th.
+	var routeDumpAny proto.Any
+	for _, conf := range w.Configs {
+		if conf.TypeUrl == "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump" {
+			routeDumpAny = conf
+		}
+	}
+	if routeDumpAny.TypeUrl == "" {
 		return nil, fmt.Errorf("config dump has no route dump")
 	}
-	routeDumpAny := w.Configs[3]
 	routeDump := &adminapi.RoutesConfigDump{}
 	err := proto.UnmarshalAny(&routeDumpAny, routeDump)
 	if err != nil {


### PR DESCRIPTION
Mitigates https://github.com/istio/istio/issues/15544 (and perhaps resolves it).

@howardjohn This PR allows istioctl 1.2.x to be run against 1.3 daily control plane.

I am not sure if this code is clever or poor.  It worked for me.  I am not an expert in the interactions between JSON and Protobufs and if you know of a better way to get the desired behavior let me know.  For that reason I marked it Work in Progress, but I am not sure any work remains.