### PR TITLE
Add SDS connection information into CSR logs

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -537,7 +537,7 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 func (sc *SecretCache) generateGatewaySecret(token string, sdsConnCtx ConnKey, t time.Time) (*model.SecretItem, error) {
 	secretItem, exist := sc.fetcher.FindIngressGatewaySecret(sdsConnCtx.ResourceName)
 	if !exist {
-		return nil, fmt.Errorf("cannot find secret %s for ingress gateway SDS request %+v", sdsConnCtx)
+		return nil, fmt.Errorf("cannot find secret for ingress gateway SDS request %+v", sdsConnCtx)
 	}
 
 	if strings.HasSuffix(sdsConnCtx.ResourceName, secretfetcher.IngressGatewaySdsCaSuffix) {
@@ -681,7 +681,8 @@ func (sc *SecretCache) isTokenExpired() bool {
 
 // sendRetriableRequest sends retriable requests for either CSR or ExchangeToken.
 // Prior to sending the request, it also sleep random millisecond to avoid thundering herd problem.
-func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte, providedExchangedToken string, sdsConnCtx ConnKey, isCSR bool) ([]string, error) {
+func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte,
+	providedExchangedToken string, sdsConnCtx ConnKey, isCSR bool) ([]string, error) {
 	backOffInMilliSec := rand.Int63n(sc.configOptions.InitialBackoff)
 	cacheLog.Debugf("Wait for %d millisec", backOffInMilliSec)
 	// Add a jitter to initial CSR to avoid thundering herd problem.

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -363,11 +363,9 @@ func (sc *SecretCache) DeleteK8sSecret(secretName string) {
 	wg := sync.WaitGroup{}
 	sc.secrets.Range(func(k interface{}, v interface{}) bool {
 		sdsConnCtx := k.(ConnKey)
-
 		if sdsConnCtx.ResourceName == secretName {
-			connectionID := sdsConnCtx.ConnectionID
 			sc.secrets.Delete(sdsConnCtx)
-			conIDresourceNamePrefix := cacheLogPrefix(connectionID, secretName)
+			conIDresourceNamePrefix := cacheLogPrefix(sdsConnCtx.ConnectionID, secretName)
 			cacheLog.Debugf("%s secret cache is deleted", conIDresourceNamePrefix)
 			wg.Add(1)
 			go func() {
@@ -392,7 +390,6 @@ func (sc *SecretCache) UpdateK8sSecret(secretName string, ns model.SecretItem) {
 		sdsConnCtx := k.(ConnKey)
 		oldSecret := v.(model.SecretItem)
 		if sdsConnCtx.ResourceName == secretName {
-			connectionID := sdsConnCtx.ConnectionID
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -418,7 +415,7 @@ func (sc *SecretCache) UpdateK8sSecret(secretName string, ns model.SecretItem) {
 					}
 				}
 				secretMap.Store(sdsConnCtx, newSecret)
-				conIDresourceNamePrefix := cacheLogPrefix(connectionID, secretName)
+				conIDresourceNamePrefix := cacheLogPrefix(sdsConnCtx.ConnectionID, secretName)
 				cacheLog.Debugf("%s secret cache is updated", conIDresourceNamePrefix)
 				sc.callbackWithTimeout(sdsConnCtx, newSecret)
 			}()

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -151,7 +151,7 @@ type SecretCache struct {
 	rootCertChangedCount uint64
 
 	// callback function to invoke when detecting secret change.
-	notifyCallback func(proxyID string, resourceName string, secret *model.SecretItem) error
+	notifyCallback func(connKey ConnKey, secret *model.SecretItem) error
 
 	// Right now always skip the check, since key rotation job checks token expire only when cert has expired;
 	// since token's TTL is much shorter than the cert, we could skip the check in normal cases.
@@ -168,7 +168,7 @@ type SecretCache struct {
 }
 
 // NewSecretCache creates a new secret cache.
-func NewSecretCache(fetcher *secretfetcher.SecretFetcher, notifyCb func(string, string, *model.SecretItem) error, options Options) *SecretCache {
+func NewSecretCache(fetcher *secretfetcher.SecretFetcher, notifyCb func(ConnKey, *model.SecretItem) error, options Options) *SecretCache {
 	ret := &SecretCache{
 		fetcher:        fetcher,
 		closing:        make(chan bool),
@@ -193,7 +193,7 @@ func NewSecretCache(fetcher *secretfetcher.SecretFetcher, notifyCb func(string, 
 // instead of reading from cache.
 func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourceName, token string) (*model.SecretItem, error) {
 	var ns *model.SecretItem
-	sdsConnCtx := ConnKey{
+	connKey := ConnKey{
 		ConnectionID: connectionID,
 		ResourceName: resourceName,
 	}
@@ -203,14 +203,14 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 		// If working as Citadel agent, send request for normal key/cert pair.
 		// If working as ingress gateway agent, fetch key/cert or root cert from SecretFetcher. Resource name for
 		// root cert ends with "-cacert".
-		ns, err := sc.generateSecret(ctx, token, sdsConnCtx, time.Now())
+		ns, err := sc.generateSecret(ctx, token, connKey, time.Now())
 		if err != nil {
 			cacheLog.Errorf("%s failed to generate secret for proxy: %v",
 				conIDresourceNamePrefix, err)
 			return nil, err
 		}
 
-		sc.secrets.Store(sdsConnCtx, *ns)
+		sc.secrets.Store(connKey, *ns)
 		return ns, nil
 	}
 
@@ -244,7 +244,7 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 		CreatedTime:  t,
 		Version:      t.String(),
 	}
-	sc.secrets.Store(sdsConnCtx, *ns)
+	sc.secrets.Store(connKey, *ns)
 	cacheLog.Debugf("%s successfully generate secret for proxy", conIDresourceNamePrefix)
 	return ns, nil
 }
@@ -252,11 +252,11 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 // SecretExist checks if secret already existed.
 // This API is used for sds server to check if coming request is ack request.
 func (sc *SecretCache) SecretExist(connectionID, resourceName, token, version string) bool {
-	key := ConnKey{
+	connKey := ConnKey{
 		ConnectionID: connectionID,
 		ResourceName: resourceName,
 	}
-	val, exist := sc.secrets.Load(key)
+	val, exist := sc.secrets.Load(connKey)
 	if !exist {
 		return false
 	}
@@ -273,13 +273,13 @@ func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceN
 		return false
 	}
 
-	key := ConnKey{
+	connKey := ConnKey{
 		ConnectionID: connectionID,
 		ResourceName: resourceName,
 	}
 	// Add an entry into cache, so that when ingress gateway secret is ready, gateway agent is able to
 	// notify the ingress gateway and push the secret to via connect ID.
-	if _, found := sc.secrets.Load(key); !found {
+	if _, found := sc.secrets.Load(connKey); !found {
 		t := time.Now()
 		dummySecret := &model.SecretItem{
 			ResourceName: resourceName,
@@ -287,7 +287,7 @@ func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceN
 			CreatedTime:  t,
 			Version:      t.String(),
 		}
-		sc.secrets.Store(key, *dummySecret)
+		sc.secrets.Store(connKey, *dummySecret)
 	}
 
 	conIDresourceNamePrefix := cacheLogPrefix(connectionID, resourceName)
@@ -308,20 +308,20 @@ func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceN
 
 // DeleteSecret deletes a secret by its key from cache.
 func (sc *SecretCache) DeleteSecret(connectionID, resourceName string) {
-	key := ConnKey{
+	connKey := ConnKey{
 		ConnectionID: connectionID,
 		ResourceName: resourceName,
 	}
-	sc.secrets.Delete(key)
+	sc.secrets.Delete(connKey)
 }
 
-func (sc *SecretCache) callbackWithTimeout(sdsConnCtx ConnKey, secret *model.SecretItem) {
+func (sc *SecretCache) callbackWithTimeout(connKey ConnKey, secret *model.SecretItem) {
 	c := make(chan struct{})
-	conIDresourceNamePrefix := cacheLogPrefix(sdsConnCtx.ConnectionID, sdsConnCtx.ResourceName)
+	conIDresourceNamePrefix := cacheLogPrefix(connKey.ConnectionID, connKey.ResourceName)
 	go func() {
 		defer close(c)
 		if sc.notifyCallback != nil {
-			if err := sc.notifyCallback(sdsConnCtx.ConnectionID, sdsConnCtx.ResourceName, secret); err != nil {
+			if err := sc.notifyCallback(connKey, secret); err != nil {
 				cacheLog.Errorf("%s failed to notify secret change for proxy: %v",
 					conIDresourceNamePrefix, err)
 			}
@@ -362,15 +362,15 @@ func (sc *SecretCache) keyCertRotationJob() {
 func (sc *SecretCache) DeleteK8sSecret(secretName string) {
 	wg := sync.WaitGroup{}
 	sc.secrets.Range(func(k interface{}, v interface{}) bool {
-		sdsConnCtx := k.(ConnKey)
-		if sdsConnCtx.ResourceName == secretName {
-			sc.secrets.Delete(sdsConnCtx)
-			conIDresourceNamePrefix := cacheLogPrefix(sdsConnCtx.ConnectionID, secretName)
+		connKey := k.(ConnKey)
+		if connKey.ResourceName == secretName {
+			sc.secrets.Delete(connKey)
+			conIDresourceNamePrefix := cacheLogPrefix(connKey.ConnectionID, secretName)
 			cacheLog.Debugf("%s secret cache is deleted", conIDresourceNamePrefix)
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				sc.callbackWithTimeout(sdsConnCtx, nil /*nil indicates close the streaming connection to proxy*/)
+				sc.callbackWithTimeout(connKey, nil /*nil indicates close the streaming connection to proxy*/)
 			}()
 			// Currently only one ingress gateway is running, therefore there is at most one cache entry.
 			// Stop the iteration once we have deleted that cache entry.
@@ -387,9 +387,9 @@ func (sc *SecretCache) UpdateK8sSecret(secretName string, ns model.SecretItem) {
 	var secretMap sync.Map
 	wg := sync.WaitGroup{}
 	sc.secrets.Range(func(k interface{}, v interface{}) bool {
-		sdsConnCtx := k.(ConnKey)
+		connKey := k.(ConnKey)
 		oldSecret := v.(model.SecretItem)
-		if sdsConnCtx.ResourceName == secretName {
+		if connKey.ResourceName == secretName {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -414,10 +414,10 @@ func (sc *SecretCache) UpdateK8sSecret(secretName string, ns model.SecretItem) {
 						Version:          ns.Version,
 					}
 				}
-				secretMap.Store(sdsConnCtx, newSecret)
-				conIDresourceNamePrefix := cacheLogPrefix(sdsConnCtx.ConnectionID, secretName)
+				secretMap.Store(connKey, newSecret)
+				conIDresourceNamePrefix := cacheLogPrefix(connKey.ConnectionID, secretName)
 				cacheLog.Debugf("%s secret cache is updated", conIDresourceNamePrefix)
-				sc.callbackWithTimeout(sdsConnCtx, newSecret)
+				sc.callbackWithTimeout(connKey, newSecret)
 			}()
 			// Currently only one ingress gateway is running, therefore there is at most one cache entry.
 			// Stop the iteration once we have updated that cache entry.
@@ -447,35 +447,35 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 	var secretMap sync.Map
 	wg := sync.WaitGroup{}
 	sc.secrets.Range(func(k interface{}, v interface{}) bool {
-		sdsConnCtx := k.(ConnKey)
+		connKey := k.(ConnKey)
 		e := v.(model.SecretItem)
-		conIDresourceNamePrefix := cacheLogPrefix(sdsConnCtx.ConnectionID, sdsConnCtx.ResourceName)
+		conIDresourceNamePrefix := cacheLogPrefix(connKey.ConnectionID, connKey.ResourceName)
 
 		// only refresh root cert if updateRootFlag is set to true.
 		if updateRootFlag {
-			if sdsConnCtx.ResourceName != RootCertReqResourceName {
+			if connKey.ResourceName != RootCertReqResourceName {
 				return true
 			}
 
 			atomic.AddUint64(&sc.rootCertChangedCount, 1)
 			t := time.Now()
 			ns := &model.SecretItem{
-				ResourceName: sdsConnCtx.ResourceName,
+				ResourceName: connKey.ResourceName,
 				RootCert:     sc.rootCert,
 				ExpireTime:   sc.rootCertExpireTime,
 				Token:        e.Token,
 				CreatedTime:  t,
 				Version:      t.String(),
 			}
-			secretMap.Store(sdsConnCtx, ns)
+			secretMap.Store(connKey, ns)
 			cacheLog.Debugf("%s secret cache is updated", conIDresourceNamePrefix)
-			sc.callbackWithTimeout(sdsConnCtx, ns)
+			sc.callbackWithTimeout(connKey, ns)
 
 			return true
 		}
 
 		// If updateRootFlag isn't set, return directly if cached item is root cert.
-		if sdsConnCtx.ResourceName == RootCertReqResourceName {
+		if connKey.ResourceName == RootCertReqResourceName {
 			return true
 		}
 
@@ -483,7 +483,7 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 
 		// Remove stale secrets from cache, this prevent the cache growing indefinitely.
 		if now.After(e.CreatedTime.Add(sc.configOptions.EvictionDuration)) {
-			sc.secrets.Delete(sdsConnCtx)
+			sc.secrets.Delete(connKey)
 			return true
 		}
 
@@ -494,7 +494,7 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 			// Send the notification to close the stream if token is expired, so that client could re-connect with a new token.
 			if sc.isTokenExpired() {
 				cacheLog.Debugf("%s token expired", conIDresourceNamePrefix)
-				sc.callbackWithTimeout(sdsConnCtx, nil /*nil indicates close the streaming connection to proxy*/)
+				sc.callbackWithTimeout(connKey, nil /*nil indicates close the streaming connection to proxy*/)
 
 				return true
 			}
@@ -507,15 +507,15 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 				// If token is still valid, re-generated the secret and push change to proxy.
 				// Most likey this code path may not necessary, since TTL of cert is much longer than token.
 				// When cert has expired, we could make it simple by assuming token has already expired.
-				ns, err := sc.generateSecret(context.Background(), e.Token, sdsConnCtx, now)
+				ns, err := sc.generateSecret(context.Background(), e.Token, connKey, now)
 				if err != nil {
 					cacheLog.Errorf("%s failed to rotate secret: %v", conIDresourceNamePrefix, err)
 					return
 				}
 
-				secretMap.Store(sdsConnCtx, ns)
+				secretMap.Store(connKey, ns)
 				cacheLog.Debugf("%s secret cache is updated", conIDresourceNamePrefix)
-				sc.callbackWithTimeout(sdsConnCtx, ns)
+				sc.callbackWithTimeout(connKey, ns)
 
 			}()
 		}
@@ -534,15 +534,15 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 }
 
 // generateGatewaySecret returns secret for ingress gateway proxy.
-func (sc *SecretCache) generateGatewaySecret(token string, sdsConnCtx ConnKey, t time.Time) (*model.SecretItem, error) {
-	secretItem, exist := sc.fetcher.FindIngressGatewaySecret(sdsConnCtx.ResourceName)
+func (sc *SecretCache) generateGatewaySecret(token string, connKey ConnKey, t time.Time) (*model.SecretItem, error) {
+	secretItem, exist := sc.fetcher.FindIngressGatewaySecret(connKey.ResourceName)
 	if !exist {
-		return nil, fmt.Errorf("cannot find secret for ingress gateway SDS request %+v", sdsConnCtx)
+		return nil, fmt.Errorf("cannot find secret for ingress gateway SDS request %+v", connKey)
 	}
 
-	if strings.HasSuffix(sdsConnCtx.ResourceName, secretfetcher.IngressGatewaySdsCaSuffix) {
+	if strings.HasSuffix(connKey.ResourceName, secretfetcher.IngressGatewaySdsCaSuffix) {
 		return &model.SecretItem{
-			ResourceName: sdsConnCtx.ResourceName,
+			ResourceName: connKey.ResourceName,
 			RootCert:     secretItem.RootCert,
 			ExpireTime:   secretItem.ExpireTime,
 			Token:        token,
@@ -554,20 +554,20 @@ func (sc *SecretCache) generateGatewaySecret(token string, sdsConnCtx ConnKey, t
 		CertificateChain: secretItem.CertificateChain,
 		ExpireTime:       secretItem.ExpireTime,
 		PrivateKey:       secretItem.PrivateKey,
-		ResourceName:     sdsConnCtx.ResourceName,
+		ResourceName:     connKey.ResourceName,
 		Token:            token,
 		CreatedTime:      t,
 		Version:          t.String(),
 	}, nil
 }
 
-func (sc *SecretCache) generateSecret(ctx context.Context, token string, sdsConnCtx ConnKey, t time.Time) (*model.SecretItem, error) {
+func (sc *SecretCache) generateSecret(ctx context.Context, token string, connKey ConnKey, t time.Time) (*model.SecretItem, error) {
 	// If node agent works as ingress gateway agent, searches for kubernetes secret instead of sending
 	// CSR to CA.
 	if !sc.fetcher.UseCaClient {
-		return sc.generateGatewaySecret(token, sdsConnCtx, t)
+		return sc.generateGatewaySecret(token, connKey, t)
 	}
-	conIDresourceNamePrefix := cacheLogPrefix(sdsConnCtx.ConnectionID, sdsConnCtx.ResourceName)
+	conIDresourceNamePrefix := cacheLogPrefix(connKey.ConnectionID, connKey.ResourceName)
 	// call authentication provider specific plugins to exchange token if necessary.
 	numOutgoingRequests.With(RequestType.Value(TokenExchange)).Increment()
 	timeBeforeTokenExchange := time.Now()
@@ -585,7 +585,7 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token string, sdsConn
 	if err != nil {
 		cacheLog.Warnf("%s failed to extract host name from jwt: %v, fallback to SDS request resource name",
 			conIDresourceNamePrefix, err)
-		csrHostName = sdsConnCtx.ResourceName
+		csrHostName = connKey.ResourceName
 	}
 	options := util.CertOptions{
 		Host:       csrHostName,
@@ -601,7 +601,7 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token string, sdsConn
 
 	numOutgoingRequests.With(RequestType.Value(CSR)).Increment()
 	timeBeforeCSR := time.Now()
-	certChainPEM, err := sc.sendRetriableRequest(ctx, csrPEM, exchangedToken, sdsConnCtx, true)
+	certChainPEM, err := sc.sendRetriableRequest(ctx, csrPEM, exchangedToken, connKey, true)
 	csrLatency := float64(time.Since(timeBeforeCSR).Nanoseconds()) / float64(time.Millisecond)
 	outgoingLatency.With(RequestType.Value(CSR)).Record(csrLatency)
 	if err != nil {
@@ -653,7 +653,7 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token string, sdsConn
 	return &model.SecretItem{
 		CertificateChain: certChain,
 		PrivateKey:       keyPEM,
-		ResourceName:     sdsConnCtx.ResourceName,
+		ResourceName:     connKey.ResourceName,
 		Token:            token,
 		CreatedTime:      t,
 		ExpireTime:       expireTime,
@@ -682,13 +682,13 @@ func (sc *SecretCache) isTokenExpired() bool {
 // sendRetriableRequest sends retriable requests for either CSR or ExchangeToken.
 // Prior to sending the request, it also sleep random millisecond to avoid thundering herd problem.
 func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte,
-	providedExchangedToken string, sdsConnCtx ConnKey, isCSR bool) ([]string, error) {
+	providedExchangedToken string, connKey ConnKey, isCSR bool) ([]string, error) {
 	backOffInMilliSec := rand.Int63n(sc.configOptions.InitialBackoff)
 	cacheLog.Debugf("Wait for %d millisec", backOffInMilliSec)
 	// Add a jitter to initial CSR to avoid thundering herd problem.
 	time.Sleep(time.Duration(backOffInMilliSec) * time.Millisecond)
 
-	conIDresourceNamePrefix := cacheLogPrefix(sdsConnCtx.ConnectionID, sdsConnCtx.ResourceName)
+	conIDresourceNamePrefix := cacheLogPrefix(connKey.ConnectionID, connKey.ResourceName)
 	startTime := time.Now()
 	var retry int64
 	var certChainPEM []string

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -200,8 +200,8 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 
 	conIDresourceNamePrefix := cacheLogPrefix(connectionID, resourceName)
 	if resourceName != RootCertReqResourceName {
-		// If working as Citadel agent, send request for normal sdsConnCtx/cert pair.
-		// If working as ingress gateway agent, fetch sdsConnCtx/cert or root cert from SecretFetcher. Resource name for
+		// If working as Citadel agent, send request for normal key/cert pair.
+		// If working as ingress gateway agent, fetch key/cert or root cert from SecretFetcher. Resource name for
 		// root cert ends with "-cacert".
 		ns, err := sc.generateSecret(ctx, token, sdsConnCtx, time.Now())
 		if err != nil {

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -894,7 +894,7 @@ func verifySecret(gotSecret *model.SecretItem, expectedSecret *model.SecretItem)
 	return nil
 }
 
-func notifyCb(_ string, _ string, _ *model.SecretItem) error {
+func notifyCb(_ ConnKey, _ *model.SecretItem) error {
 	return nil
 }
 

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -317,11 +317,12 @@ func TestStreamSecretsPush(t *testing.T) {
 	conID := proxyID + "-1"
 
 	// Test push new secret to proxy.
-	if err = NotifyProxy(conID, req.ResourceNames[0], &model.SecretItem{
-		CertificateChain: fakePushCertificateChain,
-		PrivateKey:       fakePushPrivateKey,
-		ResourceName:     testResourceName,
-	}); err != nil {
+	if err = NotifyProxy(cache.ConnKey{ConnectionID: conID, ResourceName: req.ResourceNames[0]},
+		&model.SecretItem{
+			CertificateChain: fakePushCertificateChain,
+			PrivateKey:       fakePushPrivateKey,
+			ResourceName:     testResourceName,
+		}); err != nil {
 		t.Fatalf("failed to send push notificiation to proxy %q", conID)
 	}
 	resp, err = stream.Recv()
@@ -340,7 +341,7 @@ func TestStreamSecretsPush(t *testing.T) {
 	}
 
 	// Test push nil secret(indicates close the streaming connection) to proxy.
-	if err = NotifyProxy(conID, req.ResourceNames[0], nil); err != nil {
+	if err = NotifyProxy(cache.ConnKey{ConnectionID: conID, ResourceName: req.ResourceNames[0]}, nil); err != nil {
 		t.Fatalf("failed to send push notificiation to proxy %q", conID)
 	}
 	if _, err = stream.Recv(); err == nil {


### PR DESCRIPTION
Please provide a description for what this PR is for.
Add SDS connection information into CSR logs. For each CSR, we need to know what SDS request from which SDS connection triggers the CSR. If a CSR fails or certificate parsing fails, we need to know which SDS client is affected. Currently resource name is logged in CSR. For workload SDS, there could be multiple SDS requests in parallel, with same resource name and different connection ID. We need to associate every CSR activity to each SDS client.
Also add some method interface changes that unify log pattern and simplify parameter list.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

https://github.com/istio/istio/issues/13439