### PR TITLE
Fetching ingressgateway address supports NodePort type service

### DIFF
--- a/pkg/test/framework/components/bookinfo/configs.go
+++ b/pkg/test/framework/components/bookinfo/configs.go
@@ -78,7 +78,7 @@ func (l ConfigFile) LoadGatewayFileWithNamespaceOrFail(t test.Failer, namespace 
 	return content
 }
 
-// LoadWithNamespaceOrFail loads a Book Info configuration file from the systemchanges it to be fit
+// LoadWithNamespaceOrFail loads a Book Info configuration file from the system, changes it to be fit
 // for the namespace provided and returns its contents.
 func (l ConfigFile) LoadWithNamespaceOrFail(t test.Failer, namespace string) string {
 	t.Helper()

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"net"
 	"net/http"
 	"time"

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
+
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
 	"net"
 	"net/http"
 	"time"
@@ -30,6 +29,7 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (


### PR DESCRIPTION
When using on-prem kubernetes clusters, there is no LoadBanlancer support. So we can using NodPort of ingressgateway to request services in the mesh.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
