### PR TITLE
fix stackdriver adapter getting shutdown bug

### DIFF
--- a/mixer/adapter/stackdriver/metric/bufferedClient.go
+++ b/mixer/adapter/stackdriver/metric/bufferedClient.go
@@ -83,12 +83,14 @@ func batchTimeSeries(series []*monitoringpb.TimeSeries, tsLimit int) [][]*monito
 
 func (b *buffered) start(env adapter.Env, ticker *time.Ticker, quit chan struct{}) {
 	env.ScheduleDaemon(func() {
-		select {
-		case <-ticker.C:
-			b.mergeTimeSeries()
-			b.Send()
-		case <-quit:
-			return
+		for {
+			select {
+			case <-ticker.C:
+				b.mergeTimeSeries()
+				b.Send()
+			case <-quit:
+				return
+			}
 		}
 	})
 }


### PR DESCRIPTION
This PR will fix the bug where Stackdriver adapter getting shutdown after telemetry is started. This regression is caused by #14803 which affects the versions v1.2.0 and above.


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure