### PR TITLE
Update versions field in crds definition.

### DIFF
--- a/install/kubernetes/helm/istio-init/files/crd-10.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-10.yaml
@@ -22,7 +22,10 @@ spec:
     - istio-io
     - networking-istio-io
   scope: Namespaced
-  version: v1alpha3
+  versions:
+    - name: v1alpha3
+      served: true
+      storage: true
   additionalPrinterColumns:
   - JSONPath: .spec.gateways
     description: The names of gateways and sidecars that should apply these routes
@@ -64,7 +67,10 @@ spec:
     - istio-io
     - networking-istio-io
   scope: Namespaced
-  version: v1alpha3
+  versions:
+    - name: v1alpha3
+      served: true
+      storage: true
   additionalPrinterColumns:
   - JSONPath: .spec.host
     description: The name of a service from the service registry
@@ -102,7 +108,10 @@ spec:
     - istio-io
     - networking-istio-io
   scope: Namespaced
-  version: v1alpha3
+  versions:
+    - name: v1alpha3
+      served: true
+      storage: true
   additionalPrinterColumns:
   - JSONPath: .spec.hosts
     description: The hosts associated with the ServiceEntry
@@ -147,7 +156,10 @@ spec:
     - istio-io
     - networking-istio-io
   scope: Namespaced
-  version: v1alpha3
+  versions:
+    - name: v1alpha3
+      served: true
+      storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -170,7 +182,10 @@ spec:
     - istio-io
     - networking-istio-io
   scope: Namespaced
-  version: v1alpha3
+  versions:
+    - name: v1alpha3
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -193,7 +208,10 @@ spec:
     - istio-io
     - rbac-istio-io
   scope: Cluster
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -216,7 +234,10 @@ spec:
     - istio-io
     - authentication-istio-io
   scope: Namespaced
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -240,7 +261,10 @@ spec:
     - istio-io
     - authentication-istio-io
   scope: Cluster
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -263,7 +287,10 @@ spec:
     - istio-io
     - apim-istio-io
   scope: Namespaced
-  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -286,7 +313,10 @@ spec:
     - istio-io
     - apim-istio-io
   scope: Namespaced
-  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -309,7 +339,10 @@ spec:
     - istio-io
     - apim-istio-io
   scope: Namespaced
-  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -332,7 +365,10 @@ spec:
     - istio-io
     - apim-istio-io
   scope: Namespaced
-  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -357,7 +393,10 @@ spec:
     - istio-io
     - policy-istio-io
   scope: Namespaced
-  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -382,7 +421,10 @@ spec:
     - istio-io
     - policy-istio-io
   scope: Namespaced
-  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -407,7 +449,10 @@ spec:
     - istio-io
     - rbac-istio-io
   scope: Namespaced
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -432,7 +477,10 @@ spec:
     - istio-io
     - rbac-istio-io
   scope: Namespaced
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -457,7 +505,10 @@ spec:
     - istio-io
     - rbac-istio-io
   scope: Namespaced
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   additionalPrinterColumns:
   - JSONPath: .spec.roleRef.name
     description: The name of the ServiceRole object being referenced
@@ -494,7 +545,10 @@ spec:
     - istio-io
     - policy-istio-io
   scope: Namespaced
-  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -519,7 +573,10 @@ spec:
     - istio-io
     - policy-istio-io
   scope: Namespaced
-  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -544,7 +601,10 @@ spec:
     - istio-io
     - policy-istio-io
   scope: Namespaced
-  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -569,5 +629,8 @@ spec:
     - istio-io
     - policy-istio-io
   scope: Namespaced
-  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
 ---

--- a/install/kubernetes/helm/istio-init/files/crd-11.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-11.yaml
@@ -19,5 +19,8 @@ spec:
     - istio-io
     - networking-istio-io
   scope: Namespaced
-  version: v1alpha3
+  versions:
+    - name: v1alpha3
+      served: true
+      storage: true
 ---

--- a/install/kubernetes/helm/istio-init/files/crd-12.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-12.yaml
@@ -17,5 +17,8 @@ spec:
       - istio-io
       - rbac-istio-io
   scope: Namespaced
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
 ---

--- a/install/kubernetes/helm/istio-init/files/crd-certmanager-10.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-certmanager-10.yaml
@@ -11,7 +11,10 @@ metadata:
     "helm.sh/resource-policy": keep
 spec:
   group: certmanager.k8s.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   names:
     kind: ClusterIssuer
     plural: clusterissuers
@@ -30,7 +33,10 @@ metadata:
     "helm.sh/resource-policy": keep
 spec:
   group: certmanager.k8s.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   names:
     kind: Issuer
     plural: issuers
@@ -71,7 +77,10 @@ spec:
       name: Age
       type: date
   group: certmanager.k8s.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   scope: Namespaced
   names:
     kind: Certificate

--- a/install/kubernetes/helm/istio-init/files/crd-certmanager-11.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-certmanager-11.yaml
@@ -30,7 +30,10 @@ spec:
       name: Age
       type: date
   group: certmanager.k8s.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   names:
     kind: Order
     plural: orders
@@ -66,7 +69,10 @@ spec:
       name: Age
       type: date
   group: certmanager.k8s.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   names:
     kind: Challenge
     plural: challenges


### PR DESCRIPTION
Please provide a description for what this PR is for.

Update versions field in crds definition.
According to [https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#customresourcedefinitionspec-v1beta1-apiextensions-k8s-io](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#customresourcedefinitionspec-v1beta1-apiextensions-k8s-io
) and [https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#overview](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#overview), from v1.11, the version field in CustomResourceDefinition is deprecated and optional.
From docs in [https://istio.io/docs/setup/kubernetes/](https://istio.io/docs/setup/kubernetes/), Istio 1.2 has been tested with these Kubernetes releases: 1.12, 1.13, 1.14.



And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
