### PR TITLE
Make Galley run as non-root

### DIFF
--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -4,7 +4,7 @@ ARG BASE_DISTRIBUTION=default
 # The following section is used as base image if BASE_DISTRIBUTION=default
 # hadolint ignore=DL3006
 FROM istionightly/base_debug as default
-ADD galley /usr/local/bin/
+COPY galley /usr/local/bin/
 
 # 1001 is chosen as the UID to be added to the istio group as this is the UID that galley in the docker container runs as.
 RUN addgroup --system --gid 1001 istio && \
@@ -15,7 +15,7 @@ USER istio
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless
-ADD galley /usr/local/bin/
+COPY galley /usr/local/bin/
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -13,12 +13,10 @@ RUN addgroup --system --gid 1001 istio && \
 USER istio
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-# hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless
 ADD galley /usr/local/bin/
 
 # This will build the final image based on either default or distroless from above
-# hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}
 
 ENTRYPOINT ["/usr/local/bin/galley"]

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -9,11 +9,10 @@ COPY galley /usr/local/bin/
 # 1001 is chosen as the UID to be added to the istio group as this is the UID that galley in the docker container runs as.
 RUN addgroup --system --gid 1001 istio && \
     adduser --system --uid 1001 --gid 1001 istio && \
-    chown -R 760 /usr/local/bin/galley
+    chmod -R 760 /usr/local/bin/galley
 USER istio
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-# hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless
 COPY galley /usr/local/bin/
 

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -13,10 +13,12 @@ RUN addgroup --system --gid 1001 istio && \
 USER istio
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
+# hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless
 ADD galley /usr/local/bin/
 
 # This will build the final image based on either default or distroless from above
+# hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}
 
 ENTRYPOINT ["/usr/local/bin/galley"]

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -4,13 +4,21 @@ ARG BASE_DISTRIBUTION=default
 # The following section is used as base image if BASE_DISTRIBUTION=default
 # hadolint ignore=DL3006
 FROM istionightly/base_debug as default
+ADD galley /usr/local/bin/
+
+# 1001 is chosen as the UID to be added to the istio group as this is the UID that galley in the docker container runs as.
+RUN addgroup --system --gid 1001 istio && \
+    adduser --system --uid 1001 --gid 1001 istio && \
+    chown -R 760 /usr/local/bin/galley
+USER istio
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:latest as distroless
+FROM gcr.io/distroless/static:nonroot as distroless
+ADD galley /usr/local/bin/
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}
-COPY galley /usr/local/bin/
+
 ENTRYPOINT ["/usr/local/bin/galley"]

--- a/galley/pkg/crd/validation/validation.go
+++ b/galley/pkg/crd/validation/validation.go
@@ -148,10 +148,10 @@ func isDNS1123Label(value string) bool {
 
 // validatePort checks that the network port is in range
 func validatePort(port int) error {
-	if 1 <= port && port <= 65535 {
+	if 1024 <= port && port <= 65535 {
 		return nil
 	}
-	return fmt.Errorf("port number %d must be in the range 1..65535", port)
+	return fmt.Errorf("port number %d must be in the range 1024..65535", port)
 }
 
 // Validate tests if the WebhookParameters has valid params.

--- a/galley/pkg/crd/validation/validation_test.go
+++ b/galley/pkg/crd/validation/validation_test.go
@@ -73,7 +73,7 @@ func TestValidate(t *testing.T) {
 		},
 		"invalid port": {
 			wrapFunc:      func(args *WebhookParameters) { args.Port = 100000 },
-			expectedError: "port number 100000 must be in the range 1..65535",
+			expectedError: "port number 100000 must be in the range 1024..65535",
 		},
 	}
 

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -79,9 +79,8 @@ type WebhookParameters struct {
 	// e.g. cluster.local.
 	DomainSuffix string
 
-	// Port where the webhook is served. Per k8s admission
-	// registration requirements this should be 443 unless there is
-	// only a single port for the service.
+	// Port where the webhook is served. the number should be greater than 1024, because
+	// non-root user cannot bind port number less than 1024
 	Port uint
 
 	// CertFile is the path to the x509 certificate for https.
@@ -157,7 +156,7 @@ func (p *WebhookParameters) String() string {
 // DefaultArgs allocates an WebhookParameters struct initialized with Webhook's default configuration.
 func DefaultArgs() *WebhookParameters {
 	return &WebhookParameters{
-		Port:                                443,
+		Port:                                8443,
 		CertFile:                            "/etc/certs/cert-chain.pem",
 		KeyFile:                             "/etc/certs/key.pem",
 		CACertFile:                          "/etc/certs/root-cert.pem",

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -156,7 +156,7 @@ func (p *WebhookParameters) String() string {
 // DefaultArgs allocates an WebhookParameters struct initialized with Webhook's default configuration.
 func DefaultArgs() *WebhookParameters {
 	return &WebhookParameters{
-		Port:                                8443,
+		Port:                                9443,
 		CertFile:                            "/etc/certs/cert-chain.pem",
 		KeyFile:                             "/etc/certs/key.pem",
 		CACertFile:                          "/etc/certs/root-cert.pem",

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -50,8 +50,8 @@ spec:
           - server
           - --meshConfigFile=/etc/mesh-config/mesh
           - --livenessProbeInterval=1s
-          - --livenessProbePath=/healthliveness
-          - --readinessProbePath=/healthready
+          - --livenessProbePath=/tmp/healthliveness
+          - --readinessProbePath=/tmp/healthready
           - --readinessProbeInterval=1s
           - --deployment-namespace={{ .Release.Namespace }}
 {{- if $.Values.global.controlPlaneSecurityEnabled}}
@@ -86,7 +86,7 @@ spec:
               command:
                 - /usr/local/bin/galley
                 - probe
-                - --probe-path=/healthliveness
+                - --probe-path=/tmp/healthliveness
                 - --interval=10s
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -95,7 +95,7 @@ spec:
               command:
                 - /usr/local/bin/galley
                 - probe
-                - --probe-path=/healthready
+                - --probe-path=/tmp/healthready
                 - --interval=10s
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -105,6 +105,10 @@ spec:
 {{- else }}
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
+          securityContext:
+            capabilities:
+              add:
+              - NET_BIND_SERVICE
       volumes:
       - name: certs
         secret:

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -119,6 +119,10 @@ spec:
       - name: mesh-config
         configMap:
           name: istio
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
 {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
-          - containerPort: 443
+          - containerPort: {{ .Values.validationPort }}
           - containerPort: {{ .Values.global.monitoringPort }}
           - containerPort: 9901
           command:
@@ -68,6 +68,7 @@ spec:
           - --validation-webhook-config-file
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort={{ .Values.global.monitoringPort }}
+          - --validation-port={{ .Values.validationPort }}
 {{- if $.Values.global.logging.level }}
           - --log_output_level={{ $.Values.global.logging.level }}
 {{- end}}
@@ -105,10 +106,6 @@ spec:
 {{- else }}
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
-          securityContext:
-            capabilities:
-              add:
-              - NET_BIND_SERVICE
       volumes:
       - name: certs
         secret:
@@ -119,10 +116,6 @@ spec:
       - name: mesh-config
         configMap:
           name: istio
-      securityContext:
-        sysctls:
-        - name: net.ipv4.ip_unprivileged_port_start
-          value: "0"
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
@@ -13,6 +13,7 @@ spec:
   ports:
   - port: 443
     name: https-validation
+    targetPort: {{ .Values.validationPort }}
   - port: {{ .Values.global.monitoringPort }}
     name: http-monitoring
   - port: 9901

--- a/install/kubernetes/helm/istio/charts/galley/templates/validatingwebhookconfiguration.yaml.tpl
+++ b/install/kubernetes/helm/istio/charts/galley/templates/validatingwebhookconfiguration.yaml.tpl
@@ -16,7 +16,6 @@ webhooks:
         name: istio-galley
         namespace: {{ .Release.Namespace }}
         path: "/admitpilot"
-        port: {{ .Values.validationPort }}
       caBundle: ""
     rules:
       - operations:
@@ -71,7 +70,6 @@ webhooks:
         name: istio-galley
         namespace: {{ .Release.Namespace }}
         path: "/admitmixer"
-        port: {{ .Values.validationPort }}
       caBundle: ""
     rules:
       - operations:

--- a/install/kubernetes/helm/istio/charts/galley/templates/validatingwebhookconfiguration.yaml.tpl
+++ b/install/kubernetes/helm/istio/charts/galley/templates/validatingwebhookconfiguration.yaml.tpl
@@ -16,6 +16,7 @@ webhooks:
         name: istio-galley
         namespace: {{ .Release.Namespace }}
         path: "/admitpilot"
+        port: {{ .Values.validationPort }}
       caBundle: ""
     rules:
       - operations:
@@ -70,6 +71,7 @@ webhooks:
         name: istio-galley
         namespace: {{ .Release.Namespace }}
         path: "/admitmixer"
+        port: {{ .Values.validationPort }}
       caBundle: ""
     rules:
       - operations:

--- a/install/kubernetes/helm/istio/charts/galley/values.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/values.yaml
@@ -30,4 +30,4 @@ tolerations: []
 podAntiAffinityLabelSelector: []
 podAntiAffinityTermLabelSelector: []
 #HTTPS port of the validation service
-validationPort: 8443
+validationPort: 9443

--- a/install/kubernetes/helm/istio/charts/galley/values.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/values.yaml
@@ -29,3 +29,5 @@ tolerations: []
 # "security" and value "S1".
 podAntiAffinityLabelSelector: []
 podAntiAffinityTermLabelSelector: []
+#HTTPS port of the validation service
+validationPort: 8443


### PR DESCRIPTION
Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>

this PR is for https://github.com/istio/istio/issues/10768

Just setting CAP_NET_ADMIN in the securityContext as in:
```
   securityContext:
     capabilities:
       add:
       - NET_BIND_SERVICE
```
wouldn't work because galley is started as a non-root user, and
switching to uid != 0 clears all permitted capabilities.
Docker cannot support setting ambient capabilities:
kubernetes/kubernetes#56374


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[x] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
