### PR TITLE
Generates sha256 for each istioctl archive published to GCS.

### DIFF
--- a/release/gcb/gcb_lib.sh
+++ b/release/gcb/gcb_lib.sh
@@ -95,8 +95,19 @@ function make_istio() {
   sha256sum "${ISTIO_OUT}/istio-sidecar.deb" > "${OUTPUT_PATH}/deb/istio-sidecar.deb.sha256"
   cp        "${ISTIO_OUT}/istio-sidecar.deb"   "${OUTPUT_PATH}/deb/"
   cp        "${ISTIO_OUT}"/archive/istio-*z*   "${OUTPUT_PATH}/"
-  cp        "${ISTIO_OUT}"/archive/istioctl*.tar.gz "${OUTPUT_PATH}/"
-  cp        "${ISTIO_OUT}"/archive/istioctl*.zip "${OUTPUT_PATH}/"
+
+  declare -a ISTIOCTL_ARCHIVES
+  
+  mapfile -t ISTIOCTL_ARCHIVES < <(ls "${ISTIO_OUT}"/archive/istioctl*.tar.gz)
+  mapfile -t ISTIOCTL_ARCHIVES < <(ls "${ISTIO_OUT}"/archive/istioctl*.zip)
+
+  for i in "${ISTIOCTL_ARCHIVES[@]}"; do
+    sha256sum "$i" > "$i.sha256"
+  done
+
+  cp        "${ISTIO_OUT}"/archive/istioctl*.tar.gz "${OUTPUT_PATH}/"      
+  cp        "${ISTIO_OUT}"/archive/istioctl*.zip    "${OUTPUT_PATH}/"
+  cp        "${ISTIO_OUT}"/archive/istioctl*.sha256 "${OUTPUT_PATH}/"
 
   rm -r "${ISTIO_OUT}/docker" || true
   BUILD_DOCKER_TARGETS=(docker.save)


### PR DESCRIPTION
Signed-off-by: Jason Clark <jason.clark@ibm.com>

To address #15584, this PR generates the sha256 files for each of the istioctl archives published to Google Cloud Storage (GCS).

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure
