### PR TITLE
Enable XDS marshalling to Any by default

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -110,8 +110,6 @@ spec:
           - name: PILOT_TRACE_SAMPLING
             value: "{{ .Values.traceSampling }}"
 {{- end }}
-          - name: PILOT_DISABLE_XDS_MARSHALING_TO_ANY
-            value: "1"
           resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
This feature improves pilot performance substantially, but was disabled
by default due to some proxy CPU regressions we were seeing. Since some
Envoy changes we have been unable to reproduce since then. This will
still be able to be turn off if issues do arise, but for now it seems
safe to enable this by default.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[x] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
