### PR TITLE
Don't report send error for expected errors

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -58,7 +58,7 @@ func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, v
 	err = con.send(response)
 	if err != nil {
 		adsLog.Warnf("CDS: Send failure %s: %v", con.ConID, err)
-		cdsSendErrPushes.Increment()
+		recordSendError(cdsSendErrPushes, err)
 		return err
 	}
 	cdsPushes.Increment()

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -740,7 +740,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 	err := con.send(response)
 	if err != nil {
 		adsLog.Warnf("EDS: Send failure %s: %v", con.ConID, err)
-		edsSendErrPushes.Increment()
+		recordSendError(edsSendErrPushes, err)
 		return err
 	}
 	edsPushes.Increment()

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -37,7 +37,7 @@ func (s *DiscoveryServer) pushLds(con *XdsConnection, push *model.PushContext, v
 	err = con.send(response)
 	if err != nil {
 		adsLog.Warnf("LDS: Send failure %s: %v", con.ConID, err)
-		ldsSendErrPushes.Increment()
+		recordSendError(ldsSendErrPushes, err)
 		return err
 	}
 	ldsPushes.Increment()

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -44,7 +44,7 @@ func (s *DiscoveryServer) pushRoute(con *XdsConnection, push *model.PushContext,
 	err = con.send(response)
 	if err != nil {
 		adsLog.Warnf("RDS: Send failure for node:%v: %v", con.modelNode.ID, err)
-		rdsSendErrPushes.Increment()
+		recordSendError(rdsSendErrPushes, err)
 		return err
 	}
 	rdsPushes.Increment()


### PR DESCRIPTION
Right now a metric is incremeneted for every send error. The vast
majority of the time this error is just due to standard operations with
the connection closing while sending. This masks real errors. Once
https://github.com/istio/istio/pull/15476 is merged and we have these
errors displayed more prominently, we will not want to display these
false positives.

Please provide a description for what this PR is for.

[x] Networking
[x] Policies and Telemetry