### PR TITLE
Add log dumping to kind to help debug integration test failures

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -128,15 +128,12 @@ function attempt_kind_creation() {
   attempts=0
   until [[ ${attempts} -ge 3 ]]
   do
-    kind create cluster --name=e2e-suite --loglevel debug && break
-    attempts=$[$attempts+1]
+    kind create cluster --name=e2e-suite --loglevel debug && return 0
+    attempts=$((attempts+1))
     echo "Could not setup KinD environment. Something wrong with KinD setup. Trying again."
-    sleep 1
   done
-  if [[ ! $? ]]; then
-    echo "Could not set up KinD environment."
-    exit 1
-  fi
+  echo "Could not set up KinD environment."
+  exit 1
 }
 
 function setup_kind_cluster() {

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -135,7 +135,7 @@ function setup_kind_cluster() {
   fi
 
   # Create KinD cluster
-  if ! (kind create cluster --name=e2e-suite --loglevel debug); then
+  if ! (kind create cluster --name=e2e-suite --loglevel debug --retain); then
     echo "Could not setup KinD environment. Something wrong with KinD setup. Exporting logs."
     kind export logs --name e2e-suite "${ARTIFACTS_DIR}/kind"
     exit 1

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -124,18 +124,6 @@ function check_kind() {
   fi
 }
 
-function attempt_kind_creation() {
-  attempts=0
-  until [[ ${attempts} -ge 3 ]]
-  do
-    kind create cluster --name=e2e-suite --loglevel debug && return 0
-    attempts=$((attempts+1))
-    echo "Could not setup KinD environment. Something wrong with KinD setup. Trying again."
-  done
-  echo "Could not set up KinD environment."
-  exit 1
-}
-
 function setup_kind_cluster() {
   # Installing KinD
   check_kind
@@ -147,7 +135,11 @@ function setup_kind_cluster() {
   fi
 
   # Create KinD cluster
-  attempt_kind_creation || exit 1
+  if ! (kind create cluster --name=e2e-suite --loglevel debug); then
+    echo "Could not setup KinD environment. Something wrong with KinD setup. Exporting logs."
+    kind export logs --name e2e-suite "${ARTIFACTS_DIR}/kind"
+    exit 1
+  fi
 
   KUBECONFIG="$(kind get kubeconfig-path --name="e2e-suite")"
   export KUBECONFIG

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -124,6 +124,21 @@ function check_kind() {
   fi
 }
 
+function attempt_kind_creation() {
+  attempts=0
+  until [[ ${attempts} -ge 3 ]]
+  do
+    kind create cluster --name=e2e-suite --loglevel debug && break
+    attempts=$[$attempts+1]
+    echo "Could not setup KinD environment. Something wrong with KinD setup. Trying again."
+    sleep 1
+  done
+  if [[ ! $? ]]; then
+    echo "Could not set up KinD environment."
+    exit 1
+  fi
+}
+
 function setup_kind_cluster() {
   # Installing KinD
   check_kind
@@ -135,10 +150,8 @@ function setup_kind_cluster() {
   fi
 
   # Create KinD cluster
-  if ! (kind create cluster --name=e2e-suite); then
-    echo "Could not setup KinD environment. Something wrong with KinD setup. Please check your setup and try again."
-    exit 1
-  fi
+  attempt_kind_creation || exit 1
+
   KUBECONFIG="$(kind get kubeconfig-path --name="e2e-suite")"
   export KUBECONFIG
 }


### PR DESCRIPTION
We are seeing lots of flakes due to kind failing to create the cluster.
This adds retries to cluster creation, and increase the log level so we
can help root cause the issue.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[x] Developer Infrastructure
