### PR TITLE
Build only images needed for tests

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -45,7 +45,11 @@ export HUB=${HUB:-"kindtest"}
 export TAG="${TAG:-${GIT_SHA}}"
 
 make init
-make docker
+
+# Build just the images needed for the tests
+for image in pilot proxyv2 proxy_init app test_policybackend mixer citadel galley sidecar_injector kubectl node-agent-k8s; do
+   make docker.${image}
+done
 
 function build_kind_images(){
 	# Archived local images and load it into KinD's docker daemon


### PR DESCRIPTION
Hopefully this can speed up our tests and reduce node pressure a bit

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
