### PR TITLE
fix stackdriver adapter getting shutdown (#15612)

### DIFF
--- a/mixer/adapter/stackdriver/metric/bufferedClient.go
+++ b/mixer/adapter/stackdriver/metric/bufferedClient.go
@@ -83,12 +83,14 @@ func batchTimeSeries(series []*monitoringpb.TimeSeries, tsLimit int) [][]*monito
 
 func (b *buffered) start(env adapter.Env, ticker *time.Ticker, quit chan struct{}) {
 	env.ScheduleDaemon(func() {
-		select {
-		case <-ticker.C:
-			b.mergeTimeSeries()
-			b.Send()
-		case <-quit:
-			return
+		for {
+			select {
+			case <-ticker.C:
+				b.mergeTimeSeries()
+				b.Send()
+			case <-quit:
+				return
+			}
 		}
 	})
 }


### PR DESCRIPTION
Manual cherry pick of #15612. `action/merge-to-release-1.2-branch` label does not seem to function.

@fpesce Could you please help to merge this? This is a bug in Stackdriver adapter that is found and fixed by community contributor. Without this fix, stackdriver adapter will stop after the first push. Thank you!

cc @kyessenov @canthefason 