### PR TITLE
Add support for specify redirectCode in HTTPRoute

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -2403,6 +2403,12 @@ func validateHTTPRedirect(redirect *networking.HTTPRedirect) error {
 	if redirect != nil && redirect.Uri == "" && redirect.Authority == "" {
 		return errors.New("redirect must specify URI, authority, or both")
 	}
+
+	if redirect != nil && redirect.RedirectCode != 0 {
+		if redirect.RedirectCode < 300 || redirect.RedirectCode > 399 {
+			return fmt.Errorf("%d is not a valid redirect code, must be 3xx", redirect.RedirectCode)
+		}
+	}
 	return nil
 }
 

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -2220,6 +2220,24 @@ func TestValidateHTTPRedirect(t *testing.T) {
 			valid: false,
 		},
 		{
+			name: "too small redirect code",
+			redirect: &networking.HTTPRedirect{
+				Uri:          "t",
+				Authority:    "",
+				RedirectCode: 299,
+			},
+			valid: false,
+		},
+		{
+			name: "too large redirect code",
+			redirect: &networking.HTTPRedirect{
+				Uri:          "t",
+				Authority:    "",
+				RedirectCode: 400,
+			},
+			valid: false,
+		},
+		{
 			name: "empty authority",
 			redirect: &networking.HTTPRedirect{
 				Uri:       "t",
@@ -2236,10 +2254,20 @@ func TestValidateHTTPRedirect(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "empty redirect code",
+			redirect: &networking.HTTPRedirect{
+				Uri:          "t",
+				Authority:    "t",
+				RedirectCode: 0,
+			},
+			valid: true,
+		},
+		{
 			name: "normal redirect",
 			redirect: &networking.HTTPRedirect{
-				Uri:       "t",
-				Authority: "t",
+				Uri:          "t",
+				Authority:    "t",
+				RedirectCode: 308,
 			},
 			valid: true,
 		},

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -285,6 +285,18 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}
 		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(gomega.ConsistOf(hashPolicy))
 	})
+
+	t.Run("for redirect code", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+
+		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithRedirect, serviceRegistry, 8080, model.LabelsCollection{}, gatewayNames)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(len(routes)).To(gomega.Equal(1))
+
+		redirectAction, ok := routes[0].Action.(*envoyroute.Route_Redirect)
+		g.Expect(ok).NotTo(gomega.BeFalse())
+		g.Expect(redirectAction.Redirect.ResponseCode).To(gomega.Equal(envoyroute.RedirectAction_PERMANENT_REDIRECT))
+	})
 }
 
 func loadBalancerPolicy(name string) *networking.LoadBalancerSettings_ConsistentHash {
@@ -368,6 +380,27 @@ var virtualServicePlain = model.Config{
 						},
 						Weight: 100,
 					},
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithRedirect = model.Config{
+	ConfigMeta: model.ConfigMeta{
+		Type:    model.VirtualService.Type,
+		Version: model.VirtualService.Version,
+		Name:    "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Redirect: &networking.HTTPRedirect{
+					Uri:          "example.org",
+					Authority:    "some-authority.default.svc.cluster.local",
+					RedirectCode: 308,
 				},
 			},
 		},


### PR DESCRIPTION
This adds support for specify the `redirectCode` in `HTTPRoute` of VirtualService.

Fixes https://github.com/istio/istio/issues/15292

Related commit in `istio.io/api`: https://github.com/istio/api/commit/99722f53e70c724a43544b1c685b1dcb8a6eef4e


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
