### PR TITLE
 [collab-galley] CRD Discovery support

### DIFF
--- a/galley/pkg/config/processor/metadata/collections.gen.go
+++ b/galley/pkg/config/processor/metadata/collections.gen.go
@@ -24,6 +24,99 @@ var (
 	// IstioConfigV1Alpha2Httpapispecs is the name of collection istio/config/v1alpha2/httpapispecs
 	IstioConfigV1Alpha2Httpapispecs = collection.NewName("istio/config/v1alpha2/httpapispecs")
 
+	// IstioConfigV1Alpha2LegacyApikeys is the name of collection istio/config/v1alpha2/legacy/apikeys
+	IstioConfigV1Alpha2LegacyApikeys = collection.NewName("istio/config/v1alpha2/legacy/apikeys")
+
+	// IstioConfigV1Alpha2LegacyAuthorizations is the name of collection istio/config/v1alpha2/legacy/authorizations
+	IstioConfigV1Alpha2LegacyAuthorizations = collection.NewName("istio/config/v1alpha2/legacy/authorizations")
+
+	// IstioConfigV1Alpha2LegacyBypasses is the name of collection istio/config/v1alpha2/legacy/bypasses
+	IstioConfigV1Alpha2LegacyBypasses = collection.NewName("istio/config/v1alpha2/legacy/bypasses")
+
+	// IstioConfigV1Alpha2LegacyChecknothings is the name of collection istio/config/v1alpha2/legacy/checknothings
+	IstioConfigV1Alpha2LegacyChecknothings = collection.NewName("istio/config/v1alpha2/legacy/checknothings")
+
+	// IstioConfigV1Alpha2LegacyCirconuses is the name of collection istio/config/v1alpha2/legacy/circonuses
+	IstioConfigV1Alpha2LegacyCirconuses = collection.NewName("istio/config/v1alpha2/legacy/circonuses")
+
+	// IstioConfigV1Alpha2LegacyCloudwatches is the name of collection istio/config/v1alpha2/legacy/cloudwatches
+	IstioConfigV1Alpha2LegacyCloudwatches = collection.NewName("istio/config/v1alpha2/legacy/cloudwatches")
+
+	// IstioConfigV1Alpha2LegacyDeniers is the name of collection istio/config/v1alpha2/legacy/deniers
+	IstioConfigV1Alpha2LegacyDeniers = collection.NewName("istio/config/v1alpha2/legacy/deniers")
+
+	// IstioConfigV1Alpha2LegacyDogstatsds is the name of collection istio/config/v1alpha2/legacy/dogstatsds
+	IstioConfigV1Alpha2LegacyDogstatsds = collection.NewName("istio/config/v1alpha2/legacy/dogstatsds")
+
+	// IstioConfigV1Alpha2LegacyEdges is the name of collection istio/config/v1alpha2/legacy/edges
+	IstioConfigV1Alpha2LegacyEdges = collection.NewName("istio/config/v1alpha2/legacy/edges")
+
+	// IstioConfigV1Alpha2LegacyFluentds is the name of collection istio/config/v1alpha2/legacy/fluentds
+	IstioConfigV1Alpha2LegacyFluentds = collection.NewName("istio/config/v1alpha2/legacy/fluentds")
+
+	// IstioConfigV1Alpha2LegacyKubernetesenvs is the name of collection istio/config/v1alpha2/legacy/kubernetesenvs
+	IstioConfigV1Alpha2LegacyKubernetesenvs = collection.NewName("istio/config/v1alpha2/legacy/kubernetesenvs")
+
+	// IstioConfigV1Alpha2LegacyKuberneteses is the name of collection istio/config/v1alpha2/legacy/kuberneteses
+	IstioConfigV1Alpha2LegacyKuberneteses = collection.NewName("istio/config/v1alpha2/legacy/kuberneteses")
+
+	// IstioConfigV1Alpha2LegacyListcheckers is the name of collection istio/config/v1alpha2/legacy/listcheckers
+	IstioConfigV1Alpha2LegacyListcheckers = collection.NewName("istio/config/v1alpha2/legacy/listcheckers")
+
+	// IstioConfigV1Alpha2LegacyListentries is the name of collection istio/config/v1alpha2/legacy/listentries
+	IstioConfigV1Alpha2LegacyListentries = collection.NewName("istio/config/v1alpha2/legacy/listentries")
+
+	// IstioConfigV1Alpha2LegacyLogentries is the name of collection istio/config/v1alpha2/legacy/logentries
+	IstioConfigV1Alpha2LegacyLogentries = collection.NewName("istio/config/v1alpha2/legacy/logentries")
+
+	// IstioConfigV1Alpha2LegacyMemquotas is the name of collection istio/config/v1alpha2/legacy/memquotas
+	IstioConfigV1Alpha2LegacyMemquotas = collection.NewName("istio/config/v1alpha2/legacy/memquotas")
+
+	// IstioConfigV1Alpha2LegacyMetrics is the name of collection istio/config/v1alpha2/legacy/metrics
+	IstioConfigV1Alpha2LegacyMetrics = collection.NewName("istio/config/v1alpha2/legacy/metrics")
+
+	// IstioConfigV1Alpha2LegacyNoops is the name of collection istio/config/v1alpha2/legacy/noops
+	IstioConfigV1Alpha2LegacyNoops = collection.NewName("istio/config/v1alpha2/legacy/noops")
+
+	// IstioConfigV1Alpha2LegacyOpas is the name of collection istio/config/v1alpha2/legacy/opas
+	IstioConfigV1Alpha2LegacyOpas = collection.NewName("istio/config/v1alpha2/legacy/opas")
+
+	// IstioConfigV1Alpha2LegacyPrometheuses is the name of collection istio/config/v1alpha2/legacy/prometheuses
+	IstioConfigV1Alpha2LegacyPrometheuses = collection.NewName("istio/config/v1alpha2/legacy/prometheuses")
+
+	// IstioConfigV1Alpha2LegacyQuotas is the name of collection istio/config/v1alpha2/legacy/quotas
+	IstioConfigV1Alpha2LegacyQuotas = collection.NewName("istio/config/v1alpha2/legacy/quotas")
+
+	// IstioConfigV1Alpha2LegacyRbacs is the name of collection istio/config/v1alpha2/legacy/rbacs
+	IstioConfigV1Alpha2LegacyRbacs = collection.NewName("istio/config/v1alpha2/legacy/rbacs")
+
+	// IstioConfigV1Alpha2LegacyRedisquotas is the name of collection istio/config/v1alpha2/legacy/redisquotas
+	IstioConfigV1Alpha2LegacyRedisquotas = collection.NewName("istio/config/v1alpha2/legacy/redisquotas")
+
+	// IstioConfigV1Alpha2LegacyReportnothings is the name of collection istio/config/v1alpha2/legacy/reportnothings
+	IstioConfigV1Alpha2LegacyReportnothings = collection.NewName("istio/config/v1alpha2/legacy/reportnothings")
+
+	// IstioConfigV1Alpha2LegacySignalfxs is the name of collection istio/config/v1alpha2/legacy/signalfxs
+	IstioConfigV1Alpha2LegacySignalfxs = collection.NewName("istio/config/v1alpha2/legacy/signalfxs")
+
+	// IstioConfigV1Alpha2LegacySolarwindses is the name of collection istio/config/v1alpha2/legacy/solarwindses
+	IstioConfigV1Alpha2LegacySolarwindses = collection.NewName("istio/config/v1alpha2/legacy/solarwindses")
+
+	// IstioConfigV1Alpha2LegacyStackdrivers is the name of collection istio/config/v1alpha2/legacy/stackdrivers
+	IstioConfigV1Alpha2LegacyStackdrivers = collection.NewName("istio/config/v1alpha2/legacy/stackdrivers")
+
+	// IstioConfigV1Alpha2LegacyStatsds is the name of collection istio/config/v1alpha2/legacy/statsds
+	IstioConfigV1Alpha2LegacyStatsds = collection.NewName("istio/config/v1alpha2/legacy/statsds")
+
+	// IstioConfigV1Alpha2LegacyStdios is the name of collection istio/config/v1alpha2/legacy/stdios
+	IstioConfigV1Alpha2LegacyStdios = collection.NewName("istio/config/v1alpha2/legacy/stdios")
+
+	// IstioConfigV1Alpha2LegacyTracespans is the name of collection istio/config/v1alpha2/legacy/tracespans
+	IstioConfigV1Alpha2LegacyTracespans = collection.NewName("istio/config/v1alpha2/legacy/tracespans")
+
+	// IstioConfigV1Alpha2LegacyZipkins is the name of collection istio/config/v1alpha2/legacy/zipkins
+	IstioConfigV1Alpha2LegacyZipkins = collection.NewName("istio/config/v1alpha2/legacy/zipkins")
+
 	// IstioConfigV1Alpha2Templates is the name of collection istio/config/v1alpha2/templates
 	IstioConfigV1Alpha2Templates = collection.NewName("istio/config/v1alpha2/templates")
 
@@ -93,8 +186,38 @@ var (
 	// K8SConfigIstioIoV1Alpha2Adapters is the name of collection k8s/config.istio.io/v1alpha2/adapters
 	K8SConfigIstioIoV1Alpha2Adapters = collection.NewName("k8s/config.istio.io/v1alpha2/adapters")
 
+	// K8SConfigIstioIoV1Alpha2Apikeys is the name of collection k8s/config.istio.io/v1alpha2/apikeys
+	K8SConfigIstioIoV1Alpha2Apikeys = collection.NewName("k8s/config.istio.io/v1alpha2/apikeys")
+
 	// K8SConfigIstioIoV1Alpha2Attributemanifests is the name of collection k8s/config.istio.io/v1alpha2/attributemanifests
 	K8SConfigIstioIoV1Alpha2Attributemanifests = collection.NewName("k8s/config.istio.io/v1alpha2/attributemanifests")
+
+	// K8SConfigIstioIoV1Alpha2Authorizations is the name of collection k8s/config.istio.io/v1alpha2/authorizations
+	K8SConfigIstioIoV1Alpha2Authorizations = collection.NewName("k8s/config.istio.io/v1alpha2/authorizations")
+
+	// K8SConfigIstioIoV1Alpha2Bypasses is the name of collection k8s/config.istio.io/v1alpha2/bypasses
+	K8SConfigIstioIoV1Alpha2Bypasses = collection.NewName("k8s/config.istio.io/v1alpha2/bypasses")
+
+	// K8SConfigIstioIoV1Alpha2Checknothings is the name of collection k8s/config.istio.io/v1alpha2/checknothings
+	K8SConfigIstioIoV1Alpha2Checknothings = collection.NewName("k8s/config.istio.io/v1alpha2/checknothings")
+
+	// K8SConfigIstioIoV1Alpha2Circonuses is the name of collection k8s/config.istio.io/v1alpha2/circonuses
+	K8SConfigIstioIoV1Alpha2Circonuses = collection.NewName("k8s/config.istio.io/v1alpha2/circonuses")
+
+	// K8SConfigIstioIoV1Alpha2Cloudwatches is the name of collection k8s/config.istio.io/v1alpha2/cloudwatches
+	K8SConfigIstioIoV1Alpha2Cloudwatches = collection.NewName("k8s/config.istio.io/v1alpha2/cloudwatches")
+
+	// K8SConfigIstioIoV1Alpha2Deniers is the name of collection k8s/config.istio.io/v1alpha2/deniers
+	K8SConfigIstioIoV1Alpha2Deniers = collection.NewName("k8s/config.istio.io/v1alpha2/deniers")
+
+	// K8SConfigIstioIoV1Alpha2Dogstatsds is the name of collection k8s/config.istio.io/v1alpha2/dogstatsds
+	K8SConfigIstioIoV1Alpha2Dogstatsds = collection.NewName("k8s/config.istio.io/v1alpha2/dogstatsds")
+
+	// K8SConfigIstioIoV1Alpha2Edges is the name of collection k8s/config.istio.io/v1alpha2/edges
+	K8SConfigIstioIoV1Alpha2Edges = collection.NewName("k8s/config.istio.io/v1alpha2/edges")
+
+	// K8SConfigIstioIoV1Alpha2Fluentds is the name of collection k8s/config.istio.io/v1alpha2/fluentds
+	K8SConfigIstioIoV1Alpha2Fluentds = collection.NewName("k8s/config.istio.io/v1alpha2/fluentds")
 
 	// K8SConfigIstioIoV1Alpha2Handlers is the name of collection k8s/config.istio.io/v1alpha2/handlers
 	K8SConfigIstioIoV1Alpha2Handlers = collection.NewName("k8s/config.istio.io/v1alpha2/handlers")
@@ -108,17 +231,80 @@ var (
 	// K8SConfigIstioIoV1Alpha2Instances is the name of collection k8s/config.istio.io/v1alpha2/instances
 	K8SConfigIstioIoV1Alpha2Instances = collection.NewName("k8s/config.istio.io/v1alpha2/instances")
 
+	// K8SConfigIstioIoV1Alpha2Kubernetesenvs is the name of collection k8s/config.istio.io/v1alpha2/kubernetesenvs
+	K8SConfigIstioIoV1Alpha2Kubernetesenvs = collection.NewName("k8s/config.istio.io/v1alpha2/kubernetesenvs")
+
+	// K8SConfigIstioIoV1Alpha2Kuberneteses is the name of collection k8s/config.istio.io/v1alpha2/kuberneteses
+	K8SConfigIstioIoV1Alpha2Kuberneteses = collection.NewName("k8s/config.istio.io/v1alpha2/kuberneteses")
+
+	// K8SConfigIstioIoV1Alpha2Listcheckers is the name of collection k8s/config.istio.io/v1alpha2/listcheckers
+	K8SConfigIstioIoV1Alpha2Listcheckers = collection.NewName("k8s/config.istio.io/v1alpha2/listcheckers")
+
+	// K8SConfigIstioIoV1Alpha2Listentries is the name of collection k8s/config.istio.io/v1alpha2/listentries
+	K8SConfigIstioIoV1Alpha2Listentries = collection.NewName("k8s/config.istio.io/v1alpha2/listentries")
+
+	// K8SConfigIstioIoV1Alpha2Logentries is the name of collection k8s/config.istio.io/v1alpha2/logentries
+	K8SConfigIstioIoV1Alpha2Logentries = collection.NewName("k8s/config.istio.io/v1alpha2/logentries")
+
+	// K8SConfigIstioIoV1Alpha2Memquotas is the name of collection k8s/config.istio.io/v1alpha2/memquotas
+	K8SConfigIstioIoV1Alpha2Memquotas = collection.NewName("k8s/config.istio.io/v1alpha2/memquotas")
+
+	// K8SConfigIstioIoV1Alpha2Metrics is the name of collection k8s/config.istio.io/v1alpha2/metrics
+	K8SConfigIstioIoV1Alpha2Metrics = collection.NewName("k8s/config.istio.io/v1alpha2/metrics")
+
+	// K8SConfigIstioIoV1Alpha2Noops is the name of collection k8s/config.istio.io/v1alpha2/noops
+	K8SConfigIstioIoV1Alpha2Noops = collection.NewName("k8s/config.istio.io/v1alpha2/noops")
+
+	// K8SConfigIstioIoV1Alpha2Opas is the name of collection k8s/config.istio.io/v1alpha2/opas
+	K8SConfigIstioIoV1Alpha2Opas = collection.NewName("k8s/config.istio.io/v1alpha2/opas")
+
+	// K8SConfigIstioIoV1Alpha2Prometheuses is the name of collection k8s/config.istio.io/v1alpha2/prometheuses
+	K8SConfigIstioIoV1Alpha2Prometheuses = collection.NewName("k8s/config.istio.io/v1alpha2/prometheuses")
+
+	// K8SConfigIstioIoV1Alpha2Quotas is the name of collection k8s/config.istio.io/v1alpha2/quotas
+	K8SConfigIstioIoV1Alpha2Quotas = collection.NewName("k8s/config.istio.io/v1alpha2/quotas")
+
 	// K8SConfigIstioIoV1Alpha2Quotaspecbindings is the name of collection k8s/config.istio.io/v1alpha2/quotaspecbindings
 	K8SConfigIstioIoV1Alpha2Quotaspecbindings = collection.NewName("k8s/config.istio.io/v1alpha2/quotaspecbindings")
 
 	// K8SConfigIstioIoV1Alpha2Quotaspecs is the name of collection k8s/config.istio.io/v1alpha2/quotaspecs
 	K8SConfigIstioIoV1Alpha2Quotaspecs = collection.NewName("k8s/config.istio.io/v1alpha2/quotaspecs")
 
+	// K8SConfigIstioIoV1Alpha2Rbacs is the name of collection k8s/config.istio.io/v1alpha2/rbacs
+	K8SConfigIstioIoV1Alpha2Rbacs = collection.NewName("k8s/config.istio.io/v1alpha2/rbacs")
+
+	// K8SConfigIstioIoV1Alpha2Redisquotas is the name of collection k8s/config.istio.io/v1alpha2/redisquotas
+	K8SConfigIstioIoV1Alpha2Redisquotas = collection.NewName("k8s/config.istio.io/v1alpha2/redisquotas")
+
+	// K8SConfigIstioIoV1Alpha2Reportnothings is the name of collection k8s/config.istio.io/v1alpha2/reportnothings
+	K8SConfigIstioIoV1Alpha2Reportnothings = collection.NewName("k8s/config.istio.io/v1alpha2/reportnothings")
+
 	// K8SConfigIstioIoV1Alpha2Rules is the name of collection k8s/config.istio.io/v1alpha2/rules
 	K8SConfigIstioIoV1Alpha2Rules = collection.NewName("k8s/config.istio.io/v1alpha2/rules")
 
+	// K8SConfigIstioIoV1Alpha2Signalfxs is the name of collection k8s/config.istio.io/v1alpha2/signalfxs
+	K8SConfigIstioIoV1Alpha2Signalfxs = collection.NewName("k8s/config.istio.io/v1alpha2/signalfxs")
+
+	// K8SConfigIstioIoV1Alpha2Solarwindses is the name of collection k8s/config.istio.io/v1alpha2/solarwindses
+	K8SConfigIstioIoV1Alpha2Solarwindses = collection.NewName("k8s/config.istio.io/v1alpha2/solarwindses")
+
+	// K8SConfigIstioIoV1Alpha2Stackdrivers is the name of collection k8s/config.istio.io/v1alpha2/stackdrivers
+	K8SConfigIstioIoV1Alpha2Stackdrivers = collection.NewName("k8s/config.istio.io/v1alpha2/stackdrivers")
+
+	// K8SConfigIstioIoV1Alpha2Statsds is the name of collection k8s/config.istio.io/v1alpha2/statsds
+	K8SConfigIstioIoV1Alpha2Statsds = collection.NewName("k8s/config.istio.io/v1alpha2/statsds")
+
+	// K8SConfigIstioIoV1Alpha2Stdios is the name of collection k8s/config.istio.io/v1alpha2/stdios
+	K8SConfigIstioIoV1Alpha2Stdios = collection.NewName("k8s/config.istio.io/v1alpha2/stdios")
+
 	// K8SConfigIstioIoV1Alpha2Templates is the name of collection k8s/config.istio.io/v1alpha2/templates
 	K8SConfigIstioIoV1Alpha2Templates = collection.NewName("k8s/config.istio.io/v1alpha2/templates")
+
+	// K8SConfigIstioIoV1Alpha2Tracespans is the name of collection k8s/config.istio.io/v1alpha2/tracespans
+	K8SConfigIstioIoV1Alpha2Tracespans = collection.NewName("k8s/config.istio.io/v1alpha2/tracespans")
+
+	// K8SConfigIstioIoV1Alpha2Zipkins is the name of collection k8s/config.istio.io/v1alpha2/zipkins
+	K8SConfigIstioIoV1Alpha2Zipkins = collection.NewName("k8s/config.istio.io/v1alpha2/zipkins")
 
 	// K8SCoreV1Endpoints is the name of collection k8s/core/v1/endpoints
 	K8SCoreV1Endpoints = collection.NewName("k8s/core/v1/endpoints")
@@ -180,6 +366,37 @@ func CollectionNames() []collection.Name {
 		IstioConfigV1Alpha2Adapters,
 		IstioConfigV1Alpha2Httpapispecbindings,
 		IstioConfigV1Alpha2Httpapispecs,
+		IstioConfigV1Alpha2LegacyApikeys,
+		IstioConfigV1Alpha2LegacyAuthorizations,
+		IstioConfigV1Alpha2LegacyBypasses,
+		IstioConfigV1Alpha2LegacyChecknothings,
+		IstioConfigV1Alpha2LegacyCirconuses,
+		IstioConfigV1Alpha2LegacyCloudwatches,
+		IstioConfigV1Alpha2LegacyDeniers,
+		IstioConfigV1Alpha2LegacyDogstatsds,
+		IstioConfigV1Alpha2LegacyEdges,
+		IstioConfigV1Alpha2LegacyFluentds,
+		IstioConfigV1Alpha2LegacyKubernetesenvs,
+		IstioConfigV1Alpha2LegacyKuberneteses,
+		IstioConfigV1Alpha2LegacyListcheckers,
+		IstioConfigV1Alpha2LegacyListentries,
+		IstioConfigV1Alpha2LegacyLogentries,
+		IstioConfigV1Alpha2LegacyMemquotas,
+		IstioConfigV1Alpha2LegacyMetrics,
+		IstioConfigV1Alpha2LegacyNoops,
+		IstioConfigV1Alpha2LegacyOpas,
+		IstioConfigV1Alpha2LegacyPrometheuses,
+		IstioConfigV1Alpha2LegacyQuotas,
+		IstioConfigV1Alpha2LegacyRbacs,
+		IstioConfigV1Alpha2LegacyRedisquotas,
+		IstioConfigV1Alpha2LegacyReportnothings,
+		IstioConfigV1Alpha2LegacySignalfxs,
+		IstioConfigV1Alpha2LegacySolarwindses,
+		IstioConfigV1Alpha2LegacyStackdrivers,
+		IstioConfigV1Alpha2LegacyStatsds,
+		IstioConfigV1Alpha2LegacyStdios,
+		IstioConfigV1Alpha2LegacyTracespans,
+		IstioConfigV1Alpha2LegacyZipkins,
 		IstioConfigV1Alpha2Templates,
 		IstioMeshV1Alpha1MeshConfig,
 		IstioMixerV1ConfigClientQuotaspecbindings,
@@ -203,15 +420,46 @@ func CollectionNames() []collection.Name {
 		K8SAuthenticationIstioIoV1Alpha1Meshpolicies,
 		K8SAuthenticationIstioIoV1Alpha1Policies,
 		K8SConfigIstioIoV1Alpha2Adapters,
+		K8SConfigIstioIoV1Alpha2Apikeys,
 		K8SConfigIstioIoV1Alpha2Attributemanifests,
+		K8SConfigIstioIoV1Alpha2Authorizations,
+		K8SConfigIstioIoV1Alpha2Bypasses,
+		K8SConfigIstioIoV1Alpha2Checknothings,
+		K8SConfigIstioIoV1Alpha2Circonuses,
+		K8SConfigIstioIoV1Alpha2Cloudwatches,
+		K8SConfigIstioIoV1Alpha2Deniers,
+		K8SConfigIstioIoV1Alpha2Dogstatsds,
+		K8SConfigIstioIoV1Alpha2Edges,
+		K8SConfigIstioIoV1Alpha2Fluentds,
 		K8SConfigIstioIoV1Alpha2Handlers,
 		K8SConfigIstioIoV1Alpha2Httpapispecbindings,
 		K8SConfigIstioIoV1Alpha2Httpapispecs,
 		K8SConfigIstioIoV1Alpha2Instances,
+		K8SConfigIstioIoV1Alpha2Kubernetesenvs,
+		K8SConfigIstioIoV1Alpha2Kuberneteses,
+		K8SConfigIstioIoV1Alpha2Listcheckers,
+		K8SConfigIstioIoV1Alpha2Listentries,
+		K8SConfigIstioIoV1Alpha2Logentries,
+		K8SConfigIstioIoV1Alpha2Memquotas,
+		K8SConfigIstioIoV1Alpha2Metrics,
+		K8SConfigIstioIoV1Alpha2Noops,
+		K8SConfigIstioIoV1Alpha2Opas,
+		K8SConfigIstioIoV1Alpha2Prometheuses,
+		K8SConfigIstioIoV1Alpha2Quotas,
 		K8SConfigIstioIoV1Alpha2Quotaspecbindings,
 		K8SConfigIstioIoV1Alpha2Quotaspecs,
+		K8SConfigIstioIoV1Alpha2Rbacs,
+		K8SConfigIstioIoV1Alpha2Redisquotas,
+		K8SConfigIstioIoV1Alpha2Reportnothings,
 		K8SConfigIstioIoV1Alpha2Rules,
+		K8SConfigIstioIoV1Alpha2Signalfxs,
+		K8SConfigIstioIoV1Alpha2Solarwindses,
+		K8SConfigIstioIoV1Alpha2Stackdrivers,
+		K8SConfigIstioIoV1Alpha2Statsds,
+		K8SConfigIstioIoV1Alpha2Stdios,
 		K8SConfigIstioIoV1Alpha2Templates,
+		K8SConfigIstioIoV1Alpha2Tracespans,
+		K8SConfigIstioIoV1Alpha2Zipkins,
 		K8SCoreV1Endpoints,
 		K8SCoreV1Namespaces,
 		K8SCoreV1Nodes,

--- a/galley/pkg/config/processor/metadata/metadata.gen.go
+++ b/galley/pkg/config/processor/metadata/metadata.gen.go
@@ -284,6 +284,256 @@ collections:
     proto:        "istio.rbac.v1alpha1.ServiceRole"
     protoPackage: "istio.io/api/rbac/v1alpha1"
 
+    # Keep Legacy Mixer CRD related collections separate, as these will be gone soon.
+  - name:          "k8s/config.istio.io/v1alpha2/apikeys"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/apikeys"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/authorizations"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/authorizations"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/bypasses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/bypasses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/checknothings"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/checknothings"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/circonuses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/circonuses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/cloudwatches"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/cloudwatches"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/deniers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/deniers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/dogstatsds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/dogstatsds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/edges"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/edges"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/fluentds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/fluentds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/kuberneteses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/kuberneteses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/kubernetesenvs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/kubernetesenvs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/listcheckers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/listcheckers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/listentries"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/listentries"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/logentries"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/logentries"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/memquotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/memquotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/metrics"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/metrics"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/noops"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/noops"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/opas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/opas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/prometheuses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/prometheuses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/quotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/quotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/rbacs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/rbacs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/redisquotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/redisquotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/reportnothings"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/reportnothings"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/signalfxs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/signalfxs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/solarwindses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/solarwindses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/stackdrivers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/stackdrivers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/statsds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/statsds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/stdios"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/stdios"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/tracespans"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/tracespans"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/zipkins"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/zipkins"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+
 # The snapshots to generate
 snapshots:
   - name: "default"
@@ -315,6 +565,39 @@ snapshots:
       - "istio/rbac/v1alpha1/serviceroles"
       - "k8s/core/v1/namespaces"
       - "k8s/core/v1/services"
+      # Legacy Mixer CRDs
+      - "istio/config/v1alpha2/legacy/apikeys"
+      - "istio/config/v1alpha2/legacy/authorizations"
+      - "istio/config/v1alpha2/legacy/bypasses"
+      - "istio/config/v1alpha2/legacy/checknothings"
+      - "istio/config/v1alpha2/legacy/circonuses"
+      - "istio/config/v1alpha2/legacy/cloudwatches"
+      - "istio/config/v1alpha2/legacy/deniers"
+      - "istio/config/v1alpha2/legacy/dogstatsds"
+      - "istio/config/v1alpha2/legacy/edges"
+      - "istio/config/v1alpha2/legacy/fluentds"
+      - "istio/config/v1alpha2/legacy/kuberneteses"
+      - "istio/config/v1alpha2/legacy/kubernetesenvs"
+      - "istio/config/v1alpha2/legacy/listcheckers"
+      - "istio/config/v1alpha2/legacy/listentries"
+      - "istio/config/v1alpha2/legacy/logentries"
+      - "istio/config/v1alpha2/legacy/memquotas"
+      - "istio/config/v1alpha2/legacy/metrics"
+      - "istio/config/v1alpha2/legacy/noops"
+      - "istio/config/v1alpha2/legacy/opas"
+      - "istio/config/v1alpha2/legacy/prometheuses"
+      - "istio/config/v1alpha2/legacy/quotas"
+      - "istio/config/v1alpha2/legacy/rbacs"
+      - "istio/config/v1alpha2/legacy/redisquotas"
+      - "istio/config/v1alpha2/legacy/reportnothings"
+      - "istio/config/v1alpha2/legacy/signalfxs"
+      - "istio/config/v1alpha2/legacy/solarwindses"
+      - "istio/config/v1alpha2/legacy/stackdrivers"
+      - "istio/config/v1alpha2/legacy/statsds"
+      - "istio/config/v1alpha2/legacy/stdios"
+      - "istio/config/v1alpha2/legacy/tracespans"
+      - "istio/config/v1alpha2/legacy/zipkins"
+
   - name: "syntheticServiceEntry"
     strategy: immediate
     collections:
@@ -500,6 +783,224 @@ sources:
       group:         "authentication.istio.io"
       version:       "v1alpha1"
 
+    # Legacy Mixer CRD Types
+    - collection:    "k8s/config.istio.io/v1alpha2/apikeys"
+      kind:          "apikey"
+      plural:        "apikeys"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/authorizations"
+      kind:          "authorization"
+      plural:        "authorizations"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/bypasses"
+      kind:          "bypass"
+      plural:        "bypasses"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/checknothings"
+      kind:          "checknothing"
+      plural:        "checknothings"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/circonuses"
+      kind:          "circonus"
+      plural:        "circonuses"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/cloudwatches"
+      kind:          "cloudwatch"
+      plural:        "cloudwatches"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/deniers"
+      kind:          "denier"
+      plural:        "deniers"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/dogstatsds"
+      kind:          "dogstatsd"
+      plural:        "dogstatsds"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/edges"
+      kind:          "edge"
+      plural:        "edges"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/fluentds"
+      kind:          "fluentd"
+      plural:        "fluentds"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/kuberneteses"
+      kind:          "kubernetes"
+      plural:        "kuberneteses"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/kubernetesenvs"
+      kind:          "kubernetesenv"
+      plural:        "kubernetesenvs"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/listcheckers"
+      kind:          "listchecker"
+      plural:        "listcheckers"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/listentries"
+      kind:          "listentry"
+      plural:        "listentries"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/logentries"
+      kind:          "logentry"
+      plural:        "logentries"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/memquotas"
+      kind:          "memquota"
+      plural:        "memquotas"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/metrics"
+      kind:          "metric"
+      plural:        "metrics"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/noops"
+      kind:          "noop"
+      plural:        "noops"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/opas"
+      kind:          "opa"
+      plural:        "opas"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/prometheuses"
+      kind:          "prometheus"
+      plural:        "prometheuses"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/quotas"
+      kind:          "quota"
+      plural:        "quotas"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/rbacs"
+      kind:          "rbac"
+      plural:        "rbacs"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/redisquotas"
+      kind:          "redisquota"
+      plural:        "redisquotas"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/reportnothings"
+      kind:          "reportnothing"
+      plural:        "reportnothings"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/signalfxs"
+      kind:          "signalfx"
+      plural:        "signalfxs"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/solarwindses"
+      kind:          "solarwinds"
+      plural:        "solarwindses"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/stackdrivers"
+      kind:          "stackdriver"
+      plural:        "stackdrivers"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/statsds"
+      kind:          "statsd"
+      plural:        "statsds"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/stdios"
+      kind:          "stdio"
+      plural:        "stdios"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/tracespans"
+      kind:          "tracespan"
+      plural:        "tracespans"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/zipkins"
+      kind:          "zipkin"
+      plural:        "zipkins"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
 # Transform specific configurations
 transforms:
   - type: direct
@@ -529,11 +1030,38 @@ transforms:
       "k8s/core/v1/services":                              "k8s/core/v1/services"
       "istio/mesh/v1alpha1/MeshConfig":                    "istio/mesh/v1alpha1/MeshConfig"
 
-      #      "k8s/rbac.istio.io/v1alpha3/clusterrbacconfigs":     "istio/rbac.istio.io/v1alpha3/clusterrbacconfigs"
-      #      "k8s/rbac.istio.io/v1alpha3/policy":                 "istio/rbac.istio.io/v1alpha3/policy"
-
-      #      "k8s/authentication.istio.io/v1alpha1/meshpolicies": "istio/authentication/v1alpha1/meshpolicies"
-      #      "k8s/authentication.istio.io/v1alpha1/policies":     "istio/authentication/v1alpha1/policies"
+      # Legacy Mixer CRD mappings
+      "k8s/config.istio.io/v1alpha2/apikeys":              "istio/config/v1alpha2/legacy/apikeys"
+      "k8s/config.istio.io/v1alpha2/authorizations":       "istio/config/v1alpha2/legacy/authorizations"
+      "k8s/config.istio.io/v1alpha2/bypasses":             "istio/config/v1alpha2/legacy/bypasses"
+      "k8s/config.istio.io/v1alpha2/checknothings":        "istio/config/v1alpha2/legacy/checknothings"
+      "k8s/config.istio.io/v1alpha2/circonuses":           "istio/config/v1alpha2/legacy/circonuses"
+      "k8s/config.istio.io/v1alpha2/cloudwatches":         "istio/config/v1alpha2/legacy/cloudwatches"
+      "k8s/config.istio.io/v1alpha2/deniers":              "istio/config/v1alpha2/legacy/deniers"
+      "k8s/config.istio.io/v1alpha2/dogstatsds":           "istio/config/v1alpha2/legacy/dogstatsds"
+      "k8s/config.istio.io/v1alpha2/edges":                "istio/config/v1alpha2/legacy/edges"
+      "k8s/config.istio.io/v1alpha2/fluentds":             "istio/config/v1alpha2/legacy/fluentds"
+      "k8s/config.istio.io/v1alpha2/kuberneteses":         "istio/config/v1alpha2/legacy/kuberneteses"
+      "k8s/config.istio.io/v1alpha2/kubernetesenvs":       "istio/config/v1alpha2/legacy/kubernetesenvs"
+      "k8s/config.istio.io/v1alpha2/listcheckers":         "istio/config/v1alpha2/legacy/listcheckers"
+      "k8s/config.istio.io/v1alpha2/listentries":          "istio/config/v1alpha2/legacy/listentries"
+      "k8s/config.istio.io/v1alpha2/logentries":           "istio/config/v1alpha2/legacy/logentries"
+      "k8s/config.istio.io/v1alpha2/memquotas":            "istio/config/v1alpha2/legacy/memquotas"
+      "k8s/config.istio.io/v1alpha2/metrics":              "istio/config/v1alpha2/legacy/metrics"
+      "k8s/config.istio.io/v1alpha2/noops":                "istio/config/v1alpha2/legacy/noops"
+      "k8s/config.istio.io/v1alpha2/opas":                 "istio/config/v1alpha2/legacy/opas"
+      "k8s/config.istio.io/v1alpha2/prometheuses":         "istio/config/v1alpha2/legacy/prometheuses"
+      "k8s/config.istio.io/v1alpha2/quotas":               "istio/config/v1alpha2/legacy/quotas"
+      "k8s/config.istio.io/v1alpha2/rbacs":                "istio/config/v1alpha2/legacy/rbacs"
+      "k8s/config.istio.io/v1alpha2/redisquotas":          "istio/config/v1alpha2/legacy/redisquotas"
+      "k8s/config.istio.io/v1alpha2/reportnothings":       "istio/config/v1alpha2/legacy/reportnothings"
+      "k8s/config.istio.io/v1alpha2/signalfxs":            "istio/config/v1alpha2/legacy/signalfxs"
+      "k8s/config.istio.io/v1alpha2/solarwindses":         "istio/config/v1alpha2/legacy/solarwindses"
+      "k8s/config.istio.io/v1alpha2/stackdrivers":         "istio/config/v1alpha2/legacy/stackdrivers"
+      "k8s/config.istio.io/v1alpha2/statsds":              "istio/config/v1alpha2/legacy/statsds"
+      "k8s/config.istio.io/v1alpha2/stdios":               "istio/config/v1alpha2/legacy/stdios"
+      "k8s/config.istio.io/v1alpha2/tracespans":           "istio/config/v1alpha2/legacy/tracespans"
+      "k8s/config.istio.io/v1alpha2/zipkins":              "istio/config/v1alpha2/legacy/zipkins"
 `)
 
 func metadataYamlBytes() ([]byte, error) {

--- a/galley/pkg/config/processor/metadata/metadata.yaml
+++ b/galley/pkg/config/processor/metadata/metadata.yaml
@@ -238,6 +238,256 @@ collections:
     proto:        "istio.rbac.v1alpha1.ServiceRole"
     protoPackage: "istio.io/api/rbac/v1alpha1"
 
+    # Keep Legacy Mixer CRD related collections separate, as these will be gone soon.
+  - name:          "k8s/config.istio.io/v1alpha2/apikeys"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/apikeys"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/authorizations"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/authorizations"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/bypasses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/bypasses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/checknothings"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/checknothings"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/circonuses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/circonuses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/cloudwatches"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/cloudwatches"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/deniers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/deniers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/dogstatsds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/dogstatsds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/edges"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/edges"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/fluentds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/fluentds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/kuberneteses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/kuberneteses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/kubernetesenvs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/kubernetesenvs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/listcheckers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/listcheckers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/listentries"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/listentries"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/logentries"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/logentries"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/memquotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/memquotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/metrics"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/metrics"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/noops"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/noops"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/opas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/opas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/prometheuses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/prometheuses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/quotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/quotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/rbacs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/rbacs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/redisquotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/redisquotas"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/reportnothings"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/reportnothings"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/signalfxs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/signalfxs"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/solarwindses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/solarwindses"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/stackdrivers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/stackdrivers"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/statsds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/statsds"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/stdios"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/stdios"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/tracespans"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/tracespans"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "k8s/config.istio.io/v1alpha2/zipkins"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+  - name:          "istio/config/v1alpha2/legacy/zipkins"
+    proto:         "google.protobuf.Struct"
+    protoPackage:  "github.com/gogo/protobuf/types"
+
+
 # The snapshots to generate
 snapshots:
   - name: "default"
@@ -269,6 +519,39 @@ snapshots:
       - "istio/rbac/v1alpha1/serviceroles"
       - "k8s/core/v1/namespaces"
       - "k8s/core/v1/services"
+      # Legacy Mixer CRDs
+      - "istio/config/v1alpha2/legacy/apikeys"
+      - "istio/config/v1alpha2/legacy/authorizations"
+      - "istio/config/v1alpha2/legacy/bypasses"
+      - "istio/config/v1alpha2/legacy/checknothings"
+      - "istio/config/v1alpha2/legacy/circonuses"
+      - "istio/config/v1alpha2/legacy/cloudwatches"
+      - "istio/config/v1alpha2/legacy/deniers"
+      - "istio/config/v1alpha2/legacy/dogstatsds"
+      - "istio/config/v1alpha2/legacy/edges"
+      - "istio/config/v1alpha2/legacy/fluentds"
+      - "istio/config/v1alpha2/legacy/kuberneteses"
+      - "istio/config/v1alpha2/legacy/kubernetesenvs"
+      - "istio/config/v1alpha2/legacy/listcheckers"
+      - "istio/config/v1alpha2/legacy/listentries"
+      - "istio/config/v1alpha2/legacy/logentries"
+      - "istio/config/v1alpha2/legacy/memquotas"
+      - "istio/config/v1alpha2/legacy/metrics"
+      - "istio/config/v1alpha2/legacy/noops"
+      - "istio/config/v1alpha2/legacy/opas"
+      - "istio/config/v1alpha2/legacy/prometheuses"
+      - "istio/config/v1alpha2/legacy/quotas"
+      - "istio/config/v1alpha2/legacy/rbacs"
+      - "istio/config/v1alpha2/legacy/redisquotas"
+      - "istio/config/v1alpha2/legacy/reportnothings"
+      - "istio/config/v1alpha2/legacy/signalfxs"
+      - "istio/config/v1alpha2/legacy/solarwindses"
+      - "istio/config/v1alpha2/legacy/stackdrivers"
+      - "istio/config/v1alpha2/legacy/statsds"
+      - "istio/config/v1alpha2/legacy/stdios"
+      - "istio/config/v1alpha2/legacy/tracespans"
+      - "istio/config/v1alpha2/legacy/zipkins"
+
   - name: "syntheticServiceEntry"
     strategy: immediate
     collections:
@@ -454,6 +737,224 @@ sources:
       group:         "authentication.istio.io"
       version:       "v1alpha1"
 
+    # Legacy Mixer CRD Types
+    - collection:    "k8s/config.istio.io/v1alpha2/apikeys"
+      kind:          "apikey"
+      plural:        "apikeys"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/authorizations"
+      kind:          "authorization"
+      plural:        "authorizations"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/bypasses"
+      kind:          "bypass"
+      plural:        "bypasses"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/checknothings"
+      kind:          "checknothing"
+      plural:        "checknothings"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/circonuses"
+      kind:          "circonus"
+      plural:        "circonuses"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/cloudwatches"
+      kind:          "cloudwatch"
+      plural:        "cloudwatches"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/deniers"
+      kind:          "denier"
+      plural:        "deniers"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/dogstatsds"
+      kind:          "dogstatsd"
+      plural:        "dogstatsds"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/edges"
+      kind:          "edge"
+      plural:        "edges"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/fluentds"
+      kind:          "fluentd"
+      plural:        "fluentds"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/kuberneteses"
+      kind:          "kubernetes"
+      plural:        "kuberneteses"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/kubernetesenvs"
+      kind:          "kubernetesenv"
+      plural:        "kubernetesenvs"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/listcheckers"
+      kind:          "listchecker"
+      plural:        "listcheckers"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/listentries"
+      kind:          "listentry"
+      plural:        "listentries"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/logentries"
+      kind:          "logentry"
+      plural:        "logentries"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/memquotas"
+      kind:          "memquota"
+      plural:        "memquotas"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/metrics"
+      kind:          "metric"
+      plural:        "metrics"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/noops"
+      kind:          "noop"
+      plural:        "noops"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/opas"
+      kind:          "opa"
+      plural:        "opas"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/prometheuses"
+      kind:          "prometheus"
+      plural:        "prometheuses"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/quotas"
+      kind:          "quota"
+      plural:        "quotas"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/rbacs"
+      kind:          "rbac"
+      plural:        "rbacs"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/redisquotas"
+      kind:          "redisquota"
+      plural:        "redisquotas"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/reportnothings"
+      kind:          "reportnothing"
+      plural:        "reportnothings"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/signalfxs"
+      kind:          "signalfx"
+      plural:        "signalfxs"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/solarwindses"
+      kind:          "solarwinds"
+      plural:        "solarwindses"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/stackdrivers"
+      kind:          "stackdriver"
+      plural:        "stackdrivers"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/statsds"
+      kind:          "statsd"
+      plural:        "statsds"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/stdios"
+      kind:          "stdio"
+      plural:        "stdios"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/tracespans"
+      kind:          "tracespan"
+      plural:        "tracespans"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
+    - collection:    "k8s/config.istio.io/v1alpha2/zipkins"
+      kind:          "zipkin"
+      plural:        "zipkins"
+      group:         "config.istio.io"
+      version:       "v1alpha2"
+      optional:      true
+
 # Transform specific configurations
 transforms:
   - type: direct
@@ -483,8 +984,35 @@ transforms:
       "k8s/core/v1/services":                              "k8s/core/v1/services"
       "istio/mesh/v1alpha1/MeshConfig":                    "istio/mesh/v1alpha1/MeshConfig"
 
-      #      "k8s/rbac.istio.io/v1alpha3/clusterrbacconfigs":     "istio/rbac.istio.io/v1alpha3/clusterrbacconfigs"
-      #      "k8s/rbac.istio.io/v1alpha3/policy":                 "istio/rbac.istio.io/v1alpha3/policy"
-
-      #      "k8s/authentication.istio.io/v1alpha1/meshpolicies": "istio/authentication/v1alpha1/meshpolicies"
-      #      "k8s/authentication.istio.io/v1alpha1/policies":     "istio/authentication/v1alpha1/policies"
+      # Legacy Mixer CRD mappings
+      "k8s/config.istio.io/v1alpha2/apikeys":              "istio/config/v1alpha2/legacy/apikeys"
+      "k8s/config.istio.io/v1alpha2/authorizations":       "istio/config/v1alpha2/legacy/authorizations"
+      "k8s/config.istio.io/v1alpha2/bypasses":             "istio/config/v1alpha2/legacy/bypasses"
+      "k8s/config.istio.io/v1alpha2/checknothings":        "istio/config/v1alpha2/legacy/checknothings"
+      "k8s/config.istio.io/v1alpha2/circonuses":           "istio/config/v1alpha2/legacy/circonuses"
+      "k8s/config.istio.io/v1alpha2/cloudwatches":         "istio/config/v1alpha2/legacy/cloudwatches"
+      "k8s/config.istio.io/v1alpha2/deniers":              "istio/config/v1alpha2/legacy/deniers"
+      "k8s/config.istio.io/v1alpha2/dogstatsds":           "istio/config/v1alpha2/legacy/dogstatsds"
+      "k8s/config.istio.io/v1alpha2/edges":                "istio/config/v1alpha2/legacy/edges"
+      "k8s/config.istio.io/v1alpha2/fluentds":             "istio/config/v1alpha2/legacy/fluentds"
+      "k8s/config.istio.io/v1alpha2/kuberneteses":         "istio/config/v1alpha2/legacy/kuberneteses"
+      "k8s/config.istio.io/v1alpha2/kubernetesenvs":       "istio/config/v1alpha2/legacy/kubernetesenvs"
+      "k8s/config.istio.io/v1alpha2/listcheckers":         "istio/config/v1alpha2/legacy/listcheckers"
+      "k8s/config.istio.io/v1alpha2/listentries":          "istio/config/v1alpha2/legacy/listentries"
+      "k8s/config.istio.io/v1alpha2/logentries":           "istio/config/v1alpha2/legacy/logentries"
+      "k8s/config.istio.io/v1alpha2/memquotas":            "istio/config/v1alpha2/legacy/memquotas"
+      "k8s/config.istio.io/v1alpha2/metrics":              "istio/config/v1alpha2/legacy/metrics"
+      "k8s/config.istio.io/v1alpha2/noops":                "istio/config/v1alpha2/legacy/noops"
+      "k8s/config.istio.io/v1alpha2/opas":                 "istio/config/v1alpha2/legacy/opas"
+      "k8s/config.istio.io/v1alpha2/prometheuses":         "istio/config/v1alpha2/legacy/prometheuses"
+      "k8s/config.istio.io/v1alpha2/quotas":               "istio/config/v1alpha2/legacy/quotas"
+      "k8s/config.istio.io/v1alpha2/rbacs":                "istio/config/v1alpha2/legacy/rbacs"
+      "k8s/config.istio.io/v1alpha2/redisquotas":          "istio/config/v1alpha2/legacy/redisquotas"
+      "k8s/config.istio.io/v1alpha2/reportnothings":       "istio/config/v1alpha2/legacy/reportnothings"
+      "k8s/config.istio.io/v1alpha2/signalfxs":            "istio/config/v1alpha2/legacy/signalfxs"
+      "k8s/config.istio.io/v1alpha2/solarwindses":         "istio/config/v1alpha2/legacy/solarwindses"
+      "k8s/config.istio.io/v1alpha2/stackdrivers":         "istio/config/v1alpha2/legacy/stackdrivers"
+      "k8s/config.istio.io/v1alpha2/statsds":              "istio/config/v1alpha2/legacy/statsds"
+      "k8s/config.istio.io/v1alpha2/stdios":               "istio/config/v1alpha2/legacy/stdios"
+      "k8s/config.istio.io/v1alpha2/tracespans":           "istio/config/v1alpha2/legacy/tracespans"
+      "k8s/config.istio.io/v1alpha2/zipkins":              "istio/config/v1alpha2/legacy/zipkins"

--- a/galley/pkg/config/schema/ast/ast.go
+++ b/galley/pkg/config/schema/ast/ast.go
@@ -67,7 +67,7 @@ type Resource struct {
 	Version    string `json:"version"`
 	Kind       string `json:"kind"`
 	Plural     string `json:"plural"`
-	Optional   bool   `json:"optional"` // TODO: Reconsider this
+	Optional   bool   `json:"optional"`
 	Disabled   bool   `json:"disabled"`
 }
 

--- a/galley/pkg/config/schema/schema.go
+++ b/galley/pkg/config/schema/schema.go
@@ -248,7 +248,10 @@ func Build(astm *ast.Metadata) (*Metadata, error) {
 		switch v := s.(type) {
 		case *ast.KubeSource:
 			var resources []*KubeResource
-			for _, r := range v.Resources {
+			for i, r := range v.Resources {
+				if r == nil {
+					return nil, fmt.Errorf("invalid KubeResource entry at position: %d", i)
+				}
 				col, ok := collections.Lookup(r.Collection)
 				if !ok {
 					return nil, fmt.Errorf("collection not found: %v", r.Collection)

--- a/galley/pkg/config/source/kube/apiserver/source.go
+++ b/galley/pkg/config/source/kube/apiserver/source.go
@@ -242,6 +242,6 @@ func (s *Source) stop() {
 
 }
 
-func asKey(g, k string) string {
-	return g + "/" + k
+func asKey(group, kind string) string {
+	return group + "/" + kind
 }

--- a/galley/pkg/config/source/kube/apiserver/source.go
+++ b/galley/pkg/config/source/kube/apiserver/source.go
@@ -15,19 +15,57 @@
 package apiserver
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"sync"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 
 	"istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/schema"
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/source/kube/rt"
 )
 
+var (
+	// crdKubeResource is metadata for listening to CRD resource on the API Server.
+	crdKubeResource = schema.KubeResource{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1beta1",
+		Plural:  "customresourcedefinitions",
+		Kind:    "CustomResourceDefinition",
+	}
+)
+
 // Source is an implementation of processing.KubeSource
 type Source struct {
-	mu       sync.Mutex
-	options  Options
-	started  bool
+	mu      sync.Mutex
+	options Options
+
+	// Keep the handlers that are registered by this Source. As we're recreating watchers, we need to seed them correctly
+	// with each incarnation.
+	handlers *event.Handlers
+
+	// Indicates whether this source is started or not.
+	started bool
+
+	// Set of resources that we're waiting CRD events for. As CRD events arrive, if they match to entries in expectedResources,
+	// the watchers for those resources will be created.
+	expectedResources map[string]schema.KubeResource
+
+	// publishing indicates that the CRD discovery phase is over and actual data events are being published. Until
+	// publishing set, the incoming CRD events will cause new watchers to come online. Once the publishing is set,
+	// any new CRD event will cause an event.RESET to be published.
+	publishing bool
+
+	provider *rt.Provider
+
+	// crdWatcher is a specialized watcher just for listening to CRDs.
+	crdWatcher *watcher
+
+	// watchers for each collection that were created as part of CRD discovery.
 	watchers map[collection.Name]*watcher
 }
 
@@ -36,23 +74,8 @@ var _ event.Source = &Source{}
 // New returns a new kube.Source.
 func New(o Options) *Source {
 	s := &Source{
-		watchers: make(map[collection.Name]*watcher),
 		options:  o,
-	}
-
-	p := rt.NewProvider(o.Client, o.ResyncPeriod)
-
-	scope.Source.Info("creating watchers for Kubernetes resources")
-	for i, r := range o.Resources {
-		a := p.GetAdapter(r)
-
-		scope.Source.Infof("[%d]", i)
-		scope.Source.Infof("  Source:      %s", r.CanonicalResourceName())
-		scope.Source.Infof("  Name:  		 %s", r.Collection)
-		scope.Source.Infof("  Built-in:    %v", a.IsBuiltIn())
-
-		col := newWatcher(r, a)
-		s.watchers[r.Collection.Name] = col
+		handlers: &event.Handlers{},
 	}
 
 	return s
@@ -62,10 +85,7 @@ func New(o Options) *Source {
 func (s *Source) Dispatch(h event.Handler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	for _, c := range s.watchers {
-		c.dispatch(h)
-	}
+	s.handlers.Add(h)
 }
 
 // Start implements processor.Source
@@ -78,6 +98,106 @@ func (s *Source) Start() {
 		return
 	}
 	s.started = true
+
+	// Create a set of pending resources. These will be matched up with incoming CRD events for creating watchers for
+	// each resource that we expect.
+	s.expectedResources = make(map[string]schema.KubeResource)
+	for _, r := range s.options.Resources {
+		// If we received the metadata with the resource marked as disabled, simply ignore it.
+		if r.Disabled {
+			continue
+		}
+
+		// Use the disabled bit to track whether we received an event for this resource.
+		r.Disabled = true
+		s.expectedResources[asKey(r.Group, r.Kind)] = r
+	}
+
+	// Start the CRD listener. When the listener is fully-synced, the listening of actual resources will start.
+	scope.Source.Infof("Beginning CRD Discovery, to figure out resources that are available...")
+	s.provider = rt.NewProvider(s.options.Client, s.options.ResyncPeriod)
+	a := s.provider.GetAdapter(crdKubeResource)
+	s.crdWatcher = newWatcher(crdKubeResource, a)
+	s.crdWatcher.dispatch(event.HandlerFromFn(s.onCrdEvent))
+	s.crdWatcher.start()
+}
+
+func (s *Source) onCrdEvent(e event.Event) {
+	scope.Source.Debuga("onCrdEvent: ", e)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.started {
+		// Avoid any potential timings with .Stop() being called while an event being received.
+		return
+	}
+
+	if s.publishing {
+		// Any event in publishing state causes a reset
+		scope.Source.Infof("Detected a CRD change while processing configuration events. Sending Reset event.")
+		s.handlers.Handle(event.Event{Kind: event.Reset})
+		return
+	}
+
+	switch e.Kind {
+	case event.Added:
+		crd := e.Entry.Item.(*v1beta1.CustomResourceDefinitionSpec)
+		g := crd.Group
+		k := crd.Names.Kind
+		key := asKey(g, k)
+		r, ok := s.expectedResources[key]
+		if ok {
+			scope.Source.Debugf("Marking resource as available: %v", r.CanonicalResourceName())
+			r.Disabled = false
+			s.expectedResources[key] = r
+		}
+
+	case event.FullSync:
+		scope.Source.Infof("CRD Discovery complete, starting listening to resources...")
+		s.startWatchers()
+		s.publishing = true
+
+	case event.Updated, event.Deleted, event.Reset:
+		// The code is currently not equipped to deal with this. Simply publish a reset event to get everything restarted later.
+		s.handlers.Handle(event.Event{Kind: event.Reset})
+
+	default:
+		panic(fmt.Errorf("onCrdEvent: unrecognized event: %v", e))
+	}
+}
+
+func (s *Source) startWatchers() {
+	// must be called under lock
+
+	// sort resources by name for consistent logging
+	resources := make([]schema.KubeResource, 0, len(s.expectedResources))
+	for _, r := range s.expectedResources {
+		resources = append(resources, r)
+	}
+
+	sort.Slice(resources, func(i, j int) bool {
+		return strings.Compare(resources[i].CanonicalResourceName(), resources[j].CanonicalResourceName()) < 0
+	})
+
+	scope.Source.Info("Creating watchers for Kubernetes CRDs")
+	s.watchers = make(map[collection.Name]*watcher)
+	for i, r := range resources {
+		a := s.provider.GetAdapter(r)
+
+		scope.Source.Infof("[%d]", i)
+		scope.Source.Infof("  Source:       %s", r.CanonicalResourceName())
+		scope.Source.Infof("  Name:  		 %s", r.Collection)
+		scope.Source.Infof("  Built-in:     %v", a.IsBuiltIn())
+		if !a.IsBuiltIn() {
+			scope.Source.Infof("  Found:  %v", !r.Disabled)
+		}
+
+		if a.IsBuiltIn() || !r.Disabled {
+			col := newWatcher(r, a)
+			col.dispatch(s.handlers)
+			s.watchers[r.Collection.Name] = col
+		}
+	}
 
 	for c, w := range s.watchers {
 		scope.Source.Debuga("Source.Start: starting watcher: ", c)
@@ -99,9 +219,29 @@ func (s *Source) Stop() {
 }
 
 func (s *Source) stop() {
-	for c, w := range s.watchers {
-		scope.Source.Debuga("Source.Stop: stopping watcher: ", c)
-		w.stop()
+	// must be called under lock
+
+	if s.watchers != nil {
+		for c, w := range s.watchers {
+			scope.Source.Debuga("Source.Stop: stopping watcher: ", c)
+			w.stop()
+		}
+		s.watchers = nil
 	}
+
+	if s.crdWatcher != nil {
+		s.crdWatcher.stop()
+		s.crdWatcher = nil
+	}
+
+	s.provider = nil
+	s.publishing = false
+	s.expectedResources = nil
+
 	s.started = false
+
+}
+
+func asKey(g, k string) string {
+	return g + "/" + k
 }

--- a/galley/pkg/config/source/kube/rt/adapter.go
+++ b/galley/pkg/config/source/kube/rt/adapter.go
@@ -49,7 +49,7 @@ func (p *Adapter) ExtractResource(o interface{}) (proto.Message, error) {
 }
 
 // NewInformer creates a new k8s informer for resources of this type.
-func (p *Adapter) NewInformer() (cache.SharedIndexInformer, error) {
+func (p *Adapter) NewInformer() (cache.SharedInformer, error) {
 	return p.newInformer()
 }
 

--- a/galley/pkg/server/components/processing2_test.go
+++ b/galley/pkg/server/components/processing2_test.go
@@ -88,6 +88,7 @@ loop:
 		case 6:
 			netListen = func(network, address string) (net.Listener, error) { return nil, e }
 		case 7:
+			args.DisableResourceReadyCheck = false
 			checkResourceTypesPresence = func(_ kube.Interfaces, _ schema.KubeResources) error { return e }
 		case 8:
 			args.ConfigPath = "aaa"

--- a/galley/pkg/testing/mock/kube.go
+++ b/galley/pkg/testing/mock/kube.go
@@ -15,11 +15,10 @@
 package mock
 
 import (
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-
 	"istio.io/istio/galley/pkg/source/kube/client"
 
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
@@ -31,15 +30,15 @@ type Kube struct {
 	response1 []interface{}
 	response2 []error
 
-	client    kubernetes.Interface
-	clientset clientset.Interface
+	client          kubernetes.Interface
+	APIExtClientSet *fake.Clientset
 }
 
 // NewKube returns a new instance of mock Kube.
 func NewKube() *Kube {
 	return &Kube{
-		client:    newKubeInterface(),
-		clientset: fake.NewSimpleClientset(),
+		client:          newKubeInterface(),
+		APIExtClientSet: fake.NewSimpleClientset(),
 	}
 }
 
@@ -67,11 +66,12 @@ func (k *Kube) AddResponse(r1 interface{}, r2 error) {
 	k.response2 = append(k.response2, r2)
 }
 
-// APIExtensionsClientset returns a new apiextensions clientset
+// KubeClient implements client.Interfaces
 func (k *Kube) APIExtensionsClientset() (clientset.Interface, error) {
-	return k.clientset, nil
+	return k.APIExtClientSet, nil
 }
 
+// KubeClient implements client.Interfaces
 func (k *Kube) KubeClient() (kubernetes.Interface, error) {
 	return k.client, nil
 }

--- a/galley/pkg/testing/mock/kube.go
+++ b/galley/pkg/testing/mock/kube.go
@@ -66,7 +66,7 @@ func (k *Kube) AddResponse(r1 interface{}, r2 error) {
 	k.response2 = append(k.response2, r2)
 }
 
-// KubeClient implements client.Interfaces
+// APIExtensionsClientset implements client.Interfaces
 func (k *Kube) APIExtensionsClientset() (clientset.Interface, error) {
 	return k.APIExtClientSet, nil
 }

--- a/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
@@ -37,3 +37,6 @@ rules:
   resources: ["deployments/finalizers"]
   resourceNames: ["istio-galley"]
   verbs: ["update"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Add CRD listening support to Galley API Server Source.

With CRD support, Galley will discover CRDs dynamically and will listen to only available ones. If Galley detects a change to the CRDs, then it will restart its config processing pipeline.