### PR TITLE
Reduce Galley unit test flakes

### DIFF
--- a/galley/pkg/server/server_test.go
+++ b/galley/pkg/server/server_test.go
@@ -50,6 +50,8 @@ func TestServer(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	a := settings.DefaultArgs()
+	// If the default port is used it may run into conflicts during testing
+	a.IntrospectionOptions.Port = 0
 	a.MeshConfigFile = meshFile
 	a.ConfigPath = configDir
 	a.AccessListFile = accessListFile


### PR DESCRIPTION
These tests fail sometimes due to trying to use a port that is already
in use (9876).

Part of https://github.com/istio/istio/issues/15666

Does not fix the `TestCtrlz_Basic` flakes since that would require refactoring galley to get the port number that is in use

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
