### PR TITLE
Detect ARM arch with variant when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ endif
 LOCAL_ARCH := $(shell uname -m)
 ifeq ($(LOCAL_ARCH),x86_64)
 GOARCH_LOCAL := amd64
+else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
+GOARCH_LOCAL := arm64
+else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 3),arm)
+GOARCH_LOCAL := arm
 else
 GOARCH_LOCAL := $(LOCAL_ARCH)
 endif

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ ifeq ($(LOCAL_ARCH),x86_64)
 GOARCH_LOCAL := amd64
 else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
 GOARCH_LOCAL := arm64
-else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 3),arm)
+else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
 GOARCH_LOCAL := arm
 else
 GOARCH_LOCAL := $(LOCAL_ARCH)

--- a/Makefile
+++ b/Makefile
@@ -364,11 +364,11 @@ DEBUG_LDFLAGS='-extldflags "-static"'
 # $(3): The value for LDFLAGS
 define genTargetsForNativeAndDocker
 $(ISTIO_OUT)/$(1):
-	STATIC=0 GOOS=$(GOOS) GOARCH=amd64 LDFLAGS=$(3) bin/gobuild.sh $(ISTIO_OUT)/$(1) $(2)
+	STATIC=0 GOOS=$(GOOS) GOARCH=$(GOARCH) LDFLAGS=$(3) bin/gobuild.sh $(ISTIO_OUT)/$(1) $(2)
 
 .PHONY: $(1)
 $(1):
-	STATIC=0 GOOS=$(GOOS) GOARCH=amd64 LDFLAGS=$(3) bin/gobuild.sh $(ISTIO_OUT)/$(1) $(2)
+	STATIC=0 GOOS=$(GOOS) GOARCH=$(GOARCH) LDFLAGS=$(3) bin/gobuild.sh $(ISTIO_OUT)/$(1) $(2)
 
 ifneq ($(ISTIO_OUT),$(ISTIO_OUT_LINUX))
 $(ISTIO_OUT_LINUX)/$(1):


### PR DESCRIPTION
Add ARM arch with variant checking in Makefile and set the `GOARCH` value accordingly.

Possible values that come from `uname -m` is the ARM arch with their variant. For example in Raspberry Pi, it showed `armv7l`. Therefore this PR is made to normalize those variants.

Tested manually

![image](https://user-images.githubusercontent.com/6806035/61570084-c4793f80-aa8a-11e9-87ce-47f231374fb6.png)
![image](https://user-images.githubusercontent.com/6806035/61570202-6dc03580-aa8b-11e9-8028-92b18a33247b.png)



Related issue:
https://github.com/istio/istio/issues/13321

Ref:
https://github.com/golang/go/wiki/GoArm

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[x] Developer Infrastructure
