### PR TITLE
Try fetch secret directly in case a secret is requested but cache doe…

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -600,8 +600,7 @@ func sdsDiscoveryResponse(s *model.SecretItem, conID, resourceName string) (*xds
 
 func newSDSConnection(stream discoveryStream) *sdsConnection {
 	return &sdsConnection{
-		// Make the channel size to be > 1 to avoid deadlock
-		pushChannel: make(chan *sdsEvent, 16),
+		pushChannel: make(chan *sdsEvent, 1),
 		Connect:     time.Now(),
 		stream:      stream,
 	}


### PR DESCRIPTION
During our test, sometime node agent failed to watch a secret that exists. This patch would directly fetch the secret in such case and remedy the watch failure. 
[x ] Security
