### PR TITLE
Add node image, skip options to kind tests

### DIFF
--- a/prow/e2e-kind-suite.sh
+++ b/prow/e2e-kind-suite.sh
@@ -38,7 +38,7 @@ set -x
 # shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
-setup_kind_cluster
+setup_kind_cluster ""
 
 echo 'Build'
 (cd "${ROOT}"; make build)
@@ -77,7 +77,7 @@ make docker
 function build_kind_images(){
 	# Archived local images and load it into KinD's docker daemon
 	# Kubernetes in KinD can only access local images from its docker daemon.
-	docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 kind --loglevel debug --name e2e-suite load docker-image
+	docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 kind --loglevel debug --name istio-testing load docker-image
 }
 
 build_kind_images

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -32,7 +32,44 @@ set -x
 # shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
-setup_kind_cluster
+
+function build_kind_images() {
+  # Build just the images needed for the tests
+  for image in pilot proxyv2 proxy_init app test_policybackend mixer citadel galley sidecar_injector kubectl node-agent-k8s; do
+     make docker.${image}
+  done
+	# Archived local images and load it into KinD's docker daemon
+	# Kubernetes in KinD can only access local images from its docker daemon.
+	docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 -P16 kind --loglevel debug --name istio-testing load docker-image
+}
+
+while (( "$#" )); do
+  case "$1" in
+    # Node images can be found at https://github.com/kubernetes-sigs/kind/releases
+    # For example, kindest/node:v1.14.0
+    --node-image)
+      NODE_IMAGE=$2
+      shift 2
+    ;;
+    --skip-setup)
+      SKIP_SETUP=true
+      shift
+    ;;
+    --skip-build)
+      SKIP_BUILD=true
+      shift
+    ;;
+    -*)
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS+=("$1")
+      shift
+      ;;
+  esac
+done
+
 
 # KinD will not have a LoadBalancer, so we need to disable it
 export TEST_ENV=kind
@@ -41,24 +78,22 @@ export TEST_ENV=kind
 # See https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster
 export PULL_POLICY=IfNotPresent
 
-export HUB=${HUB:-"kindtest"}
-export TAG="${TAG:-${GIT_SHA}}"
+export HUB=${HUB:-"istio-testing"}
+export TAG="${TAG:-"istio-testing"}"
+
+# Setup junit report and verbose logging
+export JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml"
+export T="${T:-"-v"}"
 
 make init
 
-# Build just the images needed for the tests
-for image in pilot proxyv2 proxy_init app test_policybackend mixer citadel galley sidecar_injector kubectl node-agent-k8s; do
-   make docker.${image}
-done
+if [[ -z "${SKIP_SETUP:-}" ]]; then
+  time setup_kind_cluster "${NODE_IMAGE:-}"
+fi
 
-function build_kind_images(){
-	# Archived local images and load it into KinD's docker daemon
-	# Kubernetes in KinD can only access local images from its docker daemon.
-	docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 -P16 kind --loglevel debug --name e2e-suite load docker-image
-}
+if [[ -z "${SKIP_BUILD:-}" ]]; then
+  time build_kind_images
+fi
 
-time build_kind_images
 
-export JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml"
-export T="-v"
-make "$@"
+make "${PARAMS[*]}"

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -125,23 +125,24 @@ function check_kind() {
 }
 
 function setup_kind_cluster() {
+  IMAGE="${1}"
   # Installing KinD
   check_kind
 
   # Delete any previous e2e KinD cluster
-  echo "Deleting previous KinD cluster with name=e2e-suite"
-  if ! (kind delete cluster --name=e2e-suite) > /dev/null; then
-  	echo "No Found existing kind cluster with name e2e-suite. Continue..."
+  echo "Deleting previous KinD cluster with name=istio-testing"
+  if ! (kind delete cluster --name=istio-testing) > /dev/null; then
+    echo "No existing kind cluster with name istio-testing. Continue..."
   fi
 
   # Create KinD cluster
-  if ! (kind create cluster --name=e2e-suite --loglevel debug --retain); then
+  if ! (kind create cluster --name=istio-testing --loglevel debug --retain --image "${IMAGE}"); then
     echo "Could not setup KinD environment. Something wrong with KinD setup. Exporting logs."
-    kind export logs --name e2e-suite "${ARTIFACTS_DIR}/kind"
+    kind export logs --name istio-testing "${ARTIFACTS_DIR}/kind"
     exit 1
   fi
 
-  KUBECONFIG="$(kind get kubeconfig-path --name="e2e-suite")"
+  KUBECONFIG="$(kind get kubeconfig-path --name="istio-testing")"
   export KUBECONFIG
 }
 


### PR DESCRIPTION
Specifying the node image will be needed to test against multiple
versions of Kubernetes. Skipping setup or image building is useful for
running locally.

Also renamed the cluster name to `istio-testing` since it isn't used only for e2e tests

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
