### PR TITLE
Optimize contextgraph batch send algorithm

### DIFF
--- a/mixer/adapter/stackdriver/contextgraph/send.go
+++ b/mixer/adapter/stackdriver/contextgraph/send.go
@@ -97,7 +97,6 @@ func splitBySizeEntity(msg *contextgraphpb.AssertBatchRequest) int {
 	for ; curIndex < len(msg.EntityPresentAssertions); curIndex++ {
 		curSize += proto.Size(msg.EntityPresentAssertions[curIndex])
 		if curSize >= maxReq {
-			curIndex--
 			break
 		}
 	}
@@ -110,7 +109,6 @@ func splitBySizeRelationship(msg *contextgraphpb.AssertBatchRequest) int {
 	for ; curIndex < len(msg.RelationshipPresentAssertions); curIndex++ {
 		curSize += proto.Size(msg.RelationshipPresentAssertions[curIndex])
 		if curSize >= maxReq {
-			curIndex--
 			break
 		}
 	}

--- a/mixer/adapter/stackdriver/contextgraph/send.go
+++ b/mixer/adapter/stackdriver/contextgraph/send.go
@@ -92,23 +92,29 @@ func (e edge) ToProto() *contextgraphpb.Relationship {
 
 // splitBySize helps find the largest BatchRequest that is smaller than the max request size
 func splitBySizeEntity(msg *contextgraphpb.AssertBatchRequest) int {
-	curSize := proto.Size(msg)
-	curIndex := len(msg.EntityPresentAssertions) - 1
-	for curSize > maxReq {
-		curSize -= proto.Size(msg.EntityPresentAssertions[curIndex])
-		curIndex--
+	curSize := 0
+	curIndex := 0
+	for ; curIndex < len(msg.EntityPresentAssertions); curIndex++ {
+		curSize += proto.Size(msg.EntityPresentAssertions[curIndex])
+		if curSize >= maxReq {
+			curIndex--
+			break
+		}
 	}
-	return curIndex + 1
+	return curIndex
 }
 
 func splitBySizeRelationship(msg *contextgraphpb.AssertBatchRequest) int {
-	curSize := proto.Size(msg)
-	curIndex := len(msg.RelationshipPresentAssertions) - 1
-	for curSize > maxReq {
-		curSize -= proto.Size(msg.RelationshipPresentAssertions[curIndex])
-		curIndex--
+	curSize := 0
+	curIndex := 0
+	for ; curIndex < len(msg.RelationshipPresentAssertions); curIndex++ {
+		curSize += proto.Size(msg.RelationshipPresentAssertions[curIndex])
+		if curSize >= maxReq {
+			curIndex--
+			break
+		}
 	}
-	return curIndex + 1
+	return curIndex
 }
 
 func (h *handler) send(ctx context.Context, t time.Time, entitiesToSend []entity, edgesToSend []edge) error {

--- a/mixer/adapter/stackdriver/contextgraph/send_test.go
+++ b/mixer/adapter/stackdriver/contextgraph/send_test.go
@@ -16,10 +16,13 @@ package contextgraph
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
-	gax "github.com/googleapis/gax-go"
+	"istio.io/istio/mixer/pkg/adapter"
+
+	"github.com/googleapis/gax-go"
 
 	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
 	env "istio.io/istio/mixer/pkg/adapter/test"
@@ -41,42 +44,37 @@ func (m *mockBatchClient) fakeAssertBatch(
 	return nil, nil
 }
 
-func TestSendBatch(t *testing.T) {
-	const (
-		numEntities = 20000
-		numEdges    = 20000
-	)
+func BenchmarkSendBatch(b *testing.B) {
 
 	m := &mockBatchClient{
 		ABCalled:    0,
 		NumEntities: 0,
 		NumEdges:    0,
 	}
-	h := &handler{
-		env:         env.NewEnv(t),
-		assertBatch: m.fakeAssertBatch,
-	}
+	for _, size := range []int{2, 200, 20000} {
+		h, entities, edges := setupSendBatch(env.NewEnv(nil), m.fakeAssertBatch, size)
 
-	entities := make([]entity, 0)
-	edges := make([]edge, 0)
-
-	for ii := 0; ii < numEntities; ii++ {
-		entities = append(entities, entity{
-			containerFullName: "asdf",
-			typeName:          "asdf",
-			fullName:          "asdf",
-			location:          "asdf",
-			shortNames:        [4]string{"asdf", "", "", ""},
+		b.Run(fmt.Sprintf("Size%d", size), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				_ = h.send(
+					context.Background(),
+					time.Unix(1337, 0),
+					entities,
+					edges,
+				)
+			}
 		})
 	}
+}
 
-	for ii := 0; ii < numEdges; ii++ {
-		edges = append(edges, edge{
-			sourceFullName:      "asdf",
-			destinationFullName: "asdf",
-			typeName:            "asdf",
-		})
+func TestSendBatch(t *testing.T) {
+	testSize := 20000
+	m := &mockBatchClient{
+		ABCalled:    0,
+		NumEntities: 0,
+		NumEdges:    0,
 	}
+	h, entities, edges := setupSendBatch(env.NewEnv(t), m.fakeAssertBatch, testSize)
 
 	h.send(
 		context.Background(),
@@ -88,10 +86,40 @@ func TestSendBatch(t *testing.T) {
 	if m.ABCalled != 4 {
 		t.Fatalf("AssertBatch expected to be called 4 times. Called %v times", m.ABCalled)
 	}
-	if m.NumEntities != numEntities {
-		t.Fatalf("%v entities expected to be sent, got %v:", numEntities, m.NumEntities)
+	if m.NumEntities != testSize {
+		t.Fatalf("%v entities expected to be sent, got %v:", testSize, m.NumEntities)
 	}
-	if m.NumEdges != numEdges {
-		t.Fatalf("%v edges expected to be sent, got %v:", numEdges, m.NumEdges)
+	if m.NumEdges != testSize {
+		t.Fatalf("%v edges expected to be sent, got %v:", testSize, m.NumEdges)
 	}
+}
+
+func setupSendBatch(env adapter.Env, assert assertBatchFn, size int) (*handler, []entity, []edge) {
+
+	h := &handler{
+		env:         env,
+		assertBatch: assert,
+	}
+
+	entities := make([]entity, 0)
+	edges := make([]edge, 0)
+
+	for ii := 0; ii < size; ii++ {
+		entities = append(entities, entity{
+			containerFullName: "asdf",
+			typeName:          "asdf",
+			fullName:          "asdf",
+			location:          "asdf",
+			shortNames:        [4]string{"asdf", "", "", ""},
+		})
+	}
+
+	for ii := 0; ii < size; ii++ {
+		edges = append(edges, edge{
+			sourceFullName:      "asdf",
+			destinationFullName: "asdf",
+			typeName:            "asdf",
+		})
+	}
+	return h, entities, edges
 }

--- a/mixer/adapter/stackdriver/contextgraph/send_test.go
+++ b/mixer/adapter/stackdriver/contextgraph/send_test.go
@@ -68,7 +68,7 @@ func BenchmarkSendBatch(b *testing.B) {
 }
 
 func TestSendBatch(t *testing.T) {
-	testSize := 20000
+	testSize := 21000
 	m := &mockBatchClient{
 		ABCalled:    0,
 		NumEntities: 0,


### PR DESCRIPTION
This function attempts to split the request size to be the largest
possible request that is smaller than the request size limit. It did
this by linearly checking size(list[:n]), size(list[:n-1])... This ends
up being extremely slow, because proto.size is not a very cheap
operation for such large objects. In the case of racetests, this test
was taking over 5 minutes sometimes.

This modifies the algorithm to do a binary search for the optimal
request; behavior should be the same.

With this change:
BenchmarkSendBatch/Size2-8                500000              3042 ns/op
BenchmarkSendBatch/Size200-8               10000            135250 ns/op
BenchmarkSendBatch/Size20000-8                30          52180768 ns/op

Without this change
BenchmarkSendBatch/Size2-8                500000              3082 ns/op
BenchmarkSendBatch/Size200-8               10000            140837 ns/op
BenchmarkSendBatch/Size20000-8                 1        7999998085 ns/op

This represents a 150x improvement on large request sizes and a
negligible change for small requests

Alternatively, if we don't care about the performance of this function,
we can disable it in the racetests and leave this code as is.

[x] Policies and Telemetry