### PR TITLE
Fix kiali upgrade issue

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.dashboard.viewOnlyMode }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,8 +11,27 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali{{- if .Values.dashboard.viewOnlyMode }}-viewer{{- end }}
+  name: kiali
 subjects:
 - kind: ServiceAccount
   name: kiali-service-account
   namespace: {{ .Release.Namespace }}
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-kiali-viewer-role-binding-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kiali-viewer
+subjects:
+- kind: ServiceAccount
+  name: kiali-service-account
+  namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>

This PR is to fix the upgrade issue - kiali.dashboard.viewOnlyMode from false to true:
```
helm upgrade istio install/kubernetes/helm/istio --namespace istio-system --set kiali.createDemoSecret=true --set kiali.enabled=true --tls --set kiali.dashboard.viewOnlyMode=true
Error: UPGRADE FAILED: ClusterRoleBinding.rbac.authorization.k8s.io “istio-kiali-admin-role-binding-istio-system” is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:“rbac.authorization.k8s.io”, Kind:“ClusterRole”, Name:“kiali-viewer”}: cannot change roleRef
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
