### PR TITLE
iptables: for listener using filter chain

### DIFF
--- a/tests/scripts/testdata/empty_parameter_golden.txt
+++ b/tests/scripts/testdata/empty_parameter_golden.txt
@@ -48,7 +48,7 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-port 15001
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 0 -j RETURN

--- a/tests/scripts/testdata/mode_redirect_golden.txt
+++ b/tests/scripts/testdata/mode_redirect_golden.txt
@@ -52,7 +52,7 @@ iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5555 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 6666 -j ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN

--- a/tests/scripts/testdata/mode_tproxy_and_ipv6_golden.txt
+++ b/tests/scripts/testdata/mode_tproxy_and_ipv6_golden.txt
@@ -62,7 +62,7 @@ iptables -t mangle -A ISTIO_INBOUND -p tcp -m socket -j ISTIO_DIVERT
 iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
@@ -96,7 +96,7 @@ ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 7777 -j RETURN
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 8888 -j RETURN
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
-ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_REDIRECT
+ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN

--- a/tests/scripts/testdata/mode_tproxy_and_wildcard_port_golden.txt
+++ b/tests/scripts/testdata/mode_tproxy_and_wildcard_port_golden.txt
@@ -62,7 +62,7 @@ iptables -t mangle -A ISTIO_INBOUND -p tcp -m socket -j ISTIO_DIVERT
 iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN

--- a/tests/scripts/testdata/mode_tproxy_golden.txt
+++ b/tests/scripts/testdata/mode_tproxy_golden.txt
@@ -63,7 +63,7 @@ iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 6666 -m socket -j ISTIO_DIVER
 iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 6666 -j ISTIO_TPROXY
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN

--- a/tests/scripts/testdata/outbound_port_exclude_golden.txt
+++ b/tests/scripts/testdata/outbound_port_exclude_golden.txt
@@ -54,7 +54,7 @@ iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 1024 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 21 -j RETURN
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN

--- a/tests/scripts/testdata/wildcard_include_ip_range_golden.txt
+++ b/tests/scripts/testdata/wildcard_include_ip_range_golden.txt
@@ -52,7 +52,7 @@ iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5555 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 6666 -j ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN

--- a/tools/istio-iptables/main.go
+++ b/tools/istio-iptables/main.go
@@ -333,7 +333,7 @@ func run(args []string, flagSet *flag.FlagSet) {
 	if env.RegisterStringVar("DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK", "", "").Get() == "" {
 		// Redirect app calls back to itself via Envoy when using the service VIP or endpoint
 		// address, e.g. appN => Envoy (client) => Envoy (server) => appN.
-		ext.RunOrFail(dep.IPTABLES, "-t", "nat", "-A", "ISTIO_OUTPUT", "-o", "lo", "!", "-d", "127.0.0.1/32", "-j", "ISTIO_REDIRECT")
+		ext.RunOrFail(dep.IPTABLES, "-t", "nat", "-A", "ISTIO_OUTPUT", "-o", "lo", "!", "-d", "127.0.0.1/32", "-j", "ISTIO_IN_REDIRECT")
 	}
 
 	for _, uid := range split(proxyUID) {
@@ -443,7 +443,7 @@ func run(args []string, flagSet *flag.FlagSet) {
 		}
 		// Redirect app calls to back itself via Envoy when using the service VIP or endpoint
 		// address, e.g. appN => Envoy (client) => Envoy (server) => appN.
-		ext.RunOrFail(dep.IP6TABLES, "-t", "nat", "-A", "ISTIO_OUTPUT", "-o", "lo", "!", "-d", "::1/128", "-j", "ISTIO_REDIRECT")
+		ext.RunOrFail(dep.IP6TABLES, "-t", "nat", "-A", "ISTIO_OUTPUT", "-o", "lo", "!", "-d", "::1/128", "-j", "ISTIO_IN_REDIRECT")
 
 		for _, uid := range split(proxyUID) {
 			// Avoid infinite loops. Don't redirect Envoy traffic directly back to

--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -410,7 +410,7 @@ fi
 if [ -z "${DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK-}" ]; then
   # Redirect app calls back to itself via Envoy when using the service VIP or endpoint
   # address, e.g. appN => Envoy (client) => Envoy (server) => appN.
-  iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+  iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 fi
 
 for uid in ${PROXY_UID}; do
@@ -539,7 +539,7 @@ if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
 
   # Redirect app calls to back itself via Envoy when using the service VIP or endpoint
   # address, e.g. appN => Envoy (client) => Envoy (server) => appN.
-  ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_REDIRECT
+  ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_IN_REDIRECT
 
   for uid in ${PROXY_UID}; do
     # Avoid infinite loops. Don't redirect Envoy traffic directly back to


### PR DESCRIPTION
Context
Inbound outbound listener split using filter chain instead of 2nd level listeners has extra requirement on iptables

Goal
The goal is the same as before: 
When client envoy send request to server envoy(through pod ip:port) and
** client envoy happens to be the same as server envoy**,
the request should be captured.

Previously it is captured by the unique capture port 15001, with the inout listener split it should be captured by 15006, 
which is the new inbound virtual listener port.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

