### PR TITLE
Fix race condition in adsc client

### DIFF
--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -210,9 +210,6 @@ func tlsConfig(certDir string) (*tls.Config, error) {
 // Close the stream.
 func (a *ADSC) Close() {
 	a.mutex.Lock()
-	if a.stream != nil {
-		_ = a.stream.CloseSend()
-	}
 	a.conn.Close()
 	a.mutex.Unlock()
 }


### PR DESCRIPTION
CloseSend and Send cannot be called concurrently, which is possible and
does happen in our tests, failing racetests. CloseSend is NOT required
and also doesn't actually close the stream (but we do that in the next
line anyways). See https://github.com/grpc/grpc-go/issues/2927 for
details.

[x] Networking