### PR TITLE
Mixer: add tests for direct HTTP response

### DIFF
--- a/mixer/pkg/runtime/dispatcher/session_test.go
+++ b/mixer/pkg/runtime/dispatcher/session_test.go
@@ -17,10 +17,15 @@ package dispatcher
 import (
 	"context"
 	"errors"
+	"net/http"
 	"reflect"
 	"testing"
 
+	"github.com/gogo/googleapis/google/rpc"
+
 	tpb "istio.io/api/mixer/adapter/model/v1beta1"
+	mixerpb "istio.io/api/mixer/v1"
+	descriptor "istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/pkg/attribute"
 )
@@ -122,5 +127,105 @@ func TestSession_EnsureParallelism(t *testing.T) {
 	s.ensureParallelism(11)
 	if cap(s.completed) < 11 {
 		t.Fail()
+	}
+}
+
+func TestDirectResponse(t *testing.T) {
+	testcases := []struct {
+		desc      string
+		status    rpc.Status
+		response  *descriptor.DirectHttpResponse
+		directive *mixerpb.RouteDirective
+	}{
+		{
+			desc:     "status success, no directives",
+			status:   rpc.Status{Code: int32(rpc.OK)},
+			response: &descriptor.DirectHttpResponse{},
+			directive: &mixerpb.RouteDirective{
+				DirectResponseCode: http.StatusOK,
+			},
+		},
+		{
+			desc:     "fallback to RPC response code (translated to http)",
+			status:   rpc.Status{Code: int32(rpc.UNAUTHENTICATED)},
+			response: &descriptor.DirectHttpResponse{},
+			directive: &mixerpb.RouteDirective{
+				DirectResponseCode: http.StatusUnauthorized,
+			},
+		},
+		{
+			desc:   "response status has precedence over RPC",
+			status: rpc.Status{Code: int32(rpc.UNIMPLEMENTED)},
+			response: &descriptor.DirectHttpResponse{
+				Code: http.StatusMovedPermanently,
+			},
+			directive: &mixerpb.RouteDirective{
+				DirectResponseCode: http.StatusMovedPermanently,
+			},
+		},
+		{
+			desc: "body is set",
+			response: &descriptor.DirectHttpResponse{
+				Code: http.StatusOK,
+				Body: "OK!",
+			},
+			directive: &mixerpb.RouteDirective{
+				DirectResponseCode: http.StatusOK,
+				DirectResponseBody: "OK!",
+			},
+		},
+		{
+			desc: "headers added",
+			response: &descriptor.DirectHttpResponse{
+				Code:    http.StatusMovedPermanently,
+				Headers: map[string]string{"Location": "URL"},
+			},
+			directive: &mixerpb.RouteDirective{
+				DirectResponseCode: http.StatusMovedPermanently,
+				ResponseHeaderOperations: []mixerpb.HeaderOperation{
+					mixerpb.HeaderOperation{
+						Operation: mixerpb.REPLACE,
+						Name:      "Location",
+						Value:     "URL",
+					},
+				},
+			},
+		},
+		{
+			desc: "multiline set-cookie header",
+			response: &descriptor.DirectHttpResponse{
+				Code:    http.StatusMovedPermanently,
+				Headers: map[string]string{"Location": "URL", "Set-Cookie": "c1=1; Secure; HttpOnly;,c2=2"},
+			},
+			directive: &mixerpb.RouteDirective{
+				DirectResponseCode: http.StatusMovedPermanently,
+				ResponseHeaderOperations: []mixerpb.HeaderOperation{
+					mixerpb.HeaderOperation{
+						Operation: mixerpb.REPLACE,
+						Name:      "Location",
+						Value:     "URL",
+					},
+					mixerpb.HeaderOperation{
+						Operation: mixerpb.APPEND,
+						Name:      "Set-Cookie",
+						Value:     "c1=1; Secure; HttpOnly;",
+					},
+					mixerpb.HeaderOperation{
+						Operation: mixerpb.APPEND,
+						Name:      "Set-Cookie",
+						Value:     "c2=2",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		s := &session{}
+		s.handleDirectResponse(tc.status, tc.response)
+		if !reflect.DeepEqual(s.checkResult.RouteDirective, tc.directive) {
+			t.Fatalf("route directive mismatch in %s '%+v' != '%+v'", tc.desc, s.checkResult.RouteDirective, tc.directive)
+		}
+
 	}
 }

--- a/mixer/pkg/runtime/dispatcher/session_test.go
+++ b/mixer/pkg/runtime/dispatcher/session_test.go
@@ -183,7 +183,7 @@ func TestDirectResponse(t *testing.T) {
 			directive: &mixerpb.RouteDirective{
 				DirectResponseCode: http.StatusMovedPermanently,
 				ResponseHeaderOperations: []mixerpb.HeaderOperation{
-					mixerpb.HeaderOperation{
+					{
 						Operation: mixerpb.REPLACE,
 						Name:      "Location",
 						Value:     "URL",
@@ -200,17 +200,17 @@ func TestDirectResponse(t *testing.T) {
 			directive: &mixerpb.RouteDirective{
 				DirectResponseCode: http.StatusMovedPermanently,
 				ResponseHeaderOperations: []mixerpb.HeaderOperation{
-					mixerpb.HeaderOperation{
+					{
 						Operation: mixerpb.REPLACE,
 						Name:      "Location",
 						Value:     "URL",
 					},
-					mixerpb.HeaderOperation{
+					{
 						Operation: mixerpb.APPEND,
 						Name:      "Set-Cookie",
 						Value:     "c1=1; Secure; HttpOnly;",
 					},
-					mixerpb.HeaderOperation{
+					{
 						Operation: mixerpb.APPEND,
 						Name:      "Set-Cookie",
 						Value:     "c2=2",


### PR DESCRIPTION
This is a follow up to #15581, adding tests for handling of DirectHttpResponse into route directives:
- validate status code setting
- confirm body setting
- header manipulation

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
