### PR TITLE
Add POD_NAMESPACE env variable to mixer containers

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -78,6 +78,11 @@
           {{- end }}
         {{- if .Values.env }}
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         {{- range $key, $val := .Values.env }}
         - name: {{ $key }}
           value: "{{ $val }}"
@@ -262,6 +267,11 @@
           - {{ $.Values.telemetry.loadshedding.mode }}
         {{- if .Values.env }}
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         {{- range $key, $val := .Values.env }}
         - name: {{ $key }}
           value: "{{ $val }}"


### PR DESCRIPTION
Some adapters (e.g. kubernetesenv) might rely on that variable, using
"istio-system" as a fallback value. This is an issue if the control plane
is deployed in another namespace.