### PR TITLE
Fix TestServerSource race condition

### DIFF
--- a/pkg/mcp/source/server_source_test.go
+++ b/pkg/mcp/source/server_source_test.go
@@ -120,11 +120,11 @@ func TestServerSource(t *testing.T) {
 	}
 
 	// ProcessStream error
+	wantError := errors.New("unknown")
+	h.setRecvError(wantError)
 	go func() {
 		errc <- s.EstablishResourceStream(h)
 	}()
-	wantError := errors.New("unknown")
-	h.setRecvError(wantError)
 	err = <-errc
 	if err != wantError {
 		t.Fatalf("Stream exited with error: got %v want %v", err, wantError)


### PR DESCRIPTION
If we set the desired error after we start the stream, the stream could
have a real error before we get to setting the error.

Fixes https://github.com/istio/istio/issues/15798

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
