### PR TITLE
Add workload SDS flow test with Google CA

### DIFF
--- a/tests/integration/security/sds_managed_ca_flow/main_test.go
+++ b/tests/integration/security/sds_managed_ca_flow/main_test.go
@@ -1,0 +1,79 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package sds_managed_ca_flow
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/pkg/env"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst istio.Instance
+	g    galley.Instance
+	p    pilot.Instance
+)
+
+// Cluster and project specific values from env vars.
+var (
+	projectId       string
+	clusterLocation string
+	clusterName     string
+)
+
+func TestMain(m *testing.M) {
+	// NOTE: Currently, this test is only intended to run manually on a managed CA whitelisted cluster.
+	projectId = env.RegisterStringVar("PROJECT_ID", "", "").Get()
+	clusterLocation = env.RegisterStringVar("CLUSTER_LOCATION", "", "").Get()
+	clusterName = env.RegisterStringVar("CLUSTER_NAME", "", "").Get()
+	if projectId == "" || clusterLocation == "" || clusterName == "" {
+		return
+	}
+	framework.
+		NewSuite("sds_managed_ca_flow_test", m).
+		Label(label.CustomSetup).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// Overwrite Istio standard helm values with managed CA and IDNS.
+	cfg.ValuesFile = "example-values/values-istio-googleca.yaml"
+	cfg.Values["global.trustDomain"] = fmt.Sprintf("%s.svc.id.goog", projectId)
+	cfg.Values["nodeagent.env.GKE_CLUSTER_URL"] = fmt.Sprintf("https://container.googleapis.com/v1/projects/%s/locations/%s/clusters/%s", projectId, clusterLocation, clusterName)
+}

--- a/tests/integration/security/sds_managed_ca_flow/main_test.go
+++ b/tests/integration/security/sds_managed_ca_flow/main_test.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package sds_managed_ca_flow
+package sdsmanagedcaflow
 
 import (
 	"fmt"
@@ -37,17 +37,17 @@ var (
 
 // Cluster and project specific values from env vars.
 var (
-	projectId       string
+	projectID       string
 	clusterLocation string
 	clusterName     string
 )
 
 func TestMain(m *testing.M) {
 	// NOTE: Currently, this test is only intended to run manually on a managed CA whitelisted cluster.
-	projectId = env.RegisterStringVar("PROJECT_ID", "", "").Get()
+	projectID = env.RegisterStringVar("PROJECT_ID", "", "").Get()
 	clusterLocation = env.RegisterStringVar("CLUSTER_LOCATION", "", "").Get()
 	clusterName = env.RegisterStringVar("CLUSTER_NAME", "", "").Get()
-	if projectId == "" || clusterLocation == "" || clusterName == "" {
+	if projectID == "" || clusterLocation == "" || clusterName == "" {
 		return
 	}
 	framework.
@@ -74,6 +74,8 @@ func setupConfig(cfg *istio.Config) {
 	}
 	// Overwrite Istio standard helm values with managed CA and IDNS.
 	cfg.ValuesFile = "example-values/values-istio-googleca.yaml"
-	cfg.Values["global.trustDomain"] = fmt.Sprintf("%s.svc.id.goog", projectId)
-	cfg.Values["nodeagent.env.GKE_CLUSTER_URL"] = fmt.Sprintf("https://container.googleapis.com/v1/projects/%s/locations/%s/clusters/%s", projectId, clusterLocation, clusterName)
+	cfg.Values["global.trustDomain"] = fmt.Sprintf("%s.svc.id.goog", projectID)
+	cfg.Values["nodeagent.env.GKE_CLUSTER_URL"] = fmt.Sprintf(
+		"https://container.googleapis.com/v1/projects/%s/locations/%s/clusters/%s",
+		projectID, clusterLocation, clusterName)
 }

--- a/tests/integration/security/sds_managed_ca_flow/sds_managed_ca_flow_test.go
+++ b/tests/integration/security/sds_managed_ca_flow/sds_managed_ca_flow_test.go
@@ -31,7 +31,7 @@ import (
 	"istio.io/istio/tests/integration/security/util/connection"
 )
 
-func TestSdsCitadelCaFlow(t *testing.T) {
+func TestSdsManagedCaFlow(t *testing.T) {
 	framework.NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {

--- a/tests/integration/security/sds_managed_ca_flow/sds_managed_ca_flow_test.go
+++ b/tests/integration/security/sds_managed_ca_flow/sds_managed_ca_flow_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_managed_ca_flow
+package sdsmanagedcaflow
 
 import (
 	"testing"

--- a/tests/integration/security/sds_managed_ca_flow/sds_managed_ca_flow_test.go
+++ b/tests/integration/security/sds_managed_ca_flow/sds_managed_ca_flow_test.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sds_managed_ca_flow
+
+import (
+	"testing"
+	"time"
+
+	"istio.io/istio/tests/integration/security/util"
+
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/tests/integration/security/util/connection"
+)
+
+func TestSdsCitadelCaFlow(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+
+			istioCfg := istio.DefaultConfigOrFail(t, ctx)
+
+			namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
+			ns := namespace.NewOrFail(t, ctx, "sds-managed-ca-flow", true)
+
+			var a, b echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
+				BuildOrFail(t)
+
+			checkers := []connection.Checker{
+				{
+					From: a,
+					Options: echo.CallOptions{
+						Target:   b,
+						PortName: "http",
+						Scheme:   scheme.HTTP,
+					},
+					ExpectSuccess: true,
+				},
+			}
+
+			for _, checker := range checkers {
+				retry.UntilSuccessOrFail(t, checker.Check, retry.Delay(time.Second), retry.Timeout(10*time.Second))
+			}
+		})
+}


### PR DESCRIPTION
Add an integration test for workload SDS flow with managed CA. This test is only intended to run manually on a managed CA white-listed cluster.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
