### PR TITLE
Cleanup and properly document pilot env vars

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/pkg/env"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -78,7 +77,7 @@ var (
 	// be used, "/"
 	BaseDir = "BASE"
 
-	// Will add "accept_http_10" to http outbound listeners. Can also be set only for specific sidecars via meta.
+	// HTTP10 will add "accept_http_10" to http outbound listeners. Can also be set only for specific sidecars via meta.
 	//
 	// Alpha in 1.1, may become the default or be turned into a Sidecar API or mesh setting. Only applies to namespaces
 	// where Sidecar is enabled.
@@ -109,13 +108,13 @@ var (
 		return time.Second * time.Duration(terminationDrainDurationVar.Get())
 	}
 
-	enableFallthroughRouteVar = env.RegisterBoolVar(
+	EnableFallthroughRoute = env.RegisterBoolVar(
 		"PILOT_ENABLE_FALLTHROUGH_ROUTE",
 		true,
 		"EnableFallthroughRoute provides an option to add a final wildcard match for routes. "+
 			"When ALLOW_ANY traffic policy is used, a Passthrough cluster is used. "+
 			"When REGISTRY_ONLY traffic policy is used, a 502 error is returned.",
-	).Get()
+	)
 
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
 	DisableXDSMarshalingToAny = env.RegisterBoolVar(
@@ -130,7 +129,7 @@ var (
 		"PILOT_ENABLE_MYSQL_FILTER",
 		false,
 		"EnableMysqlFilter enables injection of `envoy.filters.network.mysql_proxy` in the filter chain.",
-	).Get()
+	)
 
 	// EnableRedisFilter enables injection of `envoy.filters.network.redis_proxy` in the filter chain.
 	// Pilot injects this outbound filter if the service port name is `redis`.
@@ -138,7 +137,7 @@ var (
 		"PILOT_ENABLE_REDIS_FILTER",
 		false,
 		"EnableRedisFilter enables injection of `envoy.filters.network.redis_proxy` in the filter chain.",
-	).Get()
+	)
 
 	// UseRemoteAddress sets useRemoteAddress to true for side car outbound listeners so that it picks up the localhost
 	// address of the sender, which is an internal address, so that trusted headers are not sanitized.
@@ -146,7 +145,7 @@ var (
 		"PILOT_SIDECAR_USE_REMOTE_ADDRESS",
 		false,
 		"UseRemoteAddress sets useRemoteAddress to true for side car outbound listeners.",
-	).Get()
+	)
 
 	// UseIstioJWTFilter enables to use Istio JWT filter as a fall back. Pilot injects the Istio JWT
 	// filter to the filter chains if this is set to true.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -15,7 +15,6 @@
 package features
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/gogo/protobuf/types"
@@ -30,18 +29,24 @@ var (
 	// as a regular user on a VM or test environment.
 	CertDir = env.RegisterStringVar("PILOT_CERT_DIR", "", "").Get()
 
-	// MaxConcurrentStreams indicates pilot max grpc concurrent streams.
-	// Default is 100000.
-	MaxConcurrentStreams = env.RegisterIntVar("ISTIO_GPRC_MAXSTREAMS", 100000, "").Get()
+	MaxConcurrentStreams = env.RegisterIntVar(
+		"ISTIO_GPRC_MAXSTREAMS",
+		100000,
+		"Sets the maximum number of concurrent grpc streams.",
+	).Get()
 
-	// TraceSampling sets mesh-wide trace sampling
-	// percentage, should be 0.0 - 100.0 Precision to 0.01
-	// Default is 100%, not recommended for production use.
-	TraceSampling = env.RegisterFloatVar("PILOT_TRACE_SAMPLING", 100.0, "").Get()
+	TraceSampling = env.RegisterFloatVar(
+		"PILOT_TRACE_SAMPLING",
+		100.0,
+		"Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. "+
+			"Default is 100, not recommended for production use.",
+	).Get()
 
-	// PushThrottle limits the number of concurrent pushes allowed. Default is 100 concurrent pushes.
-	// On larger machines you can increase this to get faster push.
-	PushThrottle = env.RegisterIntVar("PILOT_PUSH_THROTTLE", 100, "").Get()
+	PushThrottle = env.RegisterIntVar(
+		"PILOT_PUSH_THROTTLE",
+		100,
+		"Limits the number of concurrent pushes allowed. On larger machines this can be increased for faster pushes",
+	).Get()
 
 	// DebugConfigs controls saving snapshots of configs for /debug/adsz.
 	// Defaults to false, can be enabled with PILOT_DEBUG_ADSZ_CONFIG=1
@@ -53,32 +58,35 @@ var (
 	// Default is 0 (disabled).
 	RefreshDuration = env.RegisterDurationVar("V2_REFRESH", 0, "").Get()
 
-	// DebounceAfter is the delay added to events to wait
-	// after a registry/config event for debouncing.
-	// This will delay the push by at least this interval, plus
-	// the time getting subsequent events. If no change is
-	// detected the push will happen, otherwise we'll keep
-	// delaying until things settle.
-	// Default is 100ms, Example: "300ms", "10s" or "2h45m".
-	DebounceAfter = env.RegisterDurationVar("PILOT_DEBOUNCE_AFTER", 100*time.Millisecond, "").Get()
+	DebounceAfter = env.RegisterDurationVar(
+		"PILOT_DEBOUNCE_AFTER",
+		100*time.Millisecond,
+		"The delay added to config/registry events for debouncing. This will delay the push by "+
+			"at least this internal. If no change is detected within this period, the push will happen, "+
+			" otherwise we'll keep delaying until things settle, up to a max of PILOT_DEBOUNCE_MAX.",
+	).Get()
 
-	// DebounceMax is the maximum time to wait for events
-	// while debouncing. Defaults to 10 seconds. If events keep
-	// showing up with no break for this time, we'll trigger a push.
-	// Default is 10s, Example: "300ms", "10s" or "2h45m".
-	DebounceMax = env.RegisterDurationVar("PILOT_DEBOUNCE_MAX", 10*time.Second, "").Get()
+	DebounceMax = env.RegisterDurationVar(
+		"PILOT_DEBOUNCE_MAX",
+		10*time.Second,
+		"The maximum amount of time to wait for events while debouncing. If events keep showing up with no breaks "+
+			"for this time, we'll trigger a push.",
+	).Get()
 
 	// BaseDir is the base directory for locating configs.
 	// File based certificates are located under $BaseDir/etc/certs/. If not set, the original 1.0 locations will
 	// be used, "/"
 	BaseDir = "BASE"
 
-	// HTTP10 enables the use of HTTP10 in the outbound HTTP listeners, to support legacy applications.
 	// Will add "accept_http_10" to http outbound listeners. Can also be set only for specific sidecars via meta.
 	//
 	// Alpha in 1.1, may become the default or be turned into a Sidecar API or mesh setting. Only applies to namespaces
 	// where Sidecar is enabled.
-	HTTP10 = env.RegisterBoolVar("PILOT_HTTP10", false, "").Get()
+	HTTP10 = env.RegisterBoolVar(
+		"PILOT_HTTP10",
+		false,
+		"Enables the use of HTTP 1.0 in the outbound HTTP listeners, to support legacy applications.",
+	).Get()
 
 	initialFetchTimeoutVar = env.RegisterDurationVar(
 		"PILOT_INITIAL_FETCH_TIMEOUT",
@@ -89,22 +97,16 @@ var (
 	)
 	InitialFetchTimeout = types.DurationProto(initialFetchTimeoutVar.Get())
 
-	// TerminationDrainDuration is the amount of time allowed for connections to complete on pilot-agent shutdown.
-	// On receiving SIGTERM or SIGINT, pilot-agent tells the active Envoy to start draining,
-	// preventing any new connections and allowing existing connections to complete. It then
-	// sleeps for the TerminationDrainDuration and then kills any remaining active Envoy processes.
-	terminationDrainDurationVar = env.RegisterStringVar("TERMINATION_DRAIN_DURATION_SECONDS", "", "")
-	TerminationDrainDuration    = func() time.Duration {
-		defaultDuration := time.Second * 5
-		if terminationDrainDurationVar.Get() == "" {
-			return defaultDuration
-		}
-		duration, err := strconv.Atoi(terminationDrainDurationVar.Get())
-		if err != nil {
-			log.Warnf("unable to parse env var %v, using default of %v.", terminationDrainDurationVar.Get(), defaultDuration)
-			return defaultDuration
-		}
-		return time.Second * time.Duration(duration)
+	terminationDrainDurationVar = env.RegisterIntVar(
+		"TERMINATION_DRAIN_DURATION_SECONDS",
+		5,
+		"The amount of time allowed for connections to complete on pilot-agent shutdown. "+
+			"On receiving SIGTERM or SIGINT, pilot-agent tells the active Envoy to start draining, "+
+			"preventing any new connections and allowing existing connections to complete. It then "+
+			"sleeps for the TerminationDrainDuration and then kills any remaining active Envoy processes.",
+	)
+	TerminationDrainDuration = func() time.Duration {
+		return time.Second * time.Duration(terminationDrainDurationVar.Get())
 	}
 
 	enableFallthroughRouteVar = env.RegisterBoolVar(
@@ -113,38 +115,38 @@ var (
 		"EnableFallthroughRoute provides an option to add a final wildcard match for routes. "+
 			"When ALLOW_ANY traffic policy is used, a Passthrough cluster is used. "+
 			"When REGISTRY_ONLY traffic policy is used, a 502 error is returned.",
-	)
-	EnableFallthroughRoute = enableFallthroughRouteVar.Get
+	).Get()
 
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
-	disableXDSMarshalingToAnyVar = env.RegisterStringVar("PILOT_DISABLE_XDS_MARSHALING_TO_ANY", "", "")
-	DisableXDSMarshalingToAny    = func() bool {
-		return disableXDSMarshalingToAnyVar.Get() == "1"
-	}
+	DisableXDSMarshalingToAny = env.RegisterBoolVar(
+		"PILOT_DISABLE_XDS_MARSHALING_TO_ANY",
+		false,
+		"",
+	).Get()
 
 	// EnableMysqlFilter enables injection of `envoy.filters.network.mysql_proxy` in the filter chain.
 	// Pilot injects this outbound filter if the service port name is `mysql`.
-	EnableMysqlFilter = enableMysqlFilter.Get
-	enableMysqlFilter = env.RegisterBoolVar(
+	EnableMysqlFilter = env.RegisterBoolVar(
 		"PILOT_ENABLE_MYSQL_FILTER",
 		false,
-		"EnableMysqlFilter enables injection of `envoy.filters.network.mysql_proxy` in the filter chain.")
+		"EnableMysqlFilter enables injection of `envoy.filters.network.mysql_proxy` in the filter chain.",
+	).Get()
 
 	// EnableRedisFilter enables injection of `envoy.filters.network.redis_proxy` in the filter chain.
 	// Pilot injects this outbound filter if the service port name is `redis`.
-	EnableRedisFilter = enableRedisFilter.Get
-	enableRedisFilter = env.RegisterBoolVar(
+	EnableRedisFilter = env.RegisterBoolVar(
 		"PILOT_ENABLE_REDIS_FILTER",
 		false,
-		"EnableRedisFilter enables injection of `envoy.filters.network.redis_proxy` in the filter chain.")
+		"EnableRedisFilter enables injection of `envoy.filters.network.redis_proxy` in the filter chain.",
+	).Get()
 
 	// UseRemoteAddress sets useRemoteAddress to true for side car outbound listeners so that it picks up the localhost
 	// address of the sender, which is an internal address, so that trusted headers are not sanitized.
-	UseRemoteAddress = useRemoteAddress.Get
-	useRemoteAddress = env.RegisterBoolVar(
+	UseRemoteAddress = env.RegisterBoolVar(
 		"PILOT_SIDECAR_USE_REMOTE_ADDRESS",
 		false,
-		"UseRemoteAddress sets useRemoteAddress to true for side car outbound listeners.")
+		"UseRemoteAddress sets useRemoteAddress to true for side car outbound listeners.",
+	).Get()
 
 	// UseIstioJWTFilter enables to use Istio JWT filter as a fall back. Pilot injects the Istio JWT
 	// filter to the filter chains if this is set to true.

--- a/pilot/pkg/features/pilot_test.go
+++ b/pilot/pkg/features/pilot_test.go
@@ -66,9 +66,9 @@ func Test_TerminationDrainDuration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setEnvVar {
-				os.Setenv("TERMINATION_DRAIN_DURATION_SECONDS", tt.envVar)
+				os.Setenv(terminationDrainDurationVar.Name, tt.envVar)
 			} else {
-				os.Unsetenv("TERMINATION_DRAIN_DURATION_SECONDS")
+				os.Unsetenv(terminationDrainDurationVar.Name)
 			}
 			if got := TerminationDrainDuration(); got != tt.want {
 				t.Errorf("TerminationDrainDuration() = %v, want %v", got, tt.want)

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -881,7 +881,7 @@ func applyLoadBalancer(cluster *apiv2.Cluster, lb *networking.LoadBalancerSettin
 	}
 
 	// Redis protocol must be defaulted with MAGLEV to benefit from client side sharding.
-	if features.EnableRedisFilter() && port != nil && port.Protocol == config.ProtocolRedis {
+	if features.EnableRedisFilter && port != nil && port.Protocol == config.ProtocolRedis {
 		cluster.LbPolicy = apiv2.Cluster_MAGLEV
 		return
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -881,7 +881,7 @@ func applyLoadBalancer(cluster *apiv2.Cluster, lb *networking.LoadBalancerSettin
 	}
 
 	// Redis protocol must be defaulted with MAGLEV to benefit from client side sharding.
-	if features.EnableRedisFilter && port != nil && port.Protocol == config.ProtocolRedis {
+	if features.EnableRedisFilter.Get() && port != nil && port.Protocol == config.ProtocolRedis {
 		cluster.LbPolicy = apiv2.Cluster_MAGLEV
 		return
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pilot/pkg/features"
+
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/proto"
@@ -1000,9 +1002,9 @@ func TestRedisProtocolCluster(t *testing.T) {
 	}
 
 	// enable redis filter to true
-	_ = os.Setenv("PILOT_ENABLE_REDIS_FILTER", "true")
+	_ = os.Setenv(features.EnableRedisFilter.Name, "true")
 
-	defer func() { _ = os.Unsetenv("PILOT_ENABLE_REDIS_FILTER") }()
+	defer func() { _ = os.Unsetenv(features.EnableRedisFilter.Name) }()
 
 	serviceDiscovery.ServicesReturns([]*model.Service{service}, nil)
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -210,7 +210,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 
 	util.SortVirtualHosts(virtualHosts)
 
-	if features.EnableFallthroughRoute {
+	if features.EnableFallthroughRoute.Get() {
 		// This needs to be the last virtual host, as routes are evaluated in order.
 		if isAllowAnyOutbound(node) {
 			virtualHosts = append(virtualHosts, route.VirtualHost{

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -210,7 +210,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 
 	util.SortVirtualHosts(virtualHosts)
 
-	if features.EnableFallthroughRoute() {
+	if features.EnableFallthroughRoute {
 		// This needs to be the last virtual host, as routes are evaluated in order.
 		if isAllowAnyOutbound(node) {
 			virtualHosts = append(virtualHosts, route.VirtualHost{

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -21,6 +21,8 @@ import (
 	"sort"
 	"testing"
 
+	"istio.io/istio/pilot/pkg/features"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -568,7 +570,7 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 	} else {
 		proxy.SidecarScope = model.ConvertToSidecarScope(env.PushContext, sidecarConfig, sidecarConfig.Namespace)
 	}
-	_ = os.Setenv("PILOT_ENABLE_FALLTHROUGH_ROUTE", "0")
+	_ = os.Setenv(features.EnableFallthroughRoute.Name, "0")
 	if fallthroughRoute {
 		_ = os.Setenv("PILOT_ENABLE_FALLTHROUGH_ROUTE", "1")
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -917,7 +917,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 		// Set useRemoteAddress to true for side car outbound listeners so that it picks up the localhost address of the sender,
 		// which is an internal address, so that trusted headers are not sanitized. This helps to retain the timeout headers
 		// such as "x-envoy-upstream-rq-timeout-ms" set by the calling application.
-		useRemoteAddress: features.UseRemoteAddress,
+		useRemoteAddress: features.UseRemoteAddress.Get(),
 		direction:        http_conn.EGRESS,
 		rds:              rdsName,
 	}
@@ -1647,7 +1647,7 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 // This allows external https traffic, even when port the port (usually 443) is in use by another service.
 func appendListenerFallthroughRoute(l *xdsapi.Listener, opts *buildListenerOpts, node *model.Proxy, currentListenerEntry *outboundListenerEntry) {
 	// If traffic policy is REGISTRY_ONLY, the traffic will already be blocked, so no action is needed.
-	if features.EnableFallthroughRoute && isAllowAnyOutbound(node) {
+	if features.EnableFallthroughRoute.Get() && isAllowAnyOutbound(node) {
 
 		wildcardMatch := &listener.FilterChainMatch{}
 		for _, fc := range l.FilterChains {

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -917,7 +917,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 		// Set useRemoteAddress to true for side car outbound listeners so that it picks up the localhost address of the sender,
 		// which is an internal address, so that trusted headers are not sanitized. This helps to retain the timeout headers
 		// such as "x-envoy-upstream-rq-timeout-ms" set by the calling application.
-		useRemoteAddress: features.UseRemoteAddress(),
+		useRemoteAddress: features.UseRemoteAddress,
 		direction:        http_conn.EGRESS,
 		rds:              rdsName,
 	}
@@ -1647,7 +1647,7 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 // This allows external https traffic, even when port the port (usually 443) is in use by another service.
 func appendListenerFallthroughRoute(l *xdsapi.Listener, opts *buildListenerOpts, node *model.Proxy, currentListenerEntry *outboundListenerEntry) {
 	// If traffic policy is REGISTRY_ONLY, the traffic will already be blocked, so no action is needed.
-	if features.EnableFallthroughRoute() && isAllowAnyOutbound(node) {
+	if features.EnableFallthroughRoute && isAllowAnyOutbound(node) {
 
 		wildcardMatch := &listener.FilterChainMatch{}
 		for _, fc := range l.FilterChains {

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pilot/pkg/features"
+
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
@@ -430,9 +432,9 @@ func testOutboundListenerConfigWithSidecar(t *testing.T, services ...*model.Serv
 	}
 
 	// enable mysql filter that is used here
-	_ = os.Setenv("PILOT_ENABLE_MYSQL_FILTER", "true")
+	_ = os.Setenv(features.EnableMysqlFilter.Name, "true")
 
-	defer func() { _ = os.Unsetenv("PILOT_ENABLE_MYSQL_FILTER") }()
+	defer func() { _ = os.Unsetenv(features.EnableMysqlFilter.Name) }()
 
 	listeners := buildOutboundListeners(p, sidecarConfig, nil, services...)
 	if len(listeners) != 3 {
@@ -484,9 +486,9 @@ func testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t *testing.T, ser
 	}
 
 	// enable use remote address to true
-	_ = os.Setenv("PILOT_SIDECAR_USE_REMOTE_ADDRESS", "true")
+	_ = os.Setenv(features.UseRemoteAddress.Name, "true")
 
-	defer func() { _ = os.Unsetenv("PILOT_SIDECAR_USE_REMOTE_ADDRESS") }()
+	defer func() { _ = os.Unsetenv(features.UseRemoteAddress.Name) }()
 
 	listeners := buildOutboundListeners(p, sidecarConfig, nil, services...)
 

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -186,14 +186,14 @@ func buildNetworkFiltersStack(node *model.Proxy, port *model.Port, tcpFilter *li
 	case config.ProtocolMongo:
 		filterstack = append(filterstack, buildMongoFilter(statPrefix, util.IsXDSMarshalingToAnyEnabled(node)), *tcpFilter)
 	case config.ProtocolRedis:
-		if util.IsProxyVersionGE11(node) && features.EnableRedisFilter {
+		if util.IsProxyVersionGE11(node) && features.EnableRedisFilter.Get() {
 			// redis filter has route config, it is a terminating filter, no need append tcp filter.
 			filterstack = append(filterstack, buildRedisFilter(statPrefix, clusterName, util.IsXDSMarshalingToAnyEnabled(node)))
 		} else {
 			filterstack = append(filterstack, *tcpFilter)
 		}
 	case config.ProtocolMySQL:
-		if util.IsProxyVersionGE11(node) && features.EnableMysqlFilter {
+		if util.IsProxyVersionGE11(node) && features.EnableMysqlFilter.Get() {
 			filterstack = append(filterstack, buildMySQLFilter(statPrefix, util.IsXDSMarshalingToAnyEnabled(node)))
 		}
 		filterstack = append(filterstack, *tcpFilter)

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -186,14 +186,14 @@ func buildNetworkFiltersStack(node *model.Proxy, port *model.Port, tcpFilter *li
 	case config.ProtocolMongo:
 		filterstack = append(filterstack, buildMongoFilter(statPrefix, util.IsXDSMarshalingToAnyEnabled(node)), *tcpFilter)
 	case config.ProtocolRedis:
-		if util.IsProxyVersionGE11(node) && features.EnableRedisFilter() {
+		if util.IsProxyVersionGE11(node) && features.EnableRedisFilter {
 			// redis filter has route config, it is a terminating filter, no need append tcp filter.
 			filterstack = append(filterstack, buildRedisFilter(statPrefix, clusterName, util.IsXDSMarshalingToAnyEnabled(node)))
 		} else {
 			filterstack = append(filterstack, *tcpFilter)
 		}
 	case config.ProtocolMySQL:
-		if util.IsProxyVersionGE11(node) && features.EnableMysqlFilter() {
+		if util.IsProxyVersionGE11(node) && features.EnableMysqlFilter {
 			filterstack = append(filterstack, buildMySQLFilter(statPrefix, util.IsXDSMarshalingToAnyEnabled(node)))
 		}
 		filterstack = append(filterstack, *tcpFilter)

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -255,7 +255,7 @@ func IsProxyVersionGE11(node *model.Proxy) bool {
 
 // IsXDSMarshalingToAnyEnabled controls whether "marshaling to Any" feature is enabled.
 func IsXDSMarshalingToAnyEnabled(node *model.Proxy) bool {
-	return IsProxyVersionGE11(node) && !features.DisableXDSMarshalingToAny()
+	return IsProxyVersionGE11(node) && !features.DisableXDSMarshalingToAny
 }
 
 // ResolveHostsInNetworksConfig will go through the Gateways addresses for all

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -197,7 +197,7 @@ func TestCollectJwtSpecs(t *testing.T) {
 }
 
 func setUseIstioJWTFilter(value string, t *testing.T) {
-	err := os.Setenv("USE_ISTIO_JWT_FILTER", value)
+	err := os.Setenv(features.UseIstioJWTFilter.Name, value)
 	if err != nil {
 		t.Fatalf("failed to set enable Istio JWT filter: %v", err)
 	}


### PR DESCRIPTION
Currently most of our environment variables are undocumented, and some
also use the wrong types. This makes it very confusing because you can
set FOO=false and it actually turns on FOO. This change cleans up these
cases, and adds documentation to most of the variables used in pilot.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
