### PR TITLE
Fix debounce for new configuration pushes in pilot

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debounced_channel.go
+++ b/pilot/pkg/proxy/envoy/v2/debounced_channel.go
@@ -1,0 +1,180 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"sync"
+	"time"
+
+	"istio.io/istio/pilot/pkg/model"
+)
+
+// DebouncedEvent is used as entry type, which is enqueued in DebouncedChannel
+type DebouncedEvent = interface{}
+
+// Notification is used to enqueue the DebouncedEvent
+type Notification struct {
+	// Event is the merged result of all events.
+	Event DebouncedEvent
+	// Ack must be called to acknowledge the processing of the event.
+	Ack func()
+}
+
+// DebouncedChannel is a channel which abstracts the debounce algorithm
+type DebouncedChannel struct {
+	// C channel, which can be used in selects. It delivers debounced events.
+	// The function emitted must be called. Otherwise processing is stopped.
+	C <-chan Notification
+	c chan Notification
+
+	debounceAfterEnd time.Time
+	debounceMaxEnd   time.Time
+	lastEmitTime     time.Time
+	debounceAfter    time.Duration
+	debounceMax      time.Duration
+	mutex            sync.Mutex
+
+	merge              func(accumulator DebouncedEvent, value DebouncedEvent) DebouncedEvent
+	accumulator        DebouncedEvent
+	initialAccumulator DebouncedEvent
+
+	// pushCounter is used to collect the overall number of pushes to the channel C
+	pushCounter uint32
+	// debounceCounter is used to count the number of events, which are merged together into one push to channel C
+	debounceCounter uint32
+	ackID           uint32
+	running         bool
+}
+
+// NewDebouncedChannel create a new instance of DebouncedChannel
+// debounceAfter: A new outgoing event is emitted if no additional event is enqueued during this period (resets on every enqueued event).
+// debounceMax: A new outgoing event is emitted after this period (even if additional events were enqueued in that period).
+// initialAccumulator: Initial value of the accumulator
+// merge: function, which is called to merge two events if they are debounced.
+func NewDebouncedChannel(debounceAfter time.Duration, debounceMax time.Duration,
+	initialAccumulator DebouncedEvent, merge func(accumulator DebouncedEvent, value DebouncedEvent) DebouncedEvent) *DebouncedChannel {
+
+	c := make(chan Notification, 1)
+
+	return &DebouncedChannel{
+		C:                  c,
+		c:                  c,
+		initialAccumulator: initialAccumulator,
+		accumulator:        initialAccumulator,
+		merge:              merge,
+		debounceAfter:      debounceAfter,
+		debounceMax:        debounceMax,
+		lastEmitTime:       time.Unix(0, 0),
+	}
+
+}
+
+// Enqueue pushes a new event to the channel
+func (dc *DebouncedChannel) Enqueue(element DebouncedEvent) {
+	dc.mutex.Lock()
+	defer dc.mutex.Unlock()
+	dc.accumulator = dc.merge(dc.accumulator, element)
+	if dc.debounceCounter == 0 {
+		dc.debounceMaxEnd = time.Now().Add(dc.debounceMax)
+		go func() {
+			dc.mutex.Lock()
+			defer dc.mutex.Unlock()
+
+			for {
+				debounceCounter := dc.debounceCounter
+
+				sleepDuration := min(dc.debounceAfter, time.Until(dc.debounceMaxEnd))
+				dc.mutex.Unlock()
+				time.Sleep(sleepDuration)
+				dc.mutex.Lock()
+
+				if debounceCounter == dc.debounceCounter || time.Now().After(dc.debounceMaxEnd) {
+					break
+				}
+			}
+			// Check if the notification should be sent after the timeout expired
+			dc.runIfNeededLocked()
+		}()
+	}
+
+	dc.debounceAfterEnd = time.Now().Add(dc.debounceAfter)
+	dc.debounceCounter++
+
+	// Check if the notification should be sent immediately
+	dc.runIfNeededLocked()
+}
+
+func min(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// runIfNeededLocked must be called in a locked section
+func (dc *DebouncedChannel) runIfNeededLocked() {
+	if dc.debounceCounter == 0 {
+		// No events stored. Therefore nothing to do
+		return
+	}
+	if dc.running {
+		// There is already an event being processed. We are still waiting for the acknowledgement.
+		return
+	}
+	if dc.debounceMaxEnd.Before(time.Now()) || dc.debounceAfterEnd.Before(time.Now()) {
+		// It's time to notify the worker
+
+		accumulator := dc.accumulator
+		debounceCounter := dc.debounceCounter
+		pushCounter := dc.pushCounter
+		lastEmitTime := dc.lastEmitTime
+
+		dc.running = true
+		dc.debounceCounter = 0
+		dc.pushCounter++
+		dc.accumulator = dc.initialAccumulator
+		dc.lastEmitTime = time.Now()
+
+		adsLog.Infof("Push debounce stable[%d] %d: %v since last change, %v since last push, accumulator=%v",
+			pushCounter, debounceCounter, time.Since(lastEmitTime), lastEmitTime, accumulator)
+
+		ackID := dc.ackID
+		notification := Notification{Event: accumulator, Ack: func() {
+			dc.ack(ackID)
+		}}
+		dc.c <- notification
+	}
+}
+
+func (dc *DebouncedChannel) ack(ackID uint32) {
+	dc.mutex.Lock()
+	defer dc.mutex.Unlock()
+	if ackID == dc.ackID {
+		dc.running = false
+		dc.ackID++
+		// Check if there are any new events that need to be notified while we were busy.
+		dc.runIfNeededLocked()
+	}
+}
+
+// NewUpdateRequestDebouncedChannel create a new instance of DebouncedChannel
+// For details see NewDebouncedChannel
+func NewUpdateRequestDebouncedChannel(debounceAfter time.Duration, debounceMax time.Duration, initialAccumulator *model.UpdateRequest,
+	merge func(accumulator *model.UpdateRequest, value *model.UpdateRequest) *model.UpdateRequest) *DebouncedChannel {
+
+	return NewDebouncedChannel(debounceAfter, debounceMax, initialAccumulator, func(accumulator DebouncedEvent, value DebouncedEvent) DebouncedEvent {
+		return merge(accumulator.(*model.UpdateRequest), value.(*model.UpdateRequest))
+	})
+}

--- a/pilot/pkg/proxy/envoy/v2/debounced_channel_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debounced_channel_test.go
@@ -1,0 +1,181 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
+)
+
+func newBoolDebouncedChannel(debounceAfter time.Duration, debounceMax time.Duration, initialAccumulator bool,
+	merge func(accumulator bool, value bool) bool) *v2.DebouncedChannel {
+
+	return v2.NewDebouncedChannel(debounceAfter, debounceMax, initialAccumulator,
+		func(accumulator v2.DebouncedEvent, value v2.DebouncedEvent) v2.DebouncedEvent {
+			return merge(accumulator.(bool), value.(bool))
+		})
+}
+
+func TestDebouncedChannelSimple(t *testing.T) {
+
+	dc := newBoolDebouncedChannel(0, 0, true, func(accumulator bool, value bool) bool {
+		return accumulator || value
+	})
+
+	expectNoEvent(t, dc)
+
+	dc.Enqueue(true)
+
+	expectEvent(t, dc, true)
+
+	expectNoEvent(t, dc)
+}
+
+func TestDebouncedChannelMultiple(t *testing.T) {
+
+	dc := newBoolDebouncedChannel(0, 0, false, func(accumulator bool, value bool) bool {
+		return accumulator || value
+	})
+
+	expectNoEvent(t, dc)
+
+	// first
+	dc.Enqueue(false)
+
+	// second
+	dc.Enqueue(true)
+	dc.Enqueue(false)
+
+	expectEvent(t, dc, false)
+	expectEvent(t, dc, true)
+
+	expectNoEvent(t, dc)
+}
+
+func TestDebouncedChannelMultipleWithDebounce(t *testing.T) {
+
+	dc := newBoolDebouncedChannel(100*time.Millisecond, 1*time.Hour, false, func(accumulator bool, value bool) bool {
+		return accumulator || value
+	})
+
+	expectNoEvent(t, dc)
+
+	dc.Enqueue(false)
+	dc.Enqueue(true)
+	dc.Enqueue(false)
+
+	expectNoEvent(t, dc)
+
+	expectEventBlocking(t, dc, true)
+
+	expectNoEvent(t, dc)
+}
+
+func TestDebouncedChannelMultipleWithDebounceMax(t *testing.T) {
+
+	dc := newBoolDebouncedChannel(100*time.Hour, 100*time.Millisecond, false, func(accumulator bool, value bool) bool {
+		return accumulator || value
+	})
+
+	expectNoEvent(t, dc)
+
+	dc.Enqueue(false)
+	dc.Enqueue(true)
+	dc.Enqueue(false)
+
+	expectNoEvent(t, dc)
+
+	expectEventBlocking(t, dc, true)
+
+	expectNoEvent(t, dc)
+}
+
+func TestDebouncedChannelReentrant(t *testing.T) {
+
+	const cycles = 1
+	stop := make(chan bool)
+
+	dc := newBoolDebouncedChannel(10*time.Millisecond, 100*time.Millisecond, false, func(accumulator bool, value bool) bool {
+		return accumulator || value
+	})
+
+	go func() {
+		for {
+			dc.Enqueue(true)
+			time.Sleep(time.Duration(rand.Int63n(110)) * time.Millisecond)
+			select {
+			case <-stop:
+				return
+			default:
+				break
+			}
+		}
+	}()
+
+	for i := 0; i < cycles; i++ {
+		select {
+		case notification := <-dc.C:
+			time.Sleep(time.Duration(rand.Int63n(110)) * time.Millisecond)
+			notification.Ack()
+			break
+		case <-time.After(2 * time.Second):
+			t.Fatalf("No event received within 2 seconds")
+		}
+	}
+	stop <- true
+
+}
+
+func expectNoEvent(t *testing.T, dc *v2.DebouncedChannel) {
+	select {
+	case <-dc.C:
+		t.Fatalf("unexpected event emitted")
+	default:
+		// ok
+	}
+}
+
+func expectEvent(t *testing.T, dc *v2.DebouncedChannel, expected bool) {
+	actual := !expected
+	select {
+	case notification := <-dc.C:
+		actual = notification.Event.(bool)
+		notification.Ack()
+		break
+	default:
+		t.Fatalf("No event emitted")
+	}
+	if actual != expected {
+		t.Fatalf("Invalid value for dequeued element: %t", actual)
+	}
+}
+
+func expectEventBlocking(t *testing.T, dc *v2.DebouncedChannel, expected bool) {
+	actual := !expected
+	select {
+	case notification := <-dc.C:
+		actual = notification.Event.(bool)
+		notification.Ack()
+		break
+	case <-time.After(1 * time.Second):
+		t.Fatalf("No event emitted (timeout)")
+	}
+	if actual != expected {
+		t.Fatalf("Invalid value for dequeued element: %t", actual)
+	}
+}

--- a/pilot/pkg/proxy/envoy/v2/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery_test.go
@@ -17,17 +17,14 @@ package v2
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"google.golang.org/grpc"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 )
 
@@ -166,129 +163,4 @@ func (h *fakeStream) Recv() (*xdsapi.DiscoveryRequest, error) {
 
 func (h *fakeStream) Context() context.Context {
 	return context.Background()
-}
-
-func TestDebounce(t *testing.T) {
-	// This test tests the timeout and debouncing of config updates
-	// If it is flaking, DebounceAfter may need to be increased, or the code refactored to mock time.
-	// For now, this seems to work well
-	DebounceAfter = time.Millisecond * 25
-	DebounceMax = DebounceAfter * 2
-	if err := os.Setenv(features.EnableEDSDebounce.Name, "false"); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.Unsetenv(features.EnableEDSDebounce.Name); err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	tests := []struct {
-		name            string
-		test            func(updateCh chan *model.UpdateRequest)
-		expectedFull    int32
-		expectedPartial int32
-	}{
-		{
-			name: "Should not debounce partial pushes",
-			test: func(updateCh chan *model.UpdateRequest) {
-				updateCh <- &model.UpdateRequest{Full: false}
-				updateCh <- &model.UpdateRequest{Full: false}
-				updateCh <- &model.UpdateRequest{Full: false}
-				updateCh <- &model.UpdateRequest{Full: false}
-				updateCh <- &model.UpdateRequest{Full: false}
-			},
-			expectedFull:    0,
-			expectedPartial: 5,
-		},
-		{
-			name: "Should debounce full pushes",
-			test: func(updateCh chan *model.UpdateRequest) {
-				updateCh <- &model.UpdateRequest{Full: true}
-			},
-			expectedFull:    0,
-			expectedPartial: 0,
-		},
-		{
-			name: "Should send full updates in batches",
-			test: func(updateCh chan *model.UpdateRequest) {
-				updateCh <- &model.UpdateRequest{Full: true}
-				updateCh <- &model.UpdateRequest{Full: true}
-				time.Sleep(DebounceAfter * 3 / 2)
-				updateCh <- &model.UpdateRequest{Full: true}
-			},
-			expectedFull:    1,
-			expectedPartial: 0,
-		},
-		{
-			name: "Should send full updates in batches, partial updates immediately",
-			test: func(updateCh chan *model.UpdateRequest) {
-				updateCh <- &model.UpdateRequest{Full: true}
-				updateCh <- &model.UpdateRequest{Full: true}
-				updateCh <- &model.UpdateRequest{Full: false}
-				updateCh <- &model.UpdateRequest{Full: false}
-				time.Sleep(DebounceAfter * 2)
-				updateCh <- &model.UpdateRequest{Full: false}
-			},
-			expectedFull:    1,
-			expectedPartial: 3,
-		},
-		{
-			name: "Should force a push after DebounceMax",
-			test: func(updateCh chan *model.UpdateRequest) {
-				// Send many requests within debounce window
-				updateCh <- &model.UpdateRequest{Full: true}
-				time.Sleep(DebounceAfter / 2)
-				updateCh <- &model.UpdateRequest{Full: true}
-				time.Sleep(DebounceAfter / 2)
-				updateCh <- &model.UpdateRequest{Full: true}
-				time.Sleep(DebounceAfter / 2)
-				updateCh <- &model.UpdateRequest{Full: true}
-				time.Sleep(DebounceAfter / 2)
-				// At this point a push should be triggered, from DebounceMax
-			},
-			expectedFull:    1,
-			expectedPartial: 0,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			stopCh := make(chan struct{})
-			updateCh := make(chan *model.UpdateRequest)
-
-			var partialPushes int32
-			var fullPushes int32
-
-			wg := sync.WaitGroup{}
-
-			fakePush := func(req *model.UpdateRequest) {
-				wg.Add(1)
-				go func() {
-					if req.Full {
-						atomic.AddInt32(&fullPushes, 1)
-					} else {
-						atomic.AddInt32(&partialPushes, 1)
-					}
-					wg.Done()
-				}()
-			}
-
-			wg.Add(1)
-			go func() {
-				debounce(updateCh, stopCh, fakePush)
-				wg.Done()
-			}()
-
-			// Send updates
-			tt.test(updateCh)
-
-			close(stopCh)
-			wg.Wait()
-
-			if partialPushes != tt.expectedPartial || fullPushes != tt.expectedFull {
-				t.Fatalf("Got %v full and %v partial, expected %v full and %v partial", fullPushes, partialPushes, tt.expectedFull, tt.expectedPartial)
-			}
-		})
-	}
 }


### PR DESCRIPTION
This pull request will also repair #14782

The debounce for pushes caused by configuration changes was not working correctly because the `doPush` was run as goroutine. If context calculation takes longer than debounce duration, multiple `doPush` will run in parallel. #14782 is causing this situation.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

The major changes of this PR are
* Debouncing is done before the channel
* doPush is called not within a go-routine

![image](https://user-images.githubusercontent.com/13213351/62537346-75842600-b850-11e9-83b4-9f68d57236df.png)
