### PR TITLE
Fix duplicated PortForwarder.Close()

### DIFF
--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -387,7 +387,6 @@ func (client *Client) PodsForSelector(namespace, labelSelector string) (*v1.PodL
 }
 
 func RunPortForwarder(fw *PortForward, readyFunc func(fw *PortForward) error) error {
-	defer fw.Forwarder.Close()
 
 	errCh := make(chan error)
 	go func() {


### PR DESCRIPTION
Error Info:
```console
[root@kebe-dev-m1 ~]# istio-1.2.2/bin/istioctl  experimental dashboard prometheus
http://localhost:45417
Failed to open browser; open http://localhost:45417 in your browser.

^C2019-07-24T10:47:30.842244Z	error	error closing listener: close tcp6 [::1]:45417: use of closed network connection
2019-07-24T10:47:30.842326Z	error	error closing listener: close tcp4 127.0.0.1:45417: use of closed network connection
```

Reason: `Forwarder.Close()` will be called in `fw.Forwarder.ForwardPorts `.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
