### PR TITLE
Avoid inject panic with corner case

### DIFF
--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -762,6 +762,9 @@ func intoObject(sidecarTemplate string, valuesConfig string, meshconfig *meshcon
 		// `Template` is defined as a pointer in some older API
 		// definitions, e.g. ReplicationController
 		if templateValue.Kind() == reflect.Ptr {
+			if templateValue.IsNil() {
+				return out, fmt.Errorf("spec.template is required value")
+			}
 			templateValue = templateValue.Elem()
 		}
 		metadata = templateValue.FieldByName("ObjectMeta").Addr().Interface().(*metav1.ObjectMeta)


### PR DESCRIPTION
Signed-off-by: clyang82 <clyang@cn.ibm.com>

Please provide a description for what this PR is for

This pr is to avoid generate panics on the following input for `istioctl kube-inject -f test.yaml` 

```
cat <<EOF > test.yaml
apiVersion: v1
kind: ReplicationController
metadata:
  name: my-nginx
spec:
  replicas: 1
EOF
```

FYI @esnible 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure
