### PR TITLE
Various improvements to pilot tests to make them more hermetic

### DIFF
--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -15,10 +15,11 @@
 package main
 
 import (
-	"istio.io/istio/pilot/pkg/model"
 	"os"
 	"testing"
 	"time"
+
+	"istio.io/istio/pilot/pkg/model"
 
 	"github.com/onsi/gomega"
 

--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"istio.io/istio/pilot/pkg/model"
 	"os"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ import (
 
 func TestNoPilotSanIfAuthenticationNone(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	role.TrustDomain = ""
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_NONE.String()
@@ -41,6 +43,7 @@ func TestNoPilotSanIfAuthenticationNone(t *testing.T) {
 
 func TestPilotSanIfAuthenticationMutualDomainEmptyKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
@@ -54,6 +57,7 @@ func TestPilotSanIfAuthenticationMutualDomainEmptyKubernetes(t *testing.T) {
 
 func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = "my.domain"
 	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
@@ -82,6 +86,7 @@ func TestPilotSanIfAuthenticationMutualDomainEmptyConsul(t *testing.T) {
 
 func TestPilotSanIfAuthenticationMutualTrustDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	role.TrustDomain = "secured"
 	registry = serviceregistry.KubernetesRegistry
@@ -95,6 +100,7 @@ func TestPilotSanIfAuthenticationMutualTrustDomain(t *testing.T) {
 
 func TestPilotSanIfAuthenticationMutualTrustDomainAndDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = "my.domain"
 	role.TrustDomain = "secured"
 	registry = serviceregistry.KubernetesRegistry
@@ -108,6 +114,7 @@ func TestPilotSanIfAuthenticationMutualTrustDomainAndDomain(t *testing.T) {
 
 func TestPilotDefaultDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	_ = os.Setenv("POD_NAMESPACE", "default")
@@ -219,6 +226,7 @@ func TestDetectSds(t *testing.T) {
 
 func TestPilotDefaultDomainConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role := &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	registry = serviceregistry.ConsulRegistry
 
@@ -229,6 +237,7 @@ func TestPilotDefaultDomainConsul(t *testing.T) {
 
 func TestPilotDefaultDomainOthers(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	registry = serviceregistry.MockRegistry
 
@@ -249,6 +258,7 @@ func TestPilotDomain(t *testing.T) {
 
 func TestPilotSanIfAuthenticationMutualStdDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ".svc.cluster.local"
 	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
@@ -264,6 +274,7 @@ func TestPilotSanIfAuthenticationMutualStdDomainKubernetes(t *testing.T) {
 // When pilot is started without a trust domain, the SPIFFE URI doesn't contain a host and is not valid
 func TestPilotSanIfAuthenticationMutualStdDomainConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = "service.consul"
 	role.TrustDomain = ""
 	registry = serviceregistry.ConsulRegistry
@@ -277,6 +288,7 @@ func TestPilotSanIfAuthenticationMutualStdDomainConsul(t *testing.T) {
 
 func TestCustomPilotSanIfAuthenticationMutualDomainKubernetesNoTrustDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	role.PilotIdentity = "pilot-identity"
 	registry = serviceregistry.KubernetesRegistry
@@ -290,6 +302,7 @@ func TestCustomPilotSanIfAuthenticationMutualDomainKubernetesNoTrustDomain(t *te
 
 func TestCustomPilotSanIfAuthenticationMutualDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	role.TrustDomain = "mesh.com"
 	role.PilotIdentity = "pilot-identity"
@@ -304,6 +317,7 @@ func TestCustomPilotSanIfAuthenticationMutualDomainKubernetes(t *testing.T) {
 
 func TestCustomMixerSanIfAuthenticationMutualDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	role.TrustDomain = "mesh.com"
 	role.MixerIdentity = "mixer-identity"

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -117,12 +117,13 @@ func TestAppProbe(t *testing.T) {
 	}
 	go server.Run(context.Background())
 
-	// We wait a bit here to ensure server's statusPort is updated.
-	time.Sleep(time.Second * 3)
+	var statusPort uint16
+	for statusPort == 0 {
+		server.mutex.RLock()
+		statusPort = server.statusPort
+		server.mutex.RUnlock()
+	}
 
-	server.mutex.RLock()
-	statusPort := server.statusPort
-	server.mutex.RUnlock()
 	t.Logf("status server starts at port %v, app starts at port %v", statusPort, appPort)
 	testCases := []struct {
 		probePath  string
@@ -181,12 +182,12 @@ func TestHttpsAppProbe(t *testing.T) {
 	}
 	go server.Run(context.Background())
 
-	// We wait a bit here to ensure server's statusPort is updated.
-	time.Sleep(time.Second * 3)
-
-	server.mutex.RLock()
-	statusPort := server.statusPort
-	server.mutex.RUnlock()
+	var statusPort uint16
+	for statusPort == 0 {
+		server.mutex.RLock()
+		statusPort = server.statusPort
+		server.mutex.RUnlock()
+	}
 	t.Logf("status server starts at port %v, app starts at port %v", statusPort, appPort)
 	testCases := []struct {
 		probePath  string

--- a/pilot/cmd/pilot-agent/status/util/listeners_test.go
+++ b/pilot/cmd/pilot-agent/status/util/listeners_test.go
@@ -59,11 +59,11 @@ func (ms *mockServer) shutdown() {
 }
 
 func TestGetInboundListeningPorts(t *testing.T) {
-	adminPort := uint16(1235)
 	ms := mockServer{}
-	if err := ms.serve(adminPort); err != nil {
+	if err := ms.serve(0); err != nil {
 		t.Fatalf("failed to start mock server: %s", err)
 	}
+	adminPort := uint16(ms.server.Listener.Addr().(*net.TCPAddr).Port)
 	defer func() {
 		ms.shutdown()
 	}()

--- a/pilot/pkg/config/coredatamodel/controller_test.go
+++ b/pilot/pkg/config/coredatamodel/controller_test.go
@@ -157,7 +157,6 @@ func TestOptions(t *testing.T) {
 }
 
 func TestHasSynced(t *testing.T) {
-	t.Skip("Pending: https://github.com/istio/istio/issues/7947")
 	g := gomega.NewGomegaWithT(t)
 	controller := coredatamodel.NewController(testControllerOptions)
 


### PR DESCRIPTION
Fixes a few tests in pilot that rely on global state, test ordering, or time.Sleep, and enabled a test that was skipped for a resolved issue.