### PR TITLE
jwt: fix Envoy JWT filter with correct AllowMissingOrFailed field

### DIFF
--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -253,9 +253,15 @@ func TestConvertPolicyToJwtConfig(t *testing.T) {
 				Origins: []*authn.OriginAuthenticationMethod{
 					{
 						Jwt: &authn.Jwt{
-							Issuer:     "issuer",
+							Issuer:     "issuer-0",
 							JwksUri:    jwksURI,
 							JwtHeaders: []string{exchangedTokenHeaderName, "custom"},
+						},
+					},
+					{
+						Jwt: &authn.Jwt{
+							Issuer:  "issuer-1",
+							JwksUri: jwksURI,
 						},
 					},
 				},
@@ -270,26 +276,15 @@ func TestConvertPolicyToJwtConfig(t *testing.T) {
 							},
 						},
 						Requires: &envoy_jwt.JwtRequirement{
-							RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-								RequiresAny: &envoy_jwt.JwtRequirementOrList{
-									Requirements: []*envoy_jwt.JwtRequirement{
-										{
-											RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-												ProviderName: "origins-0",
-											},
-										},
-										{
-											RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{},
-										},
-									},
-								},
+							RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
+								AllowMissingOrFailed: &types.Empty{},
 							},
 						},
 					},
 				},
 				Providers: map[string]*envoy_jwt.JwtProvider{
 					"origins-0": {
-						Issuer: "issuer",
+						Issuer: "issuer-0",
 						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
 							LocalJwks: &core.DataSource{
 								Specifier: &core.DataSource_InlineString{
@@ -298,7 +293,7 @@ func TestConvertPolicyToJwtConfig(t *testing.T) {
 							},
 						},
 						Forward:           true,
-						PayloadInMetadata: "issuer",
+						PayloadInMetadata: "issuer-0",
 						FromHeaders: []*envoy_jwt.JwtHeader{
 							{
 								Name:        exchangedTokenHeaderName,
@@ -308,6 +303,18 @@ func TestConvertPolicyToJwtConfig(t *testing.T) {
 								Name: "custom",
 							},
 						},
+					},
+					"origins-1": {
+						Issuer: "issuer-1",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: test.JwtPubKey1,
+								},
+							},
+						},
+						Forward:           true,
+						PayloadInMetadata: "issuer-1",
 					},
 				},
 			},


### PR DESCRIPTION
https://github.com/istio/istio/issues/9838

Also the `AllowMissingOrFailed` is enough for checking all the JWT providers, we don't need the `Any` rules.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
