### PR TITLE
(WIP/Draft): provide a way to supply additional trusted CA roots in the runtime

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -312,7 +312,8 @@ func runCA() {
 		sc, err := controller.NewSecretController(ca, opts.explicitOptInRequired,
 			opts.workloadCertTTL,
 			opts.workloadCertGracePeriodRatio, opts.workloadCertMinGracePeriod, opts.dualUse,
-			cs.CoreV1(), opts.signCACerts, opts.pkcs8Keys, listenedNamespaces, webhooks)
+			cs.CoreV1(), opts.signCACerts, opts.pkcs8Keys, listenedNamespaces, webhooks,
+			opts.istioCaStorageNamespace)
 		if err != nil {
 			fatalf("Failed to create secret controller: %v", err)
 		}

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -17,8 +17,12 @@ package controller
 import (
 	"bytes"
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -49,6 +53,8 @@ const (
 	RootCertID = "root-cert.pem"
 	// The key to specify corresponding service account in the annotation of K8s secrets.
 	ServiceAccountNameAnnotationKey = "istio.io/service-account.name"
+	// ConfigMap label key that indicates that the ConfigMap contains additional trusted CA roots.
+	ExtraTrustAnchorsLabel = "istio.io/extra-trust-anchors"
 
 	secretNamePrefix   = "istio."
 	secretResyncPeriod = time.Minute
@@ -116,6 +122,12 @@ type SecretController struct {
 	scrtController cache.Controller
 	scrtStore      cache.Store
 
+	// Extra trust anchors related state
+	extraTrustAnchorsController cache.Controller
+	extraTrustAnchors           map[string]map[string]string // resource name -> field name -> field value
+	primaryTrustAnchor          []byte
+	combinedTrustAnchorsBundle  []byte
+
 	monitoring monitoringMetrics
 }
 
@@ -123,7 +135,7 @@ type SecretController struct {
 func NewSecretController(ca ca.CertificateAuthority, requireOptIn bool, certTTL time.Duration,
 	gracePeriodRatio float32, minGracePeriod time.Duration, dualUse bool,
 	core corev1.CoreV1Interface, forCA bool, pkcs8Key bool, namespaces []string,
-	dnsNames map[string]*DNSNameEntry) (*SecretController, error) {
+	dnsNames map[string]*DNSNameEntry, extraTrustAnchorsNamespace string) (*SecretController, error) {
 
 	if gracePeriodRatio < 0 || gracePeriodRatio > 1 {
 		return nil, fmt.Errorf("grace period ratio %f should be within [0, 1]", gracePeriodRatio)
@@ -188,11 +200,54 @@ func NewSecretController(ca ca.CertificateAuthority, requireOptIn bool, certTTL 
 			UpdateFunc: c.scrtUpdated,
 		})
 
+	// Extra trust anchors related routines
+	c.extraTrustAnchors = map[string]map[string]string{}
+	c.refreshTrustAnchorsBundle()
+
+	extraTrustAnchorsSelector := labels.SelectorFromSet(map[string]string{ExtraTrustAnchorsLabel: "true"}).String()
+	extraTrustAnchorsLW := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.LabelSelector = extraTrustAnchorsSelector
+			return core.ConfigMaps(extraTrustAnchorsNamespace).List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.LabelSelector = extraTrustAnchorsSelector
+			return core.ConfigMaps(extraTrustAnchorsNamespace).Watch(options)
+		},
+	}
+	_, c.extraTrustAnchorsController = cache.NewInformer(extraTrustAnchorsLW, &v1.ConfigMap{}, time.Minute, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(newObj interface{}) {
+			log.Infof("Notified about a new ConfigMap containing extra trust anchors")
+			newConfigMap := newObj.(*v1.ConfigMap)
+			c.extraTrustAnchors[newConfigMap.GetName()] = newConfigMap.Data
+			c.refreshTrustAnchorsBundle()
+		},
+		DeleteFunc: func(oldObj interface{}) {
+			log.Infof("Notified about a deletion of an existing ConfigMap containing extra trust anchors")
+			oldConfigMap := oldObj.(*v1.ConfigMap)
+			delete(c.extraTrustAnchors, oldConfigMap.GetName())
+			c.refreshTrustAnchorsBundle()
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			log.Infof("Notified about an update of an existing ConfigMap containing extra trust anchors")
+			oldConfigMap := oldObj.(*v1.ConfigMap)
+			newConfigMap := newObj.(*v1.ConfigMap)
+
+			if !reflect.DeepEqual(oldConfigMap.Data, newConfigMap.Data) {
+				c.extraTrustAnchors[newConfigMap.GetName()] = newConfigMap.Data
+				c.refreshTrustAnchorsBundle()
+			}
+		},
+	})
+
 	return c, nil
 }
 
 // Run starts the SecretController until a value is sent to stopCh.
 func (sc *SecretController) Run(stopCh chan struct{}) {
+	go sc.extraTrustAnchorsController.Run(stopCh)
+	cache.WaitForCacheSync(stopCh, sc.extraTrustAnchorsController.HasSynced)
+
 	go sc.scrtController.Run(stopCh)
 
 	// saAdded calls upsertSecret to update and insert secret
@@ -276,11 +331,10 @@ func (sc *SecretController) upsertSecret(saName, saNamespace string) {
 			saNamespace, GetSecretName(saName), err)
 		return
 	}
-	rootCert := sc.ca.GetCAKeyCertBundle().GetRootCertPem()
 	secret.Data = map[string][]byte{
 		CertChainID:  chain,
 		PrivateKeyID: key,
-		RootCertID:   rootCert,
+		RootCertID:   sc.getTrustAnchorsBundle(),
 	}
 
 	// We retry several times when create secret to mitigate transient network failures.
@@ -403,13 +457,12 @@ func (sc *SecretController) scrtUpdated(oldObj, newObj interface{}) {
 			certLifeTime, sc.gracePeriodRatio, gracePeriod, sc.minGracePeriod)
 		gracePeriod = sc.minGracePeriod
 	}
-	rootCertificate := sc.ca.GetCAKeyCertBundle().GetRootCertPem()
 
 	// Refresh the secret if 1) the certificate contained in the secret is about
 	// to expire, or 2) the root certificate in the secret is different than the
 	// one held by the ca (this may happen when the CA is restarted and
 	// a new self-signed CA cert is generated).
-	if certLifeTimeLeft < gracePeriod || !bytes.Equal(rootCertificate, scrt.Data[RootCertID]) {
+	if certLifeTimeLeft < gracePeriod || !bytes.Equal(sc.getTrustAnchorsBundle(), scrt.Data[RootCertID]) {
 		if certLifeTimeLeft < gracePeriod {
 			log.Infof("Refreshing about to expire secret %s/%s", namespace, GetSecretName(name))
 		} else {
@@ -436,8 +489,39 @@ func (sc *SecretController) refreshSecret(scrt *v1.Secret) error {
 
 	scrt.Data[CertChainID] = chain
 	scrt.Data[PrivateKeyID] = key
-	scrt.Data[RootCertID] = sc.ca.GetCAKeyCertBundle().GetRootCertPem()
+	scrt.Data[RootCertID] = sc.getTrustAnchorsBundle()
 
 	_, err = sc.core.Secrets(namespace).Update(scrt)
 	return err
+}
+
+func (sc *SecretController) refreshTrustAnchorsBundle() {
+	trustAnchorsSet := map[string]struct{}{}
+
+	sc.primaryTrustAnchor = sc.ca.GetCAKeyCertBundle().GetRootCertPem()
+	primary := strings.TrimSpace(string(sc.primaryTrustAnchor))
+	trustAnchorsSet[primary] = struct{}{}
+
+	for _, configMap := range sc.extraTrustAnchors {
+		for _, value := range configMap {
+			cert := strings.TrimSpace(value)
+			trustAnchorsSet[cert] = struct{}{}
+		}
+	}
+
+	trustAnchors := make([]string, 0, len(trustAnchorsSet))
+	for trustAnchor := range trustAnchorsSet {
+		trustAnchors = append(trustAnchors, trustAnchor)
+	}
+	sort.Strings(trustAnchors)
+
+	sc.combinedTrustAnchorsBundle = []byte(strings.Join(trustAnchors, "\n") + "\n")
+}
+
+func (sc *SecretController) getTrustAnchorsBundle() []byte {
+	// TODO trigger refresh on CA secret change instead of performing this check on every get
+	if !reflect.DeepEqual(sc.primaryTrustAnchor, sc.ca.GetCAKeyCertBundle().GetRootCertPem()) {
+		sc.refreshTrustAnchorsBundle()
+	}
+	return sc.combinedTrustAnchorsBundle
 }

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -160,7 +162,7 @@ func NewSelfSignedIstioCAOptions(ctx context.Context, caCertTTL, certTTL, maxCer
 
 		options := util.CertOptions{
 			TTL:          caCertTTL,
-			Org:          org,
+			Org:          fmt.Sprintf("%s (%s)", org, uuid.New().String()),
 			IsCA:         true,
 			IsSelfSigned: true,
 			RSAKeySize:   caKeySize,


### PR DESCRIPTION
This PR is a work in progress. It provides necessary foundation to support Root CA cert rotation process as described in the corresponding [proposal doc](https://docs.google.com/document/d/1SprLnDdzK_-UgTTyUGi2KhubEwpoJTRKWTC4_OP362s/edit?usp=sharing)

Also this feature simplifies the process of setting up multicluster configurations providing an easier way to manage multiple Root CA certs and supply them in runtime without requiring to restart user workloads.

### Usage 
In order to supply additional Root CA cert create a ConfigMap labeled as `istio.io/extra-trust-anchors: "true"` under the Citadel CA storage namespace ("istio-system" by default). Additional Root CA PEM certificates can be supplied as values of ConfigMap data fields. Multiple ConfigMaps can be created if necessary.

Within a couple of minutes after any modification to labeled ConfigMaps the change will be noticed by Citadel and updated trusted Root CA certs bundle will be delivered to the workloads (currently only file-mounts based certs delivery is supported, SDS is not supported yet). Pilot-agent will notice updated certificates and reload Envoy within a minute or so.

Here's an example ConfigMap:
```
apiVersion: v1
data:
  1.pem: |
    -----BEGIN CERTIFICATE-----
    MIIDBjCCAe6gAwIBAgIRAP2hlykNC0W/ozBHOmlteh0wDQYJKoZIhvcNAQELBQAw
    LDEqMCgGA1UEChMhY2x1c3Rlci5sb2NhbE1PRFlMVU1HVVFESVdXTU5QUFFJMB4X
    DTE5MDYyODA1MjE0MFoXDTI5MDYyNTA1MjE0MFowLDEqMCgGA1UEChMhY2x1c3Rl
    ci5sb2NhbE1PRFlMVU1HVVFESVdXTU5QUFFJMIIBIjANBgkqhkiG9w0BAQEFAAOC
    AQ8AMIIBCgKCAQEAxyfZ4WuBZUb0JS6r+SbLQ7VC1Xo+qvd2B2eD0nhkm1uLPltN
    3r+iW3KSEBGaRo/0MtuUv2ONyM3bGWsu6RF/eJkXLmZ7/cqmdu+7rjAvjR/Q9pBj
    XCT6gs95ihigNKy64JxRWsgLeUB7ZXHrriozaCbL3TUKlSufm5Kv7A1/KC6eMmZF
    Svt7sN/I9ORBLiRr7mSSTEyBPNFCM2mxz4iKVOcxFJNtcX5rYjBjiGehka4NRpUH
    siGS+uwz0o8TghZgccbU1DUrCa/WlBPe0wZKoqZkLWrzMLFd1GJ9i5O5+e8ZbA9n
    ISNx0/hMO6qjUhkSJi0QLPmbgOw9CYQvs0B2cwIDAQABoyMwITAOBgNVHQ8BAf8E
    BAMCAgQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAJRabvJ0f
    fQw6ZHTZGE+nuG/ETR4u9jIpDIsCTWkXcgEuFkMAPboGyAUc8EfVAxkV4JmjMGaQ
    dqe4v0PgLBq58fLkYrWuDW6VlHd0HPQRajNjV1M0PkgDs3cQn/0MPgHiSbDPUVv4
    PVIry+jRrQDAgrutke3JZB1O8mePRgNGkwpPA6xs4rZlmlFWseZTFiDUJo7OvDfS
    BzAH4ls/tPH9LbssFIUtWWYB43/Jexh2ZFtQ+CjrXyQW+bgqIaGH9idsXKEipxXG
    52ltCH2qVg/e8H/Zo31vr3uHs7Bpn0g/O/FDbGOi0Jl3sstBm9vfvM1sNdtWVRSW
    HsR8Qd4qPIRjBg==
    -----END CERTIFICATE-----
  2.pem: |
    -----BEGIN CERTIFICATE-----
    MIIDBTCCAe2gAwIBAgIQakpRllMLzPu+P264OTDHOjANBgkqhkiG9w0BAQsFADAs
    MSowKAYDVQQKEyFjbHVzdGVyLmxvY2FsSVZGUkNQVUtFSU5NS1hCS1ZEVkEwHhcN
    MTkwNjI4MDU0NjQ0WhcNMjkwNjI1MDU0NjQ0WjAsMSowKAYDVQQKEyFjbHVzdGVy
    LmxvY2FsSVZGUkNQVUtFSU5NS1hCS1ZEVkEwggEiMA0GCSqGSIb3DQEBAQUAA4IB
    DwAwggEKAoIBAQDNrEE2LFOMOcCxwor4vEK7iV0sS3nD9xfCVG4Qbr3AoT2QaiuW
    wPd5Fopvy6yq0n3g97w95VBl8RaeLCOWrfNua0T87XLYuX3YstN5nvsNgAGOf1El
    nQX3oSqIRMdStY/SQotO7g5n6autrayn/G++1F0/6ExiEP6hBqKslK6EY7bTGXlW
    MDVXxgedakMqoD+6ra2xkb80WwLB2F347HxP6VLGhXbjtZKpTohBFU0Sh2xUUyZJ
    l+9Tr3eyYotB/RGIleTtF1//XHdD12drlUJd+cHyR5uoLYqLmvyqe0YqPHEeFYIF
    XyJa0XaRYF+v9eyHyS4WVxmgvMsKSn67HV69AgMBAAGjIzAhMA4GA1UdDwEB/wQE
    AwICBDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQDLFff7MNu6
    B7Mg+6cOW0IO4UiUsrc8BEweedBKlTX1jIKCYZGeEalBVcVPk9Mezaw5G49Zeki7
    rbKl88dP1+pgqd95nL1h4R4nuk/hNRSBk+JLDD0DcBbxyLMU+gBBBxyPhZ96AY6W
    06t3yJpllN9BqsASQJtwloSY7NeIlMXf1nSKWTNxwHJykRwfBrtll7hy8Kj3+ZhQ
    19HrO4qw5nnuqvAHeJfGP/7SRcrcOINrIXxMjweAk0tqtAiFD5FQb+VPrsv5HAuQ
    Qt2hPWR7ClP/SCgb3Ep99KkEzaLQ9jeSYtIdh5KhbNSSOTuNehENjgwF93QaI20i
    7sdfoObFCfSP
    -----END CERTIFICATE-----
kind: ConfigMap
metadata:
  labels:
    istio.io/extra-trust-anchors: "true"
  name: extra-ca-certs
  namespace: istio-system
```
Creating such map will result in all workloads trusting not only their primary Root CA cert but also two more additional Root CA certs.

### Todo
This is work in progress. The feature is working end-to-end, however the following is required to get it to a PR state:
* Need to guard the routines manipulating "extra trust anchors" related state with an RW mutex.
* Logging/metrics
* Tests

### Next steps
Once this is done, the CA cert rotation logic can rely on this functionality to perform the "3-step" rotation:
1) Citadel should create a new CA key/cert and add the cert to one of the "extra trust anchors" config maps
2) Citadel should wait until the newly added "extra trust anchor" propagates. The criteria of how to determine whether the cert has been fully propagated: no "Refreshing secret %s/%s (outdated root cert)" events occurred for longer than configured time interval T.
3) Once the new cert is fully propagated, the old CA cert can be added to "extra trust anchors" and old CA key/cert can be replaced with the new CA key/cert pair that will be used to issuing new workload certs from now on.
4) Extra background process should infrequently scan through "extra trust anchors" certs and remove expired ones.

See the doc referenced above for the details.