### PR TITLE
Validate port out of range

### DIFF
--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -311,6 +311,9 @@ func parsePort(portStr string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed parsing port '%d': %v", port, err)
 	}
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("failed parsing port '%d': port out of range", port)
+	}
 	return int(port), nil
 }
 


### PR DESCRIPTION
Port should be from 1 to 65535.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
