### PR TITLE
Makefile: add explicit make target for gcs.push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -652,15 +652,14 @@ clean.go: ; $(info $(H) cleaning...)
 #-----------------------------------------------------------------------------
 # Target: docker
 #-----------------------------------------------------------------------------
-.PHONY: artifacts gcs.push.istioctl-all artifacts installgen
+.PHONY: push gcs.push gcs.push.istioctl-all gcs.push.deb artifacts installgen
 
 # for now docker is limited to Linux compiles - why ?
 include tools/istio-docker.mk
 
-# if first part of URL (i.e., hostname) is gcr.io then upload istioctl and deb
-$(if $(findstring gcr.io,$(firstword $(subst /, ,$(HUB)))),$(eval push: gcs.push.istioctl-all gcs.push.deb),)
-
 push: docker.push installgen
+
+gcs.push: push gcs.push.istioctl-all gcs.push.deb
 
 gcs.push.istioctl-all: istioctl-all
 	gsutil -m cp -r "${ISTIO_OUT}"/istioctl-* "gs://${GS_BUCKET}/pilot/${TAG}/artifacts/istioctl"

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -42,5 +42,5 @@ if [[ -n $(git diff) ]]; then
 fi
 
 # Upload images - needed by the subsequent tests
-time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"
+time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make gcs.push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"
 


### PR DESCRIPTION
- enumerate missing PHONY targets
- add gcs.push target to replace the `push` target expansion on HUB set to gcr.io
- explicitly call gcs.push where HUB was being set to gcr.io (prow's pre-submit)
- reviewed files referencing HUB to see which target to call (may need some follow-up changes on GKE docs)

Fixes #14962

Replaces #15817 which was getting out of hand on rebase (CLA complaining on multiple authors, etc.)
CC @sushicw @utka @howardjohn @linsun 

> @utka can you verify there isn't anywhere else we need the gcs.push?

Affected areas:
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[X] Developer Infrastructure
