### PR TITLE
Fix goroutine leak on send timeout

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -718,7 +718,7 @@ func (s *DiscoveryServer) removeCon(conID string, con *XdsConnection) {
 
 // Send with timeout
 func (conn *XdsConnection) send(res *xdsapi.DiscoveryResponse) error {
-	done := make(chan error)
+	done := make(chan error, 1)
 	// hardcoded for now - not sure if we need a setting
 	t := time.NewTimer(SendTimeout)
 	go func() {


### PR DESCRIPTION

Previously the done channel was unbuffered. This means that if a timeout
occured, there would be nothing trying to read from `done`, which would
cause it to block indefinitely. Because of this, every timeout resulted
in a goroutine to be leaked. Now it is buffered so the send can occur
even after the timer completes.

Fixes https://github.com/istio/istio/issues/15876

Before and after:
![2019-29-07_07-31-24](https://user-images.githubusercontent.com/623453/62057025-a2db2f00-b1d3-11e9-8217-92ef3abd2ce5.png)