### PR TITLE
Fix broken OWNERS files

### DIFF
--- a/pilot/pkg/networking/OWNERS
+++ b/pilot/pkg/networking/OWNERS
@@ -1,7 +1,6 @@
 approvers:
   - costinm
   - GregHanson
-  - ijsnellf
   - rshriram
   - zackbutcher
   - ostromart

--- a/tests/e2e/tests/pilot/OWNERS
+++ b/tests/e2e/tests/pilot/OWNERS
@@ -3,7 +3,6 @@ approvers:
   - costinm
   - GregHanson
   - hzxuzhonghu
-  - ijsnellf
   - nmittler
   - rshriram
   - vadimeisenbergibm


### PR DESCRIPTION
This member was removed from the org, so now any update to an OWNERS
file will trigger a check that will fail
