### PR TITLE
Infloop13

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -66,6 +66,9 @@ initContainers:
   securityContext:
     runAsUser: 0
     runAsNonRoot: false
+    capabilities:
+      add:
+        - NET_ADMIN
     privileged: true
 {{ end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -237,6 +237,9 @@ containers:
     {{ if and .Values.global.sds.enabled .Values.global.sds.useTrustworthyJwt }}
     runAsGroup: 1337
     {{- end }}
+    capabilities:
+      add:
+        - NET_ADMIN
     runAsUser: 1337
     {{- end }}
   resources:

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -66,9 +66,6 @@ initContainers:
   securityContext:
     runAsUser: 0
     runAsNonRoot: false
-    capabilities:
-      add:
-        - NET_ADMIN
     privileged: true
 {{ end }}
 {{- end }}
@@ -237,9 +234,6 @@ containers:
     {{ if and .Values.global.sds.enabled .Values.global.sds.useTrustworthyJwt }}
     runAsGroup: 1337
     {{- end }}
-    capabilities:
-      add:
-        - NET_ADMIN
     runAsUser: 1337
     {{- end }}
   resources:

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -116,6 +116,7 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(env *model.Environment, prox
 	// Add a blackhole and passthrough cluster for catching traffic to unresolved routes
 	// DO NOT CALL PLUGINS for these two clusters.
 	inboundPassthroughCluster := buildDefaultPassthroughCluster(env)
+	inboundPassthroughCluster.Name = util.InboundPassthroughCluster
 	inboundPassthroughCluster.UpstreamBindConfig = &core.BindConfig{
 		SourceAddress: core.SocketAddress{
 			Address: "127.0.0.5",
@@ -124,7 +125,7 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(env *model.Environment, prox
 			},
 		},
 	}
-	clusters = append(clusters, buildBlackHoleCluster(env), inboundPassthroughCluster)
+	clusters = append(clusters, buildBlackHoleCluster(env), buildDefaultPassthroughCluster(env), inboundPassthroughCluster)
 	clusters = applyClusterPatches(env, proxy, push, clusters)
 	clusters = normalizeClusters(push, proxy, clusters)
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -421,7 +421,6 @@ func buildInboundLocalityLbEndpoints(bind string, port int) []endpoint.LocalityL
 }
 
 func generateInboundPassthroughClusters(env *model.Environment) []*apiv2.Cluster {
-	clusters := make([]*apiv2.Cluster, 0, 2)
 	inboundPassthroughClusterIpv4 := buildDefaultPassthroughCluster(env)
 	inboundPassthroughClusterIpv4.Name = util.InboundPassthroughClusterIpv4
 	inboundPassthroughClusterIpv4.UpstreamBindConfig = &core.BindConfig{
@@ -443,8 +442,10 @@ func generateInboundPassthroughClusters(env *model.Environment) []*apiv2.Cluster
 			},
 		},
 	}
-	clusters = append(clusters, inboundPassthroughClusterIpv4, inboundPassthroughClusterIpv6)
-	return clusters
+	return []*apiv2.Cluster{
+		inboundPassthroughClusterIpv4,
+		inboundPassthroughClusterIpv6,
+	}
 }
 
 func (configgen *ConfigGeneratorImpl) buildInboundClusters(env *model.Environment, proxy *model.Proxy,

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -101,6 +101,8 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(env *model.Environment, prox
 			managementPorts = append(managementPorts, env.ManagementPorts(ip)...)
 		}
 		inboundClusters := configgen.buildInboundClusters(env, proxy, push, instances, managementPorts)
+		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
+		inboundClusters = append(inboundClusters, generateInboundPassthroughClusters(env)...)
 		inboundClusters = envoyfilter.ApplyClusterPatches(networking.EnvoyFilter_SIDECAR_INBOUND, proxy, push, inboundClusters)
 		clusters = append(clusters, outboundClusters...)
 		clusters = append(clusters, inboundClusters...)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -99,7 +99,7 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 						},
 					})
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(clusters)).To(Equal(4))
+				g.Expect(len(clusters)).To(Equal(6))
 				cluster := clusters[directionInfo.clusterIndex]
 				g.Expect(len(cluster.CircuitBreakers.Thresholds)).To(Equal(1))
 				thresholds := cluster.CircuitBreakers.Thresholds[0]
@@ -160,7 +160,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 					},
 				})
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(len(clusters)).To(Equal(4))
+			g.Expect(len(clusters)).To(Equal(6))
 			cluster := clusters[directionInfo.clusterIndex]
 			g.Expect(cluster.CommonHttpProtocolOptions).To(Not(BeNil()))
 			commonHTTPProtocolOptions := cluster.CommonHttpProtocolOptions
@@ -428,7 +428,7 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 		nil, testMesh, destRule, envoyMetadata)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	g.Expect(clusters).To(HaveLen(5))
+	g.Expect(clusters).To(HaveLen(7))
 
 	expectedOutboundClusterCount := 2
 	actualOutboundClusterCount := 0
@@ -492,7 +492,7 @@ func TestBuildSidecarClustersWithMeshWideTCPKeepalive(t *testing.T) {
 	// Do not set tcp_keepalive anywhere
 	clusters, err := buildTestClustersWithTCPKeepalive(None)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(len(clusters)).To(Equal(5))
+	g.Expect(len(clusters)).To(Equal(7))
 	cluster := clusters[1]
 	g.Expect(cluster.Name).To(Equal("outbound|8080|foobar|foo.example.org"))
 	// UpstreamConnectionOptions should be nil. TcpKeepalive is the only field in it currently.
@@ -501,7 +501,7 @@ func TestBuildSidecarClustersWithMeshWideTCPKeepalive(t *testing.T) {
 	// Set mesh wide default for tcp_keepalive.
 	clusters, err = buildTestClustersWithTCPKeepalive(Mesh)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(len(clusters)).To(Equal(5))
+	g.Expect(len(clusters)).To(Equal(7))
 	cluster = clusters[1]
 	g.Expect(cluster.Name).To(Equal("outbound|8080|foobar|foo.example.org"))
 	// KeepaliveTime should be set but rest should be nil.
@@ -512,7 +512,7 @@ func TestBuildSidecarClustersWithMeshWideTCPKeepalive(t *testing.T) {
 	// Set DestinationRule override for tcp_keepalive.
 	clusters, err = buildTestClustersWithTCPKeepalive(DestinationRule)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(len(clusters)).To(Equal(5))
+	g.Expect(len(clusters)).To(Equal(7))
 	cluster = clusters[1]
 	g.Expect(cluster.Name).To(Equal("outbound|8080|foobar|foo.example.org"))
 	// KeepaliveTime should be set but rest should be nil.
@@ -523,7 +523,7 @@ func TestBuildSidecarClustersWithMeshWideTCPKeepalive(t *testing.T) {
 	// Set DestinationRule override for tcp_keepalive with empty value.
 	clusters, err = buildTestClustersWithTCPKeepalive(DestinationRuleForOsDefault)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(len(clusters)).To(Equal(5))
+	g.Expect(len(clusters)).To(Equal(7))
 	cluster = clusters[1]
 	g.Expect(cluster.Name).To(Equal("outbound|8080|foobar|foo.example.org"))
 	// TcpKeepalive should be present but with nil values.

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -290,7 +290,13 @@ func newTCPProxyListenerFilter(env *model.Environment, node *model.Proxy, isInbo
 		ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: util.BlackHoleCluster},
 	}
 
-	if isAllowAnyOutbound(node) || isInboundListener {
+	if isInboundListener {
+		tcpProxy = &tcp_proxy.TcpProxy{
+			StatPrefix:       util.InboundPassthroughCluster,
+			ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: util.InboundPassthroughCluster},
+		}
+		setAccessLog(env, node, tcpProxy)
+	} else if isAllowAnyOutbound(node) {
 		// We need a passthrough filter to fill in the filter stack for orig_dst listener
 		tcpProxy = &tcp_proxy.TcpProxy{
 			StatPrefix:       util.PassthroughCluster,

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -289,17 +289,17 @@ func newInboundPassthroughFilterChains(env *model.Environment, node *model.Proxy
 			ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: clusterName},
 		}
 
-		matchingIp := ""
+		matchingIP := ""
 		if clusterName == util.InboundPassthroughClusterIpv4 {
-			matchingIp = util.InboundPassthroughBindIpv4
+			matchingIP = util.InboundPassthroughBindIpv4
 		} else if clusterName == util.InboundPassthroughClusterIpv6 {
-			matchingIp = util.InboundPassthroughBindIpv6
+			matchingIP = util.InboundPassthroughBindIpv6
 		}
 
 		filterChainMatch := listener.FilterChainMatch{
 			// Port : EMPTY to match all ports
 			PrefixRanges: []*core.CidrRange{
-				util.ConvertAddressToCidr(matchingIp),
+				util.ConvertAddressToCidr(matchingIP),
 			},
 		}
 		setAccessLog(env, node, tcpProxy)

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -51,6 +51,9 @@ const (
 	// PassthroughRouteName is the name of the route that forwards traffic to the
 	// PassthroughCluster
 	PassthroughRouteName = "allow_any"
+
+	InboundPassthroughCluster = "InboundPassthroughCluster"
+
 	// SniClusterFilter is the name of the sni_cluster envoy filter
 	SniClusterFilter = "envoy.filters.network.sni_cluster"
 	// NoProxyLocality represents the locality associated with a proxy that doesn't have locality settings

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -52,7 +52,12 @@ const (
 	// PassthroughCluster
 	PassthroughRouteName = "allow_any"
 
-	InboundPassthroughCluster = "InboundPassthroughCluster"
+	// Inbound pass through cluster need to the bind the loopback ip address for the security and loop avoidance.
+	InboundPassthroughClusterIpv4 = "InboundPassthroughClusterIpv4"
+	InboundPassthroughClusterIpv6 = "InboundPassthroughClusterIpv6"
+	// 6 is the magical number for inbound: 15006, 127.0.0.6, ::6
+	InboundPassthroughBindIpv4 = "127.0.0.6"
+	InboundPassthroughBindIpv6 = "::6"
 
 	// SniClusterFilter is the name of the sni_cluster envoy filter
 	SniClusterFilter = "envoy.filters.network.sni_cluster"

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -239,23 +239,23 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 		return
 	}
 
-	// Expect 6 listeners : 2 orig_dst, 1 http inbound + 4 outbound (http, tcp1, istio-policy and istio-telemetry)
-	// plus 2 extra due to the mem registry
+	// Expect 7 listeners : 2 orig_dst, 1 http inbound + 4 outbound (http, tcp1, istio-policy and istio-telemetry)
 	if (len(adsResponse.HTTPListeners) + len(adsResponse.TCPListeners)) != 7 {
-		t.Fatalf("Expected 8 listeners, got %d\n", len(adsResponse.HTTPListeners)+len(adsResponse.TCPListeners))
+		t.Fatalf("Expected 7 listeners, got %d\n", len(adsResponse.HTTPListeners)+len(adsResponse.TCPListeners))
 	}
 
-	// Expect 10 CDS clusters: 1 inbound + 7 outbound (2 http services, 1 tcp service, 2 istio-system services,
-	// and 2 subsets of http1), 1 blackhole, 1 passthrough
-	// plus 2 extra due to the mem registry
-	if (len(adsResponse.Clusters) + len(adsResponse.EDSClusters)) != 10 {
+	// Expect 12 CDS clusters:
+	// 3 inbound(http, inbound passthroughipv4 and inbound passthroughipv6)
+	// 9 outbound (2 http services, 1 tcp service, 2 istio-system services,
+	//   and 2 subsets of http1, 1 blackhole, 1 passthrough)
+	if (len(adsResponse.Clusters) + len(adsResponse.EDSClusters)) != 12 {
 		t.Fatalf("Expected 12 Clusters in CDS output. Got %d", len(adsResponse.Clusters)+len(adsResponse.EDSClusters))
 	}
 
 	// Expect two vhost blocks in RDS output for 8080 (one for http1, another for http2)
 	// plus one extra due to mem registry
 	if len(adsResponse.Routes["8080"].VirtualHosts) != 3 {
-		t.Fatalf("Expected two VirtualHosts in RDS output. Got %d", len(adsResponse.Routes["8080"].VirtualHosts))
+		t.Fatalf("Expected 3 VirtualHosts in RDS output. Got %d", len(adsResponse.Routes["8080"].VirtualHosts))
 	}
 }
 

--- a/tests/scripts/testdata/empty_parameter_golden.txt
+++ b/tests/scripts/testdata/empty_parameter_golden.txt
@@ -49,6 +49,7 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-port 15006
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 0 -j RETURN

--- a/tests/scripts/testdata/mode_redirect_golden.txt
+++ b/tests/scripts/testdata/mode_redirect_golden.txt
@@ -53,6 +53,7 @@ iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5555 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 6666 -j ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN

--- a/tests/scripts/testdata/mode_tproxy_and_ipv6_golden.txt
+++ b/tests/scripts/testdata/mode_tproxy_and_ipv6_golden.txt
@@ -43,6 +43,7 @@ OUTBOUND_PORTS_EXCLUDE=
 KUBEVIRT_INTERFACES=eth1,eth2
 ENABLE_INBOUND_IPV6=2001:db8:1::1
 
+ip -6 addr add ::6/128 dev lo
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-port 12345
 iptables -t nat -N ISTIO_IN_REDIRECT
@@ -63,6 +64,7 @@ iptables -t mangle -A ISTIO_INBOUND -p tcp -m socket -j ISTIO_DIVERT
 iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
@@ -97,6 +99,7 @@ ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 7777 -j RETURN
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 8888 -j RETURN
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN

--- a/tests/scripts/testdata/mode_tproxy_and_wildcard_port_golden.txt
+++ b/tests/scripts/testdata/mode_tproxy_and_wildcard_port_golden.txt
@@ -63,6 +63,7 @@ iptables -t mangle -A ISTIO_INBOUND -p tcp -m socket -j ISTIO_DIVERT
 iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN

--- a/tests/scripts/testdata/mode_tproxy_golden.txt
+++ b/tests/scripts/testdata/mode_tproxy_golden.txt
@@ -64,6 +64,7 @@ iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 6666 -m socket -j ISTIO_DIVER
 iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 6666 -j ISTIO_TPROXY
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN

--- a/tests/scripts/testdata/outbound_port_exclude_golden.txt
+++ b/tests/scripts/testdata/outbound_port_exclude_golden.txt
@@ -55,6 +55,7 @@ iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 1024 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 21 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN

--- a/tests/scripts/testdata/wildcard_include_ip_range_golden.txt
+++ b/tests/scripts/testdata/wildcard_include_ip_range_golden.txt
@@ -53,6 +53,7 @@ iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5555 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 6666 -j ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN

--- a/tools/istio-iptables/main.go
+++ b/tools/istio-iptables/main.go
@@ -333,6 +333,9 @@ func run(args []string, flagSet *flag.FlagSet) {
 		}
 	}
 
+	// 127.0.0.6 is bind connect from inbound passthrough cluster
+	ext.RunOrFail(dep.IPTABLES, "-t", "nat", "-A", "ISTIO_OUTPUT", "-o", "lo", "!", "-d", "127.0.0.6/32", "-j", "RETURN")
+
 	if env.RegisterStringVar("DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK", "", "").Get() == "" {
 		// Redirect app calls back to itself via Envoy when using the service VIP or endpoint
 		// address, e.g. appN => Envoy (client) => Envoy (server) => appN.
@@ -444,6 +447,10 @@ func run(args []string, flagSet *flag.FlagSet) {
 				ext.RunOrFail(dep.IP6TABLES, "-t", "nat", "-A", "ISTIO_OUTPUT", "-p", "tcp", "--dport", port, "-j", "RETURN")
 			}
 		}
+
+		// ::6 is bind connect from inbound passthrough cluster
+		ext.RunOrFail(dep.IP6TABLES, "-t", "nat", "-A", "ISTIO_OUTPUT", "-o", "lo", "!", "-d", "::6/128", "-j", "RETURN")
+
 		// Redirect app calls to back itself via Envoy when using the service VIP or endpoint
 		// address, e.g. appN => Envoy (client) => Envoy (server) => appN.
 		ext.RunOrFail(dep.IP6TABLES, "-t", "nat", "-A", "ISTIO_OUTPUT", "-o", "lo", "!", "-d", "::1/128", "-j", "ISTIO_IN_REDIRECT")

--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -312,16 +312,19 @@ echo "KUBEVIRT_INTERFACES=${KUBEVIRT_INTERFACES}"
 echo "ENABLE_INBOUND_IPV6=${ENABLE_INBOUND_IPV6}"
 echo
 
-set -o errexit
-set -o nounset
-set -o pipefail
-set -x # echo on
 
+set +o nounset
+# Blindly add a ipv6 address. If it fails it's fine.
 # Add local ipv6 address to lo. Used in redirecting unknown ipv6 traffic to original dst.
 # This address does not show up in neigh table so each Pod/Vm will only see its own. Think about 127.0.0.6.
 if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
   ip -6 addr add ::6/128 dev lo
 fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x # echo on
 
 # Create a new chain for redirecting outbound traffic to the common Envoy port.
 # In both chains, '-j RETURN' bypasses Envoy and '-j ISTIO_REDIRECT'

--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -412,6 +412,9 @@ if [ -n "${OUTBOUND_PORTS_EXCLUDE}" ]; then
   done
 fi
 
+# 127.0.0.5 is binded as src ip when sidecar proxy redirect inbound original_dst traffic
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.5/32 -j RETURN
+
 if [ -z "${DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK-}" ]; then
   # Redirect app calls back to itself via Envoy when using the service VIP or endpoint
   # address, e.g. appN => Envoy (client) => Envoy (server) => appN.

--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -412,8 +412,8 @@ if [ -n "${OUTBOUND_PORTS_EXCLUDE}" ]; then
   done
 fi
 
-# 127.0.0.5 is binded as src ip when sidecar proxy redirect inbound original_dst traffic
-iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.5/32 -j RETURN
+# 127.0.0.6 is bind connect from inbound passthrough cluster
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 
 if [ -z "${DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK-}" ]; then
   # Redirect app calls back to itself via Envoy when using the service VIP or endpoint
@@ -544,6 +544,9 @@ if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
       ip6tables -t nat -A ISTIO_OUTPUT -p tcp --dport "${port}" -j RETURN
     done
   fi
+
+  # ::6 is bind when connect from inbound passthrough cluster
+  ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 
   # Redirect app calls to back itself via Envoy when using the service VIP or endpoint
   # address, e.g. appN => Envoy (client) => Envoy (server) => appN.

--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -317,6 +317,12 @@ set -o nounset
 set -o pipefail
 set -x # echo on
 
+# Add local ipv6 address to lo. Used in redirecting unknown ipv6 traffic to original dst.
+# This address does not show up in neigh table so each Pod/Vm will only see its own. Think about 127.0.0.6.
+if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
+  ip -6 addr add ::6/128 dev lo
+fi
+
 # Create a new chain for redirecting outbound traffic to the common Envoy port.
 # In both chains, '-j RETURN' bypasses Envoy and '-j ISTIO_REDIRECT'
 # redirects to Envoy.


### PR DESCRIPTION
Another attempt to fix #14242, #14443

This PR is part of the picture deprecating containerPort by isolate inbound listener and outbound listeners. More specifically, sidecar proxy need to avoid inf loop in the below conditions

- inbound listeners and outbound listeners are split and not accessible from each other
- iptables redirect all incoming traffic to inbound listener

This is done by bind magical local address when redirecting unmatched inbound listeners. Notes it's common when we allow user not specify containerPort. See istio design doc `Better Default Networking`

Meanwhile this PR should **NOT** break any functionality when in/out listener is not split.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
