### PR TITLE
Improve locality lb helm setting and enable by default

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -130,7 +130,7 @@ data:
     outboundTrafficPolicy:
       mode: {{ .Values.global.outboundTrafficPolicy.mode }}
 
-    {{- if  .Values.global.localityLbSetting }}
+    {{- if  .Values.global.localityLbSetting.enabled }}
     localityLbSetting:
 {{ toYaml .Values.global.localityLbSetting | indent 6 }}
     {{- end }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -484,9 +484,11 @@ global:
   # Specifies the global locality load balancing settings.
   # Locality-weighted load balancing allows administrators to control the distribution of traffic to
   # endpoints based on the localities of where the traffic originates and where it will terminate.
-  # Please set either failover or distribute configuration but not both.
+  # Either failover or distribute configuration can be set, but not both. If neither are provided
+  # failover mode will be used.
   #
   # localityLbSetting:
+  #   enabled: true
   #   distribute:
   #   - from: "us-central1/*"
   #     to:
@@ -494,12 +496,14 @@ global:
   #       "us-central2/*": 20
   #
   # localityLbSetting:
+  #   enabled: true
   #   failover:
   #   - from: us-east
   #     to: eu-west
   #   - from: us-west
   #     to: us-east
-  localityLbSetting: {}
+  localityLbSetting:
+    enabled: true
 
   # Specifies whether helm test is enabled or not.
   # This field is set to false by default, so 'helm template ...'


### PR DESCRIPTION
Previously, we intended for locality LB to be enabled by default, but it
actually wasn't. There is no clear way for the user to enable it either
without setting explicit failover or distribute.

In general helm api has been using the foo.enabled=true pattern, and we
can use this here. The meshconfig does NOT need to use the enabled flag.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
