### PR TITLE
Add check DNSPolicy when inject

### DIFF
--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -544,7 +544,7 @@ func InjectionData(sidecarTemplate, valuesConfig, version string, deploymentMeta
 	// If DNSPolicy is not ClusterFirst, the Envoy sidecar may not able to connect to Istio Pilot.
 	if spec.DNSPolicy != corev1.DNSClusterFirst {
 		log.Warnf("%q's DNSPolicy is not %q. The Envoy sidecar may not able to connect to Istio Pilot",
-			metadata.Namespace + "/" + metadata.Name, corev1.DNSClusterFirst)
+			metadata.Namespace+"/"+metadata.Name, corev1.DNSClusterFirst)
 	}
 
 	if err := validateAnnotations(metadata.GetAnnotations()); err != nil {

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -541,21 +541,10 @@ func InjectionData(sidecarTemplate, valuesConfig, version string, deploymentMeta
 	metadata *metav1.ObjectMeta, proxyConfig *meshconfig.ProxyConfig, meshConfig *meshconfig.MeshConfig) (
 	*SidecarInjectionSpec, string, error) {
 
-	var name string
-	if metadata.Namespace == "" {
-		if deploymentMetadata.Namespace != "" {
-			name = deploymentMetadata.Namespace + "/" + metadata.Name
-		} else {
-			name = metadata.Name
-		}
-	} else {
-		name = metadata.Namespace + "/" + metadata.Name
-	}
-
 	// If DNSPolicy is not ClusterFirst, the Envoy sidecar may not able to connect to Istio Pilot.
 	if spec.DNSPolicy != corev1.DNSClusterFirst {
-		log.Warnf("%q's DNSPolicy is not %q. The Envoy sidecar may not able to connect to Istio Pilot\n",
-			name, corev1.DNSClusterFirst)
+		log.Warnf("%q's DNSPolicy is not %q. The Envoy sidecar may not able to connect to Istio Pilot",
+			metadata.Namespace + "/" + metadata.Name, corev1.DNSClusterFirst)
 	}
 
 	if err := validateAnnotations(metadata.GetAnnotations()); err != nil {

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -541,10 +541,21 @@ func InjectionData(sidecarTemplate, valuesConfig, version string, deploymentMeta
 	metadata *metav1.ObjectMeta, proxyConfig *meshconfig.ProxyConfig, meshConfig *meshconfig.MeshConfig) (
 	*SidecarInjectionSpec, string, error) {
 
-	// If DNSPolicy is not ClusterFirst, the envoy may not able to connect to pilot.
+	var name string
+	if metadata.Namespace == "" {
+		if deploymentMetadata.Namespace != "" {
+			name = deploymentMetadata.Namespace + "/" + metadata.Name
+		} else {
+			name = metadata.Name
+		}
+	} else {
+		name = metadata.Namespace + "/" + metadata.Name
+	}
+
+	// If DNSPolicy is not ClusterFirst, the Envoy sidecar may not able to connect to Istio Pilot.
 	if spec.DNSPolicy != corev1.DNSClusterFirst {
-		log.Warnf("%q's DNSPolicy is not %s, the envoy may not able to connect to pilot\n",
-			metadata.Name, corev1.DNSClusterFirst)
+		log.Warnf("%q's DNSPolicy is not %q. The Envoy sidecar may not able to connect to Istio Pilot\n",
+			name, corev1.DNSClusterFirst)
 	}
 
 	if err := validateAnnotations(metadata.GetAnnotations()); err != nil {

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -540,6 +540,13 @@ func flippedContains(needle, haystack string) bool {
 func InjectionData(sidecarTemplate, valuesConfig, version string, deploymentMetadata *metav1.ObjectMeta, spec *corev1.PodSpec,
 	metadata *metav1.ObjectMeta, proxyConfig *meshconfig.ProxyConfig, meshConfig *meshconfig.MeshConfig) (
 	*SidecarInjectionSpec, string, error) {
+
+	// If DNSPolicy is not ClusterFirst, the envoy may not able to connect to pilot.
+	if spec.DNSPolicy != corev1.DNSClusterFirst {
+		log.Warnf("%q's DNSPolicy is not %s, the envoy may not able to connect to pilot\n",
+			metadata.Name, corev1.DNSClusterFirst)
+	}
+
 	if err := validateAnnotations(metadata.GetAnnotations()); err != nil {
 		log.Errorf("Injection failed due to invalid annotations: %v", err)
 		return nil, "", err
@@ -775,6 +782,7 @@ func intoObject(sidecarTemplate string, valuesConfig string, meshconfig *meshcon
 			metadata.Name)
 		return out, nil
 	}
+
 	//skip injection for injected pods
 	if len(podSpec.Containers) > 1 {
 		for _, c := range podSpec.Containers {


### PR DESCRIPTION
If the DNSPolicy is not ClusterFirst, the envoy may not able to resolve `istio-pilot.istio-system`, which makes istio-proxy always Unhealthy and can't fetch xDS.

In istioctl, we only show a warning in stderr, It has no effect on the original way.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
