### PR TITLE
Add EnableWebhookNamespaceSelector flag to galley for webhook config

### DIFF
--- a/galley/cmd/galley/cmd/server.go
+++ b/galley/cmd/galley/cmd/server.go
@@ -164,6 +164,9 @@ func serverCmd() *cobra.Command {
 	serverCmd.PersistentFlags().BoolVar(&serverArgs.ValidationArgs.EnableReconcileWebhookConfiguration,
 		"enable-reconcileWebhookConfiguration", serverArgs.ValidationArgs.EnableReconcileWebhookConfiguration,
 		"Enable reconciliation for webhook configuration.")
+	serverCmd.PersistentFlags().BoolVar(&serverArgs.ValidationArgs.EnableWebhookNamespaceSelector,
+		"enable-webhookNamespaceSelector", serverArgs.ValidationArgs.EnableWebhookNamespaceSelector,
+		"Enable namespace selector in webhook configuration.")
 	serverCmd.PersistentFlags().StringVar(&serverArgs.ValidationArgs.DeploymentAndServiceNamespace, "deployment-namespace", "istio-system",
 		"Namespace of the deployment for the validation pod")
 	serverCmd.PersistentFlags().StringVar(&serverArgs.ValidationArgs.DeploymentName, "deployment-name", "istio-galley",
@@ -221,6 +224,8 @@ func setupAliases() {
 	viper.RegisterAlias("processing.source.kubernetes.resyncPeriod", "resyncPeriod")
 	viper.RegisterAlias("processing.source.filesystem.path", "configPath")
 	viper.RegisterAlias("validation.enable", "enable-validation")
+	viper.RegisterAlias("validation.enableReconcileWebhookConfiguration", "enable-reconcileWebhookConfiguration")
+	viper.RegisterAlias("validation.enableWebhookNamespaceSelector", "enable-webhookNamespaceSelector")
 	viper.RegisterAlias("validation.webhookConfigFile", "validation-webhook-config-file")
 	viper.RegisterAlias("validation.webhookPort", "validation-port")
 	viper.RegisterAlias("validation.webhookName", "webhook-name")

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -64,6 +64,8 @@ const (
 	watchDebounceDelay = 100 * time.Millisecond
 
 	httpsHandlerReadyPath = "/ready"
+
+	namespaceSelectorLabelKey = "galley.istio.io/env"
 )
 
 // WebhookParameters contains the configuration for the Istio Pilot validation
@@ -120,6 +122,12 @@ type WebhookParameters struct {
 
 	// Enable reconcile validatingwebhookconfiguration
 	EnableReconcileWebhookConfiguration bool
+
+	// Enable webhook namespace selector. This causes the reconciled validatingwebhookconfiguration to include a
+	// selector that makes the webhook only apply to namespaces with a label (see NamespaceSelectorLabelKey)
+	// that points to the galley instance's configured DeploymentAndServiceNamespace. If the webhook config file
+	// already contains namespaceSelector configuration, that is used instead and this setting is ignored.
+	EnableWebhookNamespaceSelector bool
 }
 
 type createInformerEndpointSource func(cl clientset.Interface, namespace, name string) cache.ListerWatcher
@@ -150,6 +158,7 @@ func (p *WebhookParameters) String() string {
 	fmt.Fprintf(buf, "ServiceName: %s\n", p.ServiceName)
 	fmt.Fprintf(buf, "EnableValidation: %v\n", p.EnableValidation)
 	fmt.Fprintf(buf, "EnableReconcileWebhookConfiguration: %v\n", p.EnableReconcileWebhookConfiguration)
+	fmt.Fprintf(buf, "EnableWebhookNamespaceSelector: %v\n", p.EnableWebhookNamespaceSelector)
 
 	return buf.String()
 }
@@ -167,6 +176,7 @@ func DefaultArgs() *WebhookParameters {
 		WebhookName:                         "istio-galley",
 		EnableValidation:                    true,
 		EnableReconcileWebhookConfiguration: true,
+		EnableWebhookNamespaceSelector:      false,
 	}
 }
 


### PR DESCRIPTION
This allows the webhook to be scoped to a particular set of namespaces,
useful for cases where parallel istio control planes are running on the
same cluster. 
See also https://github.com/istio/istio/issues/12077

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
