### PR TITLE
Minor fix to message from successful installation of Istio using Helm

### DIFF
--- a/install/kubernetes/helm/istio/templates/NOTES.txt
+++ b/install/kubernetes/helm/istio/templates/NOTES.txt
@@ -1,6 +1,6 @@
-Thank you for installing {{ .Chart.Name }}.
+Thank you for installing {{ .Chart.Name | title }}.
 
-Your release is named {{ .Release.Name }}.
+Your release is named {{ .Release.Name | title }}.
 
 To get started running application with Istio, execute the following steps:
 


### PR DESCRIPTION
Instead of showing `istio` in the message, show it in camel case. Here
is the message that is displayed on successful installation of Istio.

>> Thank you for installing istio.
>> Your release is named istio.
>> ....

Fixes Bug: #15933

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
