### PR TITLE
pilot: no specialized slice for management listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -29,15 +29,15 @@ import (
 
 // ApplyListenerPatches applies patches to LDS output
 func ApplyListenerPatches(patchContext networking.EnvoyFilter_PatchContext,
-	proxy *model.Proxy, push *model.PushContext, listeners []*xdsapi.Listener, skipAdds bool) []*xdsapi.Listener {
+	proxy *model.Proxy, push *model.PushContext, listeners []*xdsapi.Listener) []*xdsapi.Listener {
 
 	envoyFilterWrappers := push.EnvoyFilters(proxy)
-	return doListenerListOperation(proxy, patchContext, envoyFilterWrappers, listeners, skipAdds)
+	return doListenerListOperation(proxy, patchContext, envoyFilterWrappers, listeners)
 }
 
 func doListenerListOperation(proxy *model.Proxy, patchContext networking.EnvoyFilter_PatchContext,
 	envoyFilterWrappers []*model.EnvoyFilterWrapper,
-	listeners []*xdsapi.Listener, skipAdds bool) []*xdsapi.Listener {
+	listeners []*xdsapi.Listener) []*xdsapi.Listener {
 	listenersRemoved := false
 	for _, efw := range envoyFilterWrappers {
 		// do all the changes for a single envoy filter crd object. [including adds]
@@ -50,10 +50,6 @@ func doListenerListOperation(proxy *model.Proxy, patchContext networking.EnvoyFi
 				continue
 			}
 			doListenerOperation(proxy, patchContext, efw.Patches, listener, &listenersRemoved)
-		}
-		// adds at listener level if enabled
-		if skipAdds {
-			continue
 		}
 		for _, cp := range efw.Patches[networking.EnvoyFilter_LISTENER] {
 			if cp.Operation == networking.EnvoyFilter_Patch_ADD {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -314,58 +314,6 @@ func TestApplyListenerPatches(t *testing.T) {
 		},
 	}
 
-	sidecarOutboundInNoAdd := []*xdsapi.Listener{
-		{
-			Name: "12345",
-			Address: core.Address{
-				Address: &core.Address_SocketAddress{
-					SocketAddress: &core.SocketAddress{
-						PortSpecifier: &core.SocketAddress_PortValue{
-							PortValue: 12345,
-						},
-					},
-				},
-			},
-			FilterChains: []listener.FilterChain{
-				{
-					Filters: []listener.Filter{
-						{Name: "filter1"},
-						{Name: "filter2"},
-					},
-				},
-			},
-		},
-		{
-			Name: "another-listener",
-		},
-	}
-
-	sidecarOutboundOutNoAdd := []*xdsapi.Listener{
-		{
-			Name: "12345",
-			Address: core.Address{
-				Address: &core.Address_SocketAddress{
-					SocketAddress: &core.SocketAddress{
-						PortSpecifier: &core.SocketAddress_PortValue{
-							PortValue: 12345,
-						},
-					},
-				},
-			},
-			FilterChains: []listener.FilterChain{
-				{
-					Filters: []listener.Filter{
-						{Name: "filter0"},
-						{Name: "filter1"},
-					},
-				},
-			},
-		},
-		{
-			Name: "another-listener",
-		},
-	}
-
 	sidecarInboundIn := []*xdsapi.Listener{
 		{
 			Name: "12345",
@@ -575,7 +523,6 @@ func TestApplyListenerPatches(t *testing.T) {
 		proxy        *model.Proxy
 		push         *model.PushContext
 		listeners    []*xdsapi.Listener
-		skipAdds     bool
 	}
 	tests := []struct {
 		name string
@@ -589,7 +536,6 @@ func TestApplyListenerPatches(t *testing.T) {
 				proxy:        sidecarProxy,
 				push:         push,
 				listeners:    sidecarInboundIn,
-				skipAdds:     false,
 			},
 			want: sidecarInboundOut,
 		},
@@ -600,7 +546,6 @@ func TestApplyListenerPatches(t *testing.T) {
 				proxy:        gatewayProxy,
 				push:         push,
 				listeners:    gatewayIn,
-				skipAdds:     false,
 			},
 			want: gatewayOut,
 		},
@@ -611,26 +556,14 @@ func TestApplyListenerPatches(t *testing.T) {
 				proxy:        sidecarProxy,
 				push:         push,
 				listeners:    sidecarOutboundIn,
-				skipAdds:     false,
 			},
 			want: sidecarOutboundOut,
-		},
-		{
-			name: "sidecar outbound lds - skip adds",
-			args: args{
-				patchContext: networking.EnvoyFilter_SIDECAR_OUTBOUND,
-				proxy:        sidecarProxy,
-				push:         push,
-				listeners:    sidecarOutboundInNoAdd,
-				skipAdds:     true,
-			},
-			want: sidecarOutboundOutNoAdd,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ApplyListenerPatches(tt.args.patchContext, tt.args.proxy, tt.args.push,
-				tt.args.listeners, tt.args.skipAdds)
+				tt.args.listeners)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ApplyListenerPatches(): %s mismatch (-want +got):\n%s", tt.name, diff)
 			}


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

The original motivation of specialize management listeners is that management listeners are bind to a port while the other inbound listeners are not.

While the Sidecar API is introduced any inbound listener could be captured or not independently. 

By put management listener into inbound listener we can simplify the impl of EnvoyFilter as well.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
