### PR TITLE
Add supporting implementation for ISTIO_MUTUAL Gateway TLS mode

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -377,6 +377,22 @@ func validateTLSOptions(tls *networking.Server_TLSOptions) (errs error) {
 		return
 	}
 
+	if tls.Mode == networking.Server_TLSOptions_ISTIO_MUTUAL {
+		// ISTIO_MUTUAL TLS mode uses either SDS or default certificate mount paths
+		// therefore, we should fail validation if other TLS fields are set
+		if tls.ServerCertificate != "" {
+			errs = appendErrors(errs, fmt.Errorf("ISTIO_MUTUAL TLS cannot have associated server certificate"))
+		}
+		if tls.PrivateKey != "" {
+			errs = appendErrors(errs, fmt.Errorf("ISTIO_MUTUAL TLS cannot have associated private key"))
+		}
+		if tls.CaCertificates != "" {
+			errs = appendErrors(errs, fmt.Errorf("ISTIO_MUTUAL TLS cannot have associated CA bundle"))
+		}
+
+		return
+	}
+
 	if (tls.Mode == networking.Server_TLSOptions_SIMPLE || tls.Mode == networking.Server_TLSOptions_MUTUAL) && tls.CredentialName != "" {
 		// If tls mode is SIMPLE or MUTUAL, and CredentialName is specified, credentials are fetched
 		// remotely. ServerCertificate and CaCertificates fields are not required.

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1448,6 +1448,30 @@ func TestValidateTlsOptions(t *testing.T) {
 				CaCertificates:    "",
 				CredentialName:    "sds-name"},
 			""},
+		{"istio_mutual no certs",
+			&networking.Server_TLSOptions{
+				Mode:              networking.Server_TLSOptions_ISTIO_MUTUAL,
+				ServerCertificate: "",
+				PrivateKey:        "",
+				CaCertificates:    ""},
+			""},
+		{"istio_mutual with server cert",
+			&networking.Server_TLSOptions{
+				Mode:              networking.Server_TLSOptions_ISTIO_MUTUAL,
+				ServerCertificate: "Captain Jean-Luc Picard"},
+			"cannot have associated server cert"},
+		{"istio_mutual with client bundle",
+			&networking.Server_TLSOptions{
+				Mode:              networking.Server_TLSOptions_ISTIO_MUTUAL,
+				ServerCertificate: "Captain Jean-Luc Picard",
+				PrivateKey:        "Khan Noonien Singh",
+				CaCertificates:    "Commander William T. Riker"},
+			"cannot have associated"},
+		{"istio_mutual with private key",
+			&networking.Server_TLSOptions{
+				Mode:       networking.Server_TLSOptions_ISTIO_MUTUAL,
+				PrivateKey: "Khan Noonien Singh"},
+			"cannot have associated private key"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/test/echo/common/response/response.go
+++ b/pkg/test/echo/common/response/response.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	StatusCodeOK        = strconv.Itoa(http.StatusOK)
-	StatusCodeForbidden = strconv.Itoa(http.StatusForbidden)
+	StatusCodeOK          = strconv.Itoa(http.StatusOK)
+	StatusCodeForbidden   = strconv.Itoa(http.StatusForbidden)
+	StatusCodeUnavailable = strconv.Itoa(http.StatusServiceUnavailable)
 )
 
 // Field is a list of fields returned in responses from the Echo server.

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -1,0 +1,178 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package sdsegress
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/echo/common/response"
+	epb "istio.io/istio/pkg/test/echo/proto"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/prometheus"
+	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/tests/integration/security/util"
+)
+
+const (
+	// should be templated into YAML, and made interchangeable with other sites
+	externalURL      = "http://bing.com"
+	externalReqCount = 2
+	egressName       = "istio-egressgateway"
+	// paths to test configs
+	istioMutualTLSGatewayConfig = "testdata/istio-mutual-gateway-bing.yaml"
+	simpleTLSGatewayConfig      = "testdata/simple-tls-gateway-bing.yaml"
+)
+
+// TestSdsEgressGatewayIstioMutual brings up an SDS enabled cluster and will ensure that the ISTIO_MUTUAL
+// TLS mode allows secure communication between the egress and workloads. This test brings up an ISTIO_MUTUAL enabled
+// gateway, and then, an incorrectly configured simple TLS gateway. The test will ensure that requests are routed
+// securely through the egress gateway in the first case, and fail in the second case.
+func TestSdsEgressGatewayIstioMutual(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ctx.RequireOrSkip(environment.Kube)
+			istioCfg := istio.DefaultConfigOrFail(t, ctx)
+
+			namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
+			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "sds-egress-gateway-workload",
+				Inject: true,
+			})
+			applySetupConfig(ctx, ns)
+
+			testCases := map[string]struct {
+				configPath string
+				response   string
+			}{
+				"ISTIO_MUTUAL TLS mode requests are routed through egress succeed": {
+					configPath: istioMutualTLSGatewayConfig,
+					response:   response.StatusCodeOK,
+				},
+				"SIMPLE TLS mode requests are routed through gateway but fail with 503": {
+					configPath: simpleTLSGatewayConfig,
+					response:   response.StatusCodeUnavailable,
+				},
+			}
+
+			for name, tc := range testCases {
+				ctx.NewSubTest(name).
+					Run(func(ctx framework.TestContext) {
+						doIstioMutualTest(ctx, ns, tc.configPath, tc.response)
+					})
+			}
+		})
+}
+
+func doIstioMutualTest(
+	ctx framework.TestContext, ns namespace.Instance, configPath, expectedResp string) {
+	var client echo.Instance
+	echoboot.NewBuilderOrFail(ctx, ctx).
+		With(&client, util.EchoConfig("client", ns, false, nil, g, p)).
+		BuildOrFail(ctx)
+	g.ApplyConfigOrFail(ctx, ns, file.AsStringOrFail(ctx, configPath))
+	defer g.DeleteConfigOrFail(ctx, ns, file.AsStringOrFail(ctx, configPath))
+
+	// give the configuration a moment to kick in
+	time.Sleep(time.Second * 20)
+	pretestReqCount := getEgressRequestCountOrFail(ctx, ns, prom)
+
+	for i := 0; i < externalReqCount; i++ {
+		w := client.WorkloadsOrFail(ctx)[0]
+		responses, err := w.ForwardEcho(context.TODO(), &epb.ForwardEchoRequest{
+			Url:   externalURL,
+			Count: 1,
+		})
+		if err != nil {
+			ctx.Fatalf("failed to make request from echo instance to %s: %v", externalURL, err)
+		}
+		if len(responses) < 1 {
+			ctx.Fatalf("received no responses from request to %s", externalURL)
+		}
+		resp := responses[0]
+
+		if expectedResp != resp.Code {
+			ctx.Errorf("expected status %s but got %s", expectedResp, resp.Code)
+		}
+
+	}
+
+	// give prometheus some time to ingest the metrics
+	posttestReqCount := getEgressRequestCountOrFail(ctx, ns, prom)
+	newGatewayReqs := posttestReqCount - pretestReqCount
+	if newGatewayReqs != externalReqCount {
+		ctx.Errorf("expected %d requests routed through egress, got %d",
+			externalReqCount, newGatewayReqs)
+	}
+}
+
+// sets up the destination rule to route through egress, virtual service, and service entry
+func applySetupConfig(ctx test.Failer, ns namespace.Instance) {
+	ctx.Helper()
+
+	configFiles := []string{
+		"testdata/destination-rule-bing.yaml",
+		"testdata/rule-route-sidecar-to-egress-bing.yaml",
+		"testdata/service-entry-bing.yaml",
+	}
+
+	for _, c := range configFiles {
+		if err := g.ApplyConfig(ns, file.AsStringOrFail(ctx, c)); err != nil {
+			ctx.Fatalf("failed to apply configuration file %s; err: %v", c, err)
+		}
+	}
+}
+
+func getMetric(ctx framework.TestContext, prometheus prometheus.Instance, query string) (float64, error) {
+	ctx.Helper()
+
+	value, err := prometheus.WaitForQuiesce(query)
+	if err != nil {
+		return 0, fmt.Errorf("failed to retrieve metric from prom with err: %v", err)
+	}
+
+	metric, err := prometheus.Sum(value, nil)
+	if err != nil {
+		ctx.Logf("value: %s", value.String())
+		return 0, fmt.Errorf("could not find metric value: %v", err)
+	}
+
+	return metric, nil
+}
+
+func getEgressRequestCountOrFail(ctx framework.TestContext, ns namespace.Instance, prom prometheus.Instance) int {
+	query := fmt.Sprintf("istio_requests_total{destination_app=\"%s\",source_workload_namespace=\"%s\"}",
+		egressName, ns.Name())
+	ctx.Helper()
+
+	reqCount, err := getMetric(ctx, prom, query)
+	if err != nil {
+		// assume that if the request failed, it was because there was no metric ingested
+		// if this is not the case, the test will fail down the road regardless
+		// checking for error based on string match could lead to future failure
+		reqCount = 0
+	}
+
+	return int(reqCount)
+}

--- a/tests/integration/security/sds_egress/testdata/destination-rule-bing.yaml
+++ b/tests/integration/security/sds_egress/testdata/destination-rule-bing.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: egressgateway-for-bing
+spec:
+  host: istio-egressgateway.istio-system.svc.cluster.local
+  subsets:
+    - name: bing
+      trafficPolicy:
+        loadBalancer:
+          simple: ROUND_ROBIN
+        portLevelSettings:
+          - port:
+              number: 80
+            tls:
+              mode: ISTIO_MUTUAL
+              sni: bing.com

--- a/tests/integration/security/sds_egress/testdata/istio-mutual-gateway-bing.yaml
+++ b/tests/integration/security/sds_egress/testdata/istio-mutual-gateway-bing.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: istio-egressgateway
+spec:
+  selector:
+    istio: egressgateway
+  servers:
+    - port:
+        number: 80
+        name: https
+        protocol: HTTPS
+      hosts:
+        - bing.com
+      tls:
+        mode: ISTIO_MUTUAL

--- a/tests/integration/security/sds_egress/testdata/rule-route-sidecar-to-egress-bing.yaml
+++ b/tests/integration/security/sds_egress/testdata/rule-route-sidecar-to-egress-bing.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: direct-bing-through-egress-gateway
+spec:
+  hosts:
+    - bing.com
+  gateways:
+    - istio-egressgateway
+    - mesh
+  http:
+    - match:
+        - gateways:
+            - mesh
+          port: 80
+      route:
+        - destination:
+            host: istio-egressgateway.istio-system.svc.cluster.local
+            subset: bing
+            port:
+              number: 80
+          weight: 100
+    - match:
+        - gateways:
+            - istio-egressgateway
+          port: 80
+      route:
+        - destination:
+            host: bing.com
+            port:
+              number: 80
+          weight: 100

--- a/tests/integration/security/sds_egress/testdata/service-entry-bing.yaml
+++ b/tests/integration/security/sds_egress/testdata/service-entry-bing.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: bing
+spec:
+  hosts:
+    - bing.com
+  ports:
+    - number: 80
+      name: http-port
+      protocol: HTTP
+    - number: 443
+      name: https
+      protocol: HTTPS
+  resolution: DNS

--- a/tests/integration/security/sds_egress/testdata/simple-tls-gateway-bing.yaml
+++ b/tests/integration/security/sds_egress/testdata/simple-tls-gateway-bing.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: istio-egressgateway
+spec:
+  selector:
+    istio: egressgateway
+  servers:
+    - port:
+        number: 80
+        name: https
+        protocol: HTTPS
+      hosts:
+        - bing.com
+      tls:
+        mode: SIMPLE
+        serverCertificate: /etc/certs/server.pem
+        privateKey: /etc/certs/privatekey.pem


### PR DESCRIPTION
[Relevant issue](https://github.com/istio/istio/issues/15485)
[Parallel PR into `istio/api`](https://github.com/istio/api/pull/991)

In order to support secure workload communication with egress gateways, we added an mTLS mode to the `Gateway` called `ISTIO_MUTUAL`. This PR checks for this configuration option and configures the egress gateway accordingly.

When SDS is enabled globally, the `egress gateway` will receive its TLS config from SDS. When SDS is **not** enabled globally & the `Gateway` TLS mode is `ISTIO_MUTUAL`, we default to using secret mount paths.

This is experimental, and has not been tested for `Ingress`, but has been tested to work for `Egress` gateways for both SDS-enabled and non-SDS-enabled meshes.

Note: will checkout the checked in `values-istio-sds-auth.yaml`, but wanted to include the cluster config since this is still a draft PR & it might be useful debug information

/cc @quanjielin @JimmyCYJ @incfly @vadimeisenbergibm 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
