### PR TITLE
Retrigger ADS push when inbound listeners change

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -731,14 +731,10 @@ func (s *DiscoveryServer) updateProxyServiceInstances(instance *model.ServiceIns
 	}
 
 	// Update proxy node's service instances
-	err = proxy.SetServiceInstances(s.Env)
-	if err != nil {
-		adsLog.Errorf("Error setting proxy %s service instances: %v", proxy.ID, err)
-		return err
-	}
+	proxy.ServiceInstances = instances
 
 	// Trigger an update to that particular proxy
-	s.pushQueue.Enqueue(con, &model.PushRequest{Full: true, Push: s.globalPushContext()})
+	s.pushQueue.Enqueue(con, &model.PushRequest{Full: true, Push: s.globalPushContext(), Start: time.Now()})
 
 	return nil
 }

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -705,17 +705,59 @@ func proxyNeedsPush(con *XdsConnection, targetNamespaces map[string]struct{}) bo
 	return false
 }
 
+// updateProxyServiceInstances determines whether the proxy associated with the given service instance
+// needs to refresh its local inbound listeners, and if so, triggers a push to that proxy.
+func (s *DiscoveryServer) updateProxyServiceInstances(instance *model.ServiceInstance) error {
+	instanceIP := instance.Endpoint.Address
+
+	// Check whether there's an existing connection from that IP address
+	adsClientsMutex.RLock()
+	con, ok := s.connectionsByIP[instanceIP]
+	adsClientsMutex.RUnlock()
+	if !ok {
+		return nil
+	}
+
+	proxy := con.modelNode
+	instances, err := s.Env.GetProxyServiceInstances(proxy)
+	if err != nil {
+		adsLog.Errorf("Error getting proxy %s service instances: %v", proxy.ID, err)
+		return err
+	}
+
+	if reflect.DeepEqual(instances, proxy.ServiceInstances) {
+		// no changes detected - nothing to update
+		return nil
+	}
+
+	// Update proxy node's service instances
+	err = proxy.SetServiceInstances(s.Env)
+	if err != nil {
+		adsLog.Errorf("Error setting proxy %s service instances: %v", proxy.ID, err)
+		return err
+	}
+
+	// Trigger an update to that particular proxy
+	s.pushQueue.Enqueue(con, &model.PushRequest{Full: true, Push: s.globalPushContext()})
+
+	return nil
+}
+
 func (s *DiscoveryServer) addCon(conID string, con *XdsConnection) {
 	adsClientsMutex.Lock()
 	defer adsClientsMutex.Unlock()
 	adsClients[conID] = con
 	xdsClients.Record(float64(len(adsClients)))
 	if con.modelNode != nil {
-		if _, ok := adsSidecarIDConnectionsMap[con.modelNode.ID]; !ok {
-			adsSidecarIDConnectionsMap[con.modelNode.ID] = map[string]*XdsConnection{conID: con}
+		node := con.modelNode
+
+		if _, ok := adsSidecarIDConnectionsMap[node.ID]; !ok {
+			adsSidecarIDConnectionsMap[node.ID] = map[string]*XdsConnection{conID: con}
 		} else {
-			adsSidecarIDConnectionsMap[con.modelNode.ID][conID] = con
+			adsSidecarIDConnectionsMap[node.ID][conID] = con
 		}
+
+		s.connectionsByIP[node.IPAddresses[0]] = con
 	}
 }
 
@@ -736,10 +778,14 @@ func (s *DiscoveryServer) removeCon(conID string, con *XdsConnection) {
 
 	xdsClients.Record(float64(len(adsClients)))
 	if con.modelNode != nil {
-		delete(adsSidecarIDConnectionsMap[con.modelNode.ID], conID)
-		if len(adsSidecarIDConnectionsMap[con.modelNode.ID]) == 0 {
-			delete(adsSidecarIDConnectionsMap, con.modelNode.ID)
+		node := con.modelNode
+
+		delete(adsSidecarIDConnectionsMap[node.ID], conID)
+		if len(adsSidecarIDConnectionsMap[node.ID]) == 0 {
+			delete(adsSidecarIDConnectionsMap, node.ID)
 		}
+
+		delete(s.connectionsByIP, node.IPAddresses[0])
 	}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -176,17 +176,13 @@ func NewDiscoveryServer(
 		pushQueue:               NewPushQueue(),
 	}
 
-	// Flush cached discovery responses whenever services, service
-	// instances, or routing configuration changes.
+	// Flush cached discovery responses whenever services configuration change.
 	serviceHandler := func(*model.Service, model.Event) { out.clearCache() }
 	if err := ctl.AppendServiceHandler(serviceHandler); err != nil {
 		return nil
 	}
-	instanceHandler := func(*model.ServiceInstance, model.Event) { out.clearCache() }
-	if err := ctl.AppendInstanceHandler(instanceHandler); err != nil {
-		return nil
-	}
 
+	// Trigger an individual push whenever a proxy's local service instances change.
 	instanceUpdateHandler := func(instance *model.ServiceInstance, event model.Event) {
 		err := out.updateProxyServiceInstances(instance)
 		if err != nil {

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -188,7 +188,10 @@ func NewDiscoveryServer(
 	}
 
 	instanceUpdateHandler := func(instance *model.ServiceInstance, event model.Event) {
-		out.updateProxyServiceInstances(instance)
+		err := out.updateProxyServiceInstances(instance)
+		if err != nil {
+			adsLog.Errorf("Error updating proxy service instances for instance %s: %v", instance.Endpoint.UID, err)
+		}
 	}
 	if err := ctl.AppendInstanceHandler(instanceUpdateHandler); err != nil {
 		return nil


### PR DESCRIPTION
**Please provide a description for what this PR is for.**

This PR addresses a situation in which the proxy connects to the Pilot and receives an initial LDS configuration, before the Pilot managed to learn (e.g., via a kube API event) about the pod/service endpoint. This results with the proxy container (and hence, its pod) being stuck in an unready state, until an updated LDS configuration arrives (which seems to be taking a long and even unbounded amount of time).

This PR adds an event handler that subscribes to `model.ServiceInstance` changes, and detects whenever an LDS update is needed for the proxy associated with the `ServiceInstance`. When such update is detected, the handler triggers a full ADS push, to that particular proxy.

Fixes #13106.

P.S. - I've marked _Performance and Scalability_ below because this change may have performance impact and should probably be more carefully examined.

**And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.**

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
