### PR TITLE
correct nil pointer in validateHTTPRoute

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -1947,8 +1947,8 @@ func validateHTTPRoute(http *networking.HTTPRoute) (errs error) {
 	errs = appendErrors(errs, validateCORSPolicy(http.CorsPolicy))
 	errs = appendErrors(errs, validateHTTPFaultInjection(http.Fault))
 
-	if http.Match != nil {
-		for _, match := range http.Match {
+	for _, match := range http.Match {
+		if match != nil {
 			for name, header := range match.Headers {
 				if header == nil {
 					errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -1947,20 +1947,23 @@ func validateHTTPRoute(http *networking.HTTPRoute) (errs error) {
 	errs = appendErrors(errs, validateCORSPolicy(http.CorsPolicy))
 	errs = appendErrors(errs, validateHTTPFaultInjection(http.Fault))
 
-	for _, match := range http.Match {
-		for name, header := range match.Headers {
-			if header == nil {
-				errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))
+	if http.Match != nil {
+		for _, match := range http.Match {
+			for name, header := range match.Headers {
+				if header == nil {
+					errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))
+				}
+				errs = appendErrors(errs, ValidateHTTPHeaderName(name))
 			}
-			errs = appendErrors(errs, ValidateHTTPHeaderName(name))
-		}
 
-		if match.Port != 0 {
-			errs = appendErrors(errs, ValidatePort(int(match.Port)))
+			if match.Port != 0 {
+				errs = appendErrors(errs, ValidatePort(int(match.Port)))
+			}
+			errs = appendErrors(errs, Labels(match.SourceLabels).Validate())
+			errs = appendErrors(errs, validateGatewayNames(match.Gateways))
 		}
-		errs = appendErrors(errs, Labels(match.SourceLabels).Validate())
-		errs = appendErrors(errs, validateGatewayNames(match.Gateways))
 	}
+
 	errs = appendErrors(errs, validateDestination(http.Mirror))
 	errs = appendErrors(errs, validateHTTPRedirect(http.Redirect))
 	errs = appendErrors(errs, validateHTTPRetry(http.Retries))

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -2258,6 +2258,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 		}, valid: false},
+		{name: "nil match", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: nil,
+		}, valid: true},
+		{name: "match with nil element", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{nil},
+		}, valid: true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR fix a nil pointer in validateHTTPRoute:

For now in validateHTTPRoute, we query  `match.Headers` without check whether it's nil:

```
for _, match := range http.Match {
	for name, header := range match.Headers {
		...
	}
}
```

and it may causes panic. for example, in my test, for this `VirtualService`:

```
 hosts:"ubuntu-service" http:<match:<nil> route:<destination:<host:"ubuntu-service" subset:"v1" > weight:30 > route:<destination:<host:"ubuntu-service" subset:"v2" > weight:70 > fault:<delay:<percent:91 fixed_delay:<seconds:2 > > > >
```

when apply this `VirtualService` using `client` in `istio.io/istio/pilot/pkg/model`, I get this error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1cf84eb]

goroutine 30 [running]:
istio.io/istio/pkg/config.validateHTTPRoute(0xc000126620, 0x28, 0x0)
	/go/pkg/mod/istio.io/istio@v0.0.0-20190731032002-9e92390a0478/pkg/config/validation.go:1948 +0x169b
istio.io/istio/pkg/config.ValidateVirtualService(0xc000047f40, 0x11, 0xc0000ed740, 0x7, 0x272fbc0, 0xc00013be40, 0x0, 0x0)
	/go/pkg/mod/istio.io/istio@v0.0.0-20190731032002-9e92390a0478/pkg/config/validation.go:1785 +0x42e
istio.io/istio/pilot/pkg/config/kube/crd/controller.(*Client).Update(0xc0004ea040, 0x24d2aa8, 0xf, 0xc000047f60, 0x13, 0x24ca854, 0x8, 0xc000047f40, 0x11, 0xc0000ed740, ...)
	/go/pkg/mod/istio.io/istio@v0.0.0-20190731032002-9e92390a0478/pilot/pkg/config/kube/crd/controller/client.go:397 +0x1a1
```

So this PR fix this problem.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
