### PR TITLE
Allow istioctl to be used on pods with periods in their name

### DIFF
--- a/istioctl/pkg/util/handlers/handlers.go
+++ b/istioctl/pkg/util/handlers/handlers.go
@@ -25,12 +25,12 @@ import (
 //InferPodInfo Uses proxyName to infer namespace if the passed proxyName contains namespace information.
 // Otherwise uses the namespace value passed into the function
 func InferPodInfo(proxyName, namespace string) (string, string) {
-	parsedProxy := strings.Split(proxyName, ".")
-
-	if len(parsedProxy) == 1 {
+	separator := strings.LastIndex(proxyName, ".")
+	if separator < 0 {
 		return proxyName, namespace
 	}
-	return parsedProxy[0], parsedProxy[1]
+
+	return proxyName[0:separator], proxyName[separator+1:]
 }
 
 //HandleNamespace returns the defaultNamespace if the namespace is empty

--- a/istioctl/pkg/util/handlers/handlers_test.go
+++ b/istioctl/pkg/util/handlers/handlers_test.go
@@ -44,6 +44,18 @@ func TestInferPodInfo(t *testing.T) {
 			wantPodName:   "istio-ingressgateway-8d9697654-qdzgh",
 			wantNamespace: "kube-system",
 		},
+		{
+			proxyName:     "istio-security-post-install-1.2.2-bm9w2.istio-system",
+			namespace:     "istio-system",
+			wantPodName:   "istio-security-post-install-1.2.2-bm9w2",
+			wantNamespace: "istio-system",
+		},
+		{
+			proxyName:     "istio-security-post-install-1.2.2-bm9w2.istio-system",
+			namespace:     "",
+			wantPodName:   "istio-security-post-install-1.2.2-bm9w2",
+			wantNamespace: "istio-system",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(strings.Split(tt.proxyName, ".")[0], func(t *testing.T) {


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/15793

The istioctl commands that take pod names as arguments have never been able to handle pods with periods in their names such as _istio-security-post-install-1.2.2-bm9w2.istio-system_.