### PR TITLE
Skip pushes to proxies that don't require update

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -405,7 +405,7 @@ func (s *Server) initMesh(args *PilotArgs) error {
 				s.mesh = meshConfig
 				if s.EnvoyXdsServer != nil {
 					s.EnvoyXdsServer.Env.Mesh = meshConfig
-					s.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
+					s.EnvoyXdsServer.ConfigUpdate(model.UpdateRequest{Full: true})
 				}
 			}
 		})
@@ -476,7 +476,7 @@ func (s *Server) initMeshNetworks(args *PilotArgs) error { //nolint: unparam
 			}
 			if s.EnvoyXdsServer != nil {
 				s.EnvoyXdsServer.Env.MeshNetworks = meshNetworks
-				s.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
+				s.EnvoyXdsServer.ConfigUpdate(model.UpdateRequest{Full: true})
 			}
 		}
 	})
@@ -524,7 +524,7 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 	options := coredatamodel.Options{
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 		ClearDiscoveryServerCache: func() {
-			s.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
+			s.EnvoyXdsServer.ConfigUpdate(model.UpdateRequest{Full: true})
 		},
 	}
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -405,7 +405,7 @@ func (s *Server) initMesh(args *PilotArgs) error {
 				s.mesh = meshConfig
 				if s.EnvoyXdsServer != nil {
 					s.EnvoyXdsServer.Env.Mesh = meshConfig
-					s.EnvoyXdsServer.ConfigUpdate(true)
+					s.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
 				}
 			}
 		})
@@ -476,7 +476,7 @@ func (s *Server) initMeshNetworks(args *PilotArgs) error { //nolint: unparam
 			}
 			if s.EnvoyXdsServer != nil {
 				s.EnvoyXdsServer.Env.MeshNetworks = meshNetworks
-				s.EnvoyXdsServer.ConfigUpdate(true)
+				s.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
 			}
 		}
 	})
@@ -524,7 +524,7 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 	options := coredatamodel.Options{
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 		ClearDiscoveryServerCache: func() {
-			s.EnvoyXdsServer.ConfigUpdate(true)
+			s.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
 		},
 	}
 

--- a/pilot/pkg/config/clusterregistry/multicluster.go
+++ b/pilot/pkg/config/clusterregistry/multicluster.go
@@ -105,8 +105,8 @@ func (m *Multicluster) AddMemberCluster(clientset kubernetes.Interface, clusterI
 
 	m.remoteKubeControllers[clusterID] = &remoteKubeController
 	m.m.Unlock()
-	_ = kubectl.AppendServiceHandler(func(*model.Service, model.Event) { m.XDSUpdater.ConfigUpdate(true) })
-	_ = kubectl.AppendInstanceHandler(func(*model.ServiceInstance, model.Event) { m.XDSUpdater.ConfigUpdate(true) })
+	_ = kubectl.AppendServiceHandler(func(*model.Service, model.Event) { m.XDSUpdater.ConfigUpdate(model.UpdateReq{Full: true}) })
+	_ = kubectl.AppendInstanceHandler(func(*model.ServiceInstance, model.Event) { m.XDSUpdater.ConfigUpdate(model.UpdateReq{Full: true}) })
 	go kubectl.Run(stopCh)
 	return nil
 }
@@ -126,7 +126,7 @@ func (m *Multicluster) DeleteMemberCluster(clusterID string) error {
 	close(m.remoteKubeControllers[clusterID].stopCh)
 	delete(m.remoteKubeControllers, clusterID)
 	if m.XDSUpdater != nil {
-		m.XDSUpdater.ConfigUpdate(true)
+		m.XDSUpdater.ConfigUpdate(model.UpdateReq{Full: true})
 	}
 
 	return nil

--- a/pilot/pkg/config/clusterregistry/multicluster.go
+++ b/pilot/pkg/config/clusterregistry/multicluster.go
@@ -105,8 +105,8 @@ func (m *Multicluster) AddMemberCluster(clientset kubernetes.Interface, clusterI
 
 	m.remoteKubeControllers[clusterID] = &remoteKubeController
 	m.m.Unlock()
-	_ = kubectl.AppendServiceHandler(func(*model.Service, model.Event) { m.XDSUpdater.ConfigUpdate(model.UpdateReq{Full: true}) })
-	_ = kubectl.AppendInstanceHandler(func(*model.ServiceInstance, model.Event) { m.XDSUpdater.ConfigUpdate(model.UpdateReq{Full: true}) })
+	_ = kubectl.AppendServiceHandler(func(*model.Service, model.Event) { m.XDSUpdater.ConfigUpdate(model.UpdateRequest{Full: true}) })
+	_ = kubectl.AppendInstanceHandler(func(*model.ServiceInstance, model.Event) { m.XDSUpdater.ConfigUpdate(model.UpdateRequest{Full: true}) })
 	go kubectl.Run(stopCh)
 	return nil
 }
@@ -126,7 +126,7 @@ func (m *Multicluster) DeleteMemberCluster(clusterID string) error {
 	close(m.remoteKubeControllers[clusterID].stopCh)
 	delete(m.remoteKubeControllers, clusterID)
 	if m.XDSUpdater != nil {
-		m.XDSUpdater.ConfigUpdate(model.UpdateReq{Full: true})
+		m.XDSUpdater.ConfigUpdate(model.UpdateRequest{Full: true})
 	}
 
 	return nil

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -162,6 +162,13 @@ var (
 			"could result in an infinite loop of traffic. This option is only provided for backward compatibility purposes "+
 			"and will be removed in the near future.",
 	)
+
+	ScopePushes = env.RegisterBoolVar(
+		"PILOT_SCOPE_PUSHES",
+		true,
+		"If enabled, pilot will attempt to limit unnecessary pushes by determining what proxies "+
+			"a config or endpoint update will impact.",
+	)
 )
 
 var (

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -145,12 +145,12 @@ type UpdateReq struct {
 	// Full determines whether a full push is required or not. If set to false, only endpoints will be sent.
 	Full bool
 
-	// UpdateNamespaces contains a list of namespaces that were changed in the update.
+	// TargetNamespaces contains a list of namespaces that were changed in the update.
 	// This is used as an optimization to avoid unnecessary pushes to proxies that are scoped with a Sidecar.
 	// Currently, this will only scope EDS updates, as config updates are more complicated.
 	// If this is empty, then proxies in all namespaces will get an update
 	// If this is present, then only proxies that import this namespace will get an update
-	UpdateNamespaces map[string]struct{}
+	TargetNamespaces map[string]struct{}
 }
 
 // Merge two update requests together
@@ -161,12 +161,12 @@ func (first *UpdateReq) Merge(other *UpdateReq) *UpdateReq {
 	first.Full = first.Full || other.Full
 
 	// If either does not specify only namespaces, this means update all namespaces
-	if len(first.UpdateNamespaces) == 0 || len(other.UpdateNamespaces) == 0 {
-		first.UpdateNamespaces = map[string]struct{}{}
+	if len(first.TargetNamespaces) == 0 || len(other.TargetNamespaces) == 0 {
+		first.TargetNamespaces = map[string]struct{}{}
 	} else {
 		// Merge the updates
-		for update := range other.UpdateNamespaces {
-			first.UpdateNamespaces[update] = struct{}{}
+		for update := range other.TargetNamespaces {
+			first.TargetNamespaces[update] = struct{}{}
 		}
 	}
 	return first

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package model
 
 import (

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeUpdateRequest(t *testing.T) {
+	cases := []struct {
+		name   string
+		left   *UpdateRequest
+		right  *UpdateRequest
+		merged UpdateRequest
+	}{
+		{
+			"left nil",
+			nil,
+			&UpdateRequest{true, nil},
+			UpdateRequest{true, nil},
+		},
+		{
+			"right nil",
+			&UpdateRequest{true, nil},
+			nil,
+			UpdateRequest{true, nil},
+		},
+		{
+			"simple merge",
+			&UpdateRequest{true, map[string]struct{}{"ns1": {}}},
+			&UpdateRequest{false, map[string]struct{}{"ns2": {}}},
+			UpdateRequest{true, map[string]struct{}{"ns1": {}, "ns2": {}}},
+		},
+		{
+			"incremental merge",
+			&UpdateRequest{false, map[string]struct{}{"ns1": {}}},
+			&UpdateRequest{false, map[string]struct{}{"ns2": {}}},
+			UpdateRequest{false, map[string]struct{}{"ns1": {}, "ns2": {}}},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.left.Merge(tt.right)
+			if !reflect.DeepEqual(tt.merged, got) {
+				t.Fatalf("expected %v, got %v", tt.merged, got)
+			}
+		})
+	}
+}

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -373,6 +373,20 @@ func (ilw *IstioEgressListenerWrapper) VirtualServices() []Config {
 	return ilw.virtualServices
 }
 
+// ContainsEgressNamespace determines if the Sidecar includes the given namespace.
+func (ilw *IstioEgressListenerWrapper) ContainsEgressNamespace(namespace string) bool {
+	if ilw == nil {
+		return true
+	}
+
+	for hostNs := range ilw.listenerHosts {
+		if hostNs == wildcardNamespace || namespace == hostNs {
+			return true
+		}
+	}
+	return false
+}
+
 // Given a list of virtual services visible to this namespace,
 // selectVirtualServices returns the list of virtual services that are
 // applicable to this egress listener, based on the hosts field specified

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -391,6 +391,8 @@ func TestContainsEgressNamespace(t *testing.T) {
 		{"Namespace and wildcard", []string{"ns/*", "*/*"}, "ns", true},
 		{"Just Namespace", []string{"ns/*"}, "ns", true},
 		{"Wrong Namespace", []string{"ns/*"}, "other-ns", false},
+		{"No Sidecar", nil, "ns", true},
+		{"No Sidecar Other Namespace", nil, "other-ns", false},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -412,7 +414,16 @@ func TestContainsEgressNamespace(t *testing.T) {
 			ps.Env = &Environment{
 				Mesh: &meshConfig,
 			}
+
+			services := []*Service{
+				{Hostname: "nomatch", Attributes: ServiceAttributes{Namespace: "nomatch"}},
+				{Hostname: "ns", Attributes: ServiceAttributes{Namespace: "ns"}},
+			}
+			ps.publicServices = append(ps.publicServices, services...)
 			sidecarScope := ConvertToSidecarScope(ps, cfg, "default")
+			if len(tt.egress) == 0 {
+				sidecarScope = DefaultSidecarScopeForNamespace(ps, "default")
+			}
 
 			got := sidecarScope.DependsOnNamespace(tt.namespace)
 			if got != tt.contains {

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -380,6 +380,34 @@ func TestIstioEgressListenerWrapper(t *testing.T) {
 	}
 }
 
+func TestContainsEgressNamespace(t *testing.T) {
+	cases := []struct {
+		name      string
+		egress    []string
+		namespace string
+		contains  bool
+	}{
+		{"Just wildcard", []string{"*"}, "ns", true},
+		{"Namespace and wildcard", []string{"ns", "*"}, "ns", true},
+		{"Just Namespace", []string{"ns"}, "ns", true},
+		{"Wrong Namespace", []string{"ns"}, "other-ns", false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			lw := &IstioEgressListenerWrapper{
+				listenerHosts: make(map[string][]config.Hostname),
+			}
+			for _, ns := range tt.egress {
+				lw.listenerHosts[ns] = []config.Hostname{}
+			}
+			got := lw.ContainsEgressNamespace(tt.namespace)
+			if got != tt.contains {
+				t.Fatalf("Expected contains %v, got %v", got, tt.contains)
+			}
+		})
+	}
+}
+
 func TestSidecarOutboundTrafficPolicy(t *testing.T) {
 
 	configWithoutOutboundTrafficPolicy := &Config{

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -31,6 +31,8 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
+	"istio.io/istio/pilot/pkg/features"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	istiolog "istio.io/pkg/log"
@@ -605,16 +607,16 @@ func adsClientCount() int {
 
 // AdsPushAll will send updates to all nodes, for a full config or incremental EDS.
 func AdsPushAll(s *DiscoveryServer) {
-	s.AdsPushAll(versionInfo(), s.globalPushContext(), true, nil)
+	s.AdsPushAll(versionInfo(), s.globalPushContext(), &model.UpdateReq{Full: true}, nil)
 }
 
 // AdsPushAll implements old style invalidation, generated when any rule or endpoint changes.
 // Primary code path is from v1 discoveryService.clearCache(), which is added as a handler
 // to the model ConfigStorageCache and Controller.
 func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext,
-	full bool, edsUpdates map[string]struct{}) {
-	if !full {
-		s.edsIncremental(version, push, edsUpdates)
+	req *model.UpdateReq, edsUpdates map[string]struct{}) {
+	if !req.Full {
+		s.edsIncremental(version, push, edsUpdates, req)
 		return
 	}
 
@@ -644,11 +646,11 @@ func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext,
 		}
 	}
 	adsLog.Infof("Cluster init time %v %s", time.Since(t0), version)
-	s.startPush(push, true, nil)
+	s.startPush(push, req, nil)
 }
 
 // Send a signal to all connections, with a push event.
-func (s *DiscoveryServer) startPush(push *model.PushContext, full bool, edsUpdates map[string]struct{}) {
+func (s *DiscoveryServer) startPush(push *model.PushContext, req *model.UpdateReq, edsUpdates map[string]struct{}) {
 
 	// Push config changes, iterating over connected envoys. This cover ADS and EDS(0.7), both share
 	// the same connection table
@@ -666,9 +668,33 @@ func (s *DiscoveryServer) startPush(push *model.PushContext, full bool, edsUpdat
 	}
 	startTime := time.Now()
 	for _, p := range pending {
-		pushEvent := &PushEvent{edsUpdates, push, startTime, full}
-		s.pushQueue.Enqueue(p, pushEvent)
+		if proxyNeedsPush(p, req) {
+			s.pushQueue.Enqueue(p, &PushEvent{edsUpdates, push, startTime, req.Full})
+		}
 	}
+}
+
+func proxyNeedsPush(con *XdsConnection, req *model.UpdateReq) bool {
+	if !features.ScopePushes.Get() {
+		// If push scoping is not enabled, we push for all proxies
+		return true
+	}
+
+	// If no only namespaces specified, this request applies to all proxies
+	if len(req.UpdateNamespaces) == 0 {
+		return true
+	}
+
+	// Otherwise, only apply if the egress listener will import the config present in the update
+	for _, egress := range con.modelNode.SidecarScope.EgressListeners {
+		for ns := range req.UpdateNamespaces {
+			if egress.ContainsEgressNamespace(ns) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (s *DiscoveryServer) addCon(conID string, con *XdsConnection) {

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -681,16 +681,14 @@ func proxyNeedsPush(con *XdsConnection, req *model.UpdateReq) bool {
 	}
 
 	// If no only namespaces specified, this request applies to all proxies
-	if len(req.UpdateNamespaces) == 0 {
+	if len(req.TargetNamespaces) == 0 {
 		return true
 	}
 
 	// Otherwise, only apply if the egress listener will import the config present in the update
-	for _, egress := range con.modelNode.SidecarScope.EgressListeners {
-		for ns := range req.UpdateNamespaces {
-			if egress.ContainsEgressNamespace(ns) {
-				return true
-			}
+	for ns := range req.TargetNamespaces {
+		if con.modelNode.SidecarScope.DependsOnNamespace(ns) {
+			return true
 		}
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -607,14 +607,14 @@ func adsClientCount() int {
 
 // AdsPushAll will send updates to all nodes, for a full config or incremental EDS.
 func AdsPushAll(s *DiscoveryServer) {
-	s.AdsPushAll(versionInfo(), s.globalPushContext(), &model.UpdateReq{Full: true}, nil)
+	s.AdsPushAll(versionInfo(), s.globalPushContext(), &model.UpdateRequest{Full: true}, nil)
 }
 
 // AdsPushAll implements old style invalidation, generated when any rule or endpoint changes.
 // Primary code path is from v1 discoveryService.clearCache(), which is added as a handler
 // to the model ConfigStorageCache and Controller.
 func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext,
-	req *model.UpdateReq, edsUpdates map[string]struct{}) {
+	req *model.UpdateRequest, edsUpdates map[string]struct{}) {
 	if !req.Full {
 		s.edsIncremental(version, push, edsUpdates, req)
 		return
@@ -650,7 +650,7 @@ func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext,
 }
 
 // Send a signal to all connections, with a push event.
-func (s *DiscoveryServer) startPush(push *model.PushContext, req *model.UpdateReq, edsUpdates map[string]struct{}) {
+func (s *DiscoveryServer) startPush(push *model.PushContext, req *model.UpdateRequest, edsUpdates map[string]struct{}) {
 
 	// Push config changes, iterating over connected envoys. This cover ADS and EDS(0.7), both share
 	// the same connection table
@@ -674,7 +674,7 @@ func (s *DiscoveryServer) startPush(push *model.PushContext, req *model.UpdateRe
 	}
 }
 
-func proxyNeedsPush(con *XdsConnection, req *model.UpdateReq) bool {
+func proxyNeedsPush(con *XdsConnection, req *model.UpdateRequest) bool {
 	if !features.ScopePushes.Get() {
 		// If push scoping is not enabled, we push for all proxies
 		return true

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -116,7 +116,7 @@ type DiscoveryServer struct {
 	// pushes between the 2 packages.
 	edsUpdates map[string]struct{}
 
-	updateChannel chan *updateReq
+	updateChannel chan *model.UpdateReq
 
 	// mutex used for config update scheduling (former cache update mutex)
 	updateMutex sync.RWMutex
@@ -129,11 +129,6 @@ type DiscoveryServer struct {
 
 	// pushQueue is the buffer that used after debounce and before the real xds push.
 	pushQueue *PushQueue
-}
-
-// updateReq includes info about the requested update.
-type updateReq struct {
-	full bool
 }
 
 // EndpointShards holds the set of endpoint shards of a service. Registries update
@@ -180,7 +175,7 @@ func NewDiscoveryServer(
 		edsUpdates:              map[string]struct{}{},
 		proxyUpdates:            map[string]struct{}{},
 		concurrentPushLimit:     make(chan struct{}, features.PushThrottle),
-		updateChannel:           make(chan *updateReq, 10),
+		updateChannel:           make(chan *model.UpdateReq, 10),
 		pushQueue:               NewPushQueue(),
 	}
 
@@ -244,7 +239,7 @@ func (s *DiscoveryServer) periodicRefresh(stopCh <-chan struct{}) {
 		select {
 		case <-ticker.C:
 			adsLog.Debugf("ADS: Periodic push of envoy configs version:%s", versionInfo())
-			s.AdsPushAll(versionInfo(), s.globalPushContext(), true, nil)
+			s.AdsPushAll(versionInfo(), s.globalPushContext(), &model.UpdateReq{Full: true}, nil)
 		case <-stopCh:
 			return
 		}
@@ -279,9 +274,9 @@ func (s *DiscoveryServer) periodicRefreshMetrics(stopCh <-chan struct{}) {
 
 // Push is called to push changes on config updates using ADS. This is set in DiscoveryService.Push,
 // to avoid direct dependencies.
-func (s *DiscoveryServer) Push(full bool, edsUpdates map[string]struct{}) {
-	if !full {
-		go s.AdsPushAll(versionInfo(), s.globalPushContext(), false, edsUpdates)
+func (s *DiscoveryServer) Push(req *model.UpdateReq, edsUpdates map[string]struct{}) {
+	if !req.Full {
+		go s.AdsPushAll(versionInfo(), s.globalPushContext(), req, edsUpdates)
 		return
 	}
 	// Reset the status during the push.
@@ -318,7 +313,7 @@ func (s *DiscoveryServer) Push(full bool, edsUpdates map[string]struct{}) {
 	version = versionLocal
 	versionMutex.Unlock()
 
-	go s.AdsPushAll(versionLocal, push, true, nil)
+	go s.AdsPushAll(versionLocal, push, req, nil)
 }
 
 func nonce() string {
@@ -345,7 +340,7 @@ func (s *DiscoveryServer) ClearCache() {
 }
 
 // Start the actual push. Called from a timer.
-func (s *DiscoveryServer) doPush(full bool) {
+func (s *DiscoveryServer) doPush(req *model.UpdateReq) {
 	// more config update events may happen while doPush is processing.
 	// we don't want to lose updates.
 	s.mutex.Lock()
@@ -355,21 +350,20 @@ func (s *DiscoveryServer) doPush(full bool) {
 	// Reset - any new updates will be tracked by the new map
 	s.edsUpdates = map[string]struct{}{}
 	s.mutex.Unlock()
-
-	s.Push(full, edsUpdates)
+	s.Push(req, edsUpdates)
 }
 
 // clearCache will clear all envoy caches. Called by service, instance and config handlers.
 // This will impact the performance, since envoy will need to recalculate.
 func (s *DiscoveryServer) clearCache() {
-	s.ConfigUpdate(true)
+	s.ConfigUpdate(model.UpdateReq{Full: true})
 }
 
 // ConfigUpdate implements ConfigUpdater interface, used to request pushes.
 // It replaces the 'clear cache' from v1.
-func (s *DiscoveryServer) ConfigUpdate(full bool) {
+func (s *DiscoveryServer) ConfigUpdate(req model.UpdateReq) {
 	inboundConfigUpdates.Increment()
-	s.updateChannel <- &updateReq{full: full}
+	s.updateChannel <- &req
 }
 
 // Debouncing and update request happens in a separate thread, it uses locks
@@ -385,7 +379,9 @@ func (s *DiscoveryServer) handleUpdates(stopCh <-chan struct{}) {
 	pushCounter := 0
 
 	debouncedEvents := 0
-	fullPush := false
+
+	// Keeps track of the update requests. If updates are debounce they will be merged.
+	var req *model.UpdateReq
 
 	for {
 		select {
@@ -396,10 +392,8 @@ func (s *DiscoveryServer) handleUpdates(stopCh <-chan struct{}) {
 				startDebounce = lastConfigUpdateTime
 			}
 			debouncedEvents++
-			// fullPush is sticky if any debounced event requires a fullPush
-			if r.full {
-				fullPush = true
-			}
+
+			req = req.Merge(r)
 
 		case now := <-timeChan:
 			timeChan = nil
@@ -411,10 +405,10 @@ func (s *DiscoveryServer) handleUpdates(stopCh <-chan struct{}) {
 				pushCounter++
 				adsLog.Infof("Push debounce stable[%d] %d: %v since last change, %v since last push, full=%v",
 					pushCounter, debouncedEvents,
-					quietTime, eventDelay, fullPush)
+					quietTime, eventDelay, req)
 
-				go s.doPush(fullPush)
-				fullPush = false
+				go s.doPush(req)
+				req = nil
 				debouncedEvents = 0
 				continue
 			}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -396,7 +396,7 @@ func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, ports map[string]u
 
 // Update clusters for an incremental EDS push, and initiate the push.
 // Only clusters that changed are updated/pushed.
-func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext, edsUpdates map[string]struct{}) {
+func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext, edsUpdates map[string]struct{}, req *model.UpdateReq) {
 	adsLog.Infof("XDS:EDSInc Pushing:%s Services:%v ConnectedEndpoints:%d",
 		version, edsUpdates, adsClientCount())
 	t0 := time.Now()
@@ -426,7 +426,7 @@ func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext
 	}
 	adsLog.Infof("Cluster init time %v %s", time.Since(t0), version)
 
-	s.startPush(push, false, edsUpdates)
+	s.startPush(push, req, edsUpdates)
 }
 
 // WorkloadUpdate is called when workload labels/annotations are updated.
@@ -483,7 +483,7 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, workloadLabels map[string]st
 	// no other workload can be affected. Safer option is to fallback to full push.
 
 	adsLog.Infof("Label change, full push %s ", id)
-	s.ConfigUpdate(true)
+	s.ConfigUpdate(model.UpdateReq{Full: true})
 }
 
 // EDSUpdate computes destination address membership across all clusters and networks.
@@ -574,11 +574,7 @@ func (s *DiscoveryServer) edsUpdate(shard, serviceName string, namespace string,
 	// no need to trigger push here.
 	// It is done in DiscoveryServer.Push --> AdsPushAll
 	if !internal {
-		if requireFull {
-			s.ConfigUpdate(true)
-		} else {
-			s.ConfigUpdate(false)
-		}
+		s.ConfigUpdate(model.UpdateReq{Full: requireFull, UpdateNamespaces: map[string]struct{}{namespace: {}}})
 	}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -396,7 +396,7 @@ func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, ports map[string]u
 
 // Update clusters for an incremental EDS push, and initiate the push.
 // Only clusters that changed are updated/pushed.
-func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext, edsUpdates map[string]struct{}, req *model.UpdateReq) {
+func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext, edsUpdates map[string]struct{}, req *model.UpdateRequest) {
 	adsLog.Infof("XDS:EDSInc Pushing:%s Services:%v ConnectedEndpoints:%d",
 		version, edsUpdates, adsClientCount())
 	t0 := time.Now()
@@ -483,7 +483,7 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, workloadLabels map[string]st
 	// no other workload can be affected. Safer option is to fallback to full push.
 
 	adsLog.Infof("Label change, full push %s ", id)
-	s.ConfigUpdate(model.UpdateReq{Full: true})
+	s.ConfigUpdate(model.UpdateRequest{Full: true})
 }
 
 // EDSUpdate computes destination address membership across all clusters and networks.
@@ -574,7 +574,7 @@ func (s *DiscoveryServer) edsUpdate(shard, serviceName string, namespace string,
 	// no need to trigger push here.
 	// It is done in DiscoveryServer.Push --> AdsPushAll
 	if !internal {
-		s.ConfigUpdate(model.UpdateReq{Full: requireFull, TargetNamespaces: map[string]struct{}{namespace: {}}})
+		s.ConfigUpdate(model.UpdateRequest{Full: requireFull, TargetNamespaces: map[string]struct{}{namespace: {}}})
 	}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -574,7 +574,7 @@ func (s *DiscoveryServer) edsUpdate(shard, serviceName string, namespace string,
 	// no need to trigger push here.
 	// It is done in DiscoveryServer.Push --> AdsPushAll
 	if !internal {
-		s.ConfigUpdate(model.UpdateReq{Full: requireFull, UpdateNamespaces: map[string]struct{}{namespace: {}}})
+		s.ConfigUpdate(model.UpdateReq{Full: requireFull, TargetNamespaces: map[string]struct{}{namespace: {}}})
 	}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -208,7 +208,7 @@ func addTestClientEndpoints(server *bootstrap.Server) {
 			Locality: asdc2Locality,
 		},
 	})
-	server.EnvoyXdsServer.Push(&model.UpdateReq{Full: true}, nil)
+	server.EnvoyXdsServer.Push(&model.UpdateRequest{Full: true}, nil)
 }
 
 // Verify server sends the endpoint. This check for a single endpoint with the given
@@ -257,7 +257,7 @@ func testOverlappingPorts(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.
 	// Test initial state
 	testEndpoints("10.0.0.53", "outbound|53||overlapping.cluster.local", adsc, t)
 
-	server.EnvoyXdsServer.Push(&model.UpdateReq{Full: true}, map[string]struct{}{
+	server.EnvoyXdsServer.Push(&model.UpdateRequest{Full: true}, map[string]struct{}{
 		"overlapping.cluster.local": {},
 	})
 	_, _ = adsc.Wait("", 5*time.Second)
@@ -518,7 +518,7 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 			updates := map[string]struct{}{
 				edsIncSvc: {},
 			}
-			server.EnvoyXdsServer.AdsPushAll(strconv.Itoa(j), server.EnvoyXdsServer.Env.PushContext, &model.UpdateReq{Full: true}, updates)
+			server.EnvoyXdsServer.AdsPushAll(strconv.Itoa(j), server.EnvoyXdsServer.Env.PushContext, &model.UpdateRequest{Full: true}, updates)
 		} else {
 			v2.AdsPushAll(server.EnvoyXdsServer)
 		}
@@ -585,7 +585,7 @@ func addUdsEndpoint(server *bootstrap.Server) {
 		Labels: map[string]string{"socket": "unix"},
 	})
 
-	server.EnvoyXdsServer.Push(&model.UpdateReq{Full: true}, nil)
+	server.EnvoyXdsServer.Push(&model.UpdateRequest{Full: true}, nil)
 }
 
 func addLocalityEndpoints(server *bootstrap.Server, hostname host.Name) {
@@ -622,7 +622,7 @@ func addLocalityEndpoints(server *bootstrap.Server, hostname host.Name) {
 			},
 		})
 	}
-	server.EnvoyXdsServer.Push(&model.UpdateReq{Full: true}, nil)
+	server.EnvoyXdsServer.Push(&model.UpdateRequest{Full: true}, nil)
 }
 
 func addOverlappingEndpoints(server *bootstrap.Server) {
@@ -652,7 +652,7 @@ func addOverlappingEndpoints(server *bootstrap.Server) {
 			},
 		},
 	})
-	server.EnvoyXdsServer.Push(&model.UpdateReq{Full: true}, nil)
+	server.EnvoyXdsServer.Push(&model.UpdateRequest{Full: true}, nil)
 }
 
 // Verify the endpoint debug interface is installed and returns some string.

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -208,7 +208,7 @@ func addTestClientEndpoints(server *bootstrap.Server) {
 			Locality: asdc2Locality,
 		},
 	})
-	server.EnvoyXdsServer.Push(true, nil)
+	server.EnvoyXdsServer.Push(&model.UpdateReq{Full: true}, nil)
 }
 
 // Verify server sends the endpoint. This check for a single endpoint with the given
@@ -257,7 +257,7 @@ func testOverlappingPorts(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.
 	// Test initial state
 	testEndpoints("10.0.0.53", "outbound|53||overlapping.cluster.local", adsc, t)
 
-	server.EnvoyXdsServer.Push(false, map[string]struct{}{
+	server.EnvoyXdsServer.Push(&model.UpdateReq{Full: true}, map[string]struct{}{
 		"overlapping.cluster.local": {},
 	})
 	_, _ = adsc.Wait("", 5*time.Second)
@@ -518,7 +518,7 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 			updates := map[string]struct{}{
 				edsIncSvc: {},
 			}
-			server.EnvoyXdsServer.AdsPushAll(strconv.Itoa(j), server.EnvoyXdsServer.Env.PushContext, false, updates)
+			server.EnvoyXdsServer.AdsPushAll(strconv.Itoa(j), server.EnvoyXdsServer.Env.PushContext, &model.UpdateReq{Full: true}, updates)
 		} else {
 			v2.AdsPushAll(server.EnvoyXdsServer)
 		}
@@ -585,7 +585,7 @@ func addUdsEndpoint(server *bootstrap.Server) {
 		Labels: map[string]string{"socket": "unix"},
 	})
 
-	server.EnvoyXdsServer.Push(true, nil)
+	server.EnvoyXdsServer.Push(&model.UpdateReq{Full: true}, nil)
 }
 
 func addLocalityEndpoints(server *bootstrap.Server, hostname host.Name) {
@@ -622,7 +622,7 @@ func addLocalityEndpoints(server *bootstrap.Server, hostname host.Name) {
 			},
 		})
 	}
-	server.EnvoyXdsServer.Push(true, nil)
+	server.EnvoyXdsServer.Push(&model.UpdateReq{Full: true}, nil)
 }
 
 func addOverlappingEndpoints(server *bootstrap.Server) {
@@ -652,7 +652,7 @@ func addOverlappingEndpoints(server *bootstrap.Server) {
 			},
 		},
 	})
-	server.EnvoyXdsServer.Push(true, nil)
+	server.EnvoyXdsServer.Push(&model.UpdateReq{Full: true}, nil)
 }
 
 // Verify the endpoint debug interface is installed and returns some string.

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -204,7 +204,7 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
+	server.EnvoyXdsServer.ConfigUpdate(model.UpdateRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -276,7 +276,7 @@ func TestLDSWithIngressGateway(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
+	server.EnvoyXdsServer.ConfigUpdate(model.UpdateRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -402,7 +402,7 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
+	server.EnvoyXdsServer.ConfigUpdate(model.UpdateRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -480,7 +480,7 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
+	server.EnvoyXdsServer.ConfigUpdate(model.UpdateRequest{Full: true})
 	defer tearDown()
 
 	tests := []struct {

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -204,7 +204,7 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(true)
+	server.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -276,7 +276,7 @@ func TestLDSWithIngressGateway(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(true)
+	server.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -402,7 +402,7 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(true)
+	server.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -480,7 +480,7 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(true)
+	server.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
 	defer tearDown()
 
 	tests := []struct {

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -284,7 +284,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 	server.EnvoyXdsServer.WorkloadUpdate("127.0.0.4", map[string]string{"version": "v1"}, nil)
 
 	// Update cache
-	server.EnvoyXdsServer.ConfigUpdate(true)
+	server.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
 	// TODO: channel to notify when the push is finished and to notify individual updates, for
 	// debug and for the canary.
 	time.Sleep(2 * time.Second)

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -284,7 +284,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 	server.EnvoyXdsServer.WorkloadUpdate("127.0.0.4", map[string]string{"version": "v1"}, nil)
 
 	// Update cache
-	server.EnvoyXdsServer.ConfigUpdate(model.UpdateReq{Full: true})
+	server.EnvoyXdsServer.ConfigUpdate(model.UpdateRequest{Full: true})
 	// TODO: channel to notify when the push is finished and to notify individual updates, for
 	// debug and for the canary.
 	time.Sleep(2 * time.Second)

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -66,7 +66,7 @@ const (
 	domainSuffix = "company.com"
 )
 
-func (*FakeXdsUpdater) ConfigUpdate(model.UpdateReq) {
+func (*FakeXdsUpdater) ConfigUpdate(model.UpdateRequest) {
 
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -66,7 +66,7 @@ const (
 	domainSuffix = "company.com"
 )
 
-func (*FakeXdsUpdater) ConfigUpdate(bool) {
+func (*FakeXdsUpdater) ConfigUpdate(model.UpdateReq) {
 
 }
 


### PR DESCRIPTION
Currently, any config or endpoint update in the cluster will trigger a
push to all proxies. With Sidecar isolation, this results in a lot of
unneeded pushes. Using the egress field of Sidecar, we can determine
which proxies need an update and selectively send to only those proxies.

Currently, this only does scoping for EDS, not config updates. This is
much simpler, because EDS updates are pretty straightforward, whereas
config updates are not - some configs affect cross namespace for
example. The larger problem with config updates is that we don't have
incremental MCP enabled, so we cannot tell what changed in an update.

For now doing EDS only will give us the initial logic for this and can
be extend once/if we can support config updates as well.

Dashboard from a small synthetic test where I have a sidecar and create and remove endpoints in another namespace: https://snapshot.raintank.io/dashboard/snapshot/3Vd0fn74itNXksqfDue2dRJ3J55ZRo22?orgId=2 You can see with my change there are way less EDS updates as expected.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
