### PR TITLE
Moving config visibility utils to subpackage

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -34,8 +34,10 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 
 	authn "istio.io/api/authentication/v1alpha1"
+
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/visibility"
 )
 
 // Service describes an Istio service (e.g., catalog.mystore.com:8080)
@@ -349,7 +351,7 @@ type ServiceAttributes struct {
 	UID string
 	// ExportTo defines the visibility of Service in
 	// a namespace when the namespace is imported.
-	ExportTo map[config.Visibility]bool
+	ExportTo map[visibility.Instance]bool
 
 	// For Kubernetes platform
 

--- a/pilot/pkg/serviceregistry/external/conversion.go
+++ b/pilot/pkg/serviceregistry/external/conversion.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/visibility"
 )
 
 func convertPort(port *networking.Port) *model.Port {
@@ -55,11 +56,11 @@ func convertServices(cfg model.Config) []*model.Service {
 		svcPorts = append(svcPorts, convertPort(port))
 	}
 
-	var exportTo map[config.Visibility]bool
+	var exportTo map[visibility.Instance]bool
 	if len(serviceEntry.ExportTo) > 0 {
-		exportTo = make(map[config.Visibility]bool)
+		exportTo = make(map[visibility.Instance]bool)
 		for _, e := range serviceEntry.ExportTo {
-			exportTo[config.Visibility(e)] = true
+			exportTo[visibility.Instance(e)] = true
 		}
 	}
 

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/kube"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/spiffe"
 )
 
@@ -76,7 +77,7 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 		ports = append(ports, convertPort(port))
 	}
 
-	var exportTo map[config.Visibility]bool
+	var exportTo map[visibility.Instance]bool
 	serviceaccounts := make([]string, 0)
 	if svc.Annotations != nil {
 		if svc.Annotations[annotation.AlphaCanonicalServiceAccounts.Name] != "" {
@@ -88,9 +89,9 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 			}
 		}
 		if svc.Annotations[annotation.NetworkingExportTo.Name] != "" {
-			exportTo = make(map[config.Visibility]bool)
+			exportTo = make(map[visibility.Instance]bool)
 			for _, e := range strings.Split(svc.Annotations[annotation.NetworkingExportTo.Name], ",") {
-				exportTo[config.Visibility(e)] = true
+				exportTo[visibility.Instance(e)] = true
 			}
 		}
 	}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -40,6 +40,7 @@ import (
 
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/visibility"
 )
 
 const (
@@ -453,7 +454,7 @@ func validateExportTo(exportTo []string) (errs error) {
 		if len(exportTo) > 1 {
 			errs = appendErrors(errs, fmt.Errorf("exportTo should have only one entry (. or *) in the current release"))
 		} else {
-			errs = appendErrors(errs, Visibility(exportTo[0]).Validate())
+			errs = appendErrors(errs, visibility.Instance(exportTo[0]).Validate())
 		}
 	}
 

--- a/pkg/config/visibility/visibility.go
+++ b/pkg/config/visibility/visibility.go
@@ -12,24 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package visibility
 
 import "fmt"
 
-// Visibility defines whether a given config or service is exported to local namespace, all namespaces or none
-type Visibility string
+// Instance defines whether a given config or service is exported to local namespace, all namespaces or none
+type Instance string
 
 const (
-	// VisibilityPrivate implies namespace local config
-	VisibilityPrivate Visibility = "."
-	// VisibilityPublic implies config is visible to all
-	VisibilityPublic Visibility = "*"
+	// Private implies namespace local config
+	Private Instance = "."
+	// Public implies config is visible to all
+	Public Instance = "*"
 )
 
 // Validate a visibility value.
-func (v Visibility) Validate() (errs error) {
+func (v Instance) Validate() (errs error) {
 	switch v {
-	case VisibilityPrivate, VisibilityPublic:
+	case Private, Public:
 		return nil
 	default:
 		return fmt.Errorf("only . or * is allowed in the exportTo in the current release")


### PR DESCRIPTION
This is part of the cleanup of pkg/config. Planning on moving everything here to subpackages.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
