### PR TITLE
Replace hard-coded mTLS mount paths with designated constants

### DIFF
--- a/galley/cmd/galley/cmd/server.go
+++ b/galley/cmd/galley/cmd/server.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/galley/pkg/server"
 	"istio.io/istio/galley/pkg/server/settings"
 	istiocmd "istio.io/istio/pkg/cmd"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/pkg/log"
 )
 
@@ -100,11 +101,11 @@ func serverCmd() *cobra.Command {
 		"Use a Kubernetes configuration file instead of in-cluster configuration")
 	serverCmd.PersistentFlags().DurationVar(&serverArgs.ResyncPeriod, "resyncPeriod", serverArgs.ResyncPeriod,
 		"Resync period for rescanning Kubernetes resources")
-	serverCmd.PersistentFlags().StringVar(&serverArgs.CredentialOptions.CertificateFile, "tlsCertFile", "/etc/certs/cert-chain.pem",
+	serverCmd.PersistentFlags().StringVar(&serverArgs.CredentialOptions.CertificateFile, "tlsCertFile", constants.DefaultCertChain,
 		"File containing the x509 Certificate for HTTPS.")
-	serverCmd.PersistentFlags().StringVar(&serverArgs.CredentialOptions.KeyFile, "tlsKeyFile", "/etc/certs/key.pem",
+	serverCmd.PersistentFlags().StringVar(&serverArgs.CredentialOptions.KeyFile, "tlsKeyFile", constants.DefaultKey,
 		"File containing the x509 private key matching --tlsCertFile.")
-	serverCmd.PersistentFlags().StringVar(&serverArgs.CredentialOptions.CACertificateFile, "caCertFile", "/etc/certs/root-cert.pem",
+	serverCmd.PersistentFlags().StringVar(&serverArgs.CredentialOptions.CACertificateFile, "caCertFile", constants.DefaultRootCert,
 		"File containing the caBundle that signed the cert/key specified by --tlsCertFile and --tlsKeyFile.")
 	serverCmd.PersistentFlags().StringVar(&serverArgs.Liveness.Path, "livenessProbePath", serverArgs.Liveness.Path,
 		"Path to the file for the Galley liveness probe.")

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -38,6 +38,7 @@ import (
 	mixerCrd "istio.io/istio/mixer/pkg/config/crd"
 	"istio.io/istio/mixer/pkg/config/store"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema"
 )
 
@@ -158,9 +159,9 @@ func (p *WebhookParameters) String() string {
 func DefaultArgs() *WebhookParameters {
 	return &WebhookParameters{
 		Port:                                443,
-		CertFile:                            "/etc/certs/cert-chain.pem",
-		KeyFile:                             "/etc/certs/key.pem",
-		CACertFile:                          "/etc/certs/root-cert.pem",
+		CertFile:                            constants.DefaultCertChain,
+		KeyFile:                             constants.DefaultKey,
+		CACertFile:                          constants.DefaultRootCert,
 		DeploymentAndServiceNamespace:       "istio-system",
 		DeploymentName:                      "istio-galley",
 		ServiceName:                         "istio-galley",

--- a/security/cmd/node_agent/main.go
+++ b/security/cmd/node_agent/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra/doc"
 
 	pkgcmd "istio.io/istio/pkg/cmd"
+	"istio.io/istio/pkg/config/constants"
 	nvm "istio.io/istio/security/pkg/nodeagent/vm"
 	"istio.io/pkg/collateral"
 	"istio.io/pkg/log"
@@ -64,11 +65,11 @@ func init() {
 	flags.StringVar(&cAClientConfig.Platform, "platform", "vm", "The platform istio runs on: vm | k8s")
 
 	flags.StringVar(&cAClientConfig.CertChainFile, "cert-chain",
-		"/etc/certs/cert-chain.pem", "Node Agent identity cert file")
+		constants.DefaultCertChain, "Node Agent identity cert file")
 	flags.StringVar(&cAClientConfig.KeyFile,
-		"key", "/etc/certs/key.pem", "Node Agent private key file")
+		"key", constants.DefaultKey, "Node Agent private key file")
 	flags.StringVar(&cAClientConfig.RootCertFile, "root-cert",
-		"/etc/certs/root-cert.pem", "Root Certificate file")
+		constants.DefaultRootCert, "Root Certificate file")
 
 	flags.BoolVar(&naConfig.DualUse, "experimental-dual-use",
 		false, "Enable dual-use mode. Generates certificates with a CommonName identical to the SAN.")


### PR DESCRIPTION
Scattered throughout the codebase were explicit references to the expected mount path for mTLS secrets, when there are already designated constants for those values.

This short PR switches changes those references to use the constants where possible.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
