### PR TITLE
Skip old e2e tests if sds is enabled

### DIFF
--- a/tests/e2e/tests/pilot/authn_policy_test.go
+++ b/tests/e2e/tests/pilot/authn_policy_test.go
@@ -92,6 +92,13 @@ func TestMTlsWithAuthNPolicy(t *testing.T) {
 }
 
 func TestAuthNJwt(t *testing.T) {
+	// Skip test if SDS is enabled.
+	// Istio does not support legacy JWTs anymore.
+	// Only Kubernetes 1.12 (beta) and later support trustworthy JWTs.
+	if tc.Kube.AuthSdsEnabled {
+		t.Skipf("Skipping %s: auth_sds_enable=true=true.", t.Name())
+	}
+
 	validJwtToken := jwt.TokenIssuer1
 	validJwt2Token := jwt.TokenIssuer2
 	invalidJwtToken := jwt.TokenInvalid

--- a/tests/e2e/tests/pilot/grpc_test.go
+++ b/tests/e2e/tests/pilot/grpc_test.go
@@ -20,6 +20,13 @@ import (
 )
 
 func TestGrpc(t *testing.T) {
+	// Skip test if SDS is enabled.
+	// Istio does not support legacy JWTs anymore.
+	// Only Kubernetes 1.12 (beta) and later support trustworthy JWTs.
+	if tc.Kube.AuthSdsEnabled {
+		t.Skipf("Skipping %s: auth_sds_enable=true=true.", t.Name())
+	}
+
 	srcPods := []string{"a", "b"}
 	dstPods := []string{"a", "b", "headless"}
 	ports := []string{"70", "7070"}

--- a/tests/e2e/tests/pilot/http_test.go
+++ b/tests/e2e/tests/pilot/http_test.go
@@ -20,6 +20,13 @@ import (
 )
 
 func TestHttp(t *testing.T) {
+	// Skip test if SDS is enabled.
+	// Istio does not support legacy JWTs anymore.
+	// Only Kubernetes 1.12 (beta) and later support trustworthy JWTs.
+	if tc.Kube.AuthSdsEnabled {
+		t.Skipf("Skipping %s: auth_sds_enable=true=true.", t.Name())
+	}
+
 	srcPods := []string{"a", "b", "t"}
 	dstPods := []string{"a", "b", "headless"}
 	ports := []string{"", "80", "8080"}

--- a/tests/e2e/tests/pilot/ingressgateway_test.go
+++ b/tests/e2e/tests/pilot/ingressgateway_test.go
@@ -43,6 +43,13 @@ func maybeAddTLSForDestinationRule(tc *testConfig, templateFile string) string {
 // default (kube service level) to expose ports 80/443. So our gateway specs also expose
 // ports 80/443.
 func TestGateway_HTTPIngress(t *testing.T) {
+	// Skip test if SDS is enabled.
+	// Istio does not support legacy JWTs anymore.
+	// Only Kubernetes 1.12 (beta) and later support trustworthy JWTs.
+	if tc.Kube.AuthSdsEnabled {
+		t.Skipf("Skipping %s: auth_sds_enable=true=true.", t.Name())
+	}
+
 	istioNamespace := tc.Kube.IstioSystemNamespace()
 	ingressGatewayServiceName := tc.Kube.IstioIngressGatewayService()
 
@@ -78,6 +85,13 @@ func TestGateway_HTTPIngress(t *testing.T) {
 }
 
 func TestGateway_HTTPSIngress(t *testing.T) {
+	// Skip test if SDS is enabled.
+	// Istio does not support legacy JWTs anymore.
+	// Only Kubernetes 1.12 (beta) and later support trustworthy JWTs.
+	if tc.Kube.AuthSdsEnabled {
+		t.Skipf("Skipping %s: auth_sds_enable=true=true.", t.Name())
+	}
+
 	istioNamespace := tc.Kube.IstioSystemNamespace()
 	ingressGatewayServiceName := tc.Kube.IstioIngressGatewayService()
 
@@ -113,6 +127,13 @@ func TestGateway_HTTPSIngress(t *testing.T) {
 }
 
 func TestGateway_TCPIngress(t *testing.T) {
+	// Skip test if SDS is enabled.
+	// Istio does not support legacy JWTs anymore.
+	// Only Kubernetes 1.12 (beta) and later support trustworthy JWTs.
+	if tc.Kube.AuthSdsEnabled {
+		t.Skipf("Skipping %s: auth_sds_enable=true=true.", t.Name())
+	}
+
 	istioNamespace := tc.Kube.IstioSystemNamespace()
 	ingressGatewayServiceName := tc.Kube.IstioIngressGatewayService()
 
@@ -148,6 +169,13 @@ func TestGateway_TCPIngress(t *testing.T) {
 }
 
 func TestIngressGateway503DuringRuleChange(t *testing.T) {
+	// Skip test if SDS is enabled.
+	// Istio does not support legacy JWTs anymore.
+	// Only Kubernetes 1.12 (beta) and later support trustworthy JWTs.
+	if tc.Kube.AuthSdsEnabled {
+		t.Skipf("Skipping %s: auth_sds_enable=true=true.", t.Name())
+	}
+
 	istioNamespace := tc.Kube.IstioSystemNamespace()
 	ingressGatewayServiceName := tc.Kube.IstioIngressGatewayService()
 
@@ -265,6 +293,13 @@ cleanup:
 }
 
 func TestVirtualServiceMergingAtGateway(t *testing.T) {
+	// Skip test if SDS is enabled.
+	// Istio does not support legacy JWTs anymore.
+	// Only Kubernetes 1.12 (beta) and later support trustworthy JWTs.
+	if tc.Kube.AuthSdsEnabled {
+		t.Skipf("Skipping %s: auth_sds_enable=true=true.", t.Name())
+	}
+
 	istioNamespace := tc.Kube.IstioSystemNamespace()
 	ingressGatewayServiceName := tc.Kube.IstioIngressGatewayService()
 

--- a/tests/e2e/tests/pilot/istio_rbac_test.go
+++ b/tests/e2e/tests/pilot/istio_rbac_test.go
@@ -59,6 +59,13 @@ func setupRbacRules(t *testing.T, rules []string) *deployableConfig {
 }
 
 func TestRBACForSidecar(t *testing.T) {
+	// Skip test if SDS is enabled.
+	// Istio does not support legacy JWTs anymore.
+	// Only Kubernetes 1.12 (beta) and later support trustworthy JWTs.
+	if tc.Kube.AuthSdsEnabled {
+		t.Skipf("Skipping %s: auth_sds_enable=true=true.", t.Name())
+	}
+
 	cfgs := setupRbacRules(t, []string{rbacEnableTmpl, rbacRulesTmpl})
 	if cfgs != nil {
 		if err := cfgs.Setup(); err != nil {
@@ -176,6 +183,13 @@ func TestRBACForSidecar(t *testing.T) {
 }
 
 func TestRBACForEgressGateway(t *testing.T) {
+	// Skip test if SDS is enabled.
+	// Istio does not support legacy JWTs anymore.
+	// Only Kubernetes 1.12 (beta) and later support trustworthy JWTs.
+	if tc.Kube.AuthSdsEnabled {
+		t.Skipf("Skipping %s: auth_sds_enable=true=true.", t.Name())
+	}
+
 	// Only test when Authentication enabled, otherwise there is no client certificate for the source identity.
 	if !tc.Kube.AuthEnabled {
 		return


### PR DESCRIPTION
Skip old e2e tests if SDS is enabled, since Istio won't support legacy JWTs anymore and e2e tests are running on k8s 1.11 with no trustworthy JWT support. More context #15568 (tl;dr: SDS is only possible on k8s >= 1.12)

I was gonna remove the SDS test target but I see that there is a Pilot test inside it, maybe this is a mistake? https://github.com/istio/istio/blob/master/tests/istio.mk#L209 @howardjohn 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
