### PR TITLE
correct error receiving for potential bug

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -410,9 +410,9 @@ func runCA() {
 	// Blocking until receives error.
 	for {
 		select {
-		case <-monitorErrCh:
+		case err := <-monitorErrCh:
 			fatalf("Monitoring server error: %v", err)
-		case <-rotatorErrCh:
+		case err := <-rotatorErrCh:
 			fatalf("Key cert bundle rotator error: %v", err)
 		}
 	}


### PR DESCRIPTION
It's obvious that in the `fatalf` statement the errors should come from channel `monitorErrch` and `rotatorErrch` ,  and in the case `monitor` or `rotator` runs with some errors happening, the log should not be misleading .