### PR TITLE
remove internal port from template

### DIFF
--- a/galley/cmd/galley/cmd/server.go
+++ b/galley/cmd/galley/cmd/server.go
@@ -157,8 +157,8 @@ func serverCmd() *cobra.Command {
 	serverCmd.PersistentFlags().StringVar(&serverArgs.ValidationArgs.WebhookConfigFile,
 		"validation-webhook-config-file", "",
 		"File that contains k8s validatingwebhookconfiguration yaml. Required if enable-validation is true.")
-	serverCmd.PersistentFlags().UintVar(&serverArgs.ValidationArgs.Port, "validation-port", 443,
-		"HTTPS port of the validation service. Must be 443 if service has more than one port ")
+	serverCmd.PersistentFlags().UintVar(&serverArgs.ValidationArgs.Port, "validation-port", serverArgs.ValidationArgs.Port,
+		"HTTPS port of the validation service.")
 	serverCmd.PersistentFlags().BoolVar(&serverArgs.ValidationArgs.EnableValidation, "enable-validation", serverArgs.ValidationArgs.EnableValidation,
 		"Run galley validation mode")
 	serverCmd.PersistentFlags().BoolVar(&serverArgs.ValidationArgs.EnableReconcileWebhookConfiguration,

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
 {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
-          - containerPort: {{ .Values.validationPort }}
+          - containerPort: 9443
           - containerPort: {{ .Values.global.monitoringPort }}
           - containerPort: 9901
           command:
@@ -68,7 +68,6 @@ spec:
           - --validation-webhook-config-file
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort={{ .Values.global.monitoringPort }}
-          - --validation-port={{ .Values.validationPort }}
 {{- if $.Values.global.logging.level }}
           - --log_output_level={{ $.Values.global.logging.level }}
 {{- end}}

--- a/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
   ports:
   - port: 443
     name: https-validation
-    targetPort: {{ .Values.validationPort }}
+    targetPort: 9443
   - port: {{ .Values.global.monitoringPort }}
     name: http-monitoring
   - port: 9901

--- a/install/kubernetes/helm/istio/charts/galley/values.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/values.yaml
@@ -29,5 +29,3 @@ tolerations: []
 # "security" and value "S1".
 podAntiAffinityLabelSelector: []
 podAntiAffinityTermLabelSelector: []
-#HTTPS port of the validation service
-validationPort: 9443

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -49,7 +49,6 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/tmp/health
-            - --port={{ .Values.webhookPort }}
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/service.yaml
@@ -12,6 +12,6 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: {{ .Values.webhookPort }}
+    targetPort: 9443
   selector:
     istio: sidecar-injector

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
@@ -42,6 +42,3 @@ rewriteAppHTTPProbe: false
 neverInjectSelector: []
 
 alwaysInjectSelector: []
-
-# Webhook port
-webhookPort: 9443


### PR DESCRIPTION
Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>

this PR is to address the comments from @costinm 
> Please use it as default value in code, as it is used in a lot of other places.We do not need to add a user option for every internal port or thing that shows up in a template.

FYI @costinm 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[x] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
