### PR TITLE
compare header operations based on content, not operation order

### DIFF
--- a/mixer/pkg/runtime/dispatcher/session_test.go
+++ b/mixer/pkg/runtime/dispatcher/session_test.go
@@ -25,7 +25,6 @@ import (
 
 	tpb "istio.io/api/mixer/adapter/model/v1beta1"
 	mixerpb "istio.io/api/mixer/v1"
-	v1 "istio.io/api/mixer/v1"
 	descriptor "istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/pkg/attribute"
@@ -233,11 +232,11 @@ func TestDirectResponse(t *testing.T) {
 	}
 }
 
-func equalHeaderOperations(actual, expected []v1.HeaderOperation) bool {
+func equalHeaderOperations(actual, expected []mixerpb.HeaderOperation) bool {
 	if len(actual) != len(expected) {
 		return false
 	}
-	delta := make(map[v1.HeaderOperation]int)
+	delta := make(map[mixerpb.HeaderOperation]int)
 
 	for _, ex := range expected {
 		delta[ex]++

--- a/mixer/pkg/runtime/dispatcher/session_test.go
+++ b/mixer/pkg/runtime/dispatcher/session_test.go
@@ -132,7 +132,6 @@ func TestSession_EnsureParallelism(t *testing.T) {
 }
 
 func TestDirectResponse(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/15932")
 	testcases := []struct {
 		desc      string
 		status    rpc.Status


### PR DESCRIPTION
Fixes #15932

- existing comparison would detect differnt based on reflect package
- when header operation arrays have the same elements in different order, the comparison fails
- order based on map iteration (copying from direct response object) which is  not guaranteed to return keys in fixed order
- passes `go test ./mixer/pkg/runtime/dispatcher -run TestDirectResponse -count 1000`

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
