### PR TITLE
fix(redisquota): use dimensions in quota key to match memquota

### DIFF
--- a/mixer/adapter/redisquota/keys.go
+++ b/mixer/adapter/redisquota/keys.go
@@ -1,0 +1,95 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redisquota
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+
+	"istio.io/pkg/pool"
+)
+
+// we maintain a pool of these for use by the makeKey function
+type keyWorkspace struct {
+	keys []string
+}
+
+// pool of reusable keyWorkspace structs
+var keyWorkspacePool = sync.Pool{New: func() interface{} { return &keyWorkspace{} }}
+
+// makeKey produces a unique key representing the given labels.
+func makeKey(name string, labels map[string]interface{}) string {
+	ws := keyWorkspacePool.Get().(*keyWorkspace)
+	keys := ws.keys
+	buf := pool.GetBuffer()
+
+	// ensure stable order
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	buf.WriteString(name) // nolint: gas
+	for _, k := range keys {
+		buf.WriteString(";") // nolint: gas
+		buf.WriteString(k)   // nolint: gas
+		buf.WriteString("=") // nolint: gas
+
+		switch v := labels[k].(type) {
+		case string:
+			buf.WriteString(v) // nolint: gas
+		case int64:
+			var bytes [32]byte
+			buf.Write(strconv.AppendInt(bytes[:], v, 16)) // nolint: gas
+		case float64:
+			var bytes [32]byte
+			buf.Write(strconv.AppendFloat(bytes[:], v, 'b', -1, 64)) // nolint: gas
+		case bool:
+			var bytes [32]byte
+			buf.Write(strconv.AppendBool(bytes[:], v)) // nolint: gas
+		case []byte:
+			buf.Write(v) // nolint: gas
+		case map[string]string:
+			ws := keyWorkspacePool.Get().(*keyWorkspace)
+			mk := ws.keys
+
+			// ensure stable order
+			for k2 := range v {
+				mk = append(mk, k2)
+			}
+			sort.Strings(mk)
+
+			for _, k2 := range mk {
+				buf.WriteString(k2)    // nolint: gas
+				buf.WriteString(v[k2]) // nolint: gas
+			}
+
+			ws.keys = keys[:0]
+			keyWorkspacePool.Put(ws)
+		default:
+			buf.WriteString(v.(fmt.Stringer).String()) // nolint: gas
+		}
+	}
+
+	result := buf.String()
+	pool.PutBuffer(buf)
+
+	ws.keys = keys[:0]
+	keyWorkspacePool.Put(ws)
+
+	return result
+}

--- a/mixer/adapter/redisquota/redisquota.go
+++ b/mixer/adapter/redisquota/redisquota.go
@@ -289,7 +289,7 @@ func getAllocatedTokenFromResult(result *interface{}) (int64, time.Duration, err
 // find override
 func (h *handler) getKeyAndQuotaAmount(instance *quota.Instance, quota *config.Params_Quota) (string, int64, error) {
 	maxAmount := quota.MaxAmount
-	key := quota.Name
+	key := makeKey(quota.Name, instance.Dimensions)
 
 	for idx := range quota.Overrides {
 		if matchDimensions(&quota.Overrides[idx].Dimensions, &instance.Dimensions) {

--- a/mixer/adapter/redisquota/redisquota_test.go
+++ b/mixer/adapter/redisquota/redisquota_test.go
@@ -554,7 +554,7 @@ func TestHandleQuotaErrorMsg(t *testing.T) {
 				},
 			},
 			errMsg: []string{
-				"key: fixed-window maxAmount: 10",
+				"key: fixed-window;source=test maxAmount: 10",
 				"failed to run quota script: Error",
 			},
 		},
@@ -593,7 +593,7 @@ func TestHandleQuotaErrorMsg(t *testing.T) {
 				},
 			},
 			errMsg: []string{
-				"key: fixed-window maxAmount: 10",
+				"key: fixed-window;source=test maxAmount: 10",
 				"invalid response from the redis server: [10]",
 			},
 		},

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"istio.io/istio/pkg/test/framework/label"
-
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/bookinfo"
@@ -36,6 +34,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 	"istio.io/istio/pkg/test/framework/components/redis"
+	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	util "istio.io/istio/tests/integration/mixer"
 )


### PR DESCRIPTION
This PR is meant to address the issues raised in #15543 .

It duplicates the keys.go into the `redisquota` package (for simplicity) and updates the key definition to use `makeKey`.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
