### PR TITLE
Fix CODEOWNERS directory match

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,35 +1,35 @@
 *                                                               @costinm @geeknoid @howardjohn @linsun @rshriram
-bin/                                                            @costinm @douglas-reid @mandarjog @sdake
-galley/                                                         @geeknoid @ozevren
-install/                                                        @costinm @sdake @linsun @rshriram @howardjohn @mandarjog @morvencao @ostromart
-install/kubernetes/helm/istio/charts/galley/                    @costinm @sdake @linsun @rshriram @howardjohn @mandarjog @morvencao @ostromart @cmluciano @geeknoid @ozevren @ayj
-install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/    @costinm @sdake @linsun @rshriram @howardjohn @mandarjog @morvencao @ostromart
-istioctl/                                                       @ozevren @liamawhite @nmittler @esnible @fisherxu @irisdingbj
-mixer/                                                          @douglas-reid @geeknoid @kyessenov @mandarjog
-mixer/test/client/                                              @douglas-reid @geeknoid @kyessenov @mandarjog @qiwzhang @JimmyCYJ @kyessenov @lizan
-pilot/                                                          @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher
-pilot/pkg/networking/                                           @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher @costinm @GregHanson @rshriram @zackbutcher @ostromart
-pilot/pkg/networking/plugin/authn/                              @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher @costinm @GregHanson @rshriram @zackbutcher @ostromart @diemtvu @yangminzhu
-pilot/pkg/networking/plugin/authz/                              @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher @costinm @GregHanson @rshriram @zackbutcher @ostromart @diemtvu @yangminzhu
-pilot/pkg/networking/plugin/mixer/                              @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher @costinm @GregHanson @rshriram @zackbutcher @ostromart @kyessenov @douglas-reid @mandarjog
-pilot/pkg/security/                                             @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher @diemtvu @yangminzhu @quanjielin
-pkg/                                                            @nmittler @ozevren
-pkg/bootstrap/                                                  @mandarjog @costinm
-pkg/mcp/                                                        @ozevren @ayj @nmittler
-prow/                                                           @geeknoid @howardjohn @duderino @linsun
-release/                                                        @duderino @linsun
-samples/                                                        @frankbu @kyessenov @rshriram @vadimeisenbergibm @venilnoronha
-security/                                                       @diemtvu @incfly @myidpt @quanjielin @wattli
-tests/                                                          @costinm @nmittler
-tests/e2e/local/                                                @costinm @nmittler @gargnupur @kimikowang @JimmyCYJ @m1093782566
-tests/e2e/tests/pilot/                                          @costinm @nmittler @andraxylia @GregHanson @hzxuzhonghu @rshriram @vadimeisenbergibm @zackbutcher
-tests/integration/                                              @costinm @nmittler @ozevren
-tests/integration/conformance/                                  @costinm @nmittler @ozevren
-tests/integration/framework/                                    @costinm @nmittler @ozevren
-tests/integration/galley/                                       @costinm @nmittler @ozevren @geeknoid
-tests/integration/mixer/                                        @costinm @nmittler @ozevren @bianpengyuan @douglas-reid @gargnupur @geeknoid @kyessenov @mandarjog
-tests/integration/pilot/                                        @costinm @nmittler @ozevren @andraxylia @costinm @nmittler @rshriram
-tests/integration/qualification/                                @costinm @nmittler @ozevren
-tests/integration/security/                                     @costinm @nmittler @ozevren @diemtvu @incfly @myidpt @quanjielin @wattli @yangminzhu @JimmyCYJ
-tests/integration/security/rbac/                                @costinm @nmittler @ozevren @diemtvu @incfly @myidpt @quanjielin @wattli @yangminzhu @JimmyCYJ @yangminzhu @liminw
-tools/                                                          @sdake @mandarjog @nmittler
+/bin/                                                            @costinm @douglas-reid @mandarjog @sdake
+/galley/                                                         @geeknoid @ozevren
+/install/                                                        @costinm @sdake @linsun @rshriram @howardjohn @mandarjog @morvencao @ostromart
+/install/kubernetes/helm/istio/charts/galley/                    @costinm @sdake @linsun @rshriram @howardjohn @mandarjog @morvencao @ostromart @cmluciano @geeknoid @ozevren @ayj
+/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/    @costinm @sdake @linsun @rshriram @howardjohn @mandarjog @morvencao @ostromart
+/istioctl/                                                       @ozevren @liamawhite @nmittler @esnible @fisherxu @irisdingbj
+/mixer/                                                          @douglas-reid @geeknoid @kyessenov @mandarjog
+/mixer/test/client/                                              @douglas-reid @geeknoid @kyessenov @mandarjog @qiwzhang @JimmyCYJ @kyessenov @lizan
+/pilot/                                                          @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher
+/pilot/pkg/networking/                                           @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher @costinm @GregHanson @rshriram @zackbutcher @ostromart
+/pilot/pkg/networking/plugin/authn/                              @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher @costinm @GregHanson @rshriram @zackbutcher @ostromart @diemtvu @yangminzhu
+/pilot/pkg/networking/plugin/authz/                              @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher @costinm @GregHanson @rshriram @zackbutcher @ostromart @diemtvu @yangminzhu
+/pilot/pkg/networking/plugin/mixer/                              @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher @costinm @GregHanson @rshriram @zackbutcher @ostromart @kyessenov @douglas-reid @mandarjog
+/pilot/pkg/security/                                             @andraxylia @costinm @diemtvu @GregHanson @hzxuzhonghu @nmittler @rshriram @vadimeisenbergibm @howardjohn @zackbutcher @diemtvu @yangminzhu @quanjielin
+/pkg/                                                            @nmittler @ozevren
+/pkg/bootstrap/                                                  @mandarjog @costinm
+/pkg/mcp/                                                        @ozevren @ayj @nmittler
+/prow/                                                           @geeknoid @howardjohn @duderino @linsun
+/release/                                                        @duderino @linsun
+/samples/                                                        @frankbu @kyessenov @rshriram @vadimeisenbergibm @venilnoronha
+/security/                                                       @diemtvu @incfly @myidpt @quanjielin @wattli
+/tests/                                                          @costinm @nmittler
+/tests/e2e/local/                                                @costinm @nmittler @gargnupur @kimikowang @JimmyCYJ @m1093782566
+/tests/e2e/tests/pilot/                                          @costinm @nmittler @andraxylia @GregHanson @hzxuzhonghu @rshriram @vadimeisenbergibm @zackbutcher
+/tests/integration/                                              @costinm @nmittler @ozevren
+/tests/integration/conformance/                                  @costinm @nmittler @ozevren
+/tests/integration/framework/                                    @costinm @nmittler @ozevren
+/tests/integration/galley/                                       @costinm @nmittler @ozevren @geeknoid
+/tests/integration/mixer/                                        @costinm @nmittler @ozevren @bianpengyuan @douglas-reid @gargnupur @geeknoid @kyessenov @mandarjog
+/tests/integration/pilot/                                        @costinm @nmittler @ozevren @andraxylia @costinm @nmittler @rshriram
+/tests/integration/qualification/                                @costinm @nmittler @ozevren
+/tests/integration/security/                                     @costinm @nmittler @ozevren @diemtvu @incfly @myidpt @quanjielin @wattli @yangminzhu @JimmyCYJ
+/tests/integration/security/rbac/                                @costinm @nmittler @ozevren @diemtvu @incfly @myidpt @quanjielin @wattli @yangminzhu @JimmyCYJ @yangminzhu @liminw
+/tools/                                                          @sdake @mandarjog @nmittler


### PR DESCRIPTION
From https://help.github.com/en/articles/about-code-owners

```
# In this example, @octocat owns any file in an apps directory
# anywhere in your repository.
apps/ @octocat
```

Owner of `pkg` should be owners only of `pkg` not `pilot/pkg`
