### PR TITLE
Make the output of the istioctl verify-install command more readable

### DIFF
--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -53,7 +53,7 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter resource.RESTCl
 	fmt.Fprintf(writer, "\n")
 	fmt.Fprintf(writer, "Checking the cluster to make sure it is ready for Istio installation...\n")
 	fmt.Fprintf(writer, "\n")
-	fmt.Fprintf(writer, "Kubernetes-api\n")
+	fmt.Fprintf(writer, "#1. Kubernetes-api\n")
 	fmt.Fprintf(writer, "-----------------------\n")
 	var errs error
 	c, err := clientExecFactory(restClientGetter)
@@ -71,7 +71,7 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter resource.RESTCl
 		fmt.Fprintf(writer, "Can query the Kubernetes API Server.\n")
 	}
 	fmt.Fprintf(writer, "\n")
-	fmt.Fprintf(writer, "Kubernetes-version\n")
+	fmt.Fprintf(writer, "#2. Kubernetes-version\n")
 	fmt.Fprintf(writer, "-----------------------\n")
 	res, err := checkKubernetesVersion(v)
 	if err != nil {
@@ -85,8 +85,8 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter resource.RESTCl
 		fmt.Fprintf(writer, "Istio is compatible with Kubernetes: %v.\n", v)
 	}
 
-	fmt.Fprintf(writer, "\n\n")
-	fmt.Fprintf(writer, "Istio-existence\n")
+	fmt.Fprintf(writer, "\n")
+	fmt.Fprintf(writer, "#3. Istio-existence\n")
 	fmt.Fprintf(writer, "-----------------------\n")
 	_, err = c.getNameSpace(istioNamespaceFlag)
 	if err == nil {
@@ -98,7 +98,7 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter resource.RESTCl
 	}
 
 	fmt.Fprintf(writer, "\n")
-	fmt.Fprintf(writer, "Kubernetes-setup\n")
+	fmt.Fprintf(writer, "#4. Kubernetes-setup\n")
 	fmt.Fprintf(writer, "-----------------------\n")
 	Resources := []struct {
 		namespace string
@@ -180,7 +180,7 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter resource.RESTCl
 	}
 
 	fmt.Fprintf(writer, "\n")
-	fmt.Fprintf(writer, "SideCar-Injector\n")
+	fmt.Fprintf(writer, "#5. SideCar-Injector\n")
 	fmt.Fprintf(writer, "-----------------------\n")
 	err = c.checkMutatingWebhook()
 	if err != nil {


### PR DESCRIPTION
Adding a number will make the readability higher for istioctl verify-install command.