### PR TITLE
Reduce code coverage analysis overheads

### DIFF
--- a/tests/codecov/main.go
+++ b/tests/codecov/main.go
@@ -62,10 +62,24 @@ func parseReport(filename string) (map[string]float64, error) {
 		}
 	}()
 
+	inFileList := false
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 4096*8), bufio.MaxScanTokenSize*8)
 	for scanner.Scan() {
-		if pkg, cov, err := parseReportLine(scanner.Text()); err == nil {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		} else if line == "<select id=\"files\">" { // report file list starts
+			inFileList = true
+			continue
+		} else if inFileList && line == "</select>" { // end of file list, bail
+			break
+		}
+		if !inFileList { // ignore
+			continue
+		}
+
+		if pkg, cov, err := parseReportLine(line); err == nil {
 			coverage[pkg] = cov
 		}
 	}


### PR DESCRIPTION
Refactor code coverage reporting to 
- compile regular expressions once per run and not on each function invocation
- only consider potential lines for parsing (e.g., skip empty lines and lines outside the file list)

Fixes #15060 (or, hopefully, at least helps ;-))

This is covered by existing tests and validated with manual run of sample report files (e.g., the ones provided in #15060)

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
