### PR TITLE
[WIP] Add multicluster testing to integration framework

### DIFF
--- a/pkg/test/framework/components/citadel/citadel.go
+++ b/pkg/test/framework/components/citadel/citadel.go
@@ -34,7 +34,8 @@ type Instance interface {
 }
 
 type Config struct {
-	Istio istio.Instance
+	Istio     istio.Instance
+	KubeIndex int
 }
 
 // Deploy returns a new instance of Apps

--- a/pkg/test/framework/components/citadel/kube.go
+++ b/pkg/test/framework/components/citadel/kube.go
@@ -38,19 +38,21 @@ const (
 var _ Instance = &kubeComponent{}
 
 type kubeComponent struct {
-	id     resource.ID
-	istio  istio.Instance
-	secret cv1.SecretInterface
+	id        resource.ID
+	istio     istio.Instance
+	secret    cv1.SecretInterface
+	kubeIndex int
 }
 
 func newKube(ctx resource.Context, cfg Config) Instance {
 	c := &kubeComponent{
-		istio: cfg.Istio,
+		istio:     cfg.Istio,
+		kubeIndex: cfg.KubeIndex,
 	}
 	c.id = ctx.TrackResource(c)
 
 	env := ctx.Environment().(*kube.Environment)
-	c.secret = env.GetSecret(c.istio.Settings().IstioNamespace)
+	c.secret = env.Accessors[c.kubeIndex].GetSecret(c.istio.Settings().IstioNamespace)
 
 	return c
 }

--- a/pkg/test/framework/components/deployment/deployment.go
+++ b/pkg/test/framework/components/deployment/deployment.go
@@ -39,6 +39,9 @@ type Config struct {
 
 	// The yaml contents to deploy.
 	Yaml string
+
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
 }
 
 // New returns a new instance of deployment.

--- a/pkg/test/framework/components/deployment/kube.go
+++ b/pkg/test/framework/components/deployment/kube.go
@@ -64,7 +64,7 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 		}
 	}()
 
-	if err = i.deployment.Deploy(e.Accessor, true, retry.Timeout(time.Minute*5), retry.Delay(time.Second*5)); err != nil {
+	if err = i.deployment.Deploy(e.Accessors[cfg.KubeIndex], true, retry.Timeout(time.Minute*5), retry.Delay(time.Second*5)); err != nil {
 		return nil, err
 	}
 
@@ -85,7 +85,7 @@ func (c *kubeComponent) Namespace() namespace.Instance {
 
 func (c *kubeComponent) Close() (err error) {
 	if c.deployment != nil {
-		err = c.deployment.Delete(c.env.Accessor, true, retry.Timeout(time.Minute*5), retry.Delay(time.Second*5))
+		err = c.deployment.Delete(c.env.Accessors[c.cfg.KubeIndex], true, retry.Timeout(time.Minute*5), retry.Delay(time.Second*5))
 		c.deployment = nil
 	}
 

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -63,6 +63,9 @@ type Config struct {
 	// IncludeInboundPorts provides the ports that inbound listener should capture
 	// "*" means capture all.
 	IncludeInboundPorts string
+
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
 }
 
 // String implements the Configuration interface (which implements fmt.Stringer)

--- a/pkg/test/framework/components/echo/kube/builder.go
+++ b/pkg/test/framework/components/echo/kube/builder.go
@@ -101,13 +101,14 @@ func (b *builder) initializeInstances(instances []echo.Instance) error {
 		instanceIndex := i
 		serviceName := inst.Config().Service
 		serviceNamespace := inst.Config().Namespace.Name()
+		accessor := env.Accessors[inst.Config().KubeIndex]
 
 		// Run the waits in parallel.
 		go func() {
 			defer wg.Done()
 
 			// Wait until all the endpoints are ready for this service
-			_, endpoints, err := env.WaitUntilServiceEndpointsAreReady(serviceNamespace, serviceName)
+			_, endpoints, err := accessor.WaitUntilServiceEndpointsAreReady(serviceNamespace, serviceName)
 			if err != nil {
 				aggregateErrMux.Lock()
 				aggregateErr = multierror.Append(aggregateErr, err)

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -96,7 +96,7 @@ func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err erro
 	}
 
 	// Now retrieve the service information to find the ClusterIP
-	s, err := env.GetService(cfg.Namespace.Name(), cfg.Service)
+	s, err := env.Accessors[cfg.KubeIndex].GetService(cfg.Namespace.Name(), cfg.Service)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (c *instance) initialize(endpoints *kubeCore.Endpoints) error {
 	workloads := make([]*workload, 0)
 	for _, subset := range endpoints.Subsets {
 		for _, addr := range subset.Addresses {
-			workload, err := newWorkload(addr, c.cfg.Annotations, c.grpcPort, c.env.Accessor)
+			workload, err := newWorkload(addr, c.cfg.Annotations, c.grpcPort, c.env.Accessors[c.cfg.KubeIndex])
 			if err != nil {
 				return err
 			}

--- a/pkg/test/framework/components/environment/kube/kube.go
+++ b/pkg/test/framework/components/environment/kube/kube.go
@@ -28,7 +28,8 @@ import (
 type Environment struct {
 	id resource.ID
 
-	ctx       api.Context
+	ctx api.Context
+	*kube.Accessor
 	Accessors []*kube.Accessor
 	s         *Settings
 }
@@ -61,6 +62,7 @@ func New(ctx api.Context) (resource.Environment, error) {
 			return nil, err
 		}
 	}
+	e.Accessor = e.Accessors[0]
 
 	return e, nil
 }

--- a/pkg/test/framework/components/environment/kube/kube.go
+++ b/pkg/test/framework/components/environment/kube/kube.go
@@ -28,9 +28,9 @@ import (
 type Environment struct {
 	id resource.ID
 
-	ctx api.Context
-	*kube.Accessor
-	s *Settings
+	ctx       api.Context
+	Accessors []*kube.Accessor
+	s         *Settings
 }
 
 var _ resource.Environment = &Environment{}
@@ -55,8 +55,11 @@ func New(ctx api.Context) (resource.Environment, error) {
 	}
 	e.id = ctx.TrackResource(e)
 
-	if e.Accessor, err = kube.NewAccessor(s.KubeConfig, workDir); err != nil {
-		return nil, err
+	e.Accessors = make([]*kube.Accessor, len(s.KubeConfig))
+	for i := range s.KubeConfig {
+		if e.Accessors[i], err = kube.NewAccessor(s.KubeConfig[i], workDir); err != nil {
+			return nil, err
+		}
 	}
 
 	return e, nil
@@ -85,29 +88,53 @@ func (e *Environment) Settings() *Settings {
 
 // ApplyContents applies the given yaml contents to the namespace.
 func (e *Environment) ApplyContents(namespace, yml string) error {
-	_, err := e.Accessor.ApplyContents(namespace, yml)
-	return err
+	return e.ApplyContentsIndex(0, namespace, yml)
 }
 
 // Applies the config in the given filename to the namespace.
 func (e *Environment) Apply(namespace, ymlFile string) error {
-	return e.Accessor.Apply(namespace, ymlFile)
+	return e.ApplyIndex(0, namespace, ymlFile)
 }
 
 // Deletes the given yaml contents from the namespace.
 func (e *Environment) DeleteContents(namespace, yml string) error {
-	return e.Accessor.DeleteContents(namespace, yml)
+	return e.DeleteContentsIndex(0, namespace, yml)
 }
 
 // Deletes the config in the given filename from the namespace.
 func (e *Environment) Delete(namespace, ymlFile string) error {
-	return e.Accessor.Delete(namespace, ymlFile)
+	return e.DeleteIndex(0, namespace, ymlFile)
 }
 
 func (e *Environment) DeployYaml(namespace, yamlFile string) (*deployment.Instance, error) {
+	return e.DeployYamlIndex(0, namespace, yamlFile)
+}
+
+// ApplyContentsIndex applies the given yaml contents to the namespace.
+func (e *Environment) ApplyContentsIndex(index int, namespace, yml string) error {
+	_, err := e.Accessors[index].ApplyContents(namespace, yml)
+	return err
+}
+
+// Applies the config in the given filename to the namespace.
+func (e *Environment) ApplyIndex(index int, namespace, ymlFile string) error {
+	return e.Accessors[index].Apply(namespace, ymlFile)
+}
+
+// Deletes the given yaml contents from the namespace.
+func (e *Environment) DeleteContentsIndex(index int, namespace, yml string) error {
+	return e.Accessors[index].DeleteContents(namespace, yml)
+}
+
+// Deletes the config in the given filename from the namespace.
+func (e *Environment) DeleteIndex(index int, namespace, ymlFile string) error {
+	return e.Accessors[index].Delete(namespace, ymlFile)
+}
+
+func (e *Environment) DeployYamlIndex(index int, namespace, yamlFile string) (*deployment.Instance, error) {
 	i := deployment.NewYamlDeployment(namespace, yamlFile)
 
-	err := i.Deploy(e.Accessor, true)
+	err := i.Deploy(e.Accessors[index], true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -20,8 +20,8 @@ import (
 
 // Settings provide kube-specific Settings from flags.
 type Settings struct {
-	// Path to kube config file. Required if the environment is kubernetes.
-	KubeConfig string
+	// An array of paths to kube config files. Required if the environment is kubernetes.
+	KubeConfig []string
 
 	// Indicates that the Ingress Gateway is not available. This typically happens in Minikube. The Ingress
 	// component will fall back to node-port in this case.

--- a/pkg/test/framework/components/galley/galley.go
+++ b/pkg/test/framework/components/galley/galley.go
@@ -67,6 +67,9 @@ type Config struct {
 
 	// MeshConfig to use for this instance.
 	MeshConfig string
+
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
 }
 
 // New returns a new instance of echo.

--- a/pkg/test/framework/components/ingress/ingress.go
+++ b/pkg/test/framework/components/ingress/ingress.go
@@ -99,6 +99,8 @@ type Config struct {
 	Istio istio.Instance
 	// IngressType specifies the type of ingress gateway.
 	IngressType CallType
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
 }
 
 // CallResponse is the result of a call made through Istio Ingress.

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -78,6 +78,7 @@ var (
 		CrdsFilesDir:                   env.CrdsFilesDir,
 		ValuesFile:                     E2EValuesFile,
 		CustomSidecarInjectorNamespace: "",
+		KubeIndex:                      0,
 	}
 )
 
@@ -134,6 +135,9 @@ type Config struct {
 	// CustomSidecarInjectorNamespace allows injecting the sidecar from the specified namespace.
 	// if the value is "", use the default sidecar injection instead.
 	CustomSidecarInjectorNamespace string
+
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
 }
 
 // Is mtls enabled. Check in Values flag and Values file.
@@ -292,6 +296,7 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("ValuesFile:                     %s\n", c.ValuesFile)
 	result += fmt.Sprintf("SkipWaitForValidationWebhook:   %v\n", c.SkipWaitForValidationWebhook)
 	result += fmt.Sprintf("CustomSidecarInjectorNamespace: %s\n", c.CustomSidecarInjectorNamespace)
+	result += fmt.Sprintf("KubeIndex:                      %d\n", c.KubeIndex)
 
 	return result
 }

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -153,7 +153,7 @@ func (i *kubeComponent) Close() (err error) {
 	if i.settings.DeployIstio {
 		// TODO: There is a problem with  orderly cleanup. Re-enable this once it is fixed. Delete the system namespace
 		// instead
-		//return i.deployment.Delete(i.environment.Accessors[cfg.KubeIndex], true, retry.Timeout(s.DeployTimeout))
+		//return i.deployment.Delete(i.environment.Accessors[i.settings.KubeIndex], true, retry.Timeout(s.DeployTimeout))
 		err = i.environment.Accessors[i.settings.KubeIndex].DeleteNamespace(i.settings.SystemNamespace)
 		if err == nil {
 			err = i.environment.Accessors[i.settings.KubeIndex].WaitForNamespaceDeletion(i.settings.SystemNamespace)

--- a/pkg/test/framework/components/istioctl/istioctl.go
+++ b/pkg/test/framework/components/istioctl/istioctl.go
@@ -15,6 +15,7 @@
 package istioctl
 
 import (
+	"fmt"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework/components/environment"
@@ -30,7 +31,8 @@ type Instance interface {
 
 // Structured config for the istioctl component
 type Config struct {
-	// currently nothing, we might add stuff like OS env settings later
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
 }
 
 // New returns a new instance of "istioctl".
@@ -55,4 +57,10 @@ func NewOrFail(t *testing.T, c resource.Context, config Config) Instance {
 		t.Fatalf("istioctl.NewOrFail:: %v", err)
 	}
 	return i
+}
+
+func (c *Config) String() string {
+	result := ""
+	result += fmt.Sprintf("KubeIndex:                      %d\n", c.KubeIndex)
+	return result
 }

--- a/pkg/test/framework/components/istioctl/kube.go
+++ b/pkg/test/framework/components/istioctl/kube.go
@@ -50,7 +50,7 @@ func (c *kubeComponent) ID() resource.ID {
 func (c *kubeComponent) Invoke(args []string) (string, error) {
 	var envArgs = []string{
 		"--kubeconfig",
-		c.env.Settings().KubeConfig,
+		c.env.Settings().KubeConfig[c.config.KubeIndex],
 	}
 	var out bytes.Buffer
 	rootCmd := cmd.GetRootCmd(append(envArgs, args...))

--- a/pkg/test/framework/components/mixer/kube.go
+++ b/pkg/test/framework/components/mixer/kube.go
@@ -38,12 +38,15 @@ type kubeComponent struct {
 	*client
 
 	env *kube.Environment
+
+	kubeIndex int
 }
 
 // NewKubeComponent factory function for the component
 func newKube(ctx resource.Context, cfgIn Config) (*kubeComponent, error) {
 	c := &kubeComponent{
-		env: ctx.Environment().(*kube.Environment),
+		env:       ctx.Environment().(*kube.Environment),
+		kubeIndex: cfgIn.KubeIndex,
 	}
 
 	c.client = &client{
@@ -75,7 +78,7 @@ func newKube(ctx resource.Context, cfgIn Config) (*kubeComponent, error) {
 
 		scopes.Framework.Debugf("completed wait for Mixer pod(%s)", serviceType)
 
-		port, err := getGrpcPort(c.env, ns, serviceType)
+		port, err := c.getGrpcPort(c.env, ns, serviceType)
 		if err != nil {
 			return nil, err
 		}
@@ -126,8 +129,8 @@ func (c *kubeComponent) Close() error {
 	return nil
 }
 
-func getGrpcPort(e *kube.Environment, ns, serviceType string) (uint16, error) {
-	svc, err := e.Accessors[0].GetService(ns, "istio-"+serviceType)
+func (c *kubeComponent) getGrpcPort(e *kube.Environment, ns, serviceType string) (uint16, error) {
+	svc, err := e.Accessors[c.kubeIndex].GetService(ns, "istio-"+serviceType)
 	if err != nil {
 		return 0, fmt.Errorf("failed to retrieve service %s: %v", serviceType, err)
 	}

--- a/pkg/test/framework/components/mixer/mixer.go
+++ b/pkg/test/framework/components/mixer/mixer.go
@@ -41,6 +41,8 @@ type CheckResponse struct {
 
 type Config struct {
 	Galley galley.Instance
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
 }
 
 // Succeeded returns true if the precondition check was successful.

--- a/pkg/test/framework/components/pilot/kube.go
+++ b/pkg/test/framework/components/pilot/kube.go
@@ -50,8 +50,8 @@ func newKube(ctx resource.Context, _ Config) (Instance, error) {
 	}
 	ns := icfg.ConfigNamespace
 
-	fetchFn := env.NewSinglePodFetch(ns, "istio=pilot")
-	pods, err := env.WaitUntilPodsAreReady(fetchFn)
+	fetchFn := env.Accessors[icfg.KubeIndex].NewSinglePodFetch(ns, "istio=pilot")
+	pods, err := env.Accessors[icfg.KubeIndex].WaitUntilPodsAreReady(fetchFn)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func newKube(ctx resource.Context, _ Config) (Instance, error) {
 	}()
 
 	// Start port-forwarding for pilot.
-	c.forwarder, err = env.NewPortForwarder(pod, 0, port)
+	c.forwarder, err = env.Accessors[icfg.KubeIndex].NewPortForwarder(pod, 0, port)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (c *kubeComponent) Close() (err error) {
 }
 
 func getGrpcPort(e *kube.Environment, ns string) (uint16, error) {
-	svc, err := e.Accessor.GetService(ns, pilotService)
+	svc, err := e.Accessors[0].GetService(ns, pilotService)
 	if err != nil {
 		return 0, fmt.Errorf("failed to retrieve service %s: %v", pilotService, err)
 	}

--- a/pkg/test/framework/components/pilot/pilot.go
+++ b/pkg/test/framework/components/pilot/pilot.go
@@ -61,6 +61,9 @@ type Config struct {
 	// The MeshConfig to be used for Pilot in native environment. In Kube environment this can be
 	// configured with Helm.
 	MeshConfig *meshConfig.MeshConfig
+
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
 }
 
 // New returns a new instance of echo.

--- a/pkg/test/framework/components/policybackend/kube.go
+++ b/pkg/test/framework/components/policybackend/kube.go
@@ -155,15 +155,18 @@ type kubeComponent struct {
 
 	forwarder  testKube.PortForwarder
 	deployment *deployment.Instance
+
+	kubeIndex int
 }
 
 // NewKubeComponent factory function for the component
-func newKube(ctx resource.Context) (Instance, error) {
+func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 	env := ctx.Environment().(*kube.Environment)
 	c := &kubeComponent{
-		ctx:     ctx,
-		kubeEnv: env,
-		client:  &client{},
+		ctx:       ctx,
+		kubeEnv:   env,
+		client:    &client{},
+		kubeIndex: cfg.KubeIndex,
 	}
 	c.id = ctx.TrackResource(c)
 
@@ -202,13 +205,13 @@ func newKube(ctx resource.Context) (Instance, error) {
 	}
 
 	c.deployment = deployment.NewYamlContentDeployment(c.namespace.Name(), yamlContent)
-	if err = c.deployment.Deploy(env.Accessor, false); err != nil {
+	if err = c.deployment.Deploy(env.Accessors[cfg.KubeIndex], false); err != nil {
 		scopes.CI.Info("Error applying PolicyBackend deployment config")
 		return nil, err
 	}
 
-	podFetchFunc := env.NewSinglePodFetch(c.namespace.Name(), "app=policy-backend", "version=test")
-	pods, err := env.WaitUntilPodsAreReady(podFetchFunc)
+	podFetchFunc := env.Accessors[cfg.KubeIndex].NewSinglePodFetch(c.namespace.Name(), "app=policy-backend", "version=test")
+	pods, err := env.Accessors[cfg.KubeIndex].WaitUntilPodsAreReady(podFetchFunc)
 	if err != nil {
 		scopes.CI.Infof("Error waiting for PolicyBackend pod to become running: %v", err)
 		return nil, err
@@ -216,7 +219,7 @@ func newKube(ctx resource.Context) (Instance, error) {
 	pod := pods[0]
 
 	var svc *kubeApiCore.Service
-	if svc, _, err = env.WaitUntilServiceEndpointsAreReady(c.namespace.Name(), "policy-backend"); err != nil {
+	if svc, _, err = env.Accessors[cfg.KubeIndex].WaitUntilServiceEndpointsAreReady(c.namespace.Name(), "policy-backend"); err != nil {
 		scopes.CI.Infof("Error waiting for PolicyBackend service to be available: %v", err)
 		return nil, err
 	}
@@ -224,7 +227,7 @@ func newKube(ctx resource.Context) (Instance, error) {
 	address := fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].TargetPort.IntVal)
 	scopes.Framework.Infof("Policy Backend in-cluster address: %s", address)
 
-	if c.forwarder, err = env.NewPortForwarder(
+	if c.forwarder, err = env.Accessors[cfg.KubeIndex].NewPortForwarder(
 		pod, 0, uint16(svc.Spec.Ports[0].TargetPort.IntValue())); err != nil {
 		scopes.CI.Infof("Error setting up PortForwarder for PolicyBackend: %v", err)
 		return nil, err
@@ -275,9 +278,9 @@ func (c *kubeComponent) Dump() {
 		scopes.CI.Errorf("Unable to create dump folder for policy-backend-state: %v", err)
 		return
 	}
-	deployment.DumpPodState(workDir, c.namespace.Name(), c.kubeEnv.Accessor)
+	deployment.DumpPodState(workDir, c.namespace.Name(), c.kubeEnv.Accessors[c.kubeIndex])
 
-	pods, err := c.kubeEnv.Accessor.GetPods(c.namespace.Name())
+	pods, err := c.kubeEnv.Accessors[c.kubeIndex].GetPods(c.namespace.Name())
 	if err != nil {
 		scopes.CI.Errorf("Unable to get pods from the system namespace: %v", err)
 		return
@@ -285,7 +288,7 @@ func (c *kubeComponent) Dump() {
 
 	for _, pod := range pods {
 		for _, container := range pod.Spec.Containers {
-			l, err := c.kubeEnv.Logs(pod.Namespace, pod.Name, container.Name, false /* previousLog */)
+			l, err := c.kubeEnv.Accessors[c.kubeIndex].Logs(pod.Namespace, pod.Name, container.Name, false /* previousLog */)
 			if err != nil {
 				scopes.CI.Errorf("Unable to get logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 				continue

--- a/pkg/test/framework/components/policybackend/policybackend.go
+++ b/pkg/test/framework/components/policybackend/policybackend.go
@@ -63,22 +63,27 @@ type Instance interface {
 	CreateConfigSnippet(name string, namespace string, am AdapterMode) string
 }
 
+type Config struct {
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
+}
+
 // New returns a new instance of policybackend.Instance.
-func New(ctx resource.Context) (i Instance, err error) {
+func New(ctx resource.Context, c Config) (i Instance, err error) {
 	err = resource.UnsupportedEnvironment(ctx.Environment())
 	ctx.Environment().Case(environment.Native, func() {
 		i, err = newNative(ctx)
 	})
 	ctx.Environment().Case(environment.Kube, func() {
-		i, err = newKube(ctx)
+		i, err = newKube(ctx, c)
 	})
 	return
 }
 
 // NewOrFail calls New and fails test if it returns an error.
-func NewOrFail(t test.Failer, s resource.Context) Instance {
+func NewOrFail(t test.Failer, s resource.Context, c Config) Instance {
 	t.Helper()
-	i, err := New(s)
+	i, err := New(s, c)
 	if err != nil {
 		t.Fatalf("policybackend.NewOrFail: %v", err)
 	}

--- a/pkg/test/framework/components/prometheus/prometheus.go
+++ b/pkg/test/framework/components/prometheus/prometheus.go
@@ -42,19 +42,24 @@ type Instance interface {
 	SumOrFail(t test.Failer, val prom.Value, labels map[string]string) float64
 }
 
+type Config struct {
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
+}
+
 // New returns a new instance of echo.
-func New(ctx resource.Context) (i Instance, err error) {
+func New(ctx resource.Context, c Config) (i Instance, err error) {
 	err = resource.UnsupportedEnvironment(ctx.Environment())
 	ctx.Environment().Case(environment.Kube, func() {
-		i, err = newKube(ctx)
+		i, err = newKube(ctx, c)
 	})
 	return
 }
 
 // NewOrFail returns a new Prometheus instance or fails test.
-func NewOrFail(t test.Failer, ctx resource.Context) Instance {
+func NewOrFail(t test.Failer, ctx resource.Context, c Config) Instance {
 	t.Helper()
-	i, err := New(ctx)
+	i, err := New(ctx, c)
 	if err != nil {
 		t.Fatalf("prometheus.NewOrFail: %v", err)
 	}

--- a/pkg/test/framework/components/redis/redis.go
+++ b/pkg/test/framework/components/redis/redis.go
@@ -26,19 +26,24 @@ type Instance interface {
 	GetRedisNamespace() string
 }
 
+type Config struct {
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
+}
+
 // New returns a new instance of redis.
-func New(ctx resource.Context) (i Instance, err error) {
+func New(ctx resource.Context, c Config) (i Instance, err error) {
 	err = resource.UnsupportedEnvironment(ctx.Environment())
 	ctx.Environment().Case(environment.Kube, func() {
-		i, err = newKube(ctx)
+		i, err = newKube(ctx, c)
 	})
 	return
 }
 
 // NewOrFail returns a new Redis instance or fails test.
-func NewOrFail(t test.Failer, ctx resource.Context) Instance {
+func NewOrFail(t test.Failer, ctx resource.Context, c Config) Instance {
 	t.Helper()
-	i, err := New(ctx)
+	i, err := New(ctx, c)
 	if err != nil {
 		t.Fatalf("redis.NewOrFail: %v", err)
 	}

--- a/pkg/test/framework/components/zipkin/zipkin.go
+++ b/pkg/test/framework/components/zipkin/zipkin.go
@@ -30,6 +30,11 @@ type Instance interface {
 	QueryTraces(limit int, spanName, annotationQuery string) ([]Trace, error)
 }
 
+type Config struct {
+	// Which KubeConfig should be used in a multicluster environment
+	KubeIndex int
+}
+
 // Span represents a single span, which includes span attributes for verification
 // TODO(bianpengyuan) consider using zipkin proto api https://github.com/istio/istio/issues/13926
 type Span struct {
@@ -46,18 +51,18 @@ type Trace struct {
 }
 
 // New returns a new instance of zipkin.
-func New(ctx resource.Context) (i Instance, err error) {
+func New(ctx resource.Context, c Config) (i Instance, err error) {
 	err = resource.UnsupportedEnvironment(ctx.Environment())
 	ctx.Environment().Case(environment.Kube, func() {
-		i, err = newKube(ctx)
+		i, err = newKube(ctx, c)
 	})
 	return
 }
 
 // NewOrFail returns a new zipkin instance or fails test.
-func NewOrFail(t *testing.T, ctx resource.Context) Instance {
+func NewOrFail(t *testing.T, ctx resource.Context, c Config) Instance {
 	t.Helper()
-	i, err := New(ctx)
+	i, err := New(ctx, c)
 	if err != nil {
 		t.Fatalf("zipkin.NewOrFail: %v", err)
 	}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -278,7 +278,7 @@ type Instance interface {
 ```
 
 | NOTE: A common pattern is to provide two versions of many methods: one that returns an error as well as an `OrFail` version that fails the test upon encountering an error. This provides options to the calling test and helps to simplify the calling logic. |
-| --- |  
+| --- |
 
 Next you need to implement your component for one or more environments. If possible, create both a native and Kubernetes version.
 
@@ -383,10 +383,10 @@ parallelism within the suite, even when explicitly specified via [RunParallel](#
 
 When no flags are specified, the test framework will run all applicable tests. It is possible to filter in/out specific
 tests using 2 mechanisms:
-  
+
   1. The standard ```-run <regexp>``` flag, as exposed by Go's own test framework.
   2. ```--istio.test.select <filter-expr>``` flag to select/skip framework-aware tests that use labels.
-  
+
 For example, if a test, or test suite uses labels in this fashion:
 
 ```go
@@ -537,7 +537,7 @@ $ go test galley/... --istio.test.work_dir /foo
 
 $ ls /foo
   galley-test-4ef25d910d2746f9b38/
-  
+
 $ ls /foo/galley-test-4ef25d910d2746f9b38/
   istio-system-1537332205890088657.yaml
   ...
@@ -617,7 +617,7 @@ The test framework supports the following command-line flags:
         Common image pull policy to use when deploying container images
 
   -istio.test.kube.config string
-        The path to the kube config file for cluster environments
+        A ':' seperated list of paths to kube config files for cluster environments (default is current kube context)
 
   -istio.test.kube.deploy
         Deploy Istio into the target Kubernetes environment. (default true)

--- a/tests/integration/framework/namespace_test.go
+++ b/tests/integration/framework/namespace_test.go
@@ -34,11 +34,11 @@ func TestNamespace(t *testing.T) {
 			namespaceName = ns.Name()
 
 			env := ctx.Environment().(*kube.Environment)
-			if !env.Accessors[0].NamespaceExists(ns.Name()) {
+			if !env.NamespaceExists(ns.Name()) {
 				t.Fatalf("The namespace %q should have existed.", ns.Name())
 			}
 
-			n, err := env.Accessors[0].GetNamespace(ns.Name())
+			n, err := env.GetNamespace(ns.Name())
 			if err != nil {
 				t.Fatalf("Error getting the namespace(%q): %v", ns.Name(), err)
 			}
@@ -51,7 +51,7 @@ func TestNamespace(t *testing.T) {
 
 	if !noCleanup {
 		// Check after run to see that the namespace is gone.
-		if err := env.Accessors[0].WaitForNamespaceDeletion(namespaceName); err != nil {
+		if err := env.WaitForNamespaceDeletion(namespaceName); err != nil {
 			t.Fatalf("WaitiForNamespaceDeletion failed: %v", err)
 		}
 	}

--- a/tests/integration/framework/namespace_test.go
+++ b/tests/integration/framework/namespace_test.go
@@ -34,11 +34,11 @@ func TestNamespace(t *testing.T) {
 			namespaceName = ns.Name()
 
 			env := ctx.Environment().(*kube.Environment)
-			if !env.Accessor.NamespaceExists(ns.Name()) {
+			if !env.Accessors[0].NamespaceExists(ns.Name()) {
 				t.Fatalf("The namespace %q should have existed.", ns.Name())
 			}
 
-			n, err := env.Accessor.GetNamespace(ns.Name())
+			n, err := env.Accessors[0].GetNamespace(ns.Name())
 			if err != nil {
 				t.Fatalf("Error getting the namespace(%q): %v", ns.Name(), err)
 			}
@@ -51,7 +51,7 @@ func TestNamespace(t *testing.T) {
 
 	if !noCleanup {
 		// Check after run to see that the namespace is gone.
-		if err := env.WaitForNamespaceDeletion(namespaceName); err != nil {
+		if err := env.Accessors[0].WaitForNamespaceDeletion(namespaceName); err != nil {
 			t.Fatalf("WaitiForNamespaceDeletion failed: %v", err)
 		}
 	}

--- a/tests/integration/galley/webhook/webhook_test.go
+++ b/tests/integration/galley/webhook/webhook_test.go
@@ -71,26 +71,26 @@ func TestWebhook(t *testing.T) {
 			ctx.NewSubTest("galleyUninstall").
 				Run(func(ctx framework.TestContext) {
 					// Remove galley deployment
-					env.Accessors[0].DeleteDeployment(istioNs, deployName)
+					env.DeleteDeployment(istioNs, deployName)
 
 					// Verify webhook config is deleted
-					env.Accessors[0].WaitForValidatingWebhookDeletion(vwcName)
+					env.WaitForValidatingWebhookDeletion(vwcName)
 				})
 		})
 }
 
 func scaleDeployment(namespace, deployment string, replicas int, t *testing.T, env *kube.Environment) {
-	env.Accessors[0].ScaleDeployment(namespace, deployment, replicas)
-	if err := env.Accessors[0].ScaleDeployment(namespace, deployment, replicas); err != nil {
+	env.ScaleDeployment(namespace, deployment, replicas)
+	if err := env.ScaleDeployment(namespace, deployment, replicas); err != nil {
 		t.Fatalf("Error scaling deployment %s to %d: %v", deployment, replicas, err)
 	}
-	if err := env.Accessors[0].WaitUntilDeploymentIsReady(namespace, deployment); err != nil {
+	if err := env.WaitUntilDeploymentIsReady(namespace, deployment); err != nil {
 		t.Fatalf("Error waiting for deployment %s to be ready: %v", deployment, err)
 	}
 }
 
 func getVwcGeneration(vwcName string, t *testing.T, env *kube.Environment) int64 {
-	vwc, err := env.Accessors[0].GetValidatingWebhookConfiguration(vwcName)
+	vwc, err := env.GetValidatingWebhookConfiguration(vwcName)
 	if err != nil {
 		t.Fatalf("Could not get validating webhook webhook config %s: %v", vwcName, err)
 	}

--- a/tests/integration/galley/webhook/webhook_test.go
+++ b/tests/integration/galley/webhook/webhook_test.go
@@ -71,26 +71,26 @@ func TestWebhook(t *testing.T) {
 			ctx.NewSubTest("galleyUninstall").
 				Run(func(ctx framework.TestContext) {
 					// Remove galley deployment
-					env.DeleteDeployment(istioNs, deployName)
+					env.Accessors[0].DeleteDeployment(istioNs, deployName)
 
 					// Verify webhook config is deleted
-					env.WaitForValidatingWebhookDeletion(vwcName)
+					env.Accessors[0].WaitForValidatingWebhookDeletion(vwcName)
 				})
 		})
 }
 
 func scaleDeployment(namespace, deployment string, replicas int, t *testing.T, env *kube.Environment) {
-	env.ScaleDeployment(namespace, deployment, replicas)
-	if err := env.ScaleDeployment(namespace, deployment, replicas); err != nil {
+	env.Accessors[0].ScaleDeployment(namespace, deployment, replicas)
+	if err := env.Accessors[0].ScaleDeployment(namespace, deployment, replicas); err != nil {
 		t.Fatalf("Error scaling deployment %s to %d: %v", deployment, replicas, err)
 	}
-	if err := env.WaitUntilDeploymentIsReady(namespace, deployment); err != nil {
+	if err := env.Accessors[0].WaitUntilDeploymentIsReady(namespace, deployment); err != nil {
 		t.Fatalf("Error waiting for deployment %s to be ready: %v", deployment, err)
 	}
 }
 
 func getVwcGeneration(vwcName string, t *testing.T, env *kube.Environment) int64 {
-	vwc, err := env.GetValidatingWebhookConfiguration(vwcName)
+	vwc, err := env.Accessors[0].GetValidatingWebhookConfiguration(vwcName)
 	if err != nil {
 		t.Fatalf("Could not get validating webhook webhook config %s: %v", vwcName, err)
 	}

--- a/tests/integration/mixer/check_test.go
+++ b/tests/integration/mixer/check_test.go
@@ -35,7 +35,7 @@ func TestCheck_Allow(t *testing.T) {
 			mxr := mixer.NewOrFail(t, ctx, mixer.Config{
 				Galley: gal,
 			})
-			be := policybackend.NewOrFail(t, ctx)
+			be := policybackend.NewOrFail(t, ctx, policybackend.Config{})
 
 			ns := namespace.NewOrFail(t, ctx, "testcheck-allow", false)
 
@@ -78,7 +78,7 @@ func TestCheck_Deny(t *testing.T) {
 			mxr := mixer.NewOrFail(t, ctx, mixer.Config{
 				Galley: gal,
 			})
-			be := policybackend.NewOrFail(t, ctx)
+			be := policybackend.NewOrFail(t, ctx, policybackend.Config{})
 
 			ns := namespace.NewOrFail(t, ctx, "testcheck-deny", false)
 

--- a/tests/integration/mixer/k8s/k8s_test.go
+++ b/tests/integration/mixer/k8s/k8s_test.go
@@ -48,7 +48,7 @@ func TestK8sDeployment(t *testing.T) {
 		var successCount int
 		var lastWasSuccess bool
 		for i := 0; i < tryCount; i++ {
-			if _, err := env.CheckPodsAreReady(env.NewPodFetch(cfg.IstioNamespace)); err != nil {
+			if _, err := env.Accessors[0].CheckPodsAreReady(env.Accessors[0].NewPodFetch(cfg.IstioNamespace)); err != nil {
 				lastWasSuccess = false
 				t.Logf("Error waiting for pods: %v", err)
 			} else {

--- a/tests/integration/mixer/k8s/k8s_test.go
+++ b/tests/integration/mixer/k8s/k8s_test.go
@@ -48,7 +48,7 @@ func TestK8sDeployment(t *testing.T) {
 		var successCount int
 		var lastWasSuccess bool
 		for i := 0; i < tryCount; i++ {
-			if _, err := env.Accessors[0].CheckPodsAreReady(env.Accessors[0].NewPodFetch(cfg.IstioNamespace)); err != nil {
+			if _, err := env.CheckPodsAreReady(env.NewPodFetch(cfg.IstioNamespace)); err != nil {
 				lastWasSuccess = false
 				t.Logf("Error waiting for pods: %v", err)
 			} else {

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -283,7 +283,7 @@ func testsetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return
 	}
-	prom, err = prometheus.New(ctx)
+	prom, err = prometheus.New(ctx, prometheus.Config{})
 	if err != nil {
 		return
 	}

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -275,7 +275,7 @@ func testsetup(ctx resource.Context) (err error) {
 	if _, err = mixer.New(ctx, mixer.Config{Galley: g}); err != nil {
 		return
 	}
-	red, err = redis.New(ctx)
+	red, err = redis.New(ctx, redis.Config{})
 	if err != nil {
 		return
 	}

--- a/tests/integration/mixer/report_test.go
+++ b/tests/integration/mixer/report_test.go
@@ -35,7 +35,7 @@ func TestMixer_Report_Direct(t *testing.T) {
 
 			g := galley.NewOrFail(t, ctx, galley.Config{})
 			mxr := mixer.NewOrFail(t, ctx, mixer.Config{Galley: g})
-			be := policybackend.NewOrFail(t, ctx)
+			be := policybackend.NewOrFail(t, ctx, policybackend.Config{})
 
 			ns := namespace.NewOrFail(t, ctx, "mixreport", false)
 

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -233,7 +233,7 @@ func testsetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	prom, err = prometheus.New(ctx)
+	prom, err = prometheus.New(ctx, prometheus.Config{})
 	if err != nil {
 		return err
 	}

--- a/tests/integration/multicluster/multinetwork/multinetwork_test.go
+++ b/tests/integration/multicluster/multinetwork/multinetwork_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 			if len(env.Accessors) >= 2 {
 				return nil
 			}
-			return fmt.Errorf("This test requires 2 KubeConfigs")
+			return fmt.Errorf("this test requires 2 KubeConfigs, like  --istio.test.kube.config config-a:config-b")
 		}).
 
 		// Deploy Istio

--- a/tests/integration/multicluster/multinetwork/multinetwork_test.go
+++ b/tests/integration/multicluster/multinetwork/multinetwork_test.go
@@ -1,0 +1,158 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinetwork
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/istioctl"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	primary istio.Instance
+	remote  istio.Instance
+	// env     *kube.Environment
+)
+
+// This test requires `--istio.test.env=kube` and at least two clusters on --istio.test.kube.config
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("multicluster_multi_network_integration_test", m).
+		RequireEnvironment(environment.Kube).
+		Setup(func(ctx resource.Context) (err error) {
+			env := ctx.Environment().(*kube.Environment)
+			if len(env.Accessors) >= 2 {
+				return nil
+			}
+			return fmt.Errorf("This test requires 2 KubeConfigs")
+		}).
+
+		// Deploy Istio
+		SetupOnEnv(environment.Kube, istio.Setup(&primary, nil)).
+		SetupOnEnv(environment.Kube, istio.Setup(&remote, setupConfigIndex1)).
+		Run()
+}
+
+func setupConfigIndex1(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// We want to setup Istio on the 2nd supplied KubeConfig m(index of 1)
+	cfg.KubeIndex = 1
+}
+
+// Do a test of istioctl against first cluster
+func TestIstioCtlAgainstFirstKubeConfig(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(ctx framework.TestContext) {
+			g := galley.NewOrFail(t, ctx, galley.Config{})
+			_ = pilot.NewOrFail(t, ctx, pilot.Config{Galley: g})
+
+			istioCtl := istioctl.NewOrFail(t, ctx, istioctl.Config{})
+
+			args := []string{"version", "--remote=true"}
+
+			output, fErr := istioCtl.Invoke(args)
+
+			if fErr != nil {
+				t.Fatalf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), fErr)
+			}
+
+			// istioctl will return a single "control plane version" if all control plane versions match
+			controlPlaneRegex := regexp.MustCompile(`control plane version: [a-z0-9\-]*`)
+			if controlPlaneRegex.MatchString(output) {
+				return
+			}
+
+			t.Logf("Did not find control plane version. This may mean components have different versions.")
+
+			// At this point, we expect the version for each component
+			expectedRegexps := []*regexp.Regexp{
+				regexp.MustCompile(`citadel version: [a-z0-9\-]*`),
+				regexp.MustCompile(`client version: [a-z0-9\-]*`),
+				regexp.MustCompile(`egressgateway version: [a-z0-9\-]*`),
+				regexp.MustCompile(`ingressgateway version: [a-z0-9\-]*`),
+				regexp.MustCompile(`pilot version: [a-z0-9\-]*`),
+				regexp.MustCompile(`galley version: [a-z0-9\-]*`),
+				regexp.MustCompile(`policy version: [a-z0-9\-]*`),
+				regexp.MustCompile(`sidecar-injector version: [a-z0-9\-]*`),
+				regexp.MustCompile(`telemetry version: [a-z0-9\-]*`),
+			}
+			for _, regexp := range expectedRegexps {
+				if !regexp.MatchString(output) {
+					t.Fatalf("Output didn't match for 'istioctl %s'\n got %v\nwant: %v",
+						strings.Join(args, " "), output, regexp)
+				}
+			}
+		})
+}
+
+// Do a test of istioctl against second cluster
+func TestIstioCtlAgainstSecondKubeConfig(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(ctx framework.TestContext) {
+			g := galley.NewOrFail(t, ctx, galley.Config{})
+			_ = pilot.NewOrFail(t, ctx, pilot.Config{Galley: g})
+
+			istioCtl := istioctl.NewOrFail(t, ctx, istioctl.Config{KubeIndex: 1})
+
+			args := []string{"version", "--remote=true"}
+
+			output, fErr := istioCtl.Invoke(args)
+
+			if fErr != nil {
+				t.Fatalf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), fErr)
+			}
+
+			// istioctl will return a single "control plane version" if all control plane versions match
+			controlPlaneRegex := regexp.MustCompile(`control plane version: [a-z0-9\-]*`)
+			if controlPlaneRegex.MatchString(output) {
+				return
+			}
+
+			t.Logf("Did not find control plane version. This may mean components have different versions.")
+
+			// At this point, we expect the version for each component
+			expectedRegexps := []*regexp.Regexp{
+				regexp.MustCompile(`citadel version: [a-z0-9\-]*`),
+				regexp.MustCompile(`client version: [a-z0-9\-]*`),
+				regexp.MustCompile(`egressgateway version: [a-z0-9\-]*`),
+				regexp.MustCompile(`ingressgateway version: [a-z0-9\-]*`),
+				regexp.MustCompile(`pilot version: [a-z0-9\-]*`),
+				regexp.MustCompile(`galley version: [a-z0-9\-]*`),
+				regexp.MustCompile(`policy version: [a-z0-9\-]*`),
+				regexp.MustCompile(`sidecar-injector version: [a-z0-9\-]*`),
+				regexp.MustCompile(`telemetry version: [a-z0-9\-]*`),
+			}
+			for _, regexp := range expectedRegexps {
+				if !regexp.MatchString(output) {
+					t.Fatalf("Output didn't match for 'istioctl %s'\n got %v\nwant: %v",
+						strings.Join(args, " "), output, regexp)
+				}
+			}
+		})
+}

--- a/tests/integration/qualification/loadbalancing_test.go
+++ b/tests/integration/qualification/loadbalancing_test.go
@@ -79,7 +79,7 @@ func TestIngressLoadBalancing(t *testing.T) {
 		bookinfo.NetworkingVirtualServiceAllV1.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 	)
 
-	prom := prometheus.NewOrFail(t, ctx)
+	prom := prometheus.NewOrFail(t, ctx, prometheus.Config{})
 	ing := ingress.NewOrFail(t, ctx, ingress.Config{Istio: ist})
 
 	rangeStart := time.Now()

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -101,7 +101,7 @@ func CreateIngressKubeSecret(t *testing.T, ctx framework.TestContext, credNames 
 		return
 	}
 	// Create Kubernetes secret for ingress gateway
-	kubeAccessor := ctx.Environment().(*kube.Environment).Accessor
+	kubeAccessor := ctx.Environment().(*kube.Environment).Accessors[0]
 	for _, cn := range credNames {
 		secret := createSecret(ingressType, cn, systemNS.Name(), ingressCred)
 		err := kubeAccessor.CreateSecret(systemNS.Name(), secret)
@@ -222,7 +222,7 @@ func RotateSecrets(t *testing.T, ctx framework.TestContext, credNames []string,
 func DeleteSecrets(t *testing.T, ctx framework.TestContext, credNames []string) { // nolint:interfacer
 	istioCfg := istio.DefaultConfigOrFail(t, ctx)
 	systemNS := namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
-	kubeAccessor := ctx.Environment().(*kube.Environment).Accessor
+	kubeAccessor := ctx.Environment().(*kube.Environment).Accessors[0]
 	for _, cn := range credNames {
 		err := kubeAccessor.DeleteSecret(systemNS.Name(), cn)
 		if err != nil {

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -101,7 +101,7 @@ func CreateIngressKubeSecret(t *testing.T, ctx framework.TestContext, credNames 
 		return
 	}
 	// Create Kubernetes secret for ingress gateway
-	kubeAccessor := ctx.Environment().(*kube.Environment).Accessors[0]
+	kubeAccessor := ctx.Environment().(*kube.Environment)
 	for _, cn := range credNames {
 		secret := createSecret(ingressType, cn, systemNS.Name(), ingressCred)
 		err := kubeAccessor.CreateSecret(systemNS.Name(), secret)
@@ -222,7 +222,7 @@ func RotateSecrets(t *testing.T, ctx framework.TestContext, credNames []string,
 func DeleteSecrets(t *testing.T, ctx framework.TestContext, credNames []string) { // nolint:interfacer
 	istioCfg := istio.DefaultConfigOrFail(t, ctx)
 	systemNS := namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
-	kubeAccessor := ctx.Environment().(*kube.Environment).Accessors[0]
+	kubeAccessor := ctx.Environment().(*kube.Environment)
 	for _, cn := range credNames {
 		err := kubeAccessor.DeleteSecret(systemNS.Name(), cn)
 		if err != nil {

--- a/tests/integration/telemetry/tracing/tracing.go
+++ b/tests/integration/telemetry/tracing/tracing.go
@@ -71,7 +71,7 @@ func TestSetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return
 	}
-	zipkinInst, err = zipkin.New(ctx)
+	zipkinInst, err = zipkin.New(ctx, zipkin.Config{})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This is an initial drop of adding multicluster testing to the integration framework. This is needed to add multicluster tests (we need to use more than one kubeconfig).  It is not complete, but more to start some discussion before I get too far down what might be a wrong path.

I did chat briefly with @ozevren before we both went on vacation and one thought was to make the kubeconfig command line parameter support an array of kubeconfigs. This would allow any existing tests to work will allowing multiple Accessors to be created (one per kubeconfig). The test framework components would be updated to take an optional config item to specify which kubeconfig should be used. The component would use that index for it's operations. As the config is optional, it will default to 0 which is the first kubeconfig. 

I did add a test that shows the use of 2 kubeconfigs to install Istio in the two specified clusters and then run the istioctl component against both.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ x ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure