### PR TITLE
Bring kind test improvements to e2e suite script

### DIFF
--- a/prow/e2e-kind-simpleTests.sh
+++ b/prow/e2e-kind-simpleTests.sh
@@ -30,4 +30,4 @@ set -x
 
 echo 'Running Simple test with rbac, auth Tests'
 
-./prow/e2e-kind-suite.sh --auth_enable --single_test e2e_simple
+./prow/e2e-kind-suite.sh --auth_enable --single_test e2e_simple "$@"


### PR DESCRIPTION
We made a number of improvements to the integration suite runner for
kind, but not to the e2e tests. As I am going to move these over to kind
soon, we should do the same. This includes custom node images, faster
builds, etc.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
