### PR TITLE
Helm: Use --set-string instead of --set when applicable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ export ENABLE_COREDUMP ?= false
 export ENABLE_ISTIO_CNI ?= false
 
 # NOTE: env var EXTRA_HELM_SETTINGS can contain helm chart override settings, example:
-# EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.tag=v0.1-dev-foo"
+# EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set-string istio-cni.tag=v0.1-dev-foo"
 
 #-----------------------------------------------------------------------------
 # Output control
@@ -690,8 +690,8 @@ istio-init.yaml: $(HELM) $(HOME)/.helm
 	cat install/kubernetes/namespace.yaml > install/kubernetes/$@
 	cat install/kubernetes/helm/istio-init/files/crd-* >> install/kubernetes/$@
 	$(HELM) template --name=istio --namespace=istio-system \
-		--set global.tag=${TAG_VARIANT} \
-		--set global.hub=${HUB} \
+		--set-string global.tag=${TAG_VARIANT} \
+		--set-string global.hub=${HUB} \
 		install/kubernetes/helm/istio-init >> install/kubernetes/$@
 
 
@@ -706,9 +706,9 @@ istio-demo.yaml istio-demo-auth.yaml istio-remote.yaml istio-minimal.yaml: $(HEL
 	$(HELM) template \
 		--name=istio \
 		--namespace=istio-system \
-		--set global.tag=${TAG_VARIANT} \
-		--set global.hub=${HUB} \
-		--set global.imagePullPolicy=$(PULL_POLICY) \
+		--set-string global.tag=${TAG_VARIANT} \
+		--set-string global.hub=${HUB} \
+		--set-string global.imagePullPolicy=$(PULL_POLICY) \
 		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
 		--set istio_cni.enabled=${ENABLE_ISTIO_CNI} \
 		${EXTRA_HELM_SETTINGS} \
@@ -743,9 +743,9 @@ $(e2e_files): $(HELM) $(HOME)/.helm istio-init.yaml
 	$(HELM) template \
 		--name=istio \
 		--namespace=istio-system \
-		--set global.tag=${TAG_VARIANT} \
-		--set global.hub=${HUB} \
-		--set global.imagePullPolicy=$(PULL_POLICY) \
+		--set-string global.tag=${TAG_VARIANT} \
+		--set-string global.hub=${HUB} \
+		--set-string global.imagePullPolicy=$(PULL_POLICY) \
 		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
 		--set istio_cni.enabled=${ENABLE_ISTIO_CNI} \
 		${EXTRA_HELM_SETTINGS} \

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -136,7 +136,7 @@ function cni_run_daemon() {
   helm repo add istio.io https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/release-1.1-latest-daily/charts/
   helm fetch --untar --untardir "${chartdir}" istio.io/istio-cni
  
-  helm template --values "${chartdir}"/istio-cni/values.yaml --name=istio-cni --namespace=kube-system --set "excludeNamespaces={}" --set cniBinDir=/home/kubernetes/bin --set hub="${ISTIO_CNI_HUB}" --set tag="${ISTIO_CNI_TAG}" --set pullPolicy=IfNotPresent --set logLevel="${CNI_LOGLVL:-debug}"  "${chartdir}"/istio-cni > istio-cni_install.yaml
+  helm template --values "${chartdir}"/istio-cni/values.yaml --name=istio-cni --namespace=kube-system --set "excludeNamespaces={}" --set cniBinDir=/home/kubernetes/bin --set-string hub="${ISTIO_CNI_HUB}" --set-string tag="${ISTIO_CNI_TAG}" --set-string pullPolicy=IfNotPresent --set logLevel="${CNI_LOGLVL:-debug}"  "${chartdir}"/istio-cni > istio-cni_install.yaml
 
   kubectl apply -f istio-cni_install.yaml
 

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -1045,7 +1045,7 @@ func (k *KubeInfo) deployIstioWithHelm() error {
 	// hubs and tags replacement.
 	// Helm chart assumes hub and tag are the same among multiple istio components.
 	if *pilotHub != "" && *pilotTag != "" {
-		setValue = setValue + " --set global.hub=" + *pilotHub + " --set global.tag=" + *pilotTag
+		setValue += " --set-string global.hub=" + *pilotHub + " --set-string global.tag=" + *pilotTag
 	}
 
 	if !*clusterWide {
@@ -1265,7 +1265,7 @@ func (k *KubeInfo) deployCNI() error {
 	log.Info("Deploy Istio CNI components")
 	// Some environments will require additional options to be set or changed
 	// (e.g. GKE environments need the bin directory to be changed from the default
-	setValue := " --set hub=" + *cniHub + " --set tag=" + *cniTag
+	setValue := " --set-string hub=" + *cniHub + " --set-string tag=" + *cniTag
 	setValue += " --set excludeNamespaces={} --set pullPolicy=IfNotPresent --set logLevel=debug"
 	if extraHelmValues := os.Getenv("EXTRA_HELM_SETTINGS"); extraHelmValues != "" {
 		setValue += extraHelmValues

--- a/tests/e2e/framework/multicluster.go
+++ b/tests/e2e/framework/multicluster.go
@@ -119,11 +119,11 @@ func (k *KubeInfo) generateRemoteIstio(dst string, useAutoInject bool, proxyHub,
 		log.Infof("Remote cluster auto-sidecar injection enabled")
 	}
 	if proxyHub != "" && proxyTag != "" {
-		helmSetContent += " --set global.hub=" + proxyHub + " --set global.tag=" + proxyTag
+		helmSetContent += " --set-string global.hub=" + proxyHub + " --set-string global.tag=" + proxyTag
 	}
 	err = util.HelmClientInit()
 	if err != nil {
-		log.Errorf("cnnot run helm init %v", err)
+		log.Errorf("cannot run helm init %v", err)
 		return err
 	}
 	chartDir := filepath.Join(k.ReleaseDir, "install/kubernetes/helm/istio")
@@ -167,7 +167,7 @@ func (k *KubeInfo) generateRemoteIstioForSplitHorizon(dst string, network string
 	helmSetContent += " --set gateways.istio-ingressgateway.env.ISTIO_META_NETWORK=\"" + network + "\""
 	helmSetContent += " --set global.network=\"" + network + "\""
 	if proxyHub != "" && proxyTag != "" {
-		helmSetContent += " --set global.hub=" + proxyHub + " --set global.tag=" + proxyTag
+		helmSetContent += " --set-string global.hub=" + proxyHub + " --set-string global.tag=" + proxyTag
 	}
 
 	err = util.HelmClientInit()

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -262,26 +262,26 @@ helm/install:
 	${HELM} install \
 	  install/kubernetes/helm/istio-init \
 	  --name istio-system-init --namespace istio-system \
-	  --set global.hub=${HUB} \
-	  --set global.tag=${TAG_VARIANT} \
-	  --set global.imagePullPolicy=Always \
+	  --set-string global.hub=${HUB} \
+	  --set-string global.tag=${TAG_VARIANT} \
+	  --set-string global.imagePullPolicy=Always \
 	  ${HELM_ARGS}
 	sleep 10
 	${HELM} install \
 	  install/kubernetes/helm/istio \
 	  --name istio-system --namespace istio-system \
-	  --set global.hub=${HUB} \
-	  --set global.tag=${TAG_VARIANT} \
-	  --set global.imagePullPolicy=Always \
+	  --set-string global.hub=${HUB} \
+	  --set-string global.tag=${TAG_VARIANT} \
+	  --set-string global.imagePullPolicy=Always \
 	  ${HELM_ARGS}
 
 # Upgrade istio. Options must be set:
 #  "make helm/upgrade HELM_ARGS="--values myoverride.yaml"
 helm/upgrade:
 	${HELM} upgrade \
-	  --set global.hub=${HUB} \
-	  --set global.tag=${TAG_VARIANT} \
-	  --set global.imagePullPolicy=Always \
+	  --set-string global.hub=${HUB} \
+	  --set-string global.tag=${TAG_VARIANT} \
+	  --set-string global.imagePullPolicy=Always \
 	  ${HELM_ARGS} \
 	  istio-system install/kubernetes/helm/istio
 

--- a/tests/upgrade/test_crossgrade.sh
+++ b/tests/upgrade/test_crossgrade.sh
@@ -209,8 +209,8 @@ installIstioSystemAtVersionHelmTemplate() {
         --set mixer.telemetry.autoscaleMin=2 \
         --set mixer.policy.autoscaleMin=2 \
         --set prometheus.enabled=false \
-        --set global.hub="${1}" \
-        --set global.tag="${2}" \
+        --set-string global.hub="${1}" \
+        --set-string global.tag="${2}" \
         --set global.defaultPodDisruptionBudget.enabled=true > "${ISTIO_ROOT}/istio.yaml" || die "helm template failed"
     else
         helm template "${release_path}" "${auth_opts}" \
@@ -220,8 +220,8 @@ installIstioSystemAtVersionHelmTemplate() {
         --set mixer.istio-telemetry.autoscaleMin=2 \
         --set mixer.istio-policy.autoscaleMin=2 \
         --set prometheus.enabled=false \
-        --set global.hub="${1}" \
-        --set global.tag="${2}" > "${ISTIO_ROOT}/istio.yaml" || die "helm template failed"
+        --set-string global.hub="${1}" \
+        --set-string global.tag="${2}" > "${ISTIO_ROOT}/istio.yaml" || die "helm template failed"
     fi
 
 


### PR DESCRIPTION
To avoid helm interpreting a tag like `20190806` as float `2.0190806e+07`.

Please provide a description for what this PR is for.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
