### PR TITLE
Delete kind cluster after test completion

### DIFF
--- a/prow/e2e-kind-suite.sh
+++ b/prow/e2e-kind-suite.sh
@@ -66,6 +66,10 @@ for ((i=1; i<=$#; i++)); do
           SKIP_BUILD=true
           continue
         ;;
+        --skip-cleanup)
+          SKIP_CLEANUP=true
+          shift
+        ;;
         # -s/--single_test to specify test target to run.
         # e.g. "-s e2e_mixer" will trigger e2e mixer_test
         -s|--single_test) ((i++)); SINGLE_TEST=${!i}

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -55,6 +55,10 @@ while (( "$#" )); do
       SKIP_SETUP=true
       shift
     ;;
+    --skip-cleanup)
+      SKIP_CLEANUP=true
+      shift
+    ;;
     --skip-build)
       SKIP_BUILD=true
       shift


### PR DESCRIPTION
Because we mount host paths in the pods, resources will not actually be
fully freed once a test is complete. This causes a resource leak that
eventually leads to a complete degradation of the entire node.

See https://github.com/kubernetes-sigs/kind/issues/759 for details.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
