### PR TITLE
Fix tag name validation to match Kubernetes

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/labels"
 )
 
 // UnixAddressPrefix is the prefix used to indicate an address is for a Unix Domain socket. It is used in
@@ -38,10 +39,10 @@ func (descriptor ConfigDescriptor) Validate() error {
 	clusterMessages := make(map[string]bool)
 
 	for _, v := range descriptor {
-		if !config.IsDNS1123Label(v.Type) {
+		if !labels.IsDNS1123Label(v.Type) {
 			errs = multierror.Append(errs, fmt.Errorf("invalid type: %q", v.Type))
 		}
-		if !config.IsDNS1123Label(v.Plural) {
+		if !labels.IsDNS1123Label(v.Plural) {
 			errs = multierror.Append(errs, fmt.Errorf("invalid plural: %q", v.Type))
 		}
 		if proto.MessageType(v.MessageName) == nil {
@@ -74,7 +75,7 @@ func (s *Service) Validate() error {
 	}
 	parts := strings.Split(string(s.Hostname), ".")
 	for _, part := range parts {
-		if !config.IsDNS1123Label(part) {
+		if !labels.IsDNS1123Label(part) {
 			errs = multierror.Append(errs, fmt.Errorf("invalid hostname part: %q", part))
 		}
 	}
@@ -91,7 +92,7 @@ func (s *Service) Validate() error {
 				errs = multierror.Append(errs,
 					fmt.Errorf("empty port names are not allowed for services with multiple ports"))
 			}
-		} else if !config.IsDNS1123Label(port.Name) {
+		} else if !labels.IsDNS1123Label(port.Name) {
 			errs = multierror.Append(errs, fmt.Errorf("invalid name: %q", port.Name))
 		}
 		if err := config.ValidatePort(port.Port); err != nil {

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
-	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	testConfig "istio.io/istio/pkg/test/config"
@@ -35,8 +34,8 @@ const (
 )
 
 func TestConfigDescriptorValidate(t *testing.T) {
-	badLabel := strings.Repeat("a", config.DNS1123LabelMaxLength+1)
-	goodLabel := strings.Repeat("a", config.DNS1123LabelMaxLength-1)
+	badLabel := strings.Repeat("a", labels.DNS1123LabelMaxLength+1)
+	goodLabel := strings.Repeat("a", labels.DNS1123LabelMaxLength-1)
 
 	cases := []struct {
 		name       string

--- a/pkg/config/labels/instance_test.go
+++ b/pkg/config/labels/instance_test.go
@@ -62,6 +62,16 @@ func TestInstanceValidate(t *testing.T) {
 			valid: true,
 		},
 		{
+			name:  "good tag - DNS prefix",
+			tags:  labels.Instance{"k8s.io/key": "value"},
+			valid: true,
+		},
+		{
+			name:  "good tag - subdomain DNS prefix",
+			tags:  labels.Instance{"app.kubernetes.io/name": "value"},
+			valid: true,
+		},
+		{
 			name: "bad tag - empty key",
 			tags: labels.Instance{"": "value"},
 		},
@@ -76,6 +86,10 @@ func TestInstanceValidate(t *testing.T) {
 		{
 			name: "bad tag key 3",
 			tags: labels.Instance{"key$": "value"},
+		},
+		{
+			name: "bad tag key - invalid DNS prefix",
+			tags: labels.Instance{"istio./key": "value"},
 		},
 		{
 			name: "bad tag value 1",

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -48,13 +48,6 @@ import (
 	"istio.io/istio/pkg/config/xds"
 )
 
-const (
-	DNS1123LabelMaxLength int    = 63
-	dns1123LabelFmt       string = "[a-zA-Z0-9]([-a-z-A-Z0-9]*[a-zA-Z0-9])?"
-	// a wild-card prefix is an '*', a normal DNS1123 label with a leading '*' or '*-', or a normal DNS1123 label
-	wildcardPrefix = `(\*|(\*|\*-)?` + dns1123LabelFmt + `)`
-)
-
 // Constants for duration fields
 const (
 	connectTimeoutMax = time.Second * 30
@@ -67,11 +60,6 @@ const (
 // UnixAddressPrefix is the prefix used to indicate an address is for a Unix Domain socket. It is used in
 // ServiceEntry.Endpoint.Address message.
 const UnixAddressPrefix = "unix://"
-
-var (
-	dns1123LabelRegexp   = regexp.MustCompile("^" + dns1123LabelFmt + "$")
-	wildcardPrefixRegexp = regexp.MustCompile("^" + wildcardPrefix + "$")
-)
 
 // envoy supported retry on header values
 var supportedRetryOnPolicies = map[string]bool{
@@ -142,7 +130,7 @@ func ValidateWildcardDomain(domain string) error {
 	}
 	// We only allow wildcards in the first label; split off the first label (parts[0]) from the rest of the host (parts[1])
 	parts := strings.SplitN(domain, ".", 2)
-	if !IsWildcardDNS1123Label(parts[0]) {
+	if !labels.IsWildcardDNS1123Label(parts[0]) {
 		return fmt.Errorf("domain name %q invalid (label %q invalid)", domain, parts[0])
 	} else if len(parts) > 1 {
 		return validateDNS1123Labels(parts[1])
@@ -172,23 +160,11 @@ func validateDNS1123Labels(domain string) error {
 		if i == len(parts)-1 && label == "" {
 			return nil
 		}
-		if !IsDNS1123Label(label) {
+		if !labels.IsDNS1123Label(label) {
 			return fmt.Errorf("domain name %q invalid (label %q invalid)", domain, label)
 		}
 	}
 	return nil
-}
-
-// IsDNS1123Label tests for a string that conforms to the definition of a label in
-// DNS (RFC 1123).
-func IsDNS1123Label(value string) bool {
-	return len(value) <= DNS1123LabelMaxLength && dns1123LabelRegexp.MatchString(value)
-}
-
-// IsWildcardDNS1123Label tests for a string that conforms to the definition of a label in DNS (RFC 1123), but allows
-// the wildcard label (`*`), and typical labels with a leading astrisk instead of alphabetic character (e.g. "*-foo")
-func IsWildcardDNS1123Label(value string) bool {
-	return len(value) <= DNS1123LabelMaxLength && wildcardPrefixRegexp.MatchString(value)
 }
 
 // ValidateMixerService checks for validity of a service reference
@@ -205,12 +181,12 @@ func ValidateMixerService(svc *mccpb.IstioService) (errs error) {
 			errs = multierror.Append(errs, errors.New("domain is not valid when service is provided"))
 		}
 	} else if svc.Name != "" {
-		if !IsDNS1123Label(svc.Name) {
+		if !labels.IsDNS1123Label(svc.Name) {
 			errs = multierror.Append(errs, fmt.Errorf("name %q must be a valid label", svc.Name))
 		}
 	}
 
-	if svc.Namespace != "" && !IsDNS1123Label(svc.Namespace) {
+	if svc.Namespace != "" && !labels.IsDNS1123Label(svc.Namespace) {
 		errs = multierror.Append(errs, fmt.Errorf("namespace %q must be a valid label", svc.Namespace))
 	}
 
@@ -312,7 +288,7 @@ func ValidateUnixAddress(addr string) error {
 // ValidateGateway checks gateway specifications
 func ValidateGateway(name, _ string, msg proto.Message) (errs error) {
 	// Gateway name must conform to the DNS label format (no dots)
-	if !IsDNS1123Label(name) {
+	if !labels.IsDNS1123Label(name) {
 		errs = appendErrors(errs, fmt.Errorf("invalid gateway name: %q", name))
 	}
 	value, ok := msg.(*networking.Gateway)
@@ -626,14 +602,14 @@ func validateNamespaceSlashWildcardHostname(hostname string, isGateway bool) (er
 	if !isGateway {
 		// namespace can be * or . or ~ or a valid DNS label in sidecars
 		if parts[0] != "*" && parts[0] != "." && parts[0] != "~" {
-			if !IsDNS1123Label(parts[0]) {
+			if !labels.IsDNS1123Label(parts[0]) {
 				errs = appendErrors(errs, fmt.Errorf("invalid namespace value %q in sidecar", parts[0]))
 			}
 		}
 	} else {
 		// namespace can be * or . or a valid DNS label in gateways
 		if parts[0] != "*" && parts[0] != "." {
-			if !IsDNS1123Label(parts[0]) {
+			if !labels.IsDNS1123Label(parts[0]) {
 				errs = appendErrors(errs, fmt.Errorf("invalid namespace value %q in gateway", parts[0]))
 			}
 		}
@@ -1325,7 +1301,7 @@ func ValidateHTTPAPISpecBinding(_, _ string, msg proto.Message) error {
 		if spec.Name == "" {
 			errs = multierror.Append(errs, errors.New("name is mandatory for HTTPAPISpecReference"))
 		}
-		if spec.Namespace != "" && !IsDNS1123Label(spec.Namespace) {
+		if spec.Namespace != "" && !labels.IsDNS1123Label(spec.Namespace) {
 			errs = multierror.Append(errs, fmt.Errorf("namespace %q must be a valid label", spec.Namespace))
 		}
 	}
@@ -1405,7 +1381,7 @@ func ValidateQuotaSpecBinding(_, _ string, msg proto.Message) error {
 		if spec.Name == "" {
 			errs = multierror.Append(errs, errors.New("name is mandatory for QuotaSpecReference"))
 		}
-		if spec.Namespace != "" && !IsDNS1123Label(spec.Namespace) {
+		if spec.Namespace != "" && !labels.IsDNS1123Label(spec.Namespace) {
 			errs = multierror.Append(errs, fmt.Errorf("namespace %q must be a valid label", spec.Namespace))
 		}
 	}
@@ -1722,7 +1698,7 @@ func validateAuthNPolicyTarget(target *authn.TargetSelector) (errs error) {
 	}
 
 	// AuthN policy target (host)name must be a shortname
-	if !IsDNS1123Label(target.Name) {
+	if !labels.IsDNS1123Label(target.Name) {
 		errs = multierror.Append(errs, fmt.Errorf("target name %q must be a valid label", target.Name))
 	}
 
@@ -1996,11 +1972,11 @@ func validateGatewayNames(gatewayNames []string) (errs error) {
 		}
 
 		// namespace and name must be DNS labels
-		if !IsDNS1123Label(parts[0]) {
+		if !labels.IsDNS1123Label(parts[0]) {
 			errs = appendErrors(errs, fmt.Errorf("invalid value for namespace: %q", parts[0]))
 		}
 
-		if !IsDNS1123Label(parts[1]) {
+		if !labels.IsDNS1123Label(parts[1]) {
 			errs = appendErrors(errs, fmt.Errorf("invalid value for gateway name: %q", parts[1]))
 		}
 	}
@@ -2215,7 +2191,7 @@ func validateSubsetName(name string) error {
 	if len(name) == 0 {
 		return fmt.Errorf("subset name cannot be empty")
 	}
-	if !IsDNS1123Label(name) {
+	if !labels.IsDNS1123Label(name) {
 		return fmt.Errorf("subset name is invalid: %s", name)
 	}
 	return nil
@@ -2453,7 +2429,7 @@ func ValidateServiceEntry(_, _ string, config proto.Message) (errs error) {
 }
 
 func validatePortName(name string) error {
-	if !IsDNS1123Label(name) {
+	if !labels.IsDNS1123Label(name) {
 		return fmt.Errorf("invalid port name: %s", name)
 	}
 	return nil


### PR DESCRIPTION
In #12852, the validation of tag names was changed with the goal of
matching Kubernetes. This introduced bug #14797, because the new
validation format is stricter than Kubernetes: DNS-qualified labels like
`app.kubernetes.io/name` are now rejected by Istio.

This PR updates validation tests to cover those labels, and fixes the
rules so that the tests pass.

This is a rebase of PR #14809 and replaces it.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
