### PR TITLE
scope gateways to owning namespace of router workload

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -169,6 +169,13 @@ var (
 		"If enabled, pilot will attempt to limit unnecessary pushes by determining what proxies "+
 			"a config or endpoint update will impact.",
 	)
+
+	ScopeGatewayToNamespace = env.RegisterBoolVar(
+		"PILOT_SCOPE_GATEWAY_TO_NAMESPACE",
+		false,
+		"If enabled, a gateway workload can only select gateway resources in the same namespace. "+
+			"Gateways with same selectors in different namespaces will not be applicable.",
+	)
 )
 
 var (

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -72,6 +72,8 @@ type PushContext struct {
 	sidecarsByNamespace map[string][]*SidecarScope
 	// envoy filters for each namespace including global config namespace
 	envoyFiltersByNamespace map[string][]*EnvoyFilterWrapper
+	// gateways for each namespace
+	gatewaysByNamespace map[string][]Config
 	////////// END ////////
 
 	// The following data is either a global index or used in the inbound path.
@@ -1057,6 +1059,46 @@ func (ps *PushContext) EnvoyFilters(proxy *Proxy) []*EnvoyFilterWrapper {
 	for _, efw := range ps.envoyFiltersByNamespace[proxy.ConfigNamespace] {
 		if efw.workloadSelector == nil || proxy.WorkloadLabels.IsSupersetOf(efw.workloadSelector) {
 			out = append(out, efw)
+		}
+	}
+	return out
+}
+
+// pre computes gateways per namespace
+func (ps *PushContext) initGateways(env *Environment) error {
+	gatewayConfigs, err := env.List(Gateway.Type, NamespaceAll)
+	if err != nil {
+		return err
+	}
+
+	sortConfigByCreationTime(gatewayConfigs)
+
+	ps.gatewaysByNamespace = make(map[string][]Config)
+	for _, gatewayConfig := range gatewayConfigs {
+		if _, exists := ps.gatewaysByNamespace[gatewayConfig.Namespace]; !exists {
+			ps.gatewaysByNamespace[gatewayConfig.Namespace] = make([]Config, 0)
+		}
+		ps.gatewaysByNamespace[gatewayConfig.Namespace] = append(ps.gatewaysByNamespace[gatewayConfig.Namespace], gatewayConfig)
+	}
+	return nil
+}
+
+func (ps *PushContext) Gateways(proxy *Proxy) []Config {
+	// this should never happen
+	if proxy == nil {
+		return nil
+	}
+	out := make([]Config, 0)
+	for _, cfg := range ps.gatewaysByNamespace[proxy.ConfigNamespace] {
+		gw := cfg.Spec.(*networking.Gateway)
+		if gw.GetSelector() == nil {
+			// no selector. Applies to all workloads asking for the gateway
+			out = append(out, cfg)
+		} else {
+			gatewaySelector := labels.Instance(gw.GetSelector())
+			if proxy.WorkloadLabels.IsSupersetOf(gatewaySelector) {
+				out = append(out, cfg)
+			}
 		}
 	}
 	return out

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -21,6 +21,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/monitoring"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
@@ -350,6 +351,7 @@ func NewPushContext() *PushContext {
 		},
 		sidecarsByNamespace:     map[string][]*SidecarScope{},
 		envoyFiltersByNamespace: map[string][]*EnvoyFilterWrapper{},
+		gatewaysByNamespace:     map[string][]Config{},
 
 		ServiceByHostnameAndNamespace: map[host.Name]map[string]*Service{},
 		ProxyStatus:                   map[string]map[string]ProxyPushStatus{},
@@ -631,6 +633,12 @@ func (ps *PushContext) InitContext(env *Environment) error {
 
 	if err = ps.initEnvoyFilters(env); err != nil {
 		return err
+	}
+
+	if features.ScopeGatewayToNamespace.Get() {
+		if err = ps.initGateways(env); err != nil {
+			return err
+		}
 	}
 
 	// Must be initialized in the end

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -53,7 +53,11 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 	if features.ScopeGatewayToNamespace.Get() {
 		gatewaysForWorkload = push.Gateways(node)
 	} else {
-		gatewaysForWorkload = env.Gateways(node.WorkloadLabels)
+		var workloadLabels labels.Collection
+		for _, w := range node.ServiceInstances {
+			workloadLabels = append(workloadLabels, w.Labels)
+		}
+		gatewaysForWorkload = env.Gateways(workloadLabels)
 	}
 
 	if len(gatewaysForWorkload) == 0 {


### PR DESCRIPTION
While we debate on an api-y way of doing this properly, 
adding this as a feature flag with default false.

When we add workloadSelector to gateway, the logic will become
consistent with envoy filter, sidecar, etc.

Signed-off-by: Shriram Rajagopalan <rshriram@tetrate.io>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure