### PR TITLE
Configure the option --enable-reconcileWebhookConfiguration based on DNS certificate provisioning for Galley

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -72,6 +72,7 @@ spec:
           - --enable-validation=false
 {{- end }}
           - --validation-webhook-config-file
+          - --enable-reconcileWebhookConfiguration={{ .Values.enableReconcileWebhookConfiguration }}
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort={{ .Values.global.monitoringPort }}
 {{- if $.Values.global.logging.level }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -71,7 +71,11 @@ spec:
 {{- if not $.Values.global.configValidation }}
           - --enable-validation=false
 {{- end }}
-          - --enable-reconcileWebhookConfiguration={{ .Values.enableReconcileWebhookConfiguration }}
+{{- if .Values.global.certificates }}
+          - --enable-reconcileWebhookConfiguration=false
+{{- else }}
+          - --enable-reconcileWebhookConfiguration=true
+{{- end }}
           - --validation-webhook-config-file
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort={{ .Values.global.monitoringPort }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
 {{- if not $.Values.global.configValidation }}
           - --enable-validation=false
 {{- end }}
-{{- if .Values.global.certificates }}
+{{- if .Values.global.operator }}
           - --enable-reconcileWebhookConfiguration=false
 {{- else }}
           - --enable-reconcileWebhookConfiguration=true

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -71,8 +71,8 @@ spec:
 {{- if not $.Values.global.configValidation }}
           - --enable-validation=false
 {{- end }}
-          - --validation-webhook-config-file
           - --enable-reconcileWebhookConfiguration={{ .Values.enableReconcileWebhookConfiguration }}
+          - --validation-webhook-config-file
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort={{ .Values.global.monitoringPort }}
 {{- if $.Values.global.logging.level }}

--- a/install/kubernetes/helm/istio/charts/galley/values.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/values.yaml
@@ -36,3 +36,6 @@ enableServiceDiscovery: false
 
 # Enable analysis and status update in Galley
 enableAnalysis: false
+
+# Enable reconcile validatingwebhookconfiguration
+enableReconcileWebhookConfiguration: true

--- a/install/kubernetes/helm/istio/charts/galley/values.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/values.yaml
@@ -37,5 +37,11 @@ enableServiceDiscovery: false
 # Enable analysis and status update in Galley
 enableAnalysis: false
 
-# Enable reconcile validatingwebhookconfiguration
+# Enable reconcile validatingwebhookconfiguration.
+# This parameter sets the CLI parameter enable-reconcileWebhookConfiguration of
+# Galley, which:
+# - If true, Galley will configure its k8s validatingwebhookconfiguration.
+# - If false, Galley will not configure its k8s validatingwebhookconfiguration.
+# If there is another component configures Galley's validatingwebhookconfiguration,
+# this parameter should be set as false.
 enableReconcileWebhookConfiguration: true

--- a/install/kubernetes/helm/istio/charts/galley/values.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/values.yaml
@@ -36,12 +36,3 @@ enableServiceDiscovery: false
 
 # Enable analysis and status update in Galley
 enableAnalysis: false
-
-# Enable reconcile validatingwebhookconfiguration.
-# This parameter sets the CLI parameter enable-reconcileWebhookConfiguration of
-# Galley, which:
-# - If true, Galley will configure its k8s validatingwebhookconfiguration.
-# - If false, Galley will not configure its k8s validatingwebhookconfiguration.
-# If there is another component configures Galley's validatingwebhookconfiguration,
-# this parameter should be set as false.
-enableReconcileWebhookConfiguration: true

--- a/install/kubernetes/helm/istio/charts/pilot/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/clusterrole.yaml
@@ -35,3 +35,12 @@ rules:
 - apiGroups: [""]
   resources: ["endpoints", "pods", "services", "namespaces", "nodes", "secrets"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "get", "watch", "list", "update", "delete"]
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+    - "certificatesigningrequests"
+    - "certificatesigningrequests/approval"
+    - "certificatesigningrequests/status"
+  verbs: ["update", "create", "get", "delete"]

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
-{{- if .Values.global.certificates }}
+{{- if .Values.global.operator }}
             - --reconcileWebhookConfig=false
 {{- else }}
             - --reconcileWebhookConfig=true

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -149,6 +149,10 @@ data:
     rootNamespace: {{ .Release.Namespace }}
 {{- end }}
 
+    # Configures DNS certificates provisioned through Chiron linked into Pilot.
+    certificates:
+{{ toYaml .Values.global.certificates | trim | indent 6 }}
+
     {{- if .Values.global.defaultConfigVisibilitySettings }}
     defaultServiceExportTo:
       {{- range .Values.global.defaultConfigVisibilitySettings }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -581,6 +581,16 @@ global:
   enableHelmTest: false
 
   # Configures DNS certificates provisioned through Chiron linked into Pilot.
-  # Te values in this file are all hard-coded; please ensure the namespaces
+  # The DNS names in this file are all hard-coded; please ensure the namespaces
   # in dnsNames are consistent with those of your services.
+  # Example:
+  # certificates:
+  #   - secretName: dns.istio-galley-service-account
+  #     dnsNames: [istio-galley.istio-system.svc, istio-galley.istio-system]
+  #   - secretName: dns.istio-sidecar-injector-service-account
+  #     dnsNames: [istio-sidecar-injector.istio-system.svc, istio-sidecar-injector.istio-system]
   certificates: []
+
+  # Configures whether Operator manages webhook configurations. The current behavior
+  # of Galley and Sidecar Injector is that they manage their own webhook configurations.
+  operator: false

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -579,3 +579,8 @@ global:
   # This field is set to false by default, so 'helm template ...'
   # will ignore the helm test yaml files when generating the template
   enableHelmTest: false
+
+  # Configures DNS certificates provisioned through Chiron linked into Pilot.
+  # Te values in this file are all hard-coded; please ensure the namespaces
+  # in dnsNames are consistent with those of your services.
+  certificates: []

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1241,7 +1241,7 @@ func (s *Server) initCertController(args *PilotArgs) error {
 			svcName := "istio.pilot"
 			dir := DefaultDirectoryForKeyCert
 			if _, err := os.Stat(dir); os.IsNotExist(err) {
-				err := os.Mkdir(dir, os.ModePerm)
+				err := os.MkdirAll(dir, os.ModePerm)
 				if err != nil {
 					return fmt.Errorf("err to create directory %v: %v", dir, err)
 				}


### PR DESCRIPTION
Configure the option --enable-reconcileWebhookConfiguration of Galley based on DNS certificate provisioning:
- If DNS certificates are provisioned, --enable-reconcileWebhookConfiguration is set as false.
- Otherwise, --enable-reconcileWebhookConfiguration is set as true.

Please provide a description for what this PR is for: #8736.

Design documents:
[1]https://docs.google.com/document/d/1VHyBre8943USOx_YEVtA18KfEoGTmLT1iBHESO5bzcA/edit#heading=h.qex63c29z2to
[2] https://docs.google.com/document/d/1v8BxI07u-mby5f5rCruwF7odSXgb9G8-C9W5hQtSIAg/edit#heading=h.xw1gqgyqs5b

The matching PR on istio/installer repo is: https://github.com/istio/installer/pull/428.

And to help us figure out who should review this PR, please
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
