### PR TITLE
Configure the option --reconcileWebhookConfig based on DNS certificate provisioning for Sidecar Injector

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
-            - --enableSidecarInjectorToManageWebhookConfig={{ .Values.enableSidecarInjectorToManageWebhookConfig }}
+            - --reconcileWebhookConfig={{ .Values.reconcileWebhookConfig }}
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
-            - --enableManageWebhookConfig={{ .Values.enableManageWebhookConfig }}
+            - --enableSidecarInjectorToManageWebhookConfig={{ .Values.enableSidecarInjectorToManageWebhookConfig }}
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -52,7 +52,11 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
-            - --reconcileWebhookConfig={{ .Values.reconcileWebhookConfig }}
+{{- if .Values.global.certificates }}
+            - --reconcileWebhookConfig=false
+{{- else }}
+            - --reconcileWebhookConfig=true
+{{- end }}
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
+            - --enableManageWebhookConfig={{ .Values.enableManageWebhookConfig }}
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
@@ -43,3 +43,6 @@ rewriteAppHTTPProbe: false
 neverInjectSelector: []
 
 alwaysInjectSelector: []
+
+# Enable managing webhookconfiguration
+enableManageWebhookConfig: true

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
@@ -49,4 +49,4 @@ alwaysInjectSelector: []
 # When it is false, Sidecar Injector does not configure its k8s mutatingwebhookconfiguration.
 # If another component configures the k8s mutatingwebhookconfiguration for Sidecar Injector,
 # this parameter should be set as false.
-enableSidecarInjectorToManageWebhookConfig: true
+reconcileWebhookConfig: true

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
@@ -44,5 +44,9 @@ neverInjectSelector: []
 
 alwaysInjectSelector: []
 
-# Enable managing webhookconfiguration
-enableManageWebhookConfig: true
+# Enable Sidecar Injector to configure its k8s mutatingwebhookconfiguration,
+# When it is true, Sidecar Injector configures its k8s mutatingwebhookconfiguration.
+# When it is false, Sidecar Injector does not configure its k8s mutatingwebhookconfiguration.
+# If another component configures the k8s mutatingwebhookconfiguration for Sidecar Injector,
+# this parameter should be set as false.
+enableSidecarInjectorToManageWebhookConfig: true

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
@@ -43,10 +43,3 @@ rewriteAppHTTPProbe: false
 neverInjectSelector: []
 
 alwaysInjectSelector: []
-
-# Enable Sidecar Injector to configure its k8s mutatingwebhookconfiguration,
-# When it is true, Sidecar Injector configures its k8s mutatingwebhookconfiguration.
-# When it is false, Sidecar Injector does not configure its k8s mutatingwebhookconfiguration.
-# If another component configures the k8s mutatingwebhookconfiguration for Sidecar Injector,
-# this parameter should be set as false.
-reconcileWebhookConfig: true

--- a/sidecar-injector/cmd/sidecar-injector/main.go
+++ b/sidecar-injector/cmd/sidecar-injector/main.go
@@ -47,21 +47,21 @@ var (
 	flags = struct {
 		loggingOptions *log.Options
 
-		meshconfig                                 string
-		injectConfigFile                           string
-		injectValuesFile                           string
-		certFile                                   string
-		privateKeyFile                             string
-		caCertFile                                 string
-		port                                       int
-		healthCheckInterval                        time.Duration
-		healthCheckFile                            string
-		probeOptions                               probe.Options
-		kubeconfigFile                             string
-		webhookConfigName                          string
-		webhookName                                string
-		monitoringPort                             int
-		enableSidecarInjectorToManageWebhookConfig bool
+		meshconfig             string
+		injectConfigFile       string
+		injectValuesFile       string
+		certFile               string
+		privateKeyFile         string
+		caCertFile             string
+		port                   int
+		healthCheckInterval    time.Duration
+		healthCheckFile        string
+		probeOptions           probe.Options
+		kubeconfigFile         string
+		webhookConfigName      string
+		webhookName            string
+		monitoringPort         int
+		reconcileWebhookConfig bool
 	}{
 		loggingOptions: log.DefaultOptions(),
 	}
@@ -96,7 +96,7 @@ var (
 			}
 
 			stop := make(chan struct{})
-			if flags.enableSidecarInjectorToManageWebhookConfig {
+			if flags.reconcileWebhookConfig {
 				if err := patchCertLoop(stop); err != nil {
 					return multierror.Prefix(err, "failed to start patch cert loop")
 				}
@@ -231,7 +231,7 @@ func init() {
 		"Name of the mutatingwebhookconfiguration resource in Kubernetes.")
 	rootCmd.PersistentFlags().StringVar(&flags.webhookName, "webhookName", "sidecar-injector.istio.io",
 		"Name of the webhook entry in the webhook config.")
-	rootCmd.PersistentFlags().BoolVar(&flags.enableSidecarInjectorToManageWebhookConfig, "enableSidecarInjectorToManageWebhookConfig", true,
+	rootCmd.PersistentFlags().BoolVar(&flags.reconcileWebhookConfig, "reconcileWebhookConfig", true,
 		"Enable managing webhook configuration.")
 	// Attach the Istio logging options to the command.
 	flags.loggingOptions.AttachCobraFlags(rootCmd)

--- a/sidecar-injector/cmd/sidecar-injector/main.go
+++ b/sidecar-injector/cmd/sidecar-injector/main.go
@@ -47,20 +47,21 @@ var (
 	flags = struct {
 		loggingOptions *log.Options
 
-		meshconfig          string
-		injectConfigFile    string
-		injectValuesFile    string
-		certFile            string
-		privateKeyFile      string
-		caCertFile          string
-		port                int
-		healthCheckInterval time.Duration
-		healthCheckFile     string
-		probeOptions        probe.Options
-		kubeconfigFile      string
-		webhookConfigName   string
-		webhookName         string
-		monitoringPort      int
+		meshconfig                string
+		injectConfigFile          string
+		injectValuesFile          string
+		certFile                  string
+		privateKeyFile            string
+		caCertFile                string
+		port                      int
+		healthCheckInterval       time.Duration
+		healthCheckFile           string
+		probeOptions              probe.Options
+		kubeconfigFile            string
+		webhookConfigName         string
+		webhookName               string
+		monitoringPort            int
+		enableManageWebhookConfig bool
 	}{
 		loggingOptions: log.DefaultOptions(),
 	}
@@ -95,8 +96,10 @@ var (
 			}
 
 			stop := make(chan struct{})
-			if err := patchCertLoop(stop); err != nil {
-				return multierror.Prefix(err, "failed to start patch cert loop")
+			if flags.enableManageWebhookConfig {
+				if err := patchCertLoop(stop); err != nil {
+					return multierror.Prefix(err, "failed to start patch cert loop")
+				}
 			}
 
 			go wh.Run(stop)
@@ -228,6 +231,8 @@ func init() {
 		"Name of the mutatingwebhookconfiguration resource in Kubernetes.")
 	rootCmd.PersistentFlags().StringVar(&flags.webhookName, "webhookName", "sidecar-injector.istio.io",
 		"Name of the webhook entry in the webhook config.")
+	rootCmd.PersistentFlags().BoolVar(&flags.enableManageWebhookConfig, "enableManageWebhookConfig", true,
+		"Enable managing webhook configuration.")
 	// Attach the Istio logging options to the command.
 	flags.loggingOptions.AttachCobraFlags(rootCmd)
 

--- a/sidecar-injector/cmd/sidecar-injector/main.go
+++ b/sidecar-injector/cmd/sidecar-injector/main.go
@@ -47,21 +47,21 @@ var (
 	flags = struct {
 		loggingOptions *log.Options
 
-		meshconfig                string
-		injectConfigFile          string
-		injectValuesFile          string
-		certFile                  string
-		privateKeyFile            string
-		caCertFile                string
-		port                      int
-		healthCheckInterval       time.Duration
-		healthCheckFile           string
-		probeOptions              probe.Options
-		kubeconfigFile            string
-		webhookConfigName         string
-		webhookName               string
-		monitoringPort            int
-		enableManageWebhookConfig bool
+		meshconfig                                 string
+		injectConfigFile                           string
+		injectValuesFile                           string
+		certFile                                   string
+		privateKeyFile                             string
+		caCertFile                                 string
+		port                                       int
+		healthCheckInterval                        time.Duration
+		healthCheckFile                            string
+		probeOptions                               probe.Options
+		kubeconfigFile                             string
+		webhookConfigName                          string
+		webhookName                                string
+		monitoringPort                             int
+		enableSidecarInjectorToManageWebhookConfig bool
 	}{
 		loggingOptions: log.DefaultOptions(),
 	}
@@ -96,7 +96,7 @@ var (
 			}
 
 			stop := make(chan struct{})
-			if flags.enableManageWebhookConfig {
+			if flags.enableSidecarInjectorToManageWebhookConfig {
 				if err := patchCertLoop(stop); err != nil {
 					return multierror.Prefix(err, "failed to start patch cert loop")
 				}
@@ -231,7 +231,7 @@ func init() {
 		"Name of the mutatingwebhookconfiguration resource in Kubernetes.")
 	rootCmd.PersistentFlags().StringVar(&flags.webhookName, "webhookName", "sidecar-injector.istio.io",
 		"Name of the webhook entry in the webhook config.")
-	rootCmd.PersistentFlags().BoolVar(&flags.enableManageWebhookConfig, "enableManageWebhookConfig", true,
+	rootCmd.PersistentFlags().BoolVar(&flags.enableSidecarInjectorToManageWebhookConfig, "enableSidecarInjectorToManageWebhookConfig", true,
 		"Enable managing webhook configuration.")
 	// Attach the Istio logging options to the command.
 	flags.loggingOptions.AttachCobraFlags(rootCmd)


### PR DESCRIPTION
Configure the option --reconcileWebhookConfig of Sidecar Injector based on DNS certificate provisioning: (the approach is this PR is same as that of https://github.com/istio/istio/pull/16118).

- If DNS certificates are provisioned, --enable-reconcileWebhookConfiguration is set as false.
- Otherwise, --enable-reconcileWebhookConfiguration is set as true.

Please provide a description for what this PR is for: https://github.com/istio/istio/issues/17061

Design documents:
[1]https://docs.google.com/document/d/1VHyBre8943USOx_YEVtA18KfEoGTmLT1iBHESO5bzcA/edit#heading=h.qex63c29z2to
[2] https://docs.google.com/document/d/1v8BxI07u-mby5f5rCruwF7odSXgb9G8-C9W5hQtSIAg/edit#heading=h.xw1gqgyqs5b

The matching PR on istio-installer repo: https://github.com/istio/installer/pull/428

And to help us figure out who should review this PR, please
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure