### PR TITLE
 Parse workload labels firstly from node metadata

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -275,9 +275,8 @@ func (node *Proxy) SetWorkloadLabels(env *Environment) error {
 
 	l, err := env.GetProxyWorkloadLabels(node)
 	if err != nil {
-		log.Warnf("failed to get service proxy workload labels: %v, defaulting to proxy metadata", err)
-		// TODO: node.Metadata also includes all the labels, not sure whether will be removed in future
-		l = labels.Collection{node.Metadata}
+		log.Errorf("failed to get service proxy labels: %v", err)
+		return err
 	}
 
 	node.WorkloadLabels = l

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -268,7 +268,8 @@ func (node *Proxy) SetServiceInstances(env *Environment) error {
 }
 
 func (node *Proxy) SetWorkloadLabels(env *Environment) error {
-	// The WorkloadLabels is already parsed from Node metadata["istio.io/metadata"][labels]
+	// The WorkloadLabels is already parsed from Node metadata["LABELS"]
+	// Or updated in DiscoveryServer.WorkloadUpdate.
 	if node.WorkloadLabels != nil {
 		return nil
 	}
@@ -370,8 +371,8 @@ func ParseServiceNodeWithMetadata(s string, metadata map[string]string) (*Proxy,
 	out.IstioVersion = ParseIstioVersion(metadata[NodeMetadataIstioVersion])
 
 	if data, ok := metadata[NodeMetadataLabels]; ok {
-		nodeLabels := make(map[string]string)
-		if err := json.Unmarshal([]byte(data), nodeLabels); err != nil {
+		var nodeLabels map[string]string
+		if err := json.Unmarshal([]byte(data), &nodeLabels); err != nil {
 			return out, fmt.Errorf("invalid %s: %s", NodeMetadataLabels, data)
 		}
 		if len(nodeLabels) > 0 {

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -373,7 +373,7 @@ func ParseServiceNodeWithMetadata(s string, metadata map[string]string) (*Proxy,
 	if data, ok := metadata[NodeMetadataLabels]; ok {
 		var nodeLabels map[string]string
 		if err := json.Unmarshal([]byte(data), &nodeLabels); err != nil {
-			return out, fmt.Errorf("invalid %s: %s", NodeMetadataLabels, data)
+			log.Warnf("invalid node label %s: %v", data, err)
 		}
 		if len(nodeLabels) > 0 {
 			out.WorkloadLabels = labels.Collection{nodeLabels}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -53,11 +53,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 	if features.ScopeGatewayToNamespace.Get() {
 		gatewaysForWorkload = push.Gateways(node)
 	} else {
-		var workloadLabels labels.Collection
-		for _, w := range node.ServiceInstances {
-			workloadLabels = append(workloadLabels, w.Labels)
-		}
-		gatewaysForWorkload = env.Gateways(workloadLabels)
+		gatewaysForWorkload = env.Gateways(node.WorkloadLabels)
 	}
 
 	if len(gatewaysForWorkload) == 0 {

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -345,7 +345,7 @@ func TestLDS(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer cancel()
-		err = sendLDSReq(gatewayID(gatewayIP), ldsr)
+		err = sendLDSReqWithLabels(gatewayID(gatewayIP), ldsr, map[string]string{"version": "v2", "app": "my-gateway-controller"})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -540,6 +540,43 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 	}
 }
 
+// TestLDSWithWorkloadLabelUpdate tests updating workload labels will trigger xDS
+func TestLDSWithWorkloadLabelUpdate(t *testing.T) {
+	server, tearDown := initLocalPilotTestEnv(t)
+	defer tearDown()
+
+	registry := memServiceDiscovery(server, t)
+	registry.AddWorkload(app3Ip, labels.Instance{"version": "v1"})
+
+	t.Run("workload label update", func(t *testing.T) {
+		ldsr, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+			IP:        app3Ip,
+			Namespace: "default",
+			Workload:  "app3",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ldsr.Close()
+
+		ldsr.Watch()
+
+		_, err = ldsr.Wait(5*time.Second, "lds")
+		if err != nil {
+			t.Fatal("Failed to receive LDS", err)
+			return
+		}
+
+		// trigger full push
+		registry.UpdateWorkloadLabels(app3Ip, labels.Instance{"version": "v2"})
+		_, err = ldsr.Wait(5*time.Second, "lds")
+		if err != nil {
+			t.Fatal("Failed to receive LDS", err)
+			return
+		}
+	})
+}
+
 func expectLuaFilter(t *testing.T, l *xdsapi.Listener, expected bool) {
 	if l != nil {
 		var chain *xdsapi_listener.FilterChain

--- a/pilot/pkg/proxy/envoy/v2/mem.go
+++ b/pilot/pkg/proxy/envoy/v2/mem.go
@@ -108,6 +108,7 @@ func (sd *MemServiceDiscovery) ClearErrors() {
 
 func (sd *MemServiceDiscovery) AddWorkload(ip string, labels labels.Instance) {
 	sd.ip2workloadLabels[ip] = &labels
+	sd.EDSUpdater.WorkloadUpdate(sd.ClusterID, map[string]string(labels), nil)
 }
 
 // AddHTTPService is a helper to add a service of type http, named 'http-main', with the
@@ -233,6 +234,11 @@ func (sd *MemServiceDiscovery) SetEndpoints(service string, namespace string, en
 	}
 
 	_ = sd.EDSUpdater.EDSUpdate(sd.ClusterID, service, namespace, endpoints)
+}
+
+// UpdateWorkloadLabels updates the workload labels, similar with K8S controller.
+func (sd *MemServiceDiscovery) UpdateWorkloadLabels(ip string, labels labels.Instance) {
+	sd.AddWorkload(ip, labels)
 }
 
 // Services implements discovery interface


### PR DESCRIPTION

This is kind of enhancement, as Node Metadata[labels] now include all labels associated with the workloads. So use it if it exists, otherwise, fall back to previous logic: `GetProxyWorkloadLabels`


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
