### PR TITLE
Fix the upgrade issue for tracing

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.provider "jaeger" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,7 +22,6 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         sidecar.istio.io/inject: "false"
-{{- if eq .Values.provider "jaeger" }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "16686"
 {{- if .Values.contextPath }}
@@ -43,7 +43,6 @@ spec:
 {{- end }}
 {{- end }}
       containers:
-{{- if eq .Values.provider "jaeger" }}
         - name: jaeger
           image: "{{ .Values.jaeger.hub }}/{{ .Values.jaeger.image }}:{{ .Values.jaeger.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
@@ -107,42 +106,6 @@ spec:
         emptyDir: {}
 {{- end }}
 {{- end }}
-{{- else if eq .Values.provider "zipkin"}}
-        - name: zipkin
-          image: "{{ .Values.zipkin.hub }}/{{ .Values.zipkin.image }}:{{ .Values.zipkin.tag }}"
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-          ports:
-            - containerPort: {{ .Values.zipkin.queryPort }}
-          livenessProbe:
-            initialDelaySeconds: {{ .Values.zipkin.probeStartupDelay }}
-            tcpSocket:
-              port: {{ .Values.zipkin.queryPort }}
-          readinessProbe:
-            initialDelaySeconds: {{ .Values.zipkin.probeStartupDelay }}
-            httpGet:
-              path: /health
-              port: {{ .Values.zipkin.queryPort }}
-          resources:
-{{- if .Values.zipkin.resources }}
-{{ toYaml .Values.zipkin.resources | indent 12 }}
-{{- else }}
-{{ toYaml .Values.global.defaultResources | indent 12 }}
-{{- end }}
-          env:
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: QUERY_PORT
-              value: "{{ .Values.zipkin.queryPort }}"
-            - name: JAVA_OPTS
-              value: "-XX:ConcGCThreads={{ .Values.zipkin.node.cpus }} -XX:ParallelGCThreads={{ .Values.zipkin.node.cpus }} -Djava.util.concurrent.ForkJoinPool.common.parallelism={{ .Values.zipkin.node.cpus }} -Xms{{ .Values.zipkin.javaOptsHeap }}M -Xmx{{ .Values.zipkin.javaOptsHeap }}M -XX:+UseG1GC -server"
-            - name: STORAGE_METHOD
-              value: "mem"
-            - name: ZIPKIN_STORAGE_MEM_MAXSPANS
-              value: "{{ .Values.zipkin.maxSpans }}"
-{{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
@@ -153,3 +116,4 @@ spec:
       tolerations:
 {{ toYaml .Values.global.defaultTolerations | indent 6 }}
       {{- end }}
+{{ end }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-zipkin.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-zipkin.yaml
@@ -6,18 +6,18 @@ metadata:
   name: istio-tracing
   namespace: {{ .Release.Namespace }}
   labels:
-    app: zipkin
+    app: {{ template "tracing.name" . }}
     chart: {{ template "tracing.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app: zipkin
+      app: {{ template "tracing.name" . }}
   template:
     metadata:
       labels:
-        app: zipkin
+        app: {{ template "tracing.name" . }}
         chart: {{ template "tracing.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
@@ -21,7 +21,6 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         sidecar.istio.io/inject: "false"
-        scheduler.alpha.kubernetes.io/critical-pod: ""
 {{- if eq .Values.provider "jaeger" }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "16686"

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
@@ -1,28 +1,28 @@
-{{ if eq .Values.provider "jaeger" }}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-tracing
   namespace: {{ .Release.Namespace }}
   labels:
-    app: jaeger
+    app: {{ template "tracing.name" . }}
     chart: {{ template "tracing.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app: jaeger
+      app: {{ template "tracing.name" . }}
   template:
     metadata:
       labels:
-        app: jaeger
+        app: {{ template "tracing.name" . }}
         chart: {{ template "tracing.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+{{- if eq .Values.provider "jaeger" }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "16686"
 {{- if .Values.contextPath }}
@@ -44,6 +44,7 @@ spec:
 {{- end }}
 {{- end }}
       containers:
+{{- if eq .Values.provider "jaeger" }}
         - name: jaeger
           image: "{{ .Values.jaeger.hub }}/{{ .Values.jaeger.image }}:{{ .Values.jaeger.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
@@ -97,16 +98,6 @@ spec:
 {{- else }}
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
-      affinity:
-      {{- include "nodeaffinity" . | indent 6 }}
-      {{- include "podAntiAffinity" . | indent 6 }}
-      {{- if .Values.tolerations }}
-      tolerations:
-{{ toYaml .Values.tolerations | indent 6 }}
-      {{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
-      {{- end }}
 {{- if eq .Values.jaeger.spanStorageType "badger" }}
       volumes:
       - name: data
@@ -117,4 +108,49 @@ spec:
         emptyDir: {}
 {{- end }}
 {{- end }}
-{{ end }}
+{{- else if eq .Values.provider "zipkin"}}
+        - name: zipkin
+          image: "{{ .Values.zipkin.hub }}/{{ .Values.zipkin.image }}:{{ .Values.zipkin.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - containerPort: {{ .Values.zipkin.queryPort }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.zipkin.probeStartupDelay }}
+            tcpSocket:
+              port: {{ .Values.zipkin.queryPort }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.zipkin.probeStartupDelay }}
+            httpGet:
+              path: /health
+              port: {{ .Values.zipkin.queryPort }}
+          resources:
+{{- if .Values.zipkin.resources }}
+{{ toYaml .Values.zipkin.resources | indent 12 }}
+{{- else }}
+{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{- end }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: QUERY_PORT
+              value: "{{ .Values.zipkin.queryPort }}"
+            - name: JAVA_OPTS
+              value: "-XX:ConcGCThreads={{ .Values.zipkin.node.cpus }} -XX:ParallelGCThreads={{ .Values.zipkin.node.cpus }} -Djava.util.concurrent.ForkJoinPool.common.parallelism={{ .Values.zipkin.node.cpus }} -Xms{{ .Values.zipkin.javaOptsHeap }}M -Xmx{{ .Values.zipkin.javaOptsHeap }}M -XX:+UseG1GC -server"
+            - name: STORAGE_METHOD
+              value: "mem"
+            - name: ZIPKIN_STORAGE_MEM_MAXSPANS
+              value: "{{ .Values.zipkin.maxSpans }}"
+{{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
+      {{- include "podAntiAffinity" . | indent 6 }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "tracing.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Values.provider }}
+    app: {{ template "tracing.name" . }}
     chart: {{ template "tracing.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/pvc.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   name: istio-jaeger-pvc
   namespace: {{ .Release.Namespace }}
   labels:
-    app: jaeger
+    app: {{ template "tracing.name" . }}
     chart: {{ template "tracing.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jaeger-services
   namespace: {{ .Release.Namespace }}
   labels:
-    app: jaeger
+    app: {{ template "tracing.name" . }}
     chart: {{ template "tracing.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -21,7 +21,7 @@ items:
       {{ $key }}: {{ $val | quote }}
       {{- end }}
     labels:
-      app: jaeger
+      app: {{ template "tracing.name" . }}
       jaeger-infra: jaeger-service
       chart: {{ template "tracing.chart" . }}
       heritage: {{ .Release.Service }}
@@ -33,14 +33,14 @@ items:
         protocol: TCP
         targetPort: 16686
     selector:
-      app: jaeger
+      app: {{ template "tracing.name" . }}
 - apiVersion: v1
   kind: Service
   metadata:
     name: jaeger-collector
     namespace: {{ .Release.Namespace }}
     labels:
-      app: jaeger
+      app: {{ template "tracing.name" . }}
       jaeger-infra: collector-service
       chart: {{ template "tracing.chart" . }}
       heritage: {{ .Release.Service }}
@@ -56,7 +56,7 @@ items:
       targetPort: 14268
       protocol: TCP
     selector:
-      app: jaeger
+      app: {{ template "tracing.name" . }}
     type: ClusterIP
 - apiVersion: v1
   kind: Service
@@ -64,7 +64,7 @@ items:
     name: jaeger-agent
     namespace: {{ .Release.Namespace }}
     labels:
-      app: jaeger
+      app: {{ template "tracing.name" . }}
       jaeger-infra: agent-service
       chart: {{ template "tracing.chart" . }}
       heritage: {{ .Release.Service }}
@@ -85,6 +85,6 @@ items:
       targetPort: 6832
     clusterIP: None
     selector:
-      app: jaeger
+      app: {{ template "tracing.name" . }}
 {{ end }}
 

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
@@ -51,6 +51,6 @@ items:
         targetPort: 16686
 {{ else }}
         targetPort: 9411
-{{ end}}
+{{ end }}
     selector:
       app: {{ template "tracing.name" . }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tracing-services
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Values.provider }}
+    app: {{ template "tracing.name" . }}
     chart: {{ template "tracing.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -15,7 +15,7 @@ items:
     name: zipkin
     namespace: {{ .Release.Namespace }}
     labels:
-      app: {{ .Values.provider }}
+      app: {{ template "tracing.name" . }}
       chart: {{ template "tracing.chart" . }}
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
@@ -38,7 +38,7 @@ items:
       {{ $key }}: {{ $val | quote }}
       {{- end }}
     labels:
-      app: {{ .Values.provider }}
+      app: {{ template "tracing.name" . }}
       chart: {{ template "tracing.chart" . }}
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
@@ -53,4 +53,4 @@ items:
         targetPort: 9411
 {{ end}}
     selector:
-      app: {{ .Values.provider }}
+      app: {{ template "tracing.name" . }}


### PR DESCRIPTION
Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>

When we installed the istio with tracing.provider=jaeger. then use helm to upgrade to use `zipkin` provider.
```
helm upgrade istio ./install/kubernetes/helm/istio --tls --set tracing.enabled=true --set tracing.provider=zipkin
```
 it throws 
```
Error: UPGRADE FAILED: Deployment.apps "istio-tracing" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"jaeger"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

I suggest to share the same selector for both jaeger and zipkin. the fix changes the `LabelSelector` so when upgrade from 1.2.x to this version, it needs to use `--force`. in future, do not need to force upgrade.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
