### PR TITLE
WIP: Pin base_debug to VERSION in Makefile

### DIFF
--- a/docker/Dockerfile.kubectl
+++ b/docker/Dockerfile.kubectl
@@ -4,7 +4,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 # This container should only contain kubectl.  Hard-coding to use Linux K8s 1.11.1 version.
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl /usr/bin/kubectl

--- a/docker/Dockerfile.kubectl
+++ b/docker/Dockerfile.kubectl
@@ -4,7 +4,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 
 # This container should only contain kubectl.  Hard-coding to use Linux K8s 1.11.1 version.
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl /usr/bin/kubectl

--- a/docker/Dockerfile.kubectl
+++ b/docker/Dockerfile.kubectl
@@ -1,6 +1,10 @@
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
 # Image for post install jobs
+
+# Version is the base image version from the TLD Makefile
+ARG ISTIO_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
 
 # This container should only contain kubectl.  Hard-coding to use Linux K8s 1.11.1 version.
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl /usr/bin/kubectl

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -1,9 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# Version is the base image version from the TLD Makefile
+ARG ISTIO_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# hadolint ignore=DL3006
-FROM istionightly/base_debug as default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -5,7 +5,7 @@ ARG BASE_DISTRIBUTION=default
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -5,7 +5,7 @@ ARG BASE_DISTRIBUTION=default
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/mixer/docker/Dockerfile.test_policybackend
+++ b/mixer/docker/Dockerfile.test_policybackend
@@ -1,9 +1,12 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# ISTIO_VERSION is used to specify the version of the release
+ARG ISTIO_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
 # hadolint ignore=DL3006
-FROM istionightly/base_debug as default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/mixer/docker/Dockerfile.test_policybackend
+++ b/mixer/docker/Dockerfile.test_policybackend
@@ -6,7 +6,7 @@ ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 # hadolint ignore=DL3006
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/mixer/docker/Dockerfile.test_policybackend
+++ b/mixer/docker/Dockerfile.test_policybackend
@@ -6,7 +6,7 @@ ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 # hadolint ignore=DL3006
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -1,9 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# ISTIO_VERSION is used to specify the version of the release
+ARG ISTIO_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# hadolint ignore=DL3006
-FROM istionightly/base_debug as default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -5,7 +5,7 @@ ARG BASE_DISTRIBUTION=default
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -5,7 +5,7 @@ ARG BASE_DISTRIBUTION=default
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -2,7 +2,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 
 ARG proxy_version
 ARG istio_version

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -2,7 +2,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 ARG proxy_version
 ARG istio_version

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -1,5 +1,9 @@
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
+# ISTIO_VERSION is used to specify the version of the release
+ARG ISTIO_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+
 ARG proxy_version
 ARG istio_version
 

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -2,7 +2,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 ARG proxy_version
 ARG istio_version
 

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -1,5 +1,8 @@
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
+# ISTIO_VERSION is used to specify the version of the release
+ARG ISTIO_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
 ARG proxy_version
 ARG istio_version
 

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -2,7 +2,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 ARG proxy_version
 ARG istio_version
 

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -5,7 +5,7 @@ ARG BASE_DISTRIBUTION=default
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 # Add CA certificates for SSL connections.
 # obtained from debian ca-certs deb using fetch_cacerts.sh

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -1,9 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# ISTIO_VERSION is used to specify the version of the release
+ARG ISTIO_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# hadolint ignore=DL3006
-FROM istionightly/base_debug as default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
 
 # Add CA certificates for SSL connections.
 # obtained from debian ca-certs deb using fetch_cacerts.sh

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -5,7 +5,7 @@ ARG BASE_DISTRIBUTION=default
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 
 # Add CA certificates for SSL connections.
 # obtained from debian ca-certs deb using fetch_cacerts.sh

--- a/pkg/test/docker/image.go
+++ b/pkg/test/docker/image.go
@@ -54,7 +54,7 @@ type ImageBuilder struct {
 // NewImageBuilder creates a new ImageBuilder instance.
 func NewImageBuilder() *ImageBuilder {
 	return &ImageBuilder{
-		entries: make(map[string]entry),
+		entries:   make(map[string]entry),
 		buildArgs: make(map[string]*string),
 	}
 }
@@ -62,8 +62,8 @@ func NewImageBuilder() *ImageBuilder {
 // Copy this builder.
 func (b *ImageBuilder) Copy() *ImageBuilder {
 	return &ImageBuilder{
-		tags:    append([]string{}, b.tags...),
-		entries: copyEntries(b.entries),
+		tags:      append([]string{}, b.tags...),
+		entries:   copyEntries(b.entries),
 		buildArgs: copyBuildArgs(b.buildArgs),
 	}
 }

--- a/pkg/test/docker/image.go
+++ b/pkg/test/docker/image.go
@@ -55,6 +55,7 @@ type ImageBuilder struct {
 func NewImageBuilder() *ImageBuilder {
 	return &ImageBuilder{
 		entries: make(map[string]entry),
+		buildArgs: make(map[string]*string),
 	}
 }
 
@@ -63,6 +64,7 @@ func (b *ImageBuilder) Copy() *ImageBuilder {
 	return &ImageBuilder{
 		tags:    append([]string{}, b.tags...),
 		entries: copyEntries(b.entries),
+		buildArgs: copyBuildArgs(b.buildArgs),
 	}
 }
 
@@ -212,6 +214,14 @@ func writeTarEntry(w *tar.Writer, name string, fileMode os.FileMode, content []b
 
 func copyEntries(in map[string]entry) map[string]entry {
 	out := make(map[string]entry)
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func copyBuildArgs(in map[string]*string) map[string]*string {
+	out := make(map[string]*string)
 	for k, v := range in {
 		out[k] = v
 	}

--- a/pkg/test/docker/image.go
+++ b/pkg/test/docker/image.go
@@ -47,7 +47,8 @@ type entry struct {
 type ImageBuilder struct {
 	entries map[string]entry
 	tags    []string
-	err     error
+	buildArgs map[string]*string
+	err       error
 }
 
 // NewImageBuilder creates a new ImageBuilder instance.
@@ -141,6 +142,12 @@ func (b *ImageBuilder) Tag(tags ...string) *ImageBuilder {
 	return b
 }
 
+// BuildArgs adds the given buildArg to the image.
+func (b *ImageBuilder) BuildArg(arg string, value *string) *ImageBuilder {
+	b.buildArgs[arg] = value
+	return b
+}
+
 // Build the image and return the ID.
 func (b *ImageBuilder) Build(dockerClient *client.Client) (Image, error) {
 	if b.err != nil {
@@ -169,6 +176,7 @@ func (b *ImageBuilder) Build(dockerClient *client.Client) (Image, error) {
 		Remove:      true,
 		ForceRemove: true,
 		NoCache:     true,
+		BuildArgs:   b.buildArgs,
 	})
 	if err != nil {
 		return "", err

--- a/pkg/test/docker/image.go
+++ b/pkg/test/docker/image.go
@@ -45,10 +45,10 @@ type entry struct {
 
 // ImageBuilder is a utility for creating Docker images.
 type ImageBuilder struct {
-	entries map[string]entry
-	tags    []string
 	buildArgs map[string]*string
 	err       error
+	entries   map[string]entry
+	tags      []string
 }
 
 // NewImageBuilder creates a new ImageBuilder instance.

--- a/pkg/test/echo/docker/Dockerfile.app
+++ b/pkg/test/echo/docker/Dockerfile.app
@@ -2,7 +2,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 
 COPY pkg-test-echo-cmd-client /usr/local/bin/client
 COPY pkg-test-echo-cmd-server /usr/local/bin/server

--- a/pkg/test/echo/docker/Dockerfile.app
+++ b/pkg/test/echo/docker/Dockerfile.app
@@ -2,7 +2,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 COPY pkg-test-echo-cmd-client /usr/local/bin/client
 COPY pkg-test-echo-cmd-server /usr/local/bin/server

--- a/pkg/test/echo/docker/Dockerfile.app
+++ b/pkg/test/echo/docker/Dockerfile.app
@@ -1,5 +1,8 @@
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
+# ISTIO_VERSION is used to specify the version of the release
+ARG ISTIO_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
 
 COPY pkg-test-echo-cmd-client /usr/local/bin/client
 COPY pkg-test-echo-cmd-server /usr/local/bin/server

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar
@@ -1,5 +1,8 @@
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
+# ISTIO_VERSION is used to specify the version of the release
+ARG ISTIO_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
 
 # Add CA certificates for SSL connections.
 # obtained from debian ca-certs deb using fetch_cacerts.sh

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar
@@ -2,7 +2,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 # Add CA certificates for SSL connections.
 # obtained from debian ca-certs deb using fetch_cacerts.sh

--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -59,7 +59,7 @@ var (
 	// nolint: golint
 	PULL_POLICY Variable = "PULL_POLICY"
 
-	// VERSION is Docker tag used for the base_debug image.
+	// VERSION is Docker tag used for the base image.
 	VERSION Variable = "READ_FROM_ENVIRONMENT"
 
 	// ISTIO_TEST_KUBE_CONFIG is the Kubernetes configuration file to use for testing. If a configuration file

--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -60,7 +60,7 @@ var (
 	PULL_POLICY Variable = "PULL_POLICY"
 
 	// VERSION is Docker tag used for the base_debug image.
-	VERSION Variable = "1.3.0-dev"
+	VERSION Variable = "READ_FROM_ENVIRONMENT"
 
 	// ISTIO_TEST_KUBE_CONFIG is the Kubernetes configuration file to use for testing. If a configuration file
 	// is specified on the command-line, that takes precedence.

--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -59,6 +59,9 @@ var (
 	// nolint: golint
 	PULL_POLICY Variable = "PULL_POLICY"
 
+	// VERSION is Docker tag used for the base_debug image.
+	VERSION Variable = "1.3.0-dev"
+
 	// ISTIO_TEST_KUBE_CONFIG is the Kubernetes configuration file to use for testing. If a configuration file
 	// is specified on the command-line, that takes precedence.
 	// nolint: golint

--- a/pkg/test/framework/components/echo/docker/images/image.go
+++ b/pkg/test/framework/components/echo/docker/images/image.go
@@ -248,11 +248,14 @@ func initBuilders() error {
 		return err
 	}
 
+	ver := "1.3-dev"
 	noSidecarBuilder = b.Copy().
 		Tag(noSidecarImageName+":test").
+		BuildArg("ISTIO_VERSION", &ver).
 		AddFile("Dockerfile", istioPath(noSidecarDockerFile))
 	sidecarBuilder = b.Copy().
 		Tag(sidecarImageName+":test").
+		BuildArg("ISTIO_VERSION", &ver).
 		AddFile("echo-start.sh", istioPath(sidecarStartScript)).
 		AddFile("Dockerfile", istioPath(sidecarDockerFile))
 

--- a/pkg/test/framework/core/image/flags.go
+++ b/pkg/test/framework/core/image/flags.go
@@ -27,6 +27,7 @@ var (
 		Hub:        env.HUB.Value(),
 		Tag:        env.TAG.Value(),
 		PullPolicy: env.PULL_POLICY.Value(),
+		Version:    env.VERSION.Value(),
 	}
 )
 
@@ -57,4 +58,6 @@ func init() {
 		"Common Container tag to use when deploying container images")
 	flag.StringVar(&settingsFromCommandLine.PullPolicy, "istio.test.pullpolicy", settingsFromCommandLine.PullPolicy,
 		"Common image pull policy to use when deploying container images")
+	flag.StringVar(&settingsFromCommandLine.Version, "istio.test.version", settingsFromCommandLine.Version,
+		"The base image version when deploying container images")
 }

--- a/pkg/test/framework/core/image/settings.go
+++ b/pkg/test/framework/core/image/settings.go
@@ -40,6 +40,9 @@ type Settings struct {
 
 	// Image pull policy to use for deployments. If not specified, the defaults of each deployment will be used.
 	PullPolicy string
+
+	// Version to use for base image. If not specified, latest is used by default in the build system.
+	Version string
 }
 
 func (s *Settings) clone() *Settings {

--- a/release/gcb/cloud_builder.sh
+++ b/release/gcb/cloud_builder.sh
@@ -45,6 +45,7 @@ export GOPATH
 echo gopath is "$GOPATH"
 # this is needed for istioctl and other parts of build to get the version info
 export ISTIO_VERSION="${CB_VERSION}"
+export VERSION="${CB_VERSION}"
 
 # build docker tar images
 REL_DOCKER_HUB=docker.io/istio

--- a/release/gcb/cloud_builder.sh
+++ b/release/gcb/cloud_builder.sh
@@ -48,7 +48,7 @@ export ISTIO_VERSION="${CB_VERSION}"
 export VERSION="${CB_VERSION}"
 
 # build docker tar images
-REL_DOCKER_HUB=docker.io/sdake
+REL_DOCKER_HUB=docker.io/istio
 
 make_istio "${OUTPUT_PATH}" "${CB_ISTIOCTL_DOCKER_HUB}" "${REL_DOCKER_HUB}" "${CB_VERSION}" "${CB_BRANCH}"
 cp "/workspace/manifest.txt" "${OUTPUT_PATH}"

--- a/release/gcb/cloud_builder.sh
+++ b/release/gcb/cloud_builder.sh
@@ -48,7 +48,7 @@ export ISTIO_VERSION="${CB_VERSION}"
 export VERSION="${CB_VERSION}"
 
 # build docker tar images
-REL_DOCKER_HUB=docker.io/istio
+REL_DOCKER_HUB=docker.io/sdake
 
 make_istio "${OUTPUT_PATH}" "${CB_ISTIOCTL_DOCKER_HUB}" "${REL_DOCKER_HUB}" "${CB_VERSION}" "${CB_BRANCH}"
 cp "/workspace/manifest.txt" "${OUTPUT_PATH}"

--- a/security/docker/Dockerfile.node-agent-k8s
+++ b/security/docker/Dockerfile.node-agent-k8s
@@ -1,9 +1,12 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# ISTIO_VERSION is used to specify the version of the release
+ARG ISTIO_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# hadolint ignore=DL3006
-FROM istionightly/base_debug as default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+
 # hadolint ignore=DL3005,DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && update-ca-certificates && apt-get clean  && rm -rf /var/lib/apt/lists/*
 

--- a/security/docker/Dockerfile.node-agent-k8s
+++ b/security/docker/Dockerfile.node-agent-k8s
@@ -5,7 +5,7 @@ ARG BASE_DISTRIBUTION=default
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 # hadolint ignore=DL3005,DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && update-ca-certificates && apt-get clean  && rm -rf /var/lib/apt/lists/*

--- a/security/docker/Dockerfile.node-agent-k8s
+++ b/security/docker/Dockerfile.node-agent-k8s
@@ -5,7 +5,7 @@ ARG BASE_DISTRIBUTION=default
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 
 # hadolint ignore=DL3005,DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && update-ca-certificates && apt-get clean  && rm -rf /var/lib/apt/lists/*

--- a/security/docker/Dockerfile.sdsclient
+++ b/security/docker/Dockerfile.sdsclient
@@ -1,5 +1,9 @@
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
+# ISTIO_VERSION is used to specify the version of the release
+ARG ISTIO_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+
 COPY sdsclient /
 RUN chmod 755 /sdsclient
 ENTRYPOINT ["/sdsclient"]

--- a/security/docker/Dockerfile.sdsclient
+++ b/security/docker/Dockerfile.sdsclient
@@ -2,7 +2,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 
 COPY sdsclient /
 RUN chmod 755 /sdsclient

--- a/security/docker/Dockerfile.sdsclient
+++ b/security/docker/Dockerfile.sdsclient
@@ -2,7 +2,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 COPY sdsclient /
 RUN chmod 755 /sdsclient

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -319,32 +319,32 @@ docker.scan_images: $(DOCKER_PUSH_TARGETS)
 	$(foreach TGT,$(DOCKER_TARGETS),$(call run_vulnerability_scanning,$(subst docker.,,$(TGT)),$(HUB)/$(subst docker.,,$(TGT)):$(TAG)))
 
 docker.base:
-	docker build --no-cache -t docker.io/sdake/base:${VERSION} -f docker/Dockerfile.xenial_debug docker/
+	docker build --no-cache -t docker.io/istio/base:${VERSION} -f docker/Dockerfile.xenial_debug docker/
 
 # Base image for 'debug' containers.
 # You can run it first to use local changes (or guarantee it is built from scratch)
 docker.basedebug:
-	docker build -t docker.io/sdake/base_debug:${VERSION} -f docker/Dockerfile.xenial_debug docker/
+	docker build -t docker.io/istio/base_debug:${VERSION} -f docker/Dockerfile.xenial_debug docker/
 
 # Run this target to generate images based on Bionic Ubuntu
 # This must be run as a first step, before the 'docker' step.
 docker.basedebug_bionic:
-	docker build -t docker.io/sdake/base_debug_bionic:$(VERSION) -f docker/Dockerfile.bionic_debug docker/
-	docker tag docker.io/sdake/base_debug_bionic:$(VERSION) docker.io/sdake/base_debug:$(VERSION)
+	docker build -t docker.io/istio/base_debug_bionic:$(VERSION) -f docker/Dockerfile.bionic_debug docker/
+	docker tag docker.io/istio/base_debug_bionic:$(VERSION) docker.io/istio/base_debug:$(VERSION)
 
 # Run this target to generate images based on Debian Slim
 # This must be run as a first step, before the 'docker' step.
 docker.basedebug_deb:
-	docker build -t docker.io/sdake/base_debug_deb:$(VERSION) -f docker/Dockerfile.deb_debug docker/
-	docker tag docker.io/sdake/base_debug_deb:$(VERSION) docker.io/sdake/base_debug;$(VERSION)
+	docker build -t docker.io/istio/base_debug_deb:$(VERSION) -f docker/Dockerfile.deb_debug docker/
+	docker tag docker.io/istio/base_debug_deb:$(VERSION) docker.io/istio/base_debug;$(VERSION)
 
 # Job run from the nightly cron to publish an up-to-date xenial with the debug tools.
 docker.push.basedebug: docker.basedebug
-	docker push docker.io/sdake/base_debug:$(VERSION)
+	docker push docker.io/istio/base_debug:$(VERSION)
 
 # Job run from the nightly cron to publish an up-to-date xenial with the debug tools.
 docker.push.base: docker.base
-	docker push docker.io/sdake/base:$(VERSION)
+	docker push docker.io/istio/base:$(VERSION)
 
 # Build a dev environment Docker image.
 DEV_IMAGE_NAME = istio/dev:$(USER)

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -21,7 +21,18 @@
 # It does not upload to a registry.
 docker: build-linux test-bins-linux docker.all
 
-DOCKER_TARGETS:=docker.pilot docker.proxy_debug docker.proxytproxy docker.proxyv2 docker.app docker.app_sidecar docker.test_policybackend \
+# The CI system changes VERSION from the top level makefile per build. As a result,
+# when running in CI, we always want docker.base to be generated and tagged. If the
+# base image is not regenerated and tagged per release, the tag used is undefined and
+# the Istio build is not reproducible.
+#
+# DO NOT ALTER this block without understanding how it works. Please consult #test-and-release.
+ifeq (${CI},"prow")
+DOCKER_BASE:=docker.base
+endif
+
+# Add new docker targets to the end of the DOCKER_TARGETS list.
+DOCKER_TARGETS:=$(DOCKER_BASE) docker.pilot docker.proxy_debug docker.proxytproxy docker.proxyv2 docker.app docker.app_sidecar docker.test_policybackend \
 	docker.proxy_init docker.mixer docker.mixer_codegen docker.citadel docker.galley docker.sidecar_injector docker.kubectl docker.node-agent-k8s
 
 $(ISTIO_DOCKER) $(ISTIO_DOCKER_TAR):

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -318,6 +318,9 @@ docker.push: $(DOCKER_PUSH_TARGETS)
 docker.scan_images: $(DOCKER_PUSH_TARGETS)
 	$(foreach TGT,$(DOCKER_TARGETS),$(call run_vulnerability_scanning,$(subst docker.,,$(TGT)),$(HUB)/$(subst docker.,,$(TGT)):$(TAG)))
 
+docker.base:
+	docker build --no-cache -t docker.io/sdake/base:${VERSION} -f docker/Dockerfile.xenial_debug docker/
+
 # Base image for 'debug' containers.
 # You can run it first to use local changes (or guarantee it is built from scratch)
 docker.basedebug:
@@ -338,6 +341,10 @@ docker.basedebug_deb:
 # Job run from the nightly cron to publish an up-to-date xenial with the debug tools.
 docker.push.basedebug: docker.basedebug
 	docker push docker.io/sdake/base_debug:$(VERSION)
+
+# Job run from the nightly cron to publish an up-to-date xenial with the debug tools.
+docker.push.base: docker.base
+	docker push docker.io/sdake/base:$(VERSION)
 
 # Build a dev environment Docker image.
 DEV_IMAGE_NAME = istio/dev:$(USER)

--- a/tools/packaging/deb/Dockerfile
+++ b/tools/packaging/deb/Dockerfile
@@ -4,7 +4,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
+FROM docker.io/sdake/base:${ISTIO_VERSION} as default
 
 # Micro pilot+mock mixer+echo, local kube
 COPY hyperistio kube-apiserver etcd kubectl /usr/local/bin/

--- a/tools/packaging/deb/Dockerfile
+++ b/tools/packaging/deb/Dockerfile
@@ -4,7 +4,7 @@
 ARG ISTIO_VERSION=latest
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/sdake/base:${ISTIO_VERSION} as default
+FROM docker.io/istio/base:${ISTIO_VERSION} as default
 
 # Micro pilot+mock mixer+echo, local kube
 COPY hyperistio kube-apiserver etcd kubectl /usr/local/bin/

--- a/tools/packaging/deb/Dockerfile
+++ b/tools/packaging/deb/Dockerfile
@@ -1,7 +1,10 @@
 # Base dockerfile containing ubuntu and istio debian.
 # Can be used for testing
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
+# ISTIO_VERSION is used to specify the version of the release
+ARG ISTIO_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/sdake/base_debug:${ISTIO_VERSION} as default
 
 # Micro pilot+mock mixer+echo, local kube
 COPY hyperistio kube-apiserver etcd kubectl /usr/local/bin/


### PR DESCRIPTION
The base_debug image currently pulls from latest.  If a base_debug
image is cached, docker will use the cached version, and not pull
an updated base_debug image.  This results in problems where
during T&R, a version of base_debug is used for a newer version of
Istio that is older then the last version built, depending on
the developer's environment.

The goal is to create a base_debug for every minor release.  This
results in a verified base image that has a well defined manifest
and is up to date.

Finally this cleans up a hadolint warning in many of the affected
Dockerfiles.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[] User Experience
[ ] Developer Infrastructure
