### PR TITLE
Make adsc.Wait not be dependant on ordering

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -64,7 +64,7 @@ func TestLDSIsolated(t *testing.T) {
 
 		ldsr.Watch()
 
-		_, err = ldsr.Wait("rds", 50000*time.Second)
+		_, err = ldsr.Wait(5*time.Second, "lds")
 		if err != nil {
 			t.Fatal("Failed to receive LDS", err)
 			return
@@ -141,8 +141,7 @@ func TestLDSIsolated(t *testing.T) {
 
 		ldsr.Watch()
 
-		_, err = ldsr.Wait("rds", 50000*time.Second)
-		if err != nil {
+		if _, err := ldsr.Wait(5*time.Second, "lds"); err != nil {
 			t.Fatal("Failed to receive LDS", err)
 			return
 		}
@@ -172,8 +171,7 @@ func TestLDSIsolated(t *testing.T) {
 
 		ldsr.Watch()
 
-		_, err = ldsr.Wait("rds", 50000*time.Second)
-		if err != nil {
+		if _, err = ldsr.Wait(5*time.Second, "lds"); err != nil {
 			t.Fatal("Failed to receive LDS", err)
 			return
 		}
@@ -224,19 +222,9 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 
 	adsResponse.Watch()
 
-	_, err = adsResponse.Wait("lds", 10*time.Second)
+	upd, err := adsResponse.Wait(10*time.Second, "lds", "rds", "cds")
 	if err != nil {
-		t.Fatal("Failed to receive LDS response", err)
-		return
-	}
-	_, err = adsResponse.Wait("rds", 10*time.Second)
-	if err != nil {
-		t.Fatal("Failed to receive RDS response", err)
-		return
-	}
-	_, err = adsResponse.Wait("cds", 10*time.Second)
-	if err != nil {
-		t.Fatal("Failed to receive CDS response", err)
+		t.Fatal("Failed to receive XDS response", err, upd)
 		return
 	}
 
@@ -298,7 +286,7 @@ func TestLDSWithIngressGateway(t *testing.T) {
 	adsResponse.DumpCfg = true
 	adsResponse.Watch()
 
-	_, err = adsResponse.Wait("lds", 10000*time.Second)
+	_, err = adsResponse.Wait(10*time.Second, "lds")
 	if err != nil {
 		t.Fatal("Failed to receive LDS response", err)
 		return
@@ -424,7 +412,7 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 	adsResponse.DumpCfg = true
 	adsResponse.Watch()
 
-	_, err = adsResponse.Wait("lds", 10*time.Second)
+	_, err = adsResponse.Wait(10*time.Second, "lds")
 	if err != nil {
 		t.Fatal("Failed to receive LDS response", err)
 		return
@@ -525,7 +513,7 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 
 			adsResponse.DumpCfg = false
 			adsResponse.Watch()
-			_, err = adsResponse.Wait("lds", 100*time.Second)
+			_, err = adsResponse.Wait(10*time.Second, "lds")
 			if err != nil {
 				t.Fatal("Failed to receive LDS response", err)
 				return

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -397,6 +397,8 @@ type Endpoint struct {
 
 // Save will save the json configs to files, using the base directory
 func (a *ADSC) Save(base string) error {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
 	strResponse, err := json.MarshalIndent(a.tcpListeners, "  ", "  ")
 	if err != nil {
 		return err

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -19,7 +19,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -124,11 +123,6 @@ const (
 	listenerType = typePrefix + "Listener"
 	// RouteType is sent after listeners.
 	routeType = typePrefix + "RouteConfiguration"
-)
-
-var (
-	// ErrTimeout is returned by Wait if no update is received in the given time.
-	ErrTimeout = errors.New("timeout")
 )
 
 // Dial connects to a ADS server, with optional MTLS authentication if a cert dir is specified.
@@ -612,18 +606,25 @@ func (a *ADSC) WaitClear() {
 	}
 }
 
-// Wait for an update of the specified type. If type is empty, wait for next update.
-func (a *ADSC) Wait(update string, to time.Duration) (string, error) {
+// Wait for an updates for all the specified types
+// If updates is empty, this will wait for any update
+func (a *ADSC) Wait(to time.Duration, updates ...string) ([]string, error) {
 	t := time.NewTimer(to)
-
+	want := map[string]struct{}{}
+	for _, update := range updates {
+		want[update] = struct{}{}
+	}
+	got := make([]string, 0, len(updates))
 	for {
 		select {
 		case t := <-a.Updates:
-			if len(update) == 0 || update == t {
-				return t, nil
+			delete(want, t)
+			got = append(got, t)
+			if len(want) == 0 {
+				return got, nil
 			}
 		case <-t.C:
-			return "", ErrTimeout
+			return got, fmt.Errorf("timeout, still waiting for updates: %v", want)
 		}
 	}
 }

--- a/tests/e2e/tests/pilot/performance/serviceentry_test.go
+++ b/tests/e2e/tests/pilot/performance/serviceentry_test.go
@@ -178,7 +178,7 @@ func adsConnectAndWait(n int, pilotAddr string, t *testing.T) (adscs []*adsc.ADS
 			t.Fatal(err)
 		}
 		c.Watch()
-		_, err = c.Wait("eds", 10*time.Second)
+		_, err = c.Wait(10*time.Second, "eds")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
All of our test code is inherintly racey, because they check for
specific ordering like lds, then rds, then cds. The problem is that the
pushing can come in different orders, depending on timing. For example,
we could be waiting on LDS, when a CDS push comes in, then we later wait
on a CDS push which never comes because it was already sent.

Fixes https://github.com/istio/istio/issues/15852

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
