### PR TITLE
Add istio.io docs test for security/authn-policy

### DIFF
--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -63,6 +63,7 @@ func NewTest(t *testing.T) *Test {
 
 // Label applies the given labels to this test.
 func (t *Test) Label(labels ...label.Instance) *Test {
+	t.goTest.Helper()
 	t.labels = append(t.labels, labels...)
 	return t
 }
@@ -70,12 +71,14 @@ func (t *Test) Label(labels ...label.Instance) *Test {
 // RequiresEnvironment ensures that the current environment matches what the suite expects. Otherwise it stops test
 // execution and skips the test.
 func (t *Test) RequiresEnvironment(name environment.Name) *Test {
+	t.goTest.Helper()
 	t.requiredEnv = name
 	return t
 }
 
 // Run the test, supplied as a lambda.
 func (t *Test) Run(fn func(ctx TestContext)) {
+	t.goTest.Helper()
 	t.runInternal(fn, false)
 }
 
@@ -139,6 +142,8 @@ func (t *Test) runInternal(fn func(ctx TestContext), parallel bool) {
 		panic(fmt.Sprintf("Attempting to run test `%s` more than once", testName))
 	}
 
+	t.goTest.Helper()
+
 	if t.parent != nil {
 		// Create a new subtest under the parent's test.
 		parentGoTest := t.parent.goTest
@@ -154,6 +159,8 @@ func (t *Test) runInternal(fn func(ctx TestContext), parallel bool) {
 }
 
 func (t *Test) doRun(ctx *testContext, fn func(ctx TestContext), parallel bool) {
+	t.goTest.Helper()
+
 	// Initial setup if we're running in Parallel.
 	if parallel {
 		// Inform the parent, who will need to call ctx.Done asynchronously.

--- a/pkg/test/istio.io/examples/example.go
+++ b/pkg/test/istio.io/examples/example.go
@@ -105,7 +105,7 @@ func (example *Example) Run() {
 	//f, err := os.Create(
 	//os.StdOut =
 
-	example.t.Log(fmt.Sprintf("Executing test %s (%d steps)", example.name, len(example.steps)))
+	example.t.Log(fmt.Sprintf("Executing example %s (%d steps)", example.name, len(example.steps)))
 
 	//create directory if it doesn't exist
 	if _, err := os.Stat(example.name); os.IsNotExist(err) {

--- a/pkg/test/istio.io/examples/example.go
+++ b/pkg/test/istio.io/examples/example.go
@@ -59,7 +59,17 @@ func (example *Example) AddScript(namespace string, script string, output output
 	example.t.Helper()
 
 	//fullPath := getFullPath(istioPath + script)
-	example.steps = append(example.steps, newStepScript("./"+script, output))
+	fullPath :=  "./"+script
+	stats, err := os.Stat(fullPath)
+	if os.IsNotExist(err) {
+		example.t.Fatalf("Script %q was not found", script)
+	}
+ 	if !stats.Mode().IsRegular() || stats.Mode().Perm() & 0x1 == 0 {
+		example.t.Fatalf("Script %q is not executable (mode: %s)",
+			script, stats.Mode().Perm().String())
+	}
+
+	example.steps = append(example.steps, newStepScript(fullPath, output))
 }
 
 // AddFile adds an existing file

--- a/pkg/test/istio.io/examples/example.go
+++ b/pkg/test/istio.io/examples/example.go
@@ -56,12 +56,16 @@ func New(t *testing.T, name string) Example {
 
 // AddScript adds a directive to run a script
 func (example *Example) AddScript(namespace string, script string, output outputType) {
+	example.t.Helper()
+
 	//fullPath := getFullPath(istioPath + script)
 	example.steps = append(example.steps, newStepScript("./"+script, output))
 }
 
 // AddFile adds an existing file
 func (example *Example) AddFile(namespace string, path string) {
+	example.t.Helper()
+
 	fullPath := getFullPath(istioPath + path)
 	example.steps = append(example.steps, newStepFile(namespace, fullPath))
 }
@@ -72,6 +76,8 @@ type testFunc func(t *testing.T)
 // Exec registers a callback to be invoked synchronously. This is typically used for
 // validation logic to ensure command-lines worked as intended
 func (example *Example) Exec(testFunction testFunc) {
+	example.t.Helper()
+
 	example.steps = append(example.steps, newStepFunction(testFunction))
 }
 
@@ -80,12 +86,12 @@ func (example *Example) Exec(testFunction testFunc) {
 func getFullPath(path string) string {
 	gopath := os.Getenv("GOPATH")
 	return gopath + "/src/" + path
-
 }
 
 // Run runs the scripts and capture output
 // Note that this overrides os.Stdout/os.Stderr and is not thread-safe
 func (example *Example) Run() {
+	example.t.Helper()
 
 	//override stdout and stderr for test. Is there a better way of doing this?
 
@@ -112,6 +118,8 @@ func (example *Example) Run() {
 	framework.
 		NewTest(example.t).
 		Run(func(ctx framework.TestContext) {
+			example.t.Helper()
+
 			kubeEnv, ok := ctx.Environment().(*kube.Environment)
 			if !ok {
 				example.t.Fatalf("test framework unable to get Kubernetes environment")

--- a/pkg/test/istio.io/examples/testType.go
+++ b/pkg/test/istio.io/examples/testType.go
@@ -41,6 +41,8 @@ func newStepFile(namespace string, path string) testStep {
 }
 
 func (test fileTestType) Run(env *kube.Environment, t *testing.T) (string, error) {
+	t.Helper()
+
 	t.Logf(fmt.Sprintf("Executing %s\n", test.path))
 	if err := env.Apply(test.namespace, test.path); err != nil {
 		return "", err
@@ -64,6 +66,8 @@ type functionTestType struct {
 }
 
 func (test functionTestType) Run(env *kube.Environment, t *testing.T) (string, error) {
+	t.Helper()
+
 	t.Logf(fmt.Sprintf("Executing function\n"))
 	test.testFunction(t)
 	return "", nil
@@ -88,6 +92,8 @@ type scriptTestType struct {
 }
 
 func (test scriptTestType) Run(env *kube.Environment, t *testing.T) (string, error) {
+	t.Helper()
+
 	t.Logf(fmt.Sprintf("Executing %s\n", test.script))
 	cmd := exec.Command(test.script)
 

--- a/pkg/test/istio.io/tasks/security/authn-policy/authn-policy_test.go
+++ b/pkg/test/istio.io/tasks/security/authn-policy/authn-policy_test.go
@@ -1,0 +1,168 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+package tests
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/istio.io/examples"
+)
+
+var (
+	ist istio.Instance
+)
+
+func TestMain(m *testing.M) {
+	framework.NewSuite("authn-policy", m).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
+		RequireEnvironment(environment.Kube).
+		Run()
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// This is redundant, but setting it explicitly to match the docs as it's explicitly required
+	// in the docs.
+	cfg.Values["global.mtls.enabled"] = "false"
+}
+
+// https://preliminary.istio.io/docs/tasks/security/authn-policy/
+// https://github.com/istio/istio.io/blob/master/content/docs/tasks/security/authn-policy/index.md
+func TestAuthnPolicy(t *testing.T) {
+	ex := examples.New(t, "Setup")
+
+	ex.AddScript("", "create-namespaces.sh", examples.TextOutput)
+	ex.AddFile("foo", "samples/httpbin/httpbin.yaml")
+	ex.AddFile("foo", "samples/sleep/sleep.yaml")
+	ex.AddFile("bar", "samples/httpbin/httpbin.yaml")
+	ex.AddFile("bar", "samples/sleep/sleep.yaml")
+	ex.AddFile("legacy", "samples/httpbin/httpbin.yaml")
+	ex.AddFile("legacy", "samples/sleep/sleep.yaml")
+
+	// This is missing from the docs, but it is necessary before continuing.
+	ex.AddScript("", "wait-for-containers.sh", examples.TextOutput)
+	ex.AddScript("", "verify-reachability.sh", examples.TextOutput)
+
+	// TODO: Update the docs to use commands that succeed or fail, to check the authentication
+	//  policies and destination rules, and use the same commands here.
+	ex.Run()
+
+	ex = examples.New(t, "Globally enabling Istio mutual TLS")
+
+	ex.AddScript("", "part1-configure-authentication-meshpolicy.sh", examples.TextOutput)
+	// TODO: Update the docs to add instructions to wait until the policy has been propagated,
+	//  and use the same commands here.
+
+	// TODO: Check the output of the command. Fail if curl doesn't fail.
+	ex.AddScript("", "part1-verify-reachability-from-istio.sh", examples.TextOutput)
+	ex.AddScript("", "part1-configure-destinationrule-default.sh", examples.TextOutput)
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part1-verify-reachability-from-istio.sh", examples.TextOutput)
+	// TODO: Fail if curl doesn't fail.
+	ex.AddScript("", "part1-verify-reachability-from-non-istio.sh", examples.TextOutput)
+
+	// TODO: Fail if curl doesn't fail.
+	ex.AddScript("", "part1-verify-reachability-to-legacy.sh", examples.TextOutput)
+	ex.AddScript("", "part1-configure-destinationrule-httpbin-legacy.sh", examples.TextOutput)
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part1-verify-reachability-to-legacy.sh", examples.TextOutput)
+
+	// TODO: Fail if curl doesn't fail.
+	ex.AddScript("", "part1-verify-reachability-to-k8s-api.sh", examples.TextOutput)
+	ex.AddScript("", "part1-configure-destinationrule-api-server.sh", examples.TextOutput)
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part1-verify-reachability-to-k8s-api.sh", examples.TextOutput)
+
+	ex.AddScript("", "part1-cleanup.sh", examples.TextOutput)
+
+	ex.Run()
+
+	ex = examples.New(t, "Enable mutual TLS per namespace or service")
+
+	ex.AddScript("", "part2-configure-authentication-policy-default.sh", examples.TextOutput)
+	ex.AddScript("", "part2-configure-destinationrule-default.sh", examples.TextOutput)
+	// TODO: Update the docs to add instructions to wait until the policy has been propagated,
+	//  and use the same commands here.
+
+	// TODO: Fail if curl from foo or bar to any other namespace fails.
+	// TODO: Fail if curl from legacy to foo succeeds.
+	ex.AddScript("", "part2-verify-reachability.sh", examples.TextOutput)
+	ex.AddScript("", "part2-configure-authentication-policy-httpbin.sh", examples.TextOutput)
+	ex.AddScript("", "part2-configure-destinationrule-httpbin.sh", examples.TextOutput)
+	// TODO: Fail if curl from foo or bar to any other namespace fails.
+	// TODO: Fail if curl from legacy to foo OR bar succeeds.
+	ex.AddScript("", "part2-verify-reachability.sh", examples.TextOutput)
+
+	ex.AddScript("", "part2-configure-authentication-policy-httpbin-port.sh", examples.TextOutput)
+	ex.AddScript("", "part2-configure-destinationrule-httpbin-port.sh", examples.TextOutput)
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part2-verify-reachability-to-bar-port-8000.sh", examples.TextOutput)
+
+	ex.AddScript("", "part2-configure-authentication-policy-overwrite-example.sh", examples.TextOutput)
+	ex.AddScript("", "part2-configure-destinationrule-overwrite-example.sh", examples.TextOutput)
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part2-verify-reachability-to-foo-port-8000.sh", examples.TextOutput)
+
+	ex.AddScript("", "part2-cleanup.sh", examples.TextOutput)
+
+	ex.Run()
+
+	ex = examples.New(t, "End-user authentication")
+
+	ex.AddScript("", "part3-configure-gateway-httpbin.sh", examples.TextOutput)
+	ex.AddScript("", "part3-configure-virtualservice-httpbin.sh", examples.TextOutput)
+	// TODO: Update the docs to add instructions to wait until the gateway is ready,
+	//  and use the same commands here.
+
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part3-verify-reachability-headers-without-token.sh", examples.TextOutput)
+	ex.AddScript("", "part3-configure-authentication-policy-jwt-example.sh", examples.TextOutput)
+	// TODO: Fail if curl succeeds.
+	ex.AddScript("", "part3-verify-reachability-headers-without-token.sh", examples.TextOutput)
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part3-verify-reachability-headers-with-token.sh", examples.TextOutput)
+
+	// TODO: Add the test that runs security/tools/jwt/samples/gen-jwt.py against
+	//  security/tools/jwt/samples/key.pem.
+	//  This requires having Python and the jwcrypto library installed locally.
+
+	ex.AddScript("", "part3-configure-authentication-policy-jwt-example-exclude.sh", examples.TextOutput)
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part3-verify-reachability-useragent-without-token.sh", examples.TextOutput)
+	// TODO: Fail if curl succeeds.
+	ex.AddScript("", "part3-verify-reachability-headers-without-token.sh", examples.TextOutput)
+
+	ex.AddScript("", "part3-configure-authentication-policy-jwt-example-include.sh", examples.TextOutput)
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part3-verify-reachability-useragent-without-token.sh", examples.TextOutput)
+	// TODO: Fail if curl succeeds.
+	ex.AddScript("", "part3-verify-reachability-ip-without-token.sh", examples.TextOutput)
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part3-verify-reachability-ip-with-token.sh", examples.TextOutput)
+
+	ex.AddScript("", "part3-configure-authentication-policy-jwt-mtls.sh", examples.TextOutput)
+	ex.AddScript("", "part3-configure-destinationrule-httpbin.sh", examples.TextOutput)
+	// TODO: Fail if curl fails.
+	ex.AddScript("", "part3-verify-reachability-from-istio-with-token.sh", examples.TextOutput)
+	// TODO: Fail if curl succeeds.
+	ex.AddScript("", "part3-verify-reachability-from-non-istio-with-token.sh", examples.TextOutput)
+
+	ex.AddScript("", "part3-cleanup.sh", examples.TextOutput)
+
+	ex.Run()
+}

--- a/pkg/test/istio.io/tasks/security/authn-policy/create-namespaces.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/create-namespaces.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+kubectl create ns foo
+kubectl create ns bar
+kubectl create ns legacy

--- a/pkg/test/istio.io/tasks/security/authn-policy/part1-cleanup.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part1-cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+kubectl delete meshpolicy default
+kubectl delete destinationrules httpbin-legacy -n legacy
+kubectl delete destinationrules api-server -n istio-system
+kubectl delete destinationrules default -n istio-system

--- a/pkg/test/istio.io/tasks/security/authn-policy/part1-configure-authentication-meshpolicy.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part1-configure-authentication-meshpolicy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+kubectl apply -f - <<EOF
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "MeshPolicy"
+metadata:
+  name: "default"
+spec:
+  peers:
+  - mtls: {}
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part1-configure-destinationrule-api-server.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part1-configure-destinationrule-api-server.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+kubectl apply -f - <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+ name: "api-server"
+ namespace: istio-system
+spec:
+ host: "kubernetes.default.svc.cluster.local"
+ trafficPolicy:
+   tls:
+     mode: DISABLE
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part1-configure-destinationrule-default.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part1-configure-destinationrule-default.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+kubectl apply -f - <<EOF
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  namespace: "istio-system"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part1-configure-destinationrule-httpbin-legacy.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part1-configure-destinationrule-httpbin-legacy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+kubectl apply -f - <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+ name: "httpbin-legacy"
+ namespace: "legacy"
+spec:
+ host: "httpbin.legacy.svc.cluster.local"
+ trafficPolicy:
+   tls:
+     mode: DISABLE
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part1-verify-reachability-from-istio.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part1-verify-reachability-from-istio.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+for from in "foo" "bar"; do for to in "foo" "bar"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done

--- a/pkg/test/istio.io/tasks/security/authn-policy/part1-verify-reachability-from-non-istio.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part1-verify-reachability-from-non-istio.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+for from in "legacy"; do for to in "foo" "bar"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done

--- a/pkg/test/istio.io/tasks/security/authn-policy/part1-verify-reachability-to-k8s-api.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part1-verify-reachability-to-k8s-api.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+TOKEN=$(kubectl describe secret $(kubectl get secrets | grep default-token | cut -f1 -d ' ' | head -1) | grep -E '^token' | cut -f2 -d':' | tr -d '\t')
+kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl https://kubernetes.default/api --header "Authorization: Bearer $TOKEN" --insecure -s -o /dev/null -w "%{http_code}\n"

--- a/pkg/test/istio.io/tasks/security/authn-policy/part1-verify-reachability-to-legacy.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part1-verify-reachability-to-legacy.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+for from in "foo" "bar"; do for to in "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-cleanup.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+kubectl delete policy default overwrite-example -n foo
+kubectl delete policy httpbin -n bar
+kubectl delete destinationrules default overwrite-example -n foo
+kubectl delete destinationrules httpbin -n bar

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-authentication-policy-default.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-authentication-policy-default.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+kubectl apply -f - <<EOF
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "default"
+  namespace: "foo"
+spec:
+  peers:
+  - mtls: {}
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-authentication-policy-httpbin-port.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-authentication-policy-httpbin-port.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+cat <<EOF | kubectl apply -n bar -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "httpbin"
+spec:
+  targets:
+  - name: httpbin
+    ports:
+    - number: 1234
+  peers:
+  - mtls: {}
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-authentication-policy-httpbin.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-authentication-policy-httpbin.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+cat <<EOF | kubectl apply -n bar -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "httpbin"
+spec:
+  targets:
+  - name: httpbin
+  peers:
+  - mtls: {}
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-authentication-policy-overwrite-example.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-authentication-policy-overwrite-example.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "overwrite-example"
+spec:
+  targets:
+  - name: httpbin
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-destinationrule-default.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-destinationrule-default.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+kubectl apply -f - <<EOF
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  namespace: "foo"
+spec:
+  host: "*.foo.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-destinationrule-httpbin-port.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-destinationrule-httpbin-port.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+cat <<EOF | kubectl apply -n bar -f -
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "httpbin"
+spec:
+  host: httpbin.bar.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+    portLevelSettings:
+    - port:
+        number: 1234
+      tls:
+        mode: ISTIO_MUTUAL
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-destinationrule-httpbin.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-destinationrule-httpbin.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+cat <<EOF | kubectl apply -n bar -f -
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "httpbin"
+spec:
+  host: "httpbin.bar.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-destinationrule-overwrite-example.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-configure-destinationrule-overwrite-example.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "overwrite-example"
+spec:
+  host: httpbin.foo.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-verify-reachability-to-bar-port-8000.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-verify-reachability-to-bar-port-8000.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.bar:8000/ip -s -o /dev/null -w "%{http_code}\n"

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-verify-reachability-to-foo-port-8000.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-verify-reachability-to-foo-port-8000.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"

--- a/pkg/test/istio.io/tasks/security/authn-policy/part2-verify-reachability.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part2-verify-reachability.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-cleanup.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+kubectl -n foo delete policy jwt-example
+kubectl -n foo delete destinationrule httpbin
+kubectl delete ns foo bar legacy

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-authentication-policy-jwt-example-exclude.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-authentication-policy-jwt-example-exclude.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "jwt-example"
+spec:
+  targets:
+  - name: httpbin
+  origins:
+  - jwt:
+      issuer: "testing@secure.istio.io"
+      jwksUri: "https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/jwks.json"
+      trigger_rules:
+      - excluded_paths:
+        - exact: /user-agent
+  principalBinding: USE_ORIGIN
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-authentication-policy-jwt-example-include.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-authentication-policy-jwt-example-include.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "jwt-example"
+spec:
+  targets:
+  - name: httpbin
+  origins:
+  - jwt:
+      issuer: "testing@secure.istio.io"
+      jwksUri: "https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/jwks.json"
+      trigger_rules:
+      - included_paths:
+        - exact: /ip
+  principalBinding: USE_ORIGIN
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-authentication-policy-jwt-example.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-authentication-policy-jwt-example.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "jwt-example"
+spec:
+  targets:
+  - name: httpbin
+  origins:
+  - jwt:
+      issuer: "testing@secure.istio.io"
+      jwksUri: "https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/jwks.json"
+  principalBinding: USE_ORIGIN
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-authentication-policy-jwt-mtls.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-authentication-policy-jwt-mtls.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "jwt-example"
+spec:
+  targets:
+  - name: httpbin
+  peers:
+  - mtls: {}
+  origins:
+  - jwt:
+      issuer: "testing@secure.istio.io"
+      jwksUri: "https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/jwks.json"
+  principalBinding: USE_ORIGIN
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-destinationrule-httpbin.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-destinationrule-httpbin.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+kubectl apply -f - <<EOF
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "httpbin"
+  namespace: "foo"
+spec:
+  host: "httpbin.foo.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-gateway-httpbin.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-gateway-httpbin.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+kubectl apply -f - <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: httpbin-gateway
+  namespace: foo
+spec:
+  selector:
+    istio: ingressgateway # use Istio default gateway implementation
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-virtualservice-httpbin.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-configure-virtualservice-httpbin.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+kubectl apply -f - <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: httpbin
+  namespace: foo
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - httpbin-gateway
+  http:
+  - route:
+    - destination:
+        port:
+          number: 8000
+        host: httpbin.foo.svc.cluster.local
+EOF

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-from-istio-with-token.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-from-istio-with-token.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt -s)
+kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n" --header "Authorization: Bearer $TOKEN"

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-from-non-istio-with-token.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-from-non-istio-with-token.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt -s)
+kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n" --header "Authorization: Bearer $TOKEN"

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-headers-with-token.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-headers-with-token.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt -s)
+curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-headers-without-token.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-headers-without-token.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-ip-with-token.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-ip-with-token.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt -s)
+curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/ip -s -o /dev/null -w "%{http_code}\n"

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-ip-without-token.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-ip-without-token.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+curl $INGRESS_HOST/ip -s -o /dev/null -w "%{http_code}\n"

--- a/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-useragent-without-token.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/part3-verify-reachability-useragent-without-token.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+curl $INGRESS_HOST/user-agent -s -o /dev/null -w "%{http_code}\n"

--- a/pkg/test/istio.io/tasks/security/authn-policy/verify-reachability.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/verify-reachability.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+# TODO: Remove the -f option added to every curl command, and do the assertion checking in the caller.
+kubectl exec $(kubectl get pod -l app=sleep -n bar -o jsonpath={.items..metadata.name}) -c sleep -n bar -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n" -f
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n" -f; done; done

--- a/pkg/test/istio.io/tasks/security/authn-policy/wait-for-containers.sh
+++ b/pkg/test/istio.io/tasks/security/authn-policy/wait-for-containers.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+# Wait for all containers to be ready, for up to 2 minutes = 12 * 10 seconds.
+retries=12
+while [ "$retries" -gt "0" ]; do
+  if kubectl get pods --all-namespaces -o jsonpath='{.items[?(@.status.phase != "Succeeded")].status.containerStatuses[*].ready}' | grep -q -v false; then
+    exit 0
+  fi
+  echo "Waiting for containers to become ready"
+  kubectl get pods --all-namespaces
+  retries=$((retries - 1))
+  sleep 10
+done
+exit 1


### PR DESCRIPTION
Add istio.io docs test for security/authn-policy.

Small improvements to the test framework:

- Mark test framework functions as Helpers to make logs more meaningful.
- Fix wording in `examples` test log.
- In `Example.AddScript()`, check that the script exists and is executable.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
