### PR TITLE
Expose the option --append-dns-names

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           {{- if .Values.global.sds.enabled }}
             - --sds-enabled=true
           {{- end }}
-            - --append-dns-names=true
+            - --append-dns-names={{ .Values.appendDnsNames }}
             - --grpc-port=8060
             - --citadel-storage-namespace={{ .Release.Namespace }}
             - --custom-dns-names=istio-pilot-service-account.{{ .Release.Namespace }}:istio-pilot.{{ .Release.Namespace }}

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           {{- if .Values.global.sds.enabled }}
             - --sds-enabled=true
           {{- end }}
-            - --append-dns-names={{ .Values.appendDnsNames }}
+            - --append-dns-names={{ .Values.enableGenerateWebhookCerts }}
             - --grpc-port=8060
             - --citadel-storage-namespace={{ .Release.Namespace }}
             - --custom-dns-names=istio-pilot-service-account.{{ .Release.Namespace }}:istio-pilot.{{ .Release.Namespace }}

--- a/install/kubernetes/helm/istio/charts/security/values.yaml
+++ b/install/kubernetes/helm/istio/charts/security/values.yaml
@@ -53,4 +53,4 @@ podAntiAffinityTermLabelSelector: []
 # - If true, Citadel will not generate webhook certificates.
 # If there is another component generate webhook certificates,
 # this parameter should be set as false.
-appendDnsNames: true
+enableGenerateWebhookCerts: true

--- a/install/kubernetes/helm/istio/charts/security/values.yaml
+++ b/install/kubernetes/helm/istio/charts/security/values.yaml
@@ -50,7 +50,7 @@ podAntiAffinityTermLabelSelector: []
 # This parameter sets the CLI parameter append-dns-names of
 # Citadel, which:
 # - If true, Citadel will generate webhook certificates.
-# - If true, Citadel will not generate webhook certificates.
+# - If false, Citadel will not generate webhook certificates.
 # If there is another component generate webhook certificates,
 # this parameter should be set as false.
 enableGenerateWebhookCerts: true

--- a/install/kubernetes/helm/istio/charts/security/values.yaml
+++ b/install/kubernetes/helm/istio/charts/security/values.yaml
@@ -46,3 +46,11 @@ enableNamespacesByDefault: true
 # "security" and value "S1".
 podAntiAffinityLabelSelector: []
 podAntiAffinityTermLabelSelector: []
+
+# This parameter sets the CLI parameter append-dns-names of
+# Citadel, which:
+# - If true, Citadel will generate webhook certificates.
+# - If true, Citadel will not generate webhook certificates.
+# If there is another component generate webhook certificates,
+# this parameter should be set as false.
+appendDnsNames: true


### PR DESCRIPTION
Expose the option --append-dns-names, which sets the CLI parameter append-dns-names of Citadel: 
- If true, Citadel will generate webhook certificates.
- If false, Citadel will not generate webhook certificates.
If there is another component generate webhook certificates, this parameter should be set as false.

Please provide a description for what this PR is for: #8736.

Design document: https://docs.google.com/document/d/1VHyBre8943USOx_YEVtA18KfEoGTmLT1iBHESO5bzcA

The matching PR on istio/installer repo is: https://github.com/istio/installer/pull/312.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
