### PR TITLE
Fix typo in e2e-kind-suite.sh

### DIFF
--- a/prow/e2e-kind-suite.sh
+++ b/prow/e2e-kind-suite.sh
@@ -74,7 +74,7 @@ for ((i=1; i<=$#; i++)); do
         ;;
         --skip-cleanup)
           SKIP_CLEANUP=true
-          shift
+          continue
         ;;
         # -s/--single_test to specify test target to run.
         # e.g. "-s e2e_mixer" will trigger e2e mixer_test


### PR DESCRIPTION
Shift doesn't do the right thing here since we are iterating over the args

[x] Test and Release