### PR TITLE
Remove trustworthy and legacy jwt concepts. Always use trustworthy jwt

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -247,10 +247,8 @@ spec:
           - name: sdsudspath
             mountPath: /var/run/sds
             readOnly: true
-          {{- if $.Values.global.sds.useTrustworthyJwt }}
           - name: istio-token
             mountPath: /var/run/secrets/tokens
-          {{- end }}
           {{- end }}
           {{- if $spec.sds }}
           {{- if $spec.sds.enabled }}
@@ -280,7 +278,6 @@ spec:
       - name: sdsudspath
         hostPath:
           path: /var/run/sds
-      {{- if $.Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
         projected:
           sources:
@@ -288,7 +285,6 @@ spec:
               path: istio-token
               expirationSeconds: 43200
               audience: {{ $.Values.global.trustDomain }}
-      {{- end }}
       {{- end }}
       - name: istio-certs
         secret:

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -13,7 +13,6 @@
       - hostPath:
           path: /var/run/sds
         name: sds-uds-path
-      {{- if $.Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
         projected:
           sources:
@@ -21,7 +20,6 @@
               audience: {{ $.Values.global.trustDomain }}
               expirationSeconds: 43200
               path: istio-token
-      {{- end }}
       {{- end }}
       - name: uds-socket
         emptyDir: {}
@@ -168,10 +166,8 @@
         - name: sds-uds-path
           mountPath: /var/run/sds
           readOnly: true
-        {{- if $.Values.global.sds.useTrustworthyJwt }}
         - name: istio-token
           mountPath: /var/run/secrets/tokens
-        {{- end }}
         {{- end }}
         - name: uds-socket
           mountPath: /sock
@@ -192,7 +188,6 @@
       - hostPath:
           path: /var/run/sds
         name: sds-uds-path
-      {{- if $.Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
         projected:
           sources:
@@ -200,7 +195,6 @@
               audience: {{ $.Values.global.trustDomain }}
               expirationSeconds: 43200
               path: istio-token
-      {{- end }}
       {{- end }}
       - name: uds-socket
         emptyDir: {}
@@ -353,10 +347,8 @@
         - name: sds-uds-path
           mountPath: /var/run/sds
           readOnly: true
-        {{- if $.Values.global.sds.useTrustworthyJwt }}
         - name: istio-token
           mountPath: /var/run/secrets/tokens
-        {{- end }}
         {{- end }}
         - name: uds-socket
           mountPath: /sock

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -183,10 +183,8 @@ spec:
           - name: sds-uds-path
             mountPath: /var/run/sds
             readOnly: true
-          {{- if $.Values.global.sds.useTrustworthyJwt }}
           - name: istio-token
             mountPath: /var/run/secrets/tokens
-          {{- end }}
           {{- end }}
 {{- end }}
       volumes:
@@ -194,7 +192,6 @@ spec:
       - hostPath:
           path: /var/run/sds
         name: sds-uds-path
-      {{- if $.Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
         projected:
           sources:
@@ -202,7 +199,6 @@ spec:
               audience: {{ $.Values.global.trustDomain }}
               expirationSeconds: 43200
               path: istio-token
-      {{- end }}
       {{- end }}
       - name: config-volume
         configMap:

--- a/install/kubernetes/helm/istio/example-values/values-istio-example-sds-vault.yaml
+++ b/install/kubernetes/helm/istio/example-values/values-istio-example-sds-vault.yaml
@@ -9,7 +9,6 @@ global:
   sds:
     enabled: true
     udsPath: "unix:/var/run/sds/uds_path"
-    useNormalJwt: true
 
 nodeagent:
   enabled: true

--- a/install/kubernetes/helm/istio/example-values/values-istio-googleca.yaml
+++ b/install/kubernetes/helm/istio/example-values/values-istio-googleca.yaml
@@ -9,7 +9,6 @@ global:
   sds:
     enabled: true
     udsPath: "unix:/var/run/sds/uds_path"
-    useTrustworthyJwt: true 
 
   trustDomain: ""
 

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -231,7 +231,7 @@ containers:
       - NET_ADMIN
     runAsGroup: 1337
     {{ else -}}
-    {{ if and .Values.global.sds.enabled .Values.global.sds.useTrustworthyJwt }}
+    {{ if .Values.global.sds.enabled }}
     runAsGroup: 1337
     {{- end }}
     runAsUser: 1337
@@ -261,10 +261,8 @@ containers:
   - mountPath: /var/run/sds
     name: sds-uds-path
     readOnly: true
-  {{- if .Values.global.sds.useTrustworthyJwt }}
   - mountPath: /var/run/secrets/tokens
     name: istio-token
-  {{- end }}
   {{- if .Values.global.sds.customTokenDirectory }}
   - mountPath: "{{ .Values.global.sds.customTokenDirectory -}}"
     name: custom-sds-token
@@ -299,19 +297,17 @@ volumes:
 - name: sds-uds-path
   hostPath:
     path: /var/run/sds
+- name: istio-token
+  projected:
+    sources:
+      - serviceAccountToken:
+          path: istio-token
+          expirationSeconds: 43200
+          audience: {{ .Values.global.trustDomain }}
 {{- if .Values.global.sds.customTokenDirectory }}
 - name: custom-sds-token
   secret:
     secretName: sdstokensecret
-{{- end }}
-{{- if .Values.global.sds.useTrustworthyJwt }}
-- name: istio-token
-  projected:
-    sources:
-    - serviceAccountToken:
-        path: istio-token
-        expirationSeconds: 43200
-        audience: {{ .Values.global.trustDomain }}
 {{- end }}
 {{- else }}
 - name: istio-certs

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -104,20 +104,6 @@ data:
     # key/cert for mTLS. Use secret-mount files instead of SDS if set to empty. 
     sdsUdsPath: {{ .Values.global.sds.udsPath }}
 
-    # This flag is used by secret discovery service(SDS). 
-    # If set to true(prerequisite: https://kubernetes.io/docs/concepts/storage/volumes/#projected), Istio will inject volumes mount 
-    # for k8s service account JWT, so that K8s API server mounts k8s service account JWT to envoy container, which 
-    # will be used to generate key/cert eventually. This isn't supported for non-k8s case.
-    enableSdsTokenMount: {{ .Values.global.sds.useTrustworthyJwt }}
-
-    # This flag is used by secret discovery service(SDS). 
-    # If set to true, envoy will fetch normal k8s service account JWT from '/var/run/secrets/kubernetes.io/serviceaccount/token' 
-    # (https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod) 
-    # and pass to sds server, which will be used to request key/cert eventually. 
-    # this flag is ignored if enableSdsTokenMount is set.
-    # This isn't supported for non-k8s case.
-    sdsUseK8sSaJwt: {{ .Values.global.sds.useNormalJwt }}
-
     # The trust domain corresponds to the trust root of a system.
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
     trustDomain: {{ .Values.global.trustDomain }}

--- a/install/kubernetes/helm/istio/test-values/values-istio-auth-sds.yaml
+++ b/install/kubernetes/helm/istio/test-values/values-istio-auth-sds.yaml
@@ -9,9 +9,6 @@ global:
   sds:
     enabled: true
     udsPath: "unix:/var/run/sds/uds_path"
-    # The e2e tests (old framework) are still using old Kubernetes version with no trustworthy jwts support.
-    useNormalJwt: true
-    useTrustworthyJwt: false
 
   proxy:
     enableCoreDump: true

--- a/install/kubernetes/helm/istio/values-istio-sds-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-sds-auth.yaml
@@ -9,13 +9,6 @@ global:
   sds:
     enabled: true
     udsPath: "unix:/var/run/sds/uds_path"
-    # Trustworthy JWTs are available from Kubernetes 1.12 (beta) and later.
-    # On-prem k8s needs extra configuration.
-    # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/?origin_team=T382U9E4U#service-account-token-volume-projection
-    # //TODO: Deprecate the useNormalJwt and useTrustworthyJwt fields, since trustworthy JWT
-    # is used by default when SDS is enabled.
-    useNormalJwt: false
-    useTrustworthyJwt: true
 
 nodeagent:
   enabled: true

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -449,8 +449,6 @@ global:
     # distributed through the SecretDiscoveryService instead of using K8S secrets to mount the certificates.
     enabled: false
     udsPath: ""
-    useTrustworthyJwt: false
-    useNormalJwt: false
 
   # Configure the mesh networks to be used by the Split Horizon EDS.
   #

--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -139,7 +139,6 @@ func TestDetectSds(t *testing.T) {
 		controlPlaneBootstrap   bool
 		controlPlaneAuthEnabled bool
 		udsPath                 string
-		preferTokenPath         string
 		tokenPath               string
 		expectedSdsEnabled      bool
 		expectedSdsTokenPath    string
@@ -154,7 +153,7 @@ func TestDetectSds(t *testing.T) {
 			controlPlaneBootstrap:   true,
 			controlPlaneAuthEnabled: true,
 			udsPath:                 "/tmp/testtmpuds1.log",
-			preferTokenPath:         "/tmp/testtmptoken1.log",
+			tokenPath:               "/tmp/testtmptoken1.log",
 			expectedSdsEnabled:      true,
 			expectedSdsTokenPath:    "/tmp/testtmptoken1.log",
 		},
@@ -179,7 +178,7 @@ func TestDetectSds(t *testing.T) {
 		{
 			controlPlaneBootstrap: false,
 			udsPath:               "/tmp/test_tmp_uds2",
-			preferTokenPath:       "/tmp/test_tmp_token2",
+			tokenPath:             "/tmp/test_tmp_token2",
 			expectedSdsEnabled:    true,
 			expectedSdsTokenPath:  "/tmp/test_tmp_token2",
 		},
@@ -206,12 +205,6 @@ func TestDetectSds(t *testing.T) {
 				defer os.Remove(tt.udsPath)
 			}
 		}
-		if tt.preferTokenPath != "" {
-			if _, err := os.Stat(tt.preferTokenPath); err != nil {
-				os.Create(tt.preferTokenPath)
-				defer os.Remove(tt.preferTokenPath)
-			}
-		}
 		if tt.tokenPath != "" {
 			if _, err := os.Stat(tt.tokenPath); err != nil {
 				os.Create(tt.tokenPath)
@@ -219,7 +212,7 @@ func TestDetectSds(t *testing.T) {
 			}
 		}
 
-		enabled, path := detectSds(tt.controlPlaneBootstrap, tt.controlPlaneAuthEnabled, tt.udsPath, tt.preferTokenPath, tt.tokenPath)
+		enabled, path := detectSds(tt.controlPlaneBootstrap, tt.controlPlaneAuthEnabled, tt.udsPath, tt.tokenPath)
 		g.Expect(enabled).To(gomega.Equal(tt.expectedSdsEnabled))
 		g.Expect(path).To(gomega.Equal(tt.expectedSdsTokenPath))
 	}

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -218,7 +218,6 @@ type Params struct {
 	DebugMode                    bool                   `json:"debugMode"`
 	Privileged                   bool                   `json:"privileged"`
 	SDSEnabled                   bool                   `json:"sdsEnabled"`
-	EnableSdsTokenMount          bool                   `json:"enableSdsTokenMount"`
 	PodDNSSearchNamespaces       []string               `json:"podDNSSearchNamespaces"`
 }
 
@@ -250,7 +249,6 @@ func (p *Params) intoHelmValues() map[string]string {
 		"global.proxy.readinessPeriodSeconds":        strconv.Itoa(int(p.ReadinessPeriodSeconds)),
 		"global.proxy.readinessFailureThreshold":     strconv.Itoa(int(p.ReadinessFailureThreshold)),
 		"global.sds.enabled":                         strconv.FormatBool(p.SDSEnabled),
-		"global.sds.useTrustworthyJwt":               strconv.FormatBool(p.EnableSdsTokenMount),
 		"global.proxy.includeIPRanges":               p.IncludeIPRanges,
 		"global.proxy.excludeIPRanges":               p.ExcludeIPRanges,
 		"global.proxy.includeInboundPorts":           p.IncludeInboundPorts,
@@ -821,7 +819,7 @@ func intoObject(sidecarTemplate string, valuesConfig string, meshconfig *meshcon
 	// due to bug https://github.com/kubernetes/kubernetes/issues/57923,
 	// k8s sa jwt token volume mount file is only accessible to root user, not istio-proxy(the user that istio proxy runs as).
 	// workaround by https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-	if meshconfig.EnableSdsTokenMount && meshconfig.SdsUdsPath != "" {
+	if meshconfig.SdsUdsPath != "" {
 		var grp = int64(1337)
 		podSpec.SecurityContext = &corev1.PodSecurityContext{
 			FSGroup: &grp,

--- a/pilot/pkg/kube/inject/inject_test.go
+++ b/pilot/pkg/kube/inject/inject_test.go
@@ -530,7 +530,6 @@ func TestIntoResourceFile(t *testing.T) {
 				ProxyImage:                   ProxyImageName(unitTestHub, unitTestTag, c.debugMode),
 				ImagePullPolicy:              "IfNotPresent",
 				SDSEnabled:                   false,
-				EnableSdsTokenMount:          false,
 				Verbosity:                    DefaultVerbosity,
 				SidecarProxyUID:              DefaultSidecarProxyUID,
 				Version:                      "12345678",

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -567,7 +567,7 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 	// due to bug https://github.com/kubernetes/kubernetes/issues/57923,
 	// k8s sa jwt token volume mount file is only accessible to root user, not istio-proxy(the user that istio proxy runs as).
 	// workaround by https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-	if wh.meshConfig.EnableSdsTokenMount && wh.meshConfig.SdsUdsPath != "" {
+	if wh.meshConfig.SdsUdsPath != "" {
 		var grp = int64(1337)
 		pod.Spec.SecurityContext = &corev1.PodSecurityContext{
 			FSGroup: &grp,

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1046,13 +1046,12 @@ func applyUpstreamTLSSettings(env *model.Environment, cluster *apiv2.Cluster, tl
 		} else {
 			cluster.TlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(cluster.TlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
 				authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName,
-					env.Mesh.SdsUdsPath, env.Mesh.EnableSdsTokenMount, env.Mesh.SdsUseK8SSaJwt, metadata))
+					env.Mesh.SdsUdsPath, metadata))
 
 			cluster.TlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 				CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-					DefaultValidationContext: &auth.CertificateValidationContext{VerifySubjectAltName: tls.SubjectAltNames},
-					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName, env.Mesh.SdsUdsPath,
-						env.Mesh.EnableSdsTokenMount, env.Mesh.SdsUseK8SSaJwt, metadata),
+					DefaultValidationContext:         &auth.CertificateValidationContext{VerifySubjectAltName: tls.SubjectAltNames},
+					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName, env.Mesh.SdsUdsPath, metadata),
 				},
 			}
 		}

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -36,10 +36,7 @@ func NewPlugin() plugin.Plugin {
 // OnInboundFilterChains setups filter chains based on the authentication policy.
 func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.FilterChain {
 	return factory.NewPolicyApplier(in.Env.IstioConfigStore,
-		in.ServiceInstance).InboundFilterChain(in.Env.Mesh.SdsUdsPath,
-		in.Env.Mesh.EnableSdsTokenMount,
-		in.Env.Mesh.SdsUseK8SSaJwt,
-		in.Node.Metadata)
+		in.ServiceInstance).InboundFilterChain(in.Env.Mesh.SdsUdsPath, in.Node.Metadata)
 }
 
 // OnOutboundListener is called whenever a new outbound listener is added to the LDS output for a given service

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -25,7 +25,7 @@ import (
 // authentication policy. Each version of authentication policy will implement this interface.
 type PolicyApplier interface {
 	// InboundFilterChain returns inbound filter chain(s) to enforce the underlying authentication policy.
-	InboundFilterChain(sdsUdsPath string, sdsUseTrustworthyJwt, sdsUseNormalJwt bool, meta map[string]string) []plugin.FilterChain
+	InboundFilterChain(sdsUdsPath string, meta map[string]string) []plugin.FilterChain
 
 	// AuthNFilter returns the JWT HTTP filter to enforce the underlying authentication policy.
 	// It may return nil, if no JWT validation is needed.

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -312,7 +312,7 @@ func (a v1alpha1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarsha
 	return out
 }
 
-func (a v1alpha1PolicyApplier) InboundFilterChain(sdsUdsPath string, sdsUseTrustworthyJwt, sdsUseNormalJwt bool, meta map[string]string) []plugin.FilterChain {
+func (a v1alpha1PolicyApplier) InboundFilterChain(sdsUdsPath string, meta map[string]string) []plugin.FilterChain {
 	if a.policy == nil || len(a.policy.Peers) == 0 {
 		return nil
 	}
@@ -359,14 +359,14 @@ func (a v1alpha1PolicyApplier) InboundFilterChain(sdsUdsPath string, sdsUseTrust
 		}
 	} else {
 		tls.CommonTlsContext.TlsCertificateSdsSecretConfigs = []*auth.SdsSecretConfig{
-			authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, sdsUdsPath, sdsUseTrustworthyJwt, sdsUseNormalJwt, meta),
+			authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, sdsUdsPath, meta),
 		}
 
 		tls.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
 				DefaultValidationContext: &auth.CertificateValidationContext{VerifySubjectAltName: []string{} /*subjectAltNames*/},
 				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName,
-					sdsUdsPath, sdsUseTrustworthyJwt, sdsUseNormalJwt, meta),
+					sdsUdsPath, meta),
 			},
 		}
 	}

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -404,14 +404,7 @@ func writeBootstrapForPlatform(config *meshconfig.ProxyConfig, node string, epoc
 	if opts["sds_uds_path"] != nil && opts["sds_token_path"] != nil {
 		// sds is enabled
 		meta[model.NodeMetadataSdsEnabled] = "1"
-
-		if opts["sds_token_path"] == "/var/run/secrets/kubernetes.io/serviceaccount/token" {
-			// use default jwt.
-			meta[model.NodeMetadataSdsTrustJwt] = "0"
-		} else {
-			// use trustworthy jwt.
-			meta[model.NodeMetadataSdsTrustJwt] = "1"
-		}
+		meta[model.NodeMetadataSdsTrustJwt] = "1"
 	}
 
 	ba, err := json.Marshal(meta)

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -16,7 +16,7 @@
       "ISTIO_VERSION":"release-3.1",
       "POD_NAME":"svc-0-0-0-6944fb884d-4pgx8",
       "ISTIO_META_SDS": "1",
-      "ISTIO_META_TRUSTJWT": "0",
+      "ISTIO_META_TRUSTJWT": "1",
       "istio":"sidecar",
       "istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}",
       "istio-locality": "regionA.zoneB.sub_zoneC",

--- a/security/pkg/testing/sdsc/sdsclient.go
+++ b/security/pkg/testing/sdsc/sdsclient.go
@@ -54,7 +54,7 @@ type ClientOptions struct {
 // constructSDSRequest returns the context for the outbound request to include necessary
 func constructSDSRequestContext() (context.Context, error) {
 	// Read from the designated location for Kubernetes JWT.
-	content, err := ioutil.ReadFile(authn_model.K8sSAJwtFileName)
+	content, err := ioutil.ReadFile(authn_model.K8sSATrustworthyJwtFileName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read the token file %v", err)
 	}

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -80,7 +80,6 @@ func setupConfig(cfg *istio.Config) {
 	cfg.Values["global.mtls.enabled"] = "true"
 	cfg.Values["global.sds.enabled"] = "true"
 	cfg.Values["global.sds.udsPath"] = "unix:/var/run/sds/uds_path"
-	cfg.Values["global.sds.useNormalJwt"] = "true"
 	cfg.Values["global.sds.customTokenDirectory"] = "/etc/sdstoken"
 	cfg.Values["nodeagent.enabled"] = "true"
 	cfg.Values["nodeagent.image"] = "node-agent-k8s"


### PR DESCRIPTION
Remove `useTrustworthyJwt` and `useNormalJwt` helm values. Always use trustworthy Jwts if SDS is enabled. 

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
