### PR TITLE
Support CNI install with kind

### DIFF
--- a/prow/e2e-kind-suite.sh
+++ b/prow/e2e-kind-suite.sh
@@ -116,6 +116,10 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
   time build_kind_images
 fi
 
+if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
+   cni_run_daemon_kind
+fi
+
 time ISTIO_DOCKER_HUB=$HUB \
   E2E_ARGS="${E2E_ARGS[*]}" \
   JUNIT_E2E_XML="${ARTIFACTS}/junit.xml" \


### PR DESCRIPTION
This is probably not the best way to test CNI, but this is how the
existing E2E tests work. For now, we can mirror what they do, move this
over to kind, then clean it up.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
