### PR TITLE
allow --skip-cleanup in prow/e2e-kind-suite.sh

### DIFF
--- a/prow/e2e-kind-suite.sh
+++ b/prow/e2e-kind-suite.sh
@@ -74,7 +74,7 @@ for ((i=1; i<=$#; i++)); do
         ;;
         --skip-cleanup)
           SKIP_CLEANUP=true
-          shift
+          continue
         ;;
         # -s/--single_test to specify test target to run.
         # e.g. "-s e2e_mixer" will trigger e2e mixer_test


### PR DESCRIPTION
Won't delete kind cluster.
Should only used in dev flow but not in CI

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[x] Developer Infrastructure
