### PR TITLE
Set respect_dns_ttl for strict_dns clusters

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -183,6 +183,13 @@ var (
 		"If enabled, a gateway workload can only select gateway resources in the same namespace. "+
 			"Gateways with same selectors in different namespaces will not be applicable.",
 	)
+
+	RespectDNSTTL = env.RegisterBoolVar(
+		"PILOT_RESPECT_DNS_TTL",
+		true,
+		"If enabled, DNS based clusters will respect the TTL of the DNS, rather than polling at a fixed rate. "+
+			"This option is only provided for backward compatibility purposes and will be removed in the near future.",
+	)
 )
 
 var (

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1128,6 +1128,9 @@ func buildDefaultCluster(env *model.Environment, name string, discoveryType apiv
 		cluster.DnsLookupFamily = apiv2.Cluster_V4_ONLY
 		dnsRate := util.GogoDurationToDuration(env.Mesh.DnsRefreshRate)
 		cluster.DnsRefreshRate = dnsRate
+		if util.IsIstioVersionGE13(proxy) && features.RespectDNSTTL.Get() {
+			cluster.RespectDnsTtl = true
+		}
 	}
 
 	if discoveryType == apiv2.Cluster_STATIC || discoveryType == apiv2.Cluster_STRICT_DNS {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/13710

I added a flag just in case this isn't safe for some reason... probably
a bit conservative but we can just remove it after 1.3.
