### PR TITLE
Add legacy varient to kind config patch

### DIFF
--- a/prow/config/trustworthy-jwt-12.yaml
+++ b/prow/config/trustworthy-jwt-12.yaml
@@ -1,5 +1,5 @@
 # This configs KinD to spin up a k8s cluster with trustworthy jwt (Service Account Token Volume Projection) feature.
-# This must be used for 1.14 and 1.13 k8s versions
+# This must be used for 1.12 k8s versions
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
 kubeadmConfigPatches:

--- a/prow/config/trustworthy-jwt-12.yaml
+++ b/prow/config/trustworthy-jwt-12.yaml
@@ -1,0 +1,14 @@
+# This configs KinD to spin up a k8s cluster with trustworthy jwt (Service Account Token Volume Projection) feature.
+# This must be used for 1.14 and 1.13 k8s versions
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1alpha3
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"

--- a/prow/config/trustworthy-jwt-13-14.yaml
+++ b/prow/config/trustworthy-jwt-13-14.yaml
@@ -1,0 +1,14 @@
+# This configs KinD to spin up a k8s cluster with trustworthy jwt (Service Account Token Volume Projection) feature.
+# This must be used for 1.14 and 1.13 k8s versions
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta1
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"


### PR DESCRIPTION
The config patch provided only works on 1.15, but we test on older
kubernetes versions for backwards compatibility, so we need another
variant to support these.

This fixes postsubmit test failures like https://prow.istio.io/view/gcs/istio-prow/logs/integ-k8s-112-postsubmit-master/147
