### PR TITLE
Deflake debounce test

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery_test.go
@@ -26,6 +26,7 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"google.golang.org/grpc"
+
 	"istio.io/istio/pkg/test/util/retry"
 
 	"istio.io/istio/pilot/pkg/features"


### PR DESCRIPTION
This test is unforunately very time dependant. I am not sure of a good
way to get around this fact. For now, we can deflake this by increasing
the time, which gives a bigger buffer, adding retries which gives a
chance for a slower system to catch up, and sending a couple more pushes
on one of the tests, where otherwise it would be a major race condition
between stopping the channel and the push triggering
