### PR TITLE
Add MarkDone function to pushqueue

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
+++ b/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
@@ -20,6 +20,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/pkg/log"
 )
 
 // Helper function to remove an item or timeout and return nil if there are no pending pushes
@@ -42,6 +45,7 @@ func ExpectTimeout(t *testing.T, p *PushQueue) {
 	done := make(chan struct{})
 	go func() {
 		p.Dequeue()
+		log.Errorf("howardjohn: got timed out request")
 		done <- struct{}{}
 	}()
 	select {
@@ -102,11 +106,23 @@ func TestProxyQueue(t *testing.T) {
 		ExpectTimeout(t, p)
 	})
 
-	t.Run("add and remove", func(t *testing.T) {
+	t.Run("add and remove and markdone", func(t *testing.T) {
+		p := NewPushQueue()
+		p.Enqueue(proxies[0], &PushEvent{})
+		ExpectDequeue(t, p, proxies[0])
+		p.MarkDone(proxies[0])
+		p.Enqueue(proxies[0], &PushEvent{})
+		ExpectDequeue(t, p, proxies[0])
+		ExpectTimeout(t, p)
+	})
+
+	t.Run("add and remove and add and markdone", func(t *testing.T) {
 		p := NewPushQueue()
 		p.Enqueue(proxies[0], &PushEvent{})
 		ExpectDequeue(t, p, proxies[0])
 		p.Enqueue(proxies[0], &PushEvent{})
+		p.Enqueue(proxies[0], &PushEvent{})
+		p.MarkDone(proxies[0])
 		ExpectDequeue(t, p, proxies[0])
 		ExpectTimeout(t, p)
 	})
@@ -213,6 +229,7 @@ func TestProxyQueue(t *testing.T) {
 					delete(expected, key(con, eds))
 					mu.Unlock()
 				}
+				p.MarkDone(con)
 				if len(expected) == 0 {
 					done <- struct{}{}
 				}
@@ -227,4 +244,97 @@ func TestProxyQueue(t *testing.T) {
 			t.Fatalf("failed to get all updates, still pending: %v", len(expected))
 		}
 	})
+}
+
+func TestPushEventMerge(t *testing.T) {
+	push0 := &model.PushContext{}
+	// trivially different push contexts just for testing
+	push1 := &model.PushContext{ProxyStatus: make(map[string]map[string]model.ProxyPushStatus)}
+
+	var t0 time.Time
+	t1 := t0.Add(time.Minute)
+
+	cases := []struct {
+		name   string
+		left   *PushEvent
+		right  *PushEvent
+		merged *PushEvent
+	}{
+		{
+			"left nil",
+			nil,
+			&PushEvent{push: push0, start: t1},
+			&PushEvent{push: push0, start: t1},
+		},
+		{
+			"right nil",
+			&PushEvent{push: push0, start: t1},
+			nil,
+			&PushEvent{push: push0, start: t1},
+		},
+		{
+			// Expect to keep left's start, right's push, and merge eds and full.
+			"full merge",
+			&PushEvent{
+				edsUpdatedServices: map[string]struct{}{
+					"ns1": {},
+				},
+				push:  push0,
+				start: t0,
+				full:  false,
+			},
+			&PushEvent{
+				edsUpdatedServices: map[string]struct{}{
+					"ns2": {},
+				},
+				push:  push1,
+				start: t1,
+				full:  true,
+			},
+			&PushEvent{
+				edsUpdatedServices: nil, // full push ignores this field
+				push:               push1,
+				start:              t0,
+				full:               true,
+			},
+		},
+		{
+			// Expect to keep left's start, right's push, and merge eds and full.
+			"incremental merge",
+			&PushEvent{
+				edsUpdatedServices: map[string]struct{}{
+					"ns1": {},
+				},
+				push:  push0,
+				start: t0,
+				full:  false,
+			},
+			&PushEvent{
+				edsUpdatedServices: map[string]struct{}{
+					"ns2": {},
+				},
+				push:  push1,
+				start: t1,
+				full:  false,
+			},
+			&PushEvent{
+				edsUpdatedServices: map[string]struct{}{
+					"ns1": {},
+					"ns2": {},
+				},
+				push:  push1,
+				start: t0,
+				full:  false,
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.left.Merge(tt.right)
+			if !reflect.DeepEqual(tt.merged, got) {
+				t.Fatalf("expected %v, got %v", tt.merged, got)
+			}
+		})
+	}
 }

--- a/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
+++ b/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/pkg/log"
 )
 
 // Helper function to remove an item or timeout and return nil if there are no pending pushes
@@ -45,7 +44,6 @@ func ExpectTimeout(t *testing.T, p *PushQueue) {
 	done := make(chan struct{})
 	go func() {
 		p.Dequeue()
-		log.Errorf("howardjohn: got timed out request")
 		done <- struct{}{}
 	}()
 	select {


### PR DESCRIPTION
PushQueue has a problem that changes can still stack up. This mostly happens when there are a high rate of config change but low number of connected proxies. Consider the sequence:

* Add To Queue X
* Dequeue X
* Start push 1 for X
* Add To Queue X
* Dequeue X
* Attempt to start push 2 for X, blocked because only one concurrent push allowed
* Add To Queue X
* Dequeue X
* Attempt to start push 3 for X, blocked because only one concurrent push allowed
......
* Push 1 done
* Push 3 starts (order is arbitrary! it may not be push 2)
* Push 3 finishes
* Push 2 starts
* Push 2 finishes

This has two problems: Pushes may become out of order, as indicated above, which can result in the wrong config being sent, and there are unneeded pushes (2 and 3 should be merged and sent as one push).

To test the performance differences improvement, I set up a config where I had few connections (just a sidecar + ingress), but created 100 Services 1 by one, then removed them 1 by one. 
Results: https://snapshot.raintank.io/dashboard/snapshot/ymgZuKL1hGK1Sj6eK8UqZZI8GtTJNl1R?orgId=2

The first section shows with this PR, then later with current master.

You can see with master, the rate of pushes is the same, but the time period that pushes occur is much longer. This is because there will be 100 pushes queued up, so even after the config changes stop there are still 100 pushes sent! Because 100 pushes queue up you can also see there are 100 goroutines (this isn't a huge problem since its capped at 100, just an indicator of the problem). Because all push contexts are held in memory, the current head also uses much more memory - about 42x more memory at its peak in this test. Push times on master are also WAY higher, at least 2mins (our buckets don't even go high enough to capture) vs 2 seconds.

[x] Networking
[x] Performance and Scalability

Mitigates https://github.com/istio/istio/pull/16211 