### PR TITLE
fix TestNginx on inbound filter chain

### DIFF
--- a/tests/e2e/tests/simple/testdata/nginx/nginx.yaml.tmpl
+++ b/tests/e2e/tests/simple/testdata/nginx/nginx.yaml.tmpl
@@ -234,6 +234,7 @@ spec:
         prometheus.io/scrape: 'true'
         # Do not redirect inbound traffic to Envoy.
         traffic.sidecar.istio.io/includeInboundPorts: ""
+        traffic.sidecar.istio.io/excludeInboundPorts: "80,443"
         # Exclude outbound traffic to kubernetes master from redirection.
         # This is required in order to support single-namespace Istio configurations.
         traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.KubeMasterCIDR}},1.1.1.1/24,2.2.2.2/16,3.3.3.3/20"


### PR DESCRIPTION
Detected TestNginx test failure in my experiment of [switching inbound envoy listeners using filter chain](https://github.com/istio/istio/pull/16145)
Comparing with envoy as ingress gateway, nginx as ingress gateway needs an outbound sidecar proxy to support mtls.

So the iptables need to configured 
1. do not capture inbound traffic  to bypass mtls check
2. capture outbound traffic to carry mtls identification

Before inbound filter chain was introduced, the only solution is to set `includeInboundPorts` as empty so that istio won't fill it with `containerPorts`

Once switching to inbound listener using filter chain by setting `includeInboundPorts` to "*", the nginx owner need to explicit whitelist bypassing port through `excludeInboundPorts` as in this PR.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
