### PR TITLE
Deflake locality LB integration test

### DIFF
--- a/tests/integration/pilot/locality/failover_test.go
+++ b/tests/integration/pilot/locality/failover_test.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/pkg/log"
 )
 
@@ -101,7 +102,11 @@ func TestFailover(t *testing.T) {
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (CDS) via %v", fakeHostname)
-					sendTraffic(ctx, a, fakeHostname)
+					if err := retry.UntilSuccess(func() error {
+						return sendTraffic(a, fakeHostname)
+					}); err != nil {
+						ctx.Fatal(err)
+					}
 				})
 
 			ctx.NewSubTest("EDS").
@@ -132,7 +137,11 @@ func TestFailover(t *testing.T) {
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (EDS) via %v", fakeHostname)
-					sendTraffic(ctx, a, fakeHostname)
+					if err := retry.UntilSuccess(func() error {
+						return sendTraffic(a, fakeHostname)
+					}); err != nil {
+						ctx.Fatal(err)
+					}
 				})
 		})
 }

--- a/tests/integration/pilot/locality/prioritized_test.go
+++ b/tests/integration/pilot/locality/prioritized_test.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/pkg/log"
 )
 
@@ -90,7 +91,11 @@ func TestPrioritized(t *testing.T) {
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (CDS) via %v", fakeHostname)
-					sendTraffic(ctx, a, fakeHostname)
+					if err := retry.UntilSuccess(func() error {
+						return sendTraffic(a, fakeHostname)
+					}); err != nil {
+						ctx.Fatal(err)
+					}
 				})
 
 			ctx.NewSubTest("EDS").
@@ -120,7 +125,11 @@ func TestPrioritized(t *testing.T) {
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (EDS) via %v", fakeHostname)
-					sendTraffic(ctx, a, fakeHostname)
+					if err := retry.UntilSuccess(func() error {
+						return sendTraffic(a, fakeHostname)
+					}); err != nil {
+						ctx.Fatal(err)
+					}
 				})
 		})
 }


### PR DESCRIPTION
Right now we attempt to send traffic one time and fail if it fails.
Adding a retry here seems very needed, otherwise we get race conditions
between config being pushed. With this change this seems to pass pretty
consistently.

Note - this test is postsubmit only due to flakes. I would set it as enabled in this PR, but last time I tried that it turned out I didn't fix the flakes. Once this soaks a bit with no failures I will enable it