### PR TITLE
Fix memory monitor test deadlock

### DIFF
--- a/pilot/pkg/config/memory/monitor_test.go
+++ b/pilot/pkg/config/memory/monitor_test.go
@@ -37,13 +37,14 @@ func TestEventConsistency(t *testing.T) {
 	controller.RegisterEventHandler(model.MockConfig.Type, func(config model.Config, event model.Event) {
 
 		lock.Lock()
-		defer lock.Unlock()
+		tc := testConfig
+		lock.Unlock()
 
 		if event != testEvent {
 			t.Errorf("desired %v, but %v", testEvent, event)
 		}
-		if !mock.Compare(testConfig, config) {
-			t.Errorf("desired %v, but %v", testConfig, config)
+		if !mock.Compare(tc, config) {
+			t.Errorf("desired %v, but %v", tc, config)
 		}
 		done <- true
 	})


### PR DESCRIPTION
This had a deadlock cases, where we acquire the lock, then try to send
on the done channel, but we also try to acquire the lock before
recieving on the done channel. Easy fix here is to release the lock
before sending on done channel.

Test with `go test ./pilot/pkg/config/memory -run TestEventConsistency -count 5000 -timeout=10s -race` - before it fails within 10-100 tests usually, now it never does