### PR TITLE
Simplify PushContext.ServiceByHostnameAndNamespace

### DIFF
--- a/mixer/test/client/gateway/gateway_test.go
+++ b/mixer/test/client/gateway/gateway_test.go
@@ -268,10 +268,8 @@ var (
 		ServiceDiscovery: mock{},
 	}
 	pushContext = model.PushContext{
-		ServiceByHostnameAndNamespace: map[host.Name]map[string]*model.Service{
-			host.Name("svc.ns3"): {
-				"ns3": &svc,
-			},
+		ServiceByHostname: map[host.Name]*model.Service{
+			host.Name("svc.ns3"): &svc,
 		},
 	}
 	clientParams = plugin.InputParams{

--- a/mixer/test/client/pilotplugin/pilotplugin_test.go
+++ b/mixer/test/client/pilotplugin/pilotplugin_test.go
@@ -339,10 +339,8 @@ var (
 		ServiceDiscovery: mock{},
 	}
 	pushContext = model.PushContext{
-		ServiceByHostnameAndNamespace: map[host.Name]map[string]*model.Service{
-			host.Name("svc.ns3"): {
-				"ns3": &svc,
-			},
+		ServiceByHostname: map[host.Name]*model.Service{
+			host.Name("svc.ns3"): &svc,
 		},
 	}
 	serverParams = plugin.InputParams{

--- a/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
+++ b/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
@@ -351,10 +351,8 @@ var (
 		ServiceDiscovery: mock{},
 	}
 	pushContext = model.PushContext{
-		ServiceByHostnameAndNamespace: map[host.Name]map[string]*model.Service{
-			host.Name("svc.ns3"): {
-				"ns3": &svc,
-			},
+		ServiceByHostname: map[host.Name]*model.Service{
+			host.Name("svc.ns3"): &svc,
 		},
 	}
 	serverParams = plugin.InputParams{

--- a/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
+++ b/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
@@ -219,10 +219,8 @@ var (
 		ServiceDiscovery: mock{},
 	}
 	pushContext = model.PushContext{
-		ServiceByHostnameAndNamespace: map[host.Name]map[string]*model.Service{
-			host.Name("svc.ns3"): {
-				"ns3": &svc,
-			},
+		ServiceByHostname: map[host.Name]*model.Service{
+			host.Name("svc.ns3"): &svc,
 		},
 	}
 )

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -917,12 +917,11 @@ func (ps *PushContext) initSidecarScopes(env *Environment) error {
 	// build sidecar scopes for other namespaces that dont have a sidecar CRD object.
 	// Derive the sidecar scope from the root namespace's sidecar object if present. Else fallback
 	// to the default Istio behavior mimicked by the DefaultSidecarScopeForNamespace function.
-	for _, nsMap := range ps.ServiceByHostname {
-		for ns := range nsMap {
-			if len(ps.sidecarsByNamespace[ns]) == 0 {
-				// use the contents from the root namespace or the default if there is no root namespace
-				ps.sidecarsByNamespace[ns] = []*SidecarScope{ConvertToSidecarScope(ps, rootNSConfig, ns)}
-			}
+	for _, svc := range ps.ServiceByHostname {
+		ns := svc.Attributes.Namespace
+		if len(ps.sidecarsByNamespace[ns]) == 0 {
+			// use the contents from the root namespace or the default if there is no root namespace
+			ps.sidecarsByNamespace[ns] = []*SidecarScope{ConvertToSidecarScope(ps, rootNSConfig, ns)}
 		}
 	}
 

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -289,13 +289,11 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 }
 
 // ServiceForHostname returns the service associated with a given hostname following SidecarScope
-func (sc *SidecarScope) ServiceForHostname(hostname host.Name, serviceByHostname map[host.Name]map[string]*Service) *Service {
+func (sc *SidecarScope) ServiceForHostname(hostname host.Name, serviceByHostname map[host.Name]*Service) *Service {
 	// SidecarScope shouldn't be null here. If it is, we can't disambiguate the hostname to use for a namespace,
 	// so the selection must be undefined.
 	if sc == nil {
-		for _, service := range serviceByHostname[hostname] {
-			return service
-		}
+		return serviceByHostname[hostname]
 	}
 
 	// Search through in scope services. SidecarScope will already have scoped the services to ensure

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -135,7 +135,7 @@ func buildOutboundNetworkFiltersWithWeightedClusters(env *model.Environment, nod
 	}
 
 	for _, route := range routes {
-		service := node.SidecarScope.ServiceForHostname(host.Name(route.Destination.Host), push.ServiceByHostnameAndNamespace)
+		service := node.SidecarScope.ServiceForHostname(host.Name(route.Destination.Host), push.ServiceByHostname)
 		if route.Weight > 0 {
 			clusterName := istio_route.GetDestinationCluster(route.Destination, service, port.Port)
 			clusterSpecifier.WeightedClusters.Clusters = append(clusterSpecifier.WeightedClusters.Clusters, &tcp_proxy.TcpProxy_WeightedCluster_ClusterWeight{
@@ -185,7 +185,7 @@ func buildOutboundNetworkFilters(env *model.Environment, node *model.Proxy,
 	port *model.Port, configMeta model.ConfigMeta) []*listener.Filter {
 
 	if len(routes) == 1 {
-		service := node.SidecarScope.ServiceForHostname(host.Name(routes[0].Destination.Host), push.ServiceByHostnameAndNamespace)
+		service := node.SidecarScope.ServiceForHostname(host.Name(routes[0].Destination.Host), push.ServiceByHostname)
 		clusterName := istio_route.GetDestinationCluster(routes[0].Destination, service, port.Port)
 		return buildOutboundNetworkFiltersWithSingleDestination(env, node, clusterName, port)
 	}

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -480,7 +480,7 @@ func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, 
 			if hostname == "" && upstreams.Cluster == util.PassthroughCluster {
 				attrs = addVirtualDestinationServiceAttributes(make(attributes), util.PassthroughCluster)
 			} else {
-				svc := in.Node.SidecarScope.ServiceForHostname(hostname, push.ServiceByHostnameAndNamespace)
+				svc := in.Node.SidecarScope.ServiceForHostname(hostname, push.ServiceByHostname)
 				attrs = addDestinationServiceAttributes(make(attributes), svc)
 			}
 			addFilterConfigToRoute(in, httpRoute, attrs, isXDSMarshalingToAnyEnabled)
@@ -488,7 +488,7 @@ func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, 
 		case *route.RouteAction_WeightedClusters:
 			for _, weighted := range upstreams.WeightedClusters.Clusters {
 				_, _, hostname, _ := model.ParseSubsetKey(weighted.Name)
-				svc := in.Node.SidecarScope.ServiceForHostname(hostname, push.ServiceByHostnameAndNamespace)
+				svc := in.Node.SidecarScope.ServiceForHostname(hostname, push.ServiceByHostname)
 				attrs := addDestinationServiceAttributes(make(attributes), svc)
 				if isXDSMarshalingToAnyEnabled {
 					weighted.TypedPerFilterConfig = addTypedServiceConfig(weighted.TypedPerFilterConfig, &mccpb.ServiceConfig{


### PR DESCRIPTION
This is to remove the redundant namespace key.