### PR TITLE
Ignore the tcp port of the headless service

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -722,6 +722,9 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 		}
 
 		svcConv := kube.ConvertService(*svc, c.domainSuffix, c.ClusterID)
+		if len(svcConv.Ports) == 0 {
+			return nil
+		}
 		instances := kube.ExternalNameServiceInstances(*svc, svcConv)
 		switch event {
 		case model.EventDelete:

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -28,7 +28,6 @@ import (
 
 	"istio.io/api/annotation"
 
-	"istio.io/istio-bak/pkg/log"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
@@ -36,6 +35,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/spiffe"
+	"istio.io/pkg/log"
 )
 
 const (

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -28,6 +28,7 @@ import (
 
 	"istio.io/api/annotation"
 
+	"istio.io/istio-bak/pkg/log"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
@@ -74,7 +75,12 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 
 	ports := make([]*model.Port, 0, len(svc.Spec.Ports))
 	for _, port := range svc.Spec.Ports {
-		ports = append(ports, convertPort(port))
+		mPort := convertPort(port)
+		if mPort.Protocol == protocol.TCP && resolution == model.Passthrough {
+			log.Warnf("Couldn't find an IP address for TCP port %d of service %s in namespace %s", mPort.Port, svc.Name, svc.Namespace)
+			continue
+		}
+		ports = append(ports, mPort)
 	}
 
 	var exportTo map[visibility.Instance]bool


### PR DESCRIPTION
Please provide a description for what this PR is for.
Ignore the tcp port of the headless service, I hope this can fix #16233 
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
