### PR TITLE
WIP: Initial support for galley mTLS in integration tests

### DIFF
--- a/pkg/test/framework/components/galley/galley.go
+++ b/pkg/test/framework/components/galley/galley.go
@@ -67,6 +67,15 @@ type Config struct {
 
 	// MeshConfig to use for this instance.
 	MeshConfig string
+
+	// CertPath path to the client certificate used to communicate with galley
+	CertPath string
+
+	// CertPath path to the client key used to communicate with galley
+	KeyPath string
+
+	// CertPath path to the ca used to communicate with galley
+	CAPath string
 }
 
 // New returns a new instance of echo.

--- a/pkg/test/framework/components/galley/kube.go
+++ b/pkg/test/framework/components/galley/kube.go
@@ -88,8 +88,12 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 		return nil, err
 	}
 
+	// TODO if mtls -> automactically fetch cert, ca and key from Kubernetes ?
 	n.client = &client{
-		address: fmt.Sprintf("tcp://%s", n.forwarder.Address()),
+		address:  fmt.Sprintf("tcp://%s", n.forwarder.Address()),
+		caPath:   cfg.CAPath,
+		keyPath:  cfg.KeyPath,
+		certPath: cfg.CertPath,
 	}
 
 	if err = n.client.waitForStartup(); err != nil {

--- a/pkg/test/framework/components/galley/native.go
+++ b/pkg/test/framework/components/galley/native.go
@@ -303,7 +303,10 @@ func (c *nativeComponent) restart() error {
 	time.Sleep(time.Second)
 
 	c.client = &client{
-		address: fmt.Sprintf("tcp://%s", s.Address().String()),
+		address:  fmt.Sprintf("tcp://%s", s.Address().String()),
+		caPath:   cfg.CAPath,
+		keyPath:  cfg.KeyPath,
+		certPath: cfg.CertPath,
 	}
 
 	if err := c.client.waitForStartup(); err != nil {

--- a/tests/integration/conformance/conformance_test.go
+++ b/tests/integration/conformance/conformance_test.go
@@ -51,6 +51,7 @@ func TestConformance(t *testing.T) {
 			ctx.Fatalf("error loading test cases: %v", err)
 		}
 
+		// TODO how to get the input
 		gal := galley.NewOrFail(ctx, ctx, galley.Config{})
 		p := pilot.NewOrFail(ctx, ctx, pilot.Config{Galley: gal})
 


### PR DESCRIPTION
Fixes: https://github.com/istio/istio/issues/15815

This PR allows to use the integration tests (mainly because of the conformance test) with galley running with mTLS. In the first implementation step the tester has to download the certificates (docs will be adjusted).

In a follow up PR we could check if galley is running with mTLS and automatically fetch the certificates from Kubernetes.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
