### PR TITLE
Check proxyNeedsPush after recomputing SidecarScope

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
@@ -67,6 +68,8 @@ type Environment struct {
 // In current Istio implementation nodes use a 4-parts '~' delimited ID.
 // Type~IPAddress~ID~Domain
 type Proxy struct {
+	mu sync.RWMutex
+
 	// ClusterID specifies the cluster where the proxy resides.
 	// TODO: clarify if this is needed in the new 'network' model, likely needs to
 	// be renamed to 'network'
@@ -246,13 +249,20 @@ func (node *Proxy) GetRouterMode() RouterMode {
 // Listener generation code will still use the SidecarScope object directly
 // as it needs the set of services for each listener port.
 func (node *Proxy) SetSidecarScope(ps *PushContext) {
+	node.mu.Lock()
+	defer node.mu.Unlock()
 	if node.Type == SidecarProxy {
 		node.SidecarScope = ps.getSidecarScope(node, node.WorkloadLabels)
 	} else {
 		// Gateways should just have a default scope with egress: */*
 		node.SidecarScope = DefaultSidecarScopeForNamespace(ps, node.ConfigNamespace)
 	}
+}
 
+func (node *Proxy) GetSidecarScope() *SidecarScope {
+	node.mu.RLock()
+	defer node.mu.RUnlock()
+	return node.SidecarScope
 }
 
 func (node *Proxy) SetServiceInstances(env *Environment) error {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -68,12 +68,6 @@ func TestMergeUpdateRequest(t *testing.T) {
 			},
 		},
 		{
-			"incremental target namespace merge",
-			&PushRequest{Full: false, TargetNamespaces: map[string]struct{}{"ns1": {}}},
-			&PushRequest{Full: false, TargetNamespaces: map[string]struct{}{"ns2": {}}},
-			PushRequest{Full: false, TargetNamespaces: map[string]struct{}{"ns1": {}, "ns2": {}}},
-		},
-		{
 			"incremental eds merge",
 			&PushRequest{Full: false, EdsUpdates: map[string]struct{}{"svc-1": {}}},
 			&PushRequest{Full: false, EdsUpdates: map[string]struct{}{"svc-2": {}}},

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -17,9 +17,17 @@ package model
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestMergeUpdateRequest(t *testing.T) {
+	push0 := &PushContext{}
+	// trivially different push contexts just for testing
+	push1 := &PushContext{ProxyStatus: make(map[string]map[string]ProxyPushStatus)}
+
+	var t0 time.Time
+	t1 := t0.Add(time.Minute)
+
 	cases := []struct {
 		name   string
 		left   *PushRequest
@@ -40,9 +48,24 @@ func TestMergeUpdateRequest(t *testing.T) {
 		},
 		{
 			"simple merge",
-			&PushRequest{Full: true, TargetNamespaces: map[string]struct{}{"ns1": {}}},
-			&PushRequest{Full: false, TargetNamespaces: map[string]struct{}{"ns2": {}}},
-			PushRequest{Full: true, TargetNamespaces: map[string]struct{}{"ns1": {}, "ns2": {}}},
+			&PushRequest{
+				Full:             true,
+				Push:             push0,
+				Start:            t0,
+				TargetNamespaces: map[string]struct{}{"ns1": {}},
+			},
+			&PushRequest{
+				Full:             false,
+				Push:             push1,
+				Start:            t1,
+				TargetNamespaces: map[string]struct{}{"ns2": {}},
+			},
+			PushRequest{
+				Full:             true,
+				Push:             push1,
+				Start:            t0,
+				TargetNamespaces: map[string]struct{}{"ns1": {}, "ns2": {}},
+			},
 		},
 		{
 			"incremental target namespace merge",

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -687,7 +687,7 @@ func proxyNeedsPush(con *XdsConnection, req *model.PushRequest) bool {
 
 	// Otherwise, only apply if the egress listener will import the config present in the update
 	for ns := range req.TargetNamespaces {
-		if con.modelNode.SidecarScope.DependsOnNamespace(ns) {
+		if con.modelNode.GetSidecarScope().DependsOnNamespace(ns) {
 			return true
 		}
 	}

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -687,7 +687,7 @@ func proxyNeedsPush(con *XdsConnection, req *model.PushRequest) bool {
 
 	// Otherwise, only apply if the egress listener will import the config present in the update
 	for ns := range req.TargetNamespaces {
-		if con.modelNode.GetSidecarScope().DependsOnNamespace(ns) {
+		if con.modelNode.SidecarScope.DependsOnNamespace(ns) {
 			return true
 		}
 	}

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -175,6 +175,8 @@ type XdsEvent struct {
 	// Only EDS for the listed clusters will be sent.
 	edsUpdatedServices map[string]struct{}
 
+	targetNamespaces map[string]struct{}
+
 	// Push context to use for the push.
 	push *model.PushContext
 
@@ -528,6 +530,10 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 	// TODO: update the service deps based on NetworkScope
 
 	if pushEv.edsUpdatedServices != nil {
+		if !proxyNeedsPush(con, pushEv.targetNamespaces) {
+			adsLog.Debugf("Skipping EDS push to %v, no updates required", con.ConID)
+			return nil
+		}
 		// Push only EDS. This is indexed already - push immediately
 		// (may need a throttle)
 		if len(con.Clusters) > 0 {
@@ -558,6 +564,12 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 	// have to compute this because as part of a config change, a new Sidecar could become
 	// applicable to this proxy
 	con.modelNode.SetSidecarScope(pushEv.push)
+
+	// This depends on SidecarScope updates, so it should be called after SetSidecarScope.
+	if !proxyNeedsPush(con, pushEv.targetNamespaces) {
+		adsLog.Debugf("Skipping push to %v, no updates required", con.ConID)
+		return nil
+	}
 
 	adsLog.Infof("Pushing %v", con.ConID)
 
@@ -607,21 +619,21 @@ func adsClientCount() int {
 
 // AdsPushAll will send updates to all nodes, for a full config or incremental EDS.
 func AdsPushAll(s *DiscoveryServer) {
-	s.AdsPushAll(versionInfo(), s.globalPushContext(), &model.PushRequest{Full: true})
+	s.AdsPushAll(versionInfo(), &model.PushRequest{Full: true, Push: s.globalPushContext()})
 }
 
 // AdsPushAll implements old style invalidation, generated when any rule or endpoint changes.
 // Primary code path is from v1 discoveryService.clearCache(), which is added as a handler
 // to the model ConfigStorageCache and Controller.
-func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext, req *model.PushRequest) {
+func (s *DiscoveryServer) AdsPushAll(version string, req *model.PushRequest) {
 	if !req.Full {
-		s.edsIncremental(version, push, req)
+		s.edsIncremental(version, req.Push, req)
 		return
 	}
 
 	adsLog.Infof("XDS: Pushing:%s Services:%d ConnectedEndpoints:%d",
-		version, len(push.Services(nil)), adsClientCount())
-	monServices.Record(float64(len(push.Services(nil))))
+		version, len(req.Push.Services(nil)), adsClientCount())
+	monServices.Record(float64(len(req.Push.Services(nil))))
 
 	t0 := time.Now()
 
@@ -639,18 +651,18 @@ func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext, re
 	// the update may be duplicated if multiple goroutines compute at the same time).
 	// In general this code is called from the 'event' callback that is throttled.
 	for clusterName, edsCluster := range cMap {
-		if err := s.updateCluster(push, clusterName, edsCluster); err != nil {
+		if err := s.updateCluster(req.Push, clusterName, edsCluster); err != nil {
 			adsLog.Errorf("updateCluster failed with clusterName %s", clusterName)
 			totalXDSInternalErrors.Increment()
 		}
 	}
 	adsLog.Infof("Cluster init time %v %s", time.Since(t0), version)
 	req.EdsUpdates = nil
-	s.startPush(push, req)
+	s.startPush(req)
 }
 
 // Send a signal to all connections, with a push event.
-func (s *DiscoveryServer) startPush(push *model.PushContext, req *model.PushRequest) {
+func (s *DiscoveryServer) startPush(req *model.PushRequest) {
 
 	// Push config changes, iterating over connected envoys. This cover ADS and EDS(0.7), both share
 	// the same connection table
@@ -666,27 +678,25 @@ func (s *DiscoveryServer) startPush(push *model.PushContext, req *model.PushRequ
 	if currentlyPending != 0 {
 		adsLog.Infof("Starting new push while %v were still pending", currentlyPending)
 	}
-	startTime := time.Now()
+	req.Start = time.Now()
 	for _, p := range pending {
-		if proxyNeedsPush(p, req) {
-			s.pushQueue.Enqueue(p, &PushEvent{req.EdsUpdates, push, startTime, req.Full})
-		}
+		s.pushQueue.Enqueue(p, req)
 	}
 }
 
-func proxyNeedsPush(con *XdsConnection, req *model.PushRequest) bool {
+func proxyNeedsPush(con *XdsConnection, targetNamespaces map[string]struct{}) bool {
 	if !features.ScopePushes.Get() {
 		// If push scoping is not enabled, we push for all proxies
 		return true
 	}
 
 	// If no only namespaces specified, this request applies to all proxies
-	if len(req.TargetNamespaces) == 0 {
+	if len(targetNamespaces) == 0 {
 		return true
 	}
 
 	// Otherwise, only apply if the egress listener will import the config present in the update
-	for ns := range req.TargetNamespaces {
+	for ns := range targetNamespaces {
 		if con.modelNode.SidecarScope.DependsOnNamespace(ns) {
 			return true
 		}

--- a/pilot/pkg/proxy/envoy/v2/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery_test.go
@@ -90,7 +90,7 @@ func TestSendPushesManyPushes(t *testing.T) {
 
 	for push := 0; push < 100; push++ {
 		for _, proxy := range proxies {
-			queue.Enqueue(proxy, &PushEvent{})
+			queue.Enqueue(proxy, &model.PushRequest{})
 		}
 		time.Sleep(time.Millisecond * 10)
 	}
@@ -136,7 +136,7 @@ func TestSendPushesSinglePush(t *testing.T) {
 	go doSendPushes(stopCh, semaphore, queue, mockNeedsPush)
 
 	for _, proxy := range proxies {
-		queue.Enqueue(proxy, &PushEvent{})
+		queue.Enqueue(proxy, &model.PushRequest{})
 	}
 
 	if !wgDoneOrTimeout(wg, time.Second) {

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -426,7 +426,7 @@ func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext
 	}
 	adsLog.Infof("Cluster init time %v %s", time.Since(t0), version)
 
-	s.startPush(push, req)
+	s.startPush(req)
 }
 
 // WorkloadUpdate is called when workload labels/annotations are updated.

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -511,7 +511,11 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 			updates := map[string]struct{}{
 				edsIncSvc: {},
 			}
-			server.EnvoyXdsServer.AdsPushAll(strconv.Itoa(j), server.EnvoyXdsServer.Env.PushContext, &model.PushRequest{Full: true, EdsUpdates: updates})
+			server.EnvoyXdsServer.AdsPushAll(strconv.Itoa(j), &model.PushRequest{
+				Full:       true,
+				EdsUpdates: updates,
+				Push:       server.EnvoyXdsServer.Env.PushContext,
+			})
 		} else {
 			v2.AdsPushAll(server.EnvoyXdsServer)
 		}

--- a/pilot/pkg/proxy/envoy/v2/pushqueue.go
+++ b/pilot/pkg/proxy/envoy/v2/pushqueue.go
@@ -16,49 +16,9 @@ package v2
 
 import (
 	"sync"
-	"time"
 
 	"istio.io/istio/pilot/pkg/model"
 )
-
-type PushEvent struct {
-	// If not empty, it is used to indicate the event is caused by a change in the clusters.
-	// Only EDS for the listed clusters will be sent.
-	edsUpdatedServices map[string]struct{}
-
-	push *model.PushContext
-
-	// start represents the time a push was started.
-	start time.Time
-
-	full bool
-}
-
-func (event *PushEvent) Merge(other *PushEvent) *PushEvent {
-	if event == nil {
-		return other
-	}
-	if other == nil {
-		return event
-	}
-	merged := &PushEvent{}
-	merged.push = other.push
-	merged.full = event.full || other.full
-	merged.start = event.start
-
-	// When full push, do not care about edsUpdatedServices
-	if !merged.full {
-		edsUpdates := map[string]struct{}{}
-		for endpoint := range other.edsUpdatedServices {
-			edsUpdates[endpoint] = struct{}{}
-		}
-		for endpoint := range event.edsUpdatedServices {
-			edsUpdates[endpoint] = struct{}{}
-		}
-		merged.edsUpdatedServices = edsUpdates
-	}
-	return merged
-}
 
 type PushQueue struct {
 	mu   *sync.RWMutex
@@ -66,30 +26,30 @@ type PushQueue struct {
 
 	// eventsMap stores all connections in the queue. If the same connection is enqueued again, the
 	// PushEvents will be merged.
-	eventsMap map[*XdsConnection]*PushEvent
+	eventsMap map[*XdsConnection]*model.PushRequest
 
 	// connections maintains ordering of the queue
 	connections []*XdsConnection
 
 	// inProgress stores all connections that have been Dequeue(), but not MarkDone().
 	// The value stored will be initially be nil, but may be populated if the connection is Enqueue().
-	// If PushEvent is not nil, it will be Enqueued again once MarkDone has been called.
-	inProgress map[*XdsConnection]*PushEvent
+	// If model.PushRequest is not nil, it will be Enqueued again once MarkDone has been called.
+	inProgress map[*XdsConnection]*model.PushRequest
 }
 
 func NewPushQueue() *PushQueue {
 	mu := &sync.RWMutex{}
 	return &PushQueue{
 		mu:         mu,
-		eventsMap:  make(map[*XdsConnection]*PushEvent),
-		inProgress: make(map[*XdsConnection]*PushEvent),
+		eventsMap:  make(map[*XdsConnection]*model.PushRequest),
+		inProgress: make(map[*XdsConnection]*model.PushRequest),
 		cond:       sync.NewCond(mu),
 	}
 }
 
 // Add will mark a proxy as pending a push. If it is already pending, pushInfo will be merged.
 // edsUpdatedServices will be added together, and full will be set if either were full
-func (p *PushQueue) Enqueue(proxy *XdsConnection, pushInfo *PushEvent) {
+func (p *PushQueue) Enqueue(proxy *XdsConnection, pushInfo *model.PushRequest) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -111,7 +71,7 @@ func (p *PushQueue) Enqueue(proxy *XdsConnection, pushInfo *PushEvent) {
 }
 
 // Remove a proxy from the queue. If there are no proxies ready to be removed, this will block
-func (p *PushQueue) Dequeue() (*XdsConnection, *PushEvent) {
+func (p *PushQueue) Dequeue() (*XdsConnection, *model.PushRequest) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 


### PR DESCRIPTION

Without this change, there is both a data race and a logical race
condition in proxyNeedsPush.

* SidecarScope is checked outside of a push, and it is not mutex
protected, so we can read/write to it at the same time if multiple
pushes came in (this is not hypothetical, the -race tests catch it).
* SidecarScope is checked for a push, but it doesn't consider that a
push could be changing the SidecarScope! We need to do this check after
the SidecarScope has been updated instead.

We can fix the first with a mutex, but that is a pretty dirty hack and
won't resolve the real race condition.

Rather than a hacky approach of passing of passing more fields between
PushRequest and PushEvent, which are already extremely similar, this
change just merges them together. The only downside I see to this is
that before a change has been Debounced, it will not have `start` or
`push` assigned to it. I think this is acceptable though.

By merging these structs, we can move the proxyNeedsPush check down to
just before we trigger an actual push, which is after we set
SidecarScope appropriately.
