### PR TITLE
Align egressgateway resource limit with ingress

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -174,7 +174,7 @@ istio-egressgateway:
       memory: 128Mi
     limits:
       cpu: 2000m
-      memory: 256Mi
+      memory: 1024Mi
   cpu:
     targetAverageUtilization: 80
   serviceAnnotations: {}


### PR DESCRIPTION
Having such a low limit leads to OOM on a moderate sized cluster. This
PR brings it in line with ingressgateway defaults.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
