### PR TITLE
enable serviceDiscovery in galley's template

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
 {{- else }}
           - --insecure=true
 {{- end }}
+{{- if $.Values.global.enableServiceDiscovery }}
+          - --enableServiceDiscovery=true
+{{- end }}
 {{- if not $.Values.global.useMCP }}
           - --enable-server=false
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
 {{- else }}
           - --insecure=true
 {{- end }}
-{{- if $.Values.global.enableServiceDiscovery }}
+{{- if .Values.enableServiceDiscovery }}
           - --enableServiceDiscovery=true
 {{- end }}
 {{- if not $.Values.global.useMCP }}

--- a/install/kubernetes/helm/istio/charts/galley/values.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/values.yaml
@@ -29,3 +29,6 @@ tolerations: []
 # "security" and value "S1".
 podAntiAffinityLabelSelector: []
 podAntiAffinityTermLabelSelector: []
+
+# Enable service discovery processing in Galley
+enableServiceDiscovery: false


### PR DESCRIPTION
This change allows to enable ServiceDiscovery via helm in galley's deployment template. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
