### PR TITLE
Add unix-socket support for istioctl pc endpoint

### DIFF
--- a/istioctl/pkg/writer/envoy/clusters/clusters.go
+++ b/istioctl/pkg/writer/envoy/clusters/clusters.go
@@ -65,11 +65,21 @@ func (c *ConfigWriter) Prime(b []byte) error {
 }
 
 func retrieveEndpointAddress(host *adminapi.HostStatus) string {
-	return host.Address.GetSocketAddress().Address
+	addr := host.Address.GetSocketAddress()
+	if addr != nil {
+		return addr.Address
+	} else {
+		return "unix://" + host.Address.GetPipe().Path
+	}
 }
 
 func retrieveEndpointPort(l *adminapi.HostStatus) uint32 {
-	return l.Address.GetSocketAddress().GetPortValue()
+	addr := l.Address.GetSocketAddress()
+	if addr != nil {
+		return addr.GetPortValue()
+	} else {
+		return 0
+	}
 }
 
 func retrieveEndpointStatus(l *adminapi.HostStatus) core.HealthStatus {
@@ -125,7 +135,12 @@ func (c *ConfigWriter) PrintEndpointsSummary(filter EndpointFilter) error {
 	clusterEndpoint = retrieveSortedEndpointClusterSlice(clusterEndpoint)
 	fmt.Fprintln(w, "ENDPOINT\tSTATUS\tOUTLIER CHECK\tCLUSTER")
 	for _, ce := range clusterEndpoint {
-		endpoint := ce.address + ":" + strconv.Itoa(ce.port)
+		var endpoint string
+		if ce.port != 0 {
+			endpoint = ce.address + ":" + strconv.Itoa(ce.port)
+		} else {
+			endpoint = ce.address
+		}
 		fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", endpoint, core.HealthStatus_name[int32(ce.status)], printFailedOutlierCheck(ce.failedOutlierCheck), ce.cluster)
 	}
 

--- a/istioctl/pkg/writer/envoy/clusters/clusters.go
+++ b/istioctl/pkg/writer/envoy/clusters/clusters.go
@@ -68,18 +68,16 @@ func retrieveEndpointAddress(host *adminapi.HostStatus) string {
 	addr := host.Address.GetSocketAddress()
 	if addr != nil {
 		return addr.Address
-	} else {
-		return "unix://" + host.Address.GetPipe().Path
 	}
+	return "unix://" + host.Address.GetPipe().Path
 }
 
 func retrieveEndpointPort(l *adminapi.HostStatus) uint32 {
 	addr := l.Address.GetSocketAddress()
 	if addr != nil {
 		return addr.GetPortValue()
-	} else {
-		return 0
 	}
+	return 0
 }
 
 func retrieveEndpointStatus(l *adminapi.HostStatus) core.HealthStatus {

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clusters.json
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clusters.json
@@ -348,6 +348,56 @@
           }
         }
       ]
+    },
+    {
+      "name": "inbound_9092",
+      "host_statuses": [
+        {
+          "address": {
+            "pipe": {
+              "path": "/sock/mixer.socket"
+            }
+          },
+          "stats": [
+            {
+              "value": "64",
+              "name": "cx_connect_fail"
+            },
+            {
+              "value": "72",
+              "name": "cx_total"
+            },
+            {
+              "value": "78",
+              "name": "rq_error"
+            },
+            {
+              "value": "300076",
+              "name": "rq_success"
+            },
+            {
+              "name": "rq_timeout"
+            },
+            {
+              "value": "300076",
+              "name": "rq_total"
+            },
+            {
+              "type": "GAUGE",
+              "value": "8",
+              "name": "cx_active"
+            },
+            {
+              "type": "GAUGE",
+              "name": "rq_active"
+            }
+          ],
+          "health_status": {
+            "eds_health_status": "HEALTHY"
+          },
+          "weight": 1
+        }
+      ]
     }
   ]
 }

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clustersnofiltered.txt
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clustersnofiltered.txt
@@ -347,5 +347,55 @@
                 }
             }
         ]
+    },
+    {
+        "name": "inbound_9092",
+        "hostStatuses": [
+            {
+                "address": {
+                    "pipe": {
+                        "path": "/sock/mixer.socket"
+                    }
+                },
+                "stats": [
+                    {
+                        "value": "64",
+                        "name": "cx_connect_fail"
+                    },
+                    {
+                        "value": "72",
+                        "name": "cx_total"
+                    },
+                    {
+                        "value": "78",
+                        "name": "rq_error"
+                    },
+                    {
+                        "value": "300076",
+                        "name": "rq_success"
+                    },
+                    {
+                        "name": "rq_timeout"
+                    },
+                    {
+                        "value": "300076",
+                        "name": "rq_total"
+                    },
+                    {
+                        "type": "GAUGE",
+                        "value": "8",
+                        "name": "cx_active"
+                    },
+                    {
+                        "type": "GAUGE",
+                        "name": "rq_active"
+                    }
+                ],
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                },
+                "weight": 1
+            }
+        ]
     }
 ]

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clustersummary.txt
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clustersummary.txt
@@ -1,9 +1,10 @@
-ENDPOINT              STATUS        OUTLIER CHECK     CLUSTER
-172.17.0.13:443       HEALTHY       OK                outbound|443||istio-ingressgateway.istio-system.svc.cluster.local
-172.17.0.14:15014     UNHEALTHY     OK                outbound|15014||istio-policy.istio-system.svc.cluster.local
-172.17.0.19:443       HEALTHY       OK                outbound|443||istio-galley.istio-system.svc.cluster.local
-172.17.0.24:9080      HEALTHY       OK                outbound|9080||reviews.default.svc.cluster.local
-172.17.0.26:9080      HEALTHY       OK                outbound|9080||reviews.default.svc.cluster.local
-172.17.0.27:9080      HEALTHY       FAILED            outbound|9080||reviews.default.svc.cluster.local
-172.17.0.4:443        HEALTHY       OK                outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local
-172.17.0.6:443        HEALTHY       OK                outbound|443||istio-egressgateway.istio-system.svc.cluster.local
+ENDPOINT                      STATUS        OUTLIER CHECK     CLUSTER
+172.17.0.13:443               HEALTHY       OK                outbound|443||istio-ingressgateway.istio-system.svc.cluster.local
+172.17.0.14:15014             UNHEALTHY     OK                outbound|15014||istio-policy.istio-system.svc.cluster.local
+172.17.0.19:443               HEALTHY       OK                outbound|443||istio-galley.istio-system.svc.cluster.local
+172.17.0.24:9080              HEALTHY       OK                outbound|9080||reviews.default.svc.cluster.local
+172.17.0.26:9080              HEALTHY       OK                outbound|9080||reviews.default.svc.cluster.local
+172.17.0.27:9080              HEALTHY       FAILED            outbound|9080||reviews.default.svc.cluster.local
+172.17.0.4:443                HEALTHY       OK                outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local
+172.17.0.6:443                HEALTHY       OK                outbound|443||istio-egressgateway.istio-system.svc.cluster.local
+unix:///sock/mixer.socket     HEALTHY       OK                inbound_9092


### PR DESCRIPTION
Command `istioctl pc endpoint istio-policy-7f86484668-vxrws.istio-system` return a nil point error:
```console
[root@kebe-dev-m1 ~]# istio-1.2.4/bin/istioctl pc endpoint istio-policy-7f86484668-vxrws.istio-system
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1770199]

goroutine 1 [running]:
istio.io/istio/istioctl/pkg/writer/envoy/clusters.retrieveEndpointAddress(...)
	/workspace/go/src/istio.io/istio/istioctl/pkg/writer/envoy/clusters/clusters.go:67
istio.io/istio/istioctl/pkg/writer/envoy/clusters.(*ConfigWriter).PrintEndpointsSummary(0xc4204a4280, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc42061bcb8)
	/workspace/go/src/istio.io/istio/istioctl/pkg/writer/envoy/clusters/clusters.go:111 +0x1e9
istio.io/istio/istioctl/cmd.proxyConfig.func4(0xc42067c000, 0xc42064e3c0, 0x1, 0x1, 0x0, 0x0)
	/workspace/go/src/istio.io/istio/istioctl/cmd/proxyconfig.go:261 +0x2b1
istio.io/istio/vendor/github.com/spf13/cobra.(*Command).execute(0xc42067c000, 0xc42064e380, 0x1, 0x1, 0xc42067c000, 0xc42064e380)
	/workspace/go/src/istio.io/istio/vendor/github.com/spf13/cobra/command.go:762 +0x468
istio.io/istio/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc42065c000, 0xa, 0x203af6a, 0xa)
	/workspace/go/src/istio.io/istio/vendor/github.com/spf13/cobra/command.go:852 +0x30a
istio.io/istio/vendor/github.com/spf13/cobra.(*Command).Execute(0xc42065c000, 0x3, 0x3)
	/workspace/go/src/istio.io/istio/vendor/github.com/spf13/cobra/command.go:800 +0x2b
main.main()
	/workspace/go/src/istio.io/istio/istioctl/cmd/istioctl/main.go:28 +0x75
```

### Root cause:
The `pc endpoint` not support unix-socket.

 ### Result

```console
[root@kebe-dev-m1 ~]# ./istioctl-unix pc endpoint istio-policy-7f86484668-vxrws.istio-system
ENDPOINT                      STATUS      OUTLIER CHECK     CLUSTER
10.96.0.138:15004             HEALTHY     OK                mixer_report_server
127.0.0.1:15000               HEALTHY     OK                prometheus_stats
unix:///sock/mixer.socket     HEALTHY     OK                inbound_9092
```


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
