### PR TITLE
Stop using deprecated api field in RedisProxy

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -240,7 +240,9 @@ func buildRedisFilter(statPrefix, clusterName string, isXDSMarshalingToAnyEnable
 			OpTimeout: &redisOpTimeout, // TODO: Make this user configurable
 		},
 		PrefixRoutes: &redis_proxy.RedisProxy_PrefixRoutes{
-			CatchAllCluster: clusterName,
+			CatchAllRoute: &redis_proxy.RedisProxy_PrefixRoutes_Route{
+				Cluster: clusterName,
+			},
 		},
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -39,8 +39,8 @@ func TestBuildRedisFilter(t *testing.T) {
 		if !redisProxy.LatencyInMicros {
 			t.Errorf("redis proxy latency stat is not configured for microseconds")
 		}
-		if redisProxy.PrefixRoutes.CatchAllCluster != "redis-cluster" {
-			t.Errorf("redis proxy's PrefixRoutes.CatchAllCluster is %s", redisProxy.PrefixRoutes.CatchAllCluster)
+		if redisProxy.PrefixRoutes.CatchAllRoute.Cluster != "redis-cluster" {
+			t.Errorf("redis proxy's PrefixRoutes.CatchAllCluster is %s", redisProxy.PrefixRoutes.CatchAllRoute.Cluster)
 		}
 	} else {
 		t.Errorf("redis filter type is %T not listener.Filter_TypedConfig ", redisFilter.ConfigType)


### PR DESCRIPTION
Please provide a description for what this PR is for.

without this fix, the listener can not be configured.

```
[2019-08-15 03:51:32.136][21][warning][config] [external/envoy/source/common/config/grpc_mux_subscription_impl.cc:81] gRPC config for type.googleapis.com/envoy.api.v2.Listener rejected: Error adding/updating listener(s) 0.0.0.0_6379: Proto constraint validation failed (Using deprecated option 'envoy.config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.catch_all_cluster' from file redis_proxy.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.): catch_all_cluster: "outbound|6379||redis-cart.default.svc.cluster.local"

```
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
