### PR TITLE
remove h2 from ALPN

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -137,7 +137,7 @@ const (
 )
 
 var (
-	applicationProtocols = []string{"h2", "http/1.1", "http/1.0"}
+	applicationProtocols = []string{"http/1.1", "http/1.0"}
 
 	// EnvoyJSONLogFormat12 map of values for envoy json based access logs for Istio 1.2
 	EnvoyJSONLogFormat12 = &google_protobuf.Struct{

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -583,11 +583,10 @@ func testInboundListenerConfigWithoutServiceV13(t *testing.T, proxy *model.Proxy
 
 func verifyHTTPFilterChainMatch(t *testing.T, fc *listener.FilterChain) {
 	t.Helper()
-	if len(fc.FilterChainMatch.ApplicationProtocols) != 3 ||
-		fc.FilterChainMatch.ApplicationProtocols[0] != "h2" ||
-		fc.FilterChainMatch.ApplicationProtocols[1] != "http/1.1" ||
-		fc.FilterChainMatch.ApplicationProtocols[2] != "http/1.0" {
-		t.Fatalf("expected %d application protocols, [h2, http/1.1, http/1.0]", 3)
+	if len(fc.FilterChainMatch.ApplicationProtocols) != 2 ||
+		fc.FilterChainMatch.ApplicationProtocols[0] != "http/1.1" ||
+		fc.FilterChainMatch.ApplicationProtocols[1] != "http/1.0" {
+		t.Fatalf("expected %d application protocols, [http/1.1, http/1.0]", 3)
 	}
 }
 


### PR DESCRIPTION
When using protocol sniffing for h2 port, use TCP proxy. Pilot doesn't support generate h2 filter chain, cluster and route when using protocol sniffing.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
