### PR TITLE
Fix redis connectivity 

### DIFF
--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -55,7 +55,7 @@ func convertPort(port coreV1.ServicePort) *model.Port {
 }
 
 func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *model.Service {
-	addr, external := constants.UnspecifiedIP, ""
+	addr := constants.UnspecifiedIP
 	if svc.Spec.ClusterIP != "" && svc.Spec.ClusterIP != coreV1.ClusterIPNone {
 		addr = svc.Spec.ClusterIP
 	}
@@ -64,13 +64,8 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 	meshExternal := false
 
 	if svc.Spec.Type == coreV1.ServiceTypeExternalName && svc.Spec.ExternalName != "" {
-		external = svc.Spec.ExternalName
 		resolution = model.DNSLB
 		meshExternal = true
-	}
-
-	if addr == constants.UnspecifiedIP && external == "" { // headless services should not be load balanced
-		resolution = model.Passthrough
 	}
 
 	ports := make([]*model.Port, 0, len(svc.Spec.Ports))


### PR DESCRIPTION
Please provide a description for what this PR is for.

ref: https://github.com/istio/istio/issues/15429#issuecomment-521509468

For redis filter the ORIGINAL_DST cluster with ORIGINAL_DST_LB policy will cause connection issue.

The route cause is we donot apply lb policy for k8s headless service. I think we can do do same for headless service as normal one.  I tested by hand , this works for both tcp and redis headless service.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
