### PR TITLE
Make it possible to run bookinfo without root and with readOnlyFilesystem

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -38,6 +38,19 @@ spec:
       - name: reviews
         image: docker.io/istio/examples-bookinfo-reviews-v2:1.15.0
         imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
         ports:
         - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 ---

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -156,8 +156,21 @@ spec:
       - name: reviews
         image: docker.io/istio/examples-bookinfo-reviews-v1:1.15.0
         imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
         ports:
         - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -183,8 +196,21 @@ spec:
       - name: reviews
         image: docker.io/istio/examples-bookinfo-reviews-v2:1.15.0
         imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
         ports:
         - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -210,8 +236,21 @@ spec:
       - name: reviews
         image: docker.io/istio/examples-bookinfo-reviews-v3:1.15.0
         imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
         ports:
         - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 ---
 ##################################################################################################
 # Productpage services

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -261,4 +261,10 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---

--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -33,9 +33,10 @@ EXPOSE 9080
 WORKDIR /opt/microservices
 RUN python -m unittest discover
 RUN chmod 775 /opt/microservices && \
-    touch /opt/microservices/microservice.log && \
-    chmod 664 /opt/microservices/microservice.log
+    chown daemon:daemon /tmp/microservice.log
+
+USER 1
 
 # hadolint ignore=DL3025
-CMD tail -f /opt/microservices/microservice.log & \
+CMD tail -f /tmp/microservice.log & \
     python productpage.py 9080

--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -32,11 +32,7 @@ ENV FLOOD_FACTOR ${flood_factor:-0}
 EXPOSE 9080
 WORKDIR /opt/microservices
 RUN python -m unittest discover
-RUN chmod 775 /opt/microservices && \
-    chown daemon:daemon /tmp/microservice.log
 
 USER 1
 
-# hadolint ignore=DL3025
-CMD tail -f /tmp/microservice.log & \
-    python productpage.py 9080
+CMD ["python", "productpage.py", "9080"]

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -45,7 +45,7 @@ except ImportError:
 http_client.HTTPConnection.debuglevel = 1
 
 app = Flask(__name__)
-logging.basicConfig(filename='microservice.log', filemode='w', level=logging.DEBUG)
+logging.basicConfig(filename='/tmp/microservice.log', filemode='w', level=logging.DEBUG)
 requests_log = logging.getLogger("requests.packages.urllib3")
 requests_log.setLevel(logging.DEBUG)
 requests_log.propagate = True
@@ -381,7 +381,7 @@ if __name__ == '__main__':
         sys.exit(-1)
 
     p = int(sys.argv[1])
-    sys.stderr = Writer('stderr.log')
-    sys.stdout = Writer('stdout.log')
+    sys.stderr = Writer('/tmp/stderr.log')
+    sys.stdout = Writer('/tmp/stdout.log')
     print("start at port %s" % (p))
     app.run(host='0.0.0.0', port=p, debug=True, threaded=True)

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -45,7 +45,7 @@ except ImportError:
 http_client.HTTPConnection.debuglevel = 1
 
 app = Flask(__name__)
-logging.basicConfig(filename='/tmp/microservice.log', filemode='w', level=logging.DEBUG)
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 requests_log = logging.getLogger("requests.packages.urllib3")
 requests_log.setLevel(logging.DEBUG)
 requests_log.propagate = True
@@ -377,11 +377,9 @@ class Writer(object):
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:
-        print("usage: %s port" % (sys.argv[0]))
+        logging.error("usage: %s port" % (sys.argv[0]))
         sys.exit(-1)
 
     p = int(sys.argv[1])
-    sys.stderr = Writer('/tmp/stderr.log')
-    sys.stdout = Writer('/tmp/stdout.log')
-    print("start at port %s" % (p))
+    logging.info("start at port %s" % (p))
     app.run(host='0.0.0.0', port=p, debug=True, threaded=True)


### PR DESCRIPTION
This PR makes it possible to run the productpage and reviews of the bookinfo in an environment with [restricted psp](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/restricted-psp.yaml) for default user. These changes allows it to run the bookinfo without any further privileges then the restricted psp provides. This makes it easier for people with psp activated to use the bookinfo example.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
