### PR TITLE
Fix sidecar takes too long getting initial config

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -119,12 +119,6 @@ type DiscoveryServer struct {
 	// mutex used for config update scheduling (former cache update mutex)
 	updateMutex sync.RWMutex
 
-	// mutex used for protecting proxyUpdates
-	proxyUpdatesMutex sync.RWMutex
-	// proxies that need full push during the new push epoch
-	// the key is the proxy ip address
-	proxyUpdates map[string]struct{}
-
 	// pushQueue is the buffer that used after debounce and before the real xds push.
 	pushQueue *PushQueue
 }
@@ -171,7 +165,6 @@ func NewDiscoveryServer(
 		EndpointShardsByService: map[string]map[string]*EndpointShards{},
 		WorkloadsByID:           map[string]*Workload{},
 		connectionsByIP:         map[string]*XdsConnection{},
-		proxyUpdates:            map[string]struct{}{},
 		concurrentPushLimit:     make(chan struct{}, features.PushThrottle),
 		pushChannel:             make(chan *model.PushRequest, 10),
 		pushQueue:               NewPushQueue(),
@@ -427,18 +420,7 @@ func debounce(ch chan *model.PushRequest, stopCh <-chan struct{}, fn func(req *m
 	}
 }
 
-func (s *DiscoveryServer) checkProxyNeedsFullPush(node *model.Proxy) bool {
-	full := false
-	s.proxyUpdatesMutex.Lock()
-	if _, ok := s.proxyUpdates[node.IPAddresses[0]]; ok {
-		full = true
-		delete(s.proxyUpdates, node.IPAddresses[0])
-	}
-	s.proxyUpdatesMutex.Unlock()
-	return full
-}
-
-func doSendPushes(stopCh <-chan struct{}, semaphore chan struct{}, queue *PushQueue, checkProxyNeedsFullPush func(node *model.Proxy) bool) {
+func doSendPushes(stopCh <-chan struct{}, semaphore chan struct{}, queue *PushQueue) {
 	for {
 		select {
 		case <-stopCh:
@@ -461,9 +443,7 @@ func doSendPushes(stopCh <-chan struct{}, semaphore chan struct{}, queue *PushQu
 
 			go func() {
 				edsUpdates := info.EdsUpdates
-				proxyFull := info.Full || checkProxyNeedsFullPush(client.modelNode)
-
-				if proxyFull {
+				if info.Full {
 					// Setting this to nil will trigger a full push
 					edsUpdates = nil
 				}
@@ -487,5 +467,5 @@ func doSendPushes(stopCh <-chan struct{}, semaphore chan struct{}, queue *PushQu
 }
 
 func (s *DiscoveryServer) sendPushes(stopCh <-chan struct{}) {
-	doSendPushes(stopCh, s.concurrentPushLimit, s.pushQueue, s.checkProxyNeedsFullPush)
+	doSendPushes(stopCh, s.concurrentPushLimit, s.pushQueue)
 }

--- a/pilot/pkg/proxy/envoy/v2/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery_test.go
@@ -33,10 +33,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 )
 
-func mockNeedsPush(node *model.Proxy) bool {
-	return true
-}
-
 func createProxies(n int) []*XdsConnection {
 	proxies := make([]*XdsConnection, 0, n)
 	for p := 0; p < n; p++ {
@@ -86,7 +82,7 @@ func TestSendPushesManyPushes(t *testing.T) {
 			}
 		}()
 	}
-	go doSendPushes(stopCh, semaphore, queue, mockNeedsPush)
+	go doSendPushes(stopCh, semaphore, queue)
 
 	for push := 0; push < 100; push++ {
 		for _, proxy := range proxies {
@@ -133,7 +129,7 @@ func TestSendPushesSinglePush(t *testing.T) {
 			}
 		}()
 	}
-	go doSendPushes(stopCh, semaphore, queue, mockNeedsPush)
+	go doSendPushes(stopCh, semaphore, queue)
 
 	for _, proxy := range proxies {
 		queue.Enqueue(proxy, &model.PushRequest{})

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -457,7 +457,6 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, workloadLabels map[string]st
 				// There is a possibility that the pod comes up later than endpoint.
 				// So no endpoints add/update events after this, we should request
 				// full push immediately to speed up sidecar startup.
-				_ = connection.modelNode.SetServiceInstances(s.Env)
 				s.pushQueue.Enqueue(connection, &model.PushRequest{Full: true, Push: s.globalPushContext(), Start: time.Now()})
 				return
 			}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -445,7 +445,6 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, workloadLabels map[string]st
 			Labels: workloadLabels,
 		}
 
-		fullPush := false
 		adsClientsMutex.RLock()
 		for _, connection := range adsClients {
 			// if the workload has envoy proxy and connected to server,
@@ -455,21 +454,16 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, workloadLabels map[string]st
 			//   case 2: the workload xDS connection has not been established,
 			//           also no need to trigger a full push here.
 			if connection.modelNode.IPAddresses[0] == id {
-				fullPush = true
+				// There is a possibility that the pod comes up later than endpoint.
+				// So no endpoints add/update events after this, we should request
+				// full push immediately to speed up sidecar startup.
+				_ = connection.modelNode.SetServiceInstances(s.Env)
+				s.pushQueue.Enqueue(connection, &model.PushRequest{Full: true, Push: s.globalPushContext(), Start: time.Now()})
+				return
 			}
 		}
 		adsClientsMutex.RUnlock()
 
-		if fullPush {
-			// First time this workload has been seen. Maybe after the first connect,
-			// do a full push for this proxy in the next push epoch.
-			s.proxyUpdatesMutex.Lock()
-			if s.proxyUpdates == nil {
-				s.proxyUpdates = make(map[string]struct{})
-			}
-			s.proxyUpdates[id] = struct{}{}
-			s.proxyUpdatesMutex.Unlock()
-		}
 		return
 	}
 	if reflect.DeepEqual(w.Labels, workloadLabels) {

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -458,7 +458,7 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, workloadLabels map[string]st
 				// So no endpoints add/update events after this, we should request
 				// full push immediately to speed up sidecar startup.
 				s.pushQueue.Enqueue(connection, &model.PushRequest{Full: true, Push: s.globalPushContext(), Start: time.Now()})
-				return
+				break
 			}
 		}
 		adsClientsMutex.RUnlock()


### PR DESCRIPTION
Supersede #15950, there is a possibility when pod comes up later than endpoint in k8s env. Without this pr, we only record the proxies that need full push for the next push epoch, what I do here is to trigger push immediately for the specific proxy(depends on recently added pushQueue).


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
