### PR TITLE
Skip mixer native race tests

### DIFF
--- a/tests/integration/mixer/check_test.go
+++ b/tests/integration/mixer/check_test.go
@@ -16,9 +16,10 @@ package mixer
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
+
+	"istio.io/istio/pkg/test/framework/components/environment"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/galley"
@@ -29,11 +30,9 @@ import (
 )
 
 func TestCheck_Allow(t *testing.T) {
-	if len(os.Getenv("RACE_TEST")) > 0 {
-		t.Skip("https://github.com/istio/istio/issues/15444")
-	}
 	framework.
 		NewTest(t).
+		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			gal := galley.NewOrFail(t, ctx, galley.Config{})
 			mxr := mixer.NewOrFail(t, ctx, mixer.Config{
@@ -78,11 +77,9 @@ func TestCheck_Allow(t *testing.T) {
 }
 
 func TestCheck_Deny(t *testing.T) {
-	if len(os.Getenv("RACE_TEST")) > 0 {
-		t.Skip("https://github.com/istio/istio/issues/15444")
-	}
 	framework.
 		NewTest(t).
+		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			gal := galley.NewOrFail(t, ctx, galley.Config{})
 			mxr := mixer.NewOrFail(t, ctx, mixer.Config{

--- a/tests/integration/mixer/check_test.go
+++ b/tests/integration/mixer/check_test.go
@@ -16,6 +16,7 @@ package mixer
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -28,6 +29,9 @@ import (
 )
 
 func TestCheck_Allow(t *testing.T) {
+	if len(os.Getenv("RACE_TEST")) > 0 {
+		t.Skip("https://github.com/istio/istio/issues/15444")
+	}
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
@@ -74,6 +78,9 @@ func TestCheck_Allow(t *testing.T) {
 }
 
 func TestCheck_Deny(t *testing.T) {
+	if len(os.Getenv("RACE_TEST")) > 0 {
+		t.Skip("https://github.com/istio/istio/issues/15444")
+	}
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {

--- a/tests/integration/mixer/report_test.go
+++ b/tests/integration/mixer/report_test.go
@@ -16,6 +16,7 @@ package mixer
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -29,6 +30,9 @@ import (
 )
 
 func TestMixer_Report_Direct(t *testing.T) {
+	if len(os.Getenv("RACE_TEST")) > 0 {
+		t.Skip("https://github.com/istio/istio/issues/15444")
+	}
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {

--- a/tests/integration/mixer/report_test.go
+++ b/tests/integration/mixer/report_test.go
@@ -16,9 +16,10 @@ package mixer
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
+
+	"istio.io/istio/pkg/test/framework/components/environment"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/galley"
@@ -30,11 +31,9 @@ import (
 )
 
 func TestMixer_Report_Direct(t *testing.T) {
-	if len(os.Getenv("RACE_TEST")) > 0 {
-		t.Skip("https://github.com/istio/istio/issues/15444")
-	}
 	framework.
 		NewTest(t).
+		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 
 			g := galley.NewOrFail(t, ctx, galley.Config{})

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -154,6 +154,6 @@ test.integration.kube.presubmit: | $(JUNIT_REPORT)
 .PHONY: test.integration.race.native
 test.integration.race.native: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
-	RACE_TEST=true $(GO) test -race -p 1 ${T} ${TEST_PACKAGES} -timeout 120m \
+	$(GO) test -race -p 1 ${T} ${TEST_PACKAGES} -timeout 120m \
 	--istio.test.env native \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -154,6 +154,6 @@ test.integration.kube.presubmit: | $(JUNIT_REPORT)
 .PHONY: test.integration.race.native
 test.integration.race.native: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
-	$(GO) test -race -p 1 ${T} ${TEST_PACKAGES} -timeout 120m \
+	RACE_TEST=true $(GO) test -race -p 1 ${T} ${TEST_PACKAGES} -timeout 120m \
 	--istio.test.env native \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))


### PR DESCRIPTION
Since this has been around for months with no owner, I don't know how to fix it, it is hiding possible real failures (its always red so I never look at why), and @kyessenov says these tests native mixer are useless anyways, I have disabled these tests for the race testing. See https://github.com/istio/istio/issues/15444 for details.