### PR TITLE
Filter snapshot objects by namespace

### DIFF
--- a/galley/pkg/config/resource/name.go
+++ b/galley/pkg/config/resource/name.go
@@ -14,7 +14,11 @@
 
 package resource
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
 
 // Name of the resource. It is unique within a given set of resource of the same collection.
 type Name struct{ string }
@@ -28,7 +32,27 @@ func NewName(namespace, local string) Name {
 	return Name{string: namespace + "/" + local}
 }
 
-// String inteface implementation.
+// NewFullName returns a given name as a resource Name
+func NewFullName(name string) (Name, error) {
+	if name == "" {
+		return Name{string: ""}, errors.New("invalid name: can not be empty")
+	}
+	begin := 0
+	for i, r := range name {
+		if r == '/' {
+			if begin == i {
+				return Name{string: ""}, fmt.Errorf("invalid name %s: namespace must not be empty", name)
+			}
+			begin = i + 1
+		}
+	}
+	if begin == len(name) {
+		return Name{string: ""}, fmt.Errorf("invalid name %s: name must not be empty", name)
+	}
+	return Name{string: name}, nil
+}
+
+// String interface implementation.
 func (n Name) String() string {
 	return n.string
 }

--- a/galley/pkg/config/resource/name_test.go
+++ b/galley/pkg/config/resource/name_test.go
@@ -32,6 +32,85 @@ func TestNewName_NoNamespace(t *testing.T) {
 	}
 }
 
+func TestNewFullName_Empty(t *testing.T) {
+	n, err := NewFullName("")
+	if n.String() != "" {
+		t.Fatalf("unexpected name: %v", n)
+	}
+	if err == nil {
+		t.Fatalf("expected err but got: %v", err)
+	}
+	errMsg := "invalid name: can not be empty"
+	if err.Error() != errMsg {
+		t.Fatalf("expected err \"%s\" but got: %v", errMsg, err.Error())
+	}
+}
+
+func TestNewFullName_Segments(t *testing.T) {
+	steps := []struct {
+		description string
+		name        string
+		want        string
+		err         string
+		valid       bool
+	}{
+		{
+			description: "namespace with emapty name",
+			name:        "testNamespace/",
+			want:        "",
+			err:         "invalid name testNamespace/: name must not be empty",
+			valid:       false,
+		},
+		{
+			description: "name with empty namespace",
+			name:        "/testName",
+			want:        "",
+			err:         "invalid name /testName: namespace must not be empty",
+			valid:       false,
+		},
+		{
+			description: "all empty",
+			name:        "/",
+			want:        "",
+			err:         "invalid name /: namespace must not be empty",
+			valid:       false,
+		},
+		{
+			description: "multiple segments",
+			name:        "testName//someotherStuff",
+			want:        "",
+			err:         "invalid name testName//someotherStuff: namespace must not be empty",
+			valid:       false,
+		},
+		{
+			description: "valid name with namespace",
+			name:        "testNamespace/testName",
+			want:        "testNamespace/testName",
+			valid:       true,
+		},
+	}
+	for _, s := range steps {
+		t.Run(s.description, func(tt *testing.T) {
+			n, err := NewFullName(s.name)
+			if n.String() != s.want {
+				tt.Fatalf("unexpected name: %v", n)
+			}
+			if s.valid {
+				if err != nil {
+					tt.Fatalf("expected no err but got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				tt.Fatalf("expected err but got: %v", err)
+			}
+			if err.Error() != s.err {
+				tt.Fatalf("expected err \"%s\" but got: %v", s.err, err.Error())
+			}
+		})
+	}
+}
+
 func TestName_String(t *testing.T) {
 	n := NewName("ns1", "l1")
 	if n.String() != "ns1/l1" {

--- a/pkg/test/framework/components/galley/snapshot_test.go
+++ b/pkg/test/framework/components/galley/snapshot_test.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package galley_test
+
+import (
+	"fmt"
+	"testing"
+
+	mcp "istio.io/api/mcp/v1alpha1"
+
+	"github.com/onsi/gomega"
+
+	"istio.io/istio/pkg/test/framework/components/galley"
+)
+
+func TestSingleObjectSnapshotValidator(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	actuals := []*galley.SnapshotObject{
+		{
+			TypeURL: "testURL",
+			Metadata: &mcp.Metadata{
+				Name: "testNS/testName",
+			},
+		},
+		{
+			TypeURL: "testURL2",
+			Metadata: &mcp.Metadata{
+				Name: "testNS2/testName2",
+			},
+		},
+	}
+
+	validatorFunc := galley.NewSingleObjectSnapshotValidator("testNS", testValidator)
+	err := validatorFunc(actuals)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	actuals = append(actuals, &galley.SnapshotObject{
+		TypeURL: "testURL",
+		Metadata: &mcp.Metadata{
+			Name: "testNS/otherTestName",
+		},
+	})
+	err = validatorFunc(actuals)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(gomega.Equal(fmt.Errorf("expected 1 resource, found %d", len(actuals))))
+
+}
+
+func testValidator(ns string, actual *galley.SnapshotObject) error {
+	return nil
+}


### PR DESCRIPTION
Single object snapshot validator should filter the objects by the given namespace first prior to failing. A failure could occurs when there are objects from different namespaces exist in the Snapshot. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[x] Developer Infrastructure
