### PR TITLE
Fix SetServiceInstances data race

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -730,9 +730,6 @@ func (s *DiscoveryServer) updateProxyServiceInstances(instance *model.ServiceIns
 		return nil
 	}
 
-	// Update proxy node's service instances
-	proxy.ServiceInstances = instances
-
 	// Trigger an update to that particular proxy
 	s.pushQueue.Enqueue(con, &model.PushRequest{Full: true, Push: s.globalPushContext(), Start: time.Now()})
 


### PR DESCRIPTION
A recent PR introduced a new call to SetServiceInstances that will
concurrently with another call. Since this isn't protected by a mutex
(and I think that is a good thing), this causes a data race.

In pushConnection we already call SetServiceInstances, so we don't need
to set them here as well, and removing this fixes the race.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
