### PR TITLE
Enable race test in integration presubmit

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -82,7 +82,7 @@ test.integration.new.installer: | $(JUNIT_REPORT)
 # Generate integration test targets for local environment.
 test.integration.%.local: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
-	$(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... \
+	$(GO) test -p 1 ${T} -race ./tests/integration/$(subst .,/,$*)/... \
 	--istio.test.env native \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))
 


### PR DESCRIPTION
Currently we have a postsubmit job to run the race detector. To me, it
doesn't make much sense to have it only as postsubmit, because then we
miss data races in PRs and have to fix them up later. The cost of adding
race detector is pretty low (I think -- will measure in this PR), so it
should be worthwhile.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
