### PR TITLE
Fix multicluster workload labels setting error

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -268,7 +268,7 @@ func (node *Proxy) SetServiceInstances(env *Environment) error {
 
 // SetWorkloadLabels will reset the proxy.WorkloadLabels if `force` = true,
 // otherwise only set it when it is nil.
-func (node *Proxy) SetWorkloadLabels(env *Environment, force bool) error {
+func (node *Proxy) SetWorkloadLabels(env *Environment) error {
 	// The WorkloadLabels is already parsed from Node metadata["LABELS"]
 	if node.WorkloadLabels != nil {
 		return nil

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -417,6 +417,7 @@ type ServiceDiscovery interface {
 	// determine the intended destination of a connection without a Host header on the request.
 	GetProxyServiceInstances(*Proxy) ([]*ServiceInstance, error)
 
+	// GetProxyWorkloadLabels returns the labels of the given proxy.
 	GetProxyWorkloadLabels(*Proxy) (labels.Collection, error)
 
 	// ManagementPorts lists set of management ports associated with an IPv4 address.

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -549,7 +549,7 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 	}
 
 
-	if err := con.modelNode.SetServiceInstances(pushEv.push.Env); err != nil {
+	if err := con.modelNode.SetServiceInstances(s.Env); err != nil {
 		return err
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -185,12 +185,6 @@ type XdsEvent struct {
 	done func()
 }
 
-// UpdateEvent represents a update request for the proxy.
-// This will trigger proxy specific attributes reset before each push.
-type UpdateEvent struct {
-	workloadLabel bool
-}
-
 func newXdsConnection(peerAddr string, stream DiscoveryStream) *XdsConnection {
 	return &XdsConnection{
 		pushChannel:  make(chan *XdsEvent),

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -559,13 +559,16 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 		return nil
 	}
 
-	if err := con.modelNode.SetWorkloadLabels(s.Env, false); err != nil {
-		return err
-	}
 
 	if err := con.modelNode.SetServiceInstances(pushEv.push.Env); err != nil {
 		return err
 	}
+
+	// should be after SetServiceInstances, because it depends on con.modelNode.ClusterID.
+	if err := con.modelNode.SetWorkloadLabels(s.Env, false); err != nil {
+		return err
+	}
+
 	if util.IsLocalityEmpty(con.modelNode.Locality) {
 		// Get the locality from the proxy's service instances.
 		// We expect all instances to have the same locality. So its enough to look at the first instance

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -193,13 +193,13 @@ type UpdateEvent struct {
 
 func newXdsConnection(peerAddr string, stream DiscoveryStream) *XdsConnection {
 	return &XdsConnection{
-		pushChannel:   make(chan *XdsEvent),
-		PeerAddr:      peerAddr,
-		Clusters:      []string{},
-		Connect:       time.Now(),
-		stream:        stream,
-		LDSListeners:  []*xdsapi.Listener{},
-		RouteConfigs:  map[string]*xdsapi.RouteConfiguration{},
+		pushChannel:  make(chan *XdsEvent),
+		PeerAddr:     peerAddr,
+		Clusters:     []string{},
+		Connect:      time.Now(),
+		stream:       stream,
+		LDSListeners: []*xdsapi.Listener{},
+		RouteConfigs: map[string]*xdsapi.RouteConfiguration{},
 	}
 }
 
@@ -547,7 +547,6 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 		}
 		return nil
 	}
-
 
 	if err := con.modelNode.SetServiceInstances(s.Env); err != nil {
 		return err

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -504,7 +504,7 @@ func (s *DiscoveryServer) initConnectionNode(discReq *xdsapi.DiscoveryRequest, c
 		nt.Locality = discReq.Node.Locality
 	}
 
-	if err := nt.SetWorkloadLabels(s.Env, false); err != nil {
+	if err := nt.SetWorkloadLabels(s.Env); err != nil {
 		return err
 	}
 
@@ -554,7 +554,7 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 	}
 
 	// should be after SetServiceInstances, because it depends on con.modelNode.ClusterID.
-	if err := con.modelNode.SetWorkloadLabels(s.Env, false); err != nil {
+	if err := con.modelNode.SetWorkloadLabels(s.Env); err != nil {
 		return err
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/push_test.go
+++ b/pilot/pkg/proxy/envoy/v2/push_test.go
@@ -1,0 +1,102 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"reflect"
+	"testing"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
+	"istio.io/istio/pilot/pkg/serviceregistry/aggregate/mock"
+	"istio.io/istio/pkg/config/labels"
+
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+)
+
+func TestSetProxyWorkloadLabels(t *testing.T) {
+	aggregator, cancel := mock.NewFakeAggregateControllerForMultiCluster()
+	defer cancel()
+
+	environment := &model.Environment{
+		PushContext:      model.NewPushContext(),
+		ServiceDiscovery: aggregator,
+		Mesh:             &meshconfig.MeshConfig{},
+	}
+
+	xdsServer := NewDiscoveryServer(environment, nil, aggregate.NewController(), nil, nil)
+
+	ip := "192.168.0.10"
+
+	testCases := []struct {
+		name    string
+		proxyIP string
+		network string
+		expect  labels.Collection
+	}{
+		{
+			name:    "should get labels from its own cluster workload",
+			proxyIP: ip,
+			network: "network1",
+			expect:  labels.Collection{{"app": "cluster1"}},
+		},
+		{
+			name:    "should get labels from its own cluster workload",
+			proxyIP: ip,
+			network: "network2",
+			expect:  labels.Collection{{"app": "cluster2"}},
+		},
+		{
+			name:    "can not get a workload from its cluster",
+			proxyIP: ip,
+			network: "network3",
+			expect:  labels.Collection{},
+		},
+		{
+			name:    "can not get a workload from its cluster",
+			proxyIP: "not exist ip",
+			network: "network1",
+			expect:  labels.Collection{},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			proxy := &model.Proxy{
+				Metadata:    map[string]string{model.NodeMetadataNetwork: test.network},
+				IPAddresses: []string{test.proxyIP},
+				Locality: &core.Locality{
+					Region: "placeholder",
+				},
+			}
+			connection := &XdsConnection{
+				Clusters:     []string{},
+				LDSListeners: []*xdsapi.Listener{},
+				RouteConfigs: map[string]*xdsapi.RouteConfiguration{},
+				modelNode:    proxy,
+			}
+			push := model.NewPushContext()
+			push.Env = environment
+			xdsServer.pushConnection(connection, &XdsEvent{push: push})
+			workloadlabels := proxy.WorkloadLabels
+
+			if !reflect.DeepEqual(workloadlabels, test.expect) {
+				t.Errorf("Expect labels %v != %v", test.expect, workloadlabels)
+			}
+		})
+	}
+}

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -261,7 +261,6 @@ func (c *Controller) GetProxyWorkloadLabels(proxy *model.Proxy) (labels.Collecti
 	out := make(labels.Collection, 0)
 	var errs error
 	// It doesn't make sense for a single proxy to be found in more than one registry.
-	// TODO: if otherwise, warning or else what to do about it.
 	for _, r := range c.GetRegistries() {
 		wlLabels, err := r.GetProxyWorkloadLabels(proxy)
 		if err != nil {

--- a/pilot/pkg/serviceregistry/aggregate/mock/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/mock/controller.go
@@ -1,0 +1,243 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
+	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/pkg/timedfn"
+)
+
+// FakeXdsUpdater is used to test the registry.
+type FakeXdsUpdater struct {
+	// Events tracks notifications received by the updater
+	Events chan XdsEvent
+}
+
+// XdsEvent is used to watch XdsEvents
+type XdsEvent struct {
+	// Type of the event
+	Type string
+
+	// The id of the event
+	ID string
+}
+
+func (*FakeXdsUpdater) ConfigUpdate(*model.PushRequest) {
+
+}
+
+func (fx *FakeXdsUpdater) EDSUpdate(shard, hostname string, namespace string, entry []*model.IstioEndpoint) error {
+	select {
+	case fx.Events <- XdsEvent{Type: "eds", ID: hostname}:
+	default:
+	}
+	return nil
+
+}
+
+// SvcUpdate is called when a service port mapping definition is updated.
+// This interface is WIP - labels, annotations and other changes to service may be
+// updated to force a EDS and CDS recomputation and incremental push, as it doesn't affect
+// LDS/RDS.
+func (fx *FakeXdsUpdater) SvcUpdate(shard, hostname string, ports map[string]uint32, rports map[uint32]string) {
+	select {
+	case fx.Events <- XdsEvent{Type: "service", ID: hostname}:
+	default:
+	}
+}
+
+func (fx *FakeXdsUpdater) WorkloadUpdate(id string, labels map[string]string, annotations map[string]string) {
+	select {
+	case fx.Events <- XdsEvent{Type: "workload", ID: id}:
+	default:
+	}
+}
+
+// NewFakeXDS creates a XdsUpdater reporting events via a channel.
+func NewFakeXDS() *FakeXdsUpdater {
+	return &FakeXdsUpdater{
+		Events: make(chan XdsEvent, 100),
+	}
+}
+
+func NewFakeKubeController(clusterID string) (*kubecontroller.Controller, *fake.Clientset, func()) {
+	clientSet := fake.NewSimpleClientset()
+	c := kubecontroller.NewController(clientSet, kubecontroller.Options{
+		WatchedNamespace: "", // tests create resources in multiple ns
+		DomainSuffix:     "cluster.local",
+		ClusterID:        clusterID,
+		XDSUpdater:       NewFakeXDS(),
+	})
+
+	stop := make(chan struct{})
+
+	go c.Run(stop)
+
+	return c, clientSet, func() { close(stop) }
+}
+
+func NewFakeAggregateControllerForMultiCluster() (*aggregate.Controller, func()) {
+	cluster1 := "cluster1"
+	cluster2 := "cluster2"
+	controller1, client1, cancel1 := NewFakeKubeController(cluster1)
+	controller2, client2, cancel2 := NewFakeKubeController(cluster2)
+
+	meshNetworks := &meshconfig.MeshNetworks{
+		Networks: map[string]*meshconfig.Network{
+			"network1": {
+				Endpoints: []*meshconfig.Network_NetworkEndpoints{
+					{
+						Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{
+							FromRegistry: cluster1,
+						},
+					},
+				},
+			},
+			"network2": {
+				Endpoints: []*meshconfig.Network_NetworkEndpoints{
+					{
+						Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{
+							FromRegistry: cluster2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Set controller.networkForRegistry
+	controller1.InitNetworkLookup(meshNetworks)
+	controller2.InitNetworkLookup(meshNetworks)
+
+	registry1 := aggregate.Registry{
+		Name:             serviceregistry.ServiceRegistry("mockKubernetes1"),
+		ClusterID:        cluster1,
+		ServiceDiscovery: controller1,
+		Controller:       controller1,
+	}
+
+	registry2 := aggregate.Registry{
+		Name:             serviceregistry.ServiceRegistry("mockKubernetes1"),
+		ClusterID:        cluster2,
+		ServiceDiscovery: controller2,
+		Controller:       controller2,
+	}
+
+	ctls := aggregate.NewController()
+	ctls.AddRegistry(registry1)
+	ctls.AddRegistry(registry2)
+
+	_ = ctls.AppendServiceHandler(func(*model.Service, model.Event) {})
+
+	_, _ = client1.CoreV1().Pods("test1").Create(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "test1",
+			Labels: map[string]string{
+				"app": "cluster1",
+			},
+		},
+		Spec: corev1.PodSpec{},
+		Status: corev1.PodStatus{
+			PodIP: "192.168.0.10",
+			Phase: corev1.PodRunning,
+		},
+	})
+
+	_, _ = client1.CoreV1().Services("test1").Create(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "test1",
+			Labels: map[string]string{
+				"app": "cluster1",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "cluster1",
+			},
+			ClusterIP: "127.0.0.1",
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: corev1.ProtocolTCP,
+					Port:     80,
+				},
+			},
+		},
+	})
+
+	_, _ = client2.CoreV1().Pods("test2").Create(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod2",
+			Namespace: "test2",
+			Labels: map[string]string{
+				"app": "cluster2",
+			},
+		},
+		Spec: corev1.PodSpec{},
+		Status: corev1.PodStatus{
+			PodIP: "192.168.0.10",
+			Phase: corev1.PodRunning,
+		},
+	})
+
+	_, _ = client2.CoreV1().Services("test2").Create(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc2",
+			Namespace: "test2",
+			Labels: map[string]string{
+				"app": "cluster2",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "cluster2",
+			},
+			ClusterIP: "127.0.0.1",
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: corev1.ProtocolTCP,
+					Port:     80,
+				},
+			},
+		},
+	})
+
+	stop := make(chan struct{})
+	if err := timedfn.WithTimeout(func() {
+		cache.WaitForCacheSync(stop, controller1.HasSynced)
+		cache.WaitForCacheSync(stop, controller2.HasSynced)
+	}, time.Second); err != nil {
+		close(stop)
+	}
+
+	return ctls, func() {
+		cancel1()
+		cancel2()
+	}
+}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -744,6 +744,10 @@ func (c *Controller) getProxyServiceInstancesByPod(pod *v1.Pod, service *v1.Serv
 }
 
 func (c *Controller) GetProxyWorkloadLabels(proxy *model.Proxy) (labels.Collection, error) {
+	// the given proxy does not belong to this registry.
+	if proxy.ClusterID != c.ClusterID {
+		return nil, nil
+	}
 	// There is only one IP for kube registry
 	proxyIP := proxy.IPAddresses[0]
 


### PR DESCRIPTION
 for multi-cluster mode, it is possible pods from different clusters having same podip. And we `GetProxyWorkloadLabels` simply by the ip does not seem right, we should also compare the cluster id.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
