### PR TITLE
Fix data race accessing Proxy.ServiceInstances

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -466,7 +466,10 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				return nil
 			}
 		case <-con.updateChannel:
-			s.doUpdateProxyServiceInstances(con)
+			err := s.doUpdateProxyServiceInstances(con)
+			if err != nil {
+				adsLog.Errorf("Error updating proxy service instances for proxy %s: %v", con.modelNode.IPAddresses[0], err)
+			}
 		}
 	}
 }

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -84,6 +84,10 @@ type XdsConnection struct {
 	// same info can be sent to all clients, without recomputing.
 	pushChannel chan *XdsEvent
 
+	// Sending on this channel triggers a check whether the proxy associated
+	// with the connection needs an xDS update.
+	updateChannel chan struct{}
+
 	// TODO: migrate other fields as needed from model.Proxy and replace it
 
 	//HttpConnectionManagers map[string]*http_conn.HttpConnectionManager
@@ -189,13 +193,14 @@ type XdsEvent struct {
 
 func newXdsConnection(peerAddr string, stream DiscoveryStream) *XdsConnection {
 	return &XdsConnection{
-		pushChannel:  make(chan *XdsEvent),
-		PeerAddr:     peerAddr,
-		Clusters:     []string{},
-		Connect:      time.Now(),
-		stream:       stream,
-		LDSListeners: []*xdsapi.Listener{},
-		RouteConfigs: map[string]*xdsapi.RouteConfiguration{},
+		pushChannel:   make(chan *XdsEvent),
+		updateChannel: make(chan struct{}),
+		PeerAddr:      peerAddr,
+		Clusters:      []string{},
+		Connect:       time.Now(),
+		stream:        stream,
+		LDSListeners:  []*xdsapi.Listener{},
+		RouteConfigs:  map[string]*xdsapi.RouteConfiguration{},
 	}
 }
 
@@ -460,7 +465,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 			if err != nil {
 				return nil
 			}
-
+		case <-con.updateChannel:
+			s.doUpdateProxyServiceInstances(con)
 		}
 	}
 }
@@ -705,19 +711,24 @@ func proxyNeedsPush(con *XdsConnection, targetNamespaces map[string]struct{}) bo
 	return false
 }
 
-// updateProxyServiceInstances determines whether the proxy associated with the given service instance
-// needs to refresh its local inbound listeners, and if so, triggers a push to that proxy.
-func (s *DiscoveryServer) updateProxyServiceInstances(instance *model.ServiceInstance) error {
+// updateProxyServiceInstances triggers a check whether the proxy associated with the given service instance
+// needs to refresh its local inbound listeners.
+func (s *DiscoveryServer) updateProxyServiceInstances(instance *model.ServiceInstance) {
 	instanceIP := instance.Endpoint.Address
 
 	// Check whether there's an existing connection from that IP address
 	adsClientsMutex.RLock()
 	con, ok := s.connectionsByIP[instanceIP]
 	adsClientsMutex.RUnlock()
-	if !ok {
-		return nil
-	}
 
+	if ok {
+		con.updateChannel <- struct{}{}
+	}
+}
+
+// doUpdateProxyServiceInstances determines whether the proxy associated with the given service instance
+// needs to refresh its local inbound listeners, and if so, triggers a push to that proxy.
+func (s *DiscoveryServer) doUpdateProxyServiceInstances(con *XdsConnection) error {
 	proxy := con.modelNode
 	instances, err := s.Env.GetProxyServiceInstances(proxy)
 	if err != nil {
@@ -729,6 +740,8 @@ func (s *DiscoveryServer) updateProxyServiceInstances(instance *model.ServiceIns
 		// no changes detected - nothing to update
 		return nil
 	}
+
+	proxy.ServiceInstances = instances
 
 	// Trigger an update to that particular proxy
 	s.pushQueue.Enqueue(con, &model.PushRequest{Full: true, Push: s.globalPushContext(), Start: time.Now()})

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -178,10 +178,7 @@ func NewDiscoveryServer(
 
 	// Trigger an individual push whenever a proxy's local service instances change.
 	instanceUpdateHandler := func(instance *model.ServiceInstance, event model.Event) {
-		err := out.updateProxyServiceInstances(instance)
-		if err != nil {
-			adsLog.Errorf("Error updating proxy service instances for instance %s: %v", instance.Endpoint.UID, err)
-		}
+		out.updateProxyServiceInstances(instance)
 	}
 	if err := ctl.AppendInstanceHandler(instanceUpdateHandler); err != nil {
 		return nil


### PR DESCRIPTION
Fixes a data race in accessing `model.Proxy.ServiceInstances`, which was introduced in a recent PR (#15950). Also related to #16367 which partially resolved the issue.

The race is fixed by moving the logic from the goroutine running the service instance handler, to the goroutine running the `StreamAggregatedResources()`, which is the sole goroutine accessing the `model.Proxy`'s fields.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
