### PR TITLE
Fix err check for service ingress hostname lookup

### DIFF
--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -120,7 +120,7 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 				lbAddrs = append(lbAddrs, ingress.IP)
 			} else if len(ingress.Hostname) > 0 {
 				addrs, err := net.DefaultResolver.LookupHost(context.TODO(), ingress.Hostname)
-				if err != nil {
+				if err == nil {
 					lbAddrs = append(lbAddrs, addrs...)
 				}
 			}

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -346,6 +346,12 @@ func TestLBServiceConversion(t *testing.T) {
 		{
 			IP: "127.68.32.113",
 		},
+		{
+			Hostname: "127.68.32.114",
+		},
+		{
+			Hostname: "127.68.32.115",
+		},
 	}
 
 	extSvc := coreV1.Service{


### PR DESCRIPTION
Please provide a description for what this PR is for.
Fix err nil check when lookup cluster external host LB type service ingress host.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ X ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
