### PR TITLE
Enable locality lb tests in presubmit

### DIFF
--- a/tests/integration/pilot/locality/main_test.go
+++ b/tests/integration/pilot/locality/main_test.go
@@ -124,8 +124,7 @@ func init() {
 
 func TestMain(m *testing.M) {
 	framework.NewSuite("locality_prioritized_failover_loadbalancing", m).
-		// TODO(https://github.com/istio/istio/issues/13812) remove flaky labels
-		Label(label.CustomSetup, label.Flaky).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {


### PR DESCRIPTION
See https://testgrid.k8s.io/istio-postsubmits-master#integ-pilot-k8s-postsubmit-tests-master this test has been 100% passing (finally) for a few days after recent fixes

Fixes https://github.com/istio/istio/issues/13812