### PR TITLE
xds: fix for streaming node discovery request

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -277,7 +277,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				return receiveError
 			}
 			// This should be only set for the first request. Guard with ID check regardless.
-			if discReq.Node != nil && discReq.Node.Id != nil {
+			if discReq.Node != nil && discReq.Node.Id != "" {
 				node = discReq.Node
 				err = s.initConnectionNode(discReq.Node, con)
 				if err != nil {

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -276,7 +276,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				// Remote side closed connection.
 				return receiveError
 			}
-			if discReq.Node != nil {
+			// This should be only set for the first request. Guard with ID check regardless.
+			if discReq.Node != nil && discReq.Node.Id != nil {
 				node = discReq.Node
 				err = s.initConnectionNode(discReq.Node, con)
 				if err != nil {

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -209,7 +209,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 
 	go receiveThread(con, reqChannel, &receiveError)
 
-	var node *core.Node
+	node := &core.Node{}
 	for {
 		// Block until a request is received.
 		select {

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -209,6 +209,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 
 	go receiveThread(con, reqChannel, &receiveError)
 
+	var node *core.Node
 	for {
 		// Block until a request is received.
 		select {
@@ -219,7 +220,11 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				return receiveError
 			}
 
-			if discReq.Node == nil {
+			if discReq.Node != nil {
+				node = discReq.Node
+			}
+
+			if node != nil {
 				sdsServiceLog.Errorf("Close connection. Invalid discovery request with no node")
 				return fmt.Errorf("invalid discovery request with no node")
 			}
@@ -231,7 +236,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			}
 
 			if resourceName == "" {
-				sdsServiceLog.Infof("Received empty resource name from %q", discReq.Node.Id)
+				sdsServiceLog.Infof("Received empty resource name from %q", node.Id)
 				continue
 			}
 
@@ -243,13 +248,13 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			con.mutex.Lock()
 			if con.conID == "" {
 				// first request
-				con.conID = constructConnectionID(discReq.Node.Id)
+				con.conID = constructConnectionID(node.Id)
 				key.ConnectionID = con.conID
 				addConn(key, con)
 				firstRequestFlag = true
 			}
 			conID := con.conID
-			con.proxyID = discReq.Node.Id
+			con.proxyID = node.Id
 			con.ResourceName = resourceName
 			// Reset SDS push time for new SDS push.
 			con.sdsPushTime = time.Time{}
@@ -278,18 +283,18 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// nodeagent stops sending response to envoy in this case.
 			if discReq.VersionInfo != "" && s.st.SecretExist(conID, resourceName, token, discReq.VersionInfo) {
 				sdsServiceLog.Debugf("%s received SDS ACK from proxy %q, version info %q, "+
-					"error details %s\n", conIDresourceNamePrefix, discReq.Node.Id, discReq.VersionInfo,
+					"error details %s\n", conIDresourceNamePrefix, node.Id, discReq.VersionInfo,
 					discReq.ErrorDetail.GoString())
 				continue
 			}
 
 			if firstRequestFlag {
 				sdsServiceLog.Debugf("%s received first SDS request from proxy %q, version info "+
-					"%q, error details %s\n", conIDresourceNamePrefix, discReq.Node.Id, discReq.VersionInfo,
+					"%q, error details %s\n", conIDresourceNamePrefix, node.Id, discReq.VersionInfo,
 					discReq.ErrorDetail.GoString())
 			} else {
 				sdsServiceLog.Debugf("%s received SDS request from proxy %q, version info %q, "+
-					"error details %s\n", conIDresourceNamePrefix, discReq.Node.Id, discReq.VersionInfo,
+					"error details %s\n", conIDresourceNamePrefix, node.Id, discReq.VersionInfo,
 					discReq.ErrorDetail.GoString())
 			}
 
@@ -297,14 +302,14 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// wait for secret before sending SDS response. If a kubernetes secret was deleted by operator, wait
 			// for a new kubernetes secret before sending SDS response.
 			if s.st.ShouldWaitForIngressGatewaySecret(conID, resourceName, token) {
-				sdsServiceLog.Warnf("%s waiting for ingress gateway secret for proxy %q\n", conIDresourceNamePrefix, discReq.Node.Id)
+				sdsServiceLog.Warnf("%s waiting for ingress gateway secret for proxy %q\n", conIDresourceNamePrefix, node.Id)
 				continue
 			}
 
 			secret, err := s.st.GenerateSecret(ctx, conID, resourceName, token)
 			if err != nil {
 				sdsServiceLog.Errorf("%s Close connection. Failed to get secret for proxy %q from "+
-					"secret cache: %v", conIDresourceNamePrefix, discReq.Node.Id, err)
+					"secret cache: %v", conIDresourceNamePrefix, node.Id, err)
 				return err
 			}
 
@@ -318,7 +323,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 
 			if err := pushSDS(con); err != nil {
 				sdsServiceLog.Errorf("%s Close connection. Failed to push key/cert to proxy %q: %v",
-					conIDresourceNamePrefix, discReq.Node.Id, err)
+					conIDresourceNamePrefix, node.Id, err)
 				return err
 			}
 		case <-con.pushChannel:
@@ -457,10 +462,6 @@ func recycleConnection(conID, resourceName string) {
 }
 
 func parseDiscoveryRequest(discReq *xdsapi.DiscoveryRequest) (string /*resourceName*/, error) {
-	if discReq.Node.Id == "" {
-		return "", fmt.Errorf("discovery request %+v missing node id", discReq)
-	}
-
 	if len(discReq.ResourceNames) == 0 {
 		return "", nil
 	}

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -220,13 +220,10 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				return receiveError
 			}
 
-			if discReq.Node != nil {
+			if discReq.Node == nil {
+				discReq.Node = node
+			} else {
 				node = discReq.Node
-			}
-
-			if node != nil {
-				sdsServiceLog.Errorf("Close connection. Invalid discovery request with no node")
-				return fmt.Errorf("invalid discovery request with no node")
 			}
 
 			resourceName, err := parseDiscoveryRequest(discReq)
@@ -236,7 +233,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			}
 
 			if resourceName == "" {
-				sdsServiceLog.Infof("Received empty resource name from %q", node.Id)
+				sdsServiceLog.Infof("Received empty resource name from %q", discReq.Node.Id)
 				continue
 			}
 
@@ -248,13 +245,13 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			con.mutex.Lock()
 			if con.conID == "" {
 				// first request
-				con.conID = constructConnectionID(node.Id)
+				con.conID = constructConnectionID(discReq.Node.Id)
 				key.ConnectionID = con.conID
 				addConn(key, con)
 				firstRequestFlag = true
 			}
 			conID := con.conID
-			con.proxyID = node.Id
+			con.proxyID = discReq.Node.Id
 			con.ResourceName = resourceName
 			// Reset SDS push time for new SDS push.
 			con.sdsPushTime = time.Time{}
@@ -283,18 +280,18 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// nodeagent stops sending response to envoy in this case.
 			if discReq.VersionInfo != "" && s.st.SecretExist(conID, resourceName, token, discReq.VersionInfo) {
 				sdsServiceLog.Debugf("%s received SDS ACK from proxy %q, version info %q, "+
-					"error details %s\n", conIDresourceNamePrefix, node.Id, discReq.VersionInfo,
+					"error details %s\n", conIDresourceNamePrefix, discReq.Node.Id, discReq.VersionInfo,
 					discReq.ErrorDetail.GoString())
 				continue
 			}
 
 			if firstRequestFlag {
 				sdsServiceLog.Debugf("%s received first SDS request from proxy %q, version info "+
-					"%q, error details %s\n", conIDresourceNamePrefix, node.Id, discReq.VersionInfo,
+					"%q, error details %s\n", conIDresourceNamePrefix, discReq.Node.Id, discReq.VersionInfo,
 					discReq.ErrorDetail.GoString())
 			} else {
 				sdsServiceLog.Debugf("%s received SDS request from proxy %q, version info %q, "+
-					"error details %s\n", conIDresourceNamePrefix, node.Id, discReq.VersionInfo,
+					"error details %s\n", conIDresourceNamePrefix, discReq.Node.Id, discReq.VersionInfo,
 					discReq.ErrorDetail.GoString())
 			}
 
@@ -302,14 +299,14 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// wait for secret before sending SDS response. If a kubernetes secret was deleted by operator, wait
 			// for a new kubernetes secret before sending SDS response.
 			if s.st.ShouldWaitForIngressGatewaySecret(conID, resourceName, token) {
-				sdsServiceLog.Warnf("%s waiting for ingress gateway secret for proxy %q\n", conIDresourceNamePrefix, node.Id)
+				sdsServiceLog.Warnf("%s waiting for ingress gateway secret for proxy %q\n", conIDresourceNamePrefix, discReq.Node.Id)
 				continue
 			}
 
 			secret, err := s.st.GenerateSecret(ctx, conID, resourceName, token)
 			if err != nil {
 				sdsServiceLog.Errorf("%s Close connection. Failed to get secret for proxy %q from "+
-					"secret cache: %v", conIDresourceNamePrefix, node.Id, err)
+					"secret cache: %v", conIDresourceNamePrefix, discReq.Node.Id, err)
 				return err
 			}
 
@@ -323,7 +320,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 
 			if err := pushSDS(con); err != nil {
 				sdsServiceLog.Errorf("%s Close connection. Failed to push key/cert to proxy %q: %v",
-					conIDresourceNamePrefix, node.Id, err)
+					conIDresourceNamePrefix, discReq.Node.Id, err)
 				return err
 			}
 		case <-con.pushChannel:
@@ -462,6 +459,10 @@ func recycleConnection(conID, resourceName string) {
 }
 
 func parseDiscoveryRequest(discReq *xdsapi.DiscoveryRequest) (string /*resourceName*/, error) {
+	if discReq.Node.Id == "" {
+		return "", fmt.Errorf("discovery request %+v missing node id", discReq)
+	}
+
 	if len(discReq.ResourceNames) == 0 {
 		return "", nil
 	}

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -209,7 +209,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 
 	go receiveThread(con, reqChannel, &receiveError)
 
-	node := &core.Node{}
+	var node *core.Node
 	for {
 		// Block until a request is received.
 		select {
@@ -459,6 +459,9 @@ func recycleConnection(conID, resourceName string) {
 }
 
 func parseDiscoveryRequest(discReq *xdsapi.DiscoveryRequest) (string /*resourceName*/, error) {
+	if discReq.Node == nil {
+		return "", fmt.Errorf("discovery request %+v missing node", discReq)
+	}
 	if discReq.Node.Id == "" {
 		return "", fmt.Errorf("discovery request %+v missing node id", discReq)
 	}


### PR DESCRIPTION
Per xDS protocol spec:
```
Only the first request on a stream is guaranteed to carry the node identifier. The subsequent discovery requests on the same stream may carry an empty node identifier. This holds true regardless of the acceptance of the discovery responses on the same stream. The node identifier should always be identical if present more than once on the stream. It is sufficient to only check the first message for the node identifier as a result.
```

/assign @howardjohn 