### PR TITLE
Fix url parse test

### DIFF
--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -37,12 +37,12 @@ func TestParseJwksURI(t *testing.T) {
 			expectedErrorMessage: `URI scheme "" is not supported`,
 		},
 		{
-			in:                   "tcp://foo.bar.com:abc",
+			in:                   "tcp://foo.bar.com:1234",
 			expectedErrorMessage: `URI scheme "tcp" is not supported`,
 		},
 		{
 			in:                   "http://foo.bar.com:abc",
-			expectedErrorMessage: `strconv.Atoi: parsing "abc": invalid syntax`,
+			expectedErrorMessage: `parse http://foo.bar.com:abc: invalid port ":abc" after host`,
 		},
 		{
 			in:               "http://foo.bar.com",


### PR DESCRIPTION
Fixes test breakage introduced by updating to go 1.11.13.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[X] Developer Infrastructure
