### PR TITLE
Update istiocoredns version to a recent release

### DIFF
--- a/install/kubernetes/helm/istio/charts/istiocoredns/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/istiocoredns/templates/configmap.yaml
@@ -13,11 +13,17 @@ data:
     .:53 {
           errors
           health
+          {{ if eq -1 (semver  .Values.coreDNSTag  | (semver "1.4.0").Compare) }}
+          # Removed support for the proxy plugin: https://coredns.io/2019/03/03/coredns-1.4.0-release/
+          grpc . 127.0.0.1:8053
+          forward . /etc/resolv.conf
+          {{ else }}
           proxy global 127.0.0.1:8053 {
             protocol grpc insecure
           }
-          prometheus :9153
           proxy . /etc/resolv.conf
+          {{ end }}
+          prometheus :9153
           cache 30
           reload
         }

--- a/install/kubernetes/helm/istio/charts/istiocoredns/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/istiocoredns/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
 {{- end }}
       containers:
       - name: coredns
-        image: {{ .Values.coreDNSImage }}
+        image: {{ .Values.coreDNSImage }}:{{ .Values.coreDNSTag }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:

--- a/install/kubernetes/helm/istio/charts/istiocoredns/values.yaml
+++ b/install/kubernetes/helm/istio/charts/istiocoredns/values.yaml
@@ -5,7 +5,8 @@ enabled: false
 replicaCount: 1
 rollingMaxSurge: 100%
 rollingMaxUnavailable: 25%
-coreDNSImage: coredns/coredns:1.1.2
+coreDNSImage: coredns/coredns
+coreDNSTag: 1.6.2
 # Source code for the plugin can be found at
 # https://github.com/istio-ecosystem/istio-coredns-plugin
 # The plugin listens for DNS requests from coredns server at 127.0.0.1:8053


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR updates the `istiocoredns` helm chart to use a more recent CoreDNS version than `1.1.2` which is [over an year old](https://coredns.io/2018/04/23/coredns-1.1.2-release/). The changes are backwards compatible to older CoreDNS versions. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
