### PR TITLE
Use index instead of URL to name steps of traffic test

### DIFF
--- a/tests/integration/conformance/conformance_test.go
+++ b/tests/integration/conformance/conformance_test.go
@@ -256,11 +256,11 @@ func validateTraffic(t framework.TestContext, pil pilot.Instance, gal galley.Ins
 
 	ready := make(map[string]bool)
 	vHosts := virtualServiceHosts(t, stage.Input)
-	for _, call := range stage.Traffic.Calls {
+	for i, call := range stage.Traffic.Calls {
 		call.URL = tmpl.EvaluateOrFail(t, call.URL, constraint.Params{
 			Namespace: ns.Name(),
 		})
-		t.NewSubTest(call.URL).Run(func(t framework.TestContext) {
+		t.NewSubTest(strconv.Itoa(i)).Run(func(t framework.TestContext) {
 			hostname, err := wildcardToRegexp(call.Response.Callee)
 			if err != nil {
 				t.Fatalf("Internal error: regexp.Compile: %v", err)


### PR DESCRIPTION
Quick fix for #16423. Ideally we would include a name for each subtest in the test YAML file, but I'm not sure what the wider intention for naming subtests will be. Index will be good for a now.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
