### PR TITLE
use downstream protocol on inbound clusters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -601,6 +601,9 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusterForPortOrUDS(pluginPara
 	localCluster := buildDefaultCluster(pluginParams.Env, clusterName, apiv2.Cluster_STATIC, localityLbEndpoints,
 		model.TrafficDirectionInbound, pluginParams.Node, nil)
 	setUpstreamProtocol(localCluster, instance.Endpoint.ServicePort)
+	// Set the upstream protocol selection based on the downstream protocol. This is for inbound clusters only.
+	// Use HTTP1.1 or HTTP2, depending on which one is used on the downstream connection.
+	localCluster.ProtocolSelection = apiv2.Cluster_USE_DOWNSTREAM_PROTOCOL
 	// call plugins
 	for _, p := range configgen.Plugins {
 		p.OnInboundCluster(pluginParams, localCluster)


### PR DESCRIPTION
Use HTTP1.1 or HTTP2, depending on which one is used on the downstream connection.

Signed-off-by: Shriram Rajagopalan <rshriram@tetrate.io>