### PR TITLE
Create istioctl config_dump helper to avoid use of explicit index

### DIFF
--- a/istioctl/pkg/util/configdump/bootstrap.go
+++ b/istioctl/pkg/util/configdump/bootstrap.go
@@ -21,7 +21,7 @@ import (
 
 // GetBootstrapConfigDump retrieves the bootstrap config dump from the ConfigDump
 func (w *Wrapper) GetBootstrapConfigDump() (*adminapi.BootstrapConfigDump, error) {
-	bootstrapDumpAny, err := w.configDumpSection(BootstrapConfigDumpTypeURL)
+	bootstrapDumpAny, err := w.getSection(bootstrap)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/bootstrap.go
+++ b/istioctl/pkg/util/configdump/bootstrap.go
@@ -15,22 +15,18 @@
 package configdump
 
 import (
-	"fmt"
-
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
 	proto "github.com/gogo/protobuf/types"
 )
 
 // GetBootstrapConfigDump retrieves the bootstrap config dump from the ConfigDump
 func (w *Wrapper) GetBootstrapConfigDump() (*adminapi.BootstrapConfigDump, error) {
-	// The bootstrap dump is the first one in the list.
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/admin/v2alpha/config_dump.proto
-	if len(w.Configs) < 1 {
-		return nil, fmt.Errorf("config dump has no bootstrap dump")
+	bootstrapDumpAny, err := w.configDumpSection(BootstrapConfigDumpTypeURL)
+	if err != nil {
+		return nil, err
 	}
-	bootstrapDumpAny := w.Configs[0]
 	bootstrapDump := &adminapi.BootstrapConfigDump{}
-	err := proto.UnmarshalAny(bootstrapDumpAny, bootstrapDump)
+	err = proto.UnmarshalAny(&bootstrapDumpAny, bootstrapDump)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/cluster.go
+++ b/istioctl/pkg/util/configdump/cluster.go
@@ -15,7 +15,6 @@
 package configdump
 
 import (
-	"fmt"
 	"sort"
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
@@ -43,14 +42,12 @@ func (w *Wrapper) GetDynamicClusterDump(stripVersions bool) (*adminapi.ClustersC
 
 // GetClusterConfigDump retrieves the cluster config dump from the ConfigDump
 func (w *Wrapper) GetClusterConfigDump() (*adminapi.ClustersConfigDump, error) {
-	// The cluster dump is the second one in the list.
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/admin/v2alpha/config_dump.proto
-	if len(w.Configs) < 2 {
-		return nil, fmt.Errorf("config dump has no cluster dump")
+	clusterDumpAny, err := w.configDumpSection(ClustersConfigDumpTypeURL)
+	if err != nil {
+		return nil, err
 	}
-	clusterDumpAny := w.Configs[1]
 	clusterDump := &adminapi.ClustersConfigDump{}
-	err := proto.UnmarshalAny(clusterDumpAny, clusterDump)
+	err = proto.UnmarshalAny(&clusterDumpAny, clusterDump)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/cluster.go
+++ b/istioctl/pkg/util/configdump/cluster.go
@@ -42,7 +42,7 @@ func (w *Wrapper) GetDynamicClusterDump(stripVersions bool) (*adminapi.ClustersC
 
 // GetClusterConfigDump retrieves the cluster config dump from the ConfigDump
 func (w *Wrapper) GetClusterConfigDump() (*adminapi.ClustersConfigDump, error) {
-	clusterDumpAny, err := w.configDumpSection(ClustersConfigDumpTypeURL)
+	clusterDumpAny, err := w.getSection(clusters)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/listener.go
+++ b/istioctl/pkg/util/configdump/listener.go
@@ -42,7 +42,7 @@ func (w *Wrapper) GetDynamicListenerDump(stripVersions bool) (*adminapi.Listener
 
 // GetListenerConfigDump retrieves the listener config dump from the ConfigDump
 func (w *Wrapper) GetListenerConfigDump() (*adminapi.ListenersConfigDump, error) {
-	listenerDumpAny, err := w.configDumpSection(ListenersConfigDumpTypeURL)
+	listenerDumpAny, err := w.getSection(listeners)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/listener.go
+++ b/istioctl/pkg/util/configdump/listener.go
@@ -15,7 +15,6 @@
 package configdump
 
 import (
-	"fmt"
 	"sort"
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
@@ -43,14 +42,12 @@ func (w *Wrapper) GetDynamicListenerDump(stripVersions bool) (*adminapi.Listener
 
 // GetListenerConfigDump retrieves the listener config dump from the ConfigDump
 func (w *Wrapper) GetListenerConfigDump() (*adminapi.ListenersConfigDump, error) {
-	// The listener dump is the third one in the list.
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/admin/v2alpha/config_dump.proto
-	if len(w.Configs) < 3 {
-		return nil, fmt.Errorf("config dump has no listener dump")
+	listenerDumpAny, err := w.configDumpSection(ListenersConfigDumpTypeURL)
+	if err != nil {
+		return nil, err
 	}
-	listenerDumpAny := w.Configs[2]
 	listenerDump := &adminapi.ListenersConfigDump{}
-	err := proto.UnmarshalAny(listenerDumpAny, listenerDump)
+	err = proto.UnmarshalAny(&listenerDumpAny, listenerDump)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/route.go
+++ b/istioctl/pkg/util/configdump/route.go
@@ -68,7 +68,7 @@ func (w *Wrapper) GetDynamicRouteDump(stripVersions bool) (*adminapi.RoutesConfi
 
 // GetRouteConfigDump retrieves the route config dump from the ConfigDump
 func (w *Wrapper) GetRouteConfigDump() (*adminapi.RoutesConfigDump, error) {
-	routeDumpAny, err := w.configDumpSection(RoutesConfigDumpTypeURL)
+	routeDumpAny, err := w.getSection(routes)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/route.go
+++ b/istioctl/pkg/util/configdump/route.go
@@ -15,7 +15,6 @@
 package configdump
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -69,19 +68,12 @@ func (w *Wrapper) GetDynamicRouteDump(stripVersions bool) (*adminapi.RoutesConfi
 
 // GetRouteConfigDump retrieves the route config dump from the ConfigDump
 func (w *Wrapper) GetRouteConfigDump() (*adminapi.RoutesConfigDump, error) {
-	// The route dump is no longer the 4th one;
-	// now envoy.admin.v2alpha.ScopedRoutesConfigDump may be 4th.
-	var routeDumpAny proto.Any
-	for _, conf := range w.Configs {
-		if conf.TypeUrl == "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump" {
-			routeDumpAny = *conf
-		}
-	}
-	if routeDumpAny.TypeUrl == "" {
-		return nil, fmt.Errorf("config dump has no route dump")
+	routeDumpAny, err := w.configDumpSection(RoutesConfigDumpTypeURL)
+	if err != nil {
+		return nil, err
 	}
 	routeDump := &adminapi.RoutesConfigDump{}
-	err := proto.UnmarshalAny(&routeDumpAny, routeDump)
+	err = proto.UnmarshalAny(&routeDumpAny, routeDump)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/util.go
+++ b/istioctl/pkg/util/configdump/util.go
@@ -1,0 +1,51 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configdump
+
+import (
+	"fmt"
+
+	proto "github.com/gogo/protobuf/types"
+)
+
+// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/admin/v2alpha/config_dump.proto
+const (
+	// BootstrapConfigDumpTypeURL is the unique type indicator for the Bootstrap section of the config dump
+	BootstrapConfigDumpTypeURL = "type.googleapis.com/envoy.admin.v2alpha.BootstrapConfigDump"
+
+	// ListenersConfigDumpTypeURL is the unique identifier the Listeners section of the config dump
+	ListenersConfigDumpTypeURL = "type.googleapis.com/envoy.admin.v2alpha.ListenersConfigDump"
+
+	// ClustersConfigDumpTypeURL is the unique identifier the Clusters section of the config dump
+	ClustersConfigDumpTypeURL = "type.googleapis.com/envoy.admin.v2alpha.ClustersConfigDump"
+
+	// BootstrapConfigDumpTypeURL is the unique identifier the Routes section of the config dump
+	RoutesConfigDumpTypeURL = "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump"
+)
+
+// configDumpSection takes a TypeURL and returns the types.Any from the config dump corresponding to that URL
+func (w *Wrapper) configDumpSection(sectionTypeURL string) (proto.Any, error) {
+	var dumpAny proto.Any
+	for _, conf := range w.Configs {
+		if conf.TypeUrl == sectionTypeURL {
+			dumpAny = *conf
+		}
+	}
+	if dumpAny.TypeUrl == "" {
+		return proto.Any{}, fmt.Errorf("config dump has no route %s", sectionTypeURL)
+	}
+
+	return dumpAny, nil
+}

--- a/istioctl/pkg/util/configdump/util.go
+++ b/istioctl/pkg/util/configdump/util.go
@@ -20,26 +20,21 @@ import (
 	proto "github.com/gogo/protobuf/types"
 )
 
+type configTypeURL string
+
 // See https://www.envoyproxy.io/docs/envoy/latest/api-v2/admin/v2alpha/config_dump.proto
 const (
-	// BootstrapConfigDumpTypeURL is the unique type indicator for the Bootstrap section of the config dump
-	BootstrapConfigDumpTypeURL = "type.googleapis.com/envoy.admin.v2alpha.BootstrapConfigDump"
-
-	// ListenersConfigDumpTypeURL is the unique identifier the Listeners section of the config dump
-	ListenersConfigDumpTypeURL = "type.googleapis.com/envoy.admin.v2alpha.ListenersConfigDump"
-
-	// ClustersConfigDumpTypeURL is the unique identifier the Clusters section of the config dump
-	ClustersConfigDumpTypeURL = "type.googleapis.com/envoy.admin.v2alpha.ClustersConfigDump"
-
-	// BootstrapConfigDumpTypeURL is the unique identifier the Routes section of the config dump
-	RoutesConfigDumpTypeURL = "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump"
+	bootstrap configTypeURL = "type.googleapis.com/envoy.admin.v2alpha.BootstrapConfigDump"
+	listeners configTypeURL = "type.googleapis.com/envoy.admin.v2alpha.ListenersConfigDump"
+	clusters  configTypeURL = "type.googleapis.com/envoy.admin.v2alpha.ClustersConfigDump"
+	routes    configTypeURL = "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump"
 )
 
-// configDumpSection takes a TypeURL and returns the types.Any from the config dump corresponding to that URL
-func (w *Wrapper) configDumpSection(sectionTypeURL string) (proto.Any, error) {
+// getSection takes a TypeURL and returns the types.Any from the config dump corresponding to that URL
+func (w *Wrapper) getSection(sectionTypeURL configTypeURL) (proto.Any, error) {
 	var dumpAny proto.Any
 	for _, conf := range w.Configs {
-		if conf.TypeUrl == sectionTypeURL {
+		if conf.TypeUrl == string(sectionTypeURL) {
 			dumpAny = *conf
 		}
 	}


### PR DESCRIPTION
[As seen here](https://github.com/istio/istio/compare/master...Monkeyanator:istioctl-config-dump-refactor?expand=1#diff-1dd822e7f71283efc86bff777194d13cL72), the offsets for each section on the config_dump `Configs` proto section are liable to change. This change has been made for the `Route` config dump section, but should be made proactively for the other config dump sections.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
