### PR TITLE
Remove outdated time diff info for istioctl proxy-status command.

### DIFF
--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -18,12 +18,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"sort"
 	"strings"
 	"text/tabwriter"
-	"time"
-
-	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 )
 
 // StatusWriter enables printing of sync status using multiple []byte Pilot responses
@@ -68,10 +66,10 @@ func (s *StatusWriter) PrintSingle(statuses map[string][]byte, proxyName string)
 
 func (s *StatusWriter) setupStatusPrint(statuses map[string][]byte) (*tabwriter.Writer, []*writerStatus, error) {
 	w := new(tabwriter.Writer).Init(s.Writer, 0, 8, 5, ' ', 0)
-	fmt.Fprintln(w, "NAME\tCDS\tLDS\tEDS\tRDS\tPILOT\tVERSION")
-	fullStatus := []*writerStatus{}
+	_, _ = fmt.Fprintln(w, "NAME\tCDS\tLDS\tEDS\tRDS\tPILOT\tVERSION")
+	var fullStatus []*writerStatus
 	for pilot, status := range statuses {
-		ss := []*writerStatus{}
+		var ss []*writerStatus
 		err := json.Unmarshal(status, &ss)
 		if err != nil {
 			return nil, nil, err
@@ -99,7 +97,7 @@ func statusPrintln(w io.Writer, status *writerStatus) error {
 		// but it is better than not providing any information.
 		version = status.ProxyVersion + "*"
 	}
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+	_, _ = fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 		status.ProxyID, clusterSynced, listenerSynced, endpointSynced, routeSynced, status.pilot, version)
 	return nil
 }
@@ -111,17 +109,7 @@ func xdsStatus(sent, acked string) string {
 	if sent == acked {
 		return "SYNCED"
 	}
-	timeSent, _ := parseTime(sent)
-	timeAcked, _ := parseTime(acked)
-	if timeAcked.Equal(time.Time{}) {
-		return "STALE (Never Acknowledged)"
-	}
-	timeDiff := timeSent.Sub(timeAcked)
-	return fmt.Sprintf("STALE (%v)", timeDiff.String())
-}
 
-func parseTime(s string) (time.Time, error) {
-	s = strings.Split(s, " m=+")[0]
-	layout := "2006-01-02 15:04:05 +0000 MST"
-	return time.Parse(layout, s)
+	// Since the Nonce changes to uuid, so there is no more any time diff info
+	return "STALE"
 }

--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -18,10 +18,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 )
 
 // StatusWriter enables printing of sync status using multiple []byte Pilot responses

--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -17,15 +17,22 @@ package pilot
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
 
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/tests/util"
 )
+
+var (
+	preDefinedNonce = newNonce()
+)
+
+func newNonce() string {
+	return uuid.New().String()
+}
 
 func TestStatusWriter_PrintAll(t *testing.T) {
 	tests := []struct {
@@ -160,12 +167,12 @@ func statusInput1() []v2.SyncStatus {
 		{
 			ProxyID:         "proxy1",
 			IstioVersion:    "1.1",
-			ClusterSent:     "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			ClusterAcked:    "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
-			ListenerSent:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			ListenerAcked:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			EndpointSent:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			EndpointAcked:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			ClusterSent:     preDefinedNonce,
+			ClusterAcked:    newNonce(),
+			ListenerSent:    preDefinedNonce,
+			ListenerAcked:   preDefinedNonce,
+			EndpointSent:    preDefinedNonce,
+			EndpointAcked:   preDefinedNonce,
 			EndpointPercent: 100,
 		},
 	}
@@ -176,14 +183,14 @@ func statusInput2() []v2.SyncStatus {
 		{
 			ProxyID:       "proxy2",
 			IstioVersion:  "1.1",
-			ClusterSent:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			ClusterAcked:  "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
-			ListenerSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			ListenerAcked: "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			EndpointSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			EndpointAcked: "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
-			RouteSent:     "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			RouteAcked:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			ClusterSent:   preDefinedNonce,
+			ClusterAcked:  newNonce(),
+			ListenerSent:  preDefinedNonce,
+			ListenerAcked: preDefinedNonce,
+			EndpointSent:  preDefinedNonce,
+			EndpointAcked: newNonce(),
+			RouteSent:     preDefinedNonce,
+			RouteAcked:    preDefinedNonce,
 		},
 	}
 }
@@ -193,13 +200,13 @@ func statusInput3() []v2.SyncStatus {
 		{
 			ProxyID:       "proxy3",
 			IstioVersion:  "1.1",
-			ClusterSent:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			ClusterAcked:  time.Time{}.String(),
-			ListenerAcked: "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			EndpointSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			EndpointAcked: time.Time{}.String(),
-			RouteSent:     "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			RouteAcked:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			ClusterSent:   preDefinedNonce,
+			ClusterAcked:  newNonce(),
+			ListenerAcked: preDefinedNonce,
+			EndpointSent:  preDefinedNonce,
+			EndpointAcked: newNonce(),
+			RouteSent:     preDefinedNonce,
+			RouteAcked:    preDefinedNonce,
 		},
 	}
 }
@@ -209,14 +216,14 @@ func statusInputProxyVersion() []v2.SyncStatus {
 		{
 			ProxyID:       "proxy2",
 			ProxyVersion:  "1.1",
-			ClusterSent:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			ClusterAcked:  "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
-			ListenerSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			ListenerAcked: "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			EndpointSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			EndpointAcked: "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
-			RouteSent:     "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
-			RouteAcked:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			ClusterSent:   preDefinedNonce,
+			ClusterAcked:  newNonce(),
+			ListenerSent:  preDefinedNonce,
+			ListenerAcked: preDefinedNonce,
+			EndpointSent:  preDefinedNonce,
+			EndpointAcked: newNonce(),
+			RouteSent:     preDefinedNonce,
+			RouteAcked:    preDefinedNonce,
 		},
 	}
 }

--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -18,9 +18,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/tests/util"

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
@@ -1,4 +1,4 @@
-NAME       CDS                            LDS          EDS                            RDS          PILOT      VERSION
-proxy1     STALE (1h0m0s)                 SYNCED       SYNCED                         NOT SENT     pilot1     1.1
-proxy2     STALE (1h0m0s)                 SYNCED       STALE (1h0m0s)                 SYNCED       pilot2     1.1
-proxy3     STALE (Never Acknowledged)     NOT SENT     STALE (Never Acknowledged)     SYNCED       pilot3     1.1
+NAME       CDS       LDS          EDS        RDS          PILOT      VERSION
+proxy1     STALE     SYNCED       SYNCED     NOT SENT     pilot1     1.1
+proxy2     STALE     SYNCED       STALE      SYNCED       pilot2     1.1
+proxy3     STALE     NOT SENT     STALE      SYNCED       pilot3     1.1

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
@@ -1,3 +1,3 @@
-NAME       CDS                LDS        EDS                RDS          PILOT      VERSION
-proxy1     STALE (1h0m0s)     SYNCED     SYNCED             NOT SENT     pilot1     1.1
-proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s)     SYNCED       pilot1     1.1
+NAME       CDS       LDS        EDS        RDS          PILOT      VERSION
+proxy1     STALE     SYNCED     SYNCED     NOT SENT     pilot1     1.1
+proxy2     STALE     SYNCED     STALE      SYNCED       pilot1     1.1

--- a/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
@@ -1,2 +1,2 @@
-NAME       CDS                LDS        EDS                RDS        PILOT      VERSION
-proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s)     SYNCED     pilot2     1.1
+NAME       CDS       LDS        EDS       RDS        PILOT      VERSION
+proxy2     STALE     SYNCED     STALE     SYNCED     pilot2     1.1

--- a/istioctl/pkg/writer/pilot/testdata/singleStatusFallback.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatusFallback.txt
@@ -1,2 +1,2 @@
-NAME       CDS                LDS        EDS                RDS        PILOT      VERSION
-proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s)     SYNCED     pilot2     1.1*
+NAME       CDS       LDS        EDS       RDS        PILOT      VERSION
+proxy2     STALE     SYNCED     STALE     SYNCED     pilot2     1.1*


### PR DESCRIPTION
Please provide a description for what this PR is for,
Since the Nonce changes to UUID, so remove time diff info for istioctl proxy-status command
This PR also include unit test fix and go imports reformat.

And to help us figure out who should review this PR, please
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ X ] User Experience
[ ] Developer Infrastructure