### PR TITLE
Move GetConsolidateAuthenticationPolicy under v1alpha1 folder

### DIFF
--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -18,7 +18,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/security/authn"
 	"istio.io/istio/pilot/pkg/security/authn/v1alpha1"
-	// authn_model "istio.io/istio/pilot/pkg/security/model"
 )
 
 // NewPolicyApplier returns the appropriate (policy) applier, depends on the versions of the policy exists

--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -18,7 +18,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/security/authn"
 	"istio.io/istio/pilot/pkg/security/authn/v1alpha1"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
+	// authn_model "istio.io/istio/pilot/pkg/security/model"
 )
 
 // NewPolicyApplier returns the appropriate (policy) applier, depends on the versions of the policy exists
@@ -26,6 +26,6 @@ import (
 func NewPolicyApplier(configStore model.IstioConfigStore,
 	serviceInstance *model.ServiceInstance) authn.PolicyApplier {
 	// TODO: check v1alpha2 policy and returns alpha2 applier, if exists.
-	authnPolicy := authn_model.GetConsolidateAuthenticationPolicy(configStore, serviceInstance)
+	authnPolicy := v1alpha1.GetConsolidateAuthenticationPolicy(configStore, serviceInstance)
 	return v1alpha1.NewPolicyApplier(authnPolicy)
 }

--- a/pilot/pkg/security/authn/v1alpha1/model.go
+++ b/pilot/pkg/security/authn/v1alpha1/model.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package v1alpha1
 
 import (

--- a/pilot/pkg/security/authn/v1alpha1/model.go
+++ b/pilot/pkg/security/authn/v1alpha1/model.go
@@ -1,0 +1,26 @@
+package v1alpha1
+
+import (
+	authn "istio.io/api/authentication/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	authn_model "istio.io/istio/pilot/pkg/security/model"
+)
+
+// GetConsolidateAuthenticationPolicy returns the v1alpha1 authentication policy for workload specified by
+// hostname (or label selector if specified) and port, if defined.
+// It also tries to resolve JWKS URI if necessary.
+func GetConsolidateAuthenticationPolicy(store model.IstioConfigStore, serviceInstance *model.ServiceInstance) *authn.Policy {
+	service := serviceInstance.Service
+	port := serviceInstance.Endpoint.ServicePort
+	labels := serviceInstance.Labels
+
+	config := store.AuthenticationPolicyForWorkload(service, labels, port)
+	if config != nil {
+		policy := config.Spec.(*authn.Policy)
+		if err := authn_model.JwtKeyResolver.SetAuthenticationPolicyJwksURIs(policy); err == nil {
+			return policy
+		}
+	}
+
+	return nil
+}

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -24,8 +24,6 @@ import (
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
-
-	authn "istio.io/api/authentication/v1alpha1"
 )
 
 const (
@@ -58,26 +56,7 @@ const (
 // JwtKeyResolver resolves JWT public key and JwksURI.
 var JwtKeyResolver = model.NewJwksResolver(model.JwtPubKeyEvictionDuration, model.JwtPubKeyRefreshInterval)
 
-// GetConsolidateAuthenticationPolicy returns the authentication policy for workload specified by
-// hostname (or label selector if specified) and port, if defined.
-// It also tries to resolve JWKS URI if necessary.
-func GetConsolidateAuthenticationPolicy(store model.IstioConfigStore, serviceInstance *model.ServiceInstance) *authn.Policy {
-	service := serviceInstance.Service
-	port := serviceInstance.Endpoint.ServicePort
-	labels := serviceInstance.Labels
-
-	config := store.AuthenticationPolicyForWorkload(service, labels, port)
-	if config != nil {
-		policy := config.Spec.(*authn.Policy)
-		if err := JwtKeyResolver.SetAuthenticationPolicyJwksURIs(policy); err == nil {
-			return policy
-		}
-	}
-
-	return nil
-}
-
-// ConstructSdsSecretConfig constructs SDS secret configuration for ingress gateway.
+// ConstructSdsSecretConfigForGatewayListener constructs SDS secret configuration for ingress gateway.
 func ConstructSdsSecretConfigForGatewayListener(name, sdsUdsPath string) *auth.SdsSecretConfig {
 	if name == "" || sdsUdsPath == "" {
 		return nil
@@ -176,7 +155,7 @@ func ConstructValidationContext(rootCAFilePath string, subjectAltNames []string)
 	return ret
 }
 
-// this function is used to construct SDS config which is only available from 1.1
+// ConstructgRPCCallCredentials is used to construct SDS config which is only available from 1.1
 func ConstructgRPCCallCredentials(tokenFileName, headerKey string) []*core.GrpcService_GoogleGrpc_CallCredentials {
 	// If k8s sa jwt token file exists, envoy only handles plugin credentials.
 	config := &v2alpha.FileBasedMetadataConfig{


### PR DESCRIPTION
This function is supposed to return v1alpha1 version only. Moving this under the _version_ folder make it cleaner for future development of the new API version.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
