### PR TITLE
Add ability to retrieve svc endpoint(s)

### DIFF
--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -350,6 +350,16 @@ func GetIngress(serviceName, podLabel, namespace, kubeconfig string, serviceType
 	}
 }
 
+func GetServiceEndpoint(namespace, svc string) (string, error) {
+	endpoint, err := ShellSilent(
+		"kubectl -n %s get endpoints %s -o jsonpath='{.subsets[*].addresses[*].ip}'",
+		namespace, svc)
+	if err != nil {
+		return "", err
+	}
+	return endpoint, err
+}
+
 func getServiceLoadBalancer(name, namespace, kubeconfig string) (string, error) {
 	ip, err := ShellSilent(
 		"kubectl get svc %s -n %s -o jsonpath='{.status.loadBalancer.ingress[*].ip}' --kubeconfig=%s",


### PR DESCRIPTION
Allows to get all the endpoints associated to a service. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[x] Developer Infrastructure
