### PR TITLE
DONTMERGE: expanding the testcases to verify meaningless containerPort can be removed

### DIFF
--- a/pkg/kube/inject/container_port_tool.go
+++ b/pkg/kube/inject/container_port_tool.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inject
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"regexp"
+)
+
+var (
+	// concurrencyCmdFlagName
+	shouldStripContainerPort = true
+	StripNamePattern         = regexp.MustCompile(`^$`)
+)
+
+func applyContainerPortStrip(spec *corev1.PodSpec) {
+	if !shouldStripContainerPort {
+		return
+	}
+	for i := range spec.Containers {
+		container := spec.Containers[i]
+		var newPorts []corev1.ContainerPort
+		for _, port := range container.Ports {
+			if !StripNamePattern.MatchString(port.Name) {
+				newPorts = append(newPorts, port)
+			}
+		}
+		container.Ports = newPorts
+		spec.Containers[i] = container
+	}
+}

--- a/pkg/kube/inject/container_port_tool.go
+++ b/pkg/kube/inject/container_port_tool.go
@@ -20,7 +20,6 @@ import (
 )
 
 var (
-	// concurrencyCmdFlagName
 	shouldStripContainerPort = true
 	StripNamePattern         = regexp.MustCompile(`^$`)
 )

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -790,6 +790,8 @@ func IntoObject(sidecarTemplate string, valuesConfig string, meshconfig *meshcon
 	if name == "" {
 		name = deploymentMetadata.Name
 	}
+	applyContainerPortStrip(podSpec)
+
 	// Skip injection when host networking is enabled. The problem is
 	// that the iptable changes are assumed to be within the pod when,
 	// in fact, they are changing the routing at the host level. This

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -98,7 +98,7 @@ func TestIntoResourceFile(t *testing.T) {
 			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
 			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
 		},
-		//"testdata/hello.yaml" is tested in http_test.go (with debug)
+		//verifies that some container ports are stripped
 		{
 			in:                           "hello_named_container_port.yaml",
 			want:                         "hello_named_container_port.yaml.injected",

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -98,6 +98,17 @@ func TestIntoResourceFile(t *testing.T) {
 			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
 			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
 		},
+		//"testdata/hello.yaml" is tested in http_test.go (with debug)
+		{
+			in:                           "hello_named_container_port.yaml",
+			want:                         "hello_named_container_port.yaml.injected",
+			includeIPRanges:              DefaultIncludeIPRanges,
+			includeInboundPorts:          DefaultIncludeInboundPorts,
+			statusPort:                   DefaultStatusPort,
+			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
+			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
+			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+		},
 		//verifies that the sidecar will not be injected again for an injected yaml
 		{
 			in:                           "hello.yaml.injected",

--- a/pkg/kube/inject/testdata/inject/hello_named_container_port.yaml
+++ b/pkg/kube/inject/testdata/inject/hello_named_container_port.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello
+spec:
+  replicas: 7
+  selector:
+    matchLabels: 
+      app: hello
+      tier: backend
+      track: stable
+  template:
+    metadata:
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+        - name: hello
+          image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+          ports:
+            - containerPort: 80

--- a/pkg/kube/inject/testdata/inject/hello_named_container_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello_named_container_port.yaml.injected
@@ -1,0 +1,170 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: hello
+spec:
+  replicas: 7
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/interceptionMode: REDIRECT
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
+        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --configPath
+        - /etc/istio/proxy
+        - --binaryPath
+        - /usr/local/bin/envoy
+        - --serviceCluster
+        - hello.$(POD_NAMESPACE)
+        - --drainDuration
+        - 45s
+        - --parentShutdownDuration
+        - 1m0s
+        - --discoveryAddress
+        - istio-pilot:15010
+        - --dnsRefreshRate
+        - 300s
+        - --connectTimeout
+        - 1s
+        - --proxyAdminPort
+        - "15000"
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --statusPort
+        - "15020"
+        - --applicationPorts
+        - ""
+        - --concurrency
+        - "2"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+        - name: ISTIO_METAJSON_LABELS
+          value: |
+            {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: hello
+        - name: ISTIO_META_OWNER
+          value: kubernetes://api/apps/v1/namespaces/default/deployments/hello
+        image: docker.io/istio/proxyv2:unittest
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
+        resources:
+          limits:
+            cpu: "2"
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      initContainers:
+      - args:
+        - -p
+        - "15001"
+        - -z
+        - "15006"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - '*'
+        - -d
+        - "15020"
+        image: docker.io/istio/proxy_init:unittest
+        imagePullPolicy: IfNotPresent
+        name: istio-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          runAsNonRoot: false
+          runAsUser: 0
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          secretName: istio.default
+status: {}
+---

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -13,7 +13,6 @@ spec:
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
       creationTimestamp: null
       labels:
@@ -23,8 +22,6 @@ spec:
       containers:
       - image: nginx
         name: nginx
-        ports:
-        - containerPort: 80
         resources: {}
       - args:
         - proxy
@@ -54,7 +51,7 @@ spec:
         - --statusPort
         - "15020"
         - --applicationPorts
-        - "80"
+        - ""
         - --concurrency
         - "2"
         env:
@@ -85,7 +82,6 @@ spec:
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_INCLUDE_INBOUND_PORTS
-          value: "80"
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"nginx"}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -110,8 +110,8 @@ spec:
           - "{{ .Version }}"
         ports:
 {{- range $i, $p := .ContainerPorts }}
-        - containerPort: {{ $p.Port }} 
 {{- if eq .Port 3333 }}
+        - containerPort: {{ $p.Port }} 
           name: tcp-health-port
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
