### PR TITLE
Update namespaceSelector to be configurable on sidecar injector webhook

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/mutatingwebhook.yaml
@@ -33,7 +33,6 @@ webhooks:
         values:
         - disabled
 {{- else }}
-      matchLabels:
-        istio-injection: enabled
+      {{- toYaml .Values.namespaceSelector | trim | nindent 6 }}
 {{- end }}
 

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
@@ -7,6 +7,9 @@ rollingMaxSurge: 100%
 rollingMaxUnavailable: 25%
 image: sidecar_injector
 enableNamespacesByDefault: false
+namespaceSelector:
+  matchLabels:
+    istio-injection: enabled
 nodeSelector: {}
 tolerations: []
 


### PR DESCRIPTION
I'm not sure if there's an issue lurking around for something of this nature; but for us we're having some trouble where we essentially want to declare with an annotation on a pod when the sidecar injection is enabled; by default we only have access to that when we label the namespace with `istio-injection: enabled`. Switching over to the existing variable `enableNamespacesByDefault` and setting that to `true` does solve the problem for us but also introduces a new one which is to say inside of kube-system in order for our networking to come up we need to be able to communicate with the istio webhook which obviously can't happen.

I did consider just directly adding kube-system to the `enableNamespacesByDefault` configured block and leaving it at that but it seemed like a setting which a user might want more granular control over so I instead set a default value for the namespace selector but made it fully configurable inside of the values file and did not touch the `enableNamespacesByDefault` in order to not create a breaking change.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
