### PR TITLE
cherry-pick #15941 onto release-1.3 (Add supporting implementation for ISTIO_MUTUAL Gateway TLS mode)

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/gateway"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -89,7 +90,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 			// We only need to look at the first server in the list as the merge logic
 			// ensures that all servers are of same type.
 			routeName := mergedGateway.RouteNamesByServer[servers[0]]
-			opts.filterChainOpts = []*filterChainOpts{configgen.createGatewayHTTPFilterChainOpts(node, servers[0], routeName)}
+			opts.filterChainOpts = []*filterChainOpts{configgen.createGatewayHTTPFilterChainOpts(node, servers[0], routeName, "")}
 		} else {
 			// build http connection manager with TLS context, for HTTPS servers using simple/mutual TLS
 			// build listener with tcp proxy, with or without TLS context, for TCP servers
@@ -102,7 +103,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 				if gateway.IsTLSServer(server) && gateway.IsHTTPServer(server) {
 					// This is a HTTPS server, where we are doing TLS termination. Build a http connection manager with TLS context
 					routeName := mergedGateway.RouteNamesByServer[server]
-					filterChainOpts = append(filterChainOpts, configgen.createGatewayHTTPFilterChainOpts(node, server, routeName))
+					filterChainOpts = append(filterChainOpts, configgen.createGatewayHTTPFilterChainOpts(node, server, routeName, env.Mesh.SdsUdsPath))
 				} else {
 					// passthrough or tcp, yields multiple filter chains
 					filterChainOpts = append(filterChainOpts, configgen.createGatewayTCPFilterChainOpts(node, env, push,
@@ -340,7 +341,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(env *model.Env
 
 // builds a HTTP connection manager for servers of type HTTP or HTTPS (mode: simple/mutual)
 func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
-	node *model.Proxy, server *networking.Server, routeName string) *filterChainOpts {
+	node *model.Proxy, server *networking.Server, routeName string, sdsPath string) *filterChainOpts {
 
 	serverProto := protocol.Parse(server.Port.Protocol)
 
@@ -393,7 +394,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 		// and that no two non-HTTPS servers can be on same port or share port names.
 		// Validation is done per gateway and also during merging
 		sniHosts:   getSNIHostsForServer(server),
-		tlsContext: buildGatewayListenerTLSContext(server, enableIngressSdsAgent),
+		tlsContext: buildGatewayListenerTLSContext(server, enableIngressSdsAgent, sdsPath, node.Metadata),
 		httpOpts: &httpListenerOpts{
 			rds:              routeName,
 			useRemoteAddress: true,
@@ -414,7 +415,24 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 	}
 }
 
-func buildGatewayListenerTLSContext(server *networking.Server, enableSds bool) *auth.DownstreamTlsContext {
+// enableIngressSds: signifies whether this is an SDS enabled ingress controller, with an embedded node agent running
+// alongside the gateway pod (https://istio.io/docs/tasks/traffic-management/ingress/secure-ingress-sds/)
+// sdsPath: is the path to the mesh-wide workload sds uds path, and it is assumed that if this path is unset, that sds is
+// disabled mesh-wide
+// metadata: map of miscellaneous configuration values sent from the Envoy instance back to Pilot, could include the field
+// USER_SDS which signifies that the proxy is an SDS-enabled ingress gateway
+//
+// Below is a table of potential scenarios for the gateway configuration:
+//
+// TLS mode      | Mesh-wide SDS | Ingress SDS | Resulting Configuration
+// SIMPLE/MUTUAL |    ENABLED    |   ENABLED   | support SDS at ingress gateway to terminate SSL communication outside the mesh
+// ISTIO_MUTUAL  |    ENABLED    |   DISABLED  | support SDS at gateway to terminate workload mTLS, with internal workloads
+// 											   | for egress or with another trusted cluster for ingress)
+// ISTIO_MUTUAL  |    DISABLED   |   DISABLED  | use file-mounted secret paths to terminate workload mTLS from gateway
+//
+// Note that ISTIO_MUTUAL TLS mode and ingressSds should not be used simultaneously on the same ingress gateway.
+func buildGatewayListenerTLSContext(
+	server *networking.Server, enableIngressSds bool, sdsPath string, metadata map[string]string) *auth.DownstreamTlsContext {
 	// Server.TLS cannot be nil or passthrough. But as a safety guard, return nil
 	if server.Tls == nil || gateway.IsPassThroughServer(server) {
 		return nil // We don't need to setup TLS context for passthrough mode
@@ -426,7 +444,7 @@ func buildGatewayListenerTLSContext(server *networking.Server, enableSds bool) *
 		},
 	}
 
-	if enableSds && server.Tls.CredentialName != "" {
+	if enableIngressSds && server.Tls.CredentialName != "" {
 		// If SDS is enabled at gateway, and credential name is specified at gateway config, create
 		// SDS config for gateway to fetch key/cert at gateway agent.
 		tls.CommonTlsContext.TlsCertificateSdsSecretConfigs = []*auth.SdsSecretConfig{
@@ -451,6 +469,52 @@ func buildGatewayListenerTLSContext(server *networking.Server, enableSds bool) *
 			tls.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{
 				ValidationContext: &auth.CertificateValidationContext{
 					VerifySubjectAltName: server.Tls.SubjectAltNames,
+				},
+			}
+		}
+	} else if server.Tls.Mode == networking.Server_TLSOptions_ISTIO_MUTUAL {
+		// global SDS must be enabled if the sds path is non-default, configure TLS with SDS
+		if sdsPath != "" {
+			// configure egress with SDS
+			tls.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
+				CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+					DefaultValidationContext: &auth.CertificateValidationContext{VerifySubjectAltName: server.Tls.SubjectAltNames},
+					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(
+						authn_model.SDSRootResourceName, sdsPath, metadata),
+				},
+			}
+			tls.CommonTlsContext.TlsCertificateSdsSecretConfigs = []*auth.SdsSecretConfig{
+				authn_model.ConstructSdsSecretConfig(
+					authn_model.SDSDefaultResourceName, sdsPath, metadata)}
+		} else {
+			// global SDS disabled, fall back on using mounted certificates
+			caCertificates := model.GetOrDefaultFromMap(metadata, model.NodeMetadataTLSServerRootCert, constants.DefaultRootCert)
+			trustedCa := &core.DataSource{
+				Specifier: &core.DataSource_Filename{
+					Filename: caCertificates,
+				},
+			}
+			tls.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{
+				ValidationContext: &auth.CertificateValidationContext{
+					TrustedCa:            trustedCa,
+					VerifySubjectAltName: server.Tls.SubjectAltNames,
+				},
+			}
+
+			certChainPath := model.GetOrDefaultFromMap(metadata, model.NodeMetadataTLSServerCertChain, constants.DefaultCertChain)
+			privateKeyPath := model.GetOrDefaultFromMap(metadata, model.NodeMetadataTLSServerKey, constants.DefaultKey)
+			tls.CommonTlsContext.TlsCertificates = []*auth.TlsCertificate{
+				{
+					CertificateChain: &core.DataSource{
+						Specifier: &core.DataSource_Filename{
+							Filename: certChainPath,
+						},
+					},
+					PrivateKey: &core.DataSource{
+						Specifier: &core.DataSource_Filename{
+							Filename: privateKeyPath,
+						},
+					},
 				},
 			}
 		}
@@ -489,7 +553,8 @@ func buildGatewayListenerTLSContext(server *networking.Server, enableSds bool) *
 	}
 
 	tls.RequireClientCertificate = proto.BoolFalse
-	if server.Tls.Mode == networking.Server_TLSOptions_MUTUAL {
+	if server.Tls.Mode == networking.Server_TLSOptions_MUTUAL ||
+		server.Tls.Mode == networking.Server_TLSOptions_ISTIO_MUTUAL {
 		tls.RequireClientCertificate = proto.BoolTrue
 	}
 
@@ -551,7 +616,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 			return []*filterChainOpts{
 				{
 					sniHosts:       getSNIHostsForServer(server),
-					tlsContext:     buildGatewayListenerTLSContext(server, enableIngressSdsAgent),
+					tlsContext:     buildGatewayListenerTLSContext(server, enableIngressSdsAgent, env.Mesh.SdsUdsPath, node.Metadata),
 					networkFilters: filters,
 				},
 			}

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -30,17 +30,138 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/security/model"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/proto"
 )
 
 func TestBuildGatewayListenerTlsContext(t *testing.T) {
 	testCases := []struct {
-		name      string
-		server    *networking.Server
-		enableSds bool
-		result    *auth.DownstreamTlsContext
+		name                  string
+		server                *networking.Server
+		enableIngressSdsAgent bool
+		sdsPath               string
+		result                *auth.DownstreamTlsContext
 	}{
+		{
+			name: "ingress sdsagent disabled, mesh SDS disabled, tls mode ISTIO_MUTUAL",
+			server: &networking.Server{
+				Hosts: []string{"httpbin.example.com"},
+				Tls: &networking.Server_TLSOptions{
+					Mode: networking.Server_TLSOptions_ISTIO_MUTUAL,
+				},
+			},
+			enableIngressSdsAgent: false,
+			result: &auth.DownstreamTlsContext{
+				CommonTlsContext: &auth.CommonTlsContext{
+					AlpnProtocols: util.ALPNHttp,
+					TlsCertificates: []*auth.TlsCertificate{
+						{
+							CertificateChain: &core.DataSource{
+								Specifier: &core.DataSource_Filename{
+									Filename: constants.DefaultCertChain,
+								},
+							},
+							PrivateKey: &core.DataSource{
+								Specifier: &core.DataSource_Filename{
+									Filename: constants.DefaultKey,
+								},
+							},
+						},
+					},
+					ValidationContextType: &auth.CommonTlsContext_ValidationContext{
+						ValidationContext: &auth.CertificateValidationContext{
+							TrustedCa: &core.DataSource{
+								Specifier: &core.DataSource_Filename{
+									Filename: constants.DefaultRootCert,
+								},
+							},
+						},
+					},
+				},
+				RequireClientCertificate: proto.BoolTrue,
+			},
+		},
+		{
+			name: "ingress sdsagent disabled, mesh SDS enabled, tls mode ISTIO_MUTUAL",
+			server: &networking.Server{
+				Hosts: []string{"httpbin.example.com"},
+				Tls: &networking.Server_TLSOptions{
+					Mode: networking.Server_TLSOptions_ISTIO_MUTUAL,
+				},
+			},
+			enableIngressSdsAgent: false,
+			sdsPath:               "unix:/var/run/sds/uds_path",
+			result: &auth.DownstreamTlsContext{
+				CommonTlsContext: &auth.CommonTlsContext{
+					AlpnProtocols: util.ALPNHttp,
+					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+						{
+							Name: "default",
+							SdsConfig: &core.ConfigSource{
+								InitialFetchTimeout: features.InitialFetchTimeout,
+								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+									ApiConfigSource: &core.ApiConfigSource{
+										ApiType: core.ApiConfigSource_GRPC,
+										GrpcServices: []*core.GrpcService{
+											{
+												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+													GoogleGrpc: &core.GrpcService_GoogleGrpc{
+														TargetUri:  "unix:/var/run/sds/uds_path",
+														StatPrefix: model.SDSStatPrefix,
+														ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+															CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
+																LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
+															},
+														},
+														CallCredentials:        model.ConstructgRPCCallCredentials(model.K8sSATrustworthyJwtFileName, model.K8sSAJwtTokenHeaderKey),
+														CredentialsFactoryName: model.FileBasedMetadataPlugName,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+							DefaultValidationContext: &auth.CertificateValidationContext{},
+							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+								Name: "ROOTCA",
+								SdsConfig: &core.ConfigSource{
+									InitialFetchTimeout: features.InitialFetchTimeout,
+									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+										ApiConfigSource: &core.ApiConfigSource{
+											ApiType: core.ApiConfigSource_GRPC,
+											GrpcServices: []*core.GrpcService{
+												{
+													TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+														GoogleGrpc: &core.GrpcService_GoogleGrpc{
+															TargetUri:  "unix:/var/run/sds/uds_path",
+															StatPrefix: model.SDSStatPrefix,
+															ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+																CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
+																	LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
+																},
+															},
+															CallCredentials:        model.ConstructgRPCCallCredentials(model.K8sSATrustworthyJwtFileName, model.K8sSAJwtTokenHeaderKey),
+															CredentialsFactoryName: model.FileBasedMetadataPlugName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				RequireClientCertificate: proto.BoolTrue,
+			},
+		},
 		{ // No credential name is specified, generate file paths for key/cert.
 			name: "no credential name no key no cert tls SIMPLE",
 			server: &networking.Server{
@@ -49,7 +170,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					Mode: networking.Server_TLSOptions_SIMPLE,
 				},
 			},
-			enableSds: true,
+			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -80,7 +201,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					CredentialName: "ingress-sds-resource-name",
 				},
 			},
-			enableSds: true,
+			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -122,7 +243,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					SubjectAltNames: []string{"subject.name.a.com", "subject.name.b.com"},
 				},
 			},
-			enableSds: true,
+			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -168,7 +289,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					PrivateKey:        "private-key.key",
 				},
 			},
-			enableSds: false,
+			enableIngressSdsAgent: false,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -200,7 +321,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					PrivateKey:        "private-key.key",
 				},
 			},
-			enableSds: true,
+			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -235,7 +356,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					SubjectAltNames:   []string{"subject.name.a.com", "subject.name.b.com"},
 				},
 			},
-			enableSds: true,
+			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -305,7 +426,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					VerifyCertificateSpki: []string{"abcdef"},
 				},
 			},
-			enableSds: true,
+			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -375,7 +496,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					VerifyCertificateHash: []string{"fedcba"},
 				},
 			},
-			enableSds: true,
+			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -444,13 +565,13 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					PrivateKey:        "private-key.key",
 				},
 			},
-			enableSds: true,
-			result:    nil,
+			enableIngressSdsAgent: true,
+			result:                nil,
 		},
 	}
 
 	for _, tc := range testCases {
-		ret := buildGatewayListenerTLSContext(tc.server, tc.enableSds)
+		ret := buildGatewayListenerTLSContext(tc.server, tc.enableIngressSdsAgent, tc.sdsPath, nil)
 		if !reflect.DeepEqual(tc.result, ret) {
 			t.Errorf("test case %s: expecting %v but got %v", tc.name, tc.result, ret)
 		}
@@ -503,7 +624,7 @@ func TestCreateGatewayHTTPFilterChainOpts(t *testing.T) {
 
 	for _, tc := range testCases {
 		cgi := NewConfigGenerator([]plugin.Plugin{})
-		ret := cgi.createGatewayHTTPFilterChainOpts(tc.node, tc.server, tc.routeName)
+		ret := cgi.createGatewayHTTPFilterChainOpts(tc.node, tc.server, tc.routeName, "")
 		if !reflect.DeepEqual(tc.result, ret) {
 			t.Errorf("test case %s: expecting %v but got %v", tc.name, tc.result, ret)
 		}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -377,6 +377,22 @@ func validateTLSOptions(tls *networking.Server_TLSOptions) (errs error) {
 		return
 	}
 
+	if tls.Mode == networking.Server_TLSOptions_ISTIO_MUTUAL {
+		// ISTIO_MUTUAL TLS mode uses either SDS or default certificate mount paths
+		// therefore, we should fail validation if other TLS fields are set
+		if tls.ServerCertificate != "" {
+			errs = appendErrors(errs, fmt.Errorf("ISTIO_MUTUAL TLS cannot have associated server certificate"))
+		}
+		if tls.PrivateKey != "" {
+			errs = appendErrors(errs, fmt.Errorf("ISTIO_MUTUAL TLS cannot have associated private key"))
+		}
+		if tls.CaCertificates != "" {
+			errs = appendErrors(errs, fmt.Errorf("ISTIO_MUTUAL TLS cannot have associated CA bundle"))
+		}
+
+		return
+	}
+
 	if (tls.Mode == networking.Server_TLSOptions_SIMPLE || tls.Mode == networking.Server_TLSOptions_MUTUAL) && tls.CredentialName != "" {
 		// If tls mode is SIMPLE or MUTUAL, and CredentialName is specified, credentials are fetched
 		// remotely. ServerCertificate and CaCertificates fields are not required.

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1448,6 +1448,30 @@ func TestValidateTlsOptions(t *testing.T) {
 				CaCertificates:    "",
 				CredentialName:    "sds-name"},
 			""},
+		{"istio_mutual no certs",
+			&networking.Server_TLSOptions{
+				Mode:              networking.Server_TLSOptions_ISTIO_MUTUAL,
+				ServerCertificate: "",
+				PrivateKey:        "",
+				CaCertificates:    ""},
+			""},
+		{"istio_mutual with server cert",
+			&networking.Server_TLSOptions{
+				Mode:              networking.Server_TLSOptions_ISTIO_MUTUAL,
+				ServerCertificate: "Captain Jean-Luc Picard"},
+			"cannot have associated server cert"},
+		{"istio_mutual with client bundle",
+			&networking.Server_TLSOptions{
+				Mode:              networking.Server_TLSOptions_ISTIO_MUTUAL,
+				ServerCertificate: "Captain Jean-Luc Picard",
+				PrivateKey:        "Khan Noonien Singh",
+				CaCertificates:    "Commander William T. Riker"},
+			"cannot have associated"},
+		{"istio_mutual with private key",
+			&networking.Server_TLSOptions{
+				Mode:       networking.Server_TLSOptions_ISTIO_MUTUAL,
+				PrivateKey: "Khan Noonien Singh"},
+			"cannot have associated private key"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/test/echo/common/response/response.go
+++ b/pkg/test/echo/common/response/response.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	StatusCodeOK        = strconv.Itoa(http.StatusOK)
-	StatusCodeForbidden = strconv.Itoa(http.StatusForbidden)
+	StatusCodeOK          = strconv.Itoa(http.StatusOK)
+	StatusCodeForbidden   = strconv.Itoa(http.StatusForbidden)
+	StatusCodeUnavailable = strconv.Itoa(http.StatusServiceUnavailable)
 )
 
 // Field is a list of fields returned in responses from the Echo server.

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -1,0 +1,178 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package sdsegress
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/echo/common/response"
+	epb "istio.io/istio/pkg/test/echo/proto"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/prometheus"
+	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/tests/integration/security/util"
+)
+
+const (
+	// should be templated into YAML, and made interchangeable with other sites
+	externalURL      = "http://bing.com"
+	externalReqCount = 2
+	egressName       = "istio-egressgateway"
+	// paths to test configs
+	istioMutualTLSGatewayConfig = "testdata/istio-mutual-gateway-bing.yaml"
+	simpleTLSGatewayConfig      = "testdata/simple-tls-gateway-bing.yaml"
+)
+
+// TestSdsEgressGatewayIstioMutual brings up an SDS enabled cluster and will ensure that the ISTIO_MUTUAL
+// TLS mode allows secure communication between the egress and workloads. This test brings up an ISTIO_MUTUAL enabled
+// gateway, and then, an incorrectly configured simple TLS gateway. The test will ensure that requests are routed
+// securely through the egress gateway in the first case, and fail in the second case.
+func TestSdsEgressGatewayIstioMutual(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ctx.RequireOrSkip(environment.Kube)
+			istioCfg := istio.DefaultConfigOrFail(t, ctx)
+
+			namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
+			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "sds-egress-gateway-workload",
+				Inject: true,
+			})
+			applySetupConfig(ctx, ns)
+
+			testCases := map[string]struct {
+				configPath string
+				response   string
+			}{
+				"ISTIO_MUTUAL TLS mode requests are routed through egress succeed": {
+					configPath: istioMutualTLSGatewayConfig,
+					response:   response.StatusCodeOK,
+				},
+				"SIMPLE TLS mode requests are routed through gateway but fail with 503": {
+					configPath: simpleTLSGatewayConfig,
+					response:   response.StatusCodeUnavailable,
+				},
+			}
+
+			for name, tc := range testCases {
+				ctx.NewSubTest(name).
+					Run(func(ctx framework.TestContext) {
+						doIstioMutualTest(ctx, ns, tc.configPath, tc.response)
+					})
+			}
+		})
+}
+
+func doIstioMutualTest(
+	ctx framework.TestContext, ns namespace.Instance, configPath, expectedResp string) {
+	var client echo.Instance
+	echoboot.NewBuilderOrFail(ctx, ctx).
+		With(&client, util.EchoConfig("client", ns, false, nil, g, p)).
+		BuildOrFail(ctx)
+	g.ApplyConfigOrFail(ctx, ns, file.AsStringOrFail(ctx, configPath))
+	defer g.DeleteConfigOrFail(ctx, ns, file.AsStringOrFail(ctx, configPath))
+
+	// give the configuration a moment to kick in
+	time.Sleep(time.Second * 20)
+	pretestReqCount := getEgressRequestCountOrFail(ctx, ns, prom)
+
+	for i := 0; i < externalReqCount; i++ {
+		w := client.WorkloadsOrFail(ctx)[0]
+		responses, err := w.ForwardEcho(context.TODO(), &epb.ForwardEchoRequest{
+			Url:   externalURL,
+			Count: 1,
+		})
+		if err != nil {
+			ctx.Fatalf("failed to make request from echo instance to %s: %v", externalURL, err)
+		}
+		if len(responses) < 1 {
+			ctx.Fatalf("received no responses from request to %s", externalURL)
+		}
+		resp := responses[0]
+
+		if expectedResp != resp.Code {
+			ctx.Errorf("expected status %s but got %s", expectedResp, resp.Code)
+		}
+
+	}
+
+	// give prometheus some time to ingest the metrics
+	posttestReqCount := getEgressRequestCountOrFail(ctx, ns, prom)
+	newGatewayReqs := posttestReqCount - pretestReqCount
+	if newGatewayReqs != externalReqCount {
+		ctx.Errorf("expected %d requests routed through egress, got %d",
+			externalReqCount, newGatewayReqs)
+	}
+}
+
+// sets up the destination rule to route through egress, virtual service, and service entry
+func applySetupConfig(ctx test.Failer, ns namespace.Instance) {
+	ctx.Helper()
+
+	configFiles := []string{
+		"testdata/destination-rule-bing.yaml",
+		"testdata/rule-route-sidecar-to-egress-bing.yaml",
+		"testdata/service-entry-bing.yaml",
+	}
+
+	for _, c := range configFiles {
+		if err := g.ApplyConfig(ns, file.AsStringOrFail(ctx, c)); err != nil {
+			ctx.Fatalf("failed to apply configuration file %s; err: %v", c, err)
+		}
+	}
+}
+
+func getMetric(ctx framework.TestContext, prometheus prometheus.Instance, query string) (float64, error) {
+	ctx.Helper()
+
+	value, err := prometheus.WaitForQuiesce(query)
+	if err != nil {
+		return 0, fmt.Errorf("failed to retrieve metric from prom with err: %v", err)
+	}
+
+	metric, err := prometheus.Sum(value, nil)
+	if err != nil {
+		ctx.Logf("value: %s", value.String())
+		return 0, fmt.Errorf("could not find metric value: %v", err)
+	}
+
+	return metric, nil
+}
+
+func getEgressRequestCountOrFail(ctx framework.TestContext, ns namespace.Instance, prom prometheus.Instance) int {
+	query := fmt.Sprintf("istio_requests_total{destination_app=\"%s\",source_workload_namespace=\"%s\"}",
+		egressName, ns.Name())
+	ctx.Helper()
+
+	reqCount, err := getMetric(ctx, prom, query)
+	if err != nil {
+		// assume that if the request failed, it was because there was no metric ingested
+		// if this is not the case, the test will fail down the road regardless
+		// checking for error based on string match could lead to future failure
+		reqCount = 0
+	}
+
+	return int(reqCount)
+}

--- a/tests/integration/security/sds_egress/testdata/destination-rule-bing.yaml
+++ b/tests/integration/security/sds_egress/testdata/destination-rule-bing.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: egressgateway-for-bing
+spec:
+  host: istio-egressgateway.istio-system.svc.cluster.local
+  subsets:
+    - name: bing
+      trafficPolicy:
+        loadBalancer:
+          simple: ROUND_ROBIN
+        portLevelSettings:
+          - port:
+              number: 80
+            tls:
+              mode: ISTIO_MUTUAL
+              sni: bing.com

--- a/tests/integration/security/sds_egress/testdata/istio-mutual-gateway-bing.yaml
+++ b/tests/integration/security/sds_egress/testdata/istio-mutual-gateway-bing.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: istio-egressgateway
+spec:
+  selector:
+    istio: egressgateway
+  servers:
+    - port:
+        number: 80
+        name: https
+        protocol: HTTPS
+      hosts:
+        - bing.com
+      tls:
+        mode: ISTIO_MUTUAL

--- a/tests/integration/security/sds_egress/testdata/rule-route-sidecar-to-egress-bing.yaml
+++ b/tests/integration/security/sds_egress/testdata/rule-route-sidecar-to-egress-bing.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: direct-bing-through-egress-gateway
+spec:
+  hosts:
+    - bing.com
+  gateways:
+    - istio-egressgateway
+    - mesh
+  http:
+    - match:
+        - gateways:
+            - mesh
+          port: 80
+      route:
+        - destination:
+            host: istio-egressgateway.istio-system.svc.cluster.local
+            subset: bing
+            port:
+              number: 80
+          weight: 100
+    - match:
+        - gateways:
+            - istio-egressgateway
+          port: 80
+      route:
+        - destination:
+            host: bing.com
+            port:
+              number: 80
+          weight: 100

--- a/tests/integration/security/sds_egress/testdata/service-entry-bing.yaml
+++ b/tests/integration/security/sds_egress/testdata/service-entry-bing.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: bing
+spec:
+  hosts:
+    - bing.com
+  ports:
+    - number: 80
+      name: http-port
+      protocol: HTTP
+    - number: 443
+      name: https
+      protocol: HTTPS
+  resolution: DNS

--- a/tests/integration/security/sds_egress/testdata/simple-tls-gateway-bing.yaml
+++ b/tests/integration/security/sds_egress/testdata/simple-tls-gateway-bing.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: istio-egressgateway
+spec:
+  selector:
+    istio: egressgateway
+  servers:
+    - port:
+        number: 80
+        name: https
+        protocol: HTTPS
+      hosts:
+        - bing.com
+      tls:
+        mode: SIMPLE
+        serverCertificate: /etc/certs/server.pem
+        privateKey: /etc/certs/privatekey.pem


### PR DESCRIPTION
Since the `ISTIO_MUTUAL` Gateway API change made it into 1.3, this should also make it in.

/cc @rshriram 

[ ] Configuration  Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
