### PR TITLE
test: unknown destination_container should not fail

### DIFF
--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -706,7 +706,9 @@ func TestKubeenvMetrics(t *testing.T) {
 	for _, sample := range vec {
 		metric := sample.Metric
 		for labelKey, labelVal := range metric {
-			if labelVal == "unknown" {
+			// destination_container is expected to be unknown when containerPort is removed
+			// TODO(bianpengyuan): restore the destination_container check
+			if labelVal == "unknown" && labelKey != "destination_container" {
 				errorf(t, "Unexpected 'unknown' value for label '%s' in sample '%s'", labelKey, sample)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Attempting remove useless containerPort and fix the existing tests #16496

As a known issue, mixer cannot detect the container name once containerPort is removed. 

This PR deems the unknown `destination_container` as normal.

TODO: attach the mixer issue 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
