### PR TITLE
Fix TestParseJwksURI that relies on golang version

### DIFF
--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -79,11 +79,10 @@ func TestParseJwksURI(t *testing.T) {
 	for _, c := range cases {
 		actual, err := security.ParseJwksURI(c.in)
 		if c.expectedError == (err == nil) {
-			t.Errorf("ParseJwksURI(%s): expected error (%v), got (%v)", c.in, c.expectedError, err)
-		} else {
-			if !reflect.DeepEqual(c.expected, actual) {
-				t.Errorf("expected %+v, got %+v", c.expected, actual)
-			}
+			t.Fatalf("ParseJwksURI(%s): expected error (%v), got (%v)", c.in, c.expectedError, err)
+		}
+		if !reflect.DeepEqual(c.expected, actual) {
+			t.Fatalf("expected %+v, got %+v", c.expected, actual)
 		}
 	}
 }

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -23,21 +23,21 @@ import (
 
 func TestParseJwksURI(t *testing.T) {
 	cases := []struct {
-		in                   string
-		expected             security.JwksInfo
-		expectedErrorMessage string
+		in            string
+		expected      security.JwksInfo
+		expectedError bool
 	}{
 		{
-			in:                   "foo.bar.com",
-			expectedErrorMessage: `URI scheme "" is not supported`,
+			in:            "foo.bar.com",
+			expectedError: true,
 		},
 		{
-			in:                   "tcp://foo.bar.com:abc",
-			expectedErrorMessage: `URI scheme "tcp" is not supported`,
+			in:            "tcp://foo.bar.com:abc",
+			expectedError: true,
 		},
 		{
-			in:                   "http://foo.bar.com:abc",
-			expectedErrorMessage: `strconv.Atoi: parsing "abc": invalid syntax`,
+			in:            "http://foo.bar.com:abc",
+			expectedError: true,
 		},
 		{
 			in: "http://foo.bar.com",
@@ -78,14 +78,9 @@ func TestParseJwksURI(t *testing.T) {
 	}
 	for _, c := range cases {
 		actual, err := security.ParseJwksURI(c.in)
-		if err != nil {
-			if c.expectedErrorMessage != err.Error() {
-				t.Errorf("ParseJwksURI(%s): expected error (%s), got (%v)", c.in, c.expectedErrorMessage, err)
-			}
+		if c.expectedError == (err == nil) {
+			t.Errorf("ParseJwksURI(%s): expected error (%v), got (%v)", c.in, c.expectedError, err)
 		} else {
-			if c.expectedErrorMessage != "" {
-				t.Errorf("ParseJwksURI(%s): expected error (%s), got no error", c.in, c.expectedErrorMessage)
-			}
 			if !reflect.DeepEqual(c.expected, actual) {
 				t.Errorf("expected %+v, got %+v", c.expected, actual)
 			}


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
