### PR TITLE
Create egress gateway only if egress gateway is enabled

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/preconfigured.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/preconfigured.yaml
@@ -119,6 +119,7 @@ spec:
 {{- end }}
 
 {{- if .Values.global.multiCluster.enabled }}
+{{- if (index .Values "istio-egressgateway" "enabled") }}
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -149,6 +150,7 @@ spec:
       protocol: TLS
     tls:
       mode: AUTO_PASSTHROUGH
+{{- end }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway


### PR DESCRIPTION
Please provide a description for what this PR is for.

In a multi cluster setup the `istio-multicluster-egressgateway` should only b deployed if the `istio-egressgateway` is enabled otherwise you just have an unused resource with a selector `selector: null`.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
