### PR TITLE
fix domains duplicate, ipv6 address append to domains when port not e…

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -348,8 +348,8 @@ func generateAltVirtualHosts(hostname string, port int, proxyDomain string) []st
 	return vhosts
 }
 
-// mergeAllVirtualHosts across all ports. On routes for ports other than port 80,
-// virtual hosts without an explicit port suffix (IP:PORT) should not be added
+// mergeAllVirtualHosts across all ports. On routes for port 80,
+// virtual hosts with an explicit port suffix (IP:PORT) should be added
 func mergeAllVirtualHosts(vHostPortMap map[int][]*route.VirtualHost) []*route.VirtualHost {
 	var virtualHosts []*route.VirtualHost
 	for p, vhosts := range vHostPortMap {
@@ -366,18 +366,7 @@ func mergeAllVirtualHosts(vHostPortMap map[int][]*route.VirtualHost) []*route.Vi
 				}
 			}
 		} else {
-			for _, vhost := range vhosts {
-				var newDomains []string
-				for _, domain := range vhost.Domains {
-					if strings.Contains(domain, ":") {
-						newDomains = append(newDomains, domain)
-					}
-				}
-				if len(newDomains) > 0 {
-					vhost.Domains = newDomains
-					virtualHosts = append(virtualHosts, vhost)
-				}
-			}
+			virtualHosts = append(virtualHosts, vhosts...)
 		}
 	}
 	return virtualHosts

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+
 	meshapi "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -51,8 +51,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "local.campus.net",
 			},
-			want: []string{"foo", "foo.local", "foo.local.campus", "foo.local.campus.net",
-				"foo:80", "foo.local:80", "foo.local.campus:80", "foo.local.campus.net:80"},
+			want: []string{"foo:80", "foo.local:80", "foo.local.campus:80", "foo.local.campus.net:80"},
 		},
 		{
 			name: "different domains with some shared dns",
@@ -64,8 +63,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "remote.campus.net",
 			},
-			want: []string{"foo.local", "foo.local.campus", "foo.local.campus.net",
-				"foo.local:80", "foo.local.campus:80", "foo.local.campus.net:80"},
+			want: []string{"foo.local:80", "foo.local.campus:80", "foo.local.campus.net:80"},
 		},
 		{
 			name: "different domains with no shared dns",
@@ -77,7 +75,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "example.com",
 			},
-			want: []string{"foo.local.campus.net", "foo.local.campus.net:80"},
+			want: []string{"foo.local.campus.net:80"},
 		},
 	}
 


### PR DESCRIPTION
…qual 80

IPv6 or IPv6:port both contains ":", only use strings.Contains(domain, ":") undistinguished, if k8s service export one more ports, ipv6 without port domain appear in multiple envoy.router. Only unique values for domains are permitted in envoy, type.googleapis.com/envoy.api.v2.RouteConfiguration rejected this gRPC config.