### PR TITLE
Fix cluster scoping for kube rest client

### DIFF
--- a/pilot/pkg/config/kube/crd/controller/client.go
+++ b/pilot/pkg/config/kube/crd/controller/client.go
@@ -333,7 +333,7 @@ func (cl *Client) Get(typ, name, namespace string) *model.Config {
 
 	config := t.Object.DeepCopyObject().(crd.IstioObject)
 	err := rc.dynamic.Get().
-		Namespace(namespace).
+		NamespaceIfScoped(namespace, !s.ClusterScoped).
 		Resource(crd.ResourceName(s.Plural)).
 		Name(name).
 		Do().Into(config)
@@ -374,7 +374,7 @@ func (cl *Client) Create(config model.Config) (string, error) {
 
 	obj := crd.KnownTypes[s.Type].Object.DeepCopyObject().(crd.IstioObject)
 	err = rc.dynamic.Post().
-		Namespace(out.GetObjectMeta().Namespace).
+		NamespaceIfScoped(out.GetObjectMeta().Namespace, !s.ClusterScoped).
 		Resource(crd.ResourceName(s.Plural)).
 		Body(out).
 		Do().Into(obj)
@@ -411,7 +411,7 @@ func (cl *Client) Update(config model.Config) (string, error) {
 
 	obj := crd.KnownTypes[s.Type].Object.DeepCopyObject().(crd.IstioObject)
 	err = rc.dynamic.Put().
-		Namespace(out.GetObjectMeta().Namespace).
+		NamespaceIfScoped(out.GetObjectMeta().Namespace, !s.ClusterScoped).
 		Resource(crd.ResourceName(s.Plural)).
 		Name(out.GetObjectMeta().Name).
 		Body(out).
@@ -439,7 +439,7 @@ func (cl *Client) Delete(typ, name, namespace string) error {
 	}
 
 	return rc.dynamic.Delete().
-		Namespace(namespace).
+		NamespaceIfScoped(namespace, !s.ClusterScoped).
 		Resource(crd.ResourceName(s.Plural)).
 		Name(name).
 		Do().Error()
@@ -462,7 +462,7 @@ func (cl *Client) List(typ, namespace string) ([]model.Config, error) {
 
 	list := crd.KnownTypes[s.Type].Collection.DeepCopyObject().(crd.IstioObjectList)
 	errs := rc.dynamic.Get().
-		Namespace(namespace).
+		NamespaceIfScoped(namespace, !s.ClusterScoped).
 		Resource(crd.ResourceName(s.Plural)).
 		Do().Into(list)
 


### PR DESCRIPTION
Please provide a description for what this PR is for.
The cluster scoped resources cannot be called with the `/ns/` scoping to the kubernetes api server due to the fix for CVE-2019-11247.
This fixes the issue by calling `NamespaceIfScoped` so that the parameter does not get set.

More information can be found here https://www.stackrox.com/post/2019/08/how-to-remediate-kubernetes-security-vulnerability-cve-2019-11247/

We are using this clientset in one of our projects and realized the cluster scoped actions broke.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
