### PR TITLE
Fix misleading DNSPolicy warning

### DIFF
--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -542,7 +542,7 @@ func InjectionData(sidecarTemplate, valuesConfig, version string, typeMetadata *
 	*SidecarInjectionSpec, string, error) {
 
 	// If DNSPolicy is not ClusterFirst, the Envoy sidecar may not able to connect to Istio Pilot.
-	if spec.DNSPolicy != corev1.DNSClusterFirst {
+	if spec.DNSPolicy != "" && spec.DNSPolicy != corev1.DNSClusterFirst {
 		log.Warnf("%q's DNSPolicy is not %q. The Envoy sidecar may not able to connect to Istio Pilot",
 			metadata.Namespace+"/"+metadata.Name, corev1.DNSClusterFirst)
 	}


### PR DESCRIPTION
This check, added in https://github.com/istio/istio/pull/15919, adds a
warning if DNSPolicy is not ClusterFirst. This is the default value
though, so for the normal case of not having it set we throw a warning.
It should only warn if it is explicitly set to something that is not
ClusterFirst.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure
