### PR TITLE
Fix KinD deployment with k8s v1.12 that has trustworthy JWTs

### DIFF
--- a/prow/config/trustworthy-jwt-12.yaml
+++ b/prow/config/trustworthy-jwt-12.yaml
@@ -8,7 +8,7 @@ kubeadmConfigPatches:
     kind: ClusterConfiguration
     metadata:
       name: config
-    apiServer:
-      extraArgs:
-        "service-account-issuer": "kubernetes.default.svc"
-        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+    apiServerExtraArgs:
+      "service-account-issuer": "kubernetes.default.svc"
+      "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+      "service-account-api-audiences": "kubernetes.default.svc"


### PR DESCRIPTION
`kubeadm.k8s.io/v1alpha3` uses different api language for setting extra flags for the api server. 
`service-account-api-audiences` is required until k8s v1.13.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
