### PR TITLE
Update datadog config in sidecar template

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -172,12 +172,18 @@ containers:
     valueFrom:
       fieldRef:
         fieldPath: spec.serviceAccountName
-{{ if eq .Values.global.proxy.tracer "datadog" }}
+{{- if eq .Values.global.proxy.tracer "datadog" }}
   - name: HOST_IP
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-{{ end }}
+{{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
+{{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
+  - name: {{ $key }}
+    value: "{{ $value }}"
+{{- end }}
+{{- end }}
+{{- end }}
   - name: ISTIO_META_POD_NAME
     valueFrom:
       fieldRef:


### PR DESCRIPTION
This PR updates the sidecar template when datadog tracing is enabled.
Some features in the tracing implementation (within envoy) can be controlled or overridden by environment variables.
The sidecar change means users can set those environment variables via annotations on deployments/pods.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
