### PR TITLE
log if the number of services is not 1 for gateway listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -135,11 +135,21 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 		// end shady logic
 
 		var si *model.ServiceInstance
+		serviceInstances := make([]*model.ServiceInstance, 0, len(node.ServiceInstances))
 		for _, w := range node.ServiceInstances {
 			if w.Endpoint.Port == int(portNumber) {
-				si = w
-				break
+				serviceInstances = append(serviceInstances, w)
 			}
+		}
+		if len(serviceInstances) == 1 {
+			si = serviceInstances[0]
+		} else {
+			names := make([]host.Name, 0, len(serviceInstances))
+			for _, s := range serviceInstances {
+				names = append(names, s.Service.Hostname)
+			}
+			log.Warnf("buildGatewayListeners: found %d services on port %d: %v",
+				len(serviceInstances), portNumber, names)
 		}
 
 		pluginParams := &plugin.InputParams{

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -138,12 +138,13 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 		serviceInstances := make([]*model.ServiceInstance, 0, len(node.ServiceInstances))
 		for _, w := range node.ServiceInstances {
 			if w.Endpoint.Port == int(portNumber) {
+				if si == nil {
+					si = w
+				}
 				serviceInstances = append(serviceInstances, w)
 			}
 		}
-		if len(serviceInstances) == 1 {
-			si = serviceInstances[0]
-		} else {
+		if len(serviceInstances) != 1 {
 			names := make([]host.Name, 0, len(serviceInstances))
 			for _, s := range serviceInstances {
 				names = append(names, s.Service.Hostname)


### PR DESCRIPTION
It seems not a valid case for a port with multiple services in gateway listener generation.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
