### PR TITLE
add initial authorization v1beta1 support

### DIFF
--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -16,6 +16,8 @@ package model
 
 import (
 	rbacproto "istio.io/api/rbac/v1alpha1"
+	authpb "istio.io/api/security/v1beta1"
+	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schemas"
 	istiolog "istio.io/pkg/log"
 )
@@ -35,17 +37,21 @@ type RolesAndBindings struct {
 
 // AuthorizationPolicies organizes authorization policies by namespace.
 type AuthorizationPolicies struct {
-	// Maps from namespace to RolesAndBindings.
-	namespaceToV1Policies map[string]*RolesAndBindings
+	// Maps from namespace to the v1alpha1 RBAC policies, deprecated by v1beta1 Authorization policy.
+	namespaceToV1alpha1Policies map[string]*RolesAndBindings
 
-	// The mesh global RbacConfig.
+	// The mesh global RbacConfig, deprecated by v1beta1 Authorization policy.
 	rbacConfig *rbacproto.RbacConfig
+
+	// Maps from namespace to the v1beta1 Authorization policies.
+	namespaceToV1beta1Policies map[string][]Config
 }
 
 // GetAuthorizationPolicies gets the authorization policies in the mesh.
 func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) {
 	policy := &AuthorizationPolicies{
-		namespaceToV1Policies: map[string]*RolesAndBindings{},
+		namespaceToV1alpha1Policies: map[string]*RolesAndBindings{},
+		namespaceToV1beta1Policies:  map[string][]Config{},
 	}
 
 	rbacConfig := env.IstioConfigStore.ClusterRbacConfig()
@@ -68,11 +74,17 @@ func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) 
 	}
 	policy.addServiceRoleBindings(bindings)
 
+	policies, err := env.List(schemas.AuthorizationPolicy.Type, NamespaceAll)
+	if err != nil {
+		return nil, err
+	}
+	policy.addAuthorizationPolicies(policies)
+
 	return policy, nil
 }
 
-// IsV1RbacEnabled returns true if RBAC is enabled for the service in the given namespace.
-func (policy *AuthorizationPolicies) IsV1RbacEnabled(service string, namespace string) bool {
+// IsV1alpha1RBACEnabled returns true if RBAC is enabled for the service in the given namespace.
+func (policy *AuthorizationPolicies) IsV1alpha1RBACEnabled(service string, namespace string) bool {
 	if policy == nil || policy.rbacConfig == nil {
 		return false
 	}
@@ -96,26 +108,26 @@ func (policy *AuthorizationPolicies) IsGlobalPermissiveEnabled() bool {
 		policy.rbacConfig.EnforcementMode == rbacproto.EnforcementMode_PERMISSIVE
 }
 
-// GetRolesInNamespace returns ServiceRole in the given namespace.
-func (policy *AuthorizationPolicies) GetRolesInNamespace(ns string) []Config {
+// ListServiceRoles returns ServiceRole in the given namespace.
+func (policy *AuthorizationPolicies) ListServiceRoles(ns string) []Config {
 	if policy == nil {
 		return nil
 	}
 
-	rolesAndBindings := policy.namespaceToV1Policies[ns]
+	rolesAndBindings := policy.namespaceToV1alpha1Policies[ns]
 	if rolesAndBindings == nil {
 		return nil
 	}
 	return rolesAndBindings.Roles
 }
 
-// GetBindingsInNamespace returns the ServiceRoleBindings in the given namespace.
-func (policy *AuthorizationPolicies) GetBindingsInNamespace(ns string) map[string][]*rbacproto.ServiceRoleBinding {
+// ListServiceRoleBindings returns the ServiceRoleBindings in the given namespace.
+func (policy *AuthorizationPolicies) ListServiceRoleBindings(ns string) map[string][]*rbacproto.ServiceRoleBinding {
 	if policy == nil {
 		return map[string][]*rbacproto.ServiceRoleBinding{}
 	}
 
-	rolesAndBindings := policy.namespaceToV1Policies[ns]
+	rolesAndBindings := policy.namespaceToV1alpha1Policies[ns]
 	if rolesAndBindings == nil || rolesAndBindings.Bindings == nil {
 		return map[string][]*rbacproto.ServiceRoleBinding{}
 	}
@@ -123,17 +135,40 @@ func (policy *AuthorizationPolicies) GetBindingsInNamespace(ns string) map[strin
 	return rolesAndBindings.Bindings
 }
 
+// ListAuthorizationPolicies returns the AuthorizationPolicy for the workload in the given namespace.
+func (policy *AuthorizationPolicies) ListAuthorizationPolicies(ns string, workloadLabels map[string]string) []Config {
+	if policy == nil {
+		return nil
+	}
+
+	var ret []Config
+	workload := labels.Instance(workloadLabels)
+	for _, config := range policy.namespaceToV1beta1Policies[ns] {
+		spec := config.Spec.(*authpb.AuthorizationPolicy)
+		matched := true
+		if len(spec.GetSelector().GetMatchLabels()) > 0 {
+			selector := labels.Instance(spec.Selector.MatchLabels)
+			matched = selector.SubsetOf(workload)
+		}
+		if matched {
+			ret = append(ret, config)
+		}
+	}
+
+	return ret
+}
+
 func (policy *AuthorizationPolicies) addServiceRoles(roles []Config) {
 	if policy == nil {
 		return
 	}
 	for _, role := range roles {
-		if policy.namespaceToV1Policies[role.Namespace] == nil {
-			policy.namespaceToV1Policies[role.Namespace] = &RolesAndBindings{
+		if policy.namespaceToV1alpha1Policies[role.Namespace] == nil {
+			policy.namespaceToV1alpha1Policies[role.Namespace] = &RolesAndBindings{
 				Bindings: map[string][]*rbacproto.ServiceRoleBinding{},
 			}
 		}
-		rolesAndBindings := policy.namespaceToV1Policies[role.Namespace]
+		rolesAndBindings := policy.namespaceToV1alpha1Policies[role.Namespace]
 		rolesAndBindings.Roles = append(rolesAndBindings.Roles, role)
 	}
 }
@@ -152,14 +187,25 @@ func (policy *AuthorizationPolicies) addServiceRoleBindings(bindings []Config) {
 			return
 		}
 
-		if policy.namespaceToV1Policies[binding.Namespace] == nil {
-			policy.namespaceToV1Policies[binding.Namespace] = &RolesAndBindings{
+		if policy.namespaceToV1alpha1Policies[binding.Namespace] == nil {
+			policy.namespaceToV1alpha1Policies[binding.Namespace] = &RolesAndBindings{
 				Bindings: map[string][]*rbacproto.ServiceRoleBinding{},
 			}
 		}
-		rolesAndBindings := policy.namespaceToV1Policies[binding.Namespace]
+		rolesAndBindings := policy.namespaceToV1alpha1Policies[binding.Namespace]
 		rolesAndBindings.Bindings[name] = append(
 			rolesAndBindings.Bindings[name], binding.Spec.(*rbacproto.ServiceRoleBinding))
+	}
+}
+
+func (policy *AuthorizationPolicies) addAuthorizationPolicies(configs []Config) {
+	if policy == nil {
+		return
+	}
+
+	for _, config := range configs {
+		policy.namespaceToV1beta1Policies[config.Namespace] =
+			append(policy.namespaceToV1beta1Policies[config.Namespace], config)
 	}
 }
 

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -136,17 +136,17 @@ func (policy *AuthorizationPolicies) ListServiceRoleBindings(ns string) map[stri
 }
 
 // ListAuthorizationPolicies returns the AuthorizationPolicy for the workload in the given namespace.
-func (policy *AuthorizationPolicies) ListAuthorizationPolicies(ns string, workloadLabels map[string]string) []Config {
+func (policy *AuthorizationPolicies) ListAuthorizationPolicies(ns string, workloadLabels labels.Collection) []Config {
 	if policy == nil {
 		return nil
 	}
 
 	var ret []Config
-	workload := labels.Instance(workloadLabels)
+
 	for _, config := range policy.namespaceToV1beta1Policies[ns] {
 		spec := config.Spec.(*authpb.AuthorizationPolicy)
 		selector := labels.Instance(spec.GetSelector().GetMatchLabels())
-		if selector.SubsetOf(workload) {
+		if workloadLabels.IsSupersetOf(selector) {
 			ret = append(ret, config)
 		}
 	}

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -83,8 +83,8 @@ func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) 
 	return policy, nil
 }
 
-// IsV1alpha1RBACEnabled returns true if RBAC is enabled for the service in the given namespace.
-func (policy *AuthorizationPolicies) IsV1alpha1RBACEnabled(service string, namespace string) bool {
+// IsRBACEnabled returns true if RBAC is enabled for the service in the given namespace.
+func (policy *AuthorizationPolicies) IsRBACEnabled(service string, namespace string) bool {
 	if policy == nil || policy.rbacConfig == nil {
 		return false
 	}
@@ -145,12 +145,8 @@ func (policy *AuthorizationPolicies) ListAuthorizationPolicies(ns string, worklo
 	workload := labels.Instance(workloadLabels)
 	for _, config := range policy.namespaceToV1beta1Policies[ns] {
 		spec := config.Spec.(*authpb.AuthorizationPolicy)
-		matched := true
-		if len(spec.GetSelector().GetMatchLabels()) > 0 {
-			selector := labels.Instance(spec.Selector.MatchLabels)
-			matched = selector.SubsetOf(workload)
-		}
-		if matched {
+		selector := labels.Instance(spec.GetSelector().GetMatchLabels())
+		if selector.SubsetOf(workload) {
 			ret = append(ret, config)
 		}
 	}

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -433,7 +433,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 	}
 }
 
-func TestAuthorizationPolicies_IsV1RbacEnabled(t *testing.T) {
+func TestAuthorizationPolicies_IsRBACEnabled(t *testing.T) {
 	target := &rbacproto.RbacConfig_Target{
 		Services:   []string{"review.default.svc", "product.default.svc"},
 		Namespaces: []string{"special"},
@@ -554,7 +554,7 @@ func TestAuthorizationPolicies_IsV1RbacEnabled(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			authzPolicies := createFakeAuthorizationPolicies(tc.config, t)
-			got := authzPolicies.IsV1alpha1RBACEnabled(tc.service, tc.namespace)
+			got := authzPolicies.IsRBACEnabled(tc.service, tc.namespace)
 			if tc.want != got {
 				t.Errorf("want %v but got %v", tc.want, got)
 			}

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -419,6 +419,18 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			name: "namespace not match",
+			ns:   "foo",
+			workloadLabels: map[string]string{
+				"app":     "httpbin",
+				"version": "v1",
+			},
+			configs: []Config{
+				newConfig("authz-1", "bar", policyWithSelector),
+			},
+			want: nil,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -20,11 +20,11 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
-	"istio.io/istio/pkg/config/labels"
 
 	rbacproto "istio.io/api/rbac/v1alpha1"
 	authpb "istio.io/api/security/v1beta1"
 	selectorpb "istio.io/api/type/v1beta1"
+	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schemas"
 )

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	rbacproto "istio.io/api/rbac/v1alpha1"
+	authpb "istio.io/api/security/v1beta1"
+	selectorpb "istio.io/api/type/v1beta1"
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schemas"
 )
@@ -96,7 +98,7 @@ func TestGetAuthorizationPolicies(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			authzPolicies := createFakeAuthorizationPolicies(c.config, t)
-			got := authzPolicies.namespaceToV1Policies[testNS]
+			got := authzPolicies.namespaceToV1alpha1Policies[testNS]
 			if !reflect.DeepEqual(c.want, got) {
 				t.Errorf("want:\n%s\n, got:\n%s\n", c.want, got)
 			}
@@ -104,7 +106,7 @@ func TestGetAuthorizationPolicies(t *testing.T) {
 	}
 }
 
-func TestGetRolesInNamespace(t *testing.T) {
+func TestAuthorizationPolicies_ListServiceRolesRoles(t *testing.T) {
 	role := &rbacproto.ServiceRole{}
 	binding := &rbacproto.ServiceRoleBinding{
 		Subjects: []*rbacproto.Subject{
@@ -176,7 +178,7 @@ func TestGetRolesInNamespace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			authzPolicies := createFakeAuthorizationPolicies(tc.configs, t)
 
-			got := authzPolicies.GetRolesInNamespace(tc.ns)
+			got := authzPolicies.ListServiceRoles(tc.ns)
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Errorf("want:%v\n but got: %v\n", tc.want, got)
 			}
@@ -184,7 +186,7 @@ func TestGetRolesInNamespace(t *testing.T) {
 	}
 }
 
-func TestGetBindingsInNamespace(t *testing.T) {
+func TestAuthorizationPolicies_ListServiceRoleBindings(t *testing.T) {
 	role := &rbacproto.ServiceRole{}
 	binding := &rbacproto.ServiceRoleBinding{
 		Subjects: []*rbacproto.Subject{
@@ -295,7 +297,7 @@ func TestGetBindingsInNamespace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			authzPolicies := createFakeAuthorizationPolicies(tc.configs, t)
 
-			got := authzPolicies.GetBindingsInNamespace(tc.ns)
+			got := authzPolicies.ListServiceRoleBindings(tc.ns)
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Errorf("want: %v\n but got: %v", tc.want, got)
 			}
@@ -303,7 +305,135 @@ func TestGetBindingsInNamespace(t *testing.T) {
 	}
 }
 
-func TestIsV1RbacEnabled(t *testing.T) {
+func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
+	policy := &authpb.AuthorizationPolicy{
+		Rules: []*authpb.Rule{
+			{
+				From: []*authpb.Rule_From{
+					{
+						Source: &authpb.Source{
+							Principals: []string{"sleep"},
+						},
+					},
+				},
+				To: []*authpb.Rule_To{
+					{
+						Operation: &authpb.Operation{
+							Methods: []string{"GET"},
+						},
+					},
+				},
+			},
+		},
+	}
+	policyWithSelector := proto.Clone(policy).(*authpb.AuthorizationPolicy)
+	policyWithSelector.Selector = &selectorpb.WorkloadSelector{
+		MatchLabels: map[string]string{
+			"app":     "httpbin",
+			"version": "v1",
+		},
+	}
+
+	cases := []struct {
+		name           string
+		ns             string
+		workloadLabels map[string]string
+		configs        []Config
+		want           []Config
+	}{
+		{
+			name: "no policies",
+			ns:   "foo",
+			want: nil,
+		},
+		{
+			name: "no policies in namespace foo",
+			ns:   "foo",
+			configs: []Config{
+				newConfig("authz-1", "bar", policy),
+				newConfig("authz-2", "bar", policy),
+			},
+			want: nil,
+		},
+		{
+			name: "one policy",
+			ns:   "bar",
+			configs: []Config{
+				newConfig("authz-1", "bar", policy),
+			},
+			want: []Config{
+				newConfig("authz-1", "bar", policy),
+			},
+		},
+		{
+			name: "two policies",
+			ns:   "bar",
+			configs: []Config{
+				newConfig("authz-1", "foo", policy),
+				newConfig("authz-1", "bar", policy),
+				newConfig("authz-2", "bar", policy),
+			},
+			want: []Config{
+				newConfig("authz-1", "bar", policy),
+				newConfig("authz-2", "bar", policy),
+			},
+		},
+		{
+			name: "selector exact match",
+			ns:   "bar",
+			workloadLabels: map[string]string{
+				"app":     "httpbin",
+				"version": "v1",
+			},
+			configs: []Config{
+				newConfig("authz-1", "bar", policyWithSelector),
+			},
+			want: []Config{
+				newConfig("authz-1", "bar", policyWithSelector),
+			},
+		},
+		{
+			name: "selector subset match",
+			ns:   "bar",
+			workloadLabels: map[string]string{
+				"app":     "httpbin",
+				"version": "v1",
+				"env":     "dev",
+			},
+			configs: []Config{
+				newConfig("authz-1", "bar", policyWithSelector),
+			},
+			want: []Config{
+				newConfig("authz-1", "bar", policyWithSelector),
+			},
+		},
+		{
+			name: "selector not match",
+			ns:   "bar",
+			workloadLabels: map[string]string{
+				"app":     "httpbin",
+				"version": "v2",
+			},
+			configs: []Config{
+				newConfig("authz-1", "bar", policyWithSelector),
+			},
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			authzPolicies := createFakeAuthorizationPolicies(tc.configs, t)
+
+			got := authzPolicies.ListAuthorizationPolicies(tc.ns, tc.workloadLabels)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Errorf("want:%v\n but got: %v\n", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestAuthorizationPolicies_IsV1RbacEnabled(t *testing.T) {
 	target := &rbacproto.RbacConfig_Target{
 		Services:   []string{"review.default.svc", "product.default.svc"},
 		Namespaces: []string{"special"},
@@ -424,7 +554,7 @@ func TestIsV1RbacEnabled(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			authzPolicies := createFakeAuthorizationPolicies(tc.config, t)
-			got := authzPolicies.IsV1RbacEnabled(tc.service, tc.namespace)
+			got := authzPolicies.IsV1alpha1RBACEnabled(tc.service, tc.namespace)
 			if tc.want != got {
 				t.Errorf("want %v but got %v", tc.want, got)
 			}
@@ -455,6 +585,8 @@ func newConfig(name, ns string, spec proto.Message) Config {
 		typ = schemas.ServiceRole.Type
 	case *rbacproto.ServiceRoleBinding:
 		typ = schemas.ServiceRoleBinding.Type
+	case *authpb.AuthorizationPolicy:
+		typ = schemas.AuthorizationPolicy.Type
 	}
 	return Config{
 		ConfigMeta: ConfigMeta{

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
+	"istio.io/istio/pkg/config/labels"
 
 	rbacproto "istio.io/api/rbac/v1alpha1"
 	authpb "istio.io/api/security/v1beta1"
@@ -437,7 +438,8 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			authzPolicies := createFakeAuthorizationPolicies(tc.configs, t)
 
-			got := authzPolicies.ListAuthorizationPolicies(tc.ns, tc.workloadLabels)
+			got := authzPolicies.ListAuthorizationPolicies(
+				tc.ns, []labels.Instance{labels.Instance(tc.workloadLabels)})
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Errorf("want:%v\n but got: %v\n", tc.want, got)
 			}

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -79,7 +79,8 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 		return
 	}
 
-	builder := authz_builder.NewBuilder(in.ServiceInstance, in.Push.AuthzPolicies, util.IsXDSMarshalingToAnyEnabled(in.Node))
+	builder := authz_builder.NewBuilder(in.ServiceInstance, in.Node.WorkloadLabels,
+		in.Push.AuthzPolicies, util.IsXDSMarshalingToAnyEnabled(in.Node))
 	if builder == nil {
 		return
 	}

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -95,11 +95,15 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 			httpFilter := builder.BuildHTTPFilter()
 			for cnum := range mutable.FilterChains {
 				if mutable.FilterChains[cnum].ListenerProtocol == plugin.ListenerProtocolHTTP {
-					rbacLog.Debugf("added HTTP filter to gateway filter chain %d", cnum)
-					mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, httpFilter)
+					if httpFilter != nil {
+						rbacLog.Debugf("added HTTP filter to gateway filter chain %d", cnum)
+						mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, httpFilter)
+					}
 				} else {
-					rbacLog.Debugf("added TCP filter to gateway filter chain %d", cnum)
-					mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, tcpFilter)
+					if tcpFilter != nil {
+						rbacLog.Debugf("added TCP filter to gateway filter chain %d", cnum)
+						mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, tcpFilter)
+					}
 				}
 			}
 		} else {
@@ -139,7 +143,7 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 	}
 }
 
-// OnVirtualListener implments the Plugin interface method.
+// OnVirtualListener implements the Plugin interface method.
 func (Plugin) OnVirtualListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	return nil
 }

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/security/authz/policy"
 	"istio.io/istio/pilot/pkg/security/authz/policy/v1alpha1"
 	"istio.io/istio/pilot/pkg/security/authz/policy/v1beta1"
+	"istio.io/istio/pkg/config/labels"
 	istiolog "istio.io/pkg/log"
 )
 
@@ -44,7 +45,7 @@ type Builder struct {
 }
 
 // NewBuilder creates a builder instance that can be used to build corresponding RBAC filter config.
-func NewBuilder(serviceInstance *model.ServiceInstance, policies *model.AuthorizationPolicies, isXDSMarshalingToAnyEnabled bool) *Builder {
+func NewBuilder(serviceInstance *model.ServiceInstance, workloadLabels labels.Collection, policies *model.AuthorizationPolicies, isXDSMarshalingToAnyEnabled bool) *Builder {
 	if serviceInstance.Service == nil {
 		rbacLog.Errorf("no service for serviceInstance: %v", serviceInstance)
 		return nil
@@ -72,12 +73,12 @@ func NewBuilder(serviceInstance *model.ServiceInstance, policies *model.Authoriz
 	}
 
 	// TODO: support policy in root namespace.
-	matchedPolicies := policies.ListAuthorizationPolicies(serviceNamespace, serviceMetadata.Labels)
+	matchedPolicies := policies.ListAuthorizationPolicies(serviceNamespace, workloadLabels)
 	if len(matchedPolicies) > 0 {
 		builder.v1beta1Generator = v1beta1.NewGenerator(matchedPolicies)
 	} else {
 		rbacLog.Debugf("v1beta1 authorization policies disabled for workload %v in %s",
-			serviceMetadata.Labels, serviceNamespace)
+			workloadLabels, serviceNamespace)
 	}
 
 	if builder.v1alpha1Generator == nil && builder.v1beta1Generator == nil {

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -15,15 +15,20 @@
 package builder
 
 import (
+	"fmt"
+
 	tcp_filter "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	http_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
 	http_filter "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	tcp_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rbac/v2"
+	envoy_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
 	"istio.io/istio/pilot/pkg/security/authz/policy"
-	v1 "istio.io/istio/pilot/pkg/security/authz/policy/v1"
+	"istio.io/istio/pilot/pkg/security/authz/policy/v1alpha1"
+	"istio.io/istio/pilot/pkg/security/authz/policy/v1beta1"
 	istiolog "istio.io/pkg/log"
 )
 
@@ -34,7 +39,8 @@ var (
 // Builder wraps all needed information for building the RBAC filter for a service.
 type Builder struct {
 	isXDSMarshalingToAnyEnabled bool
-	generator                   policy.Generator
+	v1alpha1Generator           policy.Generator
+	v1beta1Generator            policy.Generator
 }
 
 // NewBuilder creates a builder instance that can be used to build corresponding RBAC filter config.
@@ -47,11 +53,6 @@ func NewBuilder(serviceInstance *model.ServiceInstance, policies *model.Authoriz
 	serviceName := serviceInstance.Service.Attributes.Name
 	serviceNamespace := serviceInstance.Service.Attributes.Namespace
 	serviceHostname := string(serviceInstance.Service.Hostname)
-	if !policies.IsV1RbacEnabled(serviceHostname, serviceNamespace) {
-		rbacLog.Debugf("RBAC disabled for service %s", serviceHostname)
-		return nil
-	}
-
 	serviceMetadata, err := authz_model.NewServiceMetadata(serviceName, serviceNamespace, serviceInstance)
 	if err != nil {
 		rbacLog.Errorf("failed to create ServiceMetadata for %s: %s", serviceName, err)
@@ -59,17 +60,43 @@ func NewBuilder(serviceInstance *model.ServiceInstance, policies *model.Authoriz
 	}
 
 	isGlobalPermissiveEnabled := policies.IsGlobalPermissiveEnabled()
-	generator := v1.NewGenerator(serviceMetadata, policies, isGlobalPermissiveEnabled)
 
-	return &Builder{
+	builder := &Builder{
 		isXDSMarshalingToAnyEnabled: isXDSMarshalingToAnyEnabled,
-		generator:                   generator,
 	}
+
+	if policies.IsV1alpha1RBACEnabled(serviceHostname, serviceNamespace) {
+		builder.v1alpha1Generator = v1alpha1.NewGenerator(serviceMetadata, policies, isGlobalPermissiveEnabled)
+	} else {
+		rbacLog.Debugf("v1alpha1 RBAC policy disabled for service %s", serviceHostname)
+	}
+
+	// TODO: support policy in root namespace.
+	matchedPolicies := policies.ListAuthorizationPolicies(serviceNamespace, serviceMetadata.Labels)
+	if len(matchedPolicies) > 0 {
+		builder.v1beta1Generator = v1beta1.NewGenerator(matchedPolicies)
+	} else {
+		rbacLog.Debugf("v1beta1 authorization policies disabled for workload %v in %s",
+			serviceMetadata.Labels, serviceNamespace)
+	}
+
+	if builder.v1alpha1Generator == nil && builder.v1beta1Generator == nil {
+		return nil
+	}
+
+	return builder
 }
 
 // BuildHTTPFilter builds the RBAC HTTP filter.
 func (b *Builder) BuildHTTPFilter() *http_filter.HttpFilter {
-	rbacConfig := b.generator.Generate(false /* forTCPFilter */)
+	if b == nil {
+		return nil
+	}
+
+	rbacConfig := b.generate(false /* forTCPFilter */)
+	if rbacConfig == nil {
+		return nil
+	}
 	httpConfig := http_filter.HttpFilter{
 		Name: authz_model.RBACHTTPFilterName,
 	}
@@ -85,9 +112,16 @@ func (b *Builder) BuildHTTPFilter() *http_filter.HttpFilter {
 
 // BuildTCPFilter builds the RBAC TCP filter.
 func (b *Builder) BuildTCPFilter() *tcp_filter.Filter {
+	if b == nil {
+		return nil
+	}
+
 	// The build function always return the config for HTTP filter, we need to extract the
 	// generated rules and set it in the config for TCP filter.
-	config := b.generator.Generate(true /* forTCPFilter */)
+	config := b.generate(true /* forTCPFilter */)
+	if config == nil {
+		return nil
+	}
 	rbacConfig := &tcp_config.RBAC{
 		Rules:       config.Rules,
 		ShadowRules: config.ShadowRules,
@@ -105,4 +139,41 @@ func (b *Builder) BuildTCPFilter() *tcp_filter.Filter {
 
 	rbacLog.Debugf("built tcp filter config: %v", tcpConfig)
 	return &tcpConfig
+}
+
+func (b *Builder) generate(forTCPFilter bool) *http_config.RBAC {
+	var v1alpha1Config *http_config.RBAC
+	if b.v1alpha1Generator != nil {
+		v1alpha1Config = b.v1alpha1Generator.Generate(forTCPFilter)
+		rbacLog.Debugf("generated filter config from v1alpha1 policy: %v", v1alpha1Config)
+	}
+
+	var v1beta1Config *http_config.RBAC
+	if b.v1beta1Generator != nil {
+		v1beta1Config = b.v1beta1Generator.Generate(forTCPFilter)
+		rbacLog.Debugf("generated filter config from v1beta1 policy: %v", v1beta1Config)
+	}
+
+	if v1alpha1Config == nil && v1beta1Config == nil {
+		rbacLog.Errorf("No RBAC filter config generator available")
+		return nil
+	} else if v1alpha1Config == nil {
+		return v1beta1Config
+	} else if v1beta1Config == nil {
+		return v1alpha1Config
+	}
+
+	if v1alpha1Config.Rules == nil {
+		v1alpha1Config.Rules = &envoy_rbac.RBAC{}
+	}
+	if v1alpha1Config.Rules.Policies == nil {
+		v1alpha1Config.Rules.Policies = map[string]*envoy_rbac.Policy{}
+	}
+	// Only need to merge rules, the shadow rules is not supported in v1beta1.
+	for k, v := range v1beta1Config.GetRules().GetPolicies() {
+		name := fmt.Sprintf("authz-v1beta1-merged[%s]", k)
+		v1alpha1Config.Rules.Policies[name] = v
+	}
+	rbacLog.Debugf("merged v1beta1 to v1alpha1 config: %v", v1alpha1Config)
+	return v1alpha1Config
 }

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -45,7 +45,8 @@ type Builder struct {
 }
 
 // NewBuilder creates a builder instance that can be used to build corresponding RBAC filter config.
-func NewBuilder(serviceInstance *model.ServiceInstance, workloadLabels labels.Collection, policies *model.AuthorizationPolicies, isXDSMarshalingToAnyEnabled bool) *Builder {
+func NewBuilder(serviceInstance *model.ServiceInstance, workloadLabels labels.Collection,
+	policies *model.AuthorizationPolicies, isXDSMarshalingToAnyEnabled bool) *Builder {
 	if serviceInstance.Service == nil {
 		rbacLog.Errorf("no service for serviceInstance: %v", serviceInstance)
 		return nil

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -65,7 +65,7 @@ func NewBuilder(serviceInstance *model.ServiceInstance, policies *model.Authoriz
 		isXDSMarshalingToAnyEnabled: isXDSMarshalingToAnyEnabled,
 	}
 
-	if policies.IsV1alpha1RBACEnabled(serviceHostname, serviceNamespace) {
+	if policies.IsRBACEnabled(serviceHostname, serviceNamespace) {
 		builder.v1alpha1Generator = v1alpha1.NewGenerator(serviceMetadata, policies, isGlobalPermissiveEnabled)
 	} else {
 		rbacLog.Debugf("v1alpha1 RBAC policy disabled for service %s", serviceHostname)

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/util"
 
 	istio_rbac "istio.io/api/rbac/v1alpha1"
-
 	"istio.io/istio/pilot/pkg/model"
 	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
 	"istio.io/istio/pilot/pkg/security/authz/policy"
@@ -73,19 +72,48 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 		name                        string
 		policies                    []*model.Config
 		isXDSMarshalingToAnyEnabled bool
-		wantRuleWithPolicies        bool
+		wantPolicies                []string
 	}{
 		{
-			name:                        "XDSMarshalingToAnyEnabled",
+			name: "XDSMarshalingToAnyEnabled",
+			policies: []*model.Config{
+				policy.SimpleClusterRbacConfig(),
+			},
 			isXDSMarshalingToAnyEnabled: true,
+			wantPolicies:                []string{},
 		},
 		{
-			name: "HTTP rule",
+			name: "v1alpha1 only",
+			policies: []*model.Config{
+				policy.SimpleClusterRbacConfig(),
+				policy.SimpleRole("role-1", "a", "bar"),
+				policy.SimpleBinding("binding-1", "a", "role-1"),
+			},
+			wantPolicies: []string{"role-1"},
+		},
+		{
+			name: "v1alpha1 without ClusterRbacConfig",
 			policies: []*model.Config{
 				policy.SimpleRole("role-1", "a", "bar"),
 				policy.SimpleBinding("binding-1", "a", "role-1"),
 			},
-			wantRuleWithPolicies: true,
+		},
+		{
+			name: "v1beta1 only",
+			policies: []*model.Config{
+				policy.SimpleAuthzPolicy("authz-bar", "a"),
+			},
+			wantPolicies: []string{"authz-bar"},
+		},
+		{
+			name: "v1alpha1 and v1beta1",
+			policies: []*model.Config{
+				policy.SimpleClusterRbacConfig(),
+				policy.SimpleRole("role-1", "a", "bar"),
+				policy.SimpleBinding("binding-1", "a", "role-1"),
+				policy.SimpleAuthzPolicy("authz-bar", "a"),
+			},
+			wantPolicies: []string{"role-1", "authz-v1beta1-merged[authz-bar]"},
 		},
 	}
 
@@ -94,25 +122,41 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 		b := NewBuilder(service, p, tc.isXDSMarshalingToAnyEnabled)
 
 		got := b.BuildHTTPFilter()
-		if got.Name != authz_model.RBACHTTPFilterName {
-			t.Errorf("%s: got filter name %q but want %q", tc.name, got.Name, authz_model.RBACHTTPFilterName)
-		}
-
-		if tc.isXDSMarshalingToAnyEnabled {
-			if got.GetTypedConfig() == nil {
-				t.Errorf("%s: want typed config when isXDSMarshalingToAnyEnabled is true", tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantPolicies == nil {
+				if got != nil {
+					t.Errorf("want empty config but got: %v", got)
+				}
+			} else {
+				if got.Name != authz_model.RBACHTTPFilterName {
+					t.Errorf("got filter name %q but want %q", got.Name, authz_model.RBACHTTPFilterName)
+				}
+				if tc.isXDSMarshalingToAnyEnabled {
+					if got.GetTypedConfig() == nil {
+						t.Errorf("want typed config when isXDSMarshalingToAnyEnabled is true")
+					}
+				} else {
+					rbacConfig := &http_config.RBAC{}
+					if got.GetConfig() == nil {
+						t.Errorf("want struct config when isXDSMarshalingToAnyEnabled is false")
+					} else if err := util.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
+						t.Errorf("failed to convert struct to message: %s", err)
+					} else {
+						if len(tc.wantPolicies) == 0 {
+							if len(rbacConfig.GetRules().GetPolicies()) > 0 {
+								t.Errorf("got rules with policies %v but want no policies", rbacConfig.GetRules().GetPolicies())
+							}
+						} else {
+							for _, want := range tc.wantPolicies {
+								if _, found := rbacConfig.GetRules().GetPolicies()[want]; !found {
+									t.Errorf("got rules with policies %v but want %v", rbacConfig.GetRules().GetPolicies(), want)
+								}
+							}
+						}
+					}
+				}
 			}
-		} else {
-			rbacConfig := &http_config.RBAC{}
-			if got.GetConfig() == nil {
-				t.Errorf("%s: want struct config when isXDSMarshalingToAnyEnabled is false", tc.name)
-			} else if err := util.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
-				t.Errorf("%s: failed to convert struct to message: %s", tc.name, err)
-			} else if len(rbacConfig.GetRules().GetPolicies()) > 0 != tc.wantRuleWithPolicies {
-				t.Errorf("%s: got rules with policies %v but want %v",
-					tc.name, len(rbacConfig.GetRules().GetPolicies()) > 0, tc.wantRuleWithPolicies)
-			}
-		}
+		})
 	}
 }
 
@@ -128,12 +172,16 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 		wantShadowRules             bool
 	}{
 		{
-			name:                        "XDSMarshalingToAnyEnabled",
+			name: "XDSMarshalingToAnyEnabled",
+			policies: []*model.Config{
+				policy.SimpleClusterRbacConfig(),
+			},
 			isXDSMarshalingToAnyEnabled: true,
 		},
 		{
 			name: "HTTP rule",
 			policies: []*model.Config{
+				policy.SimpleClusterRbacConfig(),
 				policy.SimpleRole("role-1", "a", "foo"),
 				policy.SimpleBinding("binding-1", "a", "role-1"),
 			},
@@ -141,7 +189,10 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 			wantRuleWithPolicies: false,
 		},
 		{
-			name:      "normal rule",
+			name: "normal rule",
+			policies: []*model.Config{
+				policy.SimpleClusterRbacConfig(),
+			},
 			wantRules: true,
 		},
 		{
@@ -157,40 +208,42 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 		p := policy.NewAuthzPolicies(tc.policies, t)
 		b := NewBuilder(service, p, tc.isXDSMarshalingToAnyEnabled)
 
-		got := b.BuildTCPFilter()
-		if got.Name != authz_model.RBACTCPFilterName {
-			t.Errorf("%s: got filter name %q but want %q", tc.name, got.Name, authz_model.RBACTCPFilterName)
-		}
-
-		if tc.isXDSMarshalingToAnyEnabled {
-			if got.GetTypedConfig() == nil {
-				t.Errorf("%s: want typed config when isXDSMarshalingToAnyEnabled is true", tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			got := b.BuildTCPFilter()
+			if got.Name != authz_model.RBACTCPFilterName {
+				t.Errorf("got filter name %q but want %q", got.Name, authz_model.RBACTCPFilterName)
 			}
-		} else {
-			rbacConfig := &tcp_config.RBAC{}
-			if got.GetConfig() == nil {
-				t.Errorf("%s: want struct config when isXDSMarshalingToAnyEnabled is false", tc.name)
-			} else if err := util.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
-				t.Errorf("%s: failed to convert struct to message: %s", tc.name, err)
+
+			if tc.isXDSMarshalingToAnyEnabled {
+				if got.GetTypedConfig() == nil {
+					t.Errorf("want typed config when isXDSMarshalingToAnyEnabled is true")
+				}
 			} else {
-				if rbacConfig.StatPrefix != authz_model.RBACTCPFilterStatPrefix {
-					t.Errorf("%s: got filter stat prefix %q but want %q",
-						tc.name, rbacConfig.StatPrefix, authz_model.RBACTCPFilterStatPrefix)
-				}
+				rbacConfig := &tcp_config.RBAC{}
+				if got.GetConfig() == nil {
+					t.Errorf("want struct config when isXDSMarshalingToAnyEnabled is false")
+				} else if err := util.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
+					t.Errorf("failed to convert struct to message: %s", err)
+				} else {
+					if rbacConfig.StatPrefix != authz_model.RBACTCPFilterStatPrefix {
+						t.Errorf("got filter stat prefix %q but want %q",
+							rbacConfig.StatPrefix, authz_model.RBACTCPFilterStatPrefix)
+					}
 
-				if len(rbacConfig.GetRules().GetPolicies()) > 0 != tc.wantRuleWithPolicies {
-					t.Errorf("%s: got rules with policies %v but want %v",
-						tc.name, len(rbacConfig.GetRules().GetPolicies()) > 0, tc.wantRuleWithPolicies)
-				}
-				if (rbacConfig.GetRules().GetPolicies() != nil) != tc.wantRules {
-					t.Errorf("%s: got rules %v but want %v",
-						tc.name, rbacConfig.GetRules().GetPolicies() != nil, tc.wantRules)
-				}
-				if (rbacConfig.GetShadowRules().GetPolicies() != nil) != tc.wantShadowRules {
-					t.Errorf("%s: got shadow rules %v but want %v",
-						tc.name, rbacConfig.GetShadowRules().GetPolicies() != nil, tc.wantShadowRules)
+					if len(rbacConfig.GetRules().GetPolicies()) > 0 != tc.wantRuleWithPolicies {
+						t.Errorf("got rules with policies %v but want %v",
+							len(rbacConfig.GetRules().GetPolicies()) > 0, tc.wantRuleWithPolicies)
+					}
+					if (rbacConfig.GetRules().GetPolicies() != nil) != tc.wantRules {
+						t.Errorf("got rules %v but want %v",
+							rbacConfig.GetRules().GetPolicies() != nil, tc.wantRules)
+					}
+					if (rbacConfig.GetShadowRules().GetPolicies() != nil) != tc.wantShadowRules {
+						t.Errorf("got shadow rules %v but want %v",
+							rbacConfig.GetShadowRules().GetPolicies() != nil, tc.wantShadowRules)
+					}
 				}
 			}
-		}
+		})
 	}
 }

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -119,7 +119,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		p := policy.NewAuthzPolicies(tc.policies, t)
-		b := NewBuilder(service, p, tc.isXDSMarshalingToAnyEnabled)
+		b := NewBuilder(service, nil, p, tc.isXDSMarshalingToAnyEnabled)
 
 		got := b.BuildHTTPFilter()
 		t.Run(tc.name, func(t *testing.T) {
@@ -206,7 +206,7 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		p := policy.NewAuthzPolicies(tc.policies, t)
-		b := NewBuilder(service, p, tc.isXDSMarshalingToAnyEnabled)
+		b := NewBuilder(service, nil, p, tc.isXDSMarshalingToAnyEnabled)
 
 		t.Run(tc.name, func(t *testing.T) {
 			got := b.BuildTCPFilter()

--- a/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1_test.go
+++ b/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package v1alpha1
 
 import (
 	"testing"
@@ -23,7 +23,7 @@ import (
 	"istio.io/istio/pilot/pkg/security/authz/policy"
 )
 
-func TestBuilder_buildV1(t *testing.T) {
+func TestV1alpha1Generator_Generate(t *testing.T) {
 	serviceFoo := "foo"
 	namespaceA := "a"
 	serviceBar := "bar"
@@ -173,12 +173,12 @@ func TestBuilder_buildV1(t *testing.T) {
 			if authzPolicies == nil {
 				t.Fatal("failed to create authz policies")
 			}
-			b := NewGenerator(serviceFooInNamespaceA, authzPolicies, tc.isGlobalPermissiveEnabled)
-			if b == nil {
-				t.Fatal("failed to create builder")
+			g := NewGenerator(serviceFooInNamespaceA, authzPolicies, tc.isGlobalPermissiveEnabled)
+			if g == nil {
+				t.Fatal("failed to create generator")
 			}
 
-			got := b.Generate(tc.forTCPFilter)
+			got := g.Generate(tc.forTCPFilter)
 			gotStr := spew.Sdump(got)
 
 			if tc.isGlobalPermissiveEnabled {

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v2
+package v1beta1
 
 import (
 	http_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
@@ -21,7 +21,6 @@ import (
 	istiolog "istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/model"
-	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
 	"istio.io/istio/pilot/pkg/security/authz/policy"
 )
 
@@ -29,24 +28,17 @@ var (
 	rbacLog = istiolog.RegisterScope("rbac", "rbac debugging", 0)
 )
 
-type v2Generator struct {
-	serviceMetadata           *authz_model.ServiceMetadata
-	authzPolicies             *model.AuthorizationPolicies
-	isGlobalPermissiveEnabled bool
+type v1beta1Generator struct {
+	policies []model.Config
 }
 
-func NewGenerator(
-	serviceMetadata *authz_model.ServiceMetadata,
-	authzPolicies *model.AuthorizationPolicies,
-	isGlobalPermissiveEnabled bool) policy.Generator {
-	return &v2Generator{
-		serviceMetadata:           serviceMetadata,
-		authzPolicies:             authzPolicies,
-		isGlobalPermissiveEnabled: isGlobalPermissiveEnabled,
+func NewGenerator(policies []model.Config) policy.Generator {
+	return &v1beta1Generator{
+		policies: policies,
 	}
 }
 
-func (b *v2Generator) Generate(forTCPFilter bool) *http_config.RBAC {
+func (g *v1beta1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 	rbacLog.Debugf("building v1beta1 policy")
 
 	rbac := &envoy_rbac.RBAC{
@@ -54,6 +46,9 @@ func (b *v2Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 		Policies: map[string]*envoy_rbac.Policy{},
 	}
 
-	// TODO(yangminzhu): Implement the new authorization v1beta1 policy.
+	for _, config := range g.policies {
+		// TODO(yangminzhu): Implement the full authorization v1beta1 policy.
+		rbac.Policies[config.Name] = &envoy_rbac.Policy{}
+	}
 	return &http_config.RBAC{Rules: rbac}
 }

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v2
+package v1beta1
 
 import (
 	"testing"
@@ -23,14 +23,10 @@ import (
 	"istio.io/istio/pilot/pkg/security/authz/policy"
 )
 
-func TestBuilder_buildV2(t *testing.T) {
-	labelFoo := map[string]string{
-		"app": "foo",
-	}
-	serviceFooInNamespaceA := policy.NewServiceMetadata("foo.a.svc.cluster.local", labelFoo, t)
+func TestV1beta1Generator_Generate(t *testing.T) {
 	testCases := []struct {
 		name         string
-		policies     []*model.Config
+		policies     []model.Config
 		wantRules    map[string][]string
 		forTCPFilter bool
 	}{
@@ -41,16 +37,12 @@ func TestBuilder_buildV2(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			authzPolicies := policy.NewAuthzPolicies(tc.policies, t)
-			if authzPolicies == nil {
-				t.Fatal("failed to create authz policies")
-			}
-			b := NewGenerator(serviceFooInNamespaceA, authzPolicies, false)
-			if b == nil {
-				t.Fatal("failed to create builder")
+			g := NewGenerator(tc.policies)
+			if g == nil {
+				t.Fatal("failed to create generator")
 			}
 
-			got := b.Generate(tc.forTCPFilter)
+			got := g.Generate(tc.forTCPFilter)
 			gotStr := spew.Sdump(got)
 
 			if got.GetRules() == nil {


### PR DESCRIPTION
This PR adds initial support of v1beta1 authorization policy:
- add authorization policy to the model in push context
- add workload selector support
- merge v1alpha1 and v1beta1 policies if both applied to the same service/workload

This PR doesn't generate the actual RBAC filter config, will do in follow-up PRs.

https://github.com/istio/istio/issues/12394

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
