### PR TITLE
Fix mesh expansion

### DIFF
--- a/tools/packaging/common/istio-node-agent-start.sh
+++ b/tools/packaging/common/istio-node-agent-start.sh
@@ -23,6 +23,20 @@
 
 set -e
 
+# Load optional config variables
+ISTIO_SIDECAR_CONFIG=${ISTIO_SIDECAR_CONFIG:-/var/lib/istio/envoy/sidecar.env}
+if [[ -r ${ISTIO_SIDECAR_CONFIG} ]]; then
+  # shellcheck disable=SC1090
+  . "$ISTIO_SIDECAR_CONFIG"
+fi
+
+# Load config variables ISTIO_SYSTEM_NAMESPACE, CONTROL_PLANE_AUTH_POLICY
+ISTIO_CLUSTER_CONFIG=${ISTIO_CLUSTER_CONFIG:-/var/lib/istio/envoy/cluster.env}
+if [[ -r ${ISTIO_CLUSTER_CONFIG} ]]; then
+  # shellcheck disable=SC1090
+  . "$ISTIO_CLUSTER_CONFIG"
+fi
+
 # Set defaults
 ISTIO_BIN_BASE=${ISTIO_BIN_BASE:-/usr/local/bin}
 ISTIO_LOG_DIR=${ISTIO_LOG_DIR:-/var/log/istio}

--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -35,6 +35,8 @@ ISTIO_CLUSTER_CONFIG=${ISTIO_CLUSTER_CONFIG:-/var/lib/istio/envoy/cluster.env}
 if [[ -r ${ISTIO_CLUSTER_CONFIG} ]]; then
   # shellcheck disable=SC1090
   . "$ISTIO_CLUSTER_CONFIG"
+  # Make sure the documented configuration variables are exported
+  export ISTIO_CP_AUTH ISTIO_SERVICE_CIDR ISTIO_INBOUND_PORTS
 fi
 
 # Set defaults

--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -23,6 +23,20 @@ set -e
 # Match pilot/docker/Dockerfile.proxyv2
 export ISTIO_META_ISTIO_VERSION="1.3.0"
 
+# Load optional config variables
+ISTIO_SIDECAR_CONFIG=${ISTIO_SIDECAR_CONFIG:-/var/lib/istio/envoy/sidecar.env}
+if [[ -r ${ISTIO_SIDECAR_CONFIG} ]]; then
+  # shellcheck disable=SC1090
+  . "$ISTIO_SIDECAR_CONFIG"
+fi
+
+# Load config variables ISTIO_SYSTEM_NAMESPACE, CONTROL_PLANE_AUTH_POLICY
+ISTIO_CLUSTER_CONFIG=${ISTIO_CLUSTER_CONFIG:-/var/lib/istio/envoy/cluster.env}
+if [[ -r ${ISTIO_CLUSTER_CONFIG} ]]; then
+  # shellcheck disable=SC1090
+  . "$ISTIO_CLUSTER_CONFIG"
+fi
+
 # Set defaults
 ISTIO_BIN_BASE=${ISTIO_BIN_BASE:-/usr/local/bin}
 ISTIO_LOG_DIR=${ISTIO_LOG_DIR:-/var/log/istio}


### PR DESCRIPTION
This reverts the removal of reading sidecar.env and cluster.env in the startup scripts done in commit 30e0c3f78de7a. The second commit makes sure that the configuration variables become part of the environment and become visible to subprocesses.
This is intended to fix for #16599 (albeit in master).