### PR TITLE
Fix destination rule selection

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -596,6 +596,18 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 		}
 	}
 
+	// This can happen when finding the subset labels for a proxy in root namespace.
+	// Because based on a pure cluster name, we do not know the service and
+	// construct a fake service without setting Attributes at all.
+	if service.Attributes.Namespace == "" {
+		for _, svc := range ps.Services(proxy) {
+			if service.Hostname == svc.Hostname {
+				service.Attributes.Namespace = svc.Attributes.Namespace
+				break
+			}
+		}
+	}
+
 	// if no private/public rule matched in the calling proxy's namespace,
 	// check the target service's namespace for public rules
 	if service.Attributes.Namespace != "" && ps.namespaceExportedDestRules[service.Attributes.Namespace] != nil {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -601,7 +601,7 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 	// construct a fake service without setting Attributes at all.
 	if service.Attributes.Namespace == "" {
 		for _, svc := range ps.Services(proxy) {
-			if service.Hostname == svc.Hostname {
+			if service.Hostname == svc.Hostname && svc.Attributes.Namespace != "" {
 				service.Attributes.Namespace = svc.Attributes.Namespace
 				break
 			}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -596,13 +596,15 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 		}
 	}
 
+	svcNs := service.Attributes.Namespace
+
 	// This can happen when finding the subset labels for a proxy in root namespace.
 	// Because based on a pure cluster name, we do not know the service and
 	// construct a fake service without setting Attributes at all.
-	if service.Attributes.Namespace == "" {
+	if svcNs == "" {
 		for _, svc := range ps.Services(proxy) {
 			if service.Hostname == svc.Hostname && svc.Attributes.Namespace != "" {
-				service.Attributes.Namespace = svc.Attributes.Namespace
+				svcNs = svc.Attributes.Namespace
 				break
 			}
 		}
@@ -610,10 +612,10 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 
 	// if no private/public rule matched in the calling proxy's namespace,
 	// check the target service's namespace for public rules
-	if service.Attributes.Namespace != "" && ps.namespaceExportedDestRules[service.Attributes.Namespace] != nil {
+	if svcNs != "" && ps.namespaceExportedDestRules[svcNs] != nil {
 		if hostname, ok := MostSpecificHostMatch(service.Hostname,
-			ps.namespaceExportedDestRules[service.Attributes.Namespace].hosts); ok {
-			return ps.namespaceExportedDestRules[service.Attributes.Namespace].destRule[hostname].config
+			ps.namespaceExportedDestRules[svcNs].hosts); ok {
+			return ps.namespaceExportedDestRules[svcNs].destRule[hostname].config
 		}
 	}
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fix a bug when selecting subset labels for a proxy located in root namespace. The service constructed is not complete and does not include namespace info.

fixes: #16582
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
