### PR TITLE
do not start validation controller if validation is disabled

### DIFF
--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -44,8 +44,10 @@ func New(a *settings.Args) *Server {
 	readiness := components.NewProbe(&a.Readiness)
 	s.host.Add(readiness)
 
-	validation := components.NewValidation(a.KubeConfig, a.ValidationArgs, liveness.Controller(), readiness.Controller())
-	s.host.Add(validation)
+	if a.ValidationArgs != nil && a.ValidationArgs.EnableValidation {
+		validation := components.NewValidation(a.KubeConfig, a.ValidationArgs, liveness.Controller(), readiness.Controller())
+		s.host.Add(validation)
+	}
 
 	if a.EnableServer {
 		if a.UseOldProcessor {


### PR DESCRIPTION
It seems that galley starts the validation controller irrespective
of whether validation is enabled or not. The validation controller
tries to talk to Kube API server during initialization. On VMs where
there is no Kube API server, this results in constant errors and malfunction.

Signed-off-by: Shriram Rajagopalan <rshriram@tetrate.io>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure