### PR TITLE
[1.3] Fix sidecar takes too long getting initial config (#16338)

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery_test.go
@@ -33,10 +33,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 )
 
-func mockNeedsPush(node *model.Proxy) bool {
-	return true
-}
-
 func createProxies(n int) []*XdsConnection {
 	proxies := make([]*XdsConnection, 0, n)
 	for p := 0; p < n; p++ {
@@ -86,7 +82,7 @@ func TestSendPushesManyPushes(t *testing.T) {
 			}
 		}()
 	}
-	go doSendPushes(stopCh, semaphore, queue, mockNeedsPush)
+	go doSendPushes(stopCh, semaphore, queue)
 
 	for push := 0; push < 100; push++ {
 		for _, proxy := range proxies {
@@ -133,7 +129,7 @@ func TestSendPushesSinglePush(t *testing.T) {
 			}
 		}()
 	}
-	go doSendPushes(stopCh, semaphore, queue, mockNeedsPush)
+	go doSendPushes(stopCh, semaphore, queue)
 
 	for _, proxy := range proxies {
 		queue.Enqueue(proxy, &model.PushRequest{})

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -445,7 +445,6 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, workloadLabels map[string]st
 			Labels: workloadLabels,
 		}
 
-		fullPush := false
 		adsClientsMutex.RLock()
 		for _, connection := range adsClients {
 			// if the workload has envoy proxy and connected to server,
@@ -455,21 +454,15 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, workloadLabels map[string]st
 			//   case 2: the workload xDS connection has not been established,
 			//           also no need to trigger a full push here.
 			if connection.modelNode.IPAddresses[0] == id {
-				fullPush = true
+				// There is a possibility that the pod comes up later than endpoint.
+				// So no endpoints add/update events after this, we should request
+				// full push immediately to speed up sidecar startup.
+				s.pushQueue.Enqueue(connection, &model.PushRequest{Full: true, Push: s.globalPushContext(), Start: time.Now()})
+				break
 			}
 		}
 		adsClientsMutex.RUnlock()
 
-		if fullPush {
-			// First time this workload has been seen. Maybe after the first connect,
-			// do a full push for this proxy in the next push epoch.
-			s.proxyUpdatesMutex.Lock()
-			if s.proxyUpdates == nil {
-				s.proxyUpdates = make(map[string]struct{})
-			}
-			s.proxyUpdates[id] = struct{}{}
-			s.proxyUpdatesMutex.Unlock()
-		}
 		return
 	}
 	if reflect.DeepEqual(w.Labels, workloadLabels) {


### PR DESCRIPTION
* Fix sidecar takes too long getting initial config

* no need connection.modelNode.SetServiceInstances here

* fix dead lock

(cherry picked from commit 7fcc5ce5b124a9852ec53017be0e2a4e7bec003c)

https://github.com/istio/istio/pull/16338
