### PR TITLE
Fix unbuffered error channel usage

### DIFF
--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -403,7 +403,7 @@ func (client *Client) PodsForSelector(namespace, labelSelector string) (*v1.PodL
 
 func RunPortForwarder(fw *PortForward, readyFunc func(fw *PortForward) error) error {
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		errCh <- fw.Forwarder.ForwardPorts()
 	}()

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -69,8 +69,6 @@ type ADSC struct {
 	// NodeID is the node identity sent to Pilot.
 	nodeID string
 
-	done chan error
-
 	certDir string
 	url     string
 
@@ -130,7 +128,6 @@ var (
 // Dial connects to a ADS server, with optional MTLS authentication if a cert dir is specified.
 func Dial(url string, certDir string, opts *Config) (*ADSC, error) {
 	adsc := &ADSC{
-		done:        make(chan error),
 		Updates:     make(chan string, 100),
 		VersionInfo: map[string]string{},
 		certDir:     certDir,

--- a/pkg/test/docker/container.go
+++ b/pkg/test/docker/container.go
@@ -168,7 +168,7 @@ func (c *Container) Exec(ctx context.Context, cmd ...string) (ExecResult, error)
 
 	// read the output
 	var stdout, stderr bytes.Buffer
-	outputDone := make(chan error)
+	outputDone := make(chan error, 1)
 
 	go func() {
 		// StdCopy demultiplexes the stream into two buffers

--- a/pkg/test/kube/port_forwarder.go
+++ b/pkg/test/kube/port_forwarder.go
@@ -55,7 +55,7 @@ type defaultPortForwarder struct {
 }
 
 func (f *defaultPortForwarder) Start() error {
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		errCh <- f.forwarder.ForwardPorts()
 	}()

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -625,7 +625,7 @@ func CheckDeployment(ctx context.Context, namespace, deployment string, kubeconf
 		// This can be deployed by previous tests, but doesn't complete currently, blocking the test.
 		return nil
 	}
-	errc := make(chan error)
+	errc := make(chan error, 1)
 	go func() {
 		if _, err := ShellMuteOutput("kubectl -n %s rollout status %s --kubeconfig=%s", namespace, deployment, kubeconfig); err != nil {
 			errc <- fmt.Errorf("%s in namespace %s failed", deployment, namespace)


### PR DESCRIPTION
This fixes a common issue where we have an error channel that is
unbuffered. Later we have a select{}, and if that selects another case
the channel will never be read from, causing a deadlock

See https://github.com/istio/istio/pull/15897 for a real life case where
this caused Pilot to die.

Fixes https://github.com/istio/istio/issues/15902

