### PR TITLE
Use health endpoint for Grafana readiness probe

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           - containerPort: 3000
           readinessProbe:
             httpGet:
-              path: /login
+              path: /api/health
               port: 3000
           env:
           - name: GRAFANA_PORT


### PR DESCRIPTION
Prior to this change we used the login page, which returns 25kb of data.
This will cause the probe to fail in Kubernetes 1.16+
(https://github.com/kubernetes/kubernetes/pull/76518), which will limit
to 10kb.

This change mirrors the official Grafana charts readiness probe:
https://github.com/helm/charts/blob/master/stable/grafana/values.yaml#L18-L21

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
