### PR TITLE
Add helm option to set enableAutoMtls

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -126,8 +126,8 @@ data:
 
     # If set to true, and a given service does not have a corresponding DestinationRule configured,
     # or its DestinationRule does not have TLSSettings specified, Istio configures client side
-    # TLS configuration appropriately.
-    enableAutoMtls: {{ .Values.global.mtls.autoClientConfig }}
+    # TLS configuration appropriately. By default, it is true.
+    enableAutoMtls: {{ .Values.global.mtls.automatic }}
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application:
     # ALLOW_ANY - outbound traffic to unknown destinations will be allowed, in case there are no

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -124,6 +124,11 @@ data:
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
     trustDomain: {{ .Values.global.trustDomain | quote }}
 
+    # If set to true, and a given service does not have a corresponding DestinationRule configured,
+    # or its DestinationRule does not have TLSSettings specified, Istio configures client side
+    # TLS configuration appropriately.
+    enableAutoMtls: {{ .Values.global.mtls.autoClientConfig }}
+
     # Set the default behavior of the sidecar for handling outbound traffic from the application:
     # ALLOW_ANY - outbound traffic to unknown destinations will be allowed, in case there are no
     #   services or ServiceEntries for the destination port

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -124,9 +124,9 @@ data:
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
     trustDomain: {{ .Values.global.trustDomain | quote }}
 
-    # If set to true, and a given service does not have a corresponding DestinationRule configured,
-    # or its DestinationRule does not have TLSSettings specified, Istio configures client side
-    # TLS configuration appropriately.
+    # If true, automatically configure client side mTLS settings to match the corresponding service's
+    # server side mTLS authentication policy, when destination rule for that service does not specify
+    # TLS settings.
     enableAutoMtls: {{ .Values.global.mtls.automatic }}
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application:

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -53,7 +53,7 @@ data:
     enableEnvoyAccessLogService: {{ .Values.global.proxy.envoyAccessLogService.enabled }}
 
     {{- if .Values.global.istioRemote }}
-    
+
     {{- if .Values.global.remotePolicyAddress }}
     {{- if .Values.global.createRemoteSvcEndpoints }}
     mixerCheckServer: istio-policy.{{ .Release.Namespace }}:15004
@@ -68,7 +68,7 @@ data:
     mixerReportServer: {{ .Values.global.remoteTelemetryAddress }}:15004
     {{- end }}
     {{- end }}
-    
+
     {{- else }}
 
     {{- if .Values.mixer.policy.enabled }}
@@ -85,7 +85,7 @@ data:
     mixerReportServer: istio-telemetry.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}:9091
     {{- end }}
     {{- end }}
-    
+
     {{- end }}
 
     {{- if or .Values.mixer.policy.enabled (and .Values.global.istioRemote .Values.global.remotePolicyAddress) }}
@@ -127,7 +127,7 @@ data:
     # If true, automatically configure client side mTLS settings to match the corresponding service's
     # server side mTLS authentication policy, when destination rule for that service does not specify
     # TLS settings.
-    enableAutoMtls: {{ .Values.global.mtls.automatic }}
+    enableAutoMtls: {{ .Values.global.mtls.auto }}
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application:
     # ALLOW_ANY - outbound traffic to unknown destinations will be allowed, in case there are no
@@ -266,7 +266,7 @@ data:
       envoyAccessLogService:
         address: {{ .Values.global.proxy.envoyAccessLogService.host }}:{{ .Values.global.proxy.envoyAccessLogService.port }}
     {{- if .Values.global.proxy.envoyAccessLogService.tlsSettings }}
-        tlsSettings:  
+        tlsSettings:
 {{ toYaml .Values.global.proxy.envoyAccessLogService.tlsSettings | indent 10 }}
     {{- end}}
     {{- if .Values.global.proxy.envoyAccessLogService.tcpKeepalive }}

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -126,7 +126,7 @@ data:
 
     # If set to true, and a given service does not have a corresponding DestinationRule configured,
     # or its DestinationRule does not have TLSSettings specified, Istio configures client side
-    # TLS configuration appropriately. By default, it is true.
+    # TLS configuration appropriately.
     enableAutoMtls: {{ .Values.global.mtls.automatic }}
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -345,7 +345,7 @@ global:
     # If set to true, and a given service does not have a corresponding DestinationRule configured,
     # or its DestinationRule does not have TLSSettings specified, Istio configures client side
     # TLS configuration appropriately.
-    autoClientConfig: false
+    automatic: true
 
   # Lists the secrets you need to use to pull Istio images from a private registry.
   imagePullSecrets: []

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -346,7 +346,7 @@ global:
     # or its DestinationRule does not have TLSSettings specified, Istio configures client side
     # TLS configuration automatically, based on the server side mTLS authentication policy and the
     # availibity of sidecars.
-    automatic: false
+    auto: false
 
   # Lists the secrets you need to use to pull Istio images from a private registry.
   imagePullSecrets: []

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -345,7 +345,7 @@ global:
     # If set to true, and a given service does not have a corresponding DestinationRule configured,
     # or its DestinationRule does not have TLSSettings specified, Istio configures client side
     # TLS configuration appropriately.
-    automatic: true
+    automatic: false
 
   # Lists the secrets you need to use to pull Istio images from a private registry.
   imagePullSecrets: []

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -187,7 +187,7 @@ global:
         caCertificates: # example: /etc/istio/als/root-cert.pem
         sni: # example: als.somedomain
         subjectAltNames: []
-        # - als.somedomain 
+        # - als.somedomain
       tcpKeepalive:
         probes: 3
         time: 10s
@@ -342,6 +342,10 @@ global:
     # Default setting for service-to-service mtls. Can be set explicitly using
     # destination rules or service annotations.
     enabled: false
+    # If set to true, and a given service does not have a corresponding DestinationRule configured,
+    # or its DestinationRule does not have TLSSettings specified, Istio configures client side
+    # TLS configuration appropriately.
+    autoClientConfig: false
 
   # Lists the secrets you need to use to pull Istio images from a private registry.
   imagePullSecrets: []

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -344,7 +344,8 @@ global:
     enabled: false
     # If set to true, and a given service does not have a corresponding DestinationRule configured,
     # or its DestinationRule does not have TLSSettings specified, Istio configures client side
-    # TLS configuration appropriately.
+    # TLS configuration automatically, based on the server side mTLS authentication policy and the
+    # availibity of sidecars.
     automatic: false
 
   # Lists the secrets you need to use to pull Istio images from a private registry.


### PR DESCRIPTION
This PR adds enable_auto_mtls to configmap. This flag was introduced in https://github.com/istio/api/pull/1028.

Issue: https://github.com/istio/istio/issues/16586

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
