### PR TITLE
Modify binaries tests to support golang 1.13

### DIFF
--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -17,6 +17,7 @@ package binary
 import (
 	"encoding/json"
 	"flag"
+	"os"
 	"os/exec"
 	"path"
 	"strings"
@@ -30,11 +31,11 @@ var (
 	releasedir *string
 )
 
-func init() {
+func TestMain(m *testing.M) {
 	releasedir = flag.String("base-dir", "", "directory for binaries")
 	binaries = flag.String("binaries", "", "space separated binaries to test")
 	flag.Parse()
-
+	os.Exit(m.Run())
 }
 
 func TestVersion(t *testing.T) {


### PR DESCRIPTION
Golang 1.13 changes when flags are parsed, so if we do it in init it
will break the flag parsing of test flags like -v. See
https://tip.golang.org/doc/go1.13#testing.

Part of https://github.com/istio/istio/issues/16635