### PR TITLE
Use inlined jwks when set in JWT policy

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -183,7 +183,7 @@ func (r *JwksResolver) SetAuthenticationPolicyJwksURIs(policy *authn.Policy) err
 		switch method.GetParams().(type) {
 		case *authn.PeerAuthenticationMethod_Jwt:
 			policyJwt := method.GetJwt()
-			if policyJwt.JwksUri == "" {
+			if policyJwt.JwksUri == "" && policyJwt.Jwks == "" {
 				uri, err := r.resolveJwksURIUsingOpenID(policyJwt.Issuer)
 				if err != nil {
 					log.Warnf("Failed to get jwks_uri for issuer %q: %v", policyJwt.Issuer, err)
@@ -196,7 +196,7 @@ func (r *JwksResolver) SetAuthenticationPolicyJwksURIs(policy *authn.Policy) err
 	for _, method := range policy.Origins {
 		// JWT is only allowed authentication method type for Origin.
 		policyJwt := method.GetJwt()
-		if policyJwt.JwksUri == "" {
+		if policyJwt.JwksUri == "" && policyJwt.Jwks == "" {
 			uri, err := r.resolveJwksURIUsingOpenID(policyJwt.Issuer)
 			if err != nil {
 				log.Warnf("Failed to get jwks_uri for issuer %q: %v", policyJwt.Issuer, err)

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -124,6 +124,27 @@ func TestSetAuthenticationPolicyJwksURIs(t *testing.T) {
 			},
 			PrincipalBinding: authn.PrincipalBinding_USE_ORIGIN,
 		},
+		"jwks": {
+			Targets: []*authn.TargetSelector{{
+				Name: "two",
+				Ports: []*authn.PortSelector{
+					{
+						Port: &authn.PortSelector_Number{
+							Number: 80,
+						},
+					},
+				},
+			}},
+			Origins: []*authn.OriginAuthenticationMethod{
+				{
+					Jwt: &authn.Jwt{
+						Issuer: "http://abc",
+						Jwks:   "JSONWebKeySet",
+					},
+				},
+			},
+			PrincipalBinding: authn.PrincipalBinding_USE_ORIGIN,
+		},
 	}
 
 	cases := []struct {
@@ -137,6 +158,10 @@ func TestSetAuthenticationPolicyJwksURIs(t *testing.T) {
 		{
 			in:       authNPolicies["two"],
 			expected: "http://xyz",
+		},
+		{
+			in:       authNPolicies["jwks"],
+			expected: "",
 		},
 	}
 	for _, c := range cases {

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -136,9 +136,13 @@ func convertToEnvoyJwtConfig(policyJwts []*authn_v1alpha1.Jwt) *envoy_jwt.JwtAut
 		}
 		provider.FromParams = policyJwt.JwtParams
 
-		jwtPubKey, err := authn_model.JwtKeyResolver.GetPublicKey(policyJwt.JwksUri)
-		if err != nil {
-			log.Errorf("Failed to fetch jwt public key from %q: %s", policyJwt.JwksUri, err)
+		jwtPubKey := policyJwt.Jwks
+		if jwtPubKey == "" {
+			var err error
+			jwtPubKey, err = authn_model.JwtKeyResolver.GetPublicKey(policyJwt.JwksUri)
+			if err != nil {
+				log.Errorf("Failed to fetch jwt public key from %q: %s", policyJwt.JwksUri, err)
+			}
 		}
 		provider.JwksSourceSpecifier = &envoy_jwt.JwtProvider_LocalJwks{
 			LocalJwks: &core.DataSource{
@@ -191,9 +195,13 @@ func convertToIstioJwtConfig(policyJwts []*authn_v1alpha1.Jwt) *istio_jwt.JwtAut
 		}
 		jwt.FromParams = policyJwt.JwtParams
 
-		jwtPubKey, err := authn_model.JwtKeyResolver.GetPublicKey(policyJwt.JwksUri)
-		if err != nil {
-			log.Errorf("Failed to fetch jwt public key from %q: %s", policyJwt.JwksUri, err)
+		jwtPubKey := policyJwt.Jwks
+		if jwtPubKey == "" {
+			var err error
+			jwtPubKey, err = authn_model.JwtKeyResolver.GetPublicKey(policyJwt.JwksUri)
+			if err != nil {
+				log.Errorf("Failed to fetch jwt public key from %q: %s", policyJwt.JwksUri, err)
+			}
 		}
 
 		// Put empty string in config even if above ResolveJwtPubKey fails.


### PR DESCRIPTION
I intentionally didn't add validation for checking only one of jwksUri and jwks is set but just use the jwks if it's not empty. This gives us more flexibility to later decide the proper behavior here. We can only support one of the two fields, or use one of them as a fallback when the other one is not working.

https://github.com/istio/istio/issues/11439

Notes to 1.3 release managers (@rlenglet @sdake @brian-avery): The API (jwks field) is added long time before 1.3 (https://github.com/istio/api/pull/829) but we forgot to add the implementation. This PR is actually trying to fix this missing implementation bug and that's the reason for cherrypicking to 1.3 branch.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
