### PR TITLE
Fix broken doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ project. It includes:
 including Citadel (acting as Certificate Authority), citadel agent, etc.
   - [pilot](pilot/). This directory
 contains platform-specific code to populate the
-[abstract service model](https://istio.io/docs/concepts/traffic-management/overview.html), dynamically reconfigure the proxies
+[abstract service model](https://istio.io/docs/concepts/traffic-management/#pilot), dynamically reconfigure the proxies
 when the application topology changes, as well as translate
-[routing rules](https://istio.io/docs/reference/config/istio.networking.v1alpha3/) into proxy specific configuration.
+[routing rules](https://istio.io/docs/reference/config/networking/) into proxy specific configuration.
   - [istioctl](istioctl/). This directory contains code for the
 [_istioctl_](https://istio.io/docs/reference/commands/istioctl.html) command line utility.
   - [mixer](mixer/). This directory


### PR DESCRIPTION
Fix broken dock links in readme, which is outdated and return 404.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
