### PR TITLE
Cleanup pilot model structure

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -437,9 +437,8 @@ func waitForCompletion(ctx context.Context, fn func(context.Context)) {
 //explicitly setting the trustdomain so the pilot and mixer SAN will have same trustdomain
 //and the initialization of the spiffe pkg isn't linked to generating pilot's SAN first
 func setSpiffeTrustDomain(domain string) {
-
 	if controlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS.String() {
-		pilotTrustDomain := spiffe.GetTrustDomain()
+		pilotTrustDomain := trustDomain
 		if len(pilotTrustDomain) == 0 {
 			if registry == serviceregistry.KubernetesRegistry &&
 				(domain == podNamespaceVar.Get()+".svc.cluster.local" || domain == "") {
@@ -450,6 +449,7 @@ func setSpiffeTrustDomain(domain string) {
 			} else {
 				pilotTrustDomain = domain
 			}
+
 			spiffe.SetTrustDomain(pilotTrustDomain)
 		}
 	}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -60,6 +60,8 @@ var (
 	role             = &model.Proxy{Metadata: map[string]string{}}
 	proxyIP          string
 	registry         serviceregistry.ServiceRegistry
+	pilotIdentity    string
+	mixerIdentity    string
 	statusPort       uint16
 	applicationPorts []string
 
@@ -238,7 +240,7 @@ var (
 			setSpiffeTrustDomain(role.DNSDomain)
 
 			// Obtain the SAN to later create a Envoy proxy.
-			pilotSAN = getSAN(ns, envoyDiscovery.PilotSvcAccName, role.PilotIdentity)
+			pilotSAN = getSAN(ns, envoyDiscovery.PilotSvcAccName, pilotIdentity)
 			log.Infof("PilotSAN %#v", pilotSAN)
 
 			// resolve statsd address
@@ -330,7 +332,7 @@ var (
 						opts["wildcard"] = "::"
 						opts["dns_lookup_family"] = "AUTO"
 					}
-					mixerSAN := getSAN(ns, envoyDiscovery.MixerSvcAccName, role.MixerIdentity)
+					mixerSAN := getSAN(ns, envoyDiscovery.MixerSvcAccName, mixerIdentity)
 					log.Infof("MixerSAN %#v", mixerSAN)
 					if len(mixerSAN) > 1 {
 						opts["MixerSubjectAltName"] = mixerSAN[0]
@@ -573,9 +575,9 @@ func init() {
 		"DNS domain suffix. If not provided uses ${POD_NAMESPACE}.svc.cluster.local")
 	proxyCmd.PersistentFlags().StringVar(&role.TrustDomain, "trust-domain", "",
 		"The domain to use for identities")
-	proxyCmd.PersistentFlags().StringVar(&role.PilotIdentity, "pilotIdentity", "",
+	proxyCmd.PersistentFlags().StringVar(&pilotIdentity, "pilotIdentity", "",
 		"The identity used as the suffix for pilot's spiffe SAN ")
-	proxyCmd.PersistentFlags().StringVar(&role.MixerIdentity, "mixerIdentity", "",
+	proxyCmd.PersistentFlags().StringVar(&mixerIdentity, "mixerIdentity", "",
 		"The identity used as the suffix for mixer's spiffe SAN. This would only be used by pilot all other proxy would get this value from pilot")
 
 	proxyCmd.PersistentFlags().Uint16Var(&statusPort, "statusPort", 0,

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -449,9 +449,8 @@ func setSpiffeTrustDomain(domain string) {
 			} else {
 				pilotTrustDomain = domain
 			}
-
-			spiffe.SetTrustDomain(pilotTrustDomain)
 		}
+		spiffe.SetTrustDomain(pilotTrustDomain)
 	}
 
 }

--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -59,6 +59,7 @@ func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = "my.domain"
+	trustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 

--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -88,6 +88,9 @@ func TestPilotSanIfAuthenticationMutualTrustDomain(t *testing.T) {
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	trustDomain = "secured"
+	defer func() {
+		trustDomain = ""
+	}()
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
@@ -102,6 +105,9 @@ func TestPilotSanIfAuthenticationMutualTrustDomainAndDomain(t *testing.T) {
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = "my.domain"
 	trustDomain = "secured"
+	defer func() {
+		trustDomain = ""
+	}()
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 

--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -34,7 +34,6 @@ func TestNoPilotSanIfAuthenticationNone(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
-	role.TrustDomain = ""
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_NONE.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
@@ -47,7 +46,6 @@ func TestPilotSanIfAuthenticationMutualDomainEmptyKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
-	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
@@ -61,7 +59,6 @@ func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = "my.domain"
-	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
@@ -76,7 +73,6 @@ func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 func TestPilotSanIfAuthenticationMutualDomainEmptyConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role.DNSDomain = ""
-	role.TrustDomain = ""
 	registry = serviceregistry.ConsulRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
@@ -90,7 +86,7 @@ func TestPilotSanIfAuthenticationMutualTrustDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
-	role.TrustDomain = "secured"
+	trustDomain = "secured"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
@@ -104,7 +100,7 @@ func TestPilotSanIfAuthenticationMutualTrustDomainAndDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = "my.domain"
-	role.TrustDomain = "secured"
+	trustDomain = "secured"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
@@ -247,7 +243,6 @@ func TestPilotSanIfAuthenticationMutualStdDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ".svc.cluster.local"
-	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
@@ -263,7 +258,7 @@ func TestPilotSanIfAuthenticationMutualStdDomainConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = "service.consul"
-	role.TrustDomain = ""
+	trustDomain = ""
 	registry = serviceregistry.ConsulRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
@@ -291,7 +286,7 @@ func TestCustomPilotSanIfAuthenticationMutualDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
-	role.TrustDomain = "mesh.com"
+	trustDomain = "mesh.com"
 	pilotIdentity = "pilot-identity"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
@@ -306,7 +301,7 @@ func TestCustomMixerSanIfAuthenticationMutualDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
-	role.TrustDomain = "mesh.com"
+	trustDomain = "mesh.com"
 	mixerIdentity = "mixer-identity"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()

--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -38,7 +38,7 @@ func TestNoPilotSanIfAuthenticationNone(t *testing.T) {
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_NONE.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, role.PilotIdentity)
+	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, pilotIdentity)
 
 	g.Expect(pilotSAN).To(gomega.BeNil())
 }
@@ -52,7 +52,7 @@ func TestPilotSanIfAuthenticationMutualDomainEmptyKubernetes(t *testing.T) {
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, role.PilotIdentity)
+	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, pilotIdentity)
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://cluster.local/ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -66,7 +66,7 @@ func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, role.PilotIdentity)
+	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, pilotIdentity)
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://my.domain/ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -81,7 +81,7 @@ func TestPilotSanIfAuthenticationMutualDomainEmptyConsul(t *testing.T) {
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, role.PilotIdentity)
+	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, pilotIdentity)
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe:///ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -95,7 +95,7 @@ func TestPilotSanIfAuthenticationMutualTrustDomain(t *testing.T) {
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, role.PilotIdentity)
+	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, pilotIdentity)
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://secured/ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -109,7 +109,7 @@ func TestPilotSanIfAuthenticationMutualTrustDomainAndDomain(t *testing.T) {
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, role.PilotIdentity)
+	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, pilotIdentity)
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://secured/ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -252,7 +252,7 @@ func TestPilotSanIfAuthenticationMutualStdDomainKubernetes(t *testing.T) {
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, role.PilotIdentity)
+	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, pilotIdentity)
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://cluster.local/ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -268,7 +268,7 @@ func TestPilotSanIfAuthenticationMutualStdDomainConsul(t *testing.T) {
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, role.PilotIdentity)
+	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, pilotIdentity)
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe:///ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -277,12 +277,12 @@ func TestCustomPilotSanIfAuthenticationMutualDomainKubernetesNoTrustDomain(t *te
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
-	role.PilotIdentity = "pilot-identity"
+	pilotIdentity = "pilot-identity"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, role.PilotIdentity)
+	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, pilotIdentity)
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://cluster.local/pilot-identity"}))
 }
@@ -292,12 +292,12 @@ func TestCustomPilotSanIfAuthenticationMutualDomainKubernetes(t *testing.T) {
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	role.TrustDomain = "mesh.com"
-	role.PilotIdentity = "pilot-identity"
+	pilotIdentity = "pilot-identity"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, role.PilotIdentity)
+	pilotSAN := getSAN("anything", envoy.PilotSvcAccName, pilotIdentity)
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://mesh.com/pilot-identity"}))
 }
@@ -307,12 +307,12 @@ func TestCustomMixerSanIfAuthenticationMutualDomainKubernetes(t *testing.T) {
 	role = &model.Proxy{Metadata: map[string]string{}}
 	role.DNSDomain = ""
 	role.TrustDomain = "mesh.com"
-	role.MixerIdentity = "mixer-identity"
+	mixerIdentity = "mixer-identity"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain(role.DNSDomain)
-	mixerSAN := envoy.GetSAN("", role.MixerIdentity)
+	mixerSAN := envoy.GetSAN("", mixerIdentity)
 
 	g.Expect(mixerSAN).To(gomega.Equal("spiffe://mesh.com/mixer-identity"))
 }

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -94,15 +94,6 @@ type Proxy struct {
 	// TrustDomain defines the trust domain of the certificate
 	TrustDomain string
 
-	//identity that will be the suffix of the spiffe id for SAN verification when connecting to pilot
-	//spiffe://{TrustDomain}/{PilotIdentity}
-	PilotIdentity string
-
-	//identity that will be the suffix of the spiffe id for SAN verification when connecting to mixer
-	//spiffe://{TrustDomain}/{MixerIdentity}
-	//this value would only be used by pilot's proxy to connect to mixer.  All proxies would get mixer SAN pushed through pilot
-	MixerIdentity string
-
 	// ConfigNamespace defines the namespace where this proxy resides
 	// for the purposes of network scoping.
 	// NOTE: DO NOT USE THIS FIELD TO CONSTRUCT DNS NAMES

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -91,9 +91,6 @@ type Proxy struct {
 	// "default.svc.cluster.local")
 	DNSDomain string
 
-	// TrustDomain defines the trust domain of the certificate
-	TrustDomain string
-
 	// ConfigNamespace defines the namespace where this proxy resides
 	// for the purposes of network scoping.
 	// NOTE: DO NOT USE THIS FIELD TO CONSTRUCT DNS NAMES

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -42,16 +42,12 @@ type Environment struct {
 	// Mesh is the mesh config (to be merged into the config store)
 	Mesh *meshconfig.MeshConfig
 
-	// Mixer subject alternate name for mutual TLS
-	MixerSAN []string
-
 	// PushContext holds informations during push generation. It is reset on config change, at the beginning
 	// of the pushAll. It will hold all errors and stats and possibly caches needed during the entire cache computation.
 	// DO NOT USE EXCEPT FOR TESTS AND HANDLING OF NEW CONNECTIONS.
 	// ALL USE DURING A PUSH SHOULD USE THE ONE CREATED AT THE
 	// START OF THE PUSH, THE GLOBAL ONE MAY CHANGE AND REFLECT A DIFFERENT
 	// CONFIG AND PUSH
-	// Deprecated - a local config for ads will be used instead
 	PushContext *PushContext
 
 	// MeshNetworks (loaded from a config map) provides information about the

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -785,8 +785,6 @@ func buildEnv(t *testing.T, gateways []pilot_model.Config, virtualServices []pil
 		ServiceDiscovery: serviceDiscovery,
 		IstioConfigStore: configStore,
 		Mesh:             &m,
-		MixerSAN:         []string{},
-	}
 
 	if err := env.PushContext.InitContext(&env); err != nil {
 		t.Fatalf("failed to init push context: %v", err)

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -785,6 +785,7 @@ func buildEnv(t *testing.T, gateways []pilot_model.Config, virtualServices []pil
 		ServiceDiscovery: serviceDiscovery,
 		IstioConfigStore: configStore,
 		Mesh:             &m,
+	}
 
 	if err := env.PushContext.InitContext(&env); err != nil {
 		t.Fatalf("failed to init push context: %v", err)

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -191,7 +191,6 @@ func buildEnvForClustersWithDistribute(distribute []*meshconfig.LocalityLoadBala
 		ServiceDiscovery: serviceDiscovery,
 		IstioConfigStore: configStore,
 		Mesh:             meshConfig,
-		MixerSAN:         []string{},
 	}
 
 	env.PushContext = model.NewPushContext()
@@ -254,7 +253,6 @@ func buildEnvForClustersWithFailover() *model.Environment {
 		ServiceDiscovery: serviceDiscovery,
 		IstioConfigStore: configStore,
 		Mesh:             meshConfig,
-		MixerSAN:         []string{},
 	}
 
 	env.PushContext = model.NewPushContext()


### PR DESCRIPTION
Cleanup some fields in `Proxy struct`

	TrustDomain string	

	PilotIdentity string	

	MixerIdentity string

And `MixerSAN` field of `Environment`