### PR TITLE
[release-1.3] update proxy sha to include rate limiting fix

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "810138454986178b0ae8b5822147c02d0ca03424"
+		"lastStableSHA": "4a6e530c91a5173f800b9f8bcf182c2dd2034cb7"
 	},
 	{
                 "_comment": "",


### PR DESCRIPTION
This PR updates the proxy sha for the 1.3 release to include the latest commits from istio/proxy. In particular, this includes the changes from istio/proxy#2404.