### PR TITLE
Change method to determine if branch is dirty

### DIFF
--- a/bin/get_workspace_status.sh
+++ b/bin/get_workspace_status.sh
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 if BUILD_GIT_REVISION=$(git rev-parse HEAD 2> /dev/null); then
-    if ! git diff-index --quiet HEAD; then
-        BUILD_GIT_REVISION=${BUILD_GIT_REVISION}"-dirty"
-    fi
+  if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+    BUILD_GIT_REVISION=${BUILD_GIT_REVISION}"-dirty"
+  fi
 else
     BUILD_GIT_REVISION=unknown
 fi


### PR DESCRIPTION
The approach we are using has some flaws. I don't really understand why,
but it seems `git diff-index` is not idempotent or something and will
actually return dirty sometimes when it isn't. This results in our
binaries published with a `-dirty` suffix.

Kubernetes uses this approach so should be pretty stable.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
