### PR TITLE
Remove ENVOY_SHA and API_SHA from Dockerfiles

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -205,15 +205,4 @@ cp -f "${ISTIO_ENVOY_NATIVE_PATH}" "${ISTIO_OUT}/envoy"
 echo "Copying ${ISTIO_OUT}/envoy to ${ISTIO_BIN}/envoy"
 cp -f "${ISTIO_OUT}/envoy" "${ISTIO_BIN}/envoy"
 
-# Download istio.deps from the istio/proxy repository so it can be referenced, if needed
-ISTIO_PROXY_DEPS_URL="https://raw.githubusercontent.com/istio/proxy/${PROXY_REPO_SHA}/istio.deps"
-ISTIO_PROXY_DEPS_FILE="${ISTIO_OUT}/istio_proxy.deps"
-echo "Downloading istio.deps from ${ISTIO_PROXY_DEPS_URL} to ${ISTIO_PROXY_DEPS_FILE}"
-${DOWNLOAD_COMMAND} "${ISTIO_PROXY_DEPS_URL}" | sed -n '/name/,/lastStableSHA/{ //p; }' \
-    | cut -d: -f2 | sed 'N;s/\n/ /' | sed 's/[" ]//g' | sed 's/,/=/' > "${ISTIO_PROXY_DEPS_FILE}"
-ISTIO_PROXY_ISTIO_API_SHA_LABEL=$(grep ISTIO_API "${ISTIO_PROXY_DEPS_FILE}" | cut -d= -f2)
-export ISTIO_PROXY_ISTIO_API_SHA_LABEL
-ISTIO_PROXY_ENVOY_SHA_LABEL=$(grep ENVOY_SHA "${ISTIO_PROXY_DEPS_FILE}" | cut -d= -f2)
-export ISTIO_PROXY_ENVOY_SHA_LABEL
-
 "${ROOTDIR}/bin/init_helm.sh"

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -7,11 +7,6 @@ FROM docker.io/istio/base:${BASE_VERSION} as default
 ARG proxy_version
 ARG istio_version
 
-ARG ISTIO_API_SHA=unknown
-ARG ENVOY_SHA=unknown
-LABEL istio-api-vcs-ref=$ISTIO_API_SHA \
-    envoy-vcs-ref=$ENVOY_SHA
-
 # Install Envoy.
 COPY envoy /usr/local/bin/envoy
 

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -7,11 +7,6 @@ FROM docker.io/istio/base:${BASE_VERSION} as default
 ARG proxy_version
 ARG istio_version
 
-ARG ISTIO_API_SHA=unknown
-ARG ENVOY_SHA=unknown
-LABEL istio-api-vcs-ref=$ISTIO_API_SHA \
-    envoy-vcs-ref=$ENVOY_SHA
-
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -37,11 +37,6 @@ FROM ${BASE_DISTRIBUTION}
 ARG proxy_version
 ARG istio_version
 
-ARG ISTIO_API_SHA=unknown
-ARG ENVOY_SHA=unknown
-LABEL istio-api-vcs-ref=$ISTIO_API_SHA \
-    envoy-vcs-ref=$ENVOY_SHA
-
 # Install Envoy.
 COPY envoy /usr/local/bin/envoy
 

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -95,7 +95,7 @@ docker.sidecar_injector:$(ISTIO_DOCKER)/sidecar-injector
 # BUILD_ARGS tells  $(DOCKER_RULE) to execute a docker build with the specified commands
 
 docker.proxy_debug: BUILD_PRE=$(if $(filter 1,${USE_LOCAL_PROXY}),,mv envoy-debug-${PROXY_REPO_SHA} envoy &&) chmod 755 envoy pilot-agent &&
-docker.proxy_debug: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL}
+docker.proxy_debug: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION}
 docker.proxy_debug: pilot/docker/Dockerfile.proxy_debug
 docker.proxy_debug: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxy_debug: tools/packaging/common/envoy_bootstrap_drain.json
@@ -116,7 +116,7 @@ ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/envoy: ${ISTIO_ENVOY_LINUX_RELEASE_PATH}
 
 # Default proxy image.
 docker.proxyv2: BUILD_PRE=chmod 755 envoy pilot-agent &&
-docker.proxyv2: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL} --build-arg BASE_VERSION=${BASE_VERSION}
+docker.proxyv2: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION}
 docker.proxyv2: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxyv2: tools/packaging/common/envoy_bootstrap_drain.json
 docker.proxyv2: install/gcp/bootstrap/gcp_envoy_bootstrap.json
@@ -131,7 +131,7 @@ docker.proxyv2: pilot/docker/envoy_telemetry.yaml.tmpl
 	$(DOCKER_RULE)
 
 # Proxy using TPROXY interception - but no core dumps
-docker.proxytproxy: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL} --build-arg BASE_VERSION=${BASE_VERSION}
+docker.proxytproxy: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION}
 docker.proxytproxy: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxytproxy: tools/packaging/common/envoy_bootstrap_drain.json
 docker.proxytproxy: install/gcp/bootstrap/gcp_envoy_bootstrap.json


### PR DESCRIPTION
These fields do not actually work -- there have been no Istio releases
that included these. It is also misleading, see
https://github.com/istio/proxy/pull/2364.

Note -- the important fields, that are actually included in the metadata
and sent to pilot, Istio Version and Proxy Version still remain.

This only removes some labels that have not ever been included - they
were introduced in 1.2 and in all 1.2 images they are `""`.

