### PR TITLE
move mergeGateway operation out of loop to improve rds performance

### DIFF
--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -33,7 +33,7 @@ type ConfigGenerator interface {
 	BuildClusters(env *model.Environment, node *model.Proxy, push *model.PushContext) []*v2.Cluster
 
 	// BuildHTTPRoutes returns the list of HTTP routes for the given proxy. This is the RDS output
-	BuildHTTPRoutes(env *model.Environment, node *model.Proxy, push *model.PushContext, routeName string) *v2.RouteConfiguration
+	BuildHTTPRoutes(env *model.Environment, node *model.Proxy, push *model.PushContext, merged *model.MergedGateway, routeName string) *v2.RouteConfiguration
 }
 
 // NewConfigGenerator creates a new instance of the dataplane configuration generator

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -752,7 +752,8 @@ func TestGatewayHTTPRouteConfig(t *testing.T) {
 			p := &fakePlugin{}
 			configgen := NewConfigGenerator([]plugin.Plugin{p})
 			env := buildEnv(t, tt.gateways, tt.virtualServices)
-			route := configgen.buildGatewayHTTPRouteConfig(&env, &proxy, env.PushContext, proxyInstances, tt.routeName)
+			merged := pilot_model.MergeGateways(tt.gateways...)
+			route := configgen.buildGatewayHTTPRouteConfig(&env, &proxy, env.PushContext, merged, tt.routeName)
 			if route == nil {
 				t.Error("got an empty route configuration")
 			}

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -40,7 +40,7 @@ import (
 
 // BuildHTTPRoutes produces a list of routes for the proxy
 func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(env *model.Environment, node *model.Proxy, push *model.PushContext,
-	routeName string) *xdsapi.RouteConfiguration {
+	merged *model.MergedGateway, routeName string) *xdsapi.RouteConfiguration {
 	// TODO: Move all this out
 	proxyInstances := node.ServiceInstances
 	var rc *xdsapi.RouteConfiguration
@@ -52,7 +52,7 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(env *model.Environment, no
 		}
 		return rc
 	case model.Router:
-		rc = configgen.buildGatewayHTTPRouteConfig(env, node, push, proxyInstances, routeName)
+		rc = configgen.buildGatewayHTTPRouteConfig(env, node, push, merged, routeName)
 		if rc != nil {
 			rc = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_GATEWAY, node, push, rc)
 		}


### PR DESCRIPTION
Please provide a description for what this PR is for.
When kubernetes cluster scale going large, for example, in one of our prod clusters, there are around 5682 services in the cluster and two service port for each service, so in total, there are over 10000 CDS cluster count, and we have over 2000 gateway and virtualservice attached to single ingress gateway cluster.

```
kubectl get svc --all-namespaces |wc -l
5682
kubectl get gateway --all-namespaces|wc -l
2335
k33 get virtualservice --all-namespaces|wc -l
2332
```

The performance of polit becomes a challenge for such scale, and this caused two problem:
1. Pilot pod being oom killed frequently
2. The whole XDS took long time to be completed, in our case, it take around 30mins to 1 hour to complete.
We did lots of investigation and trouble shooting, and finally, it is identified that CDS and LDS can be completed in seconds(even tough the configuration is really big), while the significant performance bottleneck is in RDS, it took over 30-40 minutes to finish RDS computing. The reason is `gateways := s.Env.Gateways(workloadLabels)` need to iterate all gateway objects and even it is a memory computation, it took 1-2 second to finish, and we have 2300+ routing rule to compute, so the total time duration is (1-2) *2300, which is over 30 minutes.

But by checking the code detail, all the parameters of the logic is same, and the result is same(we proved this by dumping all the result detail as well), so it is not necessary to repeat this call in every loop.
The problem is resolved by this PR's commit, the RDS performance is improved from 30+ minutes to 3 seconds. This also fix pilot oom problem, cause it won't hold object reference for long time.
This is a critical fix and I hope it can be reviewed with priority.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
