### PR TITLE
Deduplicate hosts added to gateway listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -806,15 +806,20 @@ func getSNIHostsForServer(server *networking.Server) []string {
 		return nil
 	}
 	// sanitize the server hosts as it could contain hosts of form ns/host
-	sniHosts := make([]string, 0)
+	sniHosts := make(map[string]bool)
 	for _, h := range server.Hosts {
 		if strings.Contains(h, "/") {
 			parts := strings.Split(h, "/")
-			sniHosts = append(sniHosts, parts[1])
-		} else {
-			sniHosts = append(sniHosts, h)
+			h = parts[1]
+		}
+		// do not add hosts, that have already been added
+		if !sniHosts[h] {
+			sniHosts[h] = true
 		}
 	}
-
-	return sniHosts
+	sniHostsSlice := make([]string, 0, len(sniHosts))
+	for host := range sniHosts {
+		sniHostsSlice = append(sniHostsSlice, host)
+	}
+	return sniHostsSlice
 }


### PR DESCRIPTION
When building SNI hosts for a server's TLS filter chains hosts are sanitized to remove the `namespace/` prefix if set. To ensure that no duplicates exist after this, only hosts that weren't in the SNI host list are added to the list. When the resulting config contains duplicate hosts envoy rejects it.

Signed-off-by: Maximilian Bischoff <maximilian.bischoff@inovex.de>

Solves #16573

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
