### PR TITLE
only update router proxy when gateway update

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -524,8 +524,8 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 
 	options := coredatamodel.Options{
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
-		ClearDiscoveryServerCache: func() {
-			s.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{Full: true})
+		ClearDiscoveryServerCache: func(routerOnly bool) {
+			s.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{Full: true, RouterOnly: routerOnly})
 		},
 	}
 

--- a/pilot/pkg/config/coredatamodel/controller.go
+++ b/pilot/pkg/config/coredatamodel/controller.go
@@ -43,7 +43,7 @@ type CoreDataModel interface {
 // Options stores the configurable attributes of a Control
 type Options struct {
 	DomainSuffix              string
-	ClearDiscoveryServerCache func()
+	ClearDiscoveryServerCache func(bool)
 }
 
 // Controller is a temporary storage for the changes received
@@ -192,7 +192,7 @@ func (c *Controller) Apply(change *sink.Change) error {
 	if descriptor.Type == schemas.ServiceEntry.Type {
 		c.serviceEntryEvents(innerStore, prevStore)
 	} else {
-		c.options.ClearDiscoveryServerCache()
+		c.options.ClearDiscoveryServerCache(descriptor.Type == schemas.Gateway.Type)
 	}
 
 	return nil

--- a/pilot/pkg/config/coredatamodel/controller_test.go
+++ b/pilot/pkg/config/coredatamodel/controller_test.go
@@ -113,14 +113,14 @@ var (
 
 	testControllerOptions = coredatamodel.Options{
 		DomainSuffix:              "cluster.local",
-		ClearDiscoveryServerCache: func() {},
+		ClearDiscoveryServerCache: func(bool) {},
 	}
 )
 
 func TestOptions(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var cacheCleared bool
-	testControllerOptions.ClearDiscoveryServerCache = func() {
+	testControllerOptions.ClearDiscoveryServerCache = func(bool) {
 		cacheCleared = true
 	}
 	controller := coredatamodel.NewController(testControllerOptions)

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -151,6 +151,9 @@ type PushRequest struct {
 	// Full determines whether a full push is required or not. If set to false, only endpoints will be sent.
 	Full bool
 
+	// Route
+	RouterOnly bool
+
 	// TargetNamespaces contains a list of namespaces that were changed in the update.
 	// This is used as an optimization to avoid unnecessary pushes to proxies that are scoped with a Sidecar.
 	// Currently, this will only scope EDS updates, as config updates are more complicated.
@@ -187,6 +190,8 @@ func (first *PushRequest) Merge(other *PushRequest) *PushRequest {
 
 		// If either is full we need a full push
 		Full: first.Full || other.Full,
+
+		RouterOnly: first.RouterOnly && other.RouterOnly,
 
 		// The other push context is presumed to be later and more up to date
 		Push: other.Push,

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -667,9 +667,11 @@ func (s *DiscoveryServer) startPush(req *model.PushRequest) {
 	// the same connection table
 	adsClientsMutex.RLock()
 	// Create a temp map to avoid locking the add/remove
-	pending := []*XdsConnection{}
+	var pending []*XdsConnection
 	for _, v := range adsClients {
-		pending = append(pending, v)
+		if v.modelNode.Type == model.Router || !req.RouterOnly {
+			pending = append(pending, v)
+		}
 	}
 	adsClientsMutex.RUnlock()
 


### PR DESCRIPTION
Signed-off-by: forrestchen <forrestchen@tencent.com>

Please provide a description for what this PR is for.
The gateway CRD only affect router, so we should only trigger xDS push for routers

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
