### PR TITLE
Use error prefix for mixer/lang tests

### DIFF
--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -1387,7 +1387,7 @@ end
 		I: map[string]interface{}{
 			"as": "barfoo",
 		},
-		Err: `error converting 'barfoo' to e-mail: 'mail: no angle-addr'`,
+		Err: `error converting 'barfoo' to e-mail:`,
 	},
 
 	{
@@ -5253,7 +5253,7 @@ type TestInfo struct {
 	// ReferencedCEL overrides Referenced field for CEL-specific differences
 	ReferencedCEL []string
 
-	// Err contains the expected error message of a failed evaluation.
+	// Err contains the expected error message prefix of a failed evaluation.
 	Err string
 
 	// AstErr contains the expected error message of a failed evaluation, during AST evaluation.

--- a/mixer/pkg/lang/compiler/compiler_test.go
+++ b/mixer/pkg/lang/compiler/compiler_test.go
@@ -217,7 +217,7 @@ func TestCompile(t *testing.T) {
 			i := interpreter.New(program, externs)
 			v, err := i.Eval("eval", b)
 			if err != nil {
-				if test.Err != err.Error() {
+				if !strings.HasPrefix(err.Error(), test.Err) {
 					tt.Fatalf("expected error not found: E:'%v', A:'%v'", test.Err, err)
 				}
 				return


### PR DESCRIPTION
Different versions of golang report different error messages, so looking
at the exact error message is not stable. Specifically, golang 1.13 will
break this test. This change uses the error prefix, and removes part of
an error message that changed in go 1.13 to utilize just the common
prefix.

Note -- other tests using the same test data are already doing a prefix
check.

Part of https://github.com/istio/istio/issues/16635

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
