### PR TITLE
Pin the base image for the 1.3 branch (#16697)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,14 @@ SHELL := /bin/bash -o pipefail
 # Current version, updated after a release.
 VERSION ?= 1.3-dev
 
+# Base version of Istio image to use
+BASE_VERSION ?= 1.3
+
+export GO111MODULE ?= on
+export GOPROXY ?= https://proxy.golang.org
+export GOSUMDB ?= sum.golang.org
+>>>>>>> 3cd6c36... Pin the base image for the 1.3 branch (#16697)
+
 # locations where artifacts are stored
 ISTIO_DOCKER_HUB ?= docker.io/istio
 export ISTIO_DOCKER_HUB

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,29 @@
+FROM ubuntu:xenial
+# Base image for debug builds.
+# Built manually uploaded as "istionightly/base_debug"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Do not add more stuff to this list that isn't small or critically useful.
+# If you occasionally need something on the container do
+# sudo apt-get update && apt-get whichever
+
+# hadolint ignore=DL3005,DL3008
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+      ca-certificates \
+      curl \
+      iptables \
+      iproute2 \
+      iputils-ping \
+      knot-dnsutils \
+      netcat \
+      tcpdump \
+      net-tools \
+      lsof \
+      linux-tools-generic \
+      sudo \
+   && update-ca-certificates \
+   && apt-get upgrade -y \
+   && apt-get clean \
+   && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old

--- a/docker/Dockerfile.kubectl
+++ b/docker/Dockerfile.kubectl
@@ -1,6 +1,9 @@
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
 # Image for post install jobs
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # This container should only contain kubectl.  Hard-coding to use Linux K8s 1.11.1 version.
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl /usr/bin/kubectl

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -1,9 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# hadolint ignore=DL3006
-FROM istionightly/base_debug as default
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/mixer/docker/Dockerfile.test_policybackend
+++ b/mixer/docker/Dockerfile.test_policybackend
@@ -1,9 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# hadolint ignore=DL3006
-FROM istionightly/base_debug as default
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -1,9 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# hadolint ignore=DL3006
-FROM istionightly/base_debug as default
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -1,5 +1,9 @@
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/istio/base:${BASE_VERSION} as default
+
 ARG proxy_version
 ARG istio_version
 

--- a/pilot/docker/Dockerfile.proxy_init
+++ b/pilot/docker/Dockerfile.proxy_init
@@ -1,13 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM ubuntu:xenial as default
-# hadolint ignore=DL3005,DL3008
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    iproute2 \
-    iptables \
- && rm -rf /var/lib/apt/lists/*
+# ISTIO_VERSION is used to specify the version of the release
+ARG BASE_VERSION=latest
+
+ # The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 COPY istio-iptables.sh /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/istio-iptables.sh"]

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -1,5 +1,9 @@
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/istio/base:${BASE_VERSION} as default
+
 ARG proxy_version
 ARG istio_version
 

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -1,9 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# hadolint ignore=DL3006
-FROM istionightly/base_debug as default
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # Add CA certificates for SSL connections.
 # obtained from debian ca-certs deb using fetch_cacerts.sh

--- a/pilot/docker/Dockerfile.sidecar_injector
+++ b/pilot/docker/Dockerfile.sidecar_injector
@@ -1,10 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# No tag available https://hub.docker.com/_/scratch?tab=description
-# hadolint ignore=DL3006
-FROM scratch as default
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/security/docker/Dockerfile.citadel
+++ b/security/docker/Dockerfile.citadel
@@ -1,10 +1,12 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# No tag available https://hub.docker.com/_/scratch?tab=description
-# hadolint ignore=DL3006
-FROM scratch as default
+FROM docker.io/istio/base:${BASE_VERSION} as default
+
 # obtained from debian ca-certs deb using fetch_cacerts.sh
 ADD ca-certificates.tgz /
 

--- a/security/docker/Dockerfile.citadel-test
+++ b/security/docker/Dockerfile.citadel-test
@@ -1,4 +1,8 @@
-FROM ubuntu:xenial
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 COPY istio_ca /usr/local/bin/istio_ca
 COPY istio_ca.crt /usr/local/bin/istio_ca.crt

--- a/security/docker/Dockerfile.node-agent
+++ b/security/docker/Dockerfile.node-agent
@@ -1,10 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# No tag available https://hub.docker.com/_/scratch?tab=description
-# hadolint ignore=DL3006
-FROM scratch as default
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/security/docker/Dockerfile.node-agent-k8s
+++ b/security/docker/Dockerfile.node-agent-k8s
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
 
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
 # The following section is used as base image if BASE_DISTRIBUTION=default
-# hadolint ignore=DL3006
-FROM istionightly/base_debug as default
-# hadolint ignore=DL3005,DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && update-ca-certificates && apt-get clean  && rm -rf /var/lib/apt/lists/*
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/security/docker/Dockerfile.node-agent-test
+++ b/security/docker/Dockerfile.node-agent-test
@@ -1,4 +1,8 @@
-FROM ubuntu:xenial
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/istio/base:${BASE_VERSION} as default
 
 COPY node_agent /usr/local/bin/node_agent
 

--- a/security/docker/Dockerfile.sdsclient
+++ b/security/docker/Dockerfile.sdsclient
@@ -1,5 +1,9 @@
-# hadolint ignore=DL3006
-FROM istionightly/base_debug
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/istio/base:${BASE_VERSION} as default
+
 COPY sdsclient /
 RUN chmod 755 /sdsclient
 ENTRYPOINT ["/sdsclient"]

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -21,6 +21,7 @@
 # It does not upload to a registry.
 docker: build-linux test-bins-linux docker.all
 
+# Add new docker targets to the end of the DOCKER_TARGETS list.
 DOCKER_TARGETS:=docker.pilot docker.proxy_debug docker.proxytproxy docker.proxyv2 docker.app docker.app_sidecar docker.test_policybackend \
 	docker.proxy_init docker.mixer docker.mixer_codegen docker.citadel docker.galley docker.sidecar_injector docker.kubectl docker.node-agent-k8s
 
@@ -79,15 +80,13 @@ $(foreach FILE,$(DOCKER_FILES_FROM_ISTIO_BIN), \
 
 # pilot docker images
 
+docker.proxy_init: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.proxy_init: pilot/docker/Dockerfile.proxy_init
 docker.proxy_init: $(ISTIO_DOCKER)/istio-iptables.sh
 docker.proxy_init: $(ISTIO_DOCKER)/istio-iptables
-	# Ensure ubuntu:xenial, the base image for proxy_init, is present so build doesn't fail on network hiccup
-	if [[ "$(docker images -q ubuntu:xenial 2> /dev/null)" == "" ]]; then \
-		docker pull ubuntu:xenial || (sleep 15 ; docker pull ubuntu:xenial) || (sleep 45 ; docker pull ubuntu:xenial) \
-	fi
 	$(DOCKER_RULE)
 
+docker.sidecar_injector: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.sidecar_injector: pilot/docker/Dockerfile.sidecar_injector
 docker.sidecar_injector:$(ISTIO_DOCKER)/sidecar-injector
 	$(DOCKER_RULE)
@@ -96,7 +95,7 @@ docker.sidecar_injector:$(ISTIO_DOCKER)/sidecar-injector
 # BUILD_ARGS tells  $(DOCKER_RULE) to execute a docker build with the specified commands
 
 docker.proxy_debug: BUILD_PRE=$(if $(filter 1,${USE_LOCAL_PROXY}),,mv envoy-debug-${PROXY_REPO_SHA} envoy &&) chmod 755 envoy pilot-agent &&
-docker.proxy_debug: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL}
+docker.proxy_debug: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL}
 docker.proxy_debug: pilot/docker/Dockerfile.proxy_debug
 docker.proxy_debug: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxy_debug: tools/packaging/common/envoy_bootstrap_drain.json
@@ -117,7 +116,7 @@ ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/envoy: ${ISTIO_ENVOY_LINUX_RELEASE_PATH}
 
 # Default proxy image.
 docker.proxyv2: BUILD_PRE=chmod 755 envoy pilot-agent &&
-docker.proxyv2: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL}
+docker.proxyv2: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL} --build-arg BASE_VERSION=${BASE_VERSION}
 docker.proxyv2: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxyv2: tools/packaging/common/envoy_bootstrap_drain.json
 docker.proxyv2: install/gcp/bootstrap/gcp_envoy_bootstrap.json
@@ -132,7 +131,7 @@ docker.proxyv2: pilot/docker/envoy_telemetry.yaml.tmpl
 	$(DOCKER_RULE)
 
 # Proxy using TPROXY interception - but no core dumps
-docker.proxytproxy: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL}
+docker.proxytproxy: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg ISTIO_API_SHA=${ISTIO_PROXY_ISTIO_API_SHA_LABEL} --build-arg ENVOY_SHA=${ISTIO_PROXY_ENVOY_SHA_LABEL} --build-arg BASE_VERSION=${BASE_VERSION}
 docker.proxytproxy: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxytproxy: tools/packaging/common/envoy_bootstrap_drain.json
 docker.proxytproxy: install/gcp/bootstrap/gcp_envoy_bootstrap.json
@@ -146,6 +145,7 @@ docker.proxytproxy: tools/packaging/common/istio-iptables.sh
 docker.proxytproxy: pilot/docker/envoy_telemetry.yaml.tmpl
 	$(DOCKER_RULE)
 
+docker.pilot: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.pilot: $(ISTIO_OUT_LINUX)/pilot-discovery
 docker.pilot: tests/testdata/certs/cacert.pem
 docker.pilot: pilot/docker/Dockerfile.pilot
@@ -190,57 +190,70 @@ docker.app_sidecar: pilot/docker/envoy_telemetry.yaml.tmpl
 	$(DOCKER_RULE)
 
 # Test policy backend for mixer integration
+docker.test_policybackend: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.test_policybackend: mixer/docker/Dockerfile.test_policybackend
 docker.test_policybackend: $(ISTIO_OUT_LINUX)/mixer-test-policybackend
 	$(DOCKER_RULE)
 
+docker.kubectl: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.kubectl: docker/Dockerfile$$(suffix $$@)
 	$(DOCKER_RULE)
 
 # mixer docker images
 
+docker.mixer: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.mixer: mixer/docker/Dockerfile.mixer
 docker.mixer: $(ISTIO_DOCKER)/mixs
 docker.mixer: $(ISTIO_DOCKER)/ca-certificates.tgz
 	$(DOCKER_RULE)
 
 # mixer codegen docker images
+docker.mixer_codegen: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.mixer_codegen: mixer/docker/Dockerfile.mixer_codegen
 docker.mixer_codegen: $(ISTIO_DOCKER)/mixgen
 	$(DOCKER_RULE)
 
 # galley docker images
 
+docker.galley: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.galley: galley/docker/Dockerfile.galley
 docker.galley: $(ISTIO_DOCKER)/galley
 	$(DOCKER_RULE)
 
 # security docker images
 
+docker.citadel: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.citadel: security/docker/Dockerfile.citadel
 docker.citadel: $(ISTIO_DOCKER)/istio_ca
 docker.citadel: $(ISTIO_DOCKER)/ca-certificates.tgz
 	$(DOCKER_RULE)
 
+docker.citadel-test: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.citadel-test: security/docker/Dockerfile.citadel-test
 docker.citadel-test: $(ISTIO_DOCKER)/istio_ca
 docker.citadel-test: $(ISTIO_DOCKER)/istio_ca.crt
 docker.citadel-test: $(ISTIO_DOCKER)/istio_ca.key
 	$(DOCKER_RULE)
 
+docker.node-agent: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.node-agent: security/docker/Dockerfile.node-agent
 docker.node-agent: $(ISTIO_DOCKER)/node_agent
 	$(DOCKER_RULE)
 
+docker.node-agent-k8s: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.node-agent-k8s: security/docker/Dockerfile.node-agent-k8s
 docker.node-agent-k8s: $(ISTIO_DOCKER)/node_agent_k8s
 	$(DOCKER_RULE)
 
+docker.node-agent-test: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.node-agent-test: security/docker/Dockerfile.node-agent-test
 docker.node-agent-test: $(ISTIO_DOCKER)/node_agent
 docker.node-agent-test: $(ISTIO_DOCKER)/istio_ca.crt
 docker.node-agent-test: $(ISTIO_DOCKER)/node_agent.crt
 docker.node-agent-test: $(ISTIO_DOCKER)/node_agent.key
+	$(DOCKER_RULE)
+
+docker.base: docker/Dockerfile.base
 	$(DOCKER_RULE)
 
 # $@ is the name of the target

--- a/tools/packaging/deb/Dockerfile
+++ b/tools/packaging/deb/Dockerfile
@@ -1,5 +1,11 @@
 # Base dockerfile containing ubuntu and istio debian.
 # Can be used for testing
+# ISTIO_VERSION is used to specify the version of the release
+ARG BASE_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/istio/base:${BASE_VERSION}
+
 # hadolint ignore=DL3006
 FROM istionightly/base_debug
 


### PR DESCRIPTION
* Pin the base image for the 1.3 branch

* Move master to 1.4-dev and pin on 1.4

* Address reviewer comments.

* Add an update-ca-certificates call

* Address injector build failure

* Remove duplicate sidecar injector dockerfile

* Revert Dockerfile.app_sidecar base version changes

* Revert Dockerfile.app change

(cherry picked from commit 3cd6c36942efa3793857033d6e092e9528495465)

 Conflicts:
	Makefile
	tools/istio-docker.mk

* Additionally moved the 1.4 pins in master to target 1.3.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
