### PR TITLE
Revert change which dumped node agent cert data in base64

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -17,7 +17,6 @@ package sds
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -170,12 +169,11 @@ func (s *sdsservice) DebugInfo() (string, error) {
 
 		conn.mutex.RLock()
 		c := sdsclientdebug{
-			ConnectionID: connKey.ConnectionID,
-			ProxyID:      conn.proxyID,
-			ResourceName: conn.ResourceName,
-			// should be base64 encoded for straightforward comparison with Envoy SDS config dump format
-			CertificateChain: base64.StdEncoding.EncodeToString(conn.secret.CertificateChain),
-			RootCert:         base64.StdEncoding.EncodeToString(conn.secret.RootCert),
+			ConnectionID:     connKey.ConnectionID,
+			ProxyID:          conn.proxyID,
+			ResourceName:     conn.ResourceName,
+			CertificateChain: string(conn.secret.CertificateChain),
+			RootCert:         string(conn.secret.RootCert),
 			CreatedTime:      conn.secret.CreatedTime.Format(time.RFC3339),
 			ExpireTime:       conn.secret.ExpireTime.Format(time.RFC3339),
 		}

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -1008,6 +1008,11 @@ func TestDebugEndpoints(t *testing.T) {
 			found := false
 			for _, c := range workloadDebugResponse.Clients {
 				if p == c.ProxyID {
+					// retrieved cert chain from debug endpoint should match the mock cert chain
+					if c.CertificateChain != string(fakeCertificateChain) {
+						t.Errorf("expected cert chain: %s, but got %s",
+							string(fakeCertificateChain), c.CertificateChain)
+					}
 					found = true
 					break
 				}


### PR DESCRIPTION
[#16347](https://github.com/istio/istio/pull/16347) changed the behavior of the node agent debug endpoint to dump base64 encoded
cert data rather than plaintext. This was done for ease of comparison with
/config_dump endpoint, but since the default for JSON dump of proto is
to dump base64 encoded strings for byte arrays, this change is not
needed, as the cert will be marshaled back in plaintext anyways.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
