### PR TITLE
Control panic, mock namespace

### DIFF
--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -412,7 +412,22 @@ func generateServiceEntry(u *unstructured.Unstructured, o *vmServiceOpts) error 
 		Endpoints:  eps,
 		Resolution: v1alpha3.ServiceEntry_STATIC,
 	}
-	u.Object["spec"] = spec
+
+	// Because we are placing into an Unstructured, place as a map instead
+	// of structured Istio types.  (The go-client can handle the structured data, but the
+	// fake go-client used for mocking cannot.)
+	b, err := yaml.Marshal(spec)
+	if err != nil {
+		return err
+	}
+	iSpec := map[string]interface{}{}
+	err = yaml.Unmarshal(b, &iSpec)
+	if err != nil {
+		return err
+	}
+
+	u.Object["spec"] = iSpec
+
 	return nil
 }
 

--- a/istioctl/cmd/describe_test.go
+++ b/istioctl/cmd/describe_test.go
@@ -39,6 +39,7 @@ type execAndK8sConfigTestCase struct {
 	execClientConfig map[string][]byte // Canned Envoy configuration
 	configs          []model.Config    // Canned Istio configuration
 	k8sConfigs       []runtime.Object  // Canned K8s configuration
+	namespace        string
 
 	args []string
 
@@ -234,6 +235,7 @@ func TestDescribe(t *testing.T) {
 			execClientConfig: cannedConfig,
 			configs:          cannedIstioConfig,
 			k8sConfigs:       cannedK8sEnv,
+			namespace:        "default",
 			args:             strings.Split("experimental describe pod details-v1-5b7f94f9bc-wp5tb", " "),
 			expectedOutput: `Pod: details-v1-5b7f94f9bc-wp5tb
    Pod Ports: 15090 (istio-proxy)
@@ -284,6 +286,9 @@ func verifyExecAndK8sConfigTestCaseTestOutput(t *testing.T, c execAndK8sConfigTe
 	var out bytes.Buffer
 	rootCmd := GetRootCmd(c.args)
 	rootCmd.SetOutput(&out)
+	if c.namespace != "" {
+		namespace = c.namespace
+	}
 
 	file = "" // Clear, because we re-use
 

--- a/istioctl/cmd/remove-from-mesh_test.go
+++ b/istioctl/cmd/remove-from-mesh_test.go
@@ -141,6 +141,7 @@ func TestRemoveFromMesh(t *testing.T) {
 			args:              strings.Split("experimental remove-from-mesh service details", " "),
 			expectedException: false,
 			k8sConfigs:        cannedK8sConfig,
+			namespace:         "default",
 			expectedOutput:    "deployment \"details-v1.default\" updated successfully with Istio sidecar un-injected.\n",
 		},
 		{
@@ -151,10 +152,11 @@ func TestRemoveFromMesh(t *testing.T) {
 			expectedOutput:    "Error: service \"test\" does not exist, skip\n",
 		},
 		{
-			description:       "service without depolyment",
+			description:       "service without deployment",
 			args:              strings.Split("experimental remove-from-mesh service dummyservice", " "),
 			expectedException: false,
 			k8sConfigs:        cannedK8sConfig,
+			namespace:         "default",
 			expectedOutput:    "No deployments found for service dummyservice.default\n",
 		},
 		{
@@ -177,6 +179,7 @@ func TestRemoveFromMesh(t *testing.T) {
 			expectedException: true,
 			k8sConfigs:        cannedK8sConfig,
 			dynamicConfigs:    cannedDynamicConfig,
+			namespace:         "default",
 			expectedOutput:    "Error: service entry \"mesh-expansion-dummyservice\" does not exist, skip\n",
 		},
 		{
@@ -185,6 +188,7 @@ func TestRemoveFromMesh(t *testing.T) {
 			expectedException: false,
 			k8sConfigs:        cannedK8sConfig,
 			dynamicConfigs:    cannedDynamicConfig,
+			namespace:         "default",
 			expectedOutput: "Kubernetes Service \"vmtest.default\" has been deleted for external service \"vmtest\"\n" +
 				"Service Entry \"mesh-expansion-vmtest\" has been deleted for external service \"vmtest\"\n",
 		},


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/16639

Supercedes https://github.com/istio/istio/pull/16745 and https://github.com/istio/istio/pull/16708

@howardjohn reported the panic.  The panic was caused by putting an Istio ServiceEntry into an Unstructured.  The fake/mock go-client is more sensitive to this and also the fake client doesn't return an error for unknown namespaces.

The Istio istioctl unit tests for add-to-mesh, remove-from-mesh, and describe all inherit the default namespace from the Kubernetes context.  They were not mocked.  To reproduce the @howardjohn 's panic, get a build that doesn't include this PR and do

```
kubectl config set-context <your context> --namespace=banana
```

This PR makes the panic impossible by converting the ServiceEntry to a map[string]interface{} before putting it into the Unstructured.
This PR makes the istioctl unit tests succeed even if the default namespace is changed in the Kubernetes context.

Also add a test case for creating an external ServiceEntry.

cc @irisdingbj 