### PR TITLE
Disply error on failed Dockerfile lint

### DIFF
--- a/scripts/check_dockerfiles.sh
+++ b/scripts/check_dockerfiles.sh
@@ -23,7 +23,7 @@
 
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}")" && pwd )"
 ROOTDIR=$(dirname "${SCRIPTPATH}")
-cd "${ROOTDIR}"
+cd "${ROOTDIR}"|| exit
 
 CD_TMPFILE=$(mktemp /tmp/check_dockerfile.XXXXXX)
 HL_TMPFILE=$(mktemp /tmp/hadolint.XXXXXX)

--- a/scripts/check_dockerfiles.sh
+++ b/scripts/check_dockerfiles.sh
@@ -21,8 +21,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}")" && pwd )"
 ROOTDIR=$(dirname "${SCRIPTPATH}")
 cd "${ROOTDIR}"


### PR DESCRIPTION
This is fixed in common-files but we can't update that yet since there
were a ton of changes that this repo isn't ready for

This still exits with an error code when one is encountered because we
have `exit 1` later one, but allows an error message to be displayed
first.
Fixes https://github.com/istio/istio/issues/15626