### PR TITLE
Pilot: only generate passthrough infra with ip versions provided by proxy

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -437,31 +437,36 @@ func buildInboundLocalityLbEndpoints(bind string, port int) []*endpoint.Locality
 }
 
 func generateInboundPassthroughClusters(env *model.Environment, proxy *model.Proxy) []*apiv2.Cluster {
-	inboundPassthroughClusterIpv4 := buildDefaultPassthroughCluster(env, proxy)
-	inboundPassthroughClusterIpv4.Name = util.InboundPassthroughClusterIpv4
-	inboundPassthroughClusterIpv4.UpstreamBindConfig = &core.BindConfig{
-		SourceAddress: &core.SocketAddress{
-			Address: util.InboundPassthroughBindIpv4,
-			PortSpecifier: &core.SocketAddress_PortValue{
-				PortValue: uint32(0),
+	// ipv4 and ipv6 feature detection. Envoy cannot ignore a config where the ip version is not supported
+	ipv4, ipv6 := ipv4AndIpv6Support(proxy)
+	clusters := make([]*apiv2.Cluster, 0, 2)
+	if ipv4 {
+		inboundPassthroughClusterIpv4 := buildDefaultPassthroughCluster(env, proxy)
+		inboundPassthroughClusterIpv4.Name = util.InboundPassthroughClusterIpv4
+		inboundPassthroughClusterIpv4.UpstreamBindConfig = &core.BindConfig{
+			SourceAddress: &core.SocketAddress{
+				Address: util.InboundPassthroughBindIpv4,
+				PortSpecifier: &core.SocketAddress_PortValue{
+					PortValue: uint32(0),
+				},
 			},
-		},
+		}
+		clusters = append(clusters, inboundPassthroughClusterIpv4)
 	}
-
-	inboundPassthroughClusterIpv6 := buildDefaultPassthroughCluster(env, proxy)
-	inboundPassthroughClusterIpv6.Name = util.InboundPassthroughClusterIpv6
-	inboundPassthroughClusterIpv6.UpstreamBindConfig = &core.BindConfig{
-		SourceAddress: &core.SocketAddress{
-			Address: util.InboundPassthroughBindIpv6,
-			PortSpecifier: &core.SocketAddress_PortValue{
-				PortValue: uint32(0),
+	if ipv6 {
+		inboundPassthroughClusterIpv6 := buildDefaultPassthroughCluster(env, proxy)
+		inboundPassthroughClusterIpv6.Name = util.InboundPassthroughClusterIpv6
+		inboundPassthroughClusterIpv6.UpstreamBindConfig = &core.BindConfig{
+			SourceAddress: &core.SocketAddress{
+				Address: util.InboundPassthroughBindIpv6,
+				PortSpecifier: &core.SocketAddress_PortValue{
+					PortValue: uint32(0),
+				},
 			},
-		},
+		}
+		clusters = append(clusters, inboundPassthroughClusterIpv6)
 	}
-	return []*apiv2.Cluster{
-		inboundPassthroughClusterIpv4,
-		inboundPassthroughClusterIpv6,
-	}
+	return clusters
 }
 
 func (configgen *ConfigGeneratorImpl) buildInboundClusters(env *model.Environment, proxy *model.Proxy,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -16,12 +16,13 @@ package v1alpha3
 
 import (
 	"fmt"
-	"istio.io/istio/pilot/pkg/networking/util"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"istio.io/istio/pilot/pkg/networking/util"
 
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -2017,6 +2017,24 @@ func getActualWildcardAndLocalHost(node *model.Proxy) (string, string) {
 	return WildcardIPv6Address, LocalhostIPv6Address
 }
 
+func ipv4AndIpv6Support(node *model.Proxy) (bool, bool) {
+	ipv4, ipv6 := false, false
+	for i := 0; i < len(node.IPAddresses); i++ {
+		addr := net.ParseIP(node.IPAddresses[i])
+		if addr == nil {
+			// Should not happen, invalid IP in proxy's IPAddresses slice should have been caught earlier,
+			// skip it to prevent a panic.
+			continue
+		}
+		if addr.To4() != nil {
+			ipv4 = true
+		} else {
+			ipv6 = true
+		}
+	}
+	return ipv4, ipv6
+}
+
 // getSidecarInboundBindIP returns the IP that the proxy can bind to along with the sidecar specified port.
 // It looks for an unicast address, if none found, then the default wildcard address is used.
 // This will make the inbound listener bind to instance_ip:port instead of 0.0.0.0:port where applicable.

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -397,10 +397,18 @@ func newBlackholeFilter(enableAny bool) listener.Filter {
 
 // Create pass through filter chains matching ipv4 address and ipv6 address independently.
 func newInboundPassthroughFilterChains(env *model.Environment, node *model.Proxy) []*listener.FilterChain {
-	// ipv4 and ipv6
+	ipv4, ipv6 := ipv4AndIpv6Support(node)
+	// ipv4 and ipv6 feature detect
+	ipVersions := make([]string, 0, 2)
+	if ipv4 {
+		ipVersions = append(ipVersions, util.InboundPassthroughClusterIpv4)
+	}
+	if ipv6 {
+		ipVersions = append(ipVersions, util.InboundPassthroughClusterIpv6)
+	}
 	filterChains := make([]*listener.FilterChain, 0, 2)
-	for _, clusterName := range []string{util.InboundPassthroughClusterIpv4, util.InboundPassthroughClusterIpv6} {
 
+	for _, clusterName := range ipVersions {
 		tcpProxy := &tcp_proxy.TcpProxy{
 			StatPrefix:       clusterName,
 			ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: clusterName},

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -452,9 +452,18 @@ func newInboundPassthroughFilterChains(env *model.Environment, node *model.Proxy
 
 func newHTTPPassThroughFilterChain(configgen *ConfigGeneratorImpl, env *model.Environment,
 	node *model.Proxy, push *model.PushContext) []*listener.FilterChain {
+	ipv4, ipv6 := ipv4AndIpv6Support(node)
+	// ipv4 and ipv6 feature detect
+	ipVersions := make([]string, 0, 2)
+	if ipv4 {
+		ipVersions = append(ipVersions, util.InboundPassthroughClusterIpv4)
+	}
+	if ipv6 {
+		ipVersions = append(ipVersions, util.InboundPassthroughClusterIpv6)
+	}
 	filterChains := make([]*listener.FilterChain, 0, 2)
 
-	for _, clusterName := range []string{util.InboundPassthroughClusterIpv4, util.InboundPassthroughClusterIpv6} {
+	for _, clusterName := range ipVersions {
 		matchingIP := ""
 		if clusterName == util.InboundPassthroughClusterIpv4 {
 			matchingIP = "0.0.0.0/0"

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -214,8 +214,8 @@ func TestVirtualInboundListenerBuilder(t *testing.T) {
 	}
 
 	for k, v := range byListenerName {
-		if k == VirtualInboundListenerName && v != 4 {
-			t.Fatalf("expect virtual listener has 4 passthrough listeners, found %d", v)
+		if k == VirtualInboundListenerName && v != 2 {
+			t.Fatalf("expect virtual listener has 2 passthrough listeners, found %d", v)
 		}
 		if k == listeners[0].Name && v != len(listeners[0].FilterChains) {
 			t.Fatalf("expect virtual listener has %d filter chains from listener %s, found %d", len(listeners[0].FilterChains), l.Name, v)
@@ -233,11 +233,10 @@ func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
 	}
 
 	l := listeners[2]
-	// 4 is the 2 passthrough tcp filter chains one for ipv4 and one for ipv6
-	// and 2 http filter chains one for ipv4 and one for ipv6
-	if len(l.FilterChains) != len(listeners[0].FilterChains)+4 {
+	// 2 is the 1 passthrough tcp filter chain for ipv4 and 1 http filter chain for ipv4
+	if len(l.FilterChains) != len(listeners[0].FilterChains)+2 {
 		t.Fatalf("expect virtual listener has %d filter chains as the sum of 2nd level listeners "+
-			"plus the 4 fallthrough filter chains, found %d", len(listeners[0].FilterChains)+4, len(l.FilterChains))
+			"plus the 2 fallthrough filter chains, found %d", len(listeners[0].FilterChains)+2, len(l.FilterChains))
 	}
 
 	sawIpv4PassthroughCluster := false
@@ -271,8 +270,8 @@ func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
 		}
 	}
 
-	if !sawIpv4PassthroughCluster || !sawIpv6PassthroughCluster {
-		t.Fatalf("fail to find 1 ipv6 passthrough filter chain and 1 ipv4 passthrough filter chain in listener %v", l)
+	if !sawIpv4PassthroughCluster {
+		t.Fatalf("fail to find the ipv4 passthrough filter chain in listener %v", l)
 	}
 
 	if len(l.ListenerFilters) != 2 {

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -233,11 +233,11 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 		t.Fatalf("Expected 7 listeners, got %d\n", len(adsResponse.GetHTTPListeners())+len(adsResponse.GetTCPListeners()))
 	}
 
-	// Expect 12 CDS clusters:
-	// 3 inbound(http, inbound passthroughipv4 and inbound passthroughipv6)
+	// Expect 11 CDS clusters:
+	// 2 inbound(http, inbound passthroughipv4) notes: no passthroughipv6
 	// 9 outbound (2 http services, 1 tcp service, 2 istio-system services,
 	//   and 2 subsets of http1, 1 blackhole, 1 passthrough)
-	if (len(adsResponse.GetClusters()) + len(adsResponse.GetEdsClusters())) != 12 {
+	if (len(adsResponse.GetClusters()) + len(adsResponse.GetEdsClusters())) != 11 {
 		t.Fatalf("Expected 12 clusters in CDS output. Got %d", len(adsResponse.GetClusters())+len(adsResponse.GetEdsClusters()))
 	}
 


### PR DESCRIPTION
Generate passthough cluster and listener by ip versions provided by proxy.

fix #16763

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
