### PR TITLE
[tracing e2e test] Avoid race between destination rule and trace span generation

### DIFF
--- a/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
@@ -49,10 +49,11 @@ func TestClientTracing(t *testing.T) {
 			addr := ingress.HTTPAddress()
 			url := fmt.Sprintf("http://%s/productpage", addr.String())
 			extraHeader := fmt.Sprintf("%s: %s", traceHeader, id)
-			// Send test traffic. QPS is restricted to 10, so this will send ~20secs worth of traffic.
-			// We want a multiple of 5secs worth of traffic, given default envoy flush times on the zipkin driver.
-			util.SendTraffic(ingress, t, "Sending traffic", url, extraHeader, 200)
+
 			retry.UntilSuccessOrFail(t, func() error {
+				// Send test traffic. QPS is restricted to 10, so this will send ~20secs worth of traffic.
+				// We want a multiple of 5secs worth of traffic, given default envoy flush times on the zipkin driver.
+				util.SendTraffic(ingress, t, "Sending traffic", url, extraHeader, 200)
 				traces, err := tracing.GetZipkinInstance().QueryTraces(100,
 					fmt.Sprintf("productpage.%s.svc.cluster.local:9080/productpage", bookinfoNsInst.Name()), fmt.Sprintf("guid:x-client-trace-id=%s", id))
 				if err != nil {

--- a/tests/integration/telemetry/tracing/tracing.go
+++ b/tests/integration/telemetry/tracing/tracing.go
@@ -128,8 +128,12 @@ func CompareTrace(t *testing.T, got, want zipkin.Span) bool {
 		t.Logf("got span %+v, want span %+v", got, want)
 		return false
 	}
-	if len(got.ChildSpans) != len(want.ChildSpans) {
+	if len(got.ChildSpans) < len(want.ChildSpans) {
 		t.Logf("got %d child spans from, want %d child spans, maybe trace has not be fully reported",
+			len(got.ChildSpans), len(want.ChildSpans))
+		return false
+	} else if len(got.ChildSpans) > len(want.ChildSpans) {
+		t.Logf("got %d child spans from, want %d child spans, maybe destination rule has not became effective",
 			len(got.ChildSpans), len(want.ChildSpans))
 		return false
 	}


### PR DESCRIPTION
https://github.com/istio/istio/issues/16780

Unlike test of tracing originated by proxy, client originated tracing test does not send new traffic for every retry, which might make it fail because of race between destination rule effectiveness (which makes sure number of child spans is deterministic) and trace span generation. Also make error message more clear about what causes number of child spans to be different.