### PR TITLE
Pilot: add tls_inspector if alpn is used

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -2184,20 +2184,20 @@ func isConflictWithWellKnownPort(incoming, existing protocol.Instance, conflict 
 }
 
 func appendListenerFilters(filters []*listener.ListenerFilter) []*listener.ListenerFilter {
-	hasTlsInspector := false
-	hasHttpInspector := false
+	hasTLSInspector := false
+	hasHTTPInspector := false
 
 	for _, f := range filters {
-		hasTlsInspector = hasTlsInspector || f.Name == xdsutil.TlsInspector
-		hasHttpInspector = hasHttpInspector || f.Name == envoyListenerHTTPInspector
+		hasTLSInspector = hasTLSInspector || f.Name == xdsutil.TlsInspector
+		hasHTTPInspector = hasHTTPInspector || f.Name == envoyListenerHTTPInspector
 	}
 
-	if !hasTlsInspector {
+	if !hasTLSInspector {
 		filters =
 			append(filters, &listener.ListenerFilter{Name: xdsutil.TlsInspector})
 	}
 
-	if !hasHttpInspector {
+	if !hasHTTPInspector {
 		filters =
 			append(filters, &listener.ListenerFilter{Name: envoyListenerHTTPInspector})
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -461,9 +461,10 @@ func testOutboundListenerConflictV13(t *testing.T, services ...*model.Service) {
 		}
 
 		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2])
-		if len(listeners[0].ListenerFilters) != 1 ||
-			listeners[0].ListenerFilters[0].Name != "envoy.listener.http_inspector" {
-			t.Fatalf("expected %d listener filter, found %d", 1, len(listeners[0].ListenerFilters))
+		if len(listeners[0].ListenerFilters) != 2 ||
+			listeners[0].ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
+			listeners[0].ListenerFilters[1].Name != "envoy.listener.http_inspector" {
+			t.Fatalf("expected %d listener filter, found %d", 2, len(listeners[0].ListenerFilters))
 		}
 	} else {
 		if len(listeners[0].FilterChains) != 3 {
@@ -479,9 +480,10 @@ func testOutboundListenerConflictV13(t *testing.T, services ...*model.Service) {
 		}
 
 		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2])
-		if len(listeners[0].ListenerFilters) != 1 ||
-			listeners[0].ListenerFilters[0].Name != "envoy.listener.http_inspector" {
-			t.Fatalf("expected %d listener filter, found %d", 1, len(listeners[0].ListenerFilters))
+		if len(listeners[0].ListenerFilters) != 2 ||
+			listeners[0].ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
+			listeners[0].ListenerFilters[1].Name != "envoy.listener.http_inspector" {
+			t.Fatalf("expected %d listener filter, found %d", 2, len(listeners[0].ListenerFilters))
 		}
 	}
 }
@@ -678,9 +680,10 @@ func testOutboundListenerConfigWithSidecarV13(t *testing.T, services ...*model.S
 
 		verifyHTTPFilterChainMatch(t, l.FilterChains[3])
 
-		if len(l.ListenerFilters) != 1 ||
-			l.ListenerFilters[0].Name != "envoy.listener.http_inspector" {
-			t.Fatalf("expected %d listener filter, found %d", 1, len(l.ListenerFilters))
+		if len(l.ListenerFilters) != 2 ||
+			l.ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
+			l.ListenerFilters[1].Name != "envoy.listener.http_inspector" {
+			t.Fatalf("expected %d listener filter, found %d", 2, len(l.ListenerFilters))
 		}
 	}
 
@@ -706,9 +709,10 @@ func testOutboundListenerConfigWithSidecarV13(t *testing.T, services ...*model.S
 	}
 
 	verifyHTTPFilterChainMatch(t, l.FilterChains[1])
-	if len(l.ListenerFilters) != 1 ||
-		l.ListenerFilters[0].Name != "envoy.listener.http_inspector" {
-		t.Fatalf("expected %d listener filter, found %d", 1, len(l.ListenerFilters))
+	if len(l.ListenerFilters) != 2 ||
+		l.ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
+		l.ListenerFilters[1].Name != "envoy.listener.http_inspector" {
+		t.Fatalf("expected %d listener filter, found %d", 2, len(l.ListenerFilters))
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/16755

Envoy will check if TLS inspector is configured if ALPN is used. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
