### PR TITLE
fix codecov for unknown import path

### DIFF
--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -137,7 +137,6 @@ pushd "${OUT_DIR}"
 go get github.com/wadey/gocovmerge
 gocovmerge "${COVERAGEDIR}"/*.cov > coverage.cov
 cat "${COVERAGEDIR}"/*.report > report.out
-go tool cover -html=coverage.cov -o coverage.html
 
 # Build the combined junit.xml
 go get github.com/imsky/junit-merger/src/junit-merger


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fixes https://github.com/istio/istio/issues/16793 and confirmed in https://github.com/istio/istio/pull/16602. The codecov.html is never used after its generation, so probably just do not generate it. The `go tool cover` seems having some bugs here, not sure if it's related to the switching to GO111MODULE=on.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[X] Developer Infrastructure
