### PR TITLE
backport #16786 and #16286

### DIFF
--- a/istioctl/cmd/testdata/auth/productpage_config_dump.json
+++ b/istioctl/cmd/testdata/auth/productpage_config_dump.json
@@ -1,9546 +1,9546 @@
 {
- "configs": [
-  {
-   "@type": "type.googleapis.com/envoy.admin.v2alpha.BootstrapConfigDump",
-   "bootstrap": {
-    "node": {
-     "id": "sidecar~10.52.2.21~productpage-v1-5cb458d74f-56sx7.default~default.svc.cluster.local",
-     "cluster": "productpage.default",
-     "metadata": {
-      "pod-template-hash": "1760148309",
-      "INTERCEPTION_MODE": "REDIRECT",
-      "version": "v1",
-      "CONFIG_NAMESPACE": "default",
-      "ISTIO_VERSION": "1.1.1",
-      "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container productpage",
-      "INSTANCE_IPS": "10.52.2.21,fe80::54f8:2cff:fe2b:2dd3",
-      "POD_NAME": "productpage-v1-5cb458d74f-56sx7",
-      "istio": "sidecar",
-      "ISTIO_PROXY_SHA": "istio-proxy:55c80965eab994e6bfa2227e3942fa89928d0d70",
-      "app": "productpage"
-     },
-     "locality": {},
-     "build_version": "55c80965eab994e6bfa2227e3942fa89928d0d70/1.10.0-dev/Clean/RELEASE/BoringSSL"
-    },
-    "static_resources": {
-     "listeners": [
-      {
-       "address": {
-        "socket_address": {
-         "address": "0.0.0.0",
-         "port_value": 15090
-        }
-       },
-       "filter_chains": [
-        {
-         "filters": [
-          {
-           "name": "envoy.http_connection_manager",
-           "config": {
-            "http_filters": {
-             "name": "envoy.router"
-            },
-            "stat_prefix": "stats",
-            "route_config": {
-             "virtual_hosts": [
-              {
-               "domains": [
-                "*"
-               ],
-               "name": "backend",
-               "routes": [
-                {
-                 "route": {
-                  "cluster": "prometheus_stats"
-                 },
-                 "match": {
-                  "prefix": "/stats/prometheus"
-                 }
+  "configs": [
+    {
+      "@type": "type.googleapis.com/envoy.admin.v2alpha.BootstrapConfigDump",
+      "bootstrap": {
+        "node": {
+          "id": "sidecar~10.52.2.21~productpage-v1-5cb458d74f-56sx7.default~default.svc.cluster.local",
+          "cluster": "productpage.default",
+          "metadata": {
+            "pod-template-hash": "1760148309",
+            "INTERCEPTION_MODE": "REDIRECT",
+            "version": "v1",
+            "CONFIG_NAMESPACE": "default",
+            "ISTIO_VERSION": "1.1.1",
+            "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container productpage",
+            "INSTANCE_IPS": "10.52.2.21,fe80::54f8:2cff:fe2b:2dd3",
+            "POD_NAME": "productpage-v1-5cb458d74f-56sx7",
+            "istio": "sidecar",
+            "ISTIO_PROXY_SHA": "istio-proxy:55c80965eab994e6bfa2227e3942fa89928d0d70",
+            "app": "productpage"
+          },
+          "locality": {},
+          "build_version": "55c80965eab994e6bfa2227e3942fa89928d0d70/1.10.0-dev/Clean/RELEASE/BoringSSL"
+        },
+        "static_resources": {
+          "listeners": [
+            {
+              "address": {
+                "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 15090
                 }
-               ]
-              }
-             ]
-            },
-            "codec_type": "AUTO"
-           }
-          }
-         ]
-        }
-       ]
-      }
-     ],
-     "clusters": [
-      {
-       "name": "prometheus_stats",
-       "connect_timeout": "0.250s",
-       "hosts": [
-        {
-         "socket_address": {
-          "address": "127.0.0.1",
-          "port_value": 15000
-         }
-        }
-       ]
-      },
-      {
-       "name": "xds-grpc",
-       "type": "STRICT_DNS",
-       "connect_timeout": "10s",
-       "hosts": [
-        {
-         "socket_address": {
-          "address": "istio-pilot.istio-system",
-          "port_value": 15011
-         }
-        }
-       ],
-       "circuit_breakers": {
-        "thresholds": [
-         {
-          "max_connections": 100000,
-          "max_pending_requests": 100000,
-          "max_requests": 100000
-         },
-         {
-          "priority": "HIGH",
-          "max_connections": 100000,
-          "max_pending_requests": 100000,
-          "max_requests": 100000
-         }
-        ]
-       },
-       "tls_context": {
-        "common_tls_context": {
-         "tls_certificates": [
-          {
-           "certificate_chain": {
-            "filename": "/etc/certs/cert-chain.pem"
-           },
-           "private_key": {
-            "filename": "/etc/certs/key.pem"
-           }
-          }
-         ],
-         "validation_context": {
-          "trusted_ca": {
-           "filename": "/etc/certs/root-cert.pem"
-          },
-          "verify_subject_alt_name": [
-           "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-          ]
-         },
-         "alpn_protocols": [
-          "h2"
-         ]
-        }
-       },
-       "http2_protocol_options": {},
-       "upstream_connection_options": {
-        "tcp_keepalive": {
-         "keepalive_time": 300
-        }
-       }
-      },
-      {
-       "name": "zipkin",
-       "type": "STRICT_DNS",
-       "connect_timeout": "1s",
-       "hosts": [
-        {
-         "socket_address": {
-          "address": "zipkin.istio-system",
-          "port_value": 9411
-         }
-        }
-       ]
-      }
-     ]
-    },
-    "dynamic_resources": {
-     "lds_config": {
-      "ads": {}
-     },
-     "cds_config": {
-      "ads": {}
-     },
-     "ads_config": {
-      "api_type": "GRPC",
-      "grpc_services": [
-       {
-        "envoy_grpc": {
-         "cluster_name": "xds-grpc"
-        }
-       }
-      ]
-     }
-    },
-    "tracing": {
-     "http": {
-      "name": "envoy.zipkin",
-      "config": {
-       "trace_id_128bit": "true",
-       "shared_span_context": "false",
-       "collector_endpoint": "/api/v1/spans",
-       "collector_cluster": "zipkin"
-      }
-     }
-    },
-    "admin": {
-     "access_log_path": "/dev/null",
-     "address": {
-      "socket_address": {
-       "address": "127.0.0.1",
-       "port_value": 15000
-      }
-     }
-    },
-    "stats_config": {
-     "stats_tags": [
-      {
-       "tag_name": "cluster_name",
-       "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
-      },
-      {
-       "tag_name": "tcp_prefix",
-       "regex": "^tcp\\.((.*?)\\.)\\w+?$"
-      },
-      {
-       "tag_name": "response_code",
-       "regex": "_rq(_(\\d{3}))$"
-      },
-      {
-       "tag_name": "response_code_class",
-       "regex": "_rq(_(\\dxx))$"
-      },
-      {
-       "tag_name": "http_conn_manager_listener_prefix",
-       "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
-      {
-       "tag_name": "http_conn_manager_prefix",
-       "regex": "^http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
-      {
-       "tag_name": "listener_address",
-       "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
-      {
-       "tag_name": "mongo_prefix",
-       "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
-      }
-     ],
-     "use_all_default_tags": false,
-     "stats_matcher": {
-      "inclusion_list": {
-       "patterns": [
-        {
-         "prefix": "cluster_manager"
-        },
-        {
-         "prefix": "listener_manager"
-        },
-        {
-         "prefix": "http_mixer_filter"
-        },
-        {
-         "prefix": "tcp_mixer_filter"
-        },
-        {
-         "prefix": "server"
-        },
-        {
-         "prefix": "cluster.xds-grpc"
-        }
-       ]
-      }
-     }
-    }
-   },
-   "last_updated": "2019-04-02T19:54:30.620Z"
-  },
-  {
-   "@type": "type.googleapis.com/envoy.admin.v2alpha.ClustersConfigDump",
-   "version_info": "2019-04-02T20:47:51Z/31",
-   "static_clusters": [
-    {
-     "cluster": {
-      "name": "prometheus_stats",
-      "connect_timeout": "0.250s",
-      "hosts": [
-       {
-        "socket_address": {
-         "address": "127.0.0.1",
-         "port_value": 15000
-        }
-       }
-      ]
-     },
-     "last_updated": "2019-04-02T19:54:30.621Z"
-    },
-    {
-     "cluster": {
-      "name": "xds-grpc",
-      "type": "STRICT_DNS",
-      "connect_timeout": "10s",
-      "hosts": [
-       {
-        "socket_address": {
-         "address": "istio-pilot.istio-system",
-         "port_value": 15011
-        }
-       }
-      ],
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_connections": 100000,
-         "max_pending_requests": 100000,
-         "max_requests": 100000
-        },
-        {
-         "priority": "HIGH",
-         "max_connections": 100000,
-         "max_pending_requests": 100000,
-         "max_requests": 100000
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "h2"
-        ]
-       }
-      },
-      "http2_protocol_options": {},
-      "upstream_connection_options": {
-       "tcp_keepalive": {
-        "keepalive_time": 300
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:30.624Z"
-    },
-    {
-     "cluster": {
-      "name": "zipkin",
-      "type": "STRICT_DNS",
-      "connect_timeout": "1s",
-      "hosts": [
-       {
-        "socket_address": {
-         "address": "zipkin.istio-system",
-         "port_value": 9411
-        }
-       }
-      ]
-     },
-     "last_updated": "2019-04-02T19:54:30.624Z"
-    }
-   ],
-   "dynamic_active_clusters": [
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "BlackHoleCluster",
-      "connect_timeout": "1s"
-     },
-     "last_updated": "2019-04-02T19:54:31.795Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "PassthroughCluster",
-      "type": "ORIGINAL_DST",
-      "connect_timeout": "1s",
-      "lb_policy": "ORIGINAL_DST_LB"
-     },
-     "last_updated": "2019-04-02T19:54:31.795Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "inbound|15020|mgmt-15020|mgmtCluster",
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|15020|mgmt-15020|mgmtCluster",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 15020
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.795Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "inbound|9080|http|productpage.default.svc.cluster.local",
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|9080|http|productpage.default.svc.cluster.local",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 9080
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.795Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|14267||jaeger-collector.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|14267||jaeger-collector.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.14267_._.jaeger-collector.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.788Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|14268||jaeger-collector.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|14268||jaeger-collector.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.14268_._.jaeger-collector.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.789Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-mixer-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio",
-         "h2"
-        ]
-       },
-       "sni": "outbound_.15004_._.istio-policy.istio-system.svc.cluster.local"
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.776Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-mixer-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio",
-         "h2"
-        ]
-       },
-       "sni": "outbound_.15004_._.istio-telemetry.istio-system.svc.cluster.local"
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.785Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15010||istio-pilot.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15010||istio-pilot.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio",
-         "h2"
-        ]
-       },
-       "sni": "outbound_.15010_._.istio-pilot.istio-system.svc.cluster.local"
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.779Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15011||istio-pilot.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15011||istio-pilot.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15011_._.istio-pilot.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.780Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15014||istio-citadel.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15014||istio-citadel.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-citadel-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15014_._.istio-citadel.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.778Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15014||istio-galley.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15014||istio-galley.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15014_._.istio-galley.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.764Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15014||istio-pilot.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15014||istio-pilot.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15014_._.istio-pilot.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.782Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15014||istio-policy.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15014||istio-policy.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.776Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.785Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15020_._.istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.774Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15029_._.istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.769Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15030_._.istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.770Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15031_._.istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.771Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15032_._.istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.772Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15443_._.istio-egressgateway.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.761Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.15443_._.istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.773Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|16686||jaeger-query.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|16686||jaeger-query.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.16686_._.jaeger-query.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.787Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|20001||kiali.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|20001||kiali.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/kiali-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.20001_._.kiali.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.777Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|3000||grafana.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|3000||grafana.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.3000_._.grafana.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.757Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.31400_._.istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.768Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.785Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.443_._.istio-egressgateway.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.760Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|443||istio-galley.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||istio-galley.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.443_._.istio-galley.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.763Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.443_._.istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.767Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-sidecar-injector-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.443_._.istio-sidecar-injector.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.783Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|443||kubernetes.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||kubernetes.default.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/api-server"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.749Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|443||metrics-server.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||metrics-server.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/kube-system/sa/metrics-server"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.443_._.metrics-server.kube-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.749Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|53||kube-dns.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|53||kube-dns.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/kube-system/sa/kube-dns"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.53_._.kube-dns.kube-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.748Z"
-    },
-    {
-     "version_info": "2019-04-02T20:05:54Z/25",
-     "cluster": {
-      "name": "outbound|8000||httpbin.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|8000||httpbin.default.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/default/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.8000_._.httpbin.default.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T20:05:54.246Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|8060||istio-citadel.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|8060||istio-citadel.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-citadel-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio",
-         "h2"
-        ]
-       },
-       "sni": "outbound_.8060_._.istio-citadel.istio-system.svc.cluster.local"
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.778Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|8080||istio-pilot.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|8080||istio-pilot.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.8080_._.istio-pilot.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.781Z"
-    },
-    {
-     "version_info": "2019-04-02T20:05:55Z/26",
-     "cluster": {
-      "name": "outbound|80||alice.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||alice.default.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/default/sa/alice"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.80_._.alice.default.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T20:05:55.847Z"
-    },
-    {
-     "version_info": "2019-04-02T20:05:39Z/23",
-     "cluster": {
-      "name": "outbound|80||bob.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||bob.default.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/default/sa/bob"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.80_._.bob.default.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T20:05:39.163Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|80||default-http-backend.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||default-http-backend.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/kube-system/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.80_._.default-http-backend.kube-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.746Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|80||heapster.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||heapster.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/kube-system/sa/heapster"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.80_._.heapster.kube-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.747Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio",
-         "h2"
-        ]
-       },
-       "sni": "outbound_.80_._.istio-egressgateway.istio-system.svc.cluster.local"
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.758Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio",
-         "h2"
-        ]
-       },
-       "sni": "outbound_.80_._.istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.766Z"
-    },
-    {
-     "version_info": "2019-04-02T20:05:39Z/24",
-     "cluster": {
-      "name": "outbound|80||sleep.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||sleep.default.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/default/sa/sleep"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.80_._.sleep.default.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T20:05:39.337Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|80||tracing.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||tracing.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.80_._.tracing.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.790Z"
-    },
-    {
-     "version_info": "2019-04-02T20:05:56Z/27",
-     "cluster": {
-      "name": "outbound|9000||tcp-echo.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9000||tcp-echo.default.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/default/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.9000_._.tcp-echo.default.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T20:05:56.249Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|9080||details.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9080||details.default.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/default/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.9080_._.details.default.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.792Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:32Z/17",
-     "cluster": {
-      "name": "outbound|9080||productpage.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9080||productpage.default.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/default/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.9080_._.productpage.default.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:32.761Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|9080||ratings.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9080||ratings.default.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/default/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.9080_._.ratings.default.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.793Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|9080||reviews.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9080||reviews.default.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/default/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.9080_._.reviews.default.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.794Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|9090||prometheus.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9090||prometheus.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/prometheus"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.9090_._.prometheus.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.786Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.775Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.783Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|9411||zipkin.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9411||zipkin.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/default"
-         ]
-        },
-        "alpn_protocols": [
-         "istio"
-        ]
-       },
-       "sni": "outbound_.9411_._.zipkin.istio-system.svc.cluster.local"
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.791Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "cluster": {
-      "name": "outbound|9901||istio-galley.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9901||istio-galley.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "1s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "tls_context": {
-       "common_tls_context": {
-        "tls_certificates": [
-         {
-          "certificate_chain": {
-           "filename": "/etc/certs/cert-chain.pem"
-          },
-          "private_key": {
-           "filename": "/etc/certs/key.pem"
-          }
-         }
-        ],
-        "validation_context": {
-         "trusted_ca": {
-          "filename": "/etc/certs/root-cert.pem"
-         },
-         "verify_subject_alt_name": [
-          "spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account"
-         ]
-        },
-        "alpn_protocols": [
-         "istio",
-         "h2"
-        ]
-       },
-       "sni": "outbound_.9901_._.istio-galley.istio-system.svc.cluster.local"
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.765Z"
-    }
-   ]
-  },
-  {
-   "@type": "type.googleapis.com/envoy.admin.v2alpha.ListenersConfigDump",
-   "version_info": "2019-04-02T20:47:51Z/31",
-   "static_listeners": [
-    {
-     "listener": {
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 15090
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "codec_type": "AUTO",
-           "http_filters": {
-            "name": "envoy.router"
-           },
-           "stat_prefix": "stats",
-           "route_config": {
-            "virtual_hosts": [
-             {
-              "routes": [
-               {
-                "route": {
-                 "cluster": "prometheus_stats"
-                },
-                "match": {
-                 "prefix": "/stats/prometheus"
-                }
-               }
-              ],
-              "domains": [
-               "*"
-              ],
-              "name": "backend"
-             }
-            ]
-           }
-          }
-         }
-        ]
-       }
-      ]
-     },
-     "last_updated": "2019-04-02T19:54:30.628Z"
-    }
-   ],
-   "dynamic_active_listeners": [
-    {
-     "version_info": "2019-04-02T20:47:51Z/31",
-     "listener": {
-      "name": "10.52.2.21_9080",
-      "address": {
-       "socket_address": {
-        "address": "10.52.2.21",
-        "port_value": 9080
-       }
-      },
-      "filter_chains": [
-       {
-        "tls_context": {
-         "common_tls_context": {
-          "tls_certificates": [
-           {
-            "certificate_chain": {
-             "filename": "/etc/certs/cert-chain.pem"
-            },
-            "private_key": {
-             "filename": "/etc/certs/key.pem"
-            }
-           }
-          ],
-          "validation_context": {
-           "trusted_ca": {
-            "filename": "/etc/certs/root-cert.pem"
-           }
-          },
-          "alpn_protocols": [
-           "h2",
-           "http/1.1"
-          ]
-         },
-         "require_client_certificate": true
-        },
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "random_sampling": {
-             "value": 100
-            },
-            "overall_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            }
-           },
-           "use_remote_address": false,
-           "stat_prefix": "10.52.2.21_9080",
-           "set_current_client_cert_details": {
-            "uri": true,
-            "subject": true,
-            "dns": true
-           },
-           "stream_idle_timeout": "0s",
-           "forward_client_cert_details": "APPEND_FORWARD",
-           "server_name": "istio-envoy",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "jwt-auth",
-             "config": {
-              "allow_missing_or_failed": true,
-              "rules": [
-               {
-                "issuer": "testing@secure.istio.io",
-                "local_jwks": {
-                 "inline_string": "{ \"keys\":[ {\"e\":\"AQAB\",\"kid\":\"DHFbpoIUqrY8t2zpA2qXfCmr5VO5ZEr4RzHU_-envvQ\",\"kty\":\"RSA\",\"n\":\"xAE7eB6qugXyCAG3yhh7pkDkT65pHymX-P7KfIupjf59vsdo91bSP9C8H07pSAGQO1MV_xFj9VswgsCg4R6otmg5PV2He95lZdHtOcU5DXIg_pbhLdKXbi66GlVeK6ABZOUW3WYtnNHD-91gVuoeJT_DwtGGcp4ignkgXfkiEm4sw-4sfb4qdt5oLbyVpmW6x9cfa7vs2WTfURiCrBoUqgBo_-4WTiULmmHSGZHOjzwa8WtrtOQGsAFjIbno85jp6MnGGGZPYZbDAa_b3y5u-YpW7ypZrvD8BgtKVjgtQgZhLAGezMt0ua3DRrWnKqTZ0BJ_EyxOGuHJrLsn00fnMQ\"}]}"
-                },
-                "forward_payload_header": "istio-sec-5406b7840708063f65cbdf52153ca364a476d68b",
-                "forward": true
-               }
-              ]
-             }
-            },
-            {
-             "name": "istio_authn",
-             "config": {
-              "jwt_output_payload_locations": {
-               "testing@secure.istio.io": "istio-sec-5406b7840708063f65cbdf52153ca364a476d68b"
               },
-              "policy": {
-               "peers": [
+              "filter_chains": [
                 {
-                 "mtls": {}
+                  "filters": [
+                    {
+                      "name": "envoy.http_connection_manager",
+                      "config": {
+                        "http_filters": {
+                          "name": "envoy.router"
+                        },
+                        "stat_prefix": "stats",
+                        "route_config": {
+                          "virtual_hosts": [
+                            {
+                              "domains": [
+                                "*"
+                              ],
+                              "name": "backend",
+                              "routes": [
+                                {
+                                  "route": {
+                                    "cluster": "prometheus_stats"
+                                  },
+                                  "match": {
+                                    "prefix": "/stats/prometheus"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "codec_type": "AUTO"
+                      }
+                    }
+                  ]
                 }
-               ],
-               "principal_binding": "USE_ORIGIN",
-               "origins": [
+              ]
+            }
+          ],
+          "clusters": [
+            {
+              "name": "prometheus_stats",
+              "connect_timeout": "0.250s",
+              "hosts": [
                 {
-                 "jwt": {
-                  "jwks_uri": "https://raw.githubusercontent.com/istio/istio/release-1.1/security/tools/jwt/samples/jwks.json",
-                  "issuer": "testing@secure.istio.io"
-                 }
+                  "socket_address": {
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
                 }
-               ]
-              }
-             }
+              ]
             },
             {
-             "name": "envoy.filters.http.rbac",
-             "config": {
-              "rules": {
-               "policies": {
-                "service-viewer": {
-                 "principals": [
+              "name": "xds-grpc",
+              "type": "STRICT_DNS",
+              "connect_timeout": "10s",
+              "hosts": [
+                {
+                  "socket_address": {
+                    "address": "istio-pilot.istio-system",
+                    "port_value": 15011
+                  }
+                }
+              ],
+              "circuit_breakers": {
+                "thresholds": [
                   {
-                   "and_ids": {
-                    "ids": [
-                     {
-                      "metadata": {
-                       "filter": "istio_authn",
-                       "value": {
-                        "string_match": {
-                         "regex": ".*/ns/istio-system/.*"
-                        }
-                       },
-                       "path": [
-                        {
-                         "key": "source.principal"
-                        }
-                       ]
-                      }
-                     }
-                    ]
-                   }
+                    "max_connections": 100000,
+                    "max_pending_requests": 100000,
+                    "max_requests": 100000
                   },
                   {
-                   "and_ids": {
-                    "ids": [
-                     {
-                      "metadata": {
-                       "filter": "istio_authn",
-                       "value": {
-                        "string_match": {
-                         "regex": ".*/ns/default/.*"
-                        }
-                       },
-                       "path": [
-                        {
-                         "key": "source.principal"
-                        }
-                       ]
-                      }
-                     }
-                    ]
-                   }
+                    "priority": "HIGH",
+                    "max_connections": 100000,
+                    "max_pending_requests": 100000,
+                    "max_requests": 100000
                   }
-                 ],
-                 "permissions": [
-                  {
-                   "and_rules": {
-                    "rules": [
-                     {
-                      "or_rules": {
-                       "rules": [
-                        {
-                         "header": {
-                          "exact_match": "GET",
-                          "name": ":method"
-                         }
-                        }
-                       ]
+                ]
+              },
+              "tls_context": {
+                "common_tls_context": {
+                  "tls_certificates": [
+                    {
+                      "certificate_chain": {
+                        "filename": "/etc/certs/cert-chain.pem"
+                      },
+                      "private_key": {
+                        "filename": "/etc/certs/key.pem"
                       }
-                     }
-                    ]
-                   }
-                  }
-                 ]
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {}
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "destination.namespace": {
-                 "string_value": "default"
-                },
-                "destination.ip": {
-                 "bytes_value": "AAAAAAAAAAAAAP//CjQCFQ=="
-                },
-                "destination.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "inbound"
-                },
-                "destination.port": {
-                 "int64_value": "9080"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "route_config": {
-            "name": "inbound|9080|http|productpage.default.svc.cluster.local",
-            "validate_clusters": false,
-            "virtual_hosts": [
-             {
-              "routes": [
-               {
-                "match": {
-                 "prefix": "/"
-                },
-                "per_filter_config": {
-                 "mixer": {
-                  "mixer_attributes": {
-                   "attributes": {
-                    "destination.service.namespace": {
-                     "string_value": "default"
-                    },
-                    "destination.service.name": {
-                     "string_value": "productpage"
-                    },
-                    "destination.service.uid": {
-                     "string_value": "istio://default/services/productpage"
-                    },
-                    "destination.service.host": {
-                     "string_value": "productpage.default.svc.cluster.local"
                     }
-                   }
+                  ],
+                  "validation_context": {
+                    "trusted_ca": {
+                      "filename": "/etc/certs/root-cert.pem"
+                    },
+                    "verify_subject_alt_name": [
+                      "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
+                    ]
+                  },
+                  "alpn_protocols": [
+                    "h2"
+                  ]
+                }
+              },
+              "http2_protocol_options": {},
+              "upstream_connection_options": {
+                "tcp_keepalive": {
+                  "keepalive_time": 300
+                }
+              }
+            },
+            {
+              "name": "zipkin",
+              "type": "STRICT_DNS",
+              "connect_timeout": "1s",
+              "hosts": [
+                {
+                  "socket_address": {
+                    "address": "zipkin.istio-system",
+                    "port_value": 9411
                   }
-                 }
-                },
-                "decorator": {
-                 "operation": "productpage.default.svc.cluster.local:9080/*"
-                },
-                "route": {
-                 "max_grpc_timeout": "0s",
-                 "cluster": "inbound|9080|http|productpage.default.svc.cluster.local",
-                 "timeout": "0s"
                 }
-               }
-              ],
-              "domains": [
-               "*"
-              ],
-              "name": "inbound|http|9080"
-             }
-            ]
-           },
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
+              ]
             }
-           ]
+          ]
+        },
+        "dynamic_resources": {
+          "lds_config": {
+            "ads": {}
+          },
+          "cds_config": {
+            "ads": {}
+          },
+          "ads_config": {
+            "api_type": "GRPC",
+            "grpc_services": [
+              {
+                "envoy_grpc": {
+                  "cluster_name": "xds-grpc"
+                }
+              }
+            ]
           }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
+        },
+        "tracing": {
+          "http": {
+            "name": "envoy.zipkin",
+            "config": {
+              "trace_id_128bit": "true",
+              "shared_span_context": "false",
+              "collector_endpoint": "/api/v1/spans",
+              "collector_cluster": "zipkin"
+            }
+          }
+        },
+        "admin": {
+          "access_log_path": "/dev/null",
+          "address": {
+            "socket_address": {
+              "address": "127.0.0.1",
+              "port_value": 15000
+            }
+          }
+        },
+        "stats_config": {
+          "stats_tags": [
+            {
+              "tag_name": "cluster_name",
+              "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+            },
+            {
+              "tag_name": "tcp_prefix",
+              "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+            },
+            {
+              "tag_name": "response_code",
+              "regex": "_rq(_(\\d{3}))$"
+            },
+            {
+              "tag_name": "response_code_class",
+              "regex": "_rq(_(\\dxx))$"
+            },
+            {
+              "tag_name": "http_conn_manager_listener_prefix",
+              "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+            },
+            {
+              "tag_name": "http_conn_manager_prefix",
+              "regex": "^http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+            },
+            {
+              "tag_name": "listener_address",
+              "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+            },
+            {
+              "tag_name": "mongo_prefix",
+              "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
+            }
+          ],
+          "use_all_default_tags": false,
+          "stats_matcher": {
+            "inclusion_list": {
+              "patterns": [
+                {
+                  "prefix": "cluster_manager"
+                },
+                {
+                  "prefix": "listener_manager"
+                },
+                {
+                  "prefix": "http_mixer_filter"
+                },
+                {
+                  "prefix": "tcp_mixer_filter"
+                },
+                {
+                  "prefix": "server"
+                },
+                {
+                  "prefix": "cluster.xds-grpc"
+                }
+              ]
+            }
+          }
+        }
       },
-      "listener_filters": [
-       {
-        "name": "envoy.listener.tls_inspector"
-       }
+      "last_updated": "2019-04-02T19:54:30.620Z"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.admin.v2alpha.ClustersConfigDump",
+      "version_info": "2019-04-02T20:47:51Z/31",
+      "static_clusters": [
+        {
+          "cluster": {
+            "name": "prometheus_stats",
+            "connect_timeout": "0.250s",
+            "hosts": [
+              {
+                "socket_address": {
+                  "address": "127.0.0.1",
+                  "port_value": 15000
+                }
+              }
+            ]
+          },
+          "last_updated": "2019-04-02T19:54:30.621Z"
+        },
+        {
+          "cluster": {
+            "name": "xds-grpc",
+            "type": "STRICT_DNS",
+            "connect_timeout": "10s",
+            "hosts": [
+              {
+                "socket_address": {
+                  "address": "istio-pilot.istio-system",
+                  "port_value": 15011
+                }
+              }
+            ],
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_connections": 100000,
+                  "max_pending_requests": 100000,
+                  "max_requests": 100000
+                },
+                {
+                  "priority": "HIGH",
+                  "max_connections": 100000,
+                  "max_pending_requests": 100000,
+                  "max_requests": 100000
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "h2"
+                ]
+              }
+            },
+            "http2_protocol_options": {},
+            "upstream_connection_options": {
+              "tcp_keepalive": {
+                "keepalive_time": 300
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:30.624Z"
+        },
+        {
+          "cluster": {
+            "name": "zipkin",
+            "type": "STRICT_DNS",
+            "connect_timeout": "1s",
+            "hosts": [
+              {
+                "socket_address": {
+                  "address": "zipkin.istio-system",
+                  "port_value": 9411
+                }
+              }
+            ]
+          },
+          "last_updated": "2019-04-02T19:54:30.624Z"
+        }
+      ],
+      "dynamic_active_clusters": [
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "BlackHoleCluster",
+            "connect_timeout": "1s"
+          },
+          "last_updated": "2019-04-02T19:54:31.795Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "PassthroughCluster",
+            "type": "ORIGINAL_DST",
+            "connect_timeout": "1s",
+            "lb_policy": "CLUSTER_PROVIDED"
+          },
+          "last_updated": "2019-04-02T19:54:31.795Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "inbound|15020|mgmt-15020|mgmtCluster",
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|15020|mgmt-15020|mgmtCluster",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 15020
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.795Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "inbound|9080|http|productpage.default.svc.cluster.local",
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|9080|http|productpage.default.svc.cluster.local",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 9080
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.795Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|14267||jaeger-collector.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|14267||jaeger-collector.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.14267_._.jaeger-collector.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.788Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|14268||jaeger-collector.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|14268||jaeger-collector.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.14268_._.jaeger-collector.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.789Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-mixer-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio",
+                  "h2"
+                ]
+              },
+              "sni": "outbound_.15004_._.istio-policy.istio-system.svc.cluster.local"
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.776Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-mixer-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio",
+                  "h2"
+                ]
+              },
+              "sni": "outbound_.15004_._.istio-telemetry.istio-system.svc.cluster.local"
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.785Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15010||istio-pilot.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15010||istio-pilot.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio",
+                  "h2"
+                ]
+              },
+              "sni": "outbound_.15010_._.istio-pilot.istio-system.svc.cluster.local"
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.779Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15011||istio-pilot.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15011||istio-pilot.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15011_._.istio-pilot.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.780Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15014||istio-citadel.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15014||istio-citadel.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-citadel-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15014_._.istio-citadel.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.778Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15014||istio-galley.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15014||istio-galley.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15014_._.istio-galley.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.764Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15014||istio-pilot.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15014||istio-pilot.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15014_._.istio-pilot.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.782Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15014||istio-policy.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15014||istio-policy.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.776Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.785Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15020_._.istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.774Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15029_._.istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.769Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15030_._.istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.770Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15031_._.istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.771Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15032_._.istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.772Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15443_._.istio-egressgateway.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.761Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.15443_._.istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.773Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|16686||jaeger-query.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|16686||jaeger-query.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.16686_._.jaeger-query.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.787Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|20001||kiali.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|20001||kiali.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/kiali-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.20001_._.kiali.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.777Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|3000||grafana.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|3000||grafana.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.3000_._.grafana.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.757Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.31400_._.istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.768Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.785Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.443_._.istio-egressgateway.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.760Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|443||istio-galley.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||istio-galley.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.443_._.istio-galley.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.763Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.443_._.istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.767Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-sidecar-injector-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.443_._.istio-sidecar-injector.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.783Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|443||kubernetes.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||kubernetes.default.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/api-server"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.749Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|443||metrics-server.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||metrics-server.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/kube-system/sa/metrics-server"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.443_._.metrics-server.kube-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.749Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|53||kube-dns.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|53||kube-dns.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/kube-system/sa/kube-dns"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.53_._.kube-dns.kube-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.748Z"
+        },
+        {
+          "version_info": "2019-04-02T20:05:54Z/25",
+          "cluster": {
+            "name": "outbound|8000||httpbin.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|8000||httpbin.default.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/default/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.8000_._.httpbin.default.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T20:05:54.246Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|8060||istio-citadel.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|8060||istio-citadel.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-citadel-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio",
+                  "h2"
+                ]
+              },
+              "sni": "outbound_.8060_._.istio-citadel.istio-system.svc.cluster.local"
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.778Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|8080||istio-pilot.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|8080||istio-pilot.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.8080_._.istio-pilot.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.781Z"
+        },
+        {
+          "version_info": "2019-04-02T20:05:55Z/26",
+          "cluster": {
+            "name": "outbound|80||alice.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||alice.default.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/default/sa/alice"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.80_._.alice.default.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T20:05:55.847Z"
+        },
+        {
+          "version_info": "2019-04-02T20:05:39Z/23",
+          "cluster": {
+            "name": "outbound|80||bob.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||bob.default.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/default/sa/bob"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.80_._.bob.default.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T20:05:39.163Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|80||default-http-backend.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||default-http-backend.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/kube-system/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.80_._.default-http-backend.kube-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.746Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|80||heapster.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||heapster.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/kube-system/sa/heapster"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.80_._.heapster.kube-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.747Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio",
+                  "h2"
+                ]
+              },
+              "sni": "outbound_.80_._.istio-egressgateway.istio-system.svc.cluster.local"
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.758Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio",
+                  "h2"
+                ]
+              },
+              "sni": "outbound_.80_._.istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.766Z"
+        },
+        {
+          "version_info": "2019-04-02T20:05:39Z/24",
+          "cluster": {
+            "name": "outbound|80||sleep.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||sleep.default.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/default/sa/sleep"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.80_._.sleep.default.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T20:05:39.337Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|80||tracing.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||tracing.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.80_._.tracing.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.790Z"
+        },
+        {
+          "version_info": "2019-04-02T20:05:56Z/27",
+          "cluster": {
+            "name": "outbound|9000||tcp-echo.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9000||tcp-echo.default.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/default/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.9000_._.tcp-echo.default.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T20:05:56.249Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|9080||details.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9080||details.default.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/default/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.9080_._.details.default.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.792Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:32Z/17",
+          "cluster": {
+            "name": "outbound|9080||productpage.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9080||productpage.default.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/default/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.9080_._.productpage.default.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:32.761Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|9080||ratings.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9080||ratings.default.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/default/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.9080_._.ratings.default.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.793Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|9080||reviews.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9080||reviews.default.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/default/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.9080_._.reviews.default.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.794Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|9090||prometheus.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9090||prometheus.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/prometheus"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.9090_._.prometheus.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.786Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.775Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.783Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|9411||zipkin.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9411||zipkin.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/default"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio"
+                ]
+              },
+              "sni": "outbound_.9411_._.zipkin.istio-system.svc.cluster.local"
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.791Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "cluster": {
+            "name": "outbound|9901||istio-galley.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9901||istio-galley.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "1s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "tls_context": {
+              "common_tls_context": {
+                "tls_certificates": [
+                  {
+                    "certificate_chain": {
+                      "filename": "/etc/certs/cert-chain.pem"
+                    },
+                    "private_key": {
+                      "filename": "/etc/certs/key.pem"
+                    }
+                  }
+                ],
+                "validation_context": {
+                  "trusted_ca": {
+                    "filename": "/etc/certs/root-cert.pem"
+                  },
+                  "verify_subject_alt_name": [
+                    "spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account"
+                  ]
+                },
+                "alpn_protocols": [
+                  "istio",
+                  "h2"
+                ]
+              },
+              "sni": "outbound_.9901_._.istio-galley.istio-system.svc.cluster.local"
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/default"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.765Z"
+        }
       ]
-     },
-     "last_updated": "2019-04-02T20:47:51.639Z"
     },
     {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.8.160_31400",
-      "address": {
-       "socket_address": {
-        "address": "10.0.8.160",
-        "port_value": 31400
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.853Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.8.160_15031",
-      "address": {
-       "socket_address": {
-        "address": "10.0.8.160",
-        "port_value": 15031
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-           },
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             }
-            }
-           },
-           "disable_check_calls": true
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.854Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.8.160_15020",
-      "address": {
-       "socket_address": {
-        "address": "10.0.8.160",
-        "port_value": 15020
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.855Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.12.229_443",
-      "address": {
-       "socket_address": {
-        "address": "10.0.12.229",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.name": {
-              "string_value": "istio-sidecar-injector"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-sidecar-injector"
-             },
-             "destination.service.host": {
-              "string_value": "istio-sidecar-injector.istio-system.svc.cluster.local"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local",
-           "cluster": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.856Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.11.179_42422",
-      "address": {
-       "socket_address": {
-        "address": "10.0.11.179",
-        "port_value": 42422
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.host": {
-              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-telemetry"
-             },
-             "destination.service.name": {
-              "string_value": "istio-telemetry"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           },
-           "disable_check_calls": true
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local",
-           "cluster": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.857Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.14.38_14267",
-      "address": {
-       "socket_address": {
-        "address": "10.0.14.38",
-        "port_value": 14267
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "jaeger-collector"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/jaeger-collector"
-             },
-             "destination.service.host": {
-              "string_value": "jaeger-collector.istio-system.svc.cluster.local"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|14267||jaeger-collector.istio-system.svc.cluster.local",
-           "cluster": "outbound|14267||jaeger-collector.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.857Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.5.77_80",
-      "address": {
-       "socket_address": {
-        "address": "10.0.5.77",
-        "port_value": 80
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.namespace": {
-              "string_value": "kube-system"
-             },
-             "destination.service.name": {
-              "string_value": "heapster"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.host": {
-              "string_value": "heapster.kube-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://kube-system/services/heapster"
-             }
-            }
-           },
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "cluster": "outbound|80||heapster.kube-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|80||heapster.kube-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.858Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.13.152_443",
-      "address": {
-       "socket_address": {
-        "address": "10.0.13.152",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.name": {
-              "string_value": "metrics-server"
-             },
-             "destination.service.namespace": {
-              "string_value": "kube-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://kube-system/services/metrics-server"
-             },
-             "destination.service.host": {
-              "string_value": "metrics-server.kube-system.svc.cluster.local"
-             }
-            }
-           },
-           "disable_check_calls": true,
-           "transport": {
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|443||metrics-server.kube-system.svc.cluster.local",
-           "cluster": "outbound|443||metrics-server.kube-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.859Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.0.1_443",
-      "address": {
-       "socket_address": {
-        "address": "10.0.0.1",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.host": {
-              "string_value": "kubernetes.default.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://default/services/kubernetes"
-             },
-             "destination.service.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.name": {
-              "string_value": "kubernetes"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             }
-            }
-           },
-           "disable_check_calls": true
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|443||kubernetes.default.svc.cluster.local",
-           "cluster": "outbound|443||kubernetes.default.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.860Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.8.160_15030",
-      "address": {
-       "socket_address": {
-        "address": "10.0.8.160",
-        "port_value": 15030
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "cluster": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.861Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.8.160_15443",
-      "address": {
-       "socket_address": {
-        "address": "10.0.8.160",
-        "port_value": 15443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.862Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.0.3_443",
-      "address": {
-       "socket_address": {
-        "address": "10.0.0.3",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-galley"
-             },
-             "destination.service.host": {
-              "string_value": "istio-galley.istio-system.svc.cluster.local"
-             },
-             "destination.service.name": {
-              "string_value": "istio-galley"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|443||istio-galley.istio-system.svc.cluster.local",
-           "cluster": "outbound|443||istio-galley.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.863Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.10.164_9000",
-      "address": {
-       "socket_address": {
-        "address": "10.0.10.164",
-        "port_value": 9000
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://default/services/tcp-echo"
-             },
-             "destination.service.host": {
-              "string_value": "tcp-echo.default.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.name": {
-              "string_value": "tcp-echo"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|9000||tcp-echo.default.svc.cluster.local",
-           "cluster": "outbound|9000||tcp-echo.default.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.863Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.2.103_443",
-      "address": {
-       "socket_address": {
-        "address": "10.0.2.103",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-egressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-egressgateway"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.864Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.8.160_15032",
-      "address": {
-       "socket_address": {
-        "address": "10.0.8.160",
-        "port_value": 15032
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.865Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.2.103_15443",
-      "address": {
-       "socket_address": {
-        "address": "10.0.2.103",
-        "port_value": 15443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-           },
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-egressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.name": {
-              "string_value": "istio-egressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             }
-            }
-           },
-           "disable_check_calls": true
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.866Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.8.160_443",
-      "address": {
-       "socket_address": {
-        "address": "10.0.8.160",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.867Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.14.169_16686",
-      "address": {
-       "socket_address": {
-        "address": "10.0.14.169",
-        "port_value": 16686
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "network_fail_policy": {
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.host": {
-              "string_value": "jaeger-query.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/jaeger-query"
-             },
-             "destination.service.name": {
-              "string_value": "jaeger-query"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|16686||jaeger-query.istio-system.svc.cluster.local",
-           "cluster": "outbound|16686||jaeger-query.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.868Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.8.160_15029",
-      "address": {
-       "socket_address": {
-        "address": "10.0.8.160",
-        "port_value": 15029
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            }
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.868Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.0.10_53",
-      "address": {
-       "socket_address": {
-        "address": "10.0.0.10",
-        "port_value": 53
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://kube-system/services/kube-dns"
-             },
-             "destination.service.host": {
-              "string_value": "kube-dns.kube-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "kube-system"
-             },
-             "destination.service.name": {
-              "string_value": "kube-dns"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "cluster": "outbound|53||kube-dns.kube-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|53||kube-dns.kube-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.869Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.9.240_15011",
-      "address": {
-       "socket_address": {
-        "address": "10.0.9.240",
-        "port_value": 15011
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-pilot"
-             },
-             "destination.service.host": {
-              "string_value": "istio-pilot.istio-system.svc.cluster.local"
-             },
-             "destination.service.name": {
-              "string_value": "istio-pilot"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             }
-            }
-           },
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15011||istio-pilot.istio-system.svc.cluster.local",
-           "cluster": "outbound|15011||istio-pilot.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.870Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.0.14.38_14268",
-      "address": {
-       "socket_address": {
-        "address": "10.0.14.38",
-        "port_value": 14268
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "jaeger-collector"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-             },
-             "source.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/jaeger-collector"
-             },
-             "destination.service.host": {
-              "string_value": "jaeger-collector.istio-system.svc.cluster.local"
-             }
-            }
-           },
-           "transport": {
-            "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "cluster": "outbound|14268||jaeger-collector.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|14268||jaeger-collector.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.871Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_9080",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 9080
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "random_sampling": {
-             "value": 100
-            },
-            "overall_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           },
-           "use_remote_address": false,
-           "rds": {
-            "route_config_name": "9080",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "stat_prefix": "0.0.0.0_9080",
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "transport": {
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
+      "@type": "type.googleapis.com/envoy.admin.v2alpha.ListenersConfigDump",
+      "version_info": "2019-04-02T20:47:51Z/31",
+      "static_listeners": [
+        {
+          "listener": {
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 15090
               }
-             }
             },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.873Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_9901",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 9901
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "default_destination_service": "default",
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "mixer_attributes": {
-               "attributes": {
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                }
-               }
-              },
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "codec_type": "AUTO",
+                      "http_filters": {
+                        "name": "envoy.router"
+                      },
+                      "stat_prefix": "stats",
+                      "route_config": {
+                        "virtual_hosts": [
+                          {
+                            "routes": [
+                              {
+                                "route": {
+                                  "cluster": "prometheus_stats"
+                                },
+                                "match": {
+                                  "prefix": "/stats/prometheus"
+                                }
+                              }
+                            ],
+                            "domains": [
+                              "*"
+                            ],
+                            "name": "backend"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
               }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           },
-           "rds": {
-            "config_source": {
-             "ads": {}
-            },
-            "route_config_name": "9901"
-           },
-           "use_remote_address": false,
-           "stat_prefix": "0.0.0.0_9901"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.874Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_9411",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 9411
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "rds": {
-            "route_config_name": "9411",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "stat_prefix": "0.0.0.0_9411",
-           "use_remote_address": false,
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "config": {
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              }
-             },
-             "name": "mixer"
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS",
-            "client_sampling": {
-             "value": 100
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.876Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_80",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 80
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             },
-             "name": "envoy.file_access_log"
-            }
-           ],
-           "http_filters": [
-            {
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              }
-             },
-             "name": "mixer"
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS",
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            }
-           },
-           "rds": {
-            "config_source": {
-             "ads": {}
-            },
-            "route_config_name": "80"
-           },
-           "stat_prefix": "0.0.0.0_80",
-           "use_remote_address": false,
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.877Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_20001",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 20001
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS",
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            }
-           },
-           "rds": {
-            "route_config_name": "20001",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "stat_prefix": "0.0.0.0_20001",
-           "use_remote_address": false,
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "config": {
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "transport": {
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              }
-             },
-             "name": "mixer"
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.878Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_8060",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 8060
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS",
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            }
-           },
-           "rds": {
-            "route_config_name": "8060",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "stat_prefix": "0.0.0.0_8060",
-           "use_remote_address": false
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.879Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_9090",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 9090
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default"
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "random_sampling": {
-             "value": 100
-            },
-            "overall_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           },
-           "rds": {
-            "route_config_name": "9090",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "use_remote_address": false,
-           "stat_prefix": "0.0.0.0_9090"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.881Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_8000",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 8000
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "use_remote_address": false,
-           "rds": {
-            "config_source": {
-             "ads": {}
-            },
-            "route_config_name": "8000"
-           },
-           "stat_prefix": "0.0.0.0_8000",
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "transport": {
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-              },
-              "default_destination_service": "default"
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS",
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.882Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_3000",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 3000
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS",
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            }
-           },
-           "rds": {
-            "route_config_name": "3000",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "use_remote_address": false,
-           "stat_prefix": "0.0.0.0_3000",
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.883Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_15014",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 15014
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "stat_prefix": "0.0.0.0_15014",
-           "rds": {
-            "route_config_name": "15014",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "use_remote_address": false,
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "default_destination_service": "default"
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.885Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_15004",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 15004
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           },
-           "rds": {
-            "route_config_name": "15004",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "use_remote_address": false,
-           "stat_prefix": "0.0.0.0_15004",
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.886Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_9091",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 9091
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           },
-           "rds": {
-            "route_config_name": "9091",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "stat_prefix": "0.0.0.0_9091",
-           "use_remote_address": false
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.887Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_15010",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 15010
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "rds": {
-            "config_source": {
-             "ads": {}
-            },
-            "route_config_name": "15010"
-           },
-           "use_remote_address": false,
-           "stat_prefix": "0.0.0.0_15010",
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "random_sampling": {
-             "value": 100
-            },
-            "overall_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.888Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "0.0.0.0_8080",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 8080
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS",
-            "client_sampling": {
-             "value": 100
-            }
-           },
-           "stat_prefix": "0.0.0.0_8080",
-           "rds": {
-            "config_source": {
-             "ads": {}
-            },
-            "route_config_name": "8080"
-           },
-           "use_remote_address": false,
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "network_fail_policy": {
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s"
-               },
-               "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-               "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.namespace": {
-                 "string_value": "default"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.889Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "10.52.2.21_15020",
-      "address": {
-       "socket_address": {
-        "address": "10.52.2.21",
-        "port_value": 15020
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "inbound|15020|mgmt-15020|mgmtCluster",
-           "cluster": "inbound|15020|mgmt-15020|mgmtCluster"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-02T19:54:31.890Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "listener": {
-      "name": "virtual",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 15001
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "PassthroughCluster",
-           "cluster": "PassthroughCluster"
-          }
-         }
-        ]
-       }
-      ],
-      "use_original_dst": true
-     },
-     "last_updated": "2019-04-02T19:54:31.890Z"
-    }
-   ]
-  },
-  {
-   "@type": "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump",
-   "static_route_configs": [
-    {
-     "route_config": {
-      "name": "inbound|9080|http|productpage.default.svc.cluster.local",
-      "virtual_hosts": [
-       {
-        "name": "inbound|http|9080",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
+            ]
           },
-          "route": {
-           "cluster": "inbound|9080|http|productpage.default.svc.cluster.local",
-           "timeout": "0s",
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "productpage.default.svc.cluster.local:9080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "productpage.default.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/productpage"
-              },
-              "destination.service.name": {
-               "string_value": "productpage"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
+          "last_updated": "2019-04-02T19:54:30.628Z"
+        }
       ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-02T20:47:51.637Z"
-    },
-    {
-     "route_config": {
-      "virtual_hosts": [
-       {
-        "name": "backend",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/stats/prometheus"
+      "dynamic_active_listeners": [
+        {
+          "version_info": "2019-04-02T20:47:51Z/31",
+          "listener": {
+            "name": "10.52.2.21_9080",
+            "address": {
+              "socket_address": {
+                "address": "10.52.2.21",
+                "port_value": 9080
+              }
+            },
+            "filter_chains": [
+              {
+                "tls_context": {
+                  "common_tls_context": {
+                    "tls_certificates": [
+                      {
+                        "certificate_chain": {
+                          "filename": "/etc/certs/cert-chain.pem"
+                        },
+                        "private_key": {
+                          "filename": "/etc/certs/key.pem"
+                        }
+                      }
+                    ],
+                    "validation_context": {
+                      "trusted_ca": {
+                        "filename": "/etc/certs/root-cert.pem"
+                      }
+                    },
+                    "alpn_protocols": [
+                      "h2",
+                      "http/1.1"
+                    ]
+                  },
+                  "require_client_certificate": true
+                },
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "random_sampling": {
+                          "value": 100
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "use_remote_address": false,
+                      "stat_prefix": "10.52.2.21_9080",
+                      "set_current_client_cert_details": {
+                        "uri": true,
+                        "subject": true,
+                        "dns": true
+                      },
+                      "stream_idle_timeout": "0s",
+                      "forward_client_cert_details": "APPEND_FORWARD",
+                      "server_name": "istio-envoy",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "jwt-auth",
+                          "config": {
+                            "allow_missing_or_failed": true,
+                            "rules": [
+                              {
+                                "issuer": "testing@secure.istio.io",
+                                "local_jwks": {
+                                  "inline_string": "{ \"keys\":[ {\"e\":\"AQAB\",\"kid\":\"DHFbpoIUqrY8t2zpA2qXfCmr5VO5ZEr4RzHU_-envvQ\",\"kty\":\"RSA\",\"n\":\"xAE7eB6qugXyCAG3yhh7pkDkT65pHymX-P7KfIupjf59vsdo91bSP9C8H07pSAGQO1MV_xFj9VswgsCg4R6otmg5PV2He95lZdHtOcU5DXIg_pbhLdKXbi66GlVeK6ABZOUW3WYtnNHD-91gVuoeJT_DwtGGcp4ignkgXfkiEm4sw-4sfb4qdt5oLbyVpmW6x9cfa7vs2WTfURiCrBoUqgBo_-4WTiULmmHSGZHOjzwa8WtrtOQGsAFjIbno85jp6MnGGGZPYZbDAa_b3y5u-YpW7ypZrvD8BgtKVjgtQgZhLAGezMt0ua3DRrWnKqTZ0BJ_EyxOGuHJrLsn00fnMQ\"}]}"
+                                },
+                                "forward_payload_header": "istio-sec-5406b7840708063f65cbdf52153ca364a476d68b",
+                                "forward": true
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "name": "istio_authn",
+                          "config": {
+                            "jwt_output_payload_locations": {
+                              "testing@secure.istio.io": "istio-sec-5406b7840708063f65cbdf52153ca364a476d68b"
+                            },
+                            "policy": {
+                              "peers": [
+                                {
+                                  "mtls": {}
+                                }
+                              ],
+                              "principal_binding": "USE_ORIGIN",
+                              "origins": [
+                                {
+                                  "jwt": {
+                                    "jwks_uri": "https://raw.githubusercontent.com/istio/istio/release-1.1/security/tools/jwt/samples/jwks.json",
+                                    "issuer": "testing@secure.istio.io"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.filters.http.rbac",
+                          "config": {
+                            "rules": {
+                              "policies": {
+                                "service-viewer": {
+                                  "principals": [
+                                    {
+                                      "and_ids": {
+                                        "ids": [
+                                          {
+                                            "metadata": {
+                                              "filter": "istio_authn",
+                                              "value": {
+                                                "string_match": {
+                                                  "regex": ".*/ns/istio-system/.*"
+                                                }
+                                              },
+                                              "path": [
+                                                {
+                                                  "key": "source.principal"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "and_ids": {
+                                        "ids": [
+                                          {
+                                            "metadata": {
+                                              "filter": "istio_authn",
+                                              "value": {
+                                                "string_match": {
+                                                  "regex": ".*/ns/default/.*"
+                                                }
+                                              },
+                                              "path": [
+                                                {
+                                                  "key": "source.principal"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ],
+                                  "permissions": [
+                                    {
+                                      "and_rules": {
+                                        "rules": [
+                                          {
+                                            "or_rules": {
+                                              "rules": [
+                                                {
+                                                  "header": {
+                                                    "exact_match": "GET",
+                                                    "name": ":method"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {}
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "destination.namespace": {
+                                  "string_value": "default"
+                                },
+                                "destination.ip": {
+                                  "bytes_value": "AAAAAAAAAAAAAP//CjQCFQ=="
+                                },
+                                "destination.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "inbound"
+                                },
+                                "destination.port": {
+                                  "int64_value": "9080"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "route_config": {
+                        "name": "inbound|9080|http|productpage.default.svc.cluster.local",
+                        "validate_clusters": false,
+                        "virtual_hosts": [
+                          {
+                            "routes": [
+                              {
+                                "match": {
+                                  "prefix": "/"
+                                },
+                                "per_filter_config": {
+                                  "mixer": {
+                                    "mixer_attributes": {
+                                      "attributes": {
+                                        "destination.service.namespace": {
+                                          "string_value": "default"
+                                        },
+                                        "destination.service.name": {
+                                          "string_value": "productpage"
+                                        },
+                                        "destination.service.uid": {
+                                          "string_value": "istio://default/services/productpage"
+                                        },
+                                        "destination.service.host": {
+                                          "string_value": "productpage.default.svc.cluster.local"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "decorator": {
+                                  "operation": "productpage.default.svc.cluster.local:9080/*"
+                                },
+                                "route": {
+                                  "max_grpc_timeout": "0s",
+                                  "cluster": "inbound|9080|http|productpage.default.svc.cluster.local",
+                                  "timeout": "0s"
+                                }
+                              }
+                            ],
+                            "domains": [
+                              "*"
+                            ],
+                            "name": "inbound|http|9080"
+                          }
+                        ]
+                      },
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            },
+            "listener_filters": [
+              {
+                "name": "envoy.listener.tls_inspector"
+              }
+            ]
           },
-          "route": {
-           "cluster": "prometheus_stats"
-          }
-         }
-        ]
-       }
+          "last_updated": "2019-04-02T20:47:51.639Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.8.160_31400",
+            "address": {
+              "socket_address": {
+                "address": "10.0.8.160",
+                "port_value": 31400
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.853Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.8.160_15031",
+            "address": {
+              "socket_address": {
+                "address": "10.0.8.160",
+                "port_value": 15031
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+                      },
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.854Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.8.160_15020",
+            "address": {
+              "socket_address": {
+                "address": "10.0.8.160",
+                "port_value": 15020
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.855Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.12.229_443",
+            "address": {
+              "socket_address": {
+                "address": "10.0.12.229",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.name": {
+                            "string_value": "istio-sidecar-injector"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-sidecar-injector"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-sidecar-injector.istio-system.svc.cluster.local"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local",
+                      "cluster": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.856Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.11.179_42422",
+            "address": {
+              "socket_address": {
+                "address": "10.0.11.179",
+                "port_value": 42422
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-telemetry"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-telemetry"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local",
+                      "cluster": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.857Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.14.38_14267",
+            "address": {
+              "socket_address": {
+                "address": "10.0.14.38",
+                "port_value": 14267
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "jaeger-collector"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/jaeger-collector"
+                          },
+                          "destination.service.host": {
+                            "string_value": "jaeger-collector.istio-system.svc.cluster.local"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|14267||jaeger-collector.istio-system.svc.cluster.local",
+                      "cluster": "outbound|14267||jaeger-collector.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.857Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.5.77_80",
+            "address": {
+              "socket_address": {
+                "address": "10.0.5.77",
+                "port_value": 80
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.namespace": {
+                            "string_value": "kube-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "heapster"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.host": {
+                            "string_value": "heapster.kube-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://kube-system/services/heapster"
+                          }
+                        }
+                      },
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "cluster": "outbound|80||heapster.kube-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|80||heapster.kube-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.858Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.13.152_443",
+            "address": {
+              "socket_address": {
+                "address": "10.0.13.152",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.name": {
+                            "string_value": "metrics-server"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "kube-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://kube-system/services/metrics-server"
+                          },
+                          "destination.service.host": {
+                            "string_value": "metrics-server.kube-system.svc.cluster.local"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true,
+                      "transport": {
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|443||metrics-server.kube-system.svc.cluster.local",
+                      "cluster": "outbound|443||metrics-server.kube-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.859Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.0.1_443",
+            "address": {
+              "socket_address": {
+                "address": "10.0.0.1",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.host": {
+                            "string_value": "kubernetes.default.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://default/services/kubernetes"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.name": {
+                            "string_value": "kubernetes"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|443||kubernetes.default.svc.cluster.local",
+                      "cluster": "outbound|443||kubernetes.default.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.860Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.8.160_15030",
+            "address": {
+              "socket_address": {
+                "address": "10.0.8.160",
+                "port_value": 15030
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "cluster": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.861Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.8.160_15443",
+            "address": {
+              "socket_address": {
+                "address": "10.0.8.160",
+                "port_value": 15443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.862Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.0.3_443",
+            "address": {
+              "socket_address": {
+                "address": "10.0.0.3",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-galley"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-galley.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-galley"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|443||istio-galley.istio-system.svc.cluster.local",
+                      "cluster": "outbound|443||istio-galley.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.863Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.10.164_9000",
+            "address": {
+              "socket_address": {
+                "address": "10.0.10.164",
+                "port_value": 9000
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://default/services/tcp-echo"
+                          },
+                          "destination.service.host": {
+                            "string_value": "tcp-echo.default.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.name": {
+                            "string_value": "tcp-echo"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|9000||tcp-echo.default.svc.cluster.local",
+                      "cluster": "outbound|9000||tcp-echo.default.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.863Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.2.103_443",
+            "address": {
+              "socket_address": {
+                "address": "10.0.2.103",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-egressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-egressgateway"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.864Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.8.160_15032",
+            "address": {
+              "socket_address": {
+                "address": "10.0.8.160",
+                "port_value": 15032
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.865Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.2.103_15443",
+            "address": {
+              "socket_address": {
+                "address": "10.0.2.103",
+                "port_value": 15443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+                      },
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-egressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-egressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.866Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.8.160_443",
+            "address": {
+              "socket_address": {
+                "address": "10.0.8.160",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.867Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.14.169_16686",
+            "address": {
+              "socket_address": {
+                "address": "10.0.14.169",
+                "port_value": 16686
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "network_fail_policy": {
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.host": {
+                            "string_value": "jaeger-query.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/jaeger-query"
+                          },
+                          "destination.service.name": {
+                            "string_value": "jaeger-query"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|16686||jaeger-query.istio-system.svc.cluster.local",
+                      "cluster": "outbound|16686||jaeger-query.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.868Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.8.160_15029",
+            "address": {
+              "socket_address": {
+                "address": "10.0.8.160",
+                "port_value": 15029
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        }
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.868Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.0.10_53",
+            "address": {
+              "socket_address": {
+                "address": "10.0.0.10",
+                "port_value": 53
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://kube-system/services/kube-dns"
+                          },
+                          "destination.service.host": {
+                            "string_value": "kube-dns.kube-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "kube-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "kube-dns"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "cluster": "outbound|53||kube-dns.kube-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|53||kube-dns.kube-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.869Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.9.240_15011",
+            "address": {
+              "socket_address": {
+                "address": "10.0.9.240",
+                "port_value": 15011
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-pilot"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-pilot"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          }
+                        }
+                      },
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15011||istio-pilot.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15011||istio-pilot.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.870Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.0.14.38_14268",
+            "address": {
+              "socket_address": {
+                "address": "10.0.14.38",
+                "port_value": 14268
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "jaeger-collector"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                          },
+                          "source.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/jaeger-collector"
+                          },
+                          "destination.service.host": {
+                            "string_value": "jaeger-collector.istio-system.svc.cluster.local"
+                          }
+                        }
+                      },
+                      "transport": {
+                        "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "cluster": "outbound|14268||jaeger-collector.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|14268||jaeger-collector.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.871Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_9080",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 9080
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "random_sampling": {
+                          "value": 100
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      },
+                      "use_remote_address": false,
+                      "rds": {
+                        "route_config_name": "9080",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "stat_prefix": "0.0.0.0_9080",
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "transport": {
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.873Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_9901",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 9901
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "default_destination_service": "default",
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                }
+                              }
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      },
+                      "rds": {
+                        "config_source": {
+                          "ads": {}
+                        },
+                        "route_config_name": "9901"
+                      },
+                      "use_remote_address": false,
+                      "stat_prefix": "0.0.0.0_9901"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.874Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_9411",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 9411
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "rds": {
+                        "route_config_name": "9411",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "stat_prefix": "0.0.0.0_9411",
+                      "use_remote_address": false,
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "config": {
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            }
+                          },
+                          "name": "mixer"
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS",
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.876Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_80",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 80
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          },
+                          "name": "envoy.file_access_log"
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            }
+                          },
+                          "name": "mixer"
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS",
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "rds": {
+                        "config_source": {
+                          "ads": {}
+                        },
+                        "route_config_name": "80"
+                      },
+                      "stat_prefix": "0.0.0.0_80",
+                      "use_remote_address": false,
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.877Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_20001",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 20001
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS",
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "rds": {
+                        "route_config_name": "20001",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "stat_prefix": "0.0.0.0_20001",
+                      "use_remote_address": false,
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "config": {
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "transport": {
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            }
+                          },
+                          "name": "mixer"
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.878Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_8060",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 8060
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS",
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "rds": {
+                        "route_config_name": "8060",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "stat_prefix": "0.0.0.0_8060",
+                      "use_remote_address": false
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.879Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_9090",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 9090
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default"
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "random_sampling": {
+                          "value": 100
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      },
+                      "rds": {
+                        "route_config_name": "9090",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "use_remote_address": false,
+                      "stat_prefix": "0.0.0.0_9090"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.881Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_8000",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 8000
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "use_remote_address": false,
+                      "rds": {
+                        "config_source": {
+                          "ads": {}
+                        },
+                        "route_config_name": "8000"
+                      },
+                      "stat_prefix": "0.0.0.0_8000",
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "transport": {
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "default_destination_service": "default"
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS",
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.882Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_3000",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 3000
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS",
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "rds": {
+                        "route_config_name": "3000",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "use_remote_address": false,
+                      "stat_prefix": "0.0.0.0_3000",
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.883Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_15014",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 15014
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "stat_prefix": "0.0.0.0_15014",
+                      "rds": {
+                        "route_config_name": "15014",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "use_remote_address": false,
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "default_destination_service": "default"
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.885Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_15004",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 15004
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      },
+                      "rds": {
+                        "route_config_name": "15004",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "use_remote_address": false,
+                      "stat_prefix": "0.0.0.0_15004",
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.886Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_9091",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 9091
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      },
+                      "rds": {
+                        "route_config_name": "9091",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "stat_prefix": "0.0.0.0_9091",
+                      "use_remote_address": false
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.887Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_15010",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 15010
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "rds": {
+                        "config_source": {
+                          "ads": {}
+                        },
+                        "route_config_name": "15010"
+                      },
+                      "use_remote_address": false,
+                      "stat_prefix": "0.0.0.0_15010",
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "random_sampling": {
+                          "value": 100
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.888Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "0.0.0.0_8080",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 8080
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS",
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "stat_prefix": "0.0.0.0_8080",
+                      "rds": {
+                        "config_source": {
+                          "ads": {}
+                        },
+                        "route_config_name": "8080"
+                      },
+                      "use_remote_address": false,
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "network_fail_policy": {
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s"
+                              },
+                              "report_cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                              "check_cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.namespace": {
+                                  "string_value": "default"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://productpage-v1-5cb458d74f-56sx7.default"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.889Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "10.52.2.21_15020",
+            "address": {
+              "socket_address": {
+                "address": "10.52.2.21",
+                "port_value": 15020
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "inbound|15020|mgmt-15020|mgmtCluster",
+                      "cluster": "inbound|15020|mgmt-15020|mgmtCluster"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-02T19:54:31.890Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "listener": {
+            "name": "virtual",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 15001
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "PassthroughCluster",
+                      "cluster": "PassthroughCluster"
+                    }
+                  }
+                ]
+              }
+            ],
+            "use_original_dst": true
+          },
+          "last_updated": "2019-04-02T19:54:31.890Z"
+        }
       ]
-     },
-     "last_updated": "2019-04-02T19:54:30.628Z"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump",
+      "static_route_configs": [
+        {
+          "route_config": {
+            "name": "inbound|9080|http|productpage.default.svc.cluster.local",
+            "virtual_hosts": [
+              {
+                "name": "inbound|http|9080",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "inbound|9080|http|productpage.default.svc.cluster.local",
+                      "timeout": "0s",
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "productpage.default.svc.cluster.local:9080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "productpage.default.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/productpage"
+                            },
+                            "destination.service.name": {
+                              "string_value": "productpage"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-02T20:47:51.637Z"
+        },
+        {
+          "route_config": {
+            "virtual_hosts": [
+              {
+                "name": "backend",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/stats/prometheus"
+                    },
+                    "route": {
+                      "cluster": "prometheus_stats"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "last_updated": "2019-04-02T19:54:30.628Z"
+        }
+      ],
+      "dynamic_route_configs": [
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "8080",
+            "virtual_hosts": [
+              {
+                "name": "istio-pilot.istio-system.svc.cluster.local:8080",
+                "domains": [
+                  "istio-pilot.istio-system.svc.cluster.local",
+                  "istio-pilot.istio-system.svc.cluster.local:8080",
+                  "istio-pilot.istio-system",
+                  "istio-pilot.istio-system:8080",
+                  "istio-pilot.istio-system.svc.cluster",
+                  "istio-pilot.istio-system.svc.cluster:8080",
+                  "istio-pilot.istio-system.svc",
+                  "istio-pilot.istio-system.svc:8080",
+                  "10.0.9.240",
+                  "10.0.9.240:8080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8080||istio-pilot.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-pilot.istio-system.svc.cluster.local:8080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.670Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "15010",
+            "virtual_hosts": [
+              {
+                "name": "istio-pilot.istio-system.svc.cluster.local:15010",
+                "domains": [
+                  "istio-pilot.istio-system.svc.cluster.local",
+                  "istio-pilot.istio-system.svc.cluster.local:15010",
+                  "istio-pilot.istio-system",
+                  "istio-pilot.istio-system:15010",
+                  "istio-pilot.istio-system.svc.cluster",
+                  "istio-pilot.istio-system.svc.cluster:15010",
+                  "istio-pilot.istio-system.svc",
+                  "istio-pilot.istio-system.svc:15010",
+                  "10.0.9.240",
+                  "10.0.9.240:15010"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15010||istio-pilot.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-pilot.istio-system.svc.cluster.local:15010/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.670Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "15004",
+            "virtual_hosts": [
+              {
+                "name": "istio-policy.istio-system.svc.cluster.local:15004",
+                "domains": [
+                  "istio-policy.istio-system.svc.cluster.local",
+                  "istio-policy.istio-system.svc.cluster.local:15004",
+                  "istio-policy.istio-system",
+                  "istio-policy.istio-system:15004",
+                  "istio-policy.istio-system.svc.cluster",
+                  "istio-policy.istio-system.svc.cluster:15004",
+                  "istio-policy.istio-system.svc",
+                  "istio-policy.istio-system.svc:15004",
+                  "10.0.3.83",
+                  "10.0.3.83:15004"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-policy.istio-system.svc.cluster.local:15004/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-telemetry.istio-system.svc.cluster.local:15004",
+                "domains": [
+                  "istio-telemetry.istio-system.svc.cluster.local",
+                  "istio-telemetry.istio-system.svc.cluster.local:15004",
+                  "istio-telemetry.istio-system",
+                  "istio-telemetry.istio-system:15004",
+                  "istio-telemetry.istio-system.svc.cluster",
+                  "istio-telemetry.istio-system.svc.cluster:15004",
+                  "istio-telemetry.istio-system.svc",
+                  "istio-telemetry.istio-system.svc:15004",
+                  "10.0.11.179",
+                  "10.0.11.179:15004"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-telemetry.istio-system.svc.cluster.local:15004/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.671Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "9091",
+            "virtual_hosts": [
+              {
+                "name": "istio-policy.istio-system.svc.cluster.local:9091",
+                "domains": [
+                  "istio-policy.istio-system.svc.cluster.local",
+                  "istio-policy.istio-system.svc.cluster.local:9091",
+                  "istio-policy.istio-system",
+                  "istio-policy.istio-system:9091",
+                  "istio-policy.istio-system.svc.cluster",
+                  "istio-policy.istio-system.svc.cluster:9091",
+                  "istio-policy.istio-system.svc",
+                  "istio-policy.istio-system.svc:9091",
+                  "10.0.3.83",
+                  "10.0.3.83:9091"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-policy.istio-system.svc.cluster.local:9091/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-telemetry.istio-system.svc.cluster.local:9091",
+                "domains": [
+                  "istio-telemetry.istio-system.svc.cluster.local",
+                  "istio-telemetry.istio-system.svc.cluster.local:9091",
+                  "istio-telemetry.istio-system",
+                  "istio-telemetry.istio-system:9091",
+                  "istio-telemetry.istio-system.svc.cluster",
+                  "istio-telemetry.istio-system.svc.cluster:9091",
+                  "istio-telemetry.istio-system.svc",
+                  "istio-telemetry.istio-system.svc:9091",
+                  "10.0.11.179",
+                  "10.0.11.179:9091"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-telemetry.istio-system.svc.cluster.local:9091/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.670Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "80",
+            "virtual_hosts": [
+              {
+                "name": "alice.default.svc.cluster.local:80",
+                "domains": [
+                  "alice.default.svc.cluster.local",
+                  "alice.default.svc.cluster.local:80",
+                  "alice",
+                  "alice:80",
+                  "alice.default.svc.cluster",
+                  "alice.default.svc.cluster:80",
+                  "alice.default.svc",
+                  "alice.default.svc:80",
+                  "alice.default",
+                  "alice.default:80",
+                  "10.0.15.240",
+                  "10.0.15.240:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||alice.default.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "alice.default.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "alice.default.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/alice"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "alice"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "alice"
+                            },
+                            "destination.service.host": {
+                              "string_value": "alice.default.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/alice"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "bob.default.svc.cluster.local:80",
+                "domains": [
+                  "bob.default.svc.cluster.local",
+                  "bob.default.svc.cluster.local:80",
+                  "bob",
+                  "bob:80",
+                  "bob.default.svc.cluster",
+                  "bob.default.svc.cluster:80",
+                  "bob.default.svc",
+                  "bob.default.svc:80",
+                  "bob.default",
+                  "bob.default:80",
+                  "10.0.5.14",
+                  "10.0.5.14:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||bob.default.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "bob.default.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "bob.default.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/bob"
+                            },
+                            "destination.service.name": {
+                              "string_value": "bob"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "bob"
+                            },
+                            "destination.service.host": {
+                              "string_value": "bob.default.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/bob"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "default-http-backend.kube-system.svc.cluster.local:80",
+                "domains": [
+                  "default-http-backend.kube-system.svc.cluster.local",
+                  "default-http-backend.kube-system.svc.cluster.local:80",
+                  "default-http-backend.kube-system",
+                  "default-http-backend.kube-system:80",
+                  "default-http-backend.kube-system.svc.cluster",
+                  "default-http-backend.kube-system.svc.cluster:80",
+                  "default-http-backend.kube-system.svc",
+                  "default-http-backend.kube-system.svc:80",
+                  "10.0.5.0",
+                  "10.0.5.0:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||default-http-backend.kube-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "default-http-backend.kube-system.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://kube-system/services/default-http-backend"
+                            },
+                            "destination.service.host": {
+                              "string_value": "default-http-backend.kube-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "kube-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "default-http-backend"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://kube-system/services/default-http-backend"
+                            },
+                            "destination.service.host": {
+                              "string_value": "default-http-backend.kube-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "kube-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "default-http-backend"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-egressgateway.istio-system.svc.cluster.local:80",
+                "domains": [
+                  "istio-egressgateway.istio-system.svc.cluster.local",
+                  "istio-egressgateway.istio-system.svc.cluster.local:80",
+                  "istio-egressgateway.istio-system",
+                  "istio-egressgateway.istio-system:80",
+                  "istio-egressgateway.istio-system.svc.cluster",
+                  "istio-egressgateway.istio-system.svc.cluster:80",
+                  "istio-egressgateway.istio-system.svc",
+                  "istio-egressgateway.istio-system.svc:80",
+                  "10.0.2.103",
+                  "10.0.2.103:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-egressgateway.istio-system.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-egressgateway"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-egressgateway"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-egressgateway"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-egressgateway"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-ingressgateway.istio-system.svc.cluster.local:80",
+                "domains": [
+                  "istio-ingressgateway.istio-system.svc.cluster.local",
+                  "istio-ingressgateway.istio-system.svc.cluster.local:80",
+                  "istio-ingressgateway.istio-system",
+                  "istio-ingressgateway.istio-system:80",
+                  "istio-ingressgateway.istio-system.svc.cluster",
+                  "istio-ingressgateway.istio-system.svc.cluster:80",
+                  "istio-ingressgateway.istio-system.svc",
+                  "istio-ingressgateway.istio-system.svc:80",
+                  "10.0.8.160",
+                  "10.0.8.160:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-ingressgateway.istio-system.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-ingressgateway"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-ingressgateway"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-ingressgateway"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-ingressgateway"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "sleep.default.svc.cluster.local:80",
+                "domains": [
+                  "sleep.default.svc.cluster.local",
+                  "sleep.default.svc.cluster.local:80",
+                  "sleep",
+                  "sleep:80",
+                  "sleep.default.svc.cluster",
+                  "sleep.default.svc.cluster:80",
+                  "sleep.default.svc",
+                  "sleep.default.svc:80",
+                  "sleep.default",
+                  "sleep.default:80",
+                  "10.0.10.64",
+                  "10.0.10.64:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||sleep.default.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "sleep.default.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "sleep.default.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/sleep"
+                            },
+                            "destination.service.name": {
+                              "string_value": "sleep"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "sleep"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/sleep"
+                            },
+                            "destination.service.host": {
+                              "string_value": "sleep.default.svc.cluster.local"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "tracing.istio-system.svc.cluster.local:80",
+                "domains": [
+                  "tracing.istio-system.svc.cluster.local",
+                  "tracing.istio-system.svc.cluster.local:80",
+                  "tracing.istio-system",
+                  "tracing.istio-system:80",
+                  "tracing.istio-system.svc.cluster",
+                  "tracing.istio-system.svc.cluster:80",
+                  "tracing.istio-system.svc",
+                  "tracing.istio-system.svc:80",
+                  "10.0.2.209",
+                  "10.0.2.209:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||tracing.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "tracing.istio-system.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "tracing.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/tracing"
+                            },
+                            "destination.service.name": {
+                              "string_value": "tracing"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "tracing.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/tracing"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "tracing"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.672Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "9080",
+            "virtual_hosts": [
+              {
+                "name": "details.default.svc.cluster.local:9080",
+                "domains": [
+                  "details.default.svc.cluster.local",
+                  "details.default.svc.cluster.local:9080",
+                  "details",
+                  "details:9080",
+                  "details.default.svc.cluster",
+                  "details.default.svc.cluster:9080",
+                  "details.default.svc",
+                  "details.default.svc:9080",
+                  "details.default",
+                  "details.default:9080",
+                  "10.0.9.156",
+                  "10.0.9.156:9080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9080||details.default.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "details.default.svc.cluster.local:9080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "details"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/details"
+                            },
+                            "destination.service.host": {
+                              "string_value": "details.default.svc.cluster.local"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/details"
+                            },
+                            "destination.service.host": {
+                              "string_value": "details.default.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "details"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "productpage.default.svc.cluster.local:9080",
+                "domains": [
+                  "productpage.default.svc.cluster.local",
+                  "productpage.default.svc.cluster.local:9080",
+                  "productpage",
+                  "productpage:9080",
+                  "productpage.default.svc.cluster",
+                  "productpage.default.svc.cluster:9080",
+                  "productpage.default.svc",
+                  "productpage.default.svc:9080",
+                  "productpage.default",
+                  "productpage.default:9080",
+                  "10.0.0.4",
+                  "10.0.0.4:9080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9080||productpage.default.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "productpage.default.svc.cluster.local:9080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "productpage.default.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/productpage"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "productpage"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/productpage"
+                            },
+                            "destination.service.host": {
+                              "string_value": "productpage.default.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "productpage"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "ratings.default.svc.cluster.local:9080",
+                "domains": [
+                  "ratings.default.svc.cluster.local",
+                  "ratings.default.svc.cluster.local:9080",
+                  "ratings",
+                  "ratings:9080",
+                  "ratings.default.svc.cluster",
+                  "ratings.default.svc.cluster:9080",
+                  "ratings.default.svc",
+                  "ratings.default.svc:9080",
+                  "ratings.default",
+                  "ratings.default:9080",
+                  "10.0.8.147",
+                  "10.0.8.147:9080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9080||ratings.default.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "ratings.default.svc.cluster.local:9080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "ratings"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/ratings"
+                            },
+                            "destination.service.host": {
+                              "string_value": "ratings.default.svc.cluster.local"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/ratings"
+                            },
+                            "destination.service.host": {
+                              "string_value": "ratings.default.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "ratings"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "reviews.default.svc.cluster.local:9080",
+                "domains": [
+                  "reviews.default.svc.cluster.local",
+                  "reviews.default.svc.cluster.local:9080",
+                  "reviews",
+                  "reviews:9080",
+                  "reviews.default.svc.cluster",
+                  "reviews.default.svc.cluster:9080",
+                  "reviews.default.svc",
+                  "reviews.default.svc:9080",
+                  "reviews.default",
+                  "reviews.default:9080",
+                  "10.0.9.20",
+                  "10.0.9.20:9080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9080||reviews.default.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "reviews.default.svc.cluster.local:9080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/reviews"
+                            },
+                            "destination.service.host": {
+                              "string_value": "reviews.default.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "reviews"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "reviews"
+                            },
+                            "destination.service.host": {
+                              "string_value": "reviews.default.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/reviews"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.672Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "8060",
+            "virtual_hosts": [
+              {
+                "name": "istio-citadel.istio-system.svc.cluster.local:8060",
+                "domains": [
+                  "istio-citadel.istio-system.svc.cluster.local",
+                  "istio-citadel.istio-system.svc.cluster.local:8060",
+                  "istio-citadel.istio-system",
+                  "istio-citadel.istio-system:8060",
+                  "istio-citadel.istio-system.svc.cluster",
+                  "istio-citadel.istio-system.svc.cluster:8060",
+                  "istio-citadel.istio-system.svc",
+                  "istio-citadel.istio-system.svc:8060",
+                  "10.0.8.222",
+                  "10.0.8.222:8060"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8060||istio-citadel.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-citadel.istio-system.svc.cluster.local:8060/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-citadel"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-citadel"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-citadel.istio-system.svc.cluster.local"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-citadel.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-citadel"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-citadel"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.671Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "8000",
+            "virtual_hosts": [
+              {
+                "name": "httpbin.default.svc.cluster.local:8000",
+                "domains": [
+                  "httpbin.default.svc.cluster.local",
+                  "httpbin.default.svc.cluster.local:8000",
+                  "httpbin",
+                  "httpbin:8000",
+                  "httpbin.default.svc.cluster",
+                  "httpbin.default.svc.cluster:8000",
+                  "httpbin.default.svc",
+                  "httpbin.default.svc:8000",
+                  "httpbin.default",
+                  "httpbin.default:8000",
+                  "10.0.5.99",
+                  "10.0.5.99:8000"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8000||httpbin.default.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "httpbin.default.svc.cluster.local:8000/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/httpbin"
+                            },
+                            "destination.service.host": {
+                              "string_value": "httpbin.default.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.name": {
+                              "string_value": "httpbin"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.name": {
+                              "string_value": "httpbin"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "default"
+                            },
+                            "destination.service.host": {
+                              "string_value": "httpbin.default.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://default/services/httpbin"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.671Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "9901",
+            "virtual_hosts": [
+              {
+                "name": "istio-galley.istio-system.svc.cluster.local:9901",
+                "domains": [
+                  "istio-galley.istio-system.svc.cluster.local",
+                  "istio-galley.istio-system.svc.cluster.local:9901",
+                  "istio-galley.istio-system",
+                  "istio-galley.istio-system:9901",
+                  "istio-galley.istio-system.svc.cluster",
+                  "istio-galley.istio-system.svc.cluster:9901",
+                  "istio-galley.istio-system.svc",
+                  "istio-galley.istio-system.svc:9901",
+                  "10.0.0.3",
+                  "10.0.0.3:9901"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9901||istio-galley.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-galley.istio-system.svc.cluster.local:9901/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-galley"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-galley.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-galley"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-galley"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-galley.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-galley"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.672Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "9090",
+            "virtual_hosts": [
+              {
+                "name": "prometheus.istio-system.svc.cluster.local:9090",
+                "domains": [
+                  "prometheus.istio-system.svc.cluster.local",
+                  "prometheus.istio-system.svc.cluster.local:9090",
+                  "prometheus.istio-system",
+                  "prometheus.istio-system:9090",
+                  "prometheus.istio-system.svc.cluster",
+                  "prometheus.istio-system.svc.cluster:9090",
+                  "prometheus.istio-system.svc",
+                  "prometheus.istio-system.svc:9090",
+                  "10.0.6.88",
+                  "10.0.6.88:9090"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9090||prometheus.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "prometheus.istio-system.svc.cluster.local:9090/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/prometheus"
+                            },
+                            "destination.service.host": {
+                              "string_value": "prometheus.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "prometheus"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "prometheus.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/prometheus"
+                            },
+                            "destination.service.name": {
+                              "string_value": "prometheus"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.671Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "9411",
+            "virtual_hosts": [
+              {
+                "name": "zipkin.istio-system.svc.cluster.local:9411",
+                "domains": [
+                  "zipkin.istio-system.svc.cluster.local",
+                  "zipkin.istio-system.svc.cluster.local:9411",
+                  "zipkin.istio-system",
+                  "zipkin.istio-system:9411",
+                  "zipkin.istio-system.svc.cluster",
+                  "zipkin.istio-system.svc.cluster:9411",
+                  "zipkin.istio-system.svc",
+                  "zipkin.istio-system.svc:9411",
+                  "10.0.14.1",
+                  "10.0.14.1:9411"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9411||zipkin.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "zipkin.istio-system.svc.cluster.local:9411/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "zipkin.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/zipkin"
+                            },
+                            "destination.service.name": {
+                              "string_value": "zipkin"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/zipkin"
+                            },
+                            "destination.service.host": {
+                              "string_value": "zipkin.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "zipkin"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.672Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "3000",
+            "virtual_hosts": [
+              {
+                "name": "grafana.istio-system.svc.cluster.local:3000",
+                "domains": [
+                  "grafana.istio-system.svc.cluster.local",
+                  "grafana.istio-system.svc.cluster.local:3000",
+                  "grafana.istio-system",
+                  "grafana.istio-system:3000",
+                  "grafana.istio-system.svc.cluster",
+                  "grafana.istio-system.svc.cluster:3000",
+                  "grafana.istio-system.svc",
+                  "grafana.istio-system.svc:3000",
+                  "10.0.12.51",
+                  "10.0.12.51:3000"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|3000||grafana.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "grafana.istio-system.svc.cluster.local:3000/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "grafana"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/grafana"
+                            },
+                            "destination.service.host": {
+                              "string_value": "grafana.istio-system.svc.cluster.local"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "grafana.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/grafana"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "grafana"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.671Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "20001",
+            "virtual_hosts": [
+              {
+                "name": "kiali.istio-system.svc.cluster.local:20001",
+                "domains": [
+                  "kiali.istio-system.svc.cluster.local",
+                  "kiali.istio-system.svc.cluster.local:20001",
+                  "kiali.istio-system",
+                  "kiali.istio-system:20001",
+                  "kiali.istio-system.svc.cluster",
+                  "kiali.istio-system.svc.cluster:20001",
+                  "kiali.istio-system.svc",
+                  "kiali.istio-system.svc:20001",
+                  "10.0.1.86",
+                  "10.0.1.86:20001"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|20001||kiali.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "kiali.istio-system.svc.cluster.local:20001/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "kiali.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/kiali"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "kiali"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "kiali.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/kiali"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "kiali"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.671Z"
+        },
+        {
+          "version_info": "2019-04-02T19:54:27Z/16",
+          "route_config": {
+            "name": "15014",
+            "virtual_hosts": [
+              {
+                "name": "istio-citadel.istio-system.svc.cluster.local:15014",
+                "domains": [
+                  "istio-citadel.istio-system.svc.cluster.local",
+                  "istio-citadel.istio-system.svc.cluster.local:15014",
+                  "istio-citadel.istio-system",
+                  "istio-citadel.istio-system:15014",
+                  "istio-citadel.istio-system.svc.cluster",
+                  "istio-citadel.istio-system.svc.cluster:15014",
+                  "istio-citadel.istio-system.svc",
+                  "istio-citadel.istio-system.svc:15014",
+                  "10.0.8.222",
+                  "10.0.8.222:15014"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15014||istio-citadel.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-citadel.istio-system.svc.cluster.local:15014/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-citadel.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-citadel"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-citadel"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-citadel"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-citadel.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-citadel"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-galley.istio-system.svc.cluster.local:15014",
+                "domains": [
+                  "istio-galley.istio-system.svc.cluster.local",
+                  "istio-galley.istio-system.svc.cluster.local:15014",
+                  "istio-galley.istio-system",
+                  "istio-galley.istio-system:15014",
+                  "istio-galley.istio-system.svc.cluster",
+                  "istio-galley.istio-system.svc.cluster:15014",
+                  "istio-galley.istio-system.svc",
+                  "istio-galley.istio-system.svc:15014",
+                  "10.0.0.3",
+                  "10.0.0.3:15014"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15014||istio-galley.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-galley.istio-system.svc.cluster.local:15014/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-galley"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-galley.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-galley"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-galley.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-galley"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-galley"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-pilot.istio-system.svc.cluster.local:15014",
+                "domains": [
+                  "istio-pilot.istio-system.svc.cluster.local",
+                  "istio-pilot.istio-system.svc.cluster.local:15014",
+                  "istio-pilot.istio-system",
+                  "istio-pilot.istio-system:15014",
+                  "istio-pilot.istio-system.svc.cluster",
+                  "istio-pilot.istio-system.svc.cluster:15014",
+                  "istio-pilot.istio-system.svc",
+                  "istio-pilot.istio-system.svc:15014",
+                  "10.0.9.240",
+                  "10.0.9.240:15014"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15014||istio-pilot.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-pilot.istio-system.svc.cluster.local:15014/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-policy.istio-system.svc.cluster.local:15014",
+                "domains": [
+                  "istio-policy.istio-system.svc.cluster.local",
+                  "istio-policy.istio-system.svc.cluster.local:15014",
+                  "istio-policy.istio-system",
+                  "istio-policy.istio-system:15014",
+                  "istio-policy.istio-system.svc.cluster",
+                  "istio-policy.istio-system.svc.cluster:15014",
+                  "istio-policy.istio-system.svc",
+                  "istio-policy.istio-system.svc:15014",
+                  "10.0.3.83",
+                  "10.0.3.83:15014"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15014||istio-policy.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-policy.istio-system.svc.cluster.local:15014/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-telemetry.istio-system.svc.cluster.local:15014",
+                "domains": [
+                  "istio-telemetry.istio-system.svc.cluster.local",
+                  "istio-telemetry.istio-system.svc.cluster.local:15014",
+                  "istio-telemetry.istio-system",
+                  "istio-telemetry.istio-system:15014",
+                  "istio-telemetry.istio-system.svc.cluster",
+                  "istio-telemetry.istio-system.svc.cluster:15014",
+                  "istio-telemetry.istio-system.svc",
+                  "istio-telemetry.istio-system.svc:15014",
+                  "10.0.11.179",
+                  "10.0.11.179:15014"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-telemetry.istio-system.svc.cluster.local:15014/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-03T22:12:58.671Z"
+        }
+      ]
     }
-   ],
-   "dynamic_route_configs": [
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "8080",
-      "virtual_hosts": [
-       {
-        "name": "istio-pilot.istio-system.svc.cluster.local:8080",
-        "domains": [
-         "istio-pilot.istio-system.svc.cluster.local",
-         "istio-pilot.istio-system.svc.cluster.local:8080",
-         "istio-pilot.istio-system",
-         "istio-pilot.istio-system:8080",
-         "istio-pilot.istio-system.svc.cluster",
-         "istio-pilot.istio-system.svc.cluster:8080",
-         "istio-pilot.istio-system.svc",
-         "istio-pilot.istio-system.svc:8080",
-         "10.0.9.240",
-         "10.0.9.240:8080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8080||istio-pilot.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-pilot.istio-system.svc.cluster.local:8080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.670Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "15010",
-      "virtual_hosts": [
-       {
-        "name": "istio-pilot.istio-system.svc.cluster.local:15010",
-        "domains": [
-         "istio-pilot.istio-system.svc.cluster.local",
-         "istio-pilot.istio-system.svc.cluster.local:15010",
-         "istio-pilot.istio-system",
-         "istio-pilot.istio-system:15010",
-         "istio-pilot.istio-system.svc.cluster",
-         "istio-pilot.istio-system.svc.cluster:15010",
-         "istio-pilot.istio-system.svc",
-         "istio-pilot.istio-system.svc:15010",
-         "10.0.9.240",
-         "10.0.9.240:15010"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15010||istio-pilot.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-pilot.istio-system.svc.cluster.local:15010/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.670Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "15004",
-      "virtual_hosts": [
-       {
-        "name": "istio-policy.istio-system.svc.cluster.local:15004",
-        "domains": [
-         "istio-policy.istio-system.svc.cluster.local",
-         "istio-policy.istio-system.svc.cluster.local:15004",
-         "istio-policy.istio-system",
-         "istio-policy.istio-system:15004",
-         "istio-policy.istio-system.svc.cluster",
-         "istio-policy.istio-system.svc.cluster:15004",
-         "istio-policy.istio-system.svc",
-         "istio-policy.istio-system.svc:15004",
-         "10.0.3.83",
-         "10.0.3.83:15004"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-policy.istio-system.svc.cluster.local:15004/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              },
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              },
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-telemetry.istio-system.svc.cluster.local:15004",
-        "domains": [
-         "istio-telemetry.istio-system.svc.cluster.local",
-         "istio-telemetry.istio-system.svc.cluster.local:15004",
-         "istio-telemetry.istio-system",
-         "istio-telemetry.istio-system:15004",
-         "istio-telemetry.istio-system.svc.cluster",
-         "istio-telemetry.istio-system.svc.cluster:15004",
-         "istio-telemetry.istio-system.svc",
-         "istio-telemetry.istio-system.svc:15004",
-         "10.0.11.179",
-         "10.0.11.179:15004"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-telemetry.istio-system.svc.cluster.local:15004/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              },
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              },
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.671Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "9091",
-      "virtual_hosts": [
-       {
-        "name": "istio-policy.istio-system.svc.cluster.local:9091",
-        "domains": [
-         "istio-policy.istio-system.svc.cluster.local",
-         "istio-policy.istio-system.svc.cluster.local:9091",
-         "istio-policy.istio-system",
-         "istio-policy.istio-system:9091",
-         "istio-policy.istio-system.svc.cluster",
-         "istio-policy.istio-system.svc.cluster:9091",
-         "istio-policy.istio-system.svc",
-         "istio-policy.istio-system.svc:9091",
-         "10.0.3.83",
-         "10.0.3.83:9091"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-policy.istio-system.svc.cluster.local:9091/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              },
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-telemetry.istio-system.svc.cluster.local:9091",
-        "domains": [
-         "istio-telemetry.istio-system.svc.cluster.local",
-         "istio-telemetry.istio-system.svc.cluster.local:9091",
-         "istio-telemetry.istio-system",
-         "istio-telemetry.istio-system:9091",
-         "istio-telemetry.istio-system.svc.cluster",
-         "istio-telemetry.istio-system.svc.cluster:9091",
-         "istio-telemetry.istio-system.svc",
-         "istio-telemetry.istio-system.svc:9091",
-         "10.0.11.179",
-         "10.0.11.179:9091"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-telemetry.istio-system.svc.cluster.local:9091/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              },
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.670Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "80",
-      "virtual_hosts": [
-       {
-        "name": "alice.default.svc.cluster.local:80",
-        "domains": [
-         "alice.default.svc.cluster.local",
-         "alice.default.svc.cluster.local:80",
-         "alice",
-         "alice:80",
-         "alice.default.svc.cluster",
-         "alice.default.svc.cluster:80",
-         "alice.default.svc",
-         "alice.default.svc:80",
-         "alice.default",
-         "alice.default:80",
-         "10.0.15.240",
-         "10.0.15.240:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||alice.default.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "alice.default.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "alice.default.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/alice"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "alice"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "alice"
-              },
-              "destination.service.host": {
-               "string_value": "alice.default.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/alice"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "bob.default.svc.cluster.local:80",
-        "domains": [
-         "bob.default.svc.cluster.local",
-         "bob.default.svc.cluster.local:80",
-         "bob",
-         "bob:80",
-         "bob.default.svc.cluster",
-         "bob.default.svc.cluster:80",
-         "bob.default.svc",
-         "bob.default.svc:80",
-         "bob.default",
-         "bob.default:80",
-         "10.0.5.14",
-         "10.0.5.14:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||bob.default.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "bob.default.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "bob.default.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/bob"
-              },
-              "destination.service.name": {
-               "string_value": "bob"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "bob"
-              },
-              "destination.service.host": {
-               "string_value": "bob.default.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/bob"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "default-http-backend.kube-system.svc.cluster.local:80",
-        "domains": [
-         "default-http-backend.kube-system.svc.cluster.local",
-         "default-http-backend.kube-system.svc.cluster.local:80",
-         "default-http-backend.kube-system",
-         "default-http-backend.kube-system:80",
-         "default-http-backend.kube-system.svc.cluster",
-         "default-http-backend.kube-system.svc.cluster:80",
-         "default-http-backend.kube-system.svc",
-         "default-http-backend.kube-system.svc:80",
-         "10.0.5.0",
-         "10.0.5.0:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||default-http-backend.kube-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "default-http-backend.kube-system.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://kube-system/services/default-http-backend"
-              },
-              "destination.service.host": {
-               "string_value": "default-http-backend.kube-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "kube-system"
-              },
-              "destination.service.name": {
-               "string_value": "default-http-backend"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://kube-system/services/default-http-backend"
-              },
-              "destination.service.host": {
-               "string_value": "default-http-backend.kube-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "kube-system"
-              },
-              "destination.service.name": {
-               "string_value": "default-http-backend"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-egressgateway.istio-system.svc.cluster.local:80",
-        "domains": [
-         "istio-egressgateway.istio-system.svc.cluster.local",
-         "istio-egressgateway.istio-system.svc.cluster.local:80",
-         "istio-egressgateway.istio-system",
-         "istio-egressgateway.istio-system:80",
-         "istio-egressgateway.istio-system.svc.cluster",
-         "istio-egressgateway.istio-system.svc.cluster:80",
-         "istio-egressgateway.istio-system.svc",
-         "istio-egressgateway.istio-system.svc:80",
-         "10.0.2.103",
-         "10.0.2.103:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-egressgateway.istio-system.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-egressgateway"
-              },
-              "destination.service.host": {
-               "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-egressgateway"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-egressgateway"
-              },
-              "destination.service.host": {
-               "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-egressgateway"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-ingressgateway.istio-system.svc.cluster.local:80",
-        "domains": [
-         "istio-ingressgateway.istio-system.svc.cluster.local",
-         "istio-ingressgateway.istio-system.svc.cluster.local:80",
-         "istio-ingressgateway.istio-system",
-         "istio-ingressgateway.istio-system:80",
-         "istio-ingressgateway.istio-system.svc.cluster",
-         "istio-ingressgateway.istio-system.svc.cluster:80",
-         "istio-ingressgateway.istio-system.svc",
-         "istio-ingressgateway.istio-system.svc:80",
-         "10.0.8.160",
-         "10.0.8.160:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-ingressgateway.istio-system.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-ingressgateway"
-              },
-              "destination.service.name": {
-               "string_value": "istio-ingressgateway"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-ingressgateway"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-ingressgateway"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "sleep.default.svc.cluster.local:80",
-        "domains": [
-         "sleep.default.svc.cluster.local",
-         "sleep.default.svc.cluster.local:80",
-         "sleep",
-         "sleep:80",
-         "sleep.default.svc.cluster",
-         "sleep.default.svc.cluster:80",
-         "sleep.default.svc",
-         "sleep.default.svc:80",
-         "sleep.default",
-         "sleep.default:80",
-         "10.0.10.64",
-         "10.0.10.64:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||sleep.default.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "sleep.default.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "sleep.default.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/sleep"
-              },
-              "destination.service.name": {
-               "string_value": "sleep"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "sleep"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/sleep"
-              },
-              "destination.service.host": {
-               "string_value": "sleep.default.svc.cluster.local"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "tracing.istio-system.svc.cluster.local:80",
-        "domains": [
-         "tracing.istio-system.svc.cluster.local",
-         "tracing.istio-system.svc.cluster.local:80",
-         "tracing.istio-system",
-         "tracing.istio-system:80",
-         "tracing.istio-system.svc.cluster",
-         "tracing.istio-system.svc.cluster:80",
-         "tracing.istio-system.svc",
-         "tracing.istio-system.svc:80",
-         "10.0.2.209",
-         "10.0.2.209:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||tracing.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "tracing.istio-system.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "tracing.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/tracing"
-              },
-              "destination.service.name": {
-               "string_value": "tracing"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "tracing.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/tracing"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "tracing"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.672Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "9080",
-      "virtual_hosts": [
-       {
-        "name": "details.default.svc.cluster.local:9080",
-        "domains": [
-         "details.default.svc.cluster.local",
-         "details.default.svc.cluster.local:9080",
-         "details",
-         "details:9080",
-         "details.default.svc.cluster",
-         "details.default.svc.cluster:9080",
-         "details.default.svc",
-         "details.default.svc:9080",
-         "details.default",
-         "details.default:9080",
-         "10.0.9.156",
-         "10.0.9.156:9080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9080||details.default.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "details.default.svc.cluster.local:9080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "details"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/details"
-              },
-              "destination.service.host": {
-               "string_value": "details.default.svc.cluster.local"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://default/services/details"
-              },
-              "destination.service.host": {
-               "string_value": "details.default.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "details"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "productpage.default.svc.cluster.local:9080",
-        "domains": [
-         "productpage.default.svc.cluster.local",
-         "productpage.default.svc.cluster.local:9080",
-         "productpage",
-         "productpage:9080",
-         "productpage.default.svc.cluster",
-         "productpage.default.svc.cluster:9080",
-         "productpage.default.svc",
-         "productpage.default.svc:9080",
-         "productpage.default",
-         "productpage.default:9080",
-         "10.0.0.4",
-         "10.0.0.4:9080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9080||productpage.default.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "productpage.default.svc.cluster.local:9080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "productpage.default.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/productpage"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "productpage"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://default/services/productpage"
-              },
-              "destination.service.host": {
-               "string_value": "productpage.default.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "productpage"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "ratings.default.svc.cluster.local:9080",
-        "domains": [
-         "ratings.default.svc.cluster.local",
-         "ratings.default.svc.cluster.local:9080",
-         "ratings",
-         "ratings:9080",
-         "ratings.default.svc.cluster",
-         "ratings.default.svc.cluster:9080",
-         "ratings.default.svc",
-         "ratings.default.svc:9080",
-         "ratings.default",
-         "ratings.default:9080",
-         "10.0.8.147",
-         "10.0.8.147:9080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9080||ratings.default.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "ratings.default.svc.cluster.local:9080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "ratings"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/ratings"
-              },
-              "destination.service.host": {
-               "string_value": "ratings.default.svc.cluster.local"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://default/services/ratings"
-              },
-              "destination.service.host": {
-               "string_value": "ratings.default.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "ratings"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "reviews.default.svc.cluster.local:9080",
-        "domains": [
-         "reviews.default.svc.cluster.local",
-         "reviews.default.svc.cluster.local:9080",
-         "reviews",
-         "reviews:9080",
-         "reviews.default.svc.cluster",
-         "reviews.default.svc.cluster:9080",
-         "reviews.default.svc",
-         "reviews.default.svc:9080",
-         "reviews.default",
-         "reviews.default:9080",
-         "10.0.9.20",
-         "10.0.9.20:9080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9080||reviews.default.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "reviews.default.svc.cluster.local:9080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://default/services/reviews"
-              },
-              "destination.service.host": {
-               "string_value": "reviews.default.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "reviews"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "reviews"
-              },
-              "destination.service.host": {
-               "string_value": "reviews.default.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/reviews"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.672Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "8060",
-      "virtual_hosts": [
-       {
-        "name": "istio-citadel.istio-system.svc.cluster.local:8060",
-        "domains": [
-         "istio-citadel.istio-system.svc.cluster.local",
-         "istio-citadel.istio-system.svc.cluster.local:8060",
-         "istio-citadel.istio-system",
-         "istio-citadel.istio-system:8060",
-         "istio-citadel.istio-system.svc.cluster",
-         "istio-citadel.istio-system.svc.cluster:8060",
-         "istio-citadel.istio-system.svc",
-         "istio-citadel.istio-system.svc:8060",
-         "10.0.8.222",
-         "10.0.8.222:8060"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8060||istio-citadel.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-citadel.istio-system.svc.cluster.local:8060/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-citadel"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-citadel"
-              },
-              "destination.service.host": {
-               "string_value": "istio-citadel.istio-system.svc.cluster.local"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-citadel.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-citadel"
-              },
-              "destination.service.name": {
-               "string_value": "istio-citadel"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.671Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "8000",
-      "virtual_hosts": [
-       {
-        "name": "httpbin.default.svc.cluster.local:8000",
-        "domains": [
-         "httpbin.default.svc.cluster.local",
-         "httpbin.default.svc.cluster.local:8000",
-         "httpbin",
-         "httpbin:8000",
-         "httpbin.default.svc.cluster",
-         "httpbin.default.svc.cluster:8000",
-         "httpbin.default.svc",
-         "httpbin.default.svc:8000",
-         "httpbin.default",
-         "httpbin.default:8000",
-         "10.0.5.99",
-         "10.0.5.99:8000"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8000||httpbin.default.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "httpbin.default.svc.cluster.local:8000/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://default/services/httpbin"
-              },
-              "destination.service.host": {
-               "string_value": "httpbin.default.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.name": {
-               "string_value": "httpbin"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.name": {
-               "string_value": "httpbin"
-              },
-              "destination.service.namespace": {
-               "string_value": "default"
-              },
-              "destination.service.host": {
-               "string_value": "httpbin.default.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://default/services/httpbin"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.671Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "9901",
-      "virtual_hosts": [
-       {
-        "name": "istio-galley.istio-system.svc.cluster.local:9901",
-        "domains": [
-         "istio-galley.istio-system.svc.cluster.local",
-         "istio-galley.istio-system.svc.cluster.local:9901",
-         "istio-galley.istio-system",
-         "istio-galley.istio-system:9901",
-         "istio-galley.istio-system.svc.cluster",
-         "istio-galley.istio-system.svc.cluster:9901",
-         "istio-galley.istio-system.svc",
-         "istio-galley.istio-system.svc:9901",
-         "10.0.0.3",
-         "10.0.0.3:9901"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9901||istio-galley.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-galley.istio-system.svc.cluster.local:9901/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-galley"
-              },
-              "destination.service.host": {
-               "string_value": "istio-galley.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-galley"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-galley"
-              },
-              "destination.service.host": {
-               "string_value": "istio-galley.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-galley"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.672Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "9090",
-      "virtual_hosts": [
-       {
-        "name": "prometheus.istio-system.svc.cluster.local:9090",
-        "domains": [
-         "prometheus.istio-system.svc.cluster.local",
-         "prometheus.istio-system.svc.cluster.local:9090",
-         "prometheus.istio-system",
-         "prometheus.istio-system:9090",
-         "prometheus.istio-system.svc.cluster",
-         "prometheus.istio-system.svc.cluster:9090",
-         "prometheus.istio-system.svc",
-         "prometheus.istio-system.svc:9090",
-         "10.0.6.88",
-         "10.0.6.88:9090"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9090||prometheus.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "prometheus.istio-system.svc.cluster.local:9090/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/prometheus"
-              },
-              "destination.service.host": {
-               "string_value": "prometheus.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "prometheus"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "prometheus.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/prometheus"
-              },
-              "destination.service.name": {
-               "string_value": "prometheus"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.671Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "9411",
-      "virtual_hosts": [
-       {
-        "name": "zipkin.istio-system.svc.cluster.local:9411",
-        "domains": [
-         "zipkin.istio-system.svc.cluster.local",
-         "zipkin.istio-system.svc.cluster.local:9411",
-         "zipkin.istio-system",
-         "zipkin.istio-system:9411",
-         "zipkin.istio-system.svc.cluster",
-         "zipkin.istio-system.svc.cluster:9411",
-         "zipkin.istio-system.svc",
-         "zipkin.istio-system.svc:9411",
-         "10.0.14.1",
-         "10.0.14.1:9411"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9411||zipkin.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "zipkin.istio-system.svc.cluster.local:9411/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "zipkin.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/zipkin"
-              },
-              "destination.service.name": {
-               "string_value": "zipkin"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/zipkin"
-              },
-              "destination.service.host": {
-               "string_value": "zipkin.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "zipkin"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.672Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "3000",
-      "virtual_hosts": [
-       {
-        "name": "grafana.istio-system.svc.cluster.local:3000",
-        "domains": [
-         "grafana.istio-system.svc.cluster.local",
-         "grafana.istio-system.svc.cluster.local:3000",
-         "grafana.istio-system",
-         "grafana.istio-system:3000",
-         "grafana.istio-system.svc.cluster",
-         "grafana.istio-system.svc.cluster:3000",
-         "grafana.istio-system.svc",
-         "grafana.istio-system.svc:3000",
-         "10.0.12.51",
-         "10.0.12.51:3000"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|3000||grafana.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "grafana.istio-system.svc.cluster.local:3000/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "grafana"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/grafana"
-              },
-              "destination.service.host": {
-               "string_value": "grafana.istio-system.svc.cluster.local"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "grafana.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/grafana"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "grafana"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.671Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "20001",
-      "virtual_hosts": [
-       {
-        "name": "kiali.istio-system.svc.cluster.local:20001",
-        "domains": [
-         "kiali.istio-system.svc.cluster.local",
-         "kiali.istio-system.svc.cluster.local:20001",
-         "kiali.istio-system",
-         "kiali.istio-system:20001",
-         "kiali.istio-system.svc.cluster",
-         "kiali.istio-system.svc.cluster:20001",
-         "kiali.istio-system.svc",
-         "kiali.istio-system.svc:20001",
-         "10.0.1.86",
-         "10.0.1.86:20001"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|20001||kiali.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "kiali.istio-system.svc.cluster.local:20001/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "kiali.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/kiali"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "kiali"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "kiali.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/kiali"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "kiali"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.671Z"
-    },
-    {
-     "version_info": "2019-04-02T19:54:27Z/16",
-     "route_config": {
-      "name": "15014",
-      "virtual_hosts": [
-       {
-        "name": "istio-citadel.istio-system.svc.cluster.local:15014",
-        "domains": [
-         "istio-citadel.istio-system.svc.cluster.local",
-         "istio-citadel.istio-system.svc.cluster.local:15014",
-         "istio-citadel.istio-system",
-         "istio-citadel.istio-system:15014",
-         "istio-citadel.istio-system.svc.cluster",
-         "istio-citadel.istio-system.svc.cluster:15014",
-         "istio-citadel.istio-system.svc",
-         "istio-citadel.istio-system.svc:15014",
-         "10.0.8.222",
-         "10.0.8.222:15014"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15014||istio-citadel.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-citadel.istio-system.svc.cluster.local:15014/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-citadel.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-citadel"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-citadel"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-citadel"
-              },
-              "destination.service.host": {
-               "string_value": "istio-citadel.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-citadel"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-galley.istio-system.svc.cluster.local:15014",
-        "domains": [
-         "istio-galley.istio-system.svc.cluster.local",
-         "istio-galley.istio-system.svc.cluster.local:15014",
-         "istio-galley.istio-system",
-         "istio-galley.istio-system:15014",
-         "istio-galley.istio-system.svc.cluster",
-         "istio-galley.istio-system.svc.cluster:15014",
-         "istio-galley.istio-system.svc",
-         "istio-galley.istio-system.svc:15014",
-         "10.0.0.3",
-         "10.0.0.3:15014"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15014||istio-galley.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-galley.istio-system.svc.cluster.local:15014/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-galley"
-              },
-              "destination.service.host": {
-               "string_value": "istio-galley.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-galley"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-galley.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-galley"
-              },
-              "destination.service.name": {
-               "string_value": "istio-galley"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-pilot.istio-system.svc.cluster.local:15014",
-        "domains": [
-         "istio-pilot.istio-system.svc.cluster.local",
-         "istio-pilot.istio-system.svc.cluster.local:15014",
-         "istio-pilot.istio-system",
-         "istio-pilot.istio-system:15014",
-         "istio-pilot.istio-system.svc.cluster",
-         "istio-pilot.istio-system.svc.cluster:15014",
-         "istio-pilot.istio-system.svc",
-         "istio-pilot.istio-system.svc:15014",
-         "10.0.9.240",
-         "10.0.9.240:15014"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15014||istio-pilot.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-pilot.istio-system.svc.cluster.local:15014/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              },
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-policy.istio-system.svc.cluster.local:15014",
-        "domains": [
-         "istio-policy.istio-system.svc.cluster.local",
-         "istio-policy.istio-system.svc.cluster.local:15014",
-         "istio-policy.istio-system",
-         "istio-policy.istio-system:15014",
-         "istio-policy.istio-system.svc.cluster",
-         "istio-policy.istio-system.svc.cluster:15014",
-         "istio-policy.istio-system.svc",
-         "istio-policy.istio-system.svc:15014",
-         "10.0.3.83",
-         "10.0.3.83:15014"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15014||istio-policy.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-policy.istio-system.svc.cluster.local:15014/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-telemetry.istio-system.svc.cluster.local:15014",
-        "domains": [
-         "istio-telemetry.istio-system.svc.cluster.local",
-         "istio-telemetry.istio-system.svc.cluster.local:15014",
-         "istio-telemetry.istio-system",
-         "istio-telemetry.istio-system:15014",
-         "istio-telemetry.istio-system.svc.cluster",
-         "istio-telemetry.istio-system.svc.cluster:15014",
-         "istio-telemetry.istio-system.svc",
-         "istio-telemetry.istio-system.svc:15014",
-         "10.0.11.179",
-         "10.0.11.179:15014"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-telemetry.istio-system.svc.cluster.local:15014/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              },
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-03T22:12:58.671Z"
-    }
-   ]
-  }
- ]
+  ]
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -177,12 +177,26 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 func buildTestClusters(serviceHostname string, serviceResolution model.Resolution,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
 	destRule proto.Message) ([]*apiv2.Cluster, error) {
-	return buildTestClustersWithProxyMetadata(serviceHostname, serviceResolution, nodeType, locality, mesh, destRule, make(map[string]string))
+	return buildTestClustersWithProxyMetadata(
+		serviceHostname,
+		serviceResolution,
+		nodeType,
+		locality,
+		mesh,
+		destRule,
+		make(map[string]string),
+		model.MaxIstioVersion)
+}
+
+func buildTestClustersWithIstioVersion(serviceHostname string, serviceResolution model.Resolution,
+	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
+	destRule proto.Message, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
+	return buildTestClustersWithProxyMetadata(serviceHostname, serviceResolution, nodeType, locality, mesh, destRule, make(map[string]string), istioVersion)
 }
 
 func buildTestClustersWithProxyMetadata(serviceHostname string, serviceResolution model.Resolution,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, meta map[string]string) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, meta map[string]string, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
 	configgen := NewConfigGenerator([]plugin.Plugin{})
 
 	serviceDiscovery := &fakes.ServiceDiscovery{}
@@ -258,21 +272,23 @@ func buildTestClustersWithProxyMetadata(serviceHostname string, serviceResolutio
 	switch nodeType {
 	case model.SidecarProxy:
 		proxy = &model.Proxy{
-			ClusterID:   "some-cluster-id",
-			Type:        model.SidecarProxy,
-			IPAddresses: []string{"6.6.6.6"},
-			Locality:    locality,
-			DNSDomain:   "com",
-			Metadata:    meta,
+			ClusterID:    "some-cluster-id",
+			Type:         model.SidecarProxy,
+			IPAddresses:  []string{"6.6.6.6"},
+			Locality:     locality,
+			DNSDomain:    "com",
+			Metadata:     meta,
+			IstioVersion: istioVersion,
 		}
 	case model.Router:
 		proxy = &model.Proxy{
-			ClusterID:   "some-cluster-id",
-			Type:        model.Router,
-			IPAddresses: []string{"6.6.6.6"},
-			Locality:    locality,
-			DNSDomain:   "default.example.org",
-			Metadata:    meta,
+			ClusterID:    "some-cluster-id",
+			Type:         model.Router,
+			IPAddresses:  []string{"6.6.6.6"},
+			Locality:     locality,
+			DNSDomain:    "default.example.org",
+			Metadata:     meta,
+			IstioVersion: istioVersion,
 		}
 	default:
 		panic(fmt.Sprintf("unsupported node type: %v", nodeType))
@@ -427,7 +443,7 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 	}
 
 	clusters, err := buildTestClustersWithProxyMetadata("foo.example.org", model.ClientSideLB, model.SidecarProxy,
-		nil, testMesh, destRule, envoyMetadata)
+		nil, testMesh, destRule, envoyMetadata, model.MaxIstioVersion)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(clusters).To(HaveLen(7))
@@ -485,6 +501,7 @@ func buildSniTestClustersWithMetadata(sniValue string, meta map[string]string) (
 			},
 		},
 		meta,
+		model.MaxIstioVersion,
 	)
 }
 
@@ -892,7 +909,7 @@ func TestClusterDiscoveryTypeAndLbPolicyRoundRobin(t *testing.T) {
 		})
 
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(clusters[0].LbPolicy).To(Equal(apiv2.Cluster_ORIGINAL_DST_LB))
+	g.Expect(clusters[0].LbPolicy).To(Equal(apiv2.Cluster_CLUSTER_PROVIDED))
 	g.Expect(clusters[0].GetClusterDiscoveryType()).To(Equal(&apiv2.Cluster_Type{Type: apiv2.Cluster_ORIGINAL_DST}))
 }
 
@@ -914,6 +931,31 @@ func TestClusterDiscoveryTypeAndLbPolicyPassthrough(t *testing.T) {
 			},
 		})
 
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(clusters[0].LbPolicy).To(Equal(apiv2.Cluster_CLUSTER_PROVIDED))
+	g.Expect(clusters[0].GetClusterDiscoveryType()).To(Equal(&apiv2.Cluster_Type{Type: apiv2.Cluster_ORIGINAL_DST}))
+	g.Expect(clusters[0].EdsClusterConfig).To(BeNil())
+}
+
+func TestClusterDiscoveryTypeAndLbPolicyPassthroughIstioVersion12(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	clusters, err := buildTestClustersWithIstioVersion("*.example.org", model.ClientSideLB, model.SidecarProxy, nil, testMesh,
+		&networking.DestinationRule{
+			Host: "*.example.org",
+			TrafficPolicy: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_Simple{
+						Simple: networking.LoadBalancerSettings_PASSTHROUGH,
+					},
+				},
+				OutlierDetection: &networking.OutlierDetection{
+					ConsecutiveErrors: 5,
+				},
+			},
+		}, &model.IstioVersion{Major: 1, Minor: 2})
+
+	fmt.Printf("%+v\n", clusters[0])
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(clusters[0].LbPolicy).To(Equal(apiv2.Cluster_ORIGINAL_DST_LB))
 	g.Expect(clusters[0].GetClusterDiscoveryType()).To(Equal(&apiv2.Cluster_Type{Type: apiv2.Cluster_ORIGINAL_DST}))
@@ -973,7 +1015,7 @@ func TestRedisProtocolWithPassThroughResolution(t *testing.T) {
 	g.Expect(len(clusters)).ShouldNot(Equal(0))
 	for _, cluster := range clusters {
 		if cluster.Name == "outbound|6379||redis.com" {
-			g.Expect(clusters[0].LbPolicy).To(Equal(apiv2.Cluster_ORIGINAL_DST_LB))
+			g.Expect(clusters[0].LbPolicy).To(Equal(apiv2.Cluster_CLUSTER_PROVIDED))
 			g.Expect(clusters[0].GetClusterDiscoveryType()).To(Equal(&apiv2.Cluster_Type{Type: apiv2.Cluster_ORIGINAL_DST}))
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -2017,6 +2017,24 @@ func getActualWildcardAndLocalHost(node *model.Proxy) (string, string) {
 	return WildcardIPv6Address, LocalhostIPv6Address
 }
 
+func ipv4AndIpv6Support(node *model.Proxy) (bool, bool) {
+	ipv4, ipv6 := false, false
+	for i := 0; i < len(node.IPAddresses); i++ {
+		addr := net.ParseIP(node.IPAddresses[i])
+		if addr == nil {
+			// Should not happen, invalid IP in proxy's IPAddresses slice should have been caught earlier,
+			// skip it to prevent a panic.
+			continue
+		}
+		if addr.To4() != nil {
+			ipv4 = true
+		} else {
+			ipv6 = true
+		}
+	}
+	return ipv4, ipv6
+}
+
 // getSidecarInboundBindIP returns the IP that the proxy can bind to along with the sidecar specified port.
 // It looks for an unicast address, if none found, then the default wildcard address is used.
 // This will make the inbound listener bind to instance_ip:port instead of 0.0.0.0:port where applicable.

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -397,10 +397,18 @@ func newBlackholeFilter(enableAny bool) listener.Filter {
 
 // Create pass through filter chains matching ipv4 address and ipv6 address independently.
 func newInboundPassthroughFilterChains(env *model.Environment, node *model.Proxy) []*listener.FilterChain {
-	// ipv4 and ipv6
+	ipv4, ipv6 := ipv4AndIpv6Support(node)
+	// ipv4 and ipv6 feature detect
+	ipVersions := make([]string, 0, 2)
+	if ipv4 {
+		ipVersions = append(ipVersions, util.InboundPassthroughClusterIpv4)
+	}
+	if ipv6 {
+		ipVersions = append(ipVersions, util.InboundPassthroughClusterIpv6)
+	}
 	filterChains := make([]*listener.FilterChain, 0, 2)
-	for _, clusterName := range []string{util.InboundPassthroughClusterIpv4, util.InboundPassthroughClusterIpv6} {
 
+	for _, clusterName := range ipVersions {
 		tcpProxy := &tcp_proxy.TcpProxy{
 			StatPrefix:       clusterName,
 			ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: clusterName},
@@ -444,9 +452,18 @@ func newInboundPassthroughFilterChains(env *model.Environment, node *model.Proxy
 
 func newHTTPPassThroughFilterChain(configgen *ConfigGeneratorImpl, env *model.Environment,
 	node *model.Proxy, push *model.PushContext) []*listener.FilterChain {
+	ipv4, ipv6 := ipv4AndIpv6Support(node)
+	// ipv4 and ipv6 feature detect
+	ipVersions := make([]string, 0, 2)
+	if ipv4 {
+		ipVersions = append(ipVersions, util.InboundPassthroughClusterIpv4)
+	}
+	if ipv6 {
+		ipVersions = append(ipVersions, util.InboundPassthroughClusterIpv6)
+	}
 	filterChains := make([]*listener.FilterChain, 0, 2)
 
-	for _, clusterName := range []string{util.InboundPassthroughClusterIpv4, util.InboundPassthroughClusterIpv6} {
+	for _, clusterName := range ipVersions {
 		matchingIP := ""
 		if clusterName == util.InboundPassthroughClusterIpv4 {
 			matchingIP = "0.0.0.0/0"

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -214,8 +214,8 @@ func TestVirtualInboundListenerBuilder(t *testing.T) {
 	}
 
 	for k, v := range byListenerName {
-		if k == VirtualInboundListenerName && v != 4 {
-			t.Fatalf("expect virtual listener has 4 passthrough listeners, found %d", v)
+		if k == VirtualInboundListenerName && v != 2 {
+			t.Fatalf("expect virtual listener has 2 passthrough listeners, found %d", v)
 		}
 		if k == listeners[0].Name && v != len(listeners[0].FilterChains) {
 			t.Fatalf("expect virtual listener has %d filter chains from listener %s, found %d", len(listeners[0].FilterChains), l.Name, v)
@@ -233,11 +233,10 @@ func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
 	}
 
 	l := listeners[2]
-	// 4 is the 2 passthrough tcp filter chains one for ipv4 and one for ipv6
-	// and 2 http filter chains one for ipv4 and one for ipv6
-	if len(l.FilterChains) != len(listeners[0].FilterChains)+4 {
+	// 2 is the 1 passthrough tcp filter chain for ipv4 and 1 http filter chain for ipv4
+	if len(l.FilterChains) != len(listeners[0].FilterChains)+2 {
 		t.Fatalf("expect virtual listener has %d filter chains as the sum of 2nd level listeners "+
-			"plus the 4 fallthrough filter chains, found %d", len(listeners[0].FilterChains)+4, len(l.FilterChains))
+			"plus the 2 fallthrough filter chains, found %d", len(listeners[0].FilterChains)+2, len(l.FilterChains))
 	}
 
 	sawIpv4PassthroughCluster := false
@@ -271,8 +270,8 @@ func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
 		}
 	}
 
-	if !sawIpv4PassthroughCluster || !sawIpv6PassthroughCluster {
-		t.Fatalf("fail to find 1 ipv6 passthrough filter chain and 1 ipv4 passthrough filter chain in listener %v", l)
+	if !sawIpv4PassthroughCluster {
+		t.Fatalf("fail to find the ipv4 passthrough filter chain in listener %v", l)
 	}
 
 	if len(l.ListenerFilters) != 2 {

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -233,11 +233,11 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 		t.Fatalf("Expected 7 listeners, got %d\n", len(adsResponse.GetHTTPListeners())+len(adsResponse.GetTCPListeners()))
 	}
 
-	// Expect 12 CDS clusters:
-	// 3 inbound(http, inbound passthroughipv4 and inbound passthroughipv6)
+	// Expect 11 CDS clusters:
+	// 2 inbound(http, inbound passthroughipv4) notes: no passthroughipv6
 	// 9 outbound (2 http services, 1 tcp service, 2 istio-system services,
 	//   and 2 subsets of http1, 1 blackhole, 1 passthrough)
-	if (len(adsResponse.GetClusters()) + len(adsResponse.GetEdsClusters())) != 12 {
+	if (len(adsResponse.GetClusters()) + len(adsResponse.GetEdsClusters())) != 11 {
 		t.Fatalf("Expected 12 clusters in CDS output. Got %d", len(adsResponse.GetClusters())+len(adsResponse.GetEdsClusters()))
 	}
 

--- a/pkg/test/framework/components/echo/common/testdata/config_dump.json
+++ b/pkg/test/framework/components/echo/common/testdata/config_dump.json
@@ -1,12178 +1,12178 @@
 {
- "configs": [
-  {
-   "@type": "type.googleapis.com/envoy.admin.v2alpha.BootstrapConfigDump",
-   "bootstrap": {
-    "node": {
-     "id": "sidecar~10.40.3.59~a-6bb6dbdcc5-z58cx.apps-1-99281~apps-1-99281.svc.cluster.local",
-     "cluster": "a.apps-1-99281",
-     "metadata": {
-      "app": "a",
-      "pod-template-hash": "6bb6dbdcc5",
-      "INTERCEPTION_MODE": "REDIRECT",
-      "CONFIG_NAMESPACE": "apps-1-99281",
-      "version": "v1",
-      "ISTIO_VERSION": "1.0-dev",
-      "istio-locality": "region.zone.subzone",
-      "INSTANCE_IPS": "10.40.3.59,10.40.3.59,fe80::7cf5:f9ff:fe8f:48bb",
-      "POD_NAME": "a-6bb6dbdcc5-z58cx",
-      "istio": "sidecar",
-      "ISTIO_PROXY_SHA": "istio-proxy:ecbd1731cedc5d373766ea6e2f1c2e58623b0e28"
-     },
-     "locality": {
-      "region": "us-central1",
-      "zone": "us-central1-a"
-     },
-     "build_version": "ecbd1731cedc5d373766ea6e2f1c2e58623b0e28/1.10.0-dev/Clean/RELEASE/BoringSSL"
-    },
-    "static_resources": {
-     "listeners": [
-      {
-       "address": {
-        "socket_address": {
-         "address": "0.0.0.0",
-         "port_value": 15090
-        }
-       },
-       "filter_chains": [
-        {
-         "filters": [
-          {
-           "name": "envoy.http_connection_manager",
-           "config": {
-            "route_config": {
-             "virtual_hosts": [
+  "configs": [
+    {
+      "@type": "type.googleapis.com/envoy.admin.v2alpha.BootstrapConfigDump",
+      "bootstrap": {
+        "node": {
+          "id": "sidecar~10.40.3.59~a-6bb6dbdcc5-z58cx.apps-1-99281~apps-1-99281.svc.cluster.local",
+          "cluster": "a.apps-1-99281",
+          "metadata": {
+            "app": "a",
+            "pod-template-hash": "6bb6dbdcc5",
+            "INTERCEPTION_MODE": "REDIRECT",
+            "CONFIG_NAMESPACE": "apps-1-99281",
+            "version": "v1",
+            "ISTIO_VERSION": "1.0-dev",
+            "istio-locality": "region.zone.subzone",
+            "INSTANCE_IPS": "10.40.3.59,10.40.3.59,fe80::7cf5:f9ff:fe8f:48bb",
+            "POD_NAME": "a-6bb6dbdcc5-z58cx",
+            "istio": "sidecar",
+            "ISTIO_PROXY_SHA": "istio-proxy:ecbd1731cedc5d373766ea6e2f1c2e58623b0e28"
+          },
+          "locality": {
+            "region": "us-central1",
+            "zone": "us-central1-a"
+          },
+          "build_version": "ecbd1731cedc5d373766ea6e2f1c2e58623b0e28/1.10.0-dev/Clean/RELEASE/BoringSSL"
+        },
+        "static_resources": {
+          "listeners": [
+            {
+              "address": {
+                "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 15090
+                }
+              },
+              "filter_chains": [
+                {
+                  "filters": [
+                    {
+                      "name": "envoy.http_connection_manager",
+                      "config": {
+                        "route_config": {
+                          "virtual_hosts": [
+                            {
+                              "routes": [
+                                {
+                                  "route": {
+                                    "cluster": "prometheus_stats"
+                                  },
+                                  "match": {
+                                    "prefix": "/stats/prometheus"
+                                  }
+                                }
+                              ],
+                              "domains": [
+                                "*"
+                              ],
+                              "name": "backend"
+                            }
+                          ]
+                        },
+                        "codec_type": "AUTO",
+                        "http_filters": {
+                          "name": "envoy.router"
+                        },
+                        "stat_prefix": "stats"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "clusters": [
+            {
+              "name": "prometheus_stats",
+              "type": "STATIC",
+              "connect_timeout": "0.250s",
+              "hosts": [
+                {
+                  "socket_address": {
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              ]
+            },
+            {
+              "name": "xds-grpc",
+              "type": "STRICT_DNS",
+              "connect_timeout": "10s",
+              "hosts": [
+                {
+                  "socket_address": {
+                    "address": "istio-pilot.istio-system",
+                    "port_value": 15010
+                  }
+                }
+              ],
+              "circuit_breakers": {
+                "thresholds": [
+                  {
+                    "max_connections": 100000,
+                    "max_pending_requests": 100000,
+                    "max_requests": 100000
+                  },
+                  {
+                    "priority": "HIGH",
+                    "max_connections": 100000,
+                    "max_pending_requests": 100000,
+                    "max_requests": 100000
+                  }
+                ]
+              },
+              "http2_protocol_options": {},
+              "dns_lookup_family": "V4_ONLY",
+              "upstream_connection_options": {
+                "tcp_keepalive": {
+                  "keepalive_time": 300
+                }
+              }
+            },
+            {
+              "name": "zipkin",
+              "type": "STRICT_DNS",
+              "connect_timeout": "1s",
+              "hosts": [
+                {
+                  "socket_address": {
+                    "address": "zipkin.istio-system",
+                    "port_value": 9411
+                  }
+                }
+              ],
+              "dns_lookup_family": "V4_ONLY"
+            }
+          ]
+        },
+        "dynamic_resources": {
+          "lds_config": {
+            "ads": {}
+          },
+          "cds_config": {
+            "ads": {}
+          },
+          "ads_config": {
+            "api_type": "GRPC",
+            "grpc_services": [
               {
-               "routes": [
-                {
-                 "route": {
-                  "cluster": "prometheus_stats"
-                 },
-                 "match": {
-                  "prefix": "/stats/prometheus"
-                 }
+                "envoy_grpc": {
+                  "cluster_name": "xds-grpc"
                 }
-               ],
-               "domains": [
-                "*"
-               ],
-               "name": "backend"
               }
-             ]
-            },
-            "codec_type": "AUTO",
-            "http_filters": {
-             "name": "envoy.router"
-            },
-            "stat_prefix": "stats"
-           }
-          }
-         ]
-        }
-       ]
-      }
-     ],
-     "clusters": [
-      {
-       "name": "prometheus_stats",
-       "type": "STATIC",
-       "connect_timeout": "0.250s",
-       "hosts": [
-        {
-         "socket_address": {
-          "address": "127.0.0.1",
-          "port_value": 15000
-         }
-        }
-       ]
-      },
-      {
-       "name": "xds-grpc",
-       "type": "STRICT_DNS",
-       "connect_timeout": "10s",
-       "hosts": [
-        {
-         "socket_address": {
-          "address": "istio-pilot.istio-system",
-          "port_value": 15010
-         }
-        }
-       ],
-       "circuit_breakers": {
-        "thresholds": [
-         {
-          "max_connections": 100000,
-          "max_pending_requests": 100000,
-          "max_requests": 100000
-         },
-         {
-          "priority": "HIGH",
-          "max_connections": 100000,
-          "max_pending_requests": 100000,
-          "max_requests": 100000
-         }
-        ]
-       },
-       "http2_protocol_options": {},
-       "dns_lookup_family": "V4_ONLY",
-       "upstream_connection_options": {
-        "tcp_keepalive": {
-         "keepalive_time": 300
-        }
-       }
-      },
-      {
-       "name": "zipkin",
-       "type": "STRICT_DNS",
-       "connect_timeout": "1s",
-       "hosts": [
-        {
-         "socket_address": {
-          "address": "zipkin.istio-system",
-          "port_value": 9411
-         }
-        }
-       ],
-       "dns_lookup_family": "V4_ONLY"
-      }
-     ]
-    },
-    "dynamic_resources": {
-     "lds_config": {
-      "ads": {}
-     },
-     "cds_config": {
-      "ads": {}
-     },
-     "ads_config": {
-      "api_type": "GRPC",
-      "grpc_services": [
-       {
-        "envoy_grpc": {
-         "cluster_name": "xds-grpc"
-        }
-       }
-      ]
-     }
-    },
-    "tracing": {
-     "http": {
-      "name": "envoy.zipkin",
-      "config": {
-       "collector_cluster": "zipkin",
-       "trace_id_128bit": "true",
-       "shared_span_context": "false",
-       "collector_endpoint": "/api/v1/spans"
-      }
-     }
-    },
-    "admin": {
-     "access_log_path": "/dev/null",
-     "address": {
-      "socket_address": {
-       "address": "127.0.0.1",
-       "port_value": 15000
-      }
-     }
-    },
-    "stats_config": {
-     "stats_tags": [
-      {
-       "tag_name": "cluster_name",
-       "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
-      },
-      {
-       "tag_name": "tcp_prefix",
-       "regex": "^tcp\\.((.*?)\\.)\\w+?$"
-      },
-      {
-       "tag_name": "response_code",
-       "regex": "_rq(_(\\d{3}))$"
-      },
-      {
-       "tag_name": "response_code_class",
-       "regex": "_rq(_(\\dxx))$"
-      },
-      {
-       "tag_name": "http_conn_manager_listener_prefix",
-       "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
-      {
-       "tag_name": "http_conn_manager_prefix",
-       "regex": "^http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
-      {
-       "tag_name": "listener_address",
-       "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
-      {
-       "tag_name": "mongo_prefix",
-       "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
-      }
-     ],
-     "use_all_default_tags": false,
-     "stats_matcher": {
-      "inclusion_list": {
-       "patterns": [
-        {
-         "prefix": "cluster_manager"
-        },
-        {
-         "prefix": "listener_manager"
-        },
-        {
-         "prefix": "http_mixer_filter"
-        },
-        {
-         "prefix": "tcp_mixer_filter"
-        },
-        {
-         "prefix": "server"
-        },
-        {
-         "prefix": "cluster.xds-grpc"
-        }
-       ]
-      }
-     }
-    }
-   },
-   "last_updated": "2019-04-14T15:36:45.310Z"
-  },
-  {
-   "@type": "type.googleapis.com/envoy.admin.v2alpha.ClustersConfigDump",
-   "version_info": "2019-04-14T15:38:43Z/20",
-   "static_clusters": [
-    {
-     "cluster": {
-      "name": "prometheus_stats",
-      "type": "STATIC",
-      "connect_timeout": "0.250s",
-      "hosts": [
-       {
-        "socket_address": {
-         "address": "127.0.0.1",
-         "port_value": 15000
-        }
-       }
-      ]
-     },
-     "last_updated": "2019-04-14T15:36:45.313Z"
-    },
-    {
-     "cluster": {
-      "name": "xds-grpc",
-      "type": "STRICT_DNS",
-      "connect_timeout": "10s",
-      "hosts": [
-       {
-        "socket_address": {
-         "address": "istio-pilot.istio-system",
-         "port_value": 15010
-        }
-       }
-      ],
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_connections": 100000,
-         "max_pending_requests": 100000,
-         "max_requests": 100000
-        },
-        {
-         "priority": "HIGH",
-         "max_connections": 100000,
-         "max_pending_requests": 100000,
-         "max_requests": 100000
-        }
-       ]
-      },
-      "http2_protocol_options": {},
-      "dns_lookup_family": "V4_ONLY",
-      "upstream_connection_options": {
-       "tcp_keepalive": {
-        "keepalive_time": 300
-       }
-      }
-     },
-     "last_updated": "2019-04-14T15:36:45.314Z"
-    },
-    {
-     "cluster": {
-      "name": "zipkin",
-      "type": "STRICT_DNS",
-      "connect_timeout": "1s",
-      "hosts": [
-       {
-        "socket_address": {
-         "address": "zipkin.istio-system",
-         "port_value": 9411
-        }
-       }
-      ],
-      "dns_lookup_family": "V4_ONLY"
-     },
-     "last_updated": "2019-04-14T15:36:45.314Z"
-    }
-   ],
-   "dynamic_active_clusters": [
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "BlackHoleCluster",
-      "type": "STATIC",
-      "connect_timeout": "10s"
-     },
-     "last_updated": "2019-04-14T15:36:46.239Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "PassthroughCluster",
-      "type": "ORIGINAL_DST",
-      "connect_timeout": "10s",
-      "lb_policy": "ORIGINAL_DST_LB"
-     },
-     "last_updated": "2019-04-14T15:36:46.239Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "inbound|15020|mgmt-15020|mgmtCluster",
-      "type": "STATIC",
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|15020|mgmt-15020|mgmtCluster",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 15020
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.239Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "inbound|3333|mgmt-3333|mgmtCluster",
-      "type": "STATIC",
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|3333|mgmt-3333|mgmtCluster",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 3333
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.238Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
-      "type": "STATIC",
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 70
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.238Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
-      "type": "STATIC",
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 7070
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.237Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
-      "type": "STATIC",
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 80
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.237Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "inbound|8080|mgmt-8080|mgmtCluster",
-      "type": "STATIC",
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|8080|mgmt-8080|mgmtCluster",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 8080
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.238Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
-      "type": "STATIC",
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 8080
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.237Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "inbound|9090|https|a.apps-1-99281.svc.cluster.local",
-      "type": "STATIC",
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|9090|https|a.apps-1-99281.svc.cluster.local",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 90
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.237Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local",
-      "type": "STATIC",
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {}
-       ]
-      },
-      "load_assignment": {
-       "cluster_name": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local",
-       "endpoints": [
-        {
-         "lb_endpoints": [
-          {
-           "endpoint": {
-            "address": {
-             "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 9090
-             }
-            }
-           }
-          }
-         ]
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.237Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|10090||headless.apps-1-99281.svc.cluster.local",
-      "type": "ORIGINAL_DST",
-      "connect_timeout": "10s",
-      "lb_policy": "ORIGINAL_DST_LB",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.237Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15010||istio-pilot.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15010||istio-pilot.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.233Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15011||istio-pilot.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15011||istio-pilot.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.233Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15014||istio-citadel.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15014||istio-citadel.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.233Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15014||istio-galley.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15014||istio-galley.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15014||istio-pilot.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15014||istio-pilot.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.233Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15014||istio-policy.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15014||istio-policy.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|44134||tiller-deploy.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|44134||tiller-deploy.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|443||istio-galley.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||istio-galley.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.234Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|443||kubernetes-dashboard.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||kubernetes-dashboard.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|443||kubernetes.default.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||kubernetes.default.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.230Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|443||metrics-server.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|443||metrics-server.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|5000||kube-registry.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|5000||kube-registry.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|53||kube-dns.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|53||kube-dns.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.230Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|7070||a.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|7070||a.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|7070||b.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|7070||b.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|7070||c.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|7070||c.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|7070||d.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|7070||d.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|7070||headless.apps-1-99281.svc.cluster.local",
-      "type": "ORIGINAL_DST",
-      "connect_timeout": "10s",
-      "lb_policy": "ORIGINAL_DST_LB",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.237Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|7070||t.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|7070||t.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|70||a.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|70||a.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|70||b.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|70||b.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|70||c.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|70||c.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|70||d.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|70||d.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|70||headless.apps-1-99281.svc.cluster.local",
-      "type": "ORIGINAL_DST",
-      "connect_timeout": "10s",
-      "lb_policy": "ORIGINAL_DST_LB",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.237Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|70||t.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|70||t.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|8060||istio-citadel.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|8060||istio-citadel.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|8080||a.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|8080||a.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|8080||b.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|8080||b.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|8080||c.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|8080||c.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|8080||d.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|8080||d.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|8080||headless.apps-1-99281.svc.cluster.local",
-      "type": "ORIGINAL_DST",
-      "connect_timeout": "10s",
-      "lb_policy": "ORIGINAL_DST_LB",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.237Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|8080||istio-pilot.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|8080||istio-pilot.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.233Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|8080||t.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|8080||t.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.234Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|80||a.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||a.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|80||b.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||b.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|80||c.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||c.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|80||d.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||d.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|80||default-http-backend.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||default-http-backend.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.230Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|80||headless.apps-1-99281.svc.cluster.local",
-      "type": "ORIGINAL_DST",
-      "connect_timeout": "10s",
-      "lb_policy": "ORIGINAL_DST_LB",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|80||heapster.kube-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||heapster.kube-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.230Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|80||t.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|80||t.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.234Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|9090||a.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9090||a.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|9090||b.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9090||b.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|9090||c.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9090||c.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|9090||d.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9090||d.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|9090||prometheus.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9090||prometheus.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.234Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|9090||t.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9090||t.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "max_requests_per_connection": 10000,
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_requests": 10000,
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      },
-      "metadata": {
-       "filter_metadata": {
-        "istio": {
-         "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
-        }
-       }
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.232Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|90||a.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|90||a.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|90||b.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|90||b.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|90||c.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|90||c.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|90||d.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|90||d.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.236Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|90||t.apps-1-99281.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|90||t.apps-1-99281.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.235Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "cluster": {
-      "name": "outbound|9901||istio-galley.istio-system.svc.cluster.local",
-      "type": "EDS",
-      "eds_cluster_config": {
-       "eds_config": {
-        "ads": {}
-       },
-       "service_name": "outbound|9901||istio-galley.istio-system.svc.cluster.local"
-      },
-      "connect_timeout": "10s",
-      "circuit_breakers": {
-       "thresholds": [
-        {
-         "max_retries": 1024
-        }
-       ]
-      },
-      "http2_protocol_options": {
-       "max_concurrent_streams": 1073741824
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.231Z"
-    }
-   ]
-  },
-  {
-   "@type": "type.googleapis.com/envoy.admin.v2alpha.ListenersConfigDump",
-   "version_info": "2019-04-14T15:38:43Z/20",
-   "static_listeners": [
-    {
-     "listener": {
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 15090
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "codec_type": "AUTO",
-           "http_filters": {
-            "name": "envoy.router"
-           },
-           "stat_prefix": "stats",
-           "route_config": {
-            "virtual_hosts": [
-             {
-              "domains": [
-               "*"
-              ],
-              "name": "backend",
-              "routes": [
-               {
-                "route": {
-                 "cluster": "prometheus_stats"
-                },
-                "match": {
-                 "prefix": "/stats/prometheus"
-                }
-               }
-              ]
-             }
             ]
-           }
           }
-         }
-        ]
-       }
-      ]
-     },
-     "last_updated": "2019-04-14T15:36:45.323Z"
-    }
-   ],
-   "dynamic_active_listeners": [
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.40.3.59_8080",
-      "address": {
-       "socket_address": {
-        "address": "10.40.3.59",
-        "port_value": 8080
-       }
-      },
-      "filter_chains": [
-       {
-        "filter_chain_match": {
-         "application_protocols": [
-          "istio"
-         ]
         },
-        "tls_context": {
-         "common_tls_context": {
-          "tls_certificates": [
-           {
-            "certificate_chain": {
-             "filename": "/etc/certs/cert-chain.pem"
-            },
-            "private_key": {
-             "filename": "/etc/certs/key.pem"
+        "tracing": {
+          "http": {
+            "name": "envoy.zipkin",
+            "config": {
+              "collector_cluster": "zipkin",
+              "trace_id_128bit": "true",
+              "shared_span_context": "false",
+              "collector_endpoint": "/api/v1/spans"
             }
-           }
+          }
+        },
+        "admin": {
+          "access_log_path": "/dev/null",
+          "address": {
+            "socket_address": {
+              "address": "127.0.0.1",
+              "port_value": 15000
+            }
+          }
+        },
+        "stats_config": {
+          "stats_tags": [
+            {
+              "tag_name": "cluster_name",
+              "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+            },
+            {
+              "tag_name": "tcp_prefix",
+              "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+            },
+            {
+              "tag_name": "response_code",
+              "regex": "_rq(_(\\d{3}))$"
+            },
+            {
+              "tag_name": "response_code_class",
+              "regex": "_rq(_(\\dxx))$"
+            },
+            {
+              "tag_name": "http_conn_manager_listener_prefix",
+              "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+            },
+            {
+              "tag_name": "http_conn_manager_prefix",
+              "regex": "^http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+            },
+            {
+              "tag_name": "listener_address",
+              "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+            },
+            {
+              "tag_name": "mongo_prefix",
+              "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
+            }
           ],
-          "validation_context": {
-           "trusted_ca": {
-            "filename": "/etc/certs/root-cert.pem"
-           }
-          },
-          "alpn_protocols": [
-           "h2",
-           "http/1.1"
-          ]
-         },
-         "require_client_certificate": true
-        },
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "forward_client_cert_details": "APPEND_FORWARD",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "server_name": "istio-envoy",
-           "http_filters": [
-            {
-             "name": "istio_authn",
-             "config": {
-              "policy": {
-               "peers": [
+          "use_all_default_tags": false,
+          "stats_matcher": {
+            "inclusion_list": {
+              "patterns": [
                 {
-                 "mtls": {
-                  "mode": "PERMISSIVE"
-                 }
-                }
-               ]
-              }
-             }
-            },
-            {
-             "name": "envoy.filters.http.rbac",
-             "config": {
-              "rules": {
-               "policies": {}
-              }
-             }
-            },
-            {
-             "config": {
-              "pass_through_mode": true,
-              "headers": [
-               {
-                "exact_match": "/",
-                "name": ":path"
-               }
-              ]
-             },
-             "name": "envoy.health_check"
-            },
-            {
-             "config": {
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "destination.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                  "prefix": "cluster_manager"
                 },
-                "context.reporter.kind": {
-                 "string_value": "inbound"
-                },
-                "destination.port": {
-                 "int64_value": "8080"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "destination.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "destination.ip": {
-                 "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-                }
-               }
-              },
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {}
-              }
-             },
-             "name": "mixer"
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "route_config": {
-            "name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
-            "validate_clusters": false,
-            "virtual_hosts": [
-             {
-              "name": "inbound|http|80",
-              "routes": [
-               {
-                "decorator": {
-                 "operation": "a.apps-1-99281.svc.cluster.local:80/*"
-                },
-                "route": {
-                 "cluster": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
-                 "timeout": "0s",
-                 "max_grpc_timeout": "0s"
-                },
-                "match": {
-                 "prefix": "/"
-                },
-                "per_filter_config": {
-                 "mixer": {
-                  "mixer_attributes": {
-                   "attributes": {
-                    "destination.service.uid": {
-                     "string_value": "istio://apps-1-99281/services/a"
-                    },
-                    "destination.service.host": {
-                     "string_value": "a.apps-1-99281.svc.cluster.local"
-                    },
-                    "destination.service.namespace": {
-                     "string_value": "apps-1-99281"
-                    },
-                    "destination.service.name": {
-                     "string_value": "a"
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              ],
-              "domains": [
-               "*"
-              ]
-             }
-            ]
-           },
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "tracing": {
-            "random_sampling": {
-             "value": 1
-            },
-            "overall_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            }
-           },
-           "stat_prefix": "10.40.3.59_8080",
-           "use_remote_address": false,
-           "set_current_client_cert_details": {
-            "uri": true,
-            "subject": true,
-            "dns": true
-           },
-           "stream_idle_timeout": "0s"
-          }
-         }
-        ]
-       },
-       {
-        "filter_chain_match": {},
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "tracing": {
-            "random_sampling": {
-             "value": 1
-            },
-            "overall_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            }
-           },
-           "stat_prefix": "10.40.3.59_8080",
-           "use_remote_address": false,
-           "set_current_client_cert_details": {
-            "dns": true,
-            "subject": true,
-            "uri": true
-           },
-           "stream_idle_timeout": "0s",
-           "forward_client_cert_details": "APPEND_FORWARD",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "server_name": "istio-envoy",
-           "http_filters": [
-            {
-             "config": {
-              "policy": {
-               "peers": [
                 {
-                 "mtls": {
-                  "mode": "PERMISSIVE"
-                 }
+                  "prefix": "listener_manager"
+                },
+                {
+                  "prefix": "http_mixer_filter"
+                },
+                {
+                  "prefix": "tcp_mixer_filter"
+                },
+                {
+                  "prefix": "server"
+                },
+                {
+                  "prefix": "cluster.xds-grpc"
                 }
-               ]
-              }
-             },
-             "name": "istio_authn"
-            },
-            {
-             "name": "envoy.filters.http.rbac",
-             "config": {
-              "rules": {
-               "policies": {}
-              }
-             }
-            },
-            {
-             "name": "envoy.health_check",
-             "config": {
-              "headers": [
-               {
-                "exact_match": "/",
-                "name": ":path"
-               }
-              ],
-              "pass_through_mode": true
-             }
-            },
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {}
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.kind": {
-                 "string_value": "inbound"
-                },
-                "destination.port": {
-                 "int64_value": "8080"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "destination.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "destination.ip": {
-                 "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-                },
-                "destination.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
+              ]
             }
-           ],
-           "route_config": {
-            "name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
-            "validate_clusters": false,
-            "virtual_hosts": [
-             {
-              "routes": [
-               {
-                "decorator": {
-                 "operation": "a.apps-1-99281.svc.cluster.local:80/*"
-                },
-                "route": {
-                 "max_grpc_timeout": "0s",
-                 "cluster": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
-                 "timeout": "0s"
-                },
-                "match": {
-                 "prefix": "/"
-                },
-                "per_filter_config": {
-                 "mixer": {
-                  "mixer_attributes": {
-                   "attributes": {
-                    "destination.service.host": {
-                     "string_value": "a.apps-1-99281.svc.cluster.local"
-                    },
-                    "destination.service.uid": {
-                     "string_value": "istio://apps-1-99281/services/a"
-                    },
-                    "destination.service.namespace": {
-                     "string_value": "apps-1-99281"
-                    },
-                    "destination.service.name": {
-                     "string_value": "a"
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              ],
-              "domains": [
-               "*"
-              ],
-              "name": "inbound|http|80"
-             }
-            ]
-           }
           }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
+        }
       },
-      "listener_filters": [
-       {
-        "name": "envoy.listener.tls_inspector"
-       }
-      ]
-     },
-     "last_updated": "2019-04-14T15:36:46.335Z"
+      "last_updated": "2019-04-14T15:36:45.310Z"
     },
     {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.40.3.59_80",
-      "address": {
-       "socket_address": {
-        "address": "10.40.3.59",
-        "port_value": 80
-       }
-      },
-      "filter_chains": [
-       {
-        "filter_chain_match": {
-         "application_protocols": [
-          "istio"
-         ]
-        },
-        "tls_context": {
-         "common_tls_context": {
-          "tls_certificates": [
-           {
-            "certificate_chain": {
-             "filename": "/etc/certs/cert-chain.pem"
-            },
-            "private_key": {
-             "filename": "/etc/certs/key.pem"
-            }
-           }
-          ],
-          "validation_context": {
-           "trusted_ca": {
-            "filename": "/etc/certs/root-cert.pem"
-           }
-          },
-          "alpn_protocols": [
-           "h2",
-           "http/1.1"
-          ]
-         },
-         "require_client_certificate": true
-        },
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "client_sampling": {
-             "value": 100
-            }
-           },
-           "stat_prefix": "10.40.3.59_80",
-           "use_remote_address": false,
-           "set_current_client_cert_details": {
-            "dns": true,
-            "uri": true,
-            "subject": true
-           },
-           "stream_idle_timeout": "0s",
-           "forward_client_cert_details": "APPEND_FORWARD",
-           "server_name": "istio-envoy",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "istio_authn",
-             "config": {
-              "policy": {
-               "peers": [
-                {
-                 "mtls": {
-                  "mode": "PERMISSIVE"
-                 }
+      "@type": "type.googleapis.com/envoy.admin.v2alpha.ClustersConfigDump",
+      "version_info": "2019-04-14T15:38:43Z/20",
+      "static_clusters": [
+        {
+          "cluster": {
+            "name": "prometheus_stats",
+            "type": "STATIC",
+            "connect_timeout": "0.250s",
+            "hosts": [
+              {
+                "socket_address": {
+                  "address": "127.0.0.1",
+                  "port_value": 15000
                 }
-               ]
               }
-             }
-            },
-            {
-             "name": "envoy.filters.http.rbac",
-             "config": {
-              "rules": {
-               "policies": {}
-              }
-             }
-            },
-            {
-             "name": "mixer",
-             "config": {
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.kind": {
-                 "string_value": "inbound"
-                },
-                "destination.port": {
-                 "int64_value": "80"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "destination.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "destination.ip": {
-                 "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-                },
-                "destination.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "service_configs": {
-               "default": {}
-              },
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "default_destination_service": "default"
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "route_config": {
-            "name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
-            "validate_clusters": false,
-            "virtual_hosts": [
-             {
-              "name": "inbound|http|8080",
-              "routes": [
-               {
-                "decorator": {
-                 "operation": "a.apps-1-99281.svc.cluster.local:8080/*"
-                },
-                "route": {
-                 "cluster": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
-                 "timeout": "0s",
-                 "max_grpc_timeout": "0s"
-                },
-                "per_filter_config": {
-                 "mixer": {
-                  "mixer_attributes": {
-                   "attributes": {
-                    "destination.service.uid": {
-                     "string_value": "istio://apps-1-99281/services/a"
-                    },
-                    "destination.service.host": {
-                     "string_value": "a.apps-1-99281.svc.cluster.local"
-                    },
-                    "destination.service.namespace": {
-                     "string_value": "apps-1-99281"
-                    },
-                    "destination.service.name": {
-                     "string_value": "a"
-                    }
-                   }
-                  }
-                 }
-                },
-                "match": {
-                 "prefix": "/"
-                }
-               }
-              ],
-              "domains": [
-               "*"
-              ]
-             }
             ]
-           }
-          }
-         }
-        ]
-       },
-       {
-        "filter_chain_match": {},
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "route_config": {
-            "name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
-            "validate_clusters": false,
-            "virtual_hosts": [
-             {
-              "routes": [
-               {
-                "match": {
-                 "prefix": "/"
-                },
-                "per_filter_config": {
-                 "mixer": {
-                  "mixer_attributes": {
-                   "attributes": {
-                    "destination.service.namespace": {
-                     "string_value": "apps-1-99281"
-                    },
-                    "destination.service.name": {
-                     "string_value": "a"
-                    },
-                    "destination.service.uid": {
-                     "string_value": "istio://apps-1-99281/services/a"
-                    },
-                    "destination.service.host": {
-                     "string_value": "a.apps-1-99281.svc.cluster.local"
-                    }
-                   }
-                  }
-                 }
-                },
-                "decorator": {
-                 "operation": "a.apps-1-99281.svc.cluster.local:8080/*"
-                },
-                "route": {
-                 "max_grpc_timeout": "0s",
-                 "cluster": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
-                 "timeout": "0s"
-                }
-               }
-              ],
-              "domains": [
-               "*"
-              ],
-              "name": "inbound|http|8080"
-             }
-            ]
-           },
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "client_sampling": {
-             "value": 100
-            }
-           },
-           "stat_prefix": "10.40.3.59_80",
-           "use_remote_address": false,
-           "set_current_client_cert_details": {
-            "uri": true,
-            "subject": true,
-            "dns": true
-           },
-           "stream_idle_timeout": "0s",
-           "forward_client_cert_details": "APPEND_FORWARD",
-           "server_name": "istio-envoy",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "istio_authn",
-             "config": {
-              "policy": {
-               "peers": [
-                {
-                 "mtls": {
-                  "mode": "PERMISSIVE"
-                 }
-                }
-               ]
-              }
-             }
-            },
-            {
-             "name": "envoy.filters.http.rbac",
-             "config": {
-              "rules": {
-               "policies": {}
-              }
-             }
-            },
-            {
-             "name": "mixer",
-             "config": {
-              "service_configs": {
-               "default": {}
-              },
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "destination.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "inbound"
-                },
-                "destination.port": {
-                 "int64_value": "80"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "destination.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "destination.ip": {
-                 "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      },
-      "listener_filters": [
-       {
-        "name": "envoy.listener.tls_inspector"
-       }
-      ]
-     },
-     "last_updated": "2019-04-14T15:36:46.342Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.40.3.59_9090",
-      "address": {
-       "socket_address": {
-        "address": "10.40.3.59",
-        "port_value": 9090
-       }
-      },
-      "filter_chains": [
-       {
-        "filter_chain_match": {
-         "application_protocols": [
-          "istio"
-         ]
-        },
-        "tls_context": {
-         "common_tls_context": {
-          "tls_certificates": [
-           {
-            "certificate_chain": {
-             "filename": "/etc/certs/cert-chain.pem"
-            },
-            "private_key": {
-             "filename": "/etc/certs/key.pem"
-            }
-           }
-          ],
-          "validation_context": {
-           "trusted_ca": {
-            "filename": "/etc/certs/root-cert.pem"
-           }
           },
-          "alpn_protocols": [
-           "h2",
-           "http/1.1"
-          ]
-         },
-         "require_client_certificate": true
+          "last_updated": "2019-04-14T15:36:45.313Z"
         },
-        "filters": [
-         {
-          "name": "envoy.filters.network.rbac",
-          "config": {
-           "stat_prefix": "tcp.",
-           "rules": {
-            "policies": {}
-           }
-          }
-         },
-         {
-          "name": "mixer",
-          "config": {
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.kind": {
-              "string_value": "inbound"
-             },
-             "destination.port": {
-              "int64_value": "9090"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "destination.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.ip": {
-              "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-             },
-             "destination.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           },
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "cluster": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       },
-       {
-        "filter_chain_match": {},
-        "filters": [
-         {
-          "name": "envoy.filters.network.rbac",
-          "config": {
-           "rules": {
-            "policies": {}
-           },
-           "stat_prefix": "tcp."
-          }
-         },
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.port": {
-              "int64_value": "9090"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "destination.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.ip": {
-              "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-             },
-             "destination.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "context.reporter.kind": {
-              "string_value": "inbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local",
-           "cluster": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      },
-      "listener_filters": [
-       {
-        "name": "envoy.listener.tls_inspector"
-       }
-      ]
-     },
-     "last_updated": "2019-04-14T15:36:46.345Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.40.3.59_90",
-      "address": {
-       "socket_address": {
-        "address": "10.40.3.59",
-        "port_value": 90
-       }
-      },
-      "filter_chains": [
-       {
-        "filter_chain_match": {
-         "application_protocols": [
-          "istio"
-         ]
-        },
-        "tls_context": {
-         "common_tls_context": {
-          "tls_certificates": [
-           {
-            "certificate_chain": {
-             "filename": "/etc/certs/cert-chain.pem"
-            },
-            "private_key": {
-             "filename": "/etc/certs/key.pem"
-            }
-           }
-          ],
-          "validation_context": {
-           "trusted_ca": {
-            "filename": "/etc/certs/root-cert.pem"
-           }
-          },
-          "alpn_protocols": [
-           "h2",
-           "http/1.1"
-          ]
-         },
-         "require_client_certificate": true
-        },
-        "filters": [
-         {
-          "name": "envoy.filters.network.rbac",
-          "config": {
-           "stat_prefix": "tcp.",
-           "rules": {
-            "policies": {}
-           }
-          }
-         },
-         {
-          "name": "mixer",
-          "config": {
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.kind": {
-              "string_value": "inbound"
-             },
-             "destination.port": {
-              "int64_value": "90"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "destination.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.ip": {
-              "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-             },
-             "destination.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           },
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "inbound|9090|https|a.apps-1-99281.svc.cluster.local",
-           "cluster": "inbound|9090|https|a.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       },
-       {
-        "filter_chain_match": {},
-        "filters": [
-         {
-          "name": "envoy.filters.network.rbac",
-          "config": {
-           "stat_prefix": "tcp.",
-           "rules": {
-            "policies": {}
-           }
-          }
-         },
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.port": {
-              "int64_value": "90"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "destination.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.ip": {
-              "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-             },
-             "destination.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "context.reporter.kind": {
-              "string_value": "inbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "inbound|9090|https|a.apps-1-99281.svc.cluster.local",
-           "cluster": "inbound|9090|https|a.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      },
-      "listener_filters": [
-       {
-        "name": "envoy.listener.tls_inspector"
-       }
-      ]
-     },
-     "last_updated": "2019-04-14T15:36:46.348Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.40.3.59_7070",
-      "address": {
-       "socket_address": {
-        "address": "10.40.3.59",
-        "port_value": 7070
-       }
-      },
-      "filter_chains": [
-       {
-        "filter_chain_match": {
-         "application_protocols": [
-          "istio"
-         ]
-        },
-        "tls_context": {
-         "common_tls_context": {
-          "tls_certificates": [
-           {
-            "certificate_chain": {
-             "filename": "/etc/certs/cert-chain.pem"
-            },
-            "private_key": {
-             "filename": "/etc/certs/key.pem"
-            }
-           }
-          ],
-          "validation_context": {
-           "trusted_ca": {
-            "filename": "/etc/certs/root-cert.pem"
-           }
-          },
-          "alpn_protocols": [
-           "h2",
-           "http/1.1"
-          ]
-         },
-         "require_client_certificate": true
-        },
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "client_sampling": {
-             "value": 100
-            }
-           },
-           "stat_prefix": "10.40.3.59_7070",
-           "use_remote_address": false,
-           "set_current_client_cert_details": {
-            "dns": true,
-            "uri": true,
-            "subject": true
-           },
-           "stream_idle_timeout": "0s",
-           "forward_client_cert_details": "APPEND_FORWARD",
-           "access_log": [
-            {
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             },
-             "name": "envoy.file_access_log"
-            }
-           ],
-           "server_name": "istio-envoy",
-           "http_filters": [
-            {
-             "config": {
-              "policy": {
-               "peers": [
-                {
-                 "mtls": {
-                  "mode": "PERMISSIVE"
-                 }
+        {
+          "cluster": {
+            "name": "xds-grpc",
+            "type": "STRICT_DNS",
+            "connect_timeout": "10s",
+            "hosts": [
+              {
+                "socket_address": {
+                  "address": "istio-pilot.istio-system",
+                  "port_value": 15010
                 }
-               ]
               }
-             },
-             "name": "istio_authn"
-            },
-            {
-             "name": "envoy.filters.http.rbac",
-             "config": {
-              "rules": {
-               "policies": {}
-              }
-             }
-            },
-            {
-             "name": "mixer",
-             "config": {
-              "service_configs": {
-               "default": {}
-              },
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "destination.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "destination.ip": {
-                 "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-                },
-                "destination.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "inbound"
-                },
-                "destination.port": {
-                 "int64_value": "7070"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "http2_protocol_options": {},
-           "route_config": {
-            "name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
-            "validate_clusters": false,
-            "virtual_hosts": [
-             {
-              "routes": [
-               {
-                "decorator": {
-                 "operation": "a.apps-1-99281.svc.cluster.local:70/*"
-                },
-                "route": {
-                 "max_grpc_timeout": "0s",
-                 "cluster": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
-                 "timeout": "0s"
-                },
-                "match": {
-                 "prefix": "/"
-                },
-                "per_filter_config": {
-                 "mixer": {
-                  "mixer_attributes": {
-                   "attributes": {
-                    "destination.service.uid": {
-                     "string_value": "istio://apps-1-99281/services/a"
-                    },
-                    "destination.service.host": {
-                     "string_value": "a.apps-1-99281.svc.cluster.local"
-                    },
-                    "destination.service.namespace": {
-                     "string_value": "apps-1-99281"
-                    },
-                    "destination.service.name": {
-                     "string_value": "a"
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              ],
-              "domains": [
-               "*"
-              ],
-              "name": "inbound|http|70"
-             }
-            ]
-           }
-          }
-         }
-        ]
-       },
-       {
-        "filter_chain_match": {},
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "http2_protocol_options": {},
-           "route_config": {
-            "name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
-            "validate_clusters": false,
-            "virtual_hosts": [
-             {
-              "domains": [
-               "*"
-              ],
-              "name": "inbound|http|70",
-              "routes": [
-               {
-                "decorator": {
-                 "operation": "a.apps-1-99281.svc.cluster.local:70/*"
-                },
-                "route": {
-                 "cluster": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
-                 "timeout": "0s",
-                 "max_grpc_timeout": "0s"
-                },
-                "match": {
-                 "prefix": "/"
-                },
-                "per_filter_config": {
-                 "mixer": {
-                  "mixer_attributes": {
-                   "attributes": {
-                    "destination.service.host": {
-                     "string_value": "a.apps-1-99281.svc.cluster.local"
-                    },
-                    "destination.service.uid": {
-                     "string_value": "istio://apps-1-99281/services/a"
-                    },
-                    "destination.service.namespace": {
-                     "string_value": "apps-1-99281"
-                    },
-                    "destination.service.name": {
-                     "string_value": "a"
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              ]
-             }
-            ]
-           },
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "tracing": {
-            "client_sampling": {
-             "value": 100
-            },
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            }
-           },
-           "use_remote_address": false,
-           "stat_prefix": "10.40.3.59_7070",
-           "set_current_client_cert_details": {
-            "dns": true,
-            "uri": true,
-            "subject": true
-           },
-           "stream_idle_timeout": "0s",
-           "forward_client_cert_details": "APPEND_FORWARD",
-           "server_name": "istio-envoy",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "istio_authn",
-             "config": {
-              "policy": {
-               "peers": [
-                {
-                 "mtls": {
-                  "mode": "PERMISSIVE"
-                 }
-                }
-               ]
-              }
-             }
-            },
-            {
-             "name": "envoy.filters.http.rbac",
-             "config": {
-              "rules": {
-               "policies": {}
-              }
-             }
-            },
-            {
-             "name": "mixer",
-             "config": {
-              "service_configs": {
-               "default": {}
-              },
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "destination.port": {
-                 "int64_value": "7070"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "destination.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "destination.ip": {
-                 "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-                },
-                "destination.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "inbound"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      },
-      "listener_filters": [
-       {
-        "name": "envoy.listener.tls_inspector"
-       }
-      ]
-     },
-     "last_updated": "2019-04-14T15:36:46.355Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.40.3.59_70",
-      "address": {
-       "socket_address": {
-        "address": "10.40.3.59",
-        "port_value": 70
-       }
-      },
-      "filter_chains": [
-       {
-        "filter_chain_match": {
-         "application_protocols": [
-          "istio"
-         ]
-        },
-        "tls_context": {
-         "common_tls_context": {
-          "tls_certificates": [
-           {
-            "certificate_chain": {
-             "filename": "/etc/certs/cert-chain.pem"
-            },
-            "private_key": {
-             "filename": "/etc/certs/key.pem"
-            }
-           }
-          ],
-          "validation_context": {
-           "trusted_ca": {
-            "filename": "/etc/certs/root-cert.pem"
-           }
-          },
-          "alpn_protocols": [
-           "h2",
-           "http/1.1"
-          ]
-         },
-         "require_client_certificate": true
-        },
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "client_sampling": {
-             "value": 100
-            }
-           },
-           "use_remote_address": false,
-           "stat_prefix": "10.40.3.59_70",
-           "set_current_client_cert_details": {
-            "subject": true,
-            "uri": true,
-            "dns": true
-           },
-           "stream_idle_timeout": "0s",
-           "forward_client_cert_details": "APPEND_FORWARD",
-           "server_name": "istio-envoy",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "istio_authn",
-             "config": {
-              "policy": {
-               "peers": [
-                {
-                 "mtls": {
-                  "mode": "PERMISSIVE"
-                 }
-                }
-               ]
-              }
-             }
-            },
-            {
-             "name": "envoy.filters.http.rbac",
-             "config": {
-              "rules": {
-               "policies": {}
-              }
-             }
-            },
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {}
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "destination.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "destination.ip": {
-                 "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-                },
-                "destination.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "inbound"
-                },
-                "destination.port": {
-                 "int64_value": "70"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "http2_protocol_options": {},
-           "route_config": {
-            "name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
-            "validate_clusters": false,
-            "virtual_hosts": [
-             {
-              "routes": [
-               {
-                "decorator": {
-                 "operation": "a.apps-1-99281.svc.cluster.local:7070/*"
-                },
-                "route": {
-                 "max_grpc_timeout": "0s",
-                 "cluster": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
-                 "timeout": "0s"
-                },
-                "per_filter_config": {
-                 "mixer": {
-                  "mixer_attributes": {
-                   "attributes": {
-                    "destination.service.host": {
-                     "string_value": "a.apps-1-99281.svc.cluster.local"
-                    },
-                    "destination.service.uid": {
-                     "string_value": "istio://apps-1-99281/services/a"
-                    },
-                    "destination.service.name": {
-                     "string_value": "a"
-                    },
-                    "destination.service.namespace": {
-                     "string_value": "apps-1-99281"
-                    }
-                   }
-                  }
-                 }
-                },
-                "match": {
-                 "prefix": "/"
-                }
-               }
-              ],
-              "domains": [
-               "*"
-              ],
-              "name": "inbound|http|7070"
-             }
-            ]
-           },
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ]
-          }
-         }
-        ]
-       },
-       {
-        "filter_chain_match": {},
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "use_remote_address": false,
-           "stat_prefix": "10.40.3.59_70",
-           "set_current_client_cert_details": {
-            "dns": true,
-            "uri": true,
-            "subject": true
-           },
-           "stream_idle_timeout": "0s",
-           "forward_client_cert_details": "APPEND_FORWARD",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "server_name": "istio-envoy",
-           "http_filters": [
-            {
-             "name": "istio_authn",
-             "config": {
-              "policy": {
-               "peers": [
-                {
-                 "mtls": {
-                  "mode": "PERMISSIVE"
-                 }
-                }
-               ]
-              }
-             }
-            },
-            {
-             "name": "envoy.filters.http.rbac",
-             "config": {
-              "rules": {
-               "policies": {}
-              }
-             }
-            },
-            {
-             "name": "mixer",
-             "config": {
-              "service_configs": {
-               "default": {}
-              },
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "destination.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "destination.ip": {
-                 "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
-                },
-                "destination.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "inbound"
-                },
-                "destination.port": {
-                 "int64_value": "70"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "http2_protocol_options": {},
-           "route_config": {
-            "virtual_hosts": [
-             {
-              "domains": [
-               "*"
-              ],
-              "name": "inbound|http|7070",
-              "routes": [
-               {
-                "decorator": {
-                 "operation": "a.apps-1-99281.svc.cluster.local:7070/*"
-                },
-                "route": {
-                 "max_grpc_timeout": "0s",
-                 "cluster": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
-                 "timeout": "0s"
-                },
-                "match": {
-                 "prefix": "/"
-                },
-                "per_filter_config": {
-                 "mixer": {
-                  "mixer_attributes": {
-                   "attributes": {
-                    "destination.service.host": {
-                     "string_value": "a.apps-1-99281.svc.cluster.local"
-                    },
-                    "destination.service.uid": {
-                     "string_value": "istio://apps-1-99281/services/a"
-                    },
-                    "destination.service.namespace": {
-                     "string_value": "apps-1-99281"
-                    },
-                    "destination.service.name": {
-                     "string_value": "a"
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              ]
-             }
             ],
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_connections": 100000,
+                  "max_pending_requests": 100000,
+                  "max_requests": 100000
+                },
+                {
+                  "priority": "HIGH",
+                  "max_connections": 100000,
+                  "max_pending_requests": 100000,
+                  "max_requests": 100000
+                }
+              ]
+            },
+            "http2_protocol_options": {},
+            "dns_lookup_family": "V4_ONLY",
+            "upstream_connection_options": {
+              "tcp_keepalive": {
+                "keepalive_time": 300
+              }
+            }
+          },
+          "last_updated": "2019-04-14T15:36:45.314Z"
+        },
+        {
+          "cluster": {
+            "name": "zipkin",
+            "type": "STRICT_DNS",
+            "connect_timeout": "1s",
+            "hosts": [
+              {
+                "socket_address": {
+                  "address": "zipkin.istio-system",
+                  "port_value": 9411
+                }
+              }
+            ],
+            "dns_lookup_family": "V4_ONLY"
+          },
+          "last_updated": "2019-04-14T15:36:45.314Z"
+        }
+      ],
+      "dynamic_active_clusters": [
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "BlackHoleCluster",
+            "type": "STATIC",
+            "connect_timeout": "10s"
+          },
+          "last_updated": "2019-04-14T15:36:46.239Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "PassthroughCluster",
+            "type": "ORIGINAL_DST",
+            "connect_timeout": "10s",
+            "lb_policy": "CLUSTER_PROVIDED"
+          },
+          "last_updated": "2019-04-14T15:36:46.239Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "inbound|15020|mgmt-15020|mgmtCluster",
+            "type": "STATIC",
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|15020|mgmt-15020|mgmtCluster",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 15020
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.239Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "inbound|3333|mgmt-3333|mgmtCluster",
+            "type": "STATIC",
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|3333|mgmt-3333|mgmtCluster",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 3333
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.238Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
             "name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
+            "type": "STATIC",
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 70
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.238Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
+            "type": "STATIC",
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 7070
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.237Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
+            "type": "STATIC",
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 80
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.237Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "inbound|8080|mgmt-8080|mgmtCluster",
+            "type": "STATIC",
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|8080|mgmt-8080|mgmtCluster",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 8080
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.238Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
+            "type": "STATIC",
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 8080
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.237Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "inbound|9090|https|a.apps-1-99281.svc.cluster.local",
+            "type": "STATIC",
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|9090|https|a.apps-1-99281.svc.cluster.local",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 90
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.237Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local",
+            "type": "STATIC",
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {}
+              ]
+            },
+            "load_assignment": {
+              "cluster_name": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local",
+              "endpoints": [
+                {
+                  "lb_endpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "socket_address": {
+                            "address": "127.0.0.1",
+                            "port_value": 9090
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.237Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|10090||headless.apps-1-99281.svc.cluster.local",
+            "type": "ORIGINAL_DST",
+            "connect_timeout": "10s",
+            "lb_policy": "CLUSTER_PROVIDED",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.237Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15004||istio-policy.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15010||istio-pilot.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15010||istio-pilot.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.233Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15011||istio-pilot.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15011||istio-pilot.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.233Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15014||istio-citadel.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15014||istio-citadel.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.233Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15014||istio-galley.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15014||istio-galley.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15014||istio-pilot.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15014||istio-pilot.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.233Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15014||istio-policy.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15014||istio-policy.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|44134||tiller-deploy.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|44134||tiller-deploy.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|443||istio-galley.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||istio-galley.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.234Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|443||kubernetes-dashboard.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||kubernetes-dashboard.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|443||kubernetes.default.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||kubernetes.default.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.230Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|443||metrics-server.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|443||metrics-server.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|5000||kube-registry.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|5000||kube-registry.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|53||kube-dns.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|53||kube-dns.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.230Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|7070||a.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|7070||a.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|7070||b.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|7070||b.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|7070||c.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|7070||c.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|7070||d.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|7070||d.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|7070||headless.apps-1-99281.svc.cluster.local",
+            "type": "ORIGINAL_DST",
+            "connect_timeout": "10s",
+            "lb_policy": "CLUSTER_PROVIDED",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.237Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|7070||t.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|7070||t.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|70||a.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|70||a.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|70||b.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|70||b.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|70||c.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|70||c.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|70||d.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|70||d.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|70||headless.apps-1-99281.svc.cluster.local",
+            "type": "ORIGINAL_DST",
+            "connect_timeout": "10s",
+            "lb_policy": "CLUSTER_PROVIDED",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.237Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|70||t.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|70||t.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|8060||istio-citadel.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|8060||istio-citadel.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|8080||a.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|8080||a.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|8080||b.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|8080||b.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|8080||c.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|8080||c.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|8080||d.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|8080||d.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|8080||headless.apps-1-99281.svc.cluster.local",
+            "type": "ORIGINAL_DST",
+            "connect_timeout": "10s",
+            "lb_policy": "CLUSTER_PROVIDED",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.237Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|8080||istio-pilot.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|8080||istio-pilot.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.233Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|8080||t.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|8080||t.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.234Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|80||a.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||a.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|80||b.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||b.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|80||c.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||c.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|80||d.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||d.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|80||default-http-backend.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||default-http-backend.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.230Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|80||headless.apps-1-99281.svc.cluster.local",
+            "type": "ORIGINAL_DST",
+            "connect_timeout": "10s",
+            "lb_policy": "CLUSTER_PROVIDED",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|80||heapster.kube-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||heapster.kube-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.230Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|80||t.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|80||t.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.234Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|9090||a.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9090||a.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|9090||b.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9090||b.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|9090||c.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9090||c.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|9090||d.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9090||d.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|9090||prometheus.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9090||prometheus.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.234Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|9090||t.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9090||t.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-policy"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "max_requests_per_connection": 10000,
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_requests": 10000,
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            },
+            "metadata": {
+              "filter_metadata": {
+                "istio": {
+                  "config": "/apis/networking/v1alpha3/namespaces/istio-system/destination-rule/istio-telemetry"
+                }
+              }
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.232Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|90||a.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|90||a.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|90||b.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|90||b.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|90||c.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|90||c.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|90||d.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|90||d.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.236Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|90||t.apps-1-99281.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|90||t.apps-1-99281.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.235Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "cluster": {
+            "name": "outbound|9901||istio-galley.istio-system.svc.cluster.local",
+            "type": "EDS",
+            "eds_cluster_config": {
+              "eds_config": {
+                "ads": {}
+              },
+              "service_name": "outbound|9901||istio-galley.istio-system.svc.cluster.local"
+            },
+            "connect_timeout": "10s",
+            "circuit_breakers": {
+              "thresholds": [
+                {
+                  "max_retries": 1024
+                }
+              ]
+            },
+            "http2_protocol_options": {
+              "max_concurrent_streams": 1073741824
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.231Z"
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.admin.v2alpha.ListenersConfigDump",
+      "version_info": "2019-04-14T15:38:43Z/20",
+      "static_listeners": [
+        {
+          "listener": {
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 15090
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "codec_type": "AUTO",
+                      "http_filters": {
+                        "name": "envoy.router"
+                      },
+                      "stat_prefix": "stats",
+                      "route_config": {
+                        "virtual_hosts": [
+                          {
+                            "domains": [
+                              "*"
+                            ],
+                            "name": "backend",
+                            "routes": [
+                              {
+                                "route": {
+                                  "cluster": "prometheus_stats"
+                                },
+                                "match": {
+                                  "prefix": "/stats/prometheus"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "last_updated": "2019-04-14T15:36:45.323Z"
+        }
+      ],
+      "dynamic_active_listeners": [
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.40.3.59_8080",
+            "address": {
+              "socket_address": {
+                "address": "10.40.3.59",
+                "port_value": 8080
+              }
+            },
+            "filter_chains": [
+              {
+                "filter_chain_match": {
+                  "application_protocols": [
+                    "istio"
+                  ]
+                },
+                "tls_context": {
+                  "common_tls_context": {
+                    "tls_certificates": [
+                      {
+                        "certificate_chain": {
+                          "filename": "/etc/certs/cert-chain.pem"
+                        },
+                        "private_key": {
+                          "filename": "/etc/certs/key.pem"
+                        }
+                      }
+                    ],
+                    "validation_context": {
+                      "trusted_ca": {
+                        "filename": "/etc/certs/root-cert.pem"
+                      }
+                    },
+                    "alpn_protocols": [
+                      "h2",
+                      "http/1.1"
+                    ]
+                  },
+                  "require_client_certificate": true
+                },
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "forward_client_cert_details": "APPEND_FORWARD",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "server_name": "istio-envoy",
+                      "http_filters": [
+                        {
+                          "name": "istio_authn",
+                          "config": {
+                            "policy": {
+                              "peers": [
+                                {
+                                  "mtls": {
+                                    "mode": "PERMISSIVE"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.filters.http.rbac",
+                          "config": {
+                            "rules": {
+                              "policies": {}
+                            }
+                          }
+                        },
+                        {
+                          "config": {
+                            "pass_through_mode": true,
+                            "headers": [
+                              {
+                                "exact_match": "/",
+                                "name": ":path"
+                              }
+                            ]
+                          },
+                          "name": "envoy.health_check"
+                        },
+                        {
+                          "config": {
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "destination.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "inbound"
+                                },
+                                "destination.port": {
+                                  "int64_value": "8080"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "destination.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "destination.ip": {
+                                  "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                                }
+                              }
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {}
+                            }
+                          },
+                          "name": "mixer"
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "route_config": {
+                        "name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
+                        "validate_clusters": false,
+                        "virtual_hosts": [
+                          {
+                            "name": "inbound|http|80",
+                            "routes": [
+                              {
+                                "decorator": {
+                                  "operation": "a.apps-1-99281.svc.cluster.local:80/*"
+                                },
+                                "route": {
+                                  "cluster": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
+                                  "timeout": "0s",
+                                  "max_grpc_timeout": "0s"
+                                },
+                                "match": {
+                                  "prefix": "/"
+                                },
+                                "per_filter_config": {
+                                  "mixer": {
+                                    "mixer_attributes": {
+                                      "attributes": {
+                                        "destination.service.uid": {
+                                          "string_value": "istio://apps-1-99281/services/a"
+                                        },
+                                        "destination.service.host": {
+                                          "string_value": "a.apps-1-99281.svc.cluster.local"
+                                        },
+                                        "destination.service.namespace": {
+                                          "string_value": "apps-1-99281"
+                                        },
+                                        "destination.service.name": {
+                                          "string_value": "a"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "domains": [
+                              "*"
+                            ]
+                          }
+                        ]
+                      },
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "tracing": {
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "stat_prefix": "10.40.3.59_8080",
+                      "use_remote_address": false,
+                      "set_current_client_cert_details": {
+                        "uri": true,
+                        "subject": true,
+                        "dns": true
+                      },
+                      "stream_idle_timeout": "0s"
+                    }
+                  }
+                ]
+              },
+              {
+                "filter_chain_match": {},
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "tracing": {
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "stat_prefix": "10.40.3.59_8080",
+                      "use_remote_address": false,
+                      "set_current_client_cert_details": {
+                        "dns": true,
+                        "subject": true,
+                        "uri": true
+                      },
+                      "stream_idle_timeout": "0s",
+                      "forward_client_cert_details": "APPEND_FORWARD",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "server_name": "istio-envoy",
+                      "http_filters": [
+                        {
+                          "config": {
+                            "policy": {
+                              "peers": [
+                                {
+                                  "mtls": {
+                                    "mode": "PERMISSIVE"
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "name": "istio_authn"
+                        },
+                        {
+                          "name": "envoy.filters.http.rbac",
+                          "config": {
+                            "rules": {
+                              "policies": {}
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.health_check",
+                          "config": {
+                            "headers": [
+                              {
+                                "exact_match": "/",
+                                "name": ":path"
+                              }
+                            ],
+                            "pass_through_mode": true
+                          }
+                        },
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {}
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.kind": {
+                                  "string_value": "inbound"
+                                },
+                                "destination.port": {
+                                  "int64_value": "8080"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "destination.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "destination.ip": {
+                                  "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                                },
+                                "destination.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "route_config": {
+                        "name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
+                        "validate_clusters": false,
+                        "virtual_hosts": [
+                          {
+                            "routes": [
+                              {
+                                "decorator": {
+                                  "operation": "a.apps-1-99281.svc.cluster.local:80/*"
+                                },
+                                "route": {
+                                  "max_grpc_timeout": "0s",
+                                  "cluster": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
+                                  "timeout": "0s"
+                                },
+                                "match": {
+                                  "prefix": "/"
+                                },
+                                "per_filter_config": {
+                                  "mixer": {
+                                    "mixer_attributes": {
+                                      "attributes": {
+                                        "destination.service.host": {
+                                          "string_value": "a.apps-1-99281.svc.cluster.local"
+                                        },
+                                        "destination.service.uid": {
+                                          "string_value": "istio://apps-1-99281/services/a"
+                                        },
+                                        "destination.service.namespace": {
+                                          "string_value": "apps-1-99281"
+                                        },
+                                        "destination.service.name": {
+                                          "string_value": "a"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "domains": [
+                              "*"
+                            ],
+                            "name": "inbound|http|80"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            },
+            "listener_filters": [
+              {
+                "name": "envoy.listener.tls_inspector"
+              }
+            ]
+          },
+          "last_updated": "2019-04-14T15:36:46.335Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.40.3.59_80",
+            "address": {
+              "socket_address": {
+                "address": "10.40.3.59",
+                "port_value": 80
+              }
+            },
+            "filter_chains": [
+              {
+                "filter_chain_match": {
+                  "application_protocols": [
+                    "istio"
+                  ]
+                },
+                "tls_context": {
+                  "common_tls_context": {
+                    "tls_certificates": [
+                      {
+                        "certificate_chain": {
+                          "filename": "/etc/certs/cert-chain.pem"
+                        },
+                        "private_key": {
+                          "filename": "/etc/certs/key.pem"
+                        }
+                      }
+                    ],
+                    "validation_context": {
+                      "trusted_ca": {
+                        "filename": "/etc/certs/root-cert.pem"
+                      }
+                    },
+                    "alpn_protocols": [
+                      "h2",
+                      "http/1.1"
+                    ]
+                  },
+                  "require_client_certificate": true
+                },
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "stat_prefix": "10.40.3.59_80",
+                      "use_remote_address": false,
+                      "set_current_client_cert_details": {
+                        "dns": true,
+                        "uri": true,
+                        "subject": true
+                      },
+                      "stream_idle_timeout": "0s",
+                      "forward_client_cert_details": "APPEND_FORWARD",
+                      "server_name": "istio-envoy",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "istio_authn",
+                          "config": {
+                            "policy": {
+                              "peers": [
+                                {
+                                  "mtls": {
+                                    "mode": "PERMISSIVE"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.filters.http.rbac",
+                          "config": {
+                            "rules": {
+                              "policies": {}
+                            }
+                          }
+                        },
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.kind": {
+                                  "string_value": "inbound"
+                                },
+                                "destination.port": {
+                                  "int64_value": "80"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "destination.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "destination.ip": {
+                                  "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                                },
+                                "destination.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "service_configs": {
+                              "default": {}
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "default_destination_service": "default"
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "route_config": {
+                        "name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
+                        "validate_clusters": false,
+                        "virtual_hosts": [
+                          {
+                            "name": "inbound|http|8080",
+                            "routes": [
+                              {
+                                "decorator": {
+                                  "operation": "a.apps-1-99281.svc.cluster.local:8080/*"
+                                },
+                                "route": {
+                                  "cluster": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
+                                  "timeout": "0s",
+                                  "max_grpc_timeout": "0s"
+                                },
+                                "per_filter_config": {
+                                  "mixer": {
+                                    "mixer_attributes": {
+                                      "attributes": {
+                                        "destination.service.uid": {
+                                          "string_value": "istio://apps-1-99281/services/a"
+                                        },
+                                        "destination.service.host": {
+                                          "string_value": "a.apps-1-99281.svc.cluster.local"
+                                        },
+                                        "destination.service.namespace": {
+                                          "string_value": "apps-1-99281"
+                                        },
+                                        "destination.service.name": {
+                                          "string_value": "a"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "match": {
+                                  "prefix": "/"
+                                }
+                              }
+                            ],
+                            "domains": [
+                              "*"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "filter_chain_match": {},
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "route_config": {
+                        "name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
+                        "validate_clusters": false,
+                        "virtual_hosts": [
+                          {
+                            "routes": [
+                              {
+                                "match": {
+                                  "prefix": "/"
+                                },
+                                "per_filter_config": {
+                                  "mixer": {
+                                    "mixer_attributes": {
+                                      "attributes": {
+                                        "destination.service.namespace": {
+                                          "string_value": "apps-1-99281"
+                                        },
+                                        "destination.service.name": {
+                                          "string_value": "a"
+                                        },
+                                        "destination.service.uid": {
+                                          "string_value": "istio://apps-1-99281/services/a"
+                                        },
+                                        "destination.service.host": {
+                                          "string_value": "a.apps-1-99281.svc.cluster.local"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "decorator": {
+                                  "operation": "a.apps-1-99281.svc.cluster.local:8080/*"
+                                },
+                                "route": {
+                                  "max_grpc_timeout": "0s",
+                                  "cluster": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
+                                  "timeout": "0s"
+                                }
+                              }
+                            ],
+                            "domains": [
+                              "*"
+                            ],
+                            "name": "inbound|http|8080"
+                          }
+                        ]
+                      },
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "stat_prefix": "10.40.3.59_80",
+                      "use_remote_address": false,
+                      "set_current_client_cert_details": {
+                        "uri": true,
+                        "subject": true,
+                        "dns": true
+                      },
+                      "stream_idle_timeout": "0s",
+                      "forward_client_cert_details": "APPEND_FORWARD",
+                      "server_name": "istio-envoy",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "istio_authn",
+                          "config": {
+                            "policy": {
+                              "peers": [
+                                {
+                                  "mtls": {
+                                    "mode": "PERMISSIVE"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.filters.http.rbac",
+                          "config": {
+                            "rules": {
+                              "policies": {}
+                            }
+                          }
+                        },
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "service_configs": {
+                              "default": {}
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "destination.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "inbound"
+                                },
+                                "destination.port": {
+                                  "int64_value": "80"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "destination.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "destination.ip": {
+                                  "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            },
+            "listener_filters": [
+              {
+                "name": "envoy.listener.tls_inspector"
+              }
+            ]
+          },
+          "last_updated": "2019-04-14T15:36:46.342Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.40.3.59_9090",
+            "address": {
+              "socket_address": {
+                "address": "10.40.3.59",
+                "port_value": 9090
+              }
+            },
+            "filter_chains": [
+              {
+                "filter_chain_match": {
+                  "application_protocols": [
+                    "istio"
+                  ]
+                },
+                "tls_context": {
+                  "common_tls_context": {
+                    "tls_certificates": [
+                      {
+                        "certificate_chain": {
+                          "filename": "/etc/certs/cert-chain.pem"
+                        },
+                        "private_key": {
+                          "filename": "/etc/certs/key.pem"
+                        }
+                      }
+                    ],
+                    "validation_context": {
+                      "trusted_ca": {
+                        "filename": "/etc/certs/root-cert.pem"
+                      }
+                    },
+                    "alpn_protocols": [
+                      "h2",
+                      "http/1.1"
+                    ]
+                  },
+                  "require_client_certificate": true
+                },
+                "filters": [
+                  {
+                    "name": "envoy.filters.network.rbac",
+                    "config": {
+                      "stat_prefix": "tcp.",
+                      "rules": {
+                        "policies": {}
+                      }
+                    }
+                  },
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.kind": {
+                            "string_value": "inbound"
+                          },
+                          "destination.port": {
+                            "int64_value": "9090"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "destination.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.ip": {
+                            "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                          },
+                          "destination.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      },
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "cluster": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              },
+              {
+                "filter_chain_match": {},
+                "filters": [
+                  {
+                    "name": "envoy.filters.network.rbac",
+                    "config": {
+                      "rules": {
+                        "policies": {}
+                      },
+                      "stat_prefix": "tcp."
+                    }
+                  },
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.port": {
+                            "int64_value": "9090"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "destination.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.ip": {
+                            "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                          },
+                          "destination.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "inbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local",
+                      "cluster": "inbound|90|tcp|a.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            },
+            "listener_filters": [
+              {
+                "name": "envoy.listener.tls_inspector"
+              }
+            ]
+          },
+          "last_updated": "2019-04-14T15:36:46.345Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.40.3.59_90",
+            "address": {
+              "socket_address": {
+                "address": "10.40.3.59",
+                "port_value": 90
+              }
+            },
+            "filter_chains": [
+              {
+                "filter_chain_match": {
+                  "application_protocols": [
+                    "istio"
+                  ]
+                },
+                "tls_context": {
+                  "common_tls_context": {
+                    "tls_certificates": [
+                      {
+                        "certificate_chain": {
+                          "filename": "/etc/certs/cert-chain.pem"
+                        },
+                        "private_key": {
+                          "filename": "/etc/certs/key.pem"
+                        }
+                      }
+                    ],
+                    "validation_context": {
+                      "trusted_ca": {
+                        "filename": "/etc/certs/root-cert.pem"
+                      }
+                    },
+                    "alpn_protocols": [
+                      "h2",
+                      "http/1.1"
+                    ]
+                  },
+                  "require_client_certificate": true
+                },
+                "filters": [
+                  {
+                    "name": "envoy.filters.network.rbac",
+                    "config": {
+                      "stat_prefix": "tcp.",
+                      "rules": {
+                        "policies": {}
+                      }
+                    }
+                  },
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.kind": {
+                            "string_value": "inbound"
+                          },
+                          "destination.port": {
+                            "int64_value": "90"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "destination.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.ip": {
+                            "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                          },
+                          "destination.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      },
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "inbound|9090|https|a.apps-1-99281.svc.cluster.local",
+                      "cluster": "inbound|9090|https|a.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              },
+              {
+                "filter_chain_match": {},
+                "filters": [
+                  {
+                    "name": "envoy.filters.network.rbac",
+                    "config": {
+                      "stat_prefix": "tcp.",
+                      "rules": {
+                        "policies": {}
+                      }
+                    }
+                  },
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.port": {
+                            "int64_value": "90"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "destination.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.ip": {
+                            "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                          },
+                          "destination.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "inbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "inbound|9090|https|a.apps-1-99281.svc.cluster.local",
+                      "cluster": "inbound|9090|https|a.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            },
+            "listener_filters": [
+              {
+                "name": "envoy.listener.tls_inspector"
+              }
+            ]
+          },
+          "last_updated": "2019-04-14T15:36:46.348Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.40.3.59_7070",
+            "address": {
+              "socket_address": {
+                "address": "10.40.3.59",
+                "port_value": 7070
+              }
+            },
+            "filter_chains": [
+              {
+                "filter_chain_match": {
+                  "application_protocols": [
+                    "istio"
+                  ]
+                },
+                "tls_context": {
+                  "common_tls_context": {
+                    "tls_certificates": [
+                      {
+                        "certificate_chain": {
+                          "filename": "/etc/certs/cert-chain.pem"
+                        },
+                        "private_key": {
+                          "filename": "/etc/certs/key.pem"
+                        }
+                      }
+                    ],
+                    "validation_context": {
+                      "trusted_ca": {
+                        "filename": "/etc/certs/root-cert.pem"
+                      }
+                    },
+                    "alpn_protocols": [
+                      "h2",
+                      "http/1.1"
+                    ]
+                  },
+                  "require_client_certificate": true
+                },
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "stat_prefix": "10.40.3.59_7070",
+                      "use_remote_address": false,
+                      "set_current_client_cert_details": {
+                        "dns": true,
+                        "uri": true,
+                        "subject": true
+                      },
+                      "stream_idle_timeout": "0s",
+                      "forward_client_cert_details": "APPEND_FORWARD",
+                      "access_log": [
+                        {
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          },
+                          "name": "envoy.file_access_log"
+                        }
+                      ],
+                      "server_name": "istio-envoy",
+                      "http_filters": [
+                        {
+                          "config": {
+                            "policy": {
+                              "peers": [
+                                {
+                                  "mtls": {
+                                    "mode": "PERMISSIVE"
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "name": "istio_authn"
+                        },
+                        {
+                          "name": "envoy.filters.http.rbac",
+                          "config": {
+                            "rules": {
+                              "policies": {}
+                            }
+                          }
+                        },
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "service_configs": {
+                              "default": {}
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "destination.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "destination.ip": {
+                                  "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                                },
+                                "destination.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "inbound"
+                                },
+                                "destination.port": {
+                                  "int64_value": "7070"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "http2_protocol_options": {},
+                      "route_config": {
+                        "name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
+                        "validate_clusters": false,
+                        "virtual_hosts": [
+                          {
+                            "routes": [
+                              {
+                                "decorator": {
+                                  "operation": "a.apps-1-99281.svc.cluster.local:70/*"
+                                },
+                                "route": {
+                                  "max_grpc_timeout": "0s",
+                                  "cluster": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
+                                  "timeout": "0s"
+                                },
+                                "match": {
+                                  "prefix": "/"
+                                },
+                                "per_filter_config": {
+                                  "mixer": {
+                                    "mixer_attributes": {
+                                      "attributes": {
+                                        "destination.service.uid": {
+                                          "string_value": "istio://apps-1-99281/services/a"
+                                        },
+                                        "destination.service.host": {
+                                          "string_value": "a.apps-1-99281.svc.cluster.local"
+                                        },
+                                        "destination.service.namespace": {
+                                          "string_value": "apps-1-99281"
+                                        },
+                                        "destination.service.name": {
+                                          "string_value": "a"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "domains": [
+                              "*"
+                            ],
+                            "name": "inbound|http|70"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "filter_chain_match": {},
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "http2_protocol_options": {},
+                      "route_config": {
+                        "name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
+                        "validate_clusters": false,
+                        "virtual_hosts": [
+                          {
+                            "domains": [
+                              "*"
+                            ],
+                            "name": "inbound|http|70",
+                            "routes": [
+                              {
+                                "decorator": {
+                                  "operation": "a.apps-1-99281.svc.cluster.local:70/*"
+                                },
+                                "route": {
+                                  "cluster": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
+                                  "timeout": "0s",
+                                  "max_grpc_timeout": "0s"
+                                },
+                                "match": {
+                                  "prefix": "/"
+                                },
+                                "per_filter_config": {
+                                  "mixer": {
+                                    "mixer_attributes": {
+                                      "attributes": {
+                                        "destination.service.host": {
+                                          "string_value": "a.apps-1-99281.svc.cluster.local"
+                                        },
+                                        "destination.service.uid": {
+                                          "string_value": "istio://apps-1-99281/services/a"
+                                        },
+                                        "destination.service.namespace": {
+                                          "string_value": "apps-1-99281"
+                                        },
+                                        "destination.service.name": {
+                                          "string_value": "a"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "tracing": {
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        }
+                      },
+                      "use_remote_address": false,
+                      "stat_prefix": "10.40.3.59_7070",
+                      "set_current_client_cert_details": {
+                        "dns": true,
+                        "uri": true,
+                        "subject": true
+                      },
+                      "stream_idle_timeout": "0s",
+                      "forward_client_cert_details": "APPEND_FORWARD",
+                      "server_name": "istio-envoy",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "istio_authn",
+                          "config": {
+                            "policy": {
+                              "peers": [
+                                {
+                                  "mtls": {
+                                    "mode": "PERMISSIVE"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.filters.http.rbac",
+                          "config": {
+                            "rules": {
+                              "policies": {}
+                            }
+                          }
+                        },
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "service_configs": {
+                              "default": {}
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "destination.port": {
+                                  "int64_value": "7070"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "destination.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "destination.ip": {
+                                  "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                                },
+                                "destination.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "inbound"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            },
+            "listener_filters": [
+              {
+                "name": "envoy.listener.tls_inspector"
+              }
+            ]
+          },
+          "last_updated": "2019-04-14T15:36:46.355Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.40.3.59_70",
+            "address": {
+              "socket_address": {
+                "address": "10.40.3.59",
+                "port_value": 70
+              }
+            },
+            "filter_chains": [
+              {
+                "filter_chain_match": {
+                  "application_protocols": [
+                    "istio"
+                  ]
+                },
+                "tls_context": {
+                  "common_tls_context": {
+                    "tls_certificates": [
+                      {
+                        "certificate_chain": {
+                          "filename": "/etc/certs/cert-chain.pem"
+                        },
+                        "private_key": {
+                          "filename": "/etc/certs/key.pem"
+                        }
+                      }
+                    ],
+                    "validation_context": {
+                      "trusted_ca": {
+                        "filename": "/etc/certs/root-cert.pem"
+                      }
+                    },
+                    "alpn_protocols": [
+                      "h2",
+                      "http/1.1"
+                    ]
+                  },
+                  "require_client_certificate": true
+                },
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "use_remote_address": false,
+                      "stat_prefix": "10.40.3.59_70",
+                      "set_current_client_cert_details": {
+                        "subject": true,
+                        "uri": true,
+                        "dns": true
+                      },
+                      "stream_idle_timeout": "0s",
+                      "forward_client_cert_details": "APPEND_FORWARD",
+                      "server_name": "istio-envoy",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "istio_authn",
+                          "config": {
+                            "policy": {
+                              "peers": [
+                                {
+                                  "mtls": {
+                                    "mode": "PERMISSIVE"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.filters.http.rbac",
+                          "config": {
+                            "rules": {
+                              "policies": {}
+                            }
+                          }
+                        },
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {}
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "destination.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "destination.ip": {
+                                  "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                                },
+                                "destination.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "inbound"
+                                },
+                                "destination.port": {
+                                  "int64_value": "70"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "http2_protocol_options": {},
+                      "route_config": {
+                        "name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
+                        "validate_clusters": false,
+                        "virtual_hosts": [
+                          {
+                            "routes": [
+                              {
+                                "decorator": {
+                                  "operation": "a.apps-1-99281.svc.cluster.local:7070/*"
+                                },
+                                "route": {
+                                  "max_grpc_timeout": "0s",
+                                  "cluster": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
+                                  "timeout": "0s"
+                                },
+                                "per_filter_config": {
+                                  "mixer": {
+                                    "mixer_attributes": {
+                                      "attributes": {
+                                        "destination.service.host": {
+                                          "string_value": "a.apps-1-99281.svc.cluster.local"
+                                        },
+                                        "destination.service.uid": {
+                                          "string_value": "istio://apps-1-99281/services/a"
+                                        },
+                                        "destination.service.name": {
+                                          "string_value": "a"
+                                        },
+                                        "destination.service.namespace": {
+                                          "string_value": "apps-1-99281"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "match": {
+                                  "prefix": "/"
+                                }
+                              }
+                            ],
+                            "domains": [
+                              "*"
+                            ],
+                            "name": "inbound|http|7070"
+                          }
+                        ]
+                      },
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "filter_chain_match": {},
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "use_remote_address": false,
+                      "stat_prefix": "10.40.3.59_70",
+                      "set_current_client_cert_details": {
+                        "dns": true,
+                        "uri": true,
+                        "subject": true
+                      },
+                      "stream_idle_timeout": "0s",
+                      "forward_client_cert_details": "APPEND_FORWARD",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "server_name": "istio-envoy",
+                      "http_filters": [
+                        {
+                          "name": "istio_authn",
+                          "config": {
+                            "policy": {
+                              "peers": [
+                                {
+                                  "mtls": {
+                                    "mode": "PERMISSIVE"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.filters.http.rbac",
+                          "config": {
+                            "rules": {
+                              "policies": {}
+                            }
+                          }
+                        },
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "service_configs": {
+                              "default": {}
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "destination.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "destination.ip": {
+                                  "bytes_value": "AAAAAAAAAAAAAP//CigDOw=="
+                                },
+                                "destination.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "inbound"
+                                },
+                                "destination.port": {
+                                  "int64_value": "70"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "http2_protocol_options": {},
+                      "route_config": {
+                        "virtual_hosts": [
+                          {
+                            "domains": [
+                              "*"
+                            ],
+                            "name": "inbound|http|7070",
+                            "routes": [
+                              {
+                                "decorator": {
+                                  "operation": "a.apps-1-99281.svc.cluster.local:7070/*"
+                                },
+                                "route": {
+                                  "max_grpc_timeout": "0s",
+                                  "cluster": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
+                                  "timeout": "0s"
+                                },
+                                "match": {
+                                  "prefix": "/"
+                                },
+                                "per_filter_config": {
+                                  "mixer": {
+                                    "mixer_attributes": {
+                                      "attributes": {
+                                        "destination.service.host": {
+                                          "string_value": "a.apps-1-99281.svc.cluster.local"
+                                        },
+                                        "destination.service.uid": {
+                                          "string_value": "istio://apps-1-99281/services/a"
+                                        },
+                                        "destination.service.namespace": {
+                                          "string_value": "apps-1-99281"
+                                        },
+                                        "destination.service.name": {
+                                          "string_value": "a"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
+                        "validate_clusters": false
+                      },
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "tracing": {
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            },
+            "listener_filters": [
+              {
+                "name": "envoy.listener.tls_inspector"
+              }
+            ]
+          },
+          "last_updated": "2019-04-14T15:36:46.361Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.248.28_15031",
+            "address": {
+              "socket_address": {
+                "address": "10.43.248.28",
+                "port_value": 15031
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      },
+                      "transport": {
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.362Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.247.178_9090",
+            "address": {
+              "socket_address": {
+                "address": "10.43.247.178",
+                "port_value": 9090
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "c.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/c"
+                          },
+                          "destination.service.name": {
+                            "string_value": "c"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|9090||c.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|9090||c.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.363Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.254.82_90",
+            "address": {
+              "socket_address": {
+                "address": "10.43.254.82",
+                "port_value": 90
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/d"
+                          },
+                          "destination.service.host": {
+                            "string_value": "d.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.name": {
+                            "string_value": "d"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|90||d.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|90||d.apps-1-99281.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.364Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.241.25_443",
+            "address": {
+              "socket_address": {
+                "address": "10.43.241.25",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "metrics-server.kube-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://kube-system/services/metrics-server"
+                          },
+                          "destination.service.name": {
+                            "string_value": "metrics-server"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "kube-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          },
+                          "name": "envoy.file_access_log"
+                        }
+                      ],
+                      "stat_prefix": "outbound|443||metrics-server.kube-system.svc.cluster.local",
+                      "cluster": "outbound|443||metrics-server.kube-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.365Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.248.28_443",
+            "address": {
+              "socket_address": {
+                "address": "10.43.248.28",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      },
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "cluster": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.366Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.254.82_9090",
+            "address": {
+              "socket_address": {
+                "address": "10.43.254.82",
+                "port_value": 9090
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/d"
+                          },
+                          "destination.service.host": {
+                            "string_value": "d.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.name": {
+                            "string_value": "d"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|9090||d.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|9090||d.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.367Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.247.178_90",
+            "address": {
+              "socket_address": {
+                "address": "10.43.247.178",
+                "port_value": 90
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        }
+                      },
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "c.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/c"
+                          },
+                          "destination.service.name": {
+                            "string_value": "c"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|90||c.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|90||c.apps-1-99281.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.369Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.240.1_443",
+            "address": {
+              "socket_address": {
+                "address": "10.43.240.1",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        }
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.uid": {
+                            "string_value": "istio://default/services/kubernetes"
+                          },
+                          "destination.service.host": {
+                            "string_value": "kubernetes.default.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "default"
+                          },
+                          "destination.service.name": {
+                            "string_value": "kubernetes"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|443||kubernetes.default.svc.cluster.local",
+                      "cluster": "outbound|443||kubernetes.default.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.370Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.253.48_90",
+            "address": {
+              "socket_address": {
+                "address": "10.43.253.48",
+                "port_value": 90
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        }
+                      },
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.host": {
+                            "string_value": "t.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/t"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.name": {
+                            "string_value": "t"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|90||t.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|90||t.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.371Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.245.70_443",
+            "address": {
+              "socket_address": {
+                "address": "10.43.245.70",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.host": {
+                            "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-egressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-egressgateway"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          }
+                        }
+                      },
+                      "transport": {
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.372Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.248.28_15443",
+            "address": {
+              "socket_address": {
+                "address": "10.43.248.28",
+                "port_value": 15443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "cluster": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.373Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.248.28_15020",
+            "address": {
+              "socket_address": {
+                "address": "10.43.248.28",
+                "port_value": 15020
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.374Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.252.161_5000",
+            "address": {
+              "socket_address": {
+                "address": "10.43.252.161",
+                "port_value": 5000
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.name": {
+                            "string_value": "kube-registry"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "kube-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "kube-registry.kube-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://kube-system/services/kube-registry"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|5000||kube-registry.kube-system.svc.cluster.local",
+                      "cluster": "outbound|5000||kube-registry.kube-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.375Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.245.70_15443",
+            "address": {
+              "socket_address": {
+                "address": "10.43.245.70",
+                "port_value": 15443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-egressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-egressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.376Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.248.28_15032",
+            "address": {
+              "socket_address": {
+                "address": "10.43.248.28",
+                "port_value": 15032
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.376Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.248.244_15011",
+            "address": {
+              "socket_address": {
+                "address": "10.43.248.244",
+                "port_value": 15011
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-pilot"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-pilot"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true,
+                      "transport": {
+                        "network_fail_policy": {
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "cluster": "outbound|15011||istio-pilot.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|15011||istio-pilot.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.379Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.255.211_443",
+            "address": {
+              "socket_address": {
+                "address": "10.43.255.211",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-sidecar-injector.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-sidecar-injector"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-sidecar-injector"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local",
+                      "cluster": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.379Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.241.185_90",
+            "address": {
+              "socket_address": {
+                "address": "10.43.241.185",
+                "port_value": 90
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/b"
+                          },
+                          "destination.service.host": {
+                            "string_value": "b.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.name": {
+                            "string_value": "b"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|90||b.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|90||b.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.380Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.252.166_80",
+            "address": {
+              "socket_address": {
+                "address": "10.43.252.166",
+                "port_value": 80
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://kube-system/services/heapster"
+                          },
+                          "destination.service.host": {
+                            "string_value": "heapster.kube-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "kube-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "heapster"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|80||heapster.kube-system.svc.cluster.local",
+                      "cluster": "outbound|80||heapster.kube-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.381Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.240.10_53",
+            "address": {
+              "socket_address": {
+                "address": "10.43.240.10",
+                "port_value": 53
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "kube-dns.kube-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://kube-system/services/kube-dns"
+                          },
+                          "destination.service.name": {
+                            "string_value": "kube-dns"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "kube-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|53||kube-dns.kube-system.svc.cluster.local",
+                      "cluster": "outbound|53||kube-dns.kube-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.382Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.240.145_443",
+            "address": {
+              "socket_address": {
+                "address": "10.43.240.145",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.name": {
+                            "string_value": "istio-galley"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-galley"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-galley.istio-system.svc.cluster.local"
+                          }
+                        }
+                      },
+                      "transport": {
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|443||istio-galley.istio-system.svc.cluster.local",
+                      "cluster": "outbound|443||istio-galley.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.383Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.248.28_31400",
+            "address": {
+              "socket_address": {
+                "address": "10.43.248.28",
+                "port_value": 31400
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.384Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.255.188_42422",
+            "address": {
+              "socket_address": {
+                "address": "10.43.255.188",
+                "port_value": 42422
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-telemetry"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-telemetry"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local",
+                      "cluster": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.385Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.253.48_9090",
+            "address": {
+              "socket_address": {
+                "address": "10.43.253.48",
+                "port_value": 9090
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "t.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/t"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.name": {
+                            "string_value": "t"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      },
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|9090||t.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|9090||t.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.386Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.242.41_9090",
+            "address": {
+              "socket_address": {
+                "address": "10.43.242.41",
+                "port_value": 9090
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/a"
+                          },
+                          "destination.service.host": {
+                            "string_value": "a.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.name": {
+                            "string_value": "a"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|9090||a.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|9090||a.apps-1-99281.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.388Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.241.185_9090",
+            "address": {
+              "socket_address": {
+                "address": "10.43.241.185",
+                "port_value": 9090
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/b"
+                          },
+                          "destination.service.host": {
+                            "string_value": "b.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.name": {
+                            "string_value": "b"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|9090||b.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|9090||b.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.389Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.247.229_443",
+            "address": {
+              "socket_address": {
+                "address": "10.43.247.229",
+                "port_value": 443
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                      },
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.name": {
+                            "string_value": "kubernetes-dashboard"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "kube-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "kubernetes-dashboard.kube-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://kube-system/services/kubernetes-dashboard"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "cluster": "outbound|443||kubernetes-dashboard.kube-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|443||kubernetes-dashboard.kube-system.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.390Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.252.202_44134",
+            "address": {
+              "socket_address": {
+                "address": "10.43.252.202",
+                "port_value": 44134
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "destination.service.name": {
+                            "string_value": "tiller-deploy"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "kube-system"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "tiller-deploy.kube-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://kube-system/services/tiller-deploy"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|44134||tiller-deploy.kube-system.svc.cluster.local",
+                      "cluster": "outbound|44134||tiller-deploy.kube-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.391Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.248.28_15029",
+            "address": {
+              "socket_address": {
+                "address": "10.43.248.28",
+                "port_value": 15029
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.392Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.248.28_15030",
+            "address": {
+              "socket_address": {
+                "address": "10.43.248.28",
+                "port_value": 15030
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s"
+                        }
+                      },
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://istio-system/services/istio-ingressgateway"
+                          },
+                          "destination.service.host": {
+                            "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "istio-system"
+                          },
+                          "destination.service.name": {
+                            "string_value": "istio-ingressgateway"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      },
+                      "disable_check_calls": true
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "cluster": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          },
+                          "name": "envoy.file_access_log"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.393Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.43.242.41_90",
+            "address": {
+              "socket_address": {
+                "address": "10.43.242.41",
+                "port_value": 90
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "policy": "FAIL_CLOSE",
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.host": {
+                            "string_value": "a.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/a"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.name": {
+                            "string_value": "a"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "outbound|90||a.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|90||a.apps-1-99281.svc.cluster.local"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.395Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_10090",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 10090
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "mixer",
+                    "config": {
+                      "transport": {
+                        "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                        "network_fail_policy": {
+                          "max_retry_wait": "1s",
+                          "base_retry_wait": "0.080s",
+                          "policy": "FAIL_CLOSE"
+                        },
+                        "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                      },
+                      "disable_check_calls": true,
+                      "mixer_attributes": {
+                        "attributes": {
+                          "source.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          },
+                          "source.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "destination.service.uid": {
+                            "string_value": "istio://apps-1-99281/services/headless"
+                          },
+                          "destination.service.host": {
+                            "string_value": "headless.apps-1-99281.svc.cluster.local"
+                          },
+                          "destination.service.name": {
+                            "string_value": "headless"
+                          },
+                          "destination.service.namespace": {
+                            "string_value": "apps-1-99281"
+                          },
+                          "context.reporter.kind": {
+                            "string_value": "outbound"
+                          },
+                          "context.reporter.uid": {
+                            "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "outbound|10090||headless.apps-1-99281.svc.cluster.local",
+                      "cluster": "outbound|10090||headless.apps-1-99281.svc.cluster.local",
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.396Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_9901",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 9901
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "operation_name": "EGRESS",
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "use_remote_address": false,
+                      "rds": {
+                        "route_config_name": "9901",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "stat_prefix": "0.0.0.0_9901",
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.399Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_15004",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 15004
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      },
+                      "stat_prefix": "0.0.0.0_15004",
+                      "rds": {
+                        "route_config_name": "15004",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "use_remote_address": false,
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.409Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_8060",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 8060
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      },
+                      "use_remote_address": false,
+                      "stat_prefix": "0.0.0.0_8060",
+                      "rds": {
+                        "config_source": {
+                          "ads": {}
+                        },
+                        "route_config_name": "8060"
+                      },
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          },
+                          "name": "mixer"
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.411Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_15010",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 15010
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS",
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        }
+                      },
+                      "use_remote_address": false,
+                      "rds": {
+                        "route_config_name": "15010",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "stat_prefix": "0.0.0.0_15010",
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.413Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_70",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 70
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "stat_prefix": "0.0.0.0_70",
+                      "use_remote_address": false,
+                      "rds": {
+                        "route_config_name": "70",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "operation_name": "EGRESS",
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.415Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_7070",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 7070
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "rds": {
+                        "config_source": {
+                          "ads": {}
+                        },
+                        "route_config_name": "7070"
+                      },
+                      "stat_prefix": "0.0.0.0_7070",
+                      "use_remote_address": false,
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "config": {
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
+                            "path": "/dev/stdout"
+                          },
+                          "name": "envoy.file_access_log"
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "operation_name": "EGRESS",
+                        "client_sampling": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.416Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_15014",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 15014
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "stat_prefix": "0.0.0.0_15014",
+                      "use_remote_address": false,
+                      "rds": {
+                        "route_config_name": "15014",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS",
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.418Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_9090",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 9090
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "transport": {
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      },
+                      "rds": {
+                        "route_config_name": "9090",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "stat_prefix": "0.0.0.0_9090",
+                      "use_remote_address": false
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.419Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_8080",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 8080
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "tracing": {
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      },
+                      "use_remote_address": false,
+                      "rds": {
+                        "config_source": {
+                          "ads": {}
+                        },
+                        "route_config_name": "8080"
+                      },
+                      "stat_prefix": "0.0.0.0_8080",
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "mixer_attributes": {
+                              "attributes": {
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "transport": {
+                              "network_fail_policy": {
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default"
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.422Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_80",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 80
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s",
+                                "base_retry_wait": "0.080s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            },
+                            "default_destination_service": "default"
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "operation_name": "EGRESS",
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "random_sampling": {
+                          "value": 1
+                        }
+                      },
+                      "use_remote_address": false,
+                      "rds": {
+                        "route_config_name": "80",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      },
+                      "stat_prefix": "0.0.0.0_80",
+                      "generate_request_id": true,
+                      "stream_idle_timeout": "0s",
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          },
+                          "name": "envoy.file_access_log"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.423Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "0.0.0.0_9091",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 9091
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.http_connection_manager",
+                    "config": {
+                      "stream_idle_timeout": "0s",
+                      "generate_request_id": true,
+                      "upgrade_configs": [
+                        {
+                          "upgrade_type": "websocket"
+                        }
+                      ],
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "http_filters": [
+                        {
+                          "name": "mixer",
+                          "config": {
+                            "default_destination_service": "default",
+                            "mixer_attributes": {
+                              "attributes": {
+                                "context.reporter.kind": {
+                                  "string_value": "outbound"
+                                },
+                                "source.namespace": {
+                                  "string_value": "apps-1-99281"
+                                },
+                                "context.reporter.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                },
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "forward_attributes": {
+                              "attributes": {
+                                "source.uid": {
+                                  "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
+                                }
+                              }
+                            },
+                            "transport": {
+                              "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                              "network_fail_policy": {
+                                "base_retry_wait": "0.080s",
+                                "policy": "FAIL_CLOSE",
+                                "max_retry_wait": "1s"
+                              },
+                              "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "service_configs": {
+                              "default": {
+                                "disable_check_calls": true
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "name": "envoy.cors"
+                        },
+                        {
+                          "name": "envoy.fault"
+                        },
+                        {
+                          "name": "envoy.router"
+                        }
+                      ],
+                      "tracing": {
+                        "random_sampling": {
+                          "value": 1
+                        },
+                        "overall_sampling": {
+                          "value": 100
+                        },
+                        "client_sampling": {
+                          "value": 100
+                        },
+                        "operation_name": "EGRESS"
+                      },
+                      "use_remote_address": false,
+                      "stat_prefix": "0.0.0.0_9091",
+                      "rds": {
+                        "route_config_name": "9091",
+                        "config_source": {
+                          "ads": {}
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.425Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.40.3.59_3333",
+            "address": {
+              "socket_address": {
+                "address": "10.40.3.59",
+                "port_value": 3333
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          },
+                          "name": "envoy.file_access_log"
+                        }
+                      ],
+                      "stat_prefix": "inbound|3333|mgmt-3333|mgmtCluster",
+                      "cluster": "inbound|3333|mgmt-3333|mgmtCluster"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.425Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "10.40.3.59_15020",
+            "address": {
+              "socket_address": {
+                "address": "10.40.3.59",
+                "port_value": 15020
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "access_log": [
+                        {
+                          "name": "envoy.file_access_log",
+                          "config": {
+                            "path": "/dev/stdout",
+                            "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+                          }
+                        }
+                      ],
+                      "stat_prefix": "inbound|15020|mgmt-15020|mgmtCluster",
+                      "cluster": "inbound|15020|mgmt-15020|mgmtCluster"
+                    }
+                  }
+                ]
+              }
+            ],
+            "deprecated_v1": {
+              "bind_to_port": false
+            }
+          },
+          "last_updated": "2019-04-14T15:36:46.426Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "listener": {
+            "name": "virtual",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 15001
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.tcp_proxy",
+                    "config": {
+                      "stat_prefix": "BlackHoleCluster",
+                      "cluster": "BlackHoleCluster"
+                    }
+                  }
+                ]
+              }
+            ],
+            "use_original_dst": true
+          },
+          "last_updated": "2019-04-14T15:36:46.426Z"
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump",
+      "static_route_configs": [
+        {
+          "route_config": {
+            "name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
+            "virtual_hosts": [
+              {
+                "name": "inbound|http|7070",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:7070/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
             "validate_clusters": false
-           },
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "tracing": {
-            "client_sampling": {
-             "value": 100
-            },
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            }
-           }
-          }
-         }
-        ]
-       }
+          },
+          "last_updated": "2019-04-14T15:36:46.360Z"
+        },
+        {
+          "route_config": {
+            "name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
+            "virtual_hosts": [
+              {
+                "name": "inbound|http|7070",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:7070/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:36:46.358Z"
+        },
+        {
+          "route_config": {
+            "name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
+            "virtual_hosts": [
+              {
+                "name": "inbound|http|70",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:70/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:36:46.354Z"
+        },
+        {
+          "route_config": {
+            "name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
+            "virtual_hosts": [
+              {
+                "name": "inbound|http|70",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:70/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:36:46.352Z"
+        },
+        {
+          "route_config": {
+            "name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
+            "virtual_hosts": [
+              {
+                "name": "inbound|http|8080",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:8080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:36:46.341Z"
+        },
+        {
+          "route_config": {
+            "virtual_hosts": [
+              {
+                "name": "backend",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/stats/prometheus"
+                    },
+                    "route": {
+                      "cluster": "prometheus_stats"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "last_updated": "2019-04-14T15:36:45.323Z"
+        },
+        {
+          "route_config": {
+            "name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
+            "virtual_hosts": [
+              {
+                "name": "inbound|http|80",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:36:46.334Z"
+        },
+        {
+          "route_config": {
+            "name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
+            "virtual_hosts": [
+              {
+                "name": "inbound|http|80",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:36:46.331Z"
+        },
+        {
+          "route_config": {
+            "name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
+            "virtual_hosts": [
+              {
+                "name": "inbound|http|8080",
+                "domains": [
+                  "*"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:8080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:36:46.339Z"
+        }
       ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      },
-      "listener_filters": [
-       {
-        "name": "envoy.listener.tls_inspector"
-       }
+      "dynamic_route_configs": [
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "8060",
+            "virtual_hosts": [
+              {
+                "name": "istio-citadel.istio-system.svc.cluster.local:8060",
+                "domains": [
+                  "istio-citadel.istio-system.svc.cluster.local",
+                  "istio-citadel.istio-system.svc.cluster.local:8060",
+                  "istio-citadel.istio-system",
+                  "istio-citadel.istio-system:8060",
+                  "istio-citadel.istio-system.svc.cluster",
+                  "istio-citadel.istio-system.svc.cluster:8060",
+                  "istio-citadel.istio-system.svc",
+                  "istio-citadel.istio-system.svc:8060",
+                  "10.43.251.158",
+                  "10.43.251.158:8060"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8060||istio-citadel.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-citadel.istio-system.svc.cluster.local:8060/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-citadel.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-citadel"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-citadel"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-citadel"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-citadel.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-citadel"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.541Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "70",
+            "virtual_hosts": [
+              {
+                "name": "a.apps-1-99281.svc.cluster.local:70",
+                "domains": [
+                  "a.apps-1-99281.svc.cluster.local",
+                  "a.apps-1-99281.svc.cluster.local:70",
+                  "a",
+                  "a:70",
+                  "a.apps-1-99281.svc.cluster",
+                  "a.apps-1-99281.svc.cluster:70",
+                  "a.apps-1-99281.svc",
+                  "a.apps-1-99281.svc:70",
+                  "a.apps-1-99281",
+                  "a.apps-1-99281:70",
+                  "10.43.242.41",
+                  "10.43.242.41:70"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|70||a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:70/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "b.apps-1-99281.svc.cluster.local:70",
+                "domains": [
+                  "b.apps-1-99281.svc.cluster.local",
+                  "b.apps-1-99281.svc.cluster.local:70",
+                  "b",
+                  "b:70",
+                  "b.apps-1-99281.svc.cluster",
+                  "b.apps-1-99281.svc.cluster:70",
+                  "b.apps-1-99281.svc",
+                  "b.apps-1-99281.svc:70",
+                  "b.apps-1-99281",
+                  "b.apps-1-99281:70",
+                  "10.43.241.185",
+                  "10.43.241.185:70"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|70||b.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "b.apps-1-99281.svc.cluster.local:70/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/b"
+                            },
+                            "destination.service.host": {
+                              "string_value": "b.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "b"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "b.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/b"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "b"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "c.apps-1-99281.svc.cluster.local:70",
+                "domains": [
+                  "c.apps-1-99281.svc.cluster.local",
+                  "c.apps-1-99281.svc.cluster.local:70",
+                  "c",
+                  "c:70",
+                  "c.apps-1-99281.svc.cluster",
+                  "c.apps-1-99281.svc.cluster:70",
+                  "c.apps-1-99281.svc",
+                  "c.apps-1-99281.svc:70",
+                  "c.apps-1-99281",
+                  "c.apps-1-99281:70",
+                  "10.43.247.178",
+                  "10.43.247.178:70"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|70||c.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "c.apps-1-99281.svc.cluster.local:70/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/c"
+                            },
+                            "destination.service.host": {
+                              "string_value": "c.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "c"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/c"
+                            },
+                            "destination.service.host": {
+                              "string_value": "c.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "c"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "d.apps-1-99281.svc.cluster.local:70",
+                "domains": [
+                  "d.apps-1-99281.svc.cluster.local",
+                  "d.apps-1-99281.svc.cluster.local:70",
+                  "d",
+                  "d:70",
+                  "d.apps-1-99281.svc.cluster",
+                  "d.apps-1-99281.svc.cluster:70",
+                  "d.apps-1-99281.svc",
+                  "d.apps-1-99281.svc:70",
+                  "d.apps-1-99281",
+                  "d.apps-1-99281:70",
+                  "10.43.254.82",
+                  "10.43.254.82:70"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|70||d.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "d.apps-1-99281.svc.cluster.local:70/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "d.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/d"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "d"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "d"
+                            },
+                            "destination.service.host": {
+                              "string_value": "d.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/d"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "headless.apps-1-99281.svc.cluster.local:70",
+                "domains": [
+                  "headless.apps-1-99281.svc.cluster.local",
+                  "headless.apps-1-99281.svc.cluster.local:70",
+                  "headless",
+                  "headless:70",
+                  "headless.apps-1-99281.svc.cluster",
+                  "headless.apps-1-99281.svc.cluster:70",
+                  "headless.apps-1-99281.svc",
+                  "headless.apps-1-99281.svc:70",
+                  "headless.apps-1-99281",
+                  "headless.apps-1-99281:70"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|70||headless.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "headless.apps-1-99281.svc.cluster.local:70/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "headless"
+                            },
+                            "destination.service.host": {
+                              "string_value": "headless.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/headless"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "headless.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/headless"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "headless"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "t.apps-1-99281.svc.cluster.local:70",
+                "domains": [
+                  "t.apps-1-99281.svc.cluster.local",
+                  "t.apps-1-99281.svc.cluster.local:70",
+                  "t",
+                  "t:70",
+                  "t.apps-1-99281.svc.cluster",
+                  "t.apps-1-99281.svc.cluster:70",
+                  "t.apps-1-99281.svc",
+                  "t.apps-1-99281.svc:70",
+                  "t.apps-1-99281",
+                  "t.apps-1-99281:70",
+                  "10.43.253.48",
+                  "10.43.253.48:70"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|70||t.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "t.apps-1-99281.svc.cluster.local:70/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "t"
+                            },
+                            "destination.service.host": {
+                              "string_value": "t.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/t"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "t.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/t"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "t"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.540Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "15004",
+            "virtual_hosts": [
+              {
+                "name": "istio-policy.istio-system.svc.cluster.local:15004",
+                "domains": [
+                  "istio-policy.istio-system.svc.cluster.local",
+                  "istio-policy.istio-system.svc.cluster.local:15004",
+                  "istio-policy.istio-system",
+                  "istio-policy.istio-system:15004",
+                  "istio-policy.istio-system.svc.cluster",
+                  "istio-policy.istio-system.svc.cluster:15004",
+                  "istio-policy.istio-system.svc",
+                  "istio-policy.istio-system.svc:15004",
+                  "10.43.251.210",
+                  "10.43.251.210:15004"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-policy.istio-system.svc.cluster.local:15004/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-telemetry.istio-system.svc.cluster.local:15004",
+                "domains": [
+                  "istio-telemetry.istio-system.svc.cluster.local",
+                  "istio-telemetry.istio-system.svc.cluster.local:15004",
+                  "istio-telemetry.istio-system",
+                  "istio-telemetry.istio-system:15004",
+                  "istio-telemetry.istio-system.svc.cluster",
+                  "istio-telemetry.istio-system.svc.cluster:15004",
+                  "istio-telemetry.istio-system.svc",
+                  "istio-telemetry.istio-system.svc:15004",
+                  "10.43.255.188",
+                  "10.43.255.188:15004"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-telemetry.istio-system.svc.cluster.local:15004/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.541Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "15010",
+            "virtual_hosts": [
+              {
+                "name": "istio-pilot.istio-system.svc.cluster.local:15010",
+                "domains": [
+                  "istio-pilot.istio-system.svc.cluster.local",
+                  "istio-pilot.istio-system.svc.cluster.local:15010",
+                  "istio-pilot.istio-system",
+                  "istio-pilot.istio-system:15010",
+                  "istio-pilot.istio-system.svc.cluster",
+                  "istio-pilot.istio-system.svc.cluster:15010",
+                  "istio-pilot.istio-system.svc",
+                  "istio-pilot.istio-system.svc:15010",
+                  "10.43.248.244",
+                  "10.43.248.244:15010"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15010||istio-pilot.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-pilot.istio-system.svc.cluster.local:15010/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.541Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "9901",
+            "virtual_hosts": [
+              {
+                "name": "istio-galley.istio-system.svc.cluster.local:9901",
+                "domains": [
+                  "istio-galley.istio-system.svc.cluster.local",
+                  "istio-galley.istio-system.svc.cluster.local:9901",
+                  "istio-galley.istio-system",
+                  "istio-galley.istio-system:9901",
+                  "istio-galley.istio-system.svc.cluster",
+                  "istio-galley.istio-system.svc.cluster:9901",
+                  "istio-galley.istio-system.svc",
+                  "istio-galley.istio-system.svc:9901",
+                  "10.43.240.145",
+                  "10.43.240.145:9901"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9901||istio-galley.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-galley.istio-system.svc.cluster.local:9901/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-galley"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-galley.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-galley"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-galley"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-galley"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-galley.istio-system.svc.cluster.local"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.541Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "9090",
+            "virtual_hosts": [
+              {
+                "name": "prometheus.istio-system.svc.cluster.local:9090",
+                "domains": [
+                  "prometheus.istio-system.svc.cluster.local",
+                  "prometheus.istio-system.svc.cluster.local:9090",
+                  "prometheus.istio-system",
+                  "prometheus.istio-system:9090",
+                  "prometheus.istio-system.svc.cluster",
+                  "prometheus.istio-system.svc.cluster:9090",
+                  "prometheus.istio-system.svc",
+                  "prometheus.istio-system.svc:9090",
+                  "10.43.240.118",
+                  "10.43.240.118:9090"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9090||prometheus.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "prometheus.istio-system.svc.cluster.local:9090/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/prometheus"
+                            },
+                            "destination.service.host": {
+                              "string_value": "prometheus.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "prometheus"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/prometheus"
+                            },
+                            "destination.service.host": {
+                              "string_value": "prometheus.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "prometheus"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.539Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "7070",
+            "virtual_hosts": [
+              {
+                "name": "a.apps-1-99281.svc.cluster.local:7070",
+                "domains": [
+                  "a.apps-1-99281.svc.cluster.local",
+                  "a.apps-1-99281.svc.cluster.local:7070",
+                  "a",
+                  "a:7070",
+                  "a.apps-1-99281.svc.cluster",
+                  "a.apps-1-99281.svc.cluster:7070",
+                  "a.apps-1-99281.svc",
+                  "a.apps-1-99281.svc:7070",
+                  "a.apps-1-99281",
+                  "a.apps-1-99281:7070",
+                  "10.43.242.41",
+                  "10.43.242.41:7070"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|7070||a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:7070/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "b.apps-1-99281.svc.cluster.local:7070",
+                "domains": [
+                  "b.apps-1-99281.svc.cluster.local",
+                  "b.apps-1-99281.svc.cluster.local:7070",
+                  "b",
+                  "b:7070",
+                  "b.apps-1-99281.svc.cluster",
+                  "b.apps-1-99281.svc.cluster:7070",
+                  "b.apps-1-99281.svc",
+                  "b.apps-1-99281.svc:7070",
+                  "b.apps-1-99281",
+                  "b.apps-1-99281:7070",
+                  "10.43.241.185",
+                  "10.43.241.185:7070"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|7070||b.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "b.apps-1-99281.svc.cluster.local:7070/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "b.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/b"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "b"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "b.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/b"
+                            },
+                            "destination.service.name": {
+                              "string_value": "b"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "c.apps-1-99281.svc.cluster.local:7070",
+                "domains": [
+                  "c.apps-1-99281.svc.cluster.local",
+                  "c.apps-1-99281.svc.cluster.local:7070",
+                  "c",
+                  "c:7070",
+                  "c.apps-1-99281.svc.cluster",
+                  "c.apps-1-99281.svc.cluster:7070",
+                  "c.apps-1-99281.svc",
+                  "c.apps-1-99281.svc:7070",
+                  "c.apps-1-99281",
+                  "c.apps-1-99281:7070",
+                  "10.43.247.178",
+                  "10.43.247.178:7070"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|7070||c.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "c.apps-1-99281.svc.cluster.local:7070/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "c.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/c"
+                            },
+                            "destination.service.name": {
+                              "string_value": "c"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "c.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/c"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "c"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "d.apps-1-99281.svc.cluster.local:7070",
+                "domains": [
+                  "d.apps-1-99281.svc.cluster.local",
+                  "d.apps-1-99281.svc.cluster.local:7070",
+                  "d",
+                  "d:7070",
+                  "d.apps-1-99281.svc.cluster",
+                  "d.apps-1-99281.svc.cluster:7070",
+                  "d.apps-1-99281.svc",
+                  "d.apps-1-99281.svc:7070",
+                  "d.apps-1-99281",
+                  "d.apps-1-99281:7070",
+                  "10.43.254.82",
+                  "10.43.254.82:7070"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|7070||d.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "d.apps-1-99281.svc.cluster.local:7070/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "d.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/d"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "d"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "d.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/d"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "d"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "headless.apps-1-99281.svc.cluster.local:7070",
+                "domains": [
+                  "headless.apps-1-99281.svc.cluster.local",
+                  "headless.apps-1-99281.svc.cluster.local:7070",
+                  "headless",
+                  "headless:7070",
+                  "headless.apps-1-99281.svc.cluster",
+                  "headless.apps-1-99281.svc.cluster:7070",
+                  "headless.apps-1-99281.svc",
+                  "headless.apps-1-99281.svc:7070",
+                  "headless.apps-1-99281",
+                  "headless.apps-1-99281:7070"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|7070||headless.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "headless.apps-1-99281.svc.cluster.local:7070/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "headless.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/headless"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "headless"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "headless"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/headless"
+                            },
+                            "destination.service.host": {
+                              "string_value": "headless.apps-1-99281.svc.cluster.local"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "t.apps-1-99281.svc.cluster.local:7070",
+                "domains": [
+                  "t.apps-1-99281.svc.cluster.local",
+                  "t.apps-1-99281.svc.cluster.local:7070",
+                  "t",
+                  "t:7070",
+                  "t.apps-1-99281.svc.cluster",
+                  "t.apps-1-99281.svc.cluster:7070",
+                  "t.apps-1-99281.svc",
+                  "t.apps-1-99281.svc:7070",
+                  "t.apps-1-99281",
+                  "t.apps-1-99281:7070",
+                  "10.43.253.48",
+                  "10.43.253.48:7070"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|7070||t.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "t.apps-1-99281.svc.cluster.local:7070/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/t"
+                            },
+                            "destination.service.host": {
+                              "string_value": "t.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "t"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "t"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/t"
+                            },
+                            "destination.service.host": {
+                              "string_value": "t.apps-1-99281.svc.cluster.local"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.539Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "8080",
+            "virtual_hosts": [
+              {
+                "name": "a.apps-1-99281.svc.cluster.local:8080",
+                "domains": [
+                  "a.apps-1-99281.svc.cluster.local",
+                  "a.apps-1-99281.svc.cluster.local:8080",
+                  "a",
+                  "a:8080",
+                  "a.apps-1-99281.svc.cluster",
+                  "a.apps-1-99281.svc.cluster:8080",
+                  "a.apps-1-99281.svc",
+                  "a.apps-1-99281.svc:8080",
+                  "a.apps-1-99281",
+                  "a.apps-1-99281:8080",
+                  "10.43.242.41",
+                  "10.43.242.41:8080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8080||a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:8080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "b.apps-1-99281.svc.cluster.local:8080",
+                "domains": [
+                  "b.apps-1-99281.svc.cluster.local",
+                  "b.apps-1-99281.svc.cluster.local:8080",
+                  "b",
+                  "b:8080",
+                  "b.apps-1-99281.svc.cluster",
+                  "b.apps-1-99281.svc.cluster:8080",
+                  "b.apps-1-99281.svc",
+                  "b.apps-1-99281.svc:8080",
+                  "b.apps-1-99281",
+                  "b.apps-1-99281:8080",
+                  "10.43.241.185",
+                  "10.43.241.185:8080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8080||b.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "b.apps-1-99281.svc.cluster.local:8080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "b.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/b"
+                            },
+                            "destination.service.name": {
+                              "string_value": "b"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "b"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/b"
+                            },
+                            "destination.service.host": {
+                              "string_value": "b.apps-1-99281.svc.cluster.local"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "c.apps-1-99281.svc.cluster.local:8080",
+                "domains": [
+                  "c.apps-1-99281.svc.cluster.local",
+                  "c.apps-1-99281.svc.cluster.local:8080",
+                  "c",
+                  "c:8080",
+                  "c.apps-1-99281.svc.cluster",
+                  "c.apps-1-99281.svc.cluster:8080",
+                  "c.apps-1-99281.svc",
+                  "c.apps-1-99281.svc:8080",
+                  "c.apps-1-99281",
+                  "c.apps-1-99281:8080",
+                  "10.43.247.178",
+                  "10.43.247.178:8080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8080||c.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "c.apps-1-99281.svc.cluster.local:8080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/c"
+                            },
+                            "destination.service.host": {
+                              "string_value": "c.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "c"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/c"
+                            },
+                            "destination.service.host": {
+                              "string_value": "c.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "c"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "d.apps-1-99281.svc.cluster.local:8080",
+                "domains": [
+                  "d.apps-1-99281.svc.cluster.local",
+                  "d.apps-1-99281.svc.cluster.local:8080",
+                  "d",
+                  "d:8080",
+                  "d.apps-1-99281.svc.cluster",
+                  "d.apps-1-99281.svc.cluster:8080",
+                  "d.apps-1-99281.svc",
+                  "d.apps-1-99281.svc:8080",
+                  "d.apps-1-99281",
+                  "d.apps-1-99281:8080",
+                  "10.43.254.82",
+                  "10.43.254.82:8080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8080||d.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "d.apps-1-99281.svc.cluster.local:8080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/d"
+                            },
+                            "destination.service.host": {
+                              "string_value": "d.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "d"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/d"
+                            },
+                            "destination.service.host": {
+                              "string_value": "d.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "d"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "headless.apps-1-99281.svc.cluster.local:8080",
+                "domains": [
+                  "headless.apps-1-99281.svc.cluster.local",
+                  "headless.apps-1-99281.svc.cluster.local:8080",
+                  "headless",
+                  "headless:8080",
+                  "headless.apps-1-99281.svc.cluster",
+                  "headless.apps-1-99281.svc.cluster:8080",
+                  "headless.apps-1-99281.svc",
+                  "headless.apps-1-99281.svc:8080",
+                  "headless.apps-1-99281",
+                  "headless.apps-1-99281:8080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8080||headless.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "headless.apps-1-99281.svc.cluster.local:8080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "headless.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/headless"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "headless"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "headless"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/headless"
+                            },
+                            "destination.service.host": {
+                              "string_value": "headless.apps-1-99281.svc.cluster.local"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-pilot.istio-system.svc.cluster.local:8080",
+                "domains": [
+                  "istio-pilot.istio-system.svc.cluster.local",
+                  "istio-pilot.istio-system.svc.cluster.local:8080",
+                  "istio-pilot.istio-system",
+                  "istio-pilot.istio-system:8080",
+                  "istio-pilot.istio-system.svc.cluster",
+                  "istio-pilot.istio-system.svc.cluster:8080",
+                  "istio-pilot.istio-system.svc",
+                  "istio-pilot.istio-system.svc:8080",
+                  "10.43.248.244",
+                  "10.43.248.244:8080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8080||istio-pilot.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-pilot.istio-system.svc.cluster.local:8080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "t.apps-1-99281.svc.cluster.local:8080",
+                "domains": [
+                  "t.apps-1-99281.svc.cluster.local",
+                  "t.apps-1-99281.svc.cluster.local:8080",
+                  "t",
+                  "t:8080",
+                  "t.apps-1-99281.svc.cluster",
+                  "t.apps-1-99281.svc.cluster:8080",
+                  "t.apps-1-99281.svc",
+                  "t.apps-1-99281.svc:8080",
+                  "t.apps-1-99281",
+                  "t.apps-1-99281:8080",
+                  "10.43.253.48",
+                  "10.43.253.48:8080"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|8080||t.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "t.apps-1-99281.svc.cluster.local:8080/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "t"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/t"
+                            },
+                            "destination.service.host": {
+                              "string_value": "t.apps-1-99281.svc.cluster.local"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "t.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/t"
+                            },
+                            "destination.service.name": {
+                              "string_value": "t"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.538Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "15014",
+            "virtual_hosts": [
+              {
+                "name": "istio-citadel.istio-system.svc.cluster.local:15014",
+                "domains": [
+                  "istio-citadel.istio-system.svc.cluster.local",
+                  "istio-citadel.istio-system.svc.cluster.local:15014",
+                  "istio-citadel.istio-system",
+                  "istio-citadel.istio-system:15014",
+                  "istio-citadel.istio-system.svc.cluster",
+                  "istio-citadel.istio-system.svc.cluster:15014",
+                  "istio-citadel.istio-system.svc",
+                  "istio-citadel.istio-system.svc:15014",
+                  "10.43.251.158",
+                  "10.43.251.158:15014"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15014||istio-citadel.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-citadel.istio-system.svc.cluster.local:15014/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-citadel"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-citadel.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-citadel"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-citadel"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-citadel.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-citadel"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-galley.istio-system.svc.cluster.local:15014",
+                "domains": [
+                  "istio-galley.istio-system.svc.cluster.local",
+                  "istio-galley.istio-system.svc.cluster.local:15014",
+                  "istio-galley.istio-system",
+                  "istio-galley.istio-system:15014",
+                  "istio-galley.istio-system.svc.cluster",
+                  "istio-galley.istio-system.svc.cluster:15014",
+                  "istio-galley.istio-system.svc",
+                  "istio-galley.istio-system.svc:15014",
+                  "10.43.240.145",
+                  "10.43.240.145:15014"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15014||istio-galley.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-galley.istio-system.svc.cluster.local:15014/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-galley"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-galley.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-galley"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-galley.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-galley"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-galley"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-pilot.istio-system.svc.cluster.local:15014",
+                "domains": [
+                  "istio-pilot.istio-system.svc.cluster.local",
+                  "istio-pilot.istio-system.svc.cluster.local:15014",
+                  "istio-pilot.istio-system",
+                  "istio-pilot.istio-system:15014",
+                  "istio-pilot.istio-system.svc.cluster",
+                  "istio-pilot.istio-system.svc.cluster:15014",
+                  "istio-pilot.istio-system.svc",
+                  "istio-pilot.istio-system.svc:15014",
+                  "10.43.248.244",
+                  "10.43.248.244:15014"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15014||istio-pilot.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-pilot.istio-system.svc.cluster.local:15014/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-pilot"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-pilot"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-pilot.istio-system.svc.cluster.local"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-policy.istio-system.svc.cluster.local:15014",
+                "domains": [
+                  "istio-policy.istio-system.svc.cluster.local",
+                  "istio-policy.istio-system.svc.cluster.local:15014",
+                  "istio-policy.istio-system",
+                  "istio-policy.istio-system:15014",
+                  "istio-policy.istio-system.svc.cluster",
+                  "istio-policy.istio-system.svc.cluster:15014",
+                  "istio-policy.istio-system.svc",
+                  "istio-policy.istio-system.svc:15014",
+                  "10.43.251.210",
+                  "10.43.251.210:15014"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15014||istio-policy.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-policy.istio-system.svc.cluster.local:15014/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-telemetry.istio-system.svc.cluster.local:15014",
+                "domains": [
+                  "istio-telemetry.istio-system.svc.cluster.local",
+                  "istio-telemetry.istio-system.svc.cluster.local:15014",
+                  "istio-telemetry.istio-system",
+                  "istio-telemetry.istio-system:15014",
+                  "istio-telemetry.istio-system.svc.cluster",
+                  "istio-telemetry.istio-system.svc.cluster:15014",
+                  "istio-telemetry.istio-system.svc",
+                  "istio-telemetry.istio-system.svc:15014",
+                  "10.43.255.188",
+                  "10.43.255.188:15014"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-telemetry.istio-system.svc.cluster.local:15014/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.539Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "9091",
+            "virtual_hosts": [
+              {
+                "name": "istio-policy.istio-system.svc.cluster.local:9091",
+                "domains": [
+                  "istio-policy.istio-system.svc.cluster.local",
+                  "istio-policy.istio-system.svc.cluster.local:9091",
+                  "istio-policy.istio-system",
+                  "istio-policy.istio-system:9091",
+                  "istio-policy.istio-system.svc.cluster",
+                  "istio-policy.istio-system.svc.cluster:9091",
+                  "istio-policy.istio-system.svc",
+                  "istio-policy.istio-system.svc:9091",
+                  "10.43.251.210",
+                  "10.43.251.210:9091"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-policy.istio-system.svc.cluster.local:9091/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-policy.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-policy"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-policy"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-telemetry.istio-system.svc.cluster.local:9091",
+                "domains": [
+                  "istio-telemetry.istio-system.svc.cluster.local",
+                  "istio-telemetry.istio-system.svc.cluster.local:9091",
+                  "istio-telemetry.istio-system",
+                  "istio-telemetry.istio-system:9091",
+                  "istio-telemetry.istio-system.svc.cluster",
+                  "istio-telemetry.istio-system.svc.cluster:9091",
+                  "istio-telemetry.istio-system.svc",
+                  "istio-telemetry.istio-system.svc:9091",
+                  "10.43.255.188",
+                  "10.43.255.188:9091"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-telemetry.istio-system.svc.cluster.local:9091/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-telemetry"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-telemetry"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.536Z"
+        },
+        {
+          "version_info": "2019-04-14T15:36:44Z/18",
+          "route_config": {
+            "name": "80",
+            "virtual_hosts": [
+              {
+                "name": "a.apps-1-99281.svc.cluster.local:80",
+                "domains": [
+                  "a.apps-1-99281.svc.cluster.local",
+                  "a.apps-1-99281.svc.cluster.local:80",
+                  "a",
+                  "a:80",
+                  "a.apps-1-99281.svc.cluster",
+                  "a.apps-1-99281.svc.cluster:80",
+                  "a.apps-1-99281.svc",
+                  "a.apps-1-99281.svc:80",
+                  "a.apps-1-99281",
+                  "a.apps-1-99281:80",
+                  "10.43.242.41",
+                  "10.43.242.41:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||a.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "a.apps-1-99281.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "a"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/a"
+                            },
+                            "destination.service.host": {
+                              "string_value": "a.apps-1-99281.svc.cluster.local"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "b.apps-1-99281.svc.cluster.local:80",
+                "domains": [
+                  "b.apps-1-99281.svc.cluster.local",
+                  "b.apps-1-99281.svc.cluster.local:80",
+                  "b",
+                  "b:80",
+                  "b.apps-1-99281.svc.cluster",
+                  "b.apps-1-99281.svc.cluster:80",
+                  "b.apps-1-99281.svc",
+                  "b.apps-1-99281.svc:80",
+                  "b.apps-1-99281",
+                  "b.apps-1-99281:80",
+                  "10.43.241.185",
+                  "10.43.241.185:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||b.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "b.apps-1-99281.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "b.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/b"
+                            },
+                            "destination.service.name": {
+                              "string_value": "b"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "b.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/b"
+                            },
+                            "destination.service.name": {
+                              "string_value": "b"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "c.apps-1-99281.svc.cluster.local:80",
+                "domains": [
+                  "c.apps-1-99281.svc.cluster.local",
+                  "c.apps-1-99281.svc.cluster.local:80",
+                  "c",
+                  "c:80",
+                  "c.apps-1-99281.svc.cluster",
+                  "c.apps-1-99281.svc.cluster:80",
+                  "c.apps-1-99281.svc",
+                  "c.apps-1-99281.svc:80",
+                  "c.apps-1-99281",
+                  "c.apps-1-99281:80",
+                  "10.43.247.178",
+                  "10.43.247.178:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||c.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "c.apps-1-99281.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "c.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/c"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "c"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "c.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/c"
+                            },
+                            "destination.service.name": {
+                              "string_value": "c"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "d.apps-1-99281.svc.cluster.local:80",
+                "domains": [
+                  "d.apps-1-99281.svc.cluster.local",
+                  "d.apps-1-99281.svc.cluster.local:80",
+                  "d",
+                  "d:80",
+                  "d.apps-1-99281.svc.cluster",
+                  "d.apps-1-99281.svc.cluster:80",
+                  "d.apps-1-99281.svc",
+                  "d.apps-1-99281.svc:80",
+                  "d.apps-1-99281",
+                  "d.apps-1-99281:80",
+                  "10.43.254.82",
+                  "10.43.254.82:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||d.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "d.apps-1-99281.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "d.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/d"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "d"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "d.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/d"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "d"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "default-http-backend.kube-system.svc.cluster.local:80",
+                "domains": [
+                  "default-http-backend.kube-system.svc.cluster.local",
+                  "default-http-backend.kube-system.svc.cluster.local:80",
+                  "default-http-backend.kube-system",
+                  "default-http-backend.kube-system:80",
+                  "default-http-backend.kube-system.svc.cluster",
+                  "default-http-backend.kube-system.svc.cluster:80",
+                  "default-http-backend.kube-system.svc",
+                  "default-http-backend.kube-system.svc:80",
+                  "10.43.255.10",
+                  "10.43.255.10:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||default-http-backend.kube-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "default-http-backend.kube-system.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "disable_check_calls": true,
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "default-http-backend.kube-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://kube-system/services/default-http-backend"
+                            },
+                            "destination.service.name": {
+                              "string_value": "default-http-backend"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "kube-system"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "default-http-backend.kube-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://kube-system/services/default-http-backend"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "kube-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "default-http-backend"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "headless.apps-1-99281.svc.cluster.local:80",
+                "domains": [
+                  "headless.apps-1-99281.svc.cluster.local",
+                  "headless.apps-1-99281.svc.cluster.local:80",
+                  "headless",
+                  "headless:80",
+                  "headless.apps-1-99281.svc.cluster",
+                  "headless.apps-1-99281.svc.cluster:80",
+                  "headless.apps-1-99281.svc",
+                  "headless.apps-1-99281.svc:80",
+                  "headless.apps-1-99281",
+                  "headless.apps-1-99281:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||headless.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "headless.apps-1-99281.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "headless.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/headless"
+                            },
+                            "destination.service.name": {
+                              "string_value": "headless"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/headless"
+                            },
+                            "destination.service.host": {
+                              "string_value": "headless.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "headless"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-egressgateway.istio-system.svc.cluster.local:80",
+                "domains": [
+                  "istio-egressgateway.istio-system.svc.cluster.local",
+                  "istio-egressgateway.istio-system.svc.cluster.local:80",
+                  "istio-egressgateway.istio-system",
+                  "istio-egressgateway.istio-system:80",
+                  "istio-egressgateway.istio-system.svc.cluster",
+                  "istio-egressgateway.istio-system.svc.cluster:80",
+                  "istio-egressgateway.istio-system.svc",
+                  "istio-egressgateway.istio-system.svc:80",
+                  "10.43.245.70",
+                  "10.43.245.70:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-egressgateway.istio-system.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-egressgateway"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-egressgateway"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-egressgateway"
+                            },
+                            "destination.service.host": {
+                              "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-egressgateway"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "istio-ingressgateway.istio-system.svc.cluster.local:80",
+                "domains": [
+                  "istio-ingressgateway.istio-system.svc.cluster.local",
+                  "istio-ingressgateway.istio-system.svc.cluster.local:80",
+                  "istio-ingressgateway.istio-system",
+                  "istio-ingressgateway.istio-system:80",
+                  "istio-ingressgateway.istio-system.svc.cluster",
+                  "istio-ingressgateway.istio-system.svc.cluster:80",
+                  "istio-ingressgateway.istio-system.svc",
+                  "istio-ingressgateway.istio-system.svc:80",
+                  "10.43.248.28",
+                  "10.43.248.28:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "istio-ingressgateway.istio-system.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-ingressgateway"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-ingressgateway"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.host": {
+                              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://istio-system/services/istio-ingressgateway"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "istio-system"
+                            },
+                            "destination.service.name": {
+                              "string_value": "istio-ingressgateway"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "t.apps-1-99281.svc.cluster.local:80",
+                "domains": [
+                  "t.apps-1-99281.svc.cluster.local",
+                  "t.apps-1-99281.svc.cluster.local:80",
+                  "t",
+                  "t:80",
+                  "t.apps-1-99281.svc.cluster",
+                  "t.apps-1-99281.svc.cluster:80",
+                  "t.apps-1-99281.svc",
+                  "t.apps-1-99281.svc:80",
+                  "t.apps-1-99281",
+                  "t.apps-1-99281:80",
+                  "10.43.253.48",
+                  "10.43.253.48:80"
+                ],
+                "routes": [
+                  {
+                    "match": {
+                      "prefix": "/"
+                    },
+                    "route": {
+                      "cluster": "outbound|80||t.apps-1-99281.svc.cluster.local",
+                      "timeout": "0s",
+                      "retry_policy": {
+                        "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
+                        "num_retries": 2,
+                        "retry_host_predicate": [
+                          {
+                            "name": "envoy.retry_host_predicates.previous_hosts"
+                          }
+                        ],
+                        "host_selection_retry_max_attempts": "3",
+                        "retriable_status_codes": [
+                          503
+                        ]
+                      },
+                      "max_grpc_timeout": "0s"
+                    },
+                    "decorator": {
+                      "operation": "t.apps-1-99281.svc.cluster.local:80/*"
+                    },
+                    "per_filter_config": {
+                      "mixer": {
+                        "forward_attributes": {
+                          "attributes": {
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "t"
+                            },
+                            "destination.service.host": {
+                              "string_value": "t.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/t"
+                            }
+                          }
+                        },
+                        "mixer_attributes": {
+                          "attributes": {
+                            "destination.service.uid": {
+                              "string_value": "istio://apps-1-99281/services/t"
+                            },
+                            "destination.service.host": {
+                              "string_value": "t.apps-1-99281.svc.cluster.local"
+                            },
+                            "destination.service.namespace": {
+                              "string_value": "apps-1-99281"
+                            },
+                            "destination.service.name": {
+                              "string_value": "t"
+                            }
+                          }
+                        },
+                        "disable_check_calls": true
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "validate_clusters": false
+          },
+          "last_updated": "2019-04-14T15:38:43.536Z"
+        }
       ]
-     },
-     "last_updated": "2019-04-14T15:36:46.361Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.248.28_15031",
-      "address": {
-       "socket_address": {
-        "address": "10.43.248.28",
-        "port_value": 15031
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           },
-           "transport": {
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.362Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.247.178_9090",
-      "address": {
-       "socket_address": {
-        "address": "10.43.247.178",
-        "port_value": 9090
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "c.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/c"
-             },
-             "destination.service.name": {
-              "string_value": "c"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|9090||c.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|9090||c.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.363Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.254.82_90",
-      "address": {
-       "socket_address": {
-        "address": "10.43.254.82",
-        "port_value": 90
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/d"
-             },
-             "destination.service.host": {
-              "string_value": "d.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.name": {
-              "string_value": "d"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|90||d.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|90||d.apps-1-99281.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.364Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.241.25_443",
-      "address": {
-       "socket_address": {
-        "address": "10.43.241.25",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "metrics-server.kube-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://kube-system/services/metrics-server"
-             },
-             "destination.service.name": {
-              "string_value": "metrics-server"
-             },
-             "destination.service.namespace": {
-              "string_value": "kube-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             },
-             "name": "envoy.file_access_log"
-            }
-           ],
-           "stat_prefix": "outbound|443||metrics-server.kube-system.svc.cluster.local",
-           "cluster": "outbound|443||metrics-server.kube-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.365Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.248.28_443",
-      "address": {
-       "socket_address": {
-        "address": "10.43.248.28",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           },
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "cluster": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.366Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.254.82_9090",
-      "address": {
-       "socket_address": {
-        "address": "10.43.254.82",
-        "port_value": 9090
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/d"
-             },
-             "destination.service.host": {
-              "string_value": "d.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.name": {
-              "string_value": "d"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|9090||d.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|9090||d.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.367Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.247.178_90",
-      "address": {
-       "socket_address": {
-        "address": "10.43.247.178",
-        "port_value": 90
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            }
-           },
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "c.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/c"
-             },
-             "destination.service.name": {
-              "string_value": "c"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           },
-           "disable_check_calls": true
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|90||c.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|90||c.apps-1-99281.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.369Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.240.1_443",
-      "address": {
-       "socket_address": {
-        "address": "10.43.240.1",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            }
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.uid": {
-              "string_value": "istio://default/services/kubernetes"
-             },
-             "destination.service.host": {
-              "string_value": "kubernetes.default.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "default"
-             },
-             "destination.service.name": {
-              "string_value": "kubernetes"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|443||kubernetes.default.svc.cluster.local",
-           "cluster": "outbound|443||kubernetes.default.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.370Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.253.48_90",
-      "address": {
-       "socket_address": {
-        "address": "10.43.253.48",
-        "port_value": 90
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            }
-           },
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.host": {
-              "string_value": "t.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/t"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.name": {
-              "string_value": "t"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             }
-            }
-           },
-           "disable_check_calls": true
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|90||t.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|90||t.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.371Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.245.70_443",
-      "address": {
-       "socket_address": {
-        "address": "10.43.245.70",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.host": {
-              "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-egressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-egressgateway"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             }
-            }
-           },
-           "transport": {
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.372Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.248.28_15443",
-      "address": {
-       "socket_address": {
-        "address": "10.43.248.28",
-        "port_value": 15443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "cluster": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.373Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.248.28_15020",
-      "address": {
-       "socket_address": {
-        "address": "10.43.248.28",
-        "port_value": 15020
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15020||istio-ingressgateway.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.374Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.252.161_5000",
-      "address": {
-       "socket_address": {
-        "address": "10.43.252.161",
-        "port_value": 5000
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.name": {
-              "string_value": "kube-registry"
-             },
-             "destination.service.namespace": {
-              "string_value": "kube-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "kube-registry.kube-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://kube-system/services/kube-registry"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|5000||kube-registry.kube-system.svc.cluster.local",
-           "cluster": "outbound|5000||kube-registry.kube-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.375Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.245.70_15443",
-      "address": {
-       "socket_address": {
-        "address": "10.43.245.70",
-        "port_value": 15443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-egressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.name": {
-              "string_value": "istio-egressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15443||istio-egressgateway.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.376Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.248.28_15032",
-      "address": {
-       "socket_address": {
-        "address": "10.43.248.28",
-        "port_value": 15032
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15032||istio-ingressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.376Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.248.244_15011",
-      "address": {
-       "socket_address": {
-        "address": "10.43.248.244",
-        "port_value": 15011
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-pilot"
-             },
-             "destination.service.host": {
-              "string_value": "istio-pilot.istio-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-pilot"
-             }
-            }
-           },
-           "disable_check_calls": true,
-           "transport": {
-            "network_fail_policy": {
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "cluster": "outbound|15011||istio-pilot.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|15011||istio-pilot.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.379Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.255.211_443",
-      "address": {
-       "socket_address": {
-        "address": "10.43.255.211",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "istio-sidecar-injector.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-sidecar-injector"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-sidecar-injector"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local",
-           "cluster": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.379Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.241.185_90",
-      "address": {
-       "socket_address": {
-        "address": "10.43.241.185",
-        "port_value": 90
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/b"
-             },
-             "destination.service.host": {
-              "string_value": "b.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.name": {
-              "string_value": "b"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|90||b.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|90||b.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.380Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.252.166_80",
-      "address": {
-       "socket_address": {
-        "address": "10.43.252.166",
-        "port_value": 80
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://kube-system/services/heapster"
-             },
-             "destination.service.host": {
-              "string_value": "heapster.kube-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "kube-system"
-             },
-             "destination.service.name": {
-              "string_value": "heapster"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|80||heapster.kube-system.svc.cluster.local",
-           "cluster": "outbound|80||heapster.kube-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.381Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.240.10_53",
-      "address": {
-       "socket_address": {
-        "address": "10.43.240.10",
-        "port_value": 53
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "kube-dns.kube-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://kube-system/services/kube-dns"
-             },
-             "destination.service.name": {
-              "string_value": "kube-dns"
-             },
-             "destination.service.namespace": {
-              "string_value": "kube-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|53||kube-dns.kube-system.svc.cluster.local",
-           "cluster": "outbound|53||kube-dns.kube-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.382Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.240.145_443",
-      "address": {
-       "socket_address": {
-        "address": "10.43.240.145",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.name": {
-              "string_value": "istio-galley"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-galley"
-             },
-             "destination.service.host": {
-              "string_value": "istio-galley.istio-system.svc.cluster.local"
-             }
-            }
-           },
-           "transport": {
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|443||istio-galley.istio-system.svc.cluster.local",
-           "cluster": "outbound|443||istio-galley.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.383Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.248.28_31400",
-      "address": {
-       "socket_address": {
-        "address": "10.43.248.28",
-        "port_value": 31400
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           },
-           "disable_check_calls": true
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|31400||istio-ingressgateway.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.384Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.255.188_42422",
-      "address": {
-       "socket_address": {
-        "address": "10.43.255.188",
-        "port_value": 42422
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-telemetry"
-             },
-             "destination.service.name": {
-              "string_value": "istio-telemetry"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local",
-           "cluster": "outbound|42422||istio-telemetry.istio-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.385Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.253.48_9090",
-      "address": {
-       "socket_address": {
-        "address": "10.43.253.48",
-        "port_value": 9090
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "t.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/t"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.name": {
-              "string_value": "t"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           },
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|9090||t.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|9090||t.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.386Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.242.41_9090",
-      "address": {
-       "socket_address": {
-        "address": "10.43.242.41",
-        "port_value": 9090
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/a"
-             },
-             "destination.service.host": {
-              "string_value": "a.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.name": {
-              "string_value": "a"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             }
-            }
-           },
-           "disable_check_calls": true
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|9090||a.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|9090||a.apps-1-99281.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.388Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.241.185_9090",
-      "address": {
-       "socket_address": {
-        "address": "10.43.241.185",
-        "port_value": 9090
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/b"
-             },
-             "destination.service.host": {
-              "string_value": "b.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.name": {
-              "string_value": "b"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|9090||b.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|9090||b.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.389Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.247.229_443",
-      "address": {
-       "socket_address": {
-        "address": "10.43.247.229",
-        "port_value": 443
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-           },
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.name": {
-              "string_value": "kubernetes-dashboard"
-             },
-             "destination.service.namespace": {
-              "string_value": "kube-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "kubernetes-dashboard.kube-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://kube-system/services/kubernetes-dashboard"
-             }
-            }
-           },
-           "disable_check_calls": true
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "cluster": "outbound|443||kubernetes-dashboard.kube-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|443||kubernetes-dashboard.kube-system.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.390Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.252.202_44134",
-      "address": {
-       "socket_address": {
-        "address": "10.43.252.202",
-        "port_value": 44134
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "destination.service.name": {
-              "string_value": "tiller-deploy"
-             },
-             "destination.service.namespace": {
-              "string_value": "kube-system"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "tiller-deploy.kube-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://kube-system/services/tiller-deploy"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|44134||tiller-deploy.kube-system.svc.cluster.local",
-           "cluster": "outbound|44134||tiller-deploy.kube-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.391Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.248.28_15029",
-      "address": {
-       "socket_address": {
-        "address": "10.43.248.28",
-        "port_value": 15029
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15029||istio-ingressgateway.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.392Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.248.28_15030",
-      "address": {
-       "socket_address": {
-        "address": "10.43.248.28",
-        "port_value": 15030
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s"
-            }
-           },
-           "mixer_attributes": {
-            "attributes": {
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://istio-system/services/istio-ingressgateway"
-             },
-             "destination.service.host": {
-              "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-             },
-             "destination.service.namespace": {
-              "string_value": "istio-system"
-             },
-             "destination.service.name": {
-              "string_value": "istio-ingressgateway"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           },
-           "disable_check_calls": true
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local",
-           "cluster": "outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local",
-           "access_log": [
-            {
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             },
-             "name": "envoy.file_access_log"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.393Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.43.242.41_90",
-      "address": {
-       "socket_address": {
-        "address": "10.43.242.41",
-        "port_value": 90
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "policy": "FAIL_CLOSE",
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.host": {
-              "string_value": "a.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/a"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.name": {
-              "string_value": "a"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "outbound|90||a.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|90||a.apps-1-99281.svc.cluster.local"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.395Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_10090",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 10090
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "mixer",
-          "config": {
-           "transport": {
-            "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-            "network_fail_policy": {
-             "max_retry_wait": "1s",
-             "base_retry_wait": "0.080s",
-             "policy": "FAIL_CLOSE"
-            },
-            "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-           },
-           "disable_check_calls": true,
-           "mixer_attributes": {
-            "attributes": {
-             "source.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             },
-             "source.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "destination.service.uid": {
-              "string_value": "istio://apps-1-99281/services/headless"
-             },
-             "destination.service.host": {
-              "string_value": "headless.apps-1-99281.svc.cluster.local"
-             },
-             "destination.service.name": {
-              "string_value": "headless"
-             },
-             "destination.service.namespace": {
-              "string_value": "apps-1-99281"
-             },
-             "context.reporter.kind": {
-              "string_value": "outbound"
-             },
-             "context.reporter.uid": {
-              "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-             }
-            }
-           }
-          }
-         },
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "outbound|10090||headless.apps-1-99281.svc.cluster.local",
-           "cluster": "outbound|10090||headless.apps-1-99281.svc.cluster.local",
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.396Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_9901",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 9901
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "operation_name": "EGRESS",
-            "client_sampling": {
-             "value": 100
-            }
-           },
-           "use_remote_address": false,
-           "rds": {
-            "route_config_name": "9901",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "stat_prefix": "0.0.0.0_9901",
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.399Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_15004",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 15004
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           },
-           "stat_prefix": "0.0.0.0_15004",
-           "rds": {
-            "route_config_name": "15004",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "use_remote_address": false,
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.409Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_8060",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 8060
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           },
-           "use_remote_address": false,
-           "stat_prefix": "0.0.0.0_8060",
-           "rds": {
-            "config_source": {
-             "ads": {}
-            },
-            "route_config_name": "8060"
-           },
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             },
-             "name": "mixer"
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.411Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_15010",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 15010
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS",
-            "random_sampling": {
-             "value": 1
-            },
-            "overall_sampling": {
-             "value": 100
-            }
-           },
-           "use_remote_address": false,
-           "rds": {
-            "route_config_name": "15010",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "stat_prefix": "0.0.0.0_15010",
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.413Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_70",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 70
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "stat_prefix": "0.0.0.0_70",
-           "use_remote_address": false,
-           "rds": {
-            "route_config_name": "70",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "operation_name": "EGRESS",
-            "client_sampling": {
-             "value": 100
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.415Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_7070",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 7070
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "rds": {
-            "config_source": {
-             "ads": {}
-            },
-            "route_config_name": "7070"
-           },
-           "stat_prefix": "0.0.0.0_7070",
-           "use_remote_address": false,
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "config": {
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n",
-              "path": "/dev/stdout"
-             },
-             "name": "envoy.file_access_log"
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "operation_name": "EGRESS",
-            "client_sampling": {
-             "value": 100
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.416Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_15014",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 15014
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "stat_prefix": "0.0.0.0_15014",
-           "use_remote_address": false,
-           "rds": {
-            "route_config_name": "15014",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS",
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.418Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_9090",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 9090
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "transport": {
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           },
-           "rds": {
-            "route_config_name": "9090",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "stat_prefix": "0.0.0.0_9090",
-           "use_remote_address": false
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.419Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_8080",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 8080
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "tracing": {
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           },
-           "use_remote_address": false,
-           "rds": {
-            "config_source": {
-             "ads": {}
-            },
-            "route_config_name": "8080"
-           },
-           "stat_prefix": "0.0.0.0_8080",
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "mixer_attributes": {
-               "attributes": {
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "transport": {
-               "network_fail_policy": {
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default"
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.422Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_80",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 80
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s",
-                "base_retry_wait": "0.080s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              },
-              "default_destination_service": "default"
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "operation_name": "EGRESS",
-            "client_sampling": {
-             "value": 100
-            },
-            "overall_sampling": {
-             "value": 100
-            },
-            "random_sampling": {
-             "value": 1
-            }
-           },
-           "use_remote_address": false,
-           "rds": {
-            "route_config_name": "80",
-            "config_source": {
-             "ads": {}
-            }
-           },
-           "stat_prefix": "0.0.0.0_80",
-           "generate_request_id": true,
-           "stream_idle_timeout": "0s",
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             },
-             "name": "envoy.file_access_log"
-            }
-           ]
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.423Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "0.0.0.0_9091",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 9091
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.http_connection_manager",
-          "config": {
-           "stream_idle_timeout": "0s",
-           "generate_request_id": true,
-           "upgrade_configs": [
-            {
-             "upgrade_type": "websocket"
-            }
-           ],
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "http_filters": [
-            {
-             "name": "mixer",
-             "config": {
-              "default_destination_service": "default",
-              "mixer_attributes": {
-               "attributes": {
-                "context.reporter.kind": {
-                 "string_value": "outbound"
-                },
-                "source.namespace": {
-                 "string_value": "apps-1-99281"
-                },
-                "context.reporter.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                },
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "forward_attributes": {
-               "attributes": {
-                "source.uid": {
-                 "string_value": "kubernetes://a-6bb6dbdcc5-z58cx.apps-1-99281"
-                }
-               }
-              },
-              "transport": {
-               "check_cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-               "network_fail_policy": {
-                "base_retry_wait": "0.080s",
-                "policy": "FAIL_CLOSE",
-                "max_retry_wait": "1s"
-               },
-               "report_cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "service_configs": {
-               "default": {
-                "disable_check_calls": true
-               }
-              }
-             }
-            },
-            {
-             "name": "envoy.cors"
-            },
-            {
-             "name": "envoy.fault"
-            },
-            {
-             "name": "envoy.router"
-            }
-           ],
-           "tracing": {
-            "random_sampling": {
-             "value": 1
-            },
-            "overall_sampling": {
-             "value": 100
-            },
-            "client_sampling": {
-             "value": 100
-            },
-            "operation_name": "EGRESS"
-           },
-           "use_remote_address": false,
-           "stat_prefix": "0.0.0.0_9091",
-           "rds": {
-            "route_config_name": "9091",
-            "config_source": {
-             "ads": {}
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.425Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.40.3.59_3333",
-      "address": {
-       "socket_address": {
-        "address": "10.40.3.59",
-        "port_value": 3333
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             },
-             "name": "envoy.file_access_log"
-            }
-           ],
-           "stat_prefix": "inbound|3333|mgmt-3333|mgmtCluster",
-           "cluster": "inbound|3333|mgmt-3333|mgmtCluster"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.425Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "10.40.3.59_15020",
-      "address": {
-       "socket_address": {
-        "address": "10.40.3.59",
-        "port_value": 15020
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "access_log": [
-            {
-             "name": "envoy.file_access_log",
-             "config": {
-              "path": "/dev/stdout",
-              "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% \"%DYNAMIC_METADATA(istio.mixer:status)%\" \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
-             }
-            }
-           ],
-           "stat_prefix": "inbound|15020|mgmt-15020|mgmtCluster",
-           "cluster": "inbound|15020|mgmt-15020|mgmtCluster"
-          }
-         }
-        ]
-       }
-      ],
-      "deprecated_v1": {
-       "bind_to_port": false
-      }
-     },
-     "last_updated": "2019-04-14T15:36:46.426Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "listener": {
-      "name": "virtual",
-      "address": {
-       "socket_address": {
-        "address": "0.0.0.0",
-        "port_value": 15001
-       }
-      },
-      "filter_chains": [
-       {
-        "filters": [
-         {
-          "name": "envoy.tcp_proxy",
-          "config": {
-           "stat_prefix": "BlackHoleCluster",
-           "cluster": "BlackHoleCluster"
-          }
-         }
-        ]
-       }
-      ],
-      "use_original_dst": true
-     },
-     "last_updated": "2019-04-14T15:36:46.426Z"
     }
-   ]
-  },
-  {
-   "@type": "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump",
-   "static_route_configs": [
-    {
-     "route_config": {
-      "name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
-      "virtual_hosts": [
-       {
-        "name": "inbound|http|7070",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:7070/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:36:46.360Z"
-    },
-    {
-     "route_config": {
-      "name": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
-      "virtual_hosts": [
-       {
-        "name": "inbound|http|7070",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "inbound|7070|grpc|a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:7070/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:36:46.358Z"
-    },
-    {
-     "route_config": {
-      "name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
-      "virtual_hosts": [
-       {
-        "name": "inbound|http|70",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:70/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:36:46.354Z"
-    },
-    {
-     "route_config": {
-      "name": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
-      "virtual_hosts": [
-       {
-        "name": "inbound|http|70",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "inbound|70|http2-example|a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:70/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:36:46.352Z"
-    },
-    {
-     "route_config": {
-      "name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
-      "virtual_hosts": [
-       {
-        "name": "inbound|http|8080",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:8080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:36:46.341Z"
-    },
-    {
-     "route_config": {
-      "virtual_hosts": [
-       {
-        "name": "backend",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/stats/prometheus"
-          },
-          "route": {
-           "cluster": "prometheus_stats"
-          }
-         }
-        ]
-       }
-      ]
-     },
-     "last_updated": "2019-04-14T15:36:45.323Z"
-    },
-    {
-     "route_config": {
-      "name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
-      "virtual_hosts": [
-       {
-        "name": "inbound|http|80",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:36:46.334Z"
-    },
-    {
-     "route_config": {
-      "name": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
-      "virtual_hosts": [
-       {
-        "name": "inbound|http|80",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "inbound|80|http|a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:36:46.331Z"
-    },
-    {
-     "route_config": {
-      "name": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
-      "virtual_hosts": [
-       {
-        "name": "inbound|http|8080",
-        "domains": [
-         "*"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "inbound|8080|http-two|a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:8080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:36:46.339Z"
-    }
-   ],
-   "dynamic_route_configs": [
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "8060",
-      "virtual_hosts": [
-       {
-        "name": "istio-citadel.istio-system.svc.cluster.local:8060",
-        "domains": [
-         "istio-citadel.istio-system.svc.cluster.local",
-         "istio-citadel.istio-system.svc.cluster.local:8060",
-         "istio-citadel.istio-system",
-         "istio-citadel.istio-system:8060",
-         "istio-citadel.istio-system.svc.cluster",
-         "istio-citadel.istio-system.svc.cluster:8060",
-         "istio-citadel.istio-system.svc",
-         "istio-citadel.istio-system.svc:8060",
-         "10.43.251.158",
-         "10.43.251.158:8060"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8060||istio-citadel.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-citadel.istio-system.svc.cluster.local:8060/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-citadel.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-citadel"
-              },
-              "destination.service.name": {
-               "string_value": "istio-citadel"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-citadel"
-              },
-              "destination.service.host": {
-               "string_value": "istio-citadel.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-citadel"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.541Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "70",
-      "virtual_hosts": [
-       {
-        "name": "a.apps-1-99281.svc.cluster.local:70",
-        "domains": [
-         "a.apps-1-99281.svc.cluster.local",
-         "a.apps-1-99281.svc.cluster.local:70",
-         "a",
-         "a:70",
-         "a.apps-1-99281.svc.cluster",
-         "a.apps-1-99281.svc.cluster:70",
-         "a.apps-1-99281.svc",
-         "a.apps-1-99281.svc:70",
-         "a.apps-1-99281",
-         "a.apps-1-99281:70",
-         "10.43.242.41",
-         "10.43.242.41:70"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|70||a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:70/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "b.apps-1-99281.svc.cluster.local:70",
-        "domains": [
-         "b.apps-1-99281.svc.cluster.local",
-         "b.apps-1-99281.svc.cluster.local:70",
-         "b",
-         "b:70",
-         "b.apps-1-99281.svc.cluster",
-         "b.apps-1-99281.svc.cluster:70",
-         "b.apps-1-99281.svc",
-         "b.apps-1-99281.svc:70",
-         "b.apps-1-99281",
-         "b.apps-1-99281:70",
-         "10.43.241.185",
-         "10.43.241.185:70"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|70||b.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "b.apps-1-99281.svc.cluster.local:70/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/b"
-              },
-              "destination.service.host": {
-               "string_value": "b.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "b"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "b.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/b"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "b"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "c.apps-1-99281.svc.cluster.local:70",
-        "domains": [
-         "c.apps-1-99281.svc.cluster.local",
-         "c.apps-1-99281.svc.cluster.local:70",
-         "c",
-         "c:70",
-         "c.apps-1-99281.svc.cluster",
-         "c.apps-1-99281.svc.cluster:70",
-         "c.apps-1-99281.svc",
-         "c.apps-1-99281.svc:70",
-         "c.apps-1-99281",
-         "c.apps-1-99281:70",
-         "10.43.247.178",
-         "10.43.247.178:70"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|70||c.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "c.apps-1-99281.svc.cluster.local:70/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/c"
-              },
-              "destination.service.host": {
-               "string_value": "c.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "c"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/c"
-              },
-              "destination.service.host": {
-               "string_value": "c.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "c"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "d.apps-1-99281.svc.cluster.local:70",
-        "domains": [
-         "d.apps-1-99281.svc.cluster.local",
-         "d.apps-1-99281.svc.cluster.local:70",
-         "d",
-         "d:70",
-         "d.apps-1-99281.svc.cluster",
-         "d.apps-1-99281.svc.cluster:70",
-         "d.apps-1-99281.svc",
-         "d.apps-1-99281.svc:70",
-         "d.apps-1-99281",
-         "d.apps-1-99281:70",
-         "10.43.254.82",
-         "10.43.254.82:70"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|70||d.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "d.apps-1-99281.svc.cluster.local:70/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "d.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/d"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "d"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "d"
-              },
-              "destination.service.host": {
-               "string_value": "d.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/d"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "headless.apps-1-99281.svc.cluster.local:70",
-        "domains": [
-         "headless.apps-1-99281.svc.cluster.local",
-         "headless.apps-1-99281.svc.cluster.local:70",
-         "headless",
-         "headless:70",
-         "headless.apps-1-99281.svc.cluster",
-         "headless.apps-1-99281.svc.cluster:70",
-         "headless.apps-1-99281.svc",
-         "headless.apps-1-99281.svc:70",
-         "headless.apps-1-99281",
-         "headless.apps-1-99281:70"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|70||headless.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "headless.apps-1-99281.svc.cluster.local:70/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "headless"
-              },
-              "destination.service.host": {
-               "string_value": "headless.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/headless"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "headless.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/headless"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "headless"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "t.apps-1-99281.svc.cluster.local:70",
-        "domains": [
-         "t.apps-1-99281.svc.cluster.local",
-         "t.apps-1-99281.svc.cluster.local:70",
-         "t",
-         "t:70",
-         "t.apps-1-99281.svc.cluster",
-         "t.apps-1-99281.svc.cluster:70",
-         "t.apps-1-99281.svc",
-         "t.apps-1-99281.svc:70",
-         "t.apps-1-99281",
-         "t.apps-1-99281:70",
-         "10.43.253.48",
-         "10.43.253.48:70"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|70||t.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "t.apps-1-99281.svc.cluster.local:70/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "t"
-              },
-              "destination.service.host": {
-               "string_value": "t.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/t"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "t.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/t"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "t"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.540Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "15004",
-      "virtual_hosts": [
-       {
-        "name": "istio-policy.istio-system.svc.cluster.local:15004",
-        "domains": [
-         "istio-policy.istio-system.svc.cluster.local",
-         "istio-policy.istio-system.svc.cluster.local:15004",
-         "istio-policy.istio-system",
-         "istio-policy.istio-system:15004",
-         "istio-policy.istio-system.svc.cluster",
-         "istio-policy.istio-system.svc.cluster:15004",
-         "istio-policy.istio-system.svc",
-         "istio-policy.istio-system.svc:15004",
-         "10.43.251.210",
-         "10.43.251.210:15004"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15004||istio-policy.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-policy.istio-system.svc.cluster.local:15004/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              },
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-telemetry.istio-system.svc.cluster.local:15004",
-        "domains": [
-         "istio-telemetry.istio-system.svc.cluster.local",
-         "istio-telemetry.istio-system.svc.cluster.local:15004",
-         "istio-telemetry.istio-system",
-         "istio-telemetry.istio-system:15004",
-         "istio-telemetry.istio-system.svc.cluster",
-         "istio-telemetry.istio-system.svc.cluster:15004",
-         "istio-telemetry.istio-system.svc",
-         "istio-telemetry.istio-system.svc:15004",
-         "10.43.255.188",
-         "10.43.255.188:15004"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15004||istio-telemetry.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-telemetry.istio-system.svc.cluster.local:15004/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.541Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "15010",
-      "virtual_hosts": [
-       {
-        "name": "istio-pilot.istio-system.svc.cluster.local:15010",
-        "domains": [
-         "istio-pilot.istio-system.svc.cluster.local",
-         "istio-pilot.istio-system.svc.cluster.local:15010",
-         "istio-pilot.istio-system",
-         "istio-pilot.istio-system:15010",
-         "istio-pilot.istio-system.svc.cluster",
-         "istio-pilot.istio-system.svc.cluster:15010",
-         "istio-pilot.istio-system.svc",
-         "istio-pilot.istio-system.svc:15010",
-         "10.43.248.244",
-         "10.43.248.244:15010"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15010||istio-pilot.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-pilot.istio-system.svc.cluster.local:15010/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.541Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "9901",
-      "virtual_hosts": [
-       {
-        "name": "istio-galley.istio-system.svc.cluster.local:9901",
-        "domains": [
-         "istio-galley.istio-system.svc.cluster.local",
-         "istio-galley.istio-system.svc.cluster.local:9901",
-         "istio-galley.istio-system",
-         "istio-galley.istio-system:9901",
-         "istio-galley.istio-system.svc.cluster",
-         "istio-galley.istio-system.svc.cluster:9901",
-         "istio-galley.istio-system.svc",
-         "istio-galley.istio-system.svc:9901",
-         "10.43.240.145",
-         "10.43.240.145:9901"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9901||istio-galley.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-galley.istio-system.svc.cluster.local:9901/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-galley"
-              },
-              "destination.service.host": {
-               "string_value": "istio-galley.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-galley"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-galley"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-galley"
-              },
-              "destination.service.host": {
-               "string_value": "istio-galley.istio-system.svc.cluster.local"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.541Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "9090",
-      "virtual_hosts": [
-       {
-        "name": "prometheus.istio-system.svc.cluster.local:9090",
-        "domains": [
-         "prometheus.istio-system.svc.cluster.local",
-         "prometheus.istio-system.svc.cluster.local:9090",
-         "prometheus.istio-system",
-         "prometheus.istio-system:9090",
-         "prometheus.istio-system.svc.cluster",
-         "prometheus.istio-system.svc.cluster:9090",
-         "prometheus.istio-system.svc",
-         "prometheus.istio-system.svc:9090",
-         "10.43.240.118",
-         "10.43.240.118:9090"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9090||prometheus.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "prometheus.istio-system.svc.cluster.local:9090/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/prometheus"
-              },
-              "destination.service.host": {
-               "string_value": "prometheus.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "prometheus"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/prometheus"
-              },
-              "destination.service.host": {
-               "string_value": "prometheus.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "prometheus"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.539Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "7070",
-      "virtual_hosts": [
-       {
-        "name": "a.apps-1-99281.svc.cluster.local:7070",
-        "domains": [
-         "a.apps-1-99281.svc.cluster.local",
-         "a.apps-1-99281.svc.cluster.local:7070",
-         "a",
-         "a:7070",
-         "a.apps-1-99281.svc.cluster",
-         "a.apps-1-99281.svc.cluster:7070",
-         "a.apps-1-99281.svc",
-         "a.apps-1-99281.svc:7070",
-         "a.apps-1-99281",
-         "a.apps-1-99281:7070",
-         "10.43.242.41",
-         "10.43.242.41:7070"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|7070||a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:7070/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "b.apps-1-99281.svc.cluster.local:7070",
-        "domains": [
-         "b.apps-1-99281.svc.cluster.local",
-         "b.apps-1-99281.svc.cluster.local:7070",
-         "b",
-         "b:7070",
-         "b.apps-1-99281.svc.cluster",
-         "b.apps-1-99281.svc.cluster:7070",
-         "b.apps-1-99281.svc",
-         "b.apps-1-99281.svc:7070",
-         "b.apps-1-99281",
-         "b.apps-1-99281:7070",
-         "10.43.241.185",
-         "10.43.241.185:7070"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|7070||b.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "b.apps-1-99281.svc.cluster.local:7070/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "b.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/b"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "b"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "b.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/b"
-              },
-              "destination.service.name": {
-               "string_value": "b"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "c.apps-1-99281.svc.cluster.local:7070",
-        "domains": [
-         "c.apps-1-99281.svc.cluster.local",
-         "c.apps-1-99281.svc.cluster.local:7070",
-         "c",
-         "c:7070",
-         "c.apps-1-99281.svc.cluster",
-         "c.apps-1-99281.svc.cluster:7070",
-         "c.apps-1-99281.svc",
-         "c.apps-1-99281.svc:7070",
-         "c.apps-1-99281",
-         "c.apps-1-99281:7070",
-         "10.43.247.178",
-         "10.43.247.178:7070"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|7070||c.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "c.apps-1-99281.svc.cluster.local:7070/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "c.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/c"
-              },
-              "destination.service.name": {
-               "string_value": "c"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "c.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/c"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "c"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "d.apps-1-99281.svc.cluster.local:7070",
-        "domains": [
-         "d.apps-1-99281.svc.cluster.local",
-         "d.apps-1-99281.svc.cluster.local:7070",
-         "d",
-         "d:7070",
-         "d.apps-1-99281.svc.cluster",
-         "d.apps-1-99281.svc.cluster:7070",
-         "d.apps-1-99281.svc",
-         "d.apps-1-99281.svc:7070",
-         "d.apps-1-99281",
-         "d.apps-1-99281:7070",
-         "10.43.254.82",
-         "10.43.254.82:7070"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|7070||d.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "d.apps-1-99281.svc.cluster.local:7070/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "d.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/d"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "d"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "d.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/d"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "d"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "headless.apps-1-99281.svc.cluster.local:7070",
-        "domains": [
-         "headless.apps-1-99281.svc.cluster.local",
-         "headless.apps-1-99281.svc.cluster.local:7070",
-         "headless",
-         "headless:7070",
-         "headless.apps-1-99281.svc.cluster",
-         "headless.apps-1-99281.svc.cluster:7070",
-         "headless.apps-1-99281.svc",
-         "headless.apps-1-99281.svc:7070",
-         "headless.apps-1-99281",
-         "headless.apps-1-99281:7070"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|7070||headless.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "headless.apps-1-99281.svc.cluster.local:7070/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "headless.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/headless"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "headless"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "headless"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/headless"
-              },
-              "destination.service.host": {
-               "string_value": "headless.apps-1-99281.svc.cluster.local"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "t.apps-1-99281.svc.cluster.local:7070",
-        "domains": [
-         "t.apps-1-99281.svc.cluster.local",
-         "t.apps-1-99281.svc.cluster.local:7070",
-         "t",
-         "t:7070",
-         "t.apps-1-99281.svc.cluster",
-         "t.apps-1-99281.svc.cluster:7070",
-         "t.apps-1-99281.svc",
-         "t.apps-1-99281.svc:7070",
-         "t.apps-1-99281",
-         "t.apps-1-99281:7070",
-         "10.43.253.48",
-         "10.43.253.48:7070"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|7070||t.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "t.apps-1-99281.svc.cluster.local:7070/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/t"
-              },
-              "destination.service.host": {
-               "string_value": "t.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "t"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "t"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/t"
-              },
-              "destination.service.host": {
-               "string_value": "t.apps-1-99281.svc.cluster.local"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.539Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "8080",
-      "virtual_hosts": [
-       {
-        "name": "a.apps-1-99281.svc.cluster.local:8080",
-        "domains": [
-         "a.apps-1-99281.svc.cluster.local",
-         "a.apps-1-99281.svc.cluster.local:8080",
-         "a",
-         "a:8080",
-         "a.apps-1-99281.svc.cluster",
-         "a.apps-1-99281.svc.cluster:8080",
-         "a.apps-1-99281.svc",
-         "a.apps-1-99281.svc:8080",
-         "a.apps-1-99281",
-         "a.apps-1-99281:8080",
-         "10.43.242.41",
-         "10.43.242.41:8080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8080||a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:8080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "b.apps-1-99281.svc.cluster.local:8080",
-        "domains": [
-         "b.apps-1-99281.svc.cluster.local",
-         "b.apps-1-99281.svc.cluster.local:8080",
-         "b",
-         "b:8080",
-         "b.apps-1-99281.svc.cluster",
-         "b.apps-1-99281.svc.cluster:8080",
-         "b.apps-1-99281.svc",
-         "b.apps-1-99281.svc:8080",
-         "b.apps-1-99281",
-         "b.apps-1-99281:8080",
-         "10.43.241.185",
-         "10.43.241.185:8080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8080||b.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "b.apps-1-99281.svc.cluster.local:8080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "b.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/b"
-              },
-              "destination.service.name": {
-               "string_value": "b"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "b"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/b"
-              },
-              "destination.service.host": {
-               "string_value": "b.apps-1-99281.svc.cluster.local"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "c.apps-1-99281.svc.cluster.local:8080",
-        "domains": [
-         "c.apps-1-99281.svc.cluster.local",
-         "c.apps-1-99281.svc.cluster.local:8080",
-         "c",
-         "c:8080",
-         "c.apps-1-99281.svc.cluster",
-         "c.apps-1-99281.svc.cluster:8080",
-         "c.apps-1-99281.svc",
-         "c.apps-1-99281.svc:8080",
-         "c.apps-1-99281",
-         "c.apps-1-99281:8080",
-         "10.43.247.178",
-         "10.43.247.178:8080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8080||c.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "c.apps-1-99281.svc.cluster.local:8080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/c"
-              },
-              "destination.service.host": {
-               "string_value": "c.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "c"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/c"
-              },
-              "destination.service.host": {
-               "string_value": "c.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "c"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "d.apps-1-99281.svc.cluster.local:8080",
-        "domains": [
-         "d.apps-1-99281.svc.cluster.local",
-         "d.apps-1-99281.svc.cluster.local:8080",
-         "d",
-         "d:8080",
-         "d.apps-1-99281.svc.cluster",
-         "d.apps-1-99281.svc.cluster:8080",
-         "d.apps-1-99281.svc",
-         "d.apps-1-99281.svc:8080",
-         "d.apps-1-99281",
-         "d.apps-1-99281:8080",
-         "10.43.254.82",
-         "10.43.254.82:8080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8080||d.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "d.apps-1-99281.svc.cluster.local:8080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/d"
-              },
-              "destination.service.host": {
-               "string_value": "d.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "d"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/d"
-              },
-              "destination.service.host": {
-               "string_value": "d.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "d"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "headless.apps-1-99281.svc.cluster.local:8080",
-        "domains": [
-         "headless.apps-1-99281.svc.cluster.local",
-         "headless.apps-1-99281.svc.cluster.local:8080",
-         "headless",
-         "headless:8080",
-         "headless.apps-1-99281.svc.cluster",
-         "headless.apps-1-99281.svc.cluster:8080",
-         "headless.apps-1-99281.svc",
-         "headless.apps-1-99281.svc:8080",
-         "headless.apps-1-99281",
-         "headless.apps-1-99281:8080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8080||headless.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "headless.apps-1-99281.svc.cluster.local:8080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "headless.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/headless"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "headless"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "headless"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/headless"
-              },
-              "destination.service.host": {
-               "string_value": "headless.apps-1-99281.svc.cluster.local"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-pilot.istio-system.svc.cluster.local:8080",
-        "domains": [
-         "istio-pilot.istio-system.svc.cluster.local",
-         "istio-pilot.istio-system.svc.cluster.local:8080",
-         "istio-pilot.istio-system",
-         "istio-pilot.istio-system:8080",
-         "istio-pilot.istio-system.svc.cluster",
-         "istio-pilot.istio-system.svc.cluster:8080",
-         "istio-pilot.istio-system.svc",
-         "istio-pilot.istio-system.svc:8080",
-         "10.43.248.244",
-         "10.43.248.244:8080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8080||istio-pilot.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-pilot.istio-system.svc.cluster.local:8080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "t.apps-1-99281.svc.cluster.local:8080",
-        "domains": [
-         "t.apps-1-99281.svc.cluster.local",
-         "t.apps-1-99281.svc.cluster.local:8080",
-         "t",
-         "t:8080",
-         "t.apps-1-99281.svc.cluster",
-         "t.apps-1-99281.svc.cluster:8080",
-         "t.apps-1-99281.svc",
-         "t.apps-1-99281.svc:8080",
-         "t.apps-1-99281",
-         "t.apps-1-99281:8080",
-         "10.43.253.48",
-         "10.43.253.48:8080"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|8080||t.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "t.apps-1-99281.svc.cluster.local:8080/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "t"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/t"
-              },
-              "destination.service.host": {
-               "string_value": "t.apps-1-99281.svc.cluster.local"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "t.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/t"
-              },
-              "destination.service.name": {
-               "string_value": "t"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.538Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "15014",
-      "virtual_hosts": [
-       {
-        "name": "istio-citadel.istio-system.svc.cluster.local:15014",
-        "domains": [
-         "istio-citadel.istio-system.svc.cluster.local",
-         "istio-citadel.istio-system.svc.cluster.local:15014",
-         "istio-citadel.istio-system",
-         "istio-citadel.istio-system:15014",
-         "istio-citadel.istio-system.svc.cluster",
-         "istio-citadel.istio-system.svc.cluster:15014",
-         "istio-citadel.istio-system.svc",
-         "istio-citadel.istio-system.svc:15014",
-         "10.43.251.158",
-         "10.43.251.158:15014"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15014||istio-citadel.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-citadel.istio-system.svc.cluster.local:15014/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-citadel"
-              },
-              "destination.service.host": {
-               "string_value": "istio-citadel.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-citadel"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-citadel"
-              },
-              "destination.service.host": {
-               "string_value": "istio-citadel.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-citadel"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-galley.istio-system.svc.cluster.local:15014",
-        "domains": [
-         "istio-galley.istio-system.svc.cluster.local",
-         "istio-galley.istio-system.svc.cluster.local:15014",
-         "istio-galley.istio-system",
-         "istio-galley.istio-system:15014",
-         "istio-galley.istio-system.svc.cluster",
-         "istio-galley.istio-system.svc.cluster:15014",
-         "istio-galley.istio-system.svc",
-         "istio-galley.istio-system.svc:15014",
-         "10.43.240.145",
-         "10.43.240.145:15014"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15014||istio-galley.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-galley.istio-system.svc.cluster.local:15014/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-galley"
-              },
-              "destination.service.host": {
-               "string_value": "istio-galley.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-galley"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-galley.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-galley"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-galley"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-pilot.istio-system.svc.cluster.local:15014",
-        "domains": [
-         "istio-pilot.istio-system.svc.cluster.local",
-         "istio-pilot.istio-system.svc.cluster.local:15014",
-         "istio-pilot.istio-system",
-         "istio-pilot.istio-system:15014",
-         "istio-pilot.istio-system.svc.cluster",
-         "istio-pilot.istio-system.svc.cluster:15014",
-         "istio-pilot.istio-system.svc",
-         "istio-pilot.istio-system.svc:15014",
-         "10.43.248.244",
-         "10.43.248.244:15014"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15014||istio-pilot.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-pilot.istio-system.svc.cluster.local:15014/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-pilot"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-pilot"
-              },
-              "destination.service.host": {
-               "string_value": "istio-pilot.istio-system.svc.cluster.local"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-policy.istio-system.svc.cluster.local:15014",
-        "domains": [
-         "istio-policy.istio-system.svc.cluster.local",
-         "istio-policy.istio-system.svc.cluster.local:15014",
-         "istio-policy.istio-system",
-         "istio-policy.istio-system:15014",
-         "istio-policy.istio-system.svc.cluster",
-         "istio-policy.istio-system.svc.cluster:15014",
-         "istio-policy.istio-system.svc",
-         "istio-policy.istio-system.svc:15014",
-         "10.43.251.210",
-         "10.43.251.210:15014"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15014||istio-policy.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-policy.istio-system.svc.cluster.local:15014/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              },
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              },
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-telemetry.istio-system.svc.cluster.local:15014",
-        "domains": [
-         "istio-telemetry.istio-system.svc.cluster.local",
-         "istio-telemetry.istio-system.svc.cluster.local:15014",
-         "istio-telemetry.istio-system",
-         "istio-telemetry.istio-system:15014",
-         "istio-telemetry.istio-system.svc.cluster",
-         "istio-telemetry.istio-system.svc.cluster:15014",
-         "istio-telemetry.istio-system.svc",
-         "istio-telemetry.istio-system.svc:15014",
-         "10.43.255.188",
-         "10.43.255.188:15014"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|15014||istio-telemetry.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-telemetry.istio-system.svc.cluster.local:15014/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.539Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "9091",
-      "virtual_hosts": [
-       {
-        "name": "istio-policy.istio-system.svc.cluster.local:9091",
-        "domains": [
-         "istio-policy.istio-system.svc.cluster.local",
-         "istio-policy.istio-system.svc.cluster.local:9091",
-         "istio-policy.istio-system",
-         "istio-policy.istio-system:9091",
-         "istio-policy.istio-system.svc.cluster",
-         "istio-policy.istio-system.svc.cluster:9091",
-         "istio-policy.istio-system.svc",
-         "istio-policy.istio-system.svc:9091",
-         "10.43.251.210",
-         "10.43.251.210:9091"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9091||istio-policy.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-policy.istio-system.svc.cluster.local:9091/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              },
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-policy.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-policy"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-policy"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-telemetry.istio-system.svc.cluster.local:9091",
-        "domains": [
-         "istio-telemetry.istio-system.svc.cluster.local",
-         "istio-telemetry.istio-system.svc.cluster.local:9091",
-         "istio-telemetry.istio-system",
-         "istio-telemetry.istio-system:9091",
-         "istio-telemetry.istio-system.svc.cluster",
-         "istio-telemetry.istio-system.svc.cluster:9091",
-         "istio-telemetry.istio-system.svc",
-         "istio-telemetry.istio-system.svc:9091",
-         "10.43.255.188",
-         "10.43.255.188:9091"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|9091||istio-telemetry.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-telemetry.istio-system.svc.cluster.local:9091/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-telemetry.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-telemetry"
-              },
-              "destination.service.name": {
-               "string_value": "istio-telemetry"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.536Z"
-    },
-    {
-     "version_info": "2019-04-14T15:36:44Z/18",
-     "route_config": {
-      "name": "80",
-      "virtual_hosts": [
-       {
-        "name": "a.apps-1-99281.svc.cluster.local:80",
-        "domains": [
-         "a.apps-1-99281.svc.cluster.local",
-         "a.apps-1-99281.svc.cluster.local:80",
-         "a",
-         "a:80",
-         "a.apps-1-99281.svc.cluster",
-         "a.apps-1-99281.svc.cluster:80",
-         "a.apps-1-99281.svc",
-         "a.apps-1-99281.svc:80",
-         "a.apps-1-99281",
-         "a.apps-1-99281:80",
-         "10.43.242.41",
-         "10.43.242.41:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||a.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "a.apps-1-99281.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "a"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/a"
-              },
-              "destination.service.host": {
-               "string_value": "a.apps-1-99281.svc.cluster.local"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "b.apps-1-99281.svc.cluster.local:80",
-        "domains": [
-         "b.apps-1-99281.svc.cluster.local",
-         "b.apps-1-99281.svc.cluster.local:80",
-         "b",
-         "b:80",
-         "b.apps-1-99281.svc.cluster",
-         "b.apps-1-99281.svc.cluster:80",
-         "b.apps-1-99281.svc",
-         "b.apps-1-99281.svc:80",
-         "b.apps-1-99281",
-         "b.apps-1-99281:80",
-         "10.43.241.185",
-         "10.43.241.185:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||b.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "b.apps-1-99281.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "b.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/b"
-              },
-              "destination.service.name": {
-               "string_value": "b"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "b.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/b"
-              },
-              "destination.service.name": {
-               "string_value": "b"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "c.apps-1-99281.svc.cluster.local:80",
-        "domains": [
-         "c.apps-1-99281.svc.cluster.local",
-         "c.apps-1-99281.svc.cluster.local:80",
-         "c",
-         "c:80",
-         "c.apps-1-99281.svc.cluster",
-         "c.apps-1-99281.svc.cluster:80",
-         "c.apps-1-99281.svc",
-         "c.apps-1-99281.svc:80",
-         "c.apps-1-99281",
-         "c.apps-1-99281:80",
-         "10.43.247.178",
-         "10.43.247.178:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||c.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "c.apps-1-99281.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "c.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/c"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "c"
-              }
-             }
-            },
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "c.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/c"
-              },
-              "destination.service.name": {
-               "string_value": "c"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "d.apps-1-99281.svc.cluster.local:80",
-        "domains": [
-         "d.apps-1-99281.svc.cluster.local",
-         "d.apps-1-99281.svc.cluster.local:80",
-         "d",
-         "d:80",
-         "d.apps-1-99281.svc.cluster",
-         "d.apps-1-99281.svc.cluster:80",
-         "d.apps-1-99281.svc",
-         "d.apps-1-99281.svc:80",
-         "d.apps-1-99281",
-         "d.apps-1-99281:80",
-         "10.43.254.82",
-         "10.43.254.82:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||d.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "d.apps-1-99281.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "d.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/d"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "d"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "d.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/d"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "d"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "default-http-backend.kube-system.svc.cluster.local:80",
-        "domains": [
-         "default-http-backend.kube-system.svc.cluster.local",
-         "default-http-backend.kube-system.svc.cluster.local:80",
-         "default-http-backend.kube-system",
-         "default-http-backend.kube-system:80",
-         "default-http-backend.kube-system.svc.cluster",
-         "default-http-backend.kube-system.svc.cluster:80",
-         "default-http-backend.kube-system.svc",
-         "default-http-backend.kube-system.svc:80",
-         "10.43.255.10",
-         "10.43.255.10:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||default-http-backend.kube-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "default-http-backend.kube-system.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "disable_check_calls": true,
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "default-http-backend.kube-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://kube-system/services/default-http-backend"
-              },
-              "destination.service.name": {
-               "string_value": "default-http-backend"
-              },
-              "destination.service.namespace": {
-               "string_value": "kube-system"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "default-http-backend.kube-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://kube-system/services/default-http-backend"
-              },
-              "destination.service.namespace": {
-               "string_value": "kube-system"
-              },
-              "destination.service.name": {
-               "string_value": "default-http-backend"
-              }
-             }
-            }
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "headless.apps-1-99281.svc.cluster.local:80",
-        "domains": [
-         "headless.apps-1-99281.svc.cluster.local",
-         "headless.apps-1-99281.svc.cluster.local:80",
-         "headless",
-         "headless:80",
-         "headless.apps-1-99281.svc.cluster",
-         "headless.apps-1-99281.svc.cluster:80",
-         "headless.apps-1-99281.svc",
-         "headless.apps-1-99281.svc:80",
-         "headless.apps-1-99281",
-         "headless.apps-1-99281:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||headless.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "headless.apps-1-99281.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "headless.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/headless"
-              },
-              "destination.service.name": {
-               "string_value": "headless"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/headless"
-              },
-              "destination.service.host": {
-               "string_value": "headless.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "headless"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-egressgateway.istio-system.svc.cluster.local:80",
-        "domains": [
-         "istio-egressgateway.istio-system.svc.cluster.local",
-         "istio-egressgateway.istio-system.svc.cluster.local:80",
-         "istio-egressgateway.istio-system",
-         "istio-egressgateway.istio-system:80",
-         "istio-egressgateway.istio-system.svc.cluster",
-         "istio-egressgateway.istio-system.svc.cluster:80",
-         "istio-egressgateway.istio-system.svc",
-         "istio-egressgateway.istio-system.svc:80",
-         "10.43.245.70",
-         "10.43.245.70:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||istio-egressgateway.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-egressgateway.istio-system.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-egressgateway"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-egressgateway"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-egressgateway"
-              },
-              "destination.service.host": {
-               "string_value": "istio-egressgateway.istio-system.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-egressgateway"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "istio-ingressgateway.istio-system.svc.cluster.local:80",
-        "domains": [
-         "istio-ingressgateway.istio-system.svc.cluster.local",
-         "istio-ingressgateway.istio-system.svc.cluster.local:80",
-         "istio-ingressgateway.istio-system",
-         "istio-ingressgateway.istio-system:80",
-         "istio-ingressgateway.istio-system.svc.cluster",
-         "istio-ingressgateway.istio-system.svc.cluster:80",
-         "istio-ingressgateway.istio-system.svc",
-         "istio-ingressgateway.istio-system.svc:80",
-         "10.43.248.28",
-         "10.43.248.28:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||istio-ingressgateway.istio-system.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "istio-ingressgateway.istio-system.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-ingressgateway"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-ingressgateway"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.host": {
-               "string_value": "istio-ingressgateway.istio-system.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://istio-system/services/istio-ingressgateway"
-              },
-              "destination.service.namespace": {
-               "string_value": "istio-system"
-              },
-              "destination.service.name": {
-               "string_value": "istio-ingressgateway"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       },
-       {
-        "name": "t.apps-1-99281.svc.cluster.local:80",
-        "domains": [
-         "t.apps-1-99281.svc.cluster.local",
-         "t.apps-1-99281.svc.cluster.local:80",
-         "t",
-         "t:80",
-         "t.apps-1-99281.svc.cluster",
-         "t.apps-1-99281.svc.cluster:80",
-         "t.apps-1-99281.svc",
-         "t.apps-1-99281.svc:80",
-         "t.apps-1-99281",
-         "t.apps-1-99281:80",
-         "10.43.253.48",
-         "10.43.253.48:80"
-        ],
-        "routes": [
-         {
-          "match": {
-           "prefix": "/"
-          },
-          "route": {
-           "cluster": "outbound|80||t.apps-1-99281.svc.cluster.local",
-           "timeout": "0s",
-           "retry_policy": {
-            "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
-            "num_retries": 2,
-            "retry_host_predicate": [
-             {
-              "name": "envoy.retry_host_predicates.previous_hosts"
-             }
-            ],
-            "host_selection_retry_max_attempts": "3",
-            "retriable_status_codes": [
-             503
-            ]
-           },
-           "max_grpc_timeout": "0s"
-          },
-          "decorator": {
-           "operation": "t.apps-1-99281.svc.cluster.local:80/*"
-          },
-          "per_filter_config": {
-           "mixer": {
-            "forward_attributes": {
-             "attributes": {
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "t"
-              },
-              "destination.service.host": {
-               "string_value": "t.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/t"
-              }
-             }
-            },
-            "mixer_attributes": {
-             "attributes": {
-              "destination.service.uid": {
-               "string_value": "istio://apps-1-99281/services/t"
-              },
-              "destination.service.host": {
-               "string_value": "t.apps-1-99281.svc.cluster.local"
-              },
-              "destination.service.namespace": {
-               "string_value": "apps-1-99281"
-              },
-              "destination.service.name": {
-               "string_value": "t"
-              }
-             }
-            },
-            "disable_check_calls": true
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "validate_clusters": false
-     },
-     "last_updated": "2019-04-14T15:38:43.536Z"
-    }
-   ]
-  }
- ]
+  ]
 }


### PR DESCRIPTION
1. use CLUSTER_PROVIDED instead of ORIGINAL_DST_LB #16286
2. Pilot: only generate passthrough infra with ip versions provided by proxy #16786

@rlenglet To resolve cherry-pick conflict I cherry-pick PR 1 as well. I confirmed it is low-risk. 

CC author of 1st PR @XanderStrike 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
