### PR TITLE
Correct Kiali Annotation in values.yaml

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -36,7 +36,7 @@ ingress:
   ## Used to create an Ingress record.
   hosts:
     - kiali.local
-  annotations:
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR fixes the helm warnings if you set custom ingress annotations e.g. if set these values in your global values file:

```yaml
kiali:
  ingress:
    enabled: true
    annotations: 
      kubernetes.io/ingress.class: nginx
```

`helm` will return a warning:

```bash
2019/09/04 13:05:45 Warning: Merging destination map for chart 'kiali'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>
2019/09/04 13:05:45 Warning: Merging destination map for chart 'kiali'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>
2019/09/04 13:05:45 Warning: Merging destination map for chart 'kiali'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>
2019/09/04 13:05:45 Warning: Merging destination map for chart 'kiali'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>
2019/09/04 13:05:45 Warning: Merging destination map for chart 'kiali'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>
2019/09/04 13:05:45 Warning: Merging destination map for chart 'kiali'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>
```

Because helm tries to merge a nil object with a map.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
