### PR TITLE
Combine snapshots for analysis in AnalyzingDistributor

### DIFF
--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -39,20 +39,6 @@ type AnalyzingDistributor struct {
 
 var _ Distributor = &AnalyzingDistributor{}
 
-// StatusUpdater updates resource statuses, based on the given diagnostic messages.
-type StatusUpdater interface {
-	Update(messages diag.Messages)
-}
-
-// InMemoryStatusUpdater is an in-memory implementation of StatusUpdater
-type InMemoryStatusUpdater struct {
-	mu     sync.RWMutex
-	m      diag.Messages
-	waitCh chan struct{}
-}
-
-var _ StatusUpdater = &InMemoryStatusUpdater{}
-
 // NewAnalyzingDistributor returns a new instance of AnalyzingDistributor.
 func NewAnalyzingDistributor(u StatusUpdater, a analysis.Analyzer, d Distributor) *AnalyzingDistributor {
 	return &AnalyzingDistributor{
@@ -128,8 +114,7 @@ func (d *AnalyzingDistributor) getCombinedSnapshot() *Snapshot {
 		}
 	}
 
-	set := collection.NewSetFromCollections(collections)
-	return &Snapshot{set: set}
+	return &Snapshot{set: collection.NewSetFromCollections(collections)}
 }
 
 type context struct {
@@ -162,42 +147,5 @@ func (c *context) Canceled() bool {
 		return true
 	default:
 		return false
-	}
-}
-
-// Update implements StatusUpdater
-func (u *InMemoryStatusUpdater) Update(m diag.Messages) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	u.m = m
-	if u.waitCh != nil {
-		close(u.waitCh)
-	}
-}
-
-// Get returns the current set of captured diag.Messages
-func (u *InMemoryStatusUpdater) Get() diag.Messages {
-	u.mu.RLock()
-	defer u.mu.RUnlock()
-	return u.m
-}
-
-// WaitForReport blocks until a report is available. Returns true if a report is available, false if cancelCh was closed.
-func (u *InMemoryStatusUpdater) WaitForReport(cancelCh chan struct{}) bool {
-	u.mu.Lock()
-	if u.m != nil {
-		return true
-	}
-
-	if u.waitCh == nil {
-		u.waitCh = make(chan struct{})
-	}
-	ch := u.waitCh
-	u.mu.Unlock()
-	select {
-	case <-cancelCh:
-		return false
-	case <-ch:
-		return true
 	}
 }

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -44,13 +44,13 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 	sSynthetic := getTestSnapshot("c")
 	sOther := getTestSnapshot("a", "d")
 
-	ad.Distribute("syntheticServiceEntry", sSynthetic)
-	ad.Distribute("default", sDefault)
+	ad.Distribute(syntheticSnapshotGroup, sSynthetic)
+	ad.Distribute(defaultSnapshotGroup, sDefault)
 	ad.Distribute("other", sOther)
 
 	// Assert we sent every received snapshot to the distributor
-	g.Eventually(func() snapshot.Snapshot { return d.GetSnapshot("default") }).Should(Equal(sDefault))
-	g.Eventually(func() snapshot.Snapshot { return d.GetSnapshot("syntheticServiceEntry") }).Should(Equal(sSynthetic))
+	g.Eventually(func() snapshot.Snapshot { return d.GetSnapshot(syntheticSnapshotGroup) }).Should(Equal(sSynthetic))
+	g.Eventually(func() snapshot.Snapshot { return d.GetSnapshot(defaultSnapshotGroup) }).Should(Equal(sDefault))
 	g.Eventually(func() snapshot.Snapshot { return d.GetSnapshot("other") }).Should(Equal(sOther))
 
 	// Assert we triggered only once analysis, with the expected combination of snapshots

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package snapshotter
 
 import (

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -1,0 +1,69 @@
+package snapshotter
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/diag"
+	"istio.io/istio/galley/pkg/config/collection"
+	"istio.io/istio/pkg/mcp/snapshot"
+)
+
+type updaterMock struct{}
+
+// Update implements StatusUpdater
+func (u *updaterMock) Update(messages diag.Messages) {}
+
+type analyzerMock struct {
+	analyzeCalls []*Snapshot
+}
+
+// Analyze implements Analyzer
+func (a *analyzerMock) Analyze(c analysis.Context) {
+	ctx := *c.(*context)
+
+	a.analyzeCalls = append(a.analyzeCalls, ctx.sn)
+}
+
+// Name implements Analyzer
+func (a *analyzerMock) Name() string {
+	return ""
+}
+
+func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	u := &updaterMock{}
+	a := &analyzerMock{}
+	d := NewInMemoryDistributor()
+	ad := NewAnalyzingDistributor(u, a, d)
+
+	sDefault := getTestSnapshot("a", "b")
+	sSynthetic := getTestSnapshot("c")
+	sOther := getTestSnapshot("a", "d")
+
+	ad.Distribute("syntheticServiceEntry", sSynthetic)
+	ad.Distribute("default", sDefault)
+	ad.Distribute("other", sOther)
+
+	// Assert we sent every received snapshot to the distributor
+	g.Eventually(func() snapshot.Snapshot { return d.GetSnapshot("default") }).Should(Equal(sDefault))
+	g.Eventually(func() snapshot.Snapshot { return d.GetSnapshot("syntheticServiceEntry") }).Should(Equal(sSynthetic))
+	g.Eventually(func() snapshot.Snapshot { return d.GetSnapshot("other") }).Should(Equal(sOther))
+
+	// Assert we triggered only once analysis, with the expected combination of snapshots
+	sCombined := getTestSnapshot("a", "b", "c")
+	g.Eventually(func() []*Snapshot { return a.analyzeCalls }).Should(ConsistOf(sCombined))
+}
+
+func getTestSnapshot(names ...string) *Snapshot {
+	c := make([]*collection.Instance, 0)
+	for _, name := range names {
+		c = append(c, collection.New(collection.NewName(name)))
+	}
+	return &Snapshot{
+		set: collection.NewSetFromCollections(c),
+	}
+}

--- a/galley/pkg/config/processing/snapshotter/snapshotter.go
+++ b/galley/pkg/config/processing/snapshotter/snapshotter.go
@@ -194,8 +194,8 @@ func (s *Snapshotter) publish(o SnapshotOptions) {
 	monitoring.RecordProcessorSnapshotPublished(s.pendingEvents, now.Sub(s.lastSnapshotTime))
 	s.lastSnapshotTime = now
 	s.pendingEvents = 0
-	scope.Processing.Errora("Publishing snapshot for group: ", o.Group)
-	scope.Processing.Errora(sn)
+	scope.Processing.Infoa("Publishing snapshot for group: ", o.Group)
+	scope.Processing.Debuga(sn)
 	o.Distributor.Distribute(o.Group, sn)
 }
 

--- a/galley/pkg/config/processing/snapshotter/snapshotter.go
+++ b/galley/pkg/config/processing/snapshotter/snapshotter.go
@@ -194,8 +194,8 @@ func (s *Snapshotter) publish(o SnapshotOptions) {
 	monitoring.RecordProcessorSnapshotPublished(s.pendingEvents, now.Sub(s.lastSnapshotTime))
 	s.lastSnapshotTime = now
 	s.pendingEvents = 0
-	scope.Processing.Infoa("Publishing snapshot for group: ", o.Group)
-	scope.Processing.Debuga(sn)
+	scope.Processing.Errora("Publishing snapshot for group: ", o.Group)
+	scope.Processing.Errora(sn)
 	o.Distributor.Distribute(o.Group, sn)
 }
 

--- a/galley/pkg/config/processing/snapshotter/statusupdater.go
+++ b/galley/pkg/config/processing/snapshotter/statusupdater.go
@@ -1,0 +1,58 @@
+package snapshotter
+
+import (
+	"sync"
+
+	"istio.io/istio/galley/pkg/config/analysis/diag"
+)
+
+// StatusUpdater updates resource statuses, based on the given diagnostic messages.
+type StatusUpdater interface {
+	Update(messages diag.Messages)
+}
+
+// InMemoryStatusUpdater is an in-memory implementation of StatusUpdater
+type InMemoryStatusUpdater struct {
+	mu     sync.RWMutex
+	m      diag.Messages
+	waitCh chan struct{}
+}
+
+var _ StatusUpdater = &InMemoryStatusUpdater{}
+
+// Update implements StatusUpdater
+func (u *InMemoryStatusUpdater) Update(m diag.Messages) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.m = m
+	if u.waitCh != nil {
+		close(u.waitCh)
+	}
+}
+
+// Get returns the current set of captured diag.Messages
+func (u *InMemoryStatusUpdater) Get() diag.Messages {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	return u.m
+}
+
+// WaitForReport blocks until a report is available. Returns true if a report is available, false if cancelCh was closed.
+func (u *InMemoryStatusUpdater) WaitForReport(cancelCh chan struct{}) bool {
+	u.mu.Lock()
+	if u.m != nil {
+		return true
+	}
+
+	if u.waitCh == nil {
+		u.waitCh = make(chan struct{})
+	}
+	ch := u.waitCh
+	u.mu.Unlock()
+	select {
+	case <-cancelCh:
+		return false
+	case <-ch:
+		return true
+	}
+}

--- a/galley/pkg/config/processing/snapshotter/statusupdater.go
+++ b/galley/pkg/config/processing/snapshotter/statusupdater.go
@@ -41,6 +41,7 @@ func (u *InMemoryStatusUpdater) Get() diag.Messages {
 func (u *InMemoryStatusUpdater) WaitForReport(cancelCh chan struct{}) bool {
 	u.mu.Lock()
 	if u.m != nil {
+		u.mu.Unlock()
 		return true
 	}
 
@@ -49,6 +50,7 @@ func (u *InMemoryStatusUpdater) WaitForReport(cancelCh chan struct{}) bool {
 	}
 	ch := u.waitCh
 	u.mu.Unlock()
+
 	select {
 	case <-cancelCh:
 		return false

--- a/galley/pkg/config/processing/snapshotter/statusupdater.go
+++ b/galley/pkg/config/processing/snapshotter/statusupdater.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package snapshotter
 
 import (

--- a/galley/pkg/config/processing/snapshotter/statusupdater_test.go
+++ b/galley/pkg/config/processing/snapshotter/statusupdater_test.go
@@ -1,0 +1,44 @@
+package snapshotter
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/galley/pkg/config/analysis/diag"
+)
+
+func TestInMemoryStatusUpdaterWriteThenWait(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	su := &InMemoryStatusUpdater{}
+
+	msgs := diag.Messages{
+		diag.NewMessage(diag.Error, "test", nil, "test"),
+	}
+
+	cancelCh := make(chan struct{})
+
+	su.Update(msgs)
+	g.Expect(su.WaitForReport(cancelCh)).To(BeTrue())
+	g.Expect(su.Get()).To(Equal(msgs))
+}
+
+func TestInMemoryStatusUpdaterWaitThenWrite(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	su := &InMemoryStatusUpdater{}
+
+	msgs := diag.Messages{
+		diag.NewMessage(diag.Error, "test", nil, "test"),
+	}
+
+	cancelCh := make(chan struct{})
+
+	go func() {
+		g.Expect(su.WaitForReport(cancelCh)).To(BeTrue())
+	}()
+
+	su.Update(msgs)
+	g.Expect(su.Get()).To(Equal(msgs))
+}

--- a/galley/pkg/config/processing/snapshotter/statusupdater_test.go
+++ b/galley/pkg/config/processing/snapshotter/statusupdater_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package snapshotter
 
 import (


### PR DESCRIPTION
This change creates a combined snapshot for default and synthetic snapshot groups, so that we can have data from both when running analyzers. 

This is needed so that we can have analyzers that look at services in the mesh (e.g. checking to see if VirtualService routes go to valid host entries). 

Also added some tests & moved StatusUpdater / InMemoryStatusUpdater into its own file. 

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
