### PR TITLE
add remote service certs to tls watches

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -109,7 +109,7 @@ var (
 	sdsUdsWaitTimeout = time.Minute
 
 	// Indicates if any the remote services like AccessLogService, MetricsService have enabled tls.
-	rsTlsEnabled bool
+	rsTLSEnabled bool
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",
@@ -307,7 +307,7 @@ var (
 			// Since Envoy needs the file-mounted certs for mTLS, we wait for them to become available
 			// before starting it. Skip waiting cert if sds is enabled, otherwise it takes long time for
 			// pod to start.
-			if (controlPlaneAuthEnabled || rsTlsEnabled) && !sdsEnabled {
+			if (controlPlaneAuthEnabled || rsTLSEnabled) && !sdsEnabled {
 				log.Infof("Monitored certs: %#v", tlsCertsToWatch)
 				for _, cert := range tlsCertsToWatch {
 					waitForFile(cert, 2*time.Minute)
@@ -570,10 +570,9 @@ func appendTLSCerts(rs *meshconfig.RemoteService) {
 	if rs.TlsSettings == nil {
 		return
 	}
-	rsTlsEnabled = true
-	tlsCertsToWatch = append(tlsCertsToWatch, rs.TlsSettings.CaCertificates)
-	tlsCertsToWatch = append(tlsCertsToWatch, rs.TlsSettings.ClientCertificate)
-	tlsCertsToWatch = append(tlsCertsToWatch, rs.TlsSettings.PrivateKey)
+	rsTLSEnabled = true
+	tlsCertsToWatch = append(tlsCertsToWatch, rs.TlsSettings.CaCertificates, rs.TlsSettings.ClientCertificate,
+		rs.TlsSettings.PrivateKey)
 }
 
 func init() {

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -108,6 +108,9 @@ var (
 
 	sdsUdsWaitTimeout = time.Minute
 
+	// Indicates if any the remote services like AccessLogService, MetricsService have enabled tls.
+	rsTlsEnabled bool
+
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",
 		Short:        "Istio Pilot agent.",
@@ -184,9 +187,6 @@ var (
 				tlsClientCertChain, tlsClientKey, tlsClientRootCert,
 			}
 
-			// dedupe cert paths so we don't set up 2 watchers for the same file:
-			tlsCertsToWatch = dedupeStrings(tlsCertsToWatch)
-
 			proxyConfig := mesh.DefaultProxyConfig()
 
 			// set all flags
@@ -203,6 +203,7 @@ var (
 			if envoyAccessLogService != "" {
 				if rs := fromJSON(envoyAccessLogService); rs != nil {
 					proxyConfig.EnvoyAccessLogService = rs
+					appendTLSCerts(rs)
 				}
 			}
 			proxyConfig.ProxyAdminPort = int32(proxyAdminPort)
@@ -300,10 +301,13 @@ var (
 			controlPlaneAuthEnabled := controlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 			sdsEnabled, sdsTokenPath := detectSds(controlPlaneBootstrap, sdsUdsPathVar.Get(), trustworthyJWTPath)
 
+			// dedupe cert paths so we don't set up 2 watchers for the same file:
+			tlsCertsToWatch = dedupeStrings(tlsCertsToWatch)
+
 			// Since Envoy needs the file-mounted certs for mTLS, we wait for them to become available
 			// before starting it. Skip waiting cert if sds is enabled, otherwise it takes long time for
 			// pod to start.
-			if controlPlaneAuthEnabled && !sdsEnabled {
+			if (controlPlaneAuthEnabled || rsTlsEnabled) && !sdsEnabled {
 				log.Infof("Monitored certs: %#v", tlsCertsToWatch)
 				for _, cert := range tlsCertsToWatch {
 					waitForFile(cert, 2*time.Minute)
@@ -560,6 +564,16 @@ func fromJSON(j string) *meshconfig.RemoteService {
 
 	log.Infof("%v", m)
 	return &m
+}
+
+func appendTLSCerts(rs *meshconfig.RemoteService) {
+	if rs.TlsSettings == nil {
+		return
+	}
+	rsTlsEnabled = true
+	tlsCertsToWatch = append(tlsCertsToWatch, rs.TlsSettings.CaCertificates)
+	tlsCertsToWatch = append(tlsCertsToWatch, rs.TlsSettings.ClientCertificate)
+	tlsCertsToWatch = append(tlsCertsToWatch, rs.TlsSettings.PrivateKey)
 }
 
 func init() {

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -421,10 +421,13 @@ var (
 	}
 )
 
+// dedupes the string array and also ignores the empty string.
 func dedupeStrings(in []string) []string {
 	stringMap := map[string]bool{}
 	for _, c := range in {
-		stringMap[c] = true
+		if len(c) > 0 {
+			stringMap[c] = true
+		}
 	}
 	unique := make([]string, 0)
 	for c := range stringMap {

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/spf13/cobra/doc"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/pkg/collateral"
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
@@ -568,6 +569,9 @@ func fromJSON(j string) *meshconfig.RemoteService {
 
 func appendTLSCerts(rs *meshconfig.RemoteService) {
 	if rs.TlsSettings == nil {
+		return
+	}
+	if rs.TlsSettings.Mode == networking.TLSSettings_DISABLE {
 		return
 	}
 	rsTLSEnabled = true


### PR DESCRIPTION
Signed-off-by: Rama Chavali <rama.rao@salesforce.com>
Adds Remoteservice certs to tls watches so that they can be reloaded when they change. See https://github.com/istio/istio/pull/16161#discussion_r320633989.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
