### PR TITLE
Disable secureGrpc if sidecar is used for control plane mTLS

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -62,11 +62,9 @@ spec:
           - "-a"
           - {{ .Release.Namespace }}
 {{- end }}
-{{- if $.Values.global.controlPlaneSecurityEnabled}}
-    {{- if not .Values.sidecar }}
+{{- if and $.Values.global.controlPlaneSecurityEnabled (not .Values.sidecar)}}
           - --secureGrpcAddr
           - ":15011"
-    {{- end }}
 {{- else }}
           - --secureGrpcAddr
           - ""


### PR DESCRIPTION
Signed-off-by: Shakti <shaktiprakash.das@salesforce.com>

We would want Pilot's `secureGrpc` to be disabled when mTLS is enabled using Pilot `sidecar` option. `secureGrpc: ""` is currently skipped entirely from args if controlPlaneSecurityEnabled is true but sidecar is used for mTLS.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[X] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
