### PR TITLE
Use galley's namespace as ownerref for the validation webhook config

### DIFF
--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -31,8 +31,9 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/howeyc/fsnotify"
 	"k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
 	admissionregistration "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
@@ -63,7 +64,7 @@ type WebhookConfigController struct {
 	keyCertWatcher       *fsnotify.Watcher
 	configWatcher        *fsnotify.Watcher
 	webhookParameters    *WebhookParameters
-	ownerRefs            []v1.OwnerReference
+	ownerRefs            []metav1.OwnerReference
 	webhookConfiguration *v1beta1.ValidatingWebhookConfiguration
 
 	// test hook for informers
@@ -124,7 +125,7 @@ func createOrUpdateWebhookConfigHelper(
 	client admissionregistration.ValidatingWebhookConfigurationInterface,
 	webhookConfiguration *v1beta1.ValidatingWebhookConfiguration,
 ) (bool, error) {
-	current, err := client.Get(webhookConfiguration.Name, v1.GetOptions{})
+	current, err := client.Get(webhookConfiguration.Name, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			if _, createErr := client.Create(webhookConfiguration); createErr != nil {
@@ -165,14 +166,14 @@ func deleteWebhookConfigHelper(
 	client admissionregistration.ValidatingWebhookConfigurationInterface,
 	webhookName string,
 ) (bool, error) {
-	_, err := client.Get(webhookName, v1.GetOptions{})
+	_, err := client.Get(webhookName, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
 		return false, err
 	}
-	err = client.Delete(webhookName, &v1.DeleteOptions{})
+	err = client.Delete(webhookName, &metav1.DeleteOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -231,7 +232,7 @@ func loadCaCertPem(in io.Reader) ([]byte, error) {
 // cleaned up when istio-galley is deleted.
 func rebuildWebhookConfigHelper(
 	caFile, webhookConfigFile, webhookName string,
-	ownerRefs []v1.OwnerReference,
+	ownerRefs []metav1.OwnerReference,
 ) (*v1beta1.ValidatingWebhookConfiguration, error) {
 	// load and validate configuration
 	webhookConfigData, err := ioutil.ReadFile(webhookConfigFile)
@@ -251,7 +252,7 @@ func rebuildWebhookConfigHelper(
 			webhookConfig.Webhooks[i].FailurePolicy = &failurePolicy
 		}
 		if webhookConfig.Webhooks[i].NamespaceSelector == nil {
-			webhookConfig.Webhooks[i].NamespaceSelector = &v1.LabelSelector{}
+			webhookConfig.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{}
 		}
 	}
 
@@ -343,16 +344,16 @@ func NewWebhookConfigController(p WebhookParameters) (*WebhookConfigController, 
 	}
 
 	galleyNamespace, err := whc.webhookParameters.Clientset.CoreV1().Namespaces().Get(
-		whc.webhookParameters.DeploymentAndServiceNamespace, v1.GetOptions{})
+		whc.webhookParameters.DeploymentAndServiceNamespace, metav1.GetOptions{})
 	if err != nil {
 		scope.Warnf("Could not find %s namespace to set ownerRef. "+
 			"The validatingwebhookconfiguration must be deleted manually",
 			whc.webhookParameters.DeploymentAndServiceNamespace)
 	} else {
-		whc.ownerRefs = []v1.OwnerReference{
-			*v1.NewControllerRef(
+		whc.ownerRefs = []metav1.OwnerReference{
+			*metav1.NewControllerRef(
 				galleyNamespace,
-				v1.SchemeGroupVersion.WithKind("Namespace"),
+				corev1.SchemeGroupVersion.WithKind("Namespace"),
 			),
 		}
 	}

--- a/galley/pkg/crd/validation/config_test.go
+++ b/galley/pkg/crd/validation/config_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/onsi/gomega"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -294,7 +294,7 @@ func initValidatingWebhookConfiguration() *admissionregistrationv1beta1.Validati
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(
 					dummyNamespace,
-					v1.SchemeGroupVersion.WithKind("Namespace"),
+					corev1.SchemeGroupVersion.WithKind("Namespace"),
 				),
 			},
 		},
@@ -316,7 +316,7 @@ func initValidatingWebhookConfiguration() *admissionregistrationv1beta1.Validati
 						},
 						Rule: admissionregistrationv1beta1.Rule{
 							APIGroups:   []string{"g1"},
-							APIVersions: []string{"v1"},
+							APIVersions: []string{"corev1"},
 							Resources:   []string{"r1"},
 						},
 					},

--- a/galley/pkg/crd/validation/config_test.go
+++ b/galley/pkg/crd/validation/config_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/onsi/gomega"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -101,9 +101,9 @@ func createTestWebhookConfigController(
 		CACertFile:                    caFile,
 		Clientset:                     cl,
 		WebhookName:                   config.Name,
-		DeploymentName:                dummyDeployment.Name,
-		ServiceName:                   dummyDeployment.Name,
-		DeploymentAndServiceNamespace: dummyDeployment.Namespace,
+		DeploymentName:                dummyNamespace.Name,
+		ServiceName:                   dummyNamespace.Name,
+		DeploymentAndServiceNamespace: dummyNamespace.Namespace,
 	}
 	whc, err := NewWebhookConfigController(options)
 	if err != nil {
@@ -237,7 +237,7 @@ func TestValidatingWebhookConfig(t *testing.T) {
 	for _, tc := range ts {
 		t.Run(tc.name, func(t *testing.T) {
 			whc, cancel := createTestWebhookConfigController(t,
-				fake.NewSimpleClientset(dummyDeployment, tc.configs.DeepCopyObject()),
+				fake.NewSimpleClientset(dummyNamespace, tc.configs.DeepCopyObject()),
 				createFakeWebhookSource(), want)
 			defer cancel()
 
@@ -293,8 +293,8 @@ func initValidatingWebhookConfiguration() *admissionregistrationv1beta1.Validati
 			Name: "config1",
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(
-					dummyDeployment,
-					appsv1.SchemeGroupVersion.WithKind("Deployment"),
+					dummyNamespace,
+					v1.SchemeGroupVersion.WithKind("Namespace"),
 				),
 			},
 		},

--- a/galley/pkg/crd/validation/webhook_test.go
+++ b/galley/pkg/crd/validation/webhook_test.go
@@ -101,8 +101,8 @@ var (
 
 	dummyNamespace = &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "istio-system",
-			UID:       "deadbeef",
+			Name: "istio-system",
+			UID:  "deadbeef",
 		},
 	}
 

--- a/galley/pkg/crd/validation/webhook_test.go
+++ b/galley/pkg/crd/validation/webhook_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ghodss/yaml"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -100,23 +99,22 @@ var (
 		},
 	}
 
-	dummyDeployment = &appsv1.Deployment{
+	dummyNamespace = &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "istio-galley",
-			Namespace: "istio-system",
+			Name:      "istio-system",
 			UID:       "deadbeef",
 		},
 	}
 
-	dummyClient = fake.NewSimpleClientset(dummyDeployment)
+	dummyClient = fake.NewSimpleClientset(dummyNamespace)
 
 	createFakeWebhookSource   = fcache.NewFakeControllerSource
 	createFakeEndpointsSource = func() cache.ListerWatcher {
 		source := fcache.NewFakeControllerSource()
 		source.Add(&v1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      dummyDeployment.Name,
-				Namespace: dummyDeployment.Namespace,
+				Name:      dummyNamespace.Name,
+				Namespace: dummyNamespace.Namespace,
 			},
 			Subsets: []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
@@ -194,9 +192,9 @@ func createTestWebhook(
 		CACertFile:                    caFile,
 		Clientset:                     cl,
 		WebhookName:                   config.Name,
-		DeploymentName:                dummyDeployment.Name,
-		ServiceName:                   dummyDeployment.Name,
-		DeploymentAndServiceNamespace: dummyDeployment.Namespace,
+		DeploymentName:                dummyNamespace.Name,
+		ServiceName:                   dummyNamespace.Name,
+		DeploymentAndServiceNamespace: dummyNamespace.Namespace,
 	}
 	wh, err := NewWebhook(options)
 	if err != nil {


### PR DESCRIPTION
Cluster scoped resource it should not have an owner that is a
namespace scoped resource (see
https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents). 

Use the cluster-scoped namespace of Galley instead. This should work for most cases except where the user disables galley without removing the istio-system namespace or other components. Alternatives would be to use galley's cluster-scoped clusterrole or clusterrolebinding.

fixes https://github.com/istio/istio/issues/16818

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[X] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
