### PR TITLE
Configure mesh.sidecarToTelemetrySessionAffinity with existing helm option

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -29,6 +29,11 @@ data:
     reportBatchMaxTime: {{ .Values.mixer.telemetry.reportBatchMaxTime }}
     {{- end }}
 
+    {{- if .Values.mixer.telemetry.sessionAffinityEnabled }}
+    # sidecarToTelemetrySessionAffinity will create a STRICT_DNS type cluster for istio-telemetry.
+    sidecarToTelemetrySessionAffinity: {{ .Values.mixer.telemetry.sessionAffinityEnabled }}
+    {{- end }}
+
     # Set enableTracing to false to disable request tracing.
     enableTracing: {{ .Values.global.enableTracing }}
 


### PR DESCRIPTION
helm option `Values.mixer.telemetry.sessionAffinityEnabled` has existed for some time. It did not turn on the mesh config flag before. This PR turns the meshconfig flag if  `Values.mixer.telemetry.sessionAffinityEnabled`  is specified.

fixes #16862