### PR TITLE
Fix istioctl release binary corruption

### DIFF
--- a/release/gcb/gcb_lib.sh
+++ b/release/gcb/gcb_lib.sh
@@ -178,10 +178,10 @@ function update_helm() {
   sed -i "s|tag: .*-latest-daily|tag: ${VERSION}|g"         ./"istio-${VERSION}"/install/kubernetes/helm/istio*/values.yaml ./"istio-${VERSION}"/install/kubernetes/helm/istio-cni/values_gke.yaml
   current_tag=$(grep "appVersion" ./"istio-${VERSION}"/install/kubernetes/helm/istio/Chart.yaml  | cut -d ' ' -f2)
   if [ "${current_tag}" != "${VERSION}" ]; then
-    find . -type f -exec sed -i "s/tag: ${current_tag}/tag: ${VERSION}/g" {} \;
-    find . -type f -exec sed -i "s/version: ${current_tag}/version: ${VERSION}/g" {} \;
-    find . -type f -exec sed -i "s/appVersion: ${current_tag}/appVersion: ${VERSION}/g" {} \;
-    find . -type f -exec sed -i "s/istio-release\/releases\/${current_tag}/istio-release\/releases\/${VERSION}/g" {} \;
+    find ./"istio-${VERSION}"/install/kubernetes/helm -type f -exec sed -i "s/tag: ${current_tag}/tag: ${VERSION}/g" {} \;
+    find ./"istio-${VERSION}"/install/kubernetes/helm -type f -exec sed -i "s/version: ${current_tag}/version: ${VERSION}/g" {} \;
+    find ./"istio-${VERSION}"/install/kubernetes/helm -type f -exec sed -i "s/appVersion: ${current_tag}/appVersion: ${VERSION}/g" {} \;
+    find ./"istio-${VERSION}"/install/kubernetes/helm -type f -exec sed -i "s/istio-release\/releases\/${current_tag}/istio-release\/releases\/${VERSION}/g" {} \;
   fi
 
   # replace prerelease with release location for istio.io repo


### PR DESCRIPTION
The release acrhive scripts invoke sed to update versions fields in
several charts. This search/replace ran over the entire release
archive included istioctl binaries. The istioctl operator commands
which were introduced in
https://github.com/istio/istio/pull/16622/files include embedded
charts which matched the sed expression. This corrupted the data
portion istioctl binaries when created through the official release process.

fixes https://github.com/istio/istio/issues/16660 by reducing scope of
sed to the install/kubernetes/helm subdirectory.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
