### PR TITLE
Fix a bug in eds debug interface

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -493,6 +493,7 @@ func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
 	}
 
 	edsClusterMutex.RLock()
+	defer edsClusterMutex.RUnlock()
 	comma := false
 	if len(edsClusters) > 0 {
 		_, _ = fmt.Fprintln(w, "[")
@@ -513,7 +514,6 @@ func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
 	} else {
 		w.WriteHeader(404)
 	}
-	edsClusterMutex.RUnlock()
 }
 
 // cdsz implements a status and debug interface for CDS.


### PR DESCRIPTION
Fix a bug in eds debug interface where the eds lock is not released under abnormal conditions.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
