### PR TITLE
Correct the context to use for callback

### DIFF
--- a/tests/integration/security/reachability/context.go
+++ b/tests/integration/security/reachability/context.go
@@ -121,8 +121,8 @@ func (rc *Context) Run(testCases []TestCase) {
 		test.Run(func(ctx framework.TestContext) {
 			// Apply the policy.
 			policyYAML := file.AsStringOrFail(ctx, filepath.Join("../testdata", c.ConfigFile))
-			rc.g.ApplyConfigOrFail(rc.ctx, c.Namespace, policyYAML)
-			rc.ctx.WhenDone(func() error {
+			rc.g.ApplyConfigOrFail(ctx, c.Namespace, policyYAML)
+			ctx.WhenDone(func() error {
 				return rc.g.DeleteConfig(c.Namespace, policyYAML)
 			})
 


### PR DESCRIPTION
This PR fix the bug cause by https://github.com/istio/istio/pull/16790 that did not trigger the `WhenDone` callback.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
