### PR TITLE
HTTP Sniffing: RDS perf & bug fix

### DIFF
--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -33,7 +33,7 @@ type ConfigGenerator interface {
 	BuildClusters(env *model.Environment, node *model.Proxy, push *model.PushContext) []*v2.Cluster
 
 	// BuildHTTPRoutes returns the list of HTTP routes for the given proxy. This is the RDS output
-	BuildHTTPRoutes(env *model.Environment, node *model.Proxy, push *model.PushContext, routeName string) *v2.RouteConfiguration
+	BuildHTTPRoutes(env *model.Environment, node *model.Proxy, push *model.PushContext, routeNames []string) []*v2.RouteConfiguration
 }
 
 // NewConfigGenerator creates a new instance of the dataplane configuration generator

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -301,8 +301,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(_ *model.
 		virtualServices, listenerPort)
 	vHostPortMap := make(map[int][]*route.VirtualHost)
 	uniques := make(map[string]struct{})
-	// TODO: pruning by appropriate hostname for a sniffed listener should happen at this level
-	// where vHostWrapper.Services has only one service matching the hostname in the routeName
 	for _, virtualHostWrapper := range virtualHostWrappers {
 		// If none of the routes matched by source, skip this virtual host
 		if len(virtualHostWrapper.Routes) == 0 {

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -21,9 +21,7 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -242,7 +240,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 	return out
 }
 
-func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(env *model.Environment, node *model.Proxy, push *model.PushContext,
+func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(_ *model.Environment, node *model.Proxy, push *model.PushContext,
 	routeName string, listenerPort int) []*route.VirtualHost {
 
 	var virtualServices []model.Config
@@ -318,7 +316,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(env *mode
 				})
 			} else {
 				push.Add(model.DuplicatedDomains, name, node, fmt.Sprintf("duplicate domain from virtual service: %s", name))
-				//log.Debugf("Dropping duplicate route entry %v for %s", name, node.ID)
 			}
 		}
 
@@ -340,7 +337,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(env *mode
 				})
 			} else {
 				push.Add(model.DuplicatedDomains, name, node, fmt.Sprintf("duplicate domain from virtual service: %s", name))
-				log.Debugf("Dropping duplicate route entry %v.", name)
 			}
 		}
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -21,8 +21,8 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-
 	networking "istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter"
@@ -265,7 +265,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(env *mode
 	}
 
 	// Check the cache for pre-computed virtual host wrappers for sniffed routes
-	virtualHostWrappers = vHostWrapperCache[listenerPort]
+	virtualHostWrappers, _ = vHostWrapperCache[listenerPort]
 
 	if len(virtualHostWrappers) == 0 {
 		// Nothing found in the cache

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -21,6 +21,7 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+
 	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/features"

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -45,9 +45,9 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(env *model.Environment, no
 
 	switch node.Type {
 	case model.SidecarProxy:
-		vHostCache := make(map[int][]*route.VirtualHost)
+		vHostWrapperCache := make(map[int][]istio_route.VirtualHostWrapper)
 		for _, routeName := range routeNames {
-			rc := configgen.buildSidecarOutboundHTTPRouteConfig(env, node, push, routeName, vHostCache)
+			rc := configgen.buildSidecarOutboundHTTPRouteConfig(env, node, push, routeName, vHostWrapperCache)
 			if rc != nil {
 				rc = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, push, rc)
 			} else {
@@ -117,10 +117,10 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(env *mo
 
 // buildSidecarOutboundHTTPRouteConfig builds an outbound HTTP Route for sidecar.
 // Based on port, will determine all virtual hosts that listen on the port.
-func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *model.Environment, node *model.Proxy, push *model.PushContext,
-	routeName string, vHostCache map[int][]*route.VirtualHost) *xdsapi.RouteConfiguration {
+func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *model.Environment, node *model.Proxy,
+	push *model.PushContext, routeName string,
+	vHostWrapperCache map[int][]istio_route.VirtualHostWrapper) *xdsapi.RouteConfiguration {
 
-	var virtualHosts []*route.VirtualHost
 	listenerPort := 0
 	useSniffing := false
 	var err error
@@ -147,34 +147,11 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 		}
 	}
 
-	cacheHit := false
-	if useSniffing && listenerPort != 0 {
-		// Check if we have already computed the list of all virtual hosts for this port
-		// If so, then  we simply have to return only the relevant virtual hosts for
-		// this listener's host:port
-		if vhosts, exists := vHostCache[listenerPort]; exists {
-			virtualHosts = getVirtualHostsForSniffedServicePort(vhosts, routeName)
-			cacheHit = true
-		}
-	}
-	if !cacheHit {
-		virtualHosts = configgen.buildSidecarOutboundVirtualHosts(env, node, push, routeName, listenerPort)
-		if listenerPort > 0 {
-			// only cache for tcp ports and not for uds
-			vHostCache[listenerPort] = virtualHosts
-		}
-
-		// FIXME: This will ignore virtual services with hostnames that do not match any service in the registry
-		// per api spec, these hostnames + routes should appear in the virtual hosts (think bookinfo.com and
-		// productpage.ns1.svc.cluster.local). See the TODO in buildSidecarOutboundVirtualHosts for the right solution
-		if useSniffing {
-			virtualHosts = getVirtualHostsForSniffedServicePort(virtualHosts, routeName)
-		}
-	}
-
+	virtualHosts := configgen.buildSidecarOutboundVirtualHosts(env, node, push, routeName, listenerPort, vHostWrapperCache, useSniffing)
 	util.SortVirtualHosts(virtualHosts)
 
-	if features.EnableFallthroughRoute.Get() {
+	// Add pass through routes for non sniffed rds routes
+	if features.EnableFallthroughRoute.Get() && !useSniffing {
 		// This needs to be the last virtual host, as routes are evaluated in order.
 		if isAllowAnyOutbound(node) {
 			virtualHosts = append(virtualHosts, &route.VirtualHost{
@@ -240,11 +217,27 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 	return out
 }
 
-func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(_ *model.Environment, node *model.Proxy, push *model.PushContext,
-	routeName string, listenerPort int) []*route.VirtualHost {
+// TODO: cleanup the kitchen sink arg list
+func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(env *model.Environment, node *model.Proxy,
+	push *model.PushContext, routeName string, listenerPort int,
+	vHostWrapperCache map[int][]istio_route.VirtualHostWrapper, sniffedRoute bool) []*route.VirtualHost {
 
+	var sniffedServiceHostname host.Name
+	var virtualHostWrappers []istio_route.VirtualHostWrapper
 	var virtualServices []model.Config
 	var services []*model.Service
+
+	// Before building the wrappers, ensure that the route name is what other pieces of code
+	// expect, i.e. its either port or unix domain socket.
+	if sniffedRoute {
+		// extract the hostname from the route name and select the service corresponding  to the hostname
+		parts := strings.Split(routeName, ":")
+		sniffedServiceHostname = host.Name(parts[0])
+		// Use the standard "port" format for route name so that we can find the appropriate
+		// sidecar egress listener and other usual stuff.
+		// We will strip the unnecessary services later in this function.
+		routeName = parts[1]
+	}
 
 	// this is a user supplied sidecar scope. Get the services from the egress listener
 	egressListener := node.SidecarScope.GetEgressListenerForRDS(listenerPort, routeName)
@@ -265,6 +258,87 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(_ *model.
 	if egressListener.IstioListener != nil && egressListener.IstioListener.Port != nil {
 		listenerPort = 0
 	}
+
+	// Check the cache for pre-computed virtual host wrappers for sniffed routes
+	virtualHostWrappers, _ = vHostWrapperCache[listenerPort]
+
+	if len(virtualHostWrappers) == 0 {
+		// Nothing found in the cache
+		virtualHostWrappers = configgen.buildSidecarOutboundVHostWrappers(env, node, push, services,
+			virtualServices, listenerPort)
+		// load the cache only for non 0 listener ports i.e. do not cache for uds or http-proxy
+		if listenerPort != 0 {
+			vHostWrapperCache[listenerPort] = virtualHostWrappers
+		}
+	}
+
+	vHostPortMap := make(map[int][]*route.VirtualHost)
+	uniques := make(map[string]struct{})
+	for _, virtualHostWrapper := range virtualHostWrappers {
+		// If none of the routes matched by source, skip this virtual host
+		if len(virtualHostWrapper.Routes) == 0 {
+			continue
+		}
+
+		virtualServiceHosts := virtualHostWrapper.VirtualServiceHosts
+		registryServices := virtualHostWrapper.Services
+		if sniffedRoute {
+			// This double loop is not that bad because virtualHostWrappers is always of length 1 except
+			// for http proxy or other unix domain sockets [in which case, sniffing is false]
+			for _, svc := range virtualHostWrapper.Services {
+				if svc.Hostname == sniffedServiceHostname {
+					registryServices = []*model.Service{svc}
+					break
+				}
+			}
+		}
+
+		virtualHosts := make([]*route.VirtualHost, 0, len(virtualServiceHosts)+len(registryServices))
+		for _, hostname := range virtualServiceHosts {
+			name := fmt.Sprintf("%s:%d", hostname, virtualHostWrapper.Port)
+			if _, found := uniques[name]; !found {
+				uniques[name] = struct{}{}
+				virtualHosts = append(virtualHosts, &route.VirtualHost{
+					Name:    name,
+					Domains: []string{hostname, fmt.Sprintf("%s:%d", hostname, virtualHostWrapper.Port)},
+					Routes:  virtualHostWrapper.Routes,
+				})
+			} else {
+				push.Add(model.DuplicatedDomains, name, node, fmt.Sprintf("duplicate domain from virtual service: %s", name))
+			}
+		}
+
+		for _, svc := range registryServices {
+			name := fmt.Sprintf("%s:%d", svc.Hostname, virtualHostWrapper.Port)
+			if _, found := uniques[name]; !found {
+				uniques[name] = struct{}{}
+				domains := generateVirtualHostDomains(svc, virtualHostWrapper.Port, node)
+				virtualHosts = append(virtualHosts, &route.VirtualHost{
+					Name:    name,
+					Domains: domains,
+					Routes:  virtualHostWrapper.Routes,
+				})
+			} else {
+				push.Add(model.DuplicatedDomains, name, node, fmt.Sprintf("duplicate domain from virtual service: %s", name))
+			}
+		}
+
+		vHostPortMap[virtualHostWrapper.Port] = append(vHostPortMap[virtualHostWrapper.Port], virtualHosts...)
+	}
+
+	var virtualHosts []*route.VirtualHost
+	if listenerPort == 0 {
+		virtualHosts = mergeAllVirtualHosts(vHostPortMap)
+	} else {
+		virtualHosts = vHostPortMap[listenerPort]
+	}
+
+	return virtualHosts
+}
+
+func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVHostWrappers(_ *model.Environment, node *model.Proxy,
+	push *model.PushContext, services []*model.Service, virtualServices []model.Config,
+	listenerPort int) []istio_route.VirtualHostWrapper {
 
 	nameToServiceMap := make(map[host.Name]*model.Service)
 	for _, svc := range services {
@@ -287,90 +361,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(_ *model.
 	}
 
 	// Get list of virtual services bound to the mesh gateway
-	virtualHostWrappers := istio_route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, nameToServiceMap,
+	return istio_route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, nameToServiceMap,
 		virtualServices, listenerPort)
-	vHostPortMap := make(map[int][]*route.VirtualHost)
-	uniques := make(map[string]struct{})
-	// TODO: pruning by appropriate hostname for a sniffed listener should happen at this level
-	// where vHostWrapper.Services has only one service matching the hostname in the routeName
-	for _, virtualHostWrapper := range virtualHostWrappers {
-		// If none of the routes matched by source, skip this virtual host
-		if len(virtualHostWrapper.Routes) == 0 {
-			continue
-		}
-
-		wildcardDomain := false
-		if listenerPort != 0 {
-			wildcardDomain = true
-		}
-
-		virtualHosts := make([]*route.VirtualHost, 0, len(virtualHostWrapper.VirtualServiceHosts)+len(virtualHostWrapper.Services))
-		for _, hostname := range virtualHostWrapper.VirtualServiceHosts {
-			name := fmt.Sprintf("%s:%d", hostname, virtualHostWrapper.Port)
-			if _, found := uniques[name]; !found {
-				uniques[name] = struct{}{}
-				virtualHosts = append(virtualHosts, &route.VirtualHost{
-					Name:    name,
-					Domains: []string{hostname, fmt.Sprintf("%s:%d", hostname, virtualHostWrapper.Port)},
-					Routes:  virtualHostWrapper.Routes,
-				})
-			} else {
-				push.Add(model.DuplicatedDomains, name, node, fmt.Sprintf("duplicate domain from virtual service: %s", name))
-			}
-		}
-
-		for _, svc := range virtualHostWrapper.Services {
-			name := fmt.Sprintf("%s:%d", svc.Hostname, virtualHostWrapper.Port)
-			if _, found := uniques[name]; !found {
-				uniques[name] = struct{}{}
-				domains := generateVirtualHostDomains(svc, virtualHostWrapper.Port, node)
-				if wildcardDomain && svc.Resolution == model.Passthrough &&
-					svc.Attributes.ServiceRegistry == string(serviceregistry.KubernetesRegistry) {
-					for _, domain := range domains {
-						domains = append(domains, wildcardDomainPrefix+domain)
-					}
-				}
-				virtualHosts = append(virtualHosts, &route.VirtualHost{
-					Name:    name,
-					Domains: domains,
-					Routes:  virtualHostWrapper.Routes,
-				})
-			} else {
-				push.Add(model.DuplicatedDomains, name, node, fmt.Sprintf("duplicate domain from virtual service: %s", name))
-			}
-		}
-
-		vHostPortMap[virtualHostWrapper.Port] = append(vHostPortMap[virtualHostWrapper.Port], virtualHosts...)
-	}
-
-	var tmpVirtualHosts []*route.VirtualHost
-	if listenerPort == 0 {
-		tmpVirtualHosts = mergeAllVirtualHosts(vHostPortMap)
-	} else {
-		tmpVirtualHosts = vHostPortMap[listenerPort]
-	}
-
-	return tmpVirtualHosts
-}
-
-// Returns the set of virtual hosts that correspond to the listener that has HTTP protocol detection
-// setup. This listener should only get the virtual hosts that correspond to this service+port and not
-// all virtual hosts that are usually supplied for 0.0.0.0:PORT.
-func getVirtualHostsForSniffedServicePort(vhosts []*route.VirtualHost, routeName string) []*route.VirtualHost {
-	var virtualHosts []*route.VirtualHost
-	for _, vh := range vhosts {
-		for _, domain := range vh.Domains {
-			if domain == routeName {
-				virtualHosts = append(virtualHosts, vh)
-				break
-			}
-		}
-	}
-
-	if len(virtualHosts) == 0 {
-		virtualHosts = vhosts
-	}
-	return virtualHosts
 }
 
 // generateVirtualHostDomains generates the set of domain matches for a service being accessed from
@@ -378,6 +370,16 @@ func getVirtualHostsForSniffedServicePort(vhosts []*route.VirtualHost, routeName
 func generateVirtualHostDomains(service *model.Service, port int, node *model.Proxy) []string {
 	domains := []string{string(service.Hostname), fmt.Sprintf("%s:%d", service.Hostname, port)}
 	domains = append(domains, generateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)...)
+	// Workaround for stateful sets in kubernetes as they are resolvable using
+	// 0.name.ns.svc.cluster.local, 1.name.ns.svc.cluster.local, etc.
+	// So  we need to tack a * to each of the vhost domains so that they become
+	// *.name.ns.svc.cluster.local
+	if service.Resolution == model.Passthrough &&
+		service.Attributes.ServiceRegistry == string(serviceregistry.KubernetesRegistry) {
+		for _, domain := range domains {
+			domains = append(domains, wildcardDomainPrefix+domain)
+		}
+	}
 
 	if len(service.Address) > 0 && service.Address != constants.UnspecifiedIP {
 		svcAddr := service.GetServiceAddressForProxy(node)

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -21,8 +21,8 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	networking "istio.io/api/networking/v1alpha3"
 
+	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter"
@@ -265,7 +265,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(env *mode
 	}
 
 	// Check the cache for pre-computed virtual host wrappers for sniffed routes
-	virtualHostWrappers, _ = vHostWrapperCache[listenerPort]
+	virtualHostWrappers = vHostWrapperCache[listenerPort]
 
 	if len(virtualHostWrappers) == 0 {
 		// Nothing found in the cache

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+
 	meshapi "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -21,12 +21,12 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	meshapi "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	istio_route "istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/host"
@@ -378,18 +378,19 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		Spec: virtualServiceSpec4,
 	}
 	// With the config above, RDS should return a valid route for the following route names
-	// port 9000 - [bookinfo.com:9999], [bookinfo.com:70] but no bookinfo.com
-	// unix://foo/bar/baz - [bookinfo.com:9999], [bookinfo.com:70] but no bookinfo.com
-	// port 8080 - [bookinfo.com:9999], [bookinfo.com:70], [test.com:8080, 8.8.8.8:8080], but no bookinfo.com or test.com
-	// port 9999 - [bookinfo.com, bookinfo.com:9999]
+	// port 9000 - [bookinfo.com:9999, *.bookinfo.com:9990], [bookinfo.com:70, *.bookinfo.com:70] but no bookinfo.com
+	// unix://foo/bar/baz - [bookinfo.com:9999, *.bookinfo.com:9999], [bookinfo.com:70, *.bookinfo.com:70] but no bookinfo.com
+	// port 8080 - [bookinfo.com:9999, *.bookinfo.com:9999], [bookinfo.com:70, *.bookinfo.com:70],
+	//             [test.com:8080, 8.8.8.8:8080], but no bookinfo.com or test.com
+	// port 9999 - [bookinfo.com, bookinfo.com:9999, *.bookinfo.com, *.bookinfo.com:9999]
 	// port 80 - [test-private.com, test-private.com:80, 9.9.9.9:80, 9.9.9.9]
 	// port 70 - [test-private.com, test-private.com:70, 9.9.9.9, 9.9.9.9:70], [bookinfo.com, bookinfo.com:70]
 
 	// Without sidecar config [same as wildcard egress listener], expect routes
-	// 9999 - [bookinfo.com, bookinfo.com:9999],
+	// 9999 - [bookinfo.com, bookinfo.com:9999, *.bookinfo.com, *.bookinfo.com:9999],
 	// 8080 - [test.com, test.com:8080, 8.8.8.8:8080, 8.8.8.8]
 	// 80 - [test-private.com, test-private.com:80, 9.9.9.9:80, 9.9.9.9]
-	// 70 - [bookinfo.com, bookinfo.com:70],[test-private.com, test-private.com:70, 9.9.9.9:70, 9.9.9.9]
+	// 70 - [bookinfo.com, bookinfo.com:70, *.bookinfo.com:70],[test-private.com, test-private.com:70, 9.9.9.9:70, 9.9.9.9]
 	cases := []struct {
 		name                  string
 		routeName             string
@@ -406,8 +407,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
 			},
 		},
 		{
@@ -416,8 +417,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
 			},
 		},
 		{
@@ -426,8 +427,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
 				"test.com:8080":     {"test.com:8080": true, "8.8.8.8:8080": true},
 			},
 		},
@@ -629,7 +630,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"test-headless.com:8888": {"test-headless.com:8888": true},
+				"test-headless.com:8888": {"test-headless.com:8888": true, "*.test-headless.com:8888": true},
 			},
 		},
 		{
@@ -638,7 +639,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfigWithRegistryOnly,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"test-headless.com:8888": {"test-headless.com:8888": true},
+				"test-headless.com:8888": {"test-headless.com:8888": true, "*.test-headless.com:8888": true},
 			},
 		},
 	}
@@ -676,8 +677,8 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 		_ = os.Setenv("PILOT_ENABLE_FALLTHROUGH_ROUTE", "1")
 	}
 
-	vHostCache := make(map[int][]*route.VirtualHost)
-	route := configgen.buildSidecarOutboundHTTPRouteConfig(&env, &proxy, env.PushContext, routeName, vHostCache)
+	vHostWrapperCache := make(map[int][]istio_route.VirtualHostWrapper)
+	route := configgen.buildSidecarOutboundHTTPRouteConfig(&env, &proxy, env.PushContext, routeName, vHostWrapperCache)
 	if route == nil {
 		t.Fatalf("got nil route for %s", routeName)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -378,18 +378,19 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		Spec: virtualServiceSpec4,
 	}
 	// With the config above, RDS should return a valid route for the following route names
-	// port 9000 - [bookinfo.com:9999], [bookinfo.com:70] but no bookinfo.com
-	// unix://foo/bar/baz - [bookinfo.com:9999], [bookinfo.com:70] but no bookinfo.com
-	// port 8080 - [bookinfo.com:9999], [bookinfo.com:70], [test.com:8080, 8.8.8.8:8080], but no bookinfo.com or test.com
-	// port 9999 - [bookinfo.com, bookinfo.com:9999]
+	// port 9000 - [bookinfo.com:9999, *.bookinfo.com:9990], [bookinfo.com:70, *.bookinfo.com:70] but no bookinfo.com
+	// unix://foo/bar/baz - [bookinfo.com:9999, *.bookinfo.com:9999], [bookinfo.com:70, *.bookinfo.com:70] but no bookinfo.com
+	// port 8080 - [bookinfo.com:9999, *.bookinfo.com:9999], [bookinfo.com:70, *.bookinfo.com:70],
+	//             [test.com:8080, 8.8.8.8:8080], but no bookinfo.com or test.com
+	// port 9999 - [bookinfo.com, bookinfo.com:9999, *.bookinfo.com, *.bookinfo.com:9999]
 	// port 80 - [test-private.com, test-private.com:80, 9.9.9.9:80, 9.9.9.9]
 	// port 70 - [test-private.com, test-private.com:70, 9.9.9.9, 9.9.9.9:70], [bookinfo.com, bookinfo.com:70]
 
 	// Without sidecar config [same as wildcard egress listener], expect routes
-	// 9999 - [bookinfo.com, bookinfo.com:9999],
+	// 9999 - [bookinfo.com, bookinfo.com:9999, *.bookinfo.com, *.bookinfo.com:9999],
 	// 8080 - [test.com, test.com:8080, 8.8.8.8:8080, 8.8.8.8]
 	// 80 - [test-private.com, test-private.com:80, 9.9.9.9:80, 9.9.9.9]
-	// 70 - [bookinfo.com, bookinfo.com:70],[test-private.com, test-private.com:70, 9.9.9.9:70, 9.9.9.9]
+	// 70 - [bookinfo.com, bookinfo.com:70, *.bookinfo.com:70],[test-private.com, test-private.com:70, 9.9.9.9:70, 9.9.9.9]
 	cases := []struct {
 		name                  string
 		routeName             string
@@ -406,8 +407,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
 			},
 		},
 		{
@@ -416,8 +417,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
 			},
 		},
 		{
@@ -426,8 +427,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
 				"test.com:8080":     {"test.com:8080": true, "8.8.8.8:8080": true},
 			},
 		},
@@ -543,6 +544,17 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			},
 		},
 		{
+			name:                  "no sidecar config - import public services from other namespaces: 70 with sniffing",
+			routeName:             "test-private.com:70",
+			sidecarConfig:         nil,
+			virtualServiceConfigs: nil,
+			expectedHosts: map[string]map[string]bool{
+				"test-private.com:70": {
+					"test-private.com": true, "test-private.com:70": true, "9.9.9.9": true, "9.9.9.9:70": true,
+				},
+			},
+		},
+		{
 			name:                  "no sidecar config - import public services from other namespaces: 80 with fallthrough",
 			routeName:             "80",
 			sidecarConfig:         nil,
@@ -629,7 +641,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"test-headless.com:8888": {"test-headless.com:8888": true},
+				"test-headless.com:8888": {"test-headless.com:8888": true, "*.test-headless.com:8888": true},
 			},
 		},
 		{
@@ -638,7 +650,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfigWithRegistryOnly,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"test-headless.com:8888": {"test-headless.com:8888": true},
+				"test-headless.com:8888": {"test-headless.com:8888": true, "*.test-headless.com:8888": true},
 			},
 		},
 	}

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	meshapi "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 
@@ -675,7 +676,8 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 		_ = os.Setenv("PILOT_ENABLE_FALLTHROUGH_ROUTE", "1")
 	}
 
-	route := configgen.buildSidecarOutboundHTTPRouteConfig(&env, &proxy, env.PushContext, routeName)
+	vHostCache := make(map[int][]*route.VirtualHost)
+	route := configgen.buildSidecarOutboundHTTPRouteConfig(&env, &proxy, env.PushContext, routeName, vHostCache)
 	if route == nil {
 		t.Fatalf("got nil route for %s", routeName)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -110,8 +110,6 @@ func BuildSidecarVirtualHostsFromConfigAndRegistry(
 	for fqdn := range missing {
 		svc := serviceRegistry[fqdn]
 		for _, port := range svc.Ports {
-			// TODO(crazyxy): When a HCM is installed in a auto listener that is bound to x.x.x.x:port (where x.x.x.x != 0.0.0.0),
-			//  then the RDS response from Pilot will return all possible hosts from that port. Not just the host for the specific service.
 			if port.Protocol.IsHTTP() || util.IsProtocolSniffingEnabledForPort(node, port) {
 				cluster := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", svc.Hostname, port.Port)
 				traceOperation := fmt.Sprintf("%s:%d/*", svc.Hostname, port.Port)


### PR DESCRIPTION
HTTP Sniffing significantly decreased Pilot performance due to
repeated re-computation of all virtual hosts for a port, while
the route only required just one. This PR fixes the performance issue.

Please note that a previous PR that prunned the virtual hosts for sniffed
ports introduced a bug : virtual services with hosts like bookinfo.com that
did not correspond to any internal service, did not appear in the list of 
virtual hosts for the sniffed port. 

This PR fixes that bug. In addition, passthrough routes were being added for sniffed RDS routes as well.  This is semantically incorrect. So I fixed that piece as well in the same PR.

Finally, for headless services, wildcard prefixed hostnames were not being generated for listeners on unix domain sockets or Sidecar Egress ports. Fixed the bug in the same PR (hence the changes in tests).

Signed-off-by: Shriram Rajagopalan <rshriram@tetrate.io>