### PR TITLE
install: helm values for tls certs in side car injector

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -45,9 +45,9 @@ spec:
 {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
-            - --caCertFile=/etc/istio/certs/root-cert.pem
-            - --tlsCertFile=/etc/istio/certs/cert-chain.pem
-            - --tlsKeyFile=/etc/istio/certs/key.pem
+            - --caCertFile={{ .Vallues.caCertFile }}
+            - --tlsCertFile={{ .Vallues.tlsCertFile }}
+            - --tlsKeyFile={{ .Vallues.tlsKeyFile }}
             - --injectConfig=/etc/istio/inject/config
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -45,9 +45,9 @@ spec:
 {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
-            - --caCertFile={{ .Vallues.caCertFile }}
-            - --tlsCertFile={{ .Vallues.tlsCertFile }}
-            - --tlsKeyFile={{ .Vallues.tlsKeyFile }}
+            - --caCertFile={{ .Values.caCertFile }}
+            - --tlsCertFile={{ .Values.tlsCertFile }}
+            - --tlsKeyFile={{ .Values.tlsKeyFile }}
             - --injectConfig=/etc/istio/inject/config
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
@@ -7,6 +7,9 @@ rollingMaxSurge: 100%
 rollingMaxUnavailable: 25%
 image: sidecar_injector
 enableNamespacesByDefault: false
+caCertFile: /etc/istio/certs/root-cert.pem
+tlsCertFile: /etc/istio/certs/cert-chain.pem
+tlsKeyFile: /etc/istio/certs/key.pem
 nodeSelector: {}
 tolerations: []
 podAnnotations: {}


### PR DESCRIPTION
Signed-off-by: Rama Chavali <rama.rao@salesforce.com>

Makes TLS certs configurable for sidecar injector via Helm values. Implements https://github.com/istio/istio/issues/15001

[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
