### PR TITLE
Show correct ip in double stack

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -155,10 +155,12 @@ var (
 				}
 			}
 
-			// Obtain all the IPs from the node
-			if ipAddrs, ok := proxy.GetPrivateIPs(context.Background()); ok {
-				log.Infof("Obtained private IP %v", ipAddrs)
-				role.IPAddresses = append(role.IPAddresses, ipAddrs...)
+			// No IP addresses provided, obtain all the IPs from the node
+			if len(role.IPAddresses) == 0 {
+				if ipAddrs, ok := proxy.GetPrivateIPs(context.Background()); ok {
+					log.Infof("Obtained private IP %v", ipAddrs)
+					role.IPAddresses = append(role.IPAddresses, ipAddrs...)
+				}
 			}
 
 			// No IP addresses provided, append 127.0.0.1 for ipv4 and ::1 for ipv6


### PR DESCRIPTION
Please provide a description for what this PR is for.

I have set up a kubernetes with double stack: ipv4 and ipv6, while a ipv6 address shows in the pod.

```text
eth0      Link encap:Ethernet  HWaddr b6:26:ea:52:73:69
          inet6 addr: fe80::b426:eaff:fe52:7369/64 Scope:Link
          inet6 addr: 2002:ac1b:ea2b:1::601:21f3/80 Scope:Global
          UP BROADCAST RUNNING MULTICAST  MTU:1460  Metric:1
          RX packets:1109619 errors:0 dropped:6 overruns:0 frame:0
          TX packets:139431 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:75673384 (75.6 MB)  TX bytes:15188041 (15.1 MB)

net0      Link encap:Ethernet  HWaddr ce:bd:d8:7b:14:56
          inet addr:6.1.33.243  Bcast:6.1.255.255  Mask:255.255.0.0
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:968800 errors:0 dropped:6 overruns:0 frame:0
          TX packets:5 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:59250783 (59.2 MB)  TX bytes:274 (274.0 B)
```

\#  kubectl get pod -o wide

```
NAME                    READY   STATUS    RESTARTS   AGE   IP                           NODE            NOMINATED NODE   READINESS GATES
echo-6485759b96-6fd6r   1/2     Running   0          14h   2002:ac1b:ea2b:1::601:21f3   192.168.2.100   <none>           <none>
```

But when a pod injected with a sidecar, envoy started with parameter "--local-address-ip-version v4" and error occured.

```
2019-09-19T07:26:55.142588Z info  Epoch 0 starting
2019-09-19T07:26:55.256310Z info  Envoy command: [-c /etc/istio/proxy/envoy-rev0.json --restart-epoch 0 --drain-time-s 45 --parent-shutdown-time-s 60 --service-cluster echo.prj-wcytest --service-node sidecar~2002:ac1b:ea2b:1::601:21f3~echo-6485759b96-6fd6r.prj-wcytest~prj-wcytest.svc.cluster.local --max-obj-name-len 189 --local-address-ip-version v4 --allow-unknown-fields -l info --component-log-level misc:error --concurrency 2]
[2019-09-19 07:26:55.269][18][warning][config] [external/envoy/source/server/options_impl.cc:193] --allow-unknown-fields is deprecated, use --allow-unknown-static-fields instead.
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:244] initializing epoch 0 (hot restart version=11.104)
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:246] statically linked extensions:
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:248]   access_loggers: envoy.file_access_log,envoy.http_grpc_access_log,envoy.wasm_access_log
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:251]   filters.http: envoy.buffer,envoy.cors,envoy.csrf,envoy.ext_authz,envoy.fault,envoy.filters.http.dynamic_forward_proxy,envoy.filters.http.grpc_http1_reverse_bridge,envoy.filters.http.header_to_metadata,envoy.filters.http.jwt_authn,envoy.filters.http.original_src,envoy.filters.http.rbac,envoy.filters.http.tap,envoy.grpc_http1_bridge,envoy.grpc_json_transcoder,envoy.grpc_web,envoy.gzip,envoy.health_check,envoy.http_dynamo_filter,envoy.ip_tagging,envoy.lua,envoy.rate_limit,envoy.router,envoy.squash,envoy.wasm,istio_authn,jwt-auth,mixer
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:254]   filters.listener: envoy.listener.http_inspector,envoy.listener.original_dst,envoy.listener.original_src,envoy.listener.proxy_protocol,envoy.listener.tls_inspector
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:257]   filters.network: envoy.client_ssl_auth,envoy.echo,envoy.ext_authz,envoy.filters.network.dubbo_proxy,envoy.filters.network.mysql_proxy,envoy.filters.network.rbac,envoy.filters.network.sni_cluster,envoy.filters.network.tcp_cluster_rewrite,envoy.filters.network.thrift_proxy,envoy.filters.network.zookeeper_proxy,envoy.http_connection_manager,envoy.mongo_proxy,envoy.ratelimit,envoy.redis_proxy,envoy.tcp_proxy,forward_downstream_sni,mixer,sni_verifier
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:259]   stat_sinks: envoy.dog_statsd,envoy.metrics_service,envoy.stat_sinks.hystrix,envoy.statsd
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:261]   tracers: envoy.dynamic.ot,envoy.lightstep,envoy.tracers.datadog,envoy.tracers.opencensus,envoy.zipkin
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:264]   transport_sockets.downstream: envoy.transport_sockets.alts,envoy.transport_sockets.tap,raw_buffer,tls
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:267]   transport_sockets.upstream: envoy.transport_sockets.alts,envoy.transport_sockets.tap,raw_buffer,tls
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:269]   wasm: envoy.wasm
[2019-09-19 07:26:55.272][18][info][main] [external/envoy/source/server/server.cc:275] buffer implementation: new
[2019-09-19 07:26:55.276][18][info][main] [external/envoy/source/server/server.cc:335] admin address: 127.0.0.1:15000
[2019-09-19 07:26:55.278][18][info][main] [external/envoy/source/server/server.cc:473] runtime: layers:
  - name: base
    static_layer:
      {}
  - name: admin
    admin_layer:
      {}
[2019-09-19 07:26:55.278][18][info][config] [external/envoy/source/server/configuration_impl.cc:62] loading 0 static secret(s)
[2019-09-19 07:26:55.278][18][info][config] [external/envoy/source/server/configuration_impl.cc:68] loading 3 cluster(s)
[2019-09-19 07:26:55.293][18][warning][config] [bazel-out/k8-opt/bin/external/envoy/source/common/config/_virtual_includes/grpc_stream_lib/common/config/grpc_stream.h:87] gRPC config stream closed: 14, no healthy upstream
[2019-09-19 07:26:55.293][18][warning][config] [bazel-out/k8-opt/bin/external/envoy/source/common/config/_virtual_includes/grpc_stream_lib/common/config/grpc_stream.h:50] Unable to establish new stream
[2019-09-19 07:26:55.293][18][info][config] [external/envoy/source/server/configuration_impl.cc:72] loading 1 listener(s)
[2019-09-19 07:26:55.294][18][info][config] [external/envoy/source/server/configuration_impl.cc:97] loading tracing configuration
[2019-09-19 07:26:55.294][18][info][config] [external/envoy/source/server/configuration_impl.cc:106]   loading tracing driver: envoy.zipkin
[2019-09-19 07:26:55.294][18][info][config] [external/envoy/source/server/configuration_impl.cc:117] loading stats sink configuration
[2019-09-19 07:26:55.295][18][info][main] [external/envoy/source/server/server.cc:558] starting main dispatch loop
[2019-09-19 07:26:55.296][18][info][upstream] [external/envoy/source/common/upstream/cluster_manager_impl.cc:143] cm init: initializing cds
[2019-09-19 07:26:56.056][18][warning][config] [bazel-out/k8-opt/bin/external/envoy/source/common/config/_virtual_includes/grpc_stream_lib/common/config/grpc_stream.h:87] gRPC config stream closed: 14, no healthy upstream
[2019-09-19 07:26:56.056][18][info][upstream] [external/envoy/source/common/upstream/cluster_manager_impl.cc:147] cm init: all clusters initialized
[2019-09-19 07:26:56.056][18][info][main] [external/envoy/source/server/server.cc:541] all clusters initialized. initializing init manager
[2019-09-19 07:26:56.056][18][warning][config] [bazel-out/k8-opt/bin/external/envoy/source/common/config/_virtual_includes/grpc_stream_lib/common/config/grpc_stream.h:50] Unable to establish new stream
[2019-09-19 07:26:56.056][18][info][config] [external/envoy/source/server/listener_manager_impl.cc:777] all dependencies initialized. starting workers
[2019-09-19 07:26:56.385][18][warning][config] [bazel-out/k8-opt/bin/external/envoy/source/common/config/_virtual_includes/grpc_stream_lib/common/config/grpc_stream.h:87] gRPC config stream closed: 14, no healthy upstream
[2019-09-19 07:26:56.385][18][warning][config] [bazel-out/k8-opt/bin/external/envoy/source/common/config/_virtual_includes/grpc_stream_lib/common/config/grpc_stream.h:50] Unable to establish new stream
[2019-09-19 07:26:56.647][18][warning][config] [bazel-out/k8-opt/bin/external/envoy/source/common/config/_virtual_includes/grpc_stream_lib/common/config/grpc_stream.h:87] gRPC config stream closed: 14, no healthy upstream
[2019-09-19 07:26:56.647][18][warning][config] [bazel-out/k8-opt/bin/external/envoy/source/common/config/_virtual_includes/grpc_stream_lib/common/config/grpc_stream.h:50] Unable to establish new stream
2019-09-19T07:26:57.581876Z info  Envoy proxy is NOT ready: config not received from Pilot (is Pilot running?): cds updates: 0 successful, 0 rejected; lds updates: 0 successful, 0 rejected
2019-09-19T07:26:59.581559Z info  Envoy proxy is NOT ready: config not received from Pilot (is Pilot running?): cds updates: 0 successful, 0 rejected; lds updates: 0 successful, 0 rejected

```

It is a IPv6 environment primary, but sidecar Identified as ipv4 environment

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ x ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
