### PR TITLE
Bump kubectl to 1.13

### DIFF
--- a/docker/Dockerfile.kubectl
+++ b/docker/Dockerfile.kubectl
@@ -5,8 +5,8 @@ ARG BASE_VERSION=latest
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
 
-# This container should only contain kubectl.  Hard-coding to use Linux K8s 1.11.1 version.
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl /usr/bin/kubectl
+# This container should only contain kubectl.  Hard-coding to use Linux K8s 1.13.10 version.
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.13.10/bin/linux/amd64/kubectl /usr/bin/kubectl
 RUN chmod +x /usr/bin/kubectl
 
 # Ensure a kubectl compatible with the container OS was used.  This is a safety


### PR DESCRIPTION
Please provide a description for what this PR is for.

Starting with istio 1.3 the following Kubernetes releases are supported: 1.13, 1.14, 1.15.
See https://preliminary.istio.io/docs/setup/

According to the kubernetes documentation we should use kubectl 1.13
> kubelet must not be newer than kube-apiserver, and may be up to two minor versions older.
https://kubernetes.io/docs/setup/release/version-skew-policy/

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
