### PR TITLE
Remove setting of sbit. Use USER command instead

### DIFF
--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -55,6 +55,7 @@ RUN useradd -m --uid 1337 istio-proxy && \
 # istio-proxy" will not match connections from those processes anymore.
 # Instead, rely on the process's effective gid being istio-proxy and create a
 # "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
+# hadolint ignore=DL3002
 USER 0:1337
 
 # The pilot-agent will bootstrap Envoy.

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -30,14 +30,6 @@ COPY envoy /usr/local/bin/envoy
 
 COPY pilot-agent /usr/local/bin/pilot-agent
 
-# pilot-agent and envoy may run with effective uid 0 in order to run envoy with
-# CAP_NET_ADMIN, so any iptables rule matching on "-m owner --uid-owner
-# istio-proxy" will not match connections from those processes anymore.
-# Instead, rely on the process's effective gid being istio-proxy and create a
-# "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
-RUN \
-  chgrp 1337 /usr/local/bin/envoy /usr/local/bin/pilot-agent && \
-  chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
 
 COPY envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 COPY envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
@@ -57,6 +49,13 @@ ADD ca-certificates.tgz /
 RUN useradd -m --uid 1337 istio-proxy && \
     echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers && \
     chown -R istio-proxy /var/lib/istio
+
+# pilot-agent and envoy may run with effective uid 0 in order to run envoy with
+# CAP_NET_ADMIN, so any iptables rule matching on "-m owner --uid-owner
+# istio-proxy" will not match connections from those processes anymore.
+# Instead, rely on the process's effective gid being istio-proxy and create a
+# "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
+USER 0:1337
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]


### PR DESCRIPTION
Please provide a description for what this PR is for.

We would like to add distroless support to the proxytproxy docker images. 

Therefore, as a first step we removed the setting of the sbit in the Dockerfile and replaced it by a USER command because chmod is not available in the distroless variant.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
