### PR TITLE
Fixed bug for headless services

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -60,6 +60,8 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(env *model.Environment, no
 	return nil
 }
 
+const wildcardDomainPrefix = "*."
+
 // buildSidecarInboundHTTPRouteConfig builds the route config with a single wildcard virtual host on the inbound path
 // TODO: trace decorators, inbound timeouts
 func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(env *model.Environment,
@@ -168,6 +170,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 				Hostname:     svc.Hostname,
 				Address:      svc.Address,
 				MeshExternal: svc.MeshExternal,
+				Resolution:   svc.Resolution,
 				Ports:        []*model.Port{svcPort},
 			}
 		}
@@ -316,6 +319,12 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 func generateVirtualHostDomains(service *model.Service, port int, node *model.Proxy) []string {
 	domains := []string{string(service.Hostname), domainName(string(service.Hostname), port)}
 	domains = append(domains, generateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)...)
+
+	if service.Resolution == model.Passthrough {
+		for _, domain := range domains {
+			domains = append(domains, wildcardDomainPrefix+domain)
+		}
+	}
 
 	if len(service.Address) > 0 && service.Address != constants.UnspecifiedIP {
 		svcAddr := service.GetServiceAddressForProxy(node)

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -354,8 +354,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
 			},
 		},
 		{
@@ -364,8 +364,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
 			},
 		},
 		{
@@ -374,8 +374,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
 				"test.com:8080":     {"test.com:8080": true, "8.8.8.8:8080": true},
 			},
 		},
@@ -418,7 +418,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true, "bookinfo.com": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "bookinfo.com": true,
+					"*.bookinfo.com:9999": true, "*.bookinfo.com": true},
 			},
 		},
 		{
@@ -441,7 +442,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 				"test-private.com:70": {
 					"test-private.com": true, "test-private.com:70": true, "9.9.9.9": true, "9.9.9.9:70": true,
 				},
-				"bookinfo.com:70": {"bookinfo.com": true, "bookinfo.com:70": true},
+				"bookinfo.com:70": {"bookinfo.com": true, "bookinfo.com:70": true,
+					"*.bookinfo.com": true, "*.bookinfo.com:70": true},
 			},
 		},
 		{
@@ -450,7 +452,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         nil,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true, "bookinfo.com": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "bookinfo.com": true,
+					"*.bookinfo.com:9999": true, "*.bookinfo.com": true},
 			},
 		},
 		{
@@ -483,7 +486,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 				"test-private.com:70": {
 					"test-private.com": true, "test-private.com:70": true, "9.9.9.9": true, "9.9.9.9:70": true,
 				},
-				"bookinfo.com:70": {"bookinfo.com": true, "bookinfo.com:70": true},
+				"bookinfo.com:70": {"bookinfo.com": true, "bookinfo.com:70": true,
+					"*.bookinfo.com": true, "*.bookinfo.com:70": true},
 			},
 		},
 		{
@@ -607,11 +611,14 @@ func buildHTTPService(hostname string, v visibility.Instance, ip, namespace stri
 		Hostname:     host.Name(hostname),
 		Address:      ip,
 		ClusterVIPs:  make(map[string]string),
-		Resolution:   model.Passthrough,
+		Resolution:   model.DNSLB,
 		Attributes: model.ServiceAttributes{
 			Namespace: namespace,
 			ExportTo:  map[visibility.Instance]bool{v: true},
 		},
+	}
+	if service.Address == wildcardIP {
+		service.Resolution = model.Passthrough
 	}
 
 	Ports := make([]*model.Port, 0)


### PR DESCRIPTION
This PR fixes a bug by extending the http route domains to include
entries in the form of *.svc such that traffic destinated for specific
pods in stateful sets can be captured appropriately.

It does not change the behavioe wrt how stateful sets are supported
as in the work done in #16845 and therefore does not have any performance
implications to be tested.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
