### PR TITLE
Remove the flaky label of sds_vault_flow test

### DIFF
--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -54,8 +54,8 @@ func TestMain(m *testing.M) {
 	// Integration test for the SDS Vault CA flow, as well as mutual TLS
 	// with the certificates issued by the SDS Vault CA flow.
 	framework.NewSuite("sds_vault_flow_test", m).
-		// TODO(https://github.com/istio/istio/issues/14364) remove flaky label
-		Label(label.CustomSetup, label.Flaky).
+		// Based on https://github.com/istio/istio/issues/14364, the flaky label is removed.
+		Label(label.CustomSetup).
 		// SDS requires Kubernetes 1.13
 		RequireEnvironmentVersion("1.13").
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -54,7 +54,6 @@ func TestMain(m *testing.M) {
 	// Integration test for the SDS Vault CA flow, as well as mutual TLS
 	// with the certificates issued by the SDS Vault CA flow.
 	framework.NewSuite("sds_vault_flow_test", m).
-		// Based on https://github.com/istio/istio/issues/14364, the flaky label is removed.
 		Label(label.CustomSetup).
 		// SDS requires Kubernetes 1.13
 		RequireEnvironmentVersion("1.13").


### PR DESCRIPTION
Based on https://github.com/istio/istio/issues/14364 and the comments in https://github.com/istio/istio/pull/16912, the flaky label of the sds_vault_flow test is removed.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X] Security
[ X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
