### PR TITLE
Fix aggregate workload labels response

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -258,7 +258,7 @@ func (c *Controller) GetProxyServiceInstances(node *model.Proxy) ([]*model.Servi
 }
 
 func (c *Controller) GetProxyWorkloadLabels(proxy *model.Proxy) (labels.Collection, error) {
-	out := make(labels.Collection, 0)
+	var out labels.Collection
 	var errs error
 	// It doesn't make sense for a single proxy to be found in more than one registry.
 	// TODO: if otherwise, warning or else what to do about it.

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -285,6 +285,20 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	}
 }
 
+func TestGetProxyWorkloadLabels(t *testing.T) {
+	// If no registries return workload labels, we must return nil, rather than an empty list.
+	// This ensures callers can distinguish between no labels, and labels not found.
+	aggregateCtl := buildMockController()
+
+	instances, err := aggregateCtl.GetProxyWorkloadLabels(&model.Proxy{IPAddresses: []string{memory.HelloInstanceV0}})
+	if err != nil {
+		t.Fatalf("GetProxyServiceInstances() encountered unexpected error: %v", err)
+	}
+	if instances != nil {
+		t.Fatalf("expected nil workload labels, got: %v", instances)
+	}
+}
+
 func TestGetProxyServiceInstancesError(t *testing.T) {
 	aggregateCtl := buildMockController()
 


### PR DESCRIPTION
Previously, aggregate controller would always return labels. If
registries failed to respond with labels, it would return an empty list.
This caused WorkloadLabels to never be updated correctly, because it was
already set (this was added as an optimization). This change properly
returns nil if there was no response, fixing the issue.

Fixes https://github.com/istio/istio/issues/16916
