### PR TITLE
Expose Citadel node agent metrics to Prometheus through Service and Prom configmap

### DIFF
--- a/install/kubernetes/helm/istio/charts/nodeagent/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/nodeagent/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # we use the normal name here (e.g. 'prometheus')
+  # as grafana is configured to use this as a data source
+  name: istio-nodeagent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "nodeagent.name" . }}
+    chart: {{ template "nodeagent.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    istio: nodeagent
+spec:
+  ports:
+    - name: http-monitoring
+      port: {{ .Values.global.monitoringPort }}
+  selector:
+    istio: nodeagent

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -111,6 +111,20 @@ data:
         action: keep
         regex: istio-citadel;http-monitoring
 
+{{- if .Values.global.sds.enabled }}
+    - job_name: 'citadel-nodeagent'
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - {{ .Release.Namespace }}
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-nodeagent;http-monitoring
+{{- end }}
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:


### PR DESCRIPTION
Citadel node agent metrics were previously accessible through the `/metrics` endpoint on `15014`, but weren't configured to export these metrics to Prometheus. This change creates a `Service` which exposes the `http-monitoring` endpoint on the `istio-nodeagent`, and configures Prom to scrape that endpoint for metrics.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
