### PR TITLE
Make metrics experimental again

### DIFF
--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -67,7 +67,7 @@ var (
 
 func podDescribeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "pod",
+		Use:   "pod <pod>",
 		Short: "Describe pods and their Istio configuration [kube-only]",
 		Long: `Analyzes pod, its Services, DestinationRules, and VirtualServices and reports
 the configuration objects that affect that pod.

--- a/istioctl/cmd/metrics_test.go
+++ b/istioctl/cmd/metrics_test.go
@@ -48,18 +48,13 @@ func TestMetricsNoPrometheus(t *testing.T) {
 
 	cases := []testCase{
 		{ // case 0
-			args:           strings.Split("metrics", " "),
+			args:           strings.Split("experimental metrics", " "),
 			expectedRegexp: regexp.MustCompile("Error: metrics requires workload name\n"),
 			wantException:  true,
 		},
 		{ // case 1
-			args:           strings.Split("metrics details", " "),
-			expectedOutput: "Error: no Prometheus pods found\n",
-			wantException:  true,
-		},
-		{ // case 2
 			args:           strings.Split("experimental metrics details", " "),
-			expectedOutput: "Error: (metrics has graduated.  Use `istioctl metrics`)\n",
+			expectedOutput: "Error: no Prometheus pods found\n",
 			wantException:  true,
 		},
 	}
@@ -76,8 +71,9 @@ func TestMetrics(t *testing.T) {
 
 	cases := []testCase{
 		{ // case 0
-			args:          strings.Split("experimental metrics details", " "),
-			wantException: true,
+			args:           strings.Split("experimental metrics details", " "),
+			expectedRegexp: regexp.MustCompile("Error: could not build port forwarder for prometheus"),
+			wantException:  true,
 		},
 	}
 

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -112,7 +112,6 @@ debug and diagnose their Istio mesh.
 
 	rootCmd.AddCommand(convertIngress())
 	rootCmd.AddCommand(dashboard())
-	rootCmd.AddCommand(metricsCmd)
 	rootCmd.AddCommand(statusCommand())
 
 	rootCmd.AddCommand(install.NewVerifyCommand())
@@ -121,7 +120,7 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(graduatedCmd("convert-ingress"))
 	experimentalCmd.AddCommand(graduatedCmd("dashboard"))
 	experimentalCmd.AddCommand(uninjectCommand())
-	experimentalCmd.AddCommand(graduatedCmd("metrics"))
+	experimentalCmd.AddCommand(metricsCmd)
 	experimentalCmd.AddCommand(describe())
 	experimentalCmd.AddCommand(addToMeshCmd())
 	experimentalCmd.AddCommand(removeFromMeshCmd())


### PR DESCRIPTION
Some folks felt `istioctl experimental metrics` is not ready to graduate.

If you like this PR remove `do-not-merge` and also cherry-pick for release-1.3.
This should go into master and release-1.3, or neither.