### PR TITLE
Add RPS threshold for average latency load-shedding

### DIFF
--- a/mixer/pkg/loadshedding/grpclatency.go
+++ b/mixer/pkg/loadshedding/grpclatency.go
@@ -29,6 +29,8 @@ const (
 	// DefaultHalfLife controls the decay rate of an individual sample.
 	DefaultHalfLife = 1 * time.Second // Impact of each sample is expected to last ~2s.
 
+	DefaultEnforcementThreshold = rate.Limit(100.0)
+
 	// GRPCLatencyEvaluatorName is the name of the gRPC Response Latency LoadEvaluator.
 	GRPCLatencyEvaluatorName = "grpcResponseLatency"
 )
@@ -41,12 +43,17 @@ var (
 // GRPCLatencyEvaluator calculates the moving average of response latency (as reported via the gRPC stats.Handler interface).
 // It then evaluates incoming requests by comparing the average response latency against a threshold.
 type GRPCLatencyEvaluator struct {
-	sampler     *rate.Limiter
-	loadAverage *exponentialMovingAverage
+	sampler                     *rate.Limiter
+	enforcementThresholdLimiter *rate.Limiter
+	loadAverage                 *exponentialMovingAverage
 }
 
 // NewGRPCLatencyEvaluator creates a new LoadEvaluator that uses an average of gRPC Response Latency.
 func NewGRPCLatencyEvaluator(sampleFrequency rate.Limit, averageHalfLife time.Duration) *GRPCLatencyEvaluator {
+	return NewGRPCLatencyEvaluatorWithThreshold(sampleFrequency, averageHalfLife, DefaultEnforcementThreshold)
+}
+
+func NewGRPCLatencyEvaluatorWithThreshold(sampleFrequency rate.Limit, averageHalfLife time.Duration, enforcementThreshold rate.Limit) *GRPCLatencyEvaluator {
 
 	sf := sampleFrequency
 	if sf == 0 {
@@ -58,9 +65,16 @@ func NewGRPCLatencyEvaluator(sampleFrequency rate.Limit, averageHalfLife time.Du
 		hl = DefaultHalfLife
 	}
 
+	thresholdLimiter := &rate.Limiter{}
+	if enforcementThreshold != 0 {
+		// allow burstiness in enforcement threshold evaluation -- up to 100% of threshold (all simultaneous requests)
+		thresholdLimiter = rate.NewLimiter(enforcementThreshold, int(enforcementThreshold))
+	}
+
 	return &GRPCLatencyEvaluator{
-		sampler:     rate.NewLimiter(sf, 1), // no need to support burstiness beyond 1 event per Allow()
-		loadAverage: newExponentialMovingAverage(hl, 0, time.Now()),
+		sampler:                     rate.NewLimiter(sf, 1), // no need to support burstiness beyond 1 event per Allow()
+		enforcementThresholdLimiter: thresholdLimiter,
+		loadAverage:                 newExponentialMovingAverage(hl, 0, time.Now()),
 	}
 }
 
@@ -71,6 +85,12 @@ func (g GRPCLatencyEvaluator) Name() string {
 
 // EvaluateAgainst implements the LoadEvaluator interface.
 func (g *GRPCLatencyEvaluator) EvaluateAgainst(ri RequestInfo, threshold float64) LoadEvaluation {
+
+	if g.enforcementThresholdLimiter.Allow() {
+		// if we haven't hit the enforcement limit, then just allow
+		return LoadEvaluation{Status: BelowThreshold}
+	}
+
 	load := g.currentLoad()
 	if load < threshold {
 		return LoadEvaluation{Status: BelowThreshold}

--- a/mixer/pkg/loadshedding/options.go
+++ b/mixer/pkg/loadshedding/options.go
@@ -57,17 +57,20 @@ type Options struct {
 	// configured maximum for a period of time. This allows for handling bursty
 	// traffic patterns. If this is set to 0, no traffic will be allowed.
 	BurstSize int
+
+	LatencyEnforcementThreshold rate.Limit
 }
 
 // DefaultOptions returns a new set of options, initialized to the defaults
 func DefaultOptions() Options {
 	return Options{
-		AverageLatencyThreshold: 0,
-		SamplesPerSecond:        DefaultSampleFrequency,
-		SampleHalfLife:          DefaultHalfLife,
-		MaxRequestsPerSecond:    0,
-		BurstSize:               0,
-		Mode:                    Disabled,
+		AverageLatencyThreshold:     0,
+		SamplesPerSecond:            DefaultSampleFrequency,
+		SampleHalfLife:              DefaultHalfLife,
+		MaxRequestsPerSecond:        0,
+		BurstSize:                   0,
+		Mode:                        Disabled,
+		LatencyEnforcementThreshold: DefaultEnforcementThreshold,
 	}
 }
 
@@ -94,6 +97,9 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().IntVarP(&o.BurstSize, "burstSize", "", 0,
 		"Number of requests that are permitted beyond the configured maximum for a period of time. Only valid when used with 'maxRequestsPerSecond'.")
+
+	cmd.PersistentFlags().VarP(newLimitValue(DefaultEnforcementThreshold, &o.LatencyEnforcementThreshold), "latencyEnforcementThreshold", "",
+		"Controls the threshold, in requests per second, above which the average latency threshold will be enforced for load-shedding")
 }
 
 type modeValue ThrottlerMode

--- a/mixer/pkg/loadshedding/options.go
+++ b/mixer/pkg/loadshedding/options.go
@@ -45,7 +45,7 @@ type Options struct {
 
 	// LatencyEnforcementThreshold is the threshold for enforcement of response
 	// latency. Above the threshold, requests will be throttled based on average
-	// respone latency. Below the threshold, no load-shedding will take place.
+	// response latency. Below the threshold, no load-shedding will take place.
 	// This provides an option for ignoring load-shedding at low request volumes
 	// while preserving the protection at volume.
 	LatencyEnforcementThreshold rate.Limit

--- a/mixer/pkg/loadshedding/options.go
+++ b/mixer/pkg/loadshedding/options.go
@@ -43,6 +43,13 @@ type Options struct {
 	// SampleHalfLife controls the decay rate of observations of response latencies.
 	SampleHalfLife time.Duration
 
+	// LatencyEnforcementThreshold is the threshold for enforcement of response
+	// latency. Above the threshold, requests will be throttled based on average
+	// respone latency. Below the threshold, no load-shedding will take place.
+	// This provides an option for ignoring load-shedding at low request volumes
+	// while preserving the protection at volume.
+	LatencyEnforcementThreshold rate.Limit
+
 	// Options for the rate limit evaluator
 
 	// MaxRequestsPerSecond controls the rate of requests over which the
@@ -57,8 +64,6 @@ type Options struct {
 	// configured maximum for a period of time. This allows for handling bursty
 	// traffic patterns. If this is set to 0, no traffic will be allowed.
 	BurstSize int
-
-	LatencyEnforcementThreshold rate.Limit
 }
 
 // DefaultOptions returns a new set of options, initialized to the defaults

--- a/mixer/pkg/loadshedding/options_test.go
+++ b/mixer/pkg/loadshedding/options_test.go
@@ -31,37 +31,43 @@ func TestOpts(t *testing.T) {
 		result  loadshedding.Options
 	}{
 		{"--loadsheddingMode logonly", loadshedding.Options{
-			Mode:             loadshedding.LogOnly,
-			SamplesPerSecond: loadshedding.DefaultSampleFrequency,
-			SampleHalfLife:   loadshedding.DefaultHalfLife,
+			Mode:                        loadshedding.LogOnly,
+			SamplesPerSecond:            loadshedding.DefaultSampleFrequency,
+			SampleHalfLife:              loadshedding.DefaultHalfLife,
+			LatencyEnforcementThreshold: loadshedding.DefaultEnforcementThreshold,
 		}},
 
 		{"--averageLatencyThreshold 1s", loadshedding.Options{
-			AverageLatencyThreshold: 1 * time.Second,
-			SamplesPerSecond:        loadshedding.DefaultSampleFrequency,
-			SampleHalfLife:          loadshedding.DefaultHalfLife,
+			AverageLatencyThreshold:     1 * time.Second,
+			SamplesPerSecond:            loadshedding.DefaultSampleFrequency,
+			SampleHalfLife:              loadshedding.DefaultHalfLife,
+			LatencyEnforcementThreshold: loadshedding.DefaultEnforcementThreshold,
 		}},
 
 		{"--latencySamplesPerSecond 1000", loadshedding.Options{
-			SamplesPerSecond: 1000,
-			SampleHalfLife:   loadshedding.DefaultHalfLife,
+			SamplesPerSecond:            1000,
+			SampleHalfLife:              loadshedding.DefaultHalfLife,
+			LatencyEnforcementThreshold: loadshedding.DefaultEnforcementThreshold,
 		}},
 
 		{"--latencySampleHalflife 10s", loadshedding.Options{
-			SamplesPerSecond: loadshedding.DefaultSampleFrequency,
-			SampleHalfLife:   10 * time.Second,
+			SamplesPerSecond:            loadshedding.DefaultSampleFrequency,
+			SampleHalfLife:              10 * time.Second,
+			LatencyEnforcementThreshold: loadshedding.DefaultEnforcementThreshold,
 		}},
 
 		{"--maxRequestsPerSecond 100", loadshedding.Options{
-			MaxRequestsPerSecond: 100,
-			SamplesPerSecond:     loadshedding.DefaultSampleFrequency,
-			SampleHalfLife:       loadshedding.DefaultHalfLife,
+			MaxRequestsPerSecond:        100,
+			SamplesPerSecond:            loadshedding.DefaultSampleFrequency,
+			SampleHalfLife:              loadshedding.DefaultHalfLife,
+			LatencyEnforcementThreshold: loadshedding.DefaultEnforcementThreshold,
 		}},
 
 		{"--burstSize 10", loadshedding.Options{
-			BurstSize:        10,
-			SamplesPerSecond: loadshedding.DefaultSampleFrequency,
-			SampleHalfLife:   loadshedding.DefaultHalfLife,
+			BurstSize:                   10,
+			SamplesPerSecond:            loadshedding.DefaultSampleFrequency,
+			SampleHalfLife:              loadshedding.DefaultHalfLife,
+			LatencyEnforcementThreshold: loadshedding.DefaultEnforcementThreshold,
 		}},
 	}
 

--- a/mixer/pkg/loadshedding/throttler.go
+++ b/mixer/pkg/loadshedding/throttler.go
@@ -15,13 +15,10 @@
 package loadshedding
 
 import (
-	"context"
 	"fmt"
 
-	"go.opencensus.io/stats"
-	"go.opencensus.io/stats/view"
-
 	"istio.io/pkg/log"
+	"istio.io/pkg/monitoring"
 )
 
 const (
@@ -71,22 +68,17 @@ var (
 		"enforce":  Enforce,
 	}
 
-	throttled = stats.Int64(
-		"loadshedding/requests_throttled",
-		"The number of requests that have been dropped by the loadshedder.",
-		stats.UnitDimensionless)
+	predictedCost = monitoring.NewSum(
+		"mixer/loadshedding/predicted_cost_shed_total",
+		"The total predicted cost of all requests that have been dropped.")
 
-	throttledView = &view.View{
-		Name:        "mixer/" + throttled.Name(),
-		Measure:     throttled,
-		Aggregation: view.Count(),
-	}
+	throttled = monitoring.NewSum(
+		"mixer/loadshedding/requests_throttled",
+		"The number of requests that have been dropped by the loadshedder.")
 )
 
 func init() {
-	if err := view.Register(throttledView); err != nil {
-		panic(err)
-	}
+	monitoring.MustRegister(throttled, predictedCost)
 }
 
 // NewThrottler builds a Throttler based on the configured options.
@@ -145,7 +137,8 @@ func (t *Throttler) Throttle(ri RequestInfo) bool {
 				scope.Infoa("LogOnly - ", msg)
 				continue
 			}
-			stats.Record(context.Background(), throttled.M(1))
+			throttled.Increment()
+			predictedCost.Record(ri.PredictedCost)
 			scope.Warn(msg)
 			return true
 		}

--- a/mixer/pkg/loadshedding/throttler.go
+++ b/mixer/pkg/loadshedding/throttler.go
@@ -104,7 +104,7 @@ func NewThrottler(opts Options) *Throttler {
 	}
 
 	if opts.AverageLatencyThreshold > 0 {
-		e := NewGRPCLatencyEvaluator(opts.SamplesPerSecond, opts.SampleHalfLife)
+		e := NewGRPCLatencyEvaluatorWithThreshold(opts.SamplesPerSecond, opts.SampleHalfLife, opts.LatencyEnforcementThreshold)
 		t.evaluators[e.Name()] = e
 		t.thresholds[e.Name()] = opts.AverageLatencyThreshold.Seconds()
 	}


### PR DESCRIPTION
This PR enables a default RPS threshold for enforcing average latency load-shedding for Mixer.

The motivation for this PR is to prevent load-shedding from occurring at low volumes (for instance, we wouldn't want a single GC-impacted slow response to cause Mixer to shed load). There had been reports of load-shedding with sustained low-volume mesh traffic. This PR provides a tool for preventing that scenarios.

It also adds a new metric for calculating the sum of the total predicted cost of a request that was load-shed. For `Report` calls, this should translate to dropped mesh requests (undimensioned). This enables operators to get a better feel for the impact of load-shedding.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
