### PR TITLE
Pilot: add protocol sniffing flag for inbound listener

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -111,8 +111,10 @@ spec:
           - name: PILOT_TRACE_SAMPLING
             value: "{{ .Values.traceSampling }}"
 {{- end }}
-          - name: PILOT_ENABLE_PROTOCOL_SNIFFING
-            value: "{{ .Values.enableProtocolSniffing }}"
+          - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
+            value: "{{ .Values.enableProtocolSniffingForOutbound }}"
+          - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
+            value: "{{ .Values.enableProtocolSniffingForInbound }}"
           resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 12 }}

--- a/install/kubernetes/helm/istio/charts/pilot/values.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/values.yaml
@@ -12,8 +12,10 @@ rollingMaxUnavailable: 25%
 image: pilot
 sidecar: true
 traceSampling: 1.0
-# if protocol sniffing is enabled. Default to true.
-enableProtocolSniffing: true
+# if protocol sniffing is enabled for outbound. Default to true.
+enableProtocolSniffingForOutbound: true
+# if protocol sniffing is enabled for inbound. Default to true.
+enableProtocolSniffingForInbound: true
 # Resources for a small pilot install
 resources:
   requests:

--- a/install/kubernetes/helm/istio/charts/pilot/values.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/values.yaml
@@ -12,9 +12,9 @@ rollingMaxUnavailable: 25%
 image: pilot
 sidecar: true
 traceSampling: 1.0
-# if protocol sniffing is enabled for outbound. Default to true.
+# if protocol sniffing is enabled for outbound
 enableProtocolSniffingForOutbound: true
-# if protocol sniffing is enabled for inbound. Default to true.
+# if protocol sniffing is enabled for inbound
 enableProtocolSniffingForInbound: false
 # Resources for a small pilot install
 resources:

--- a/install/kubernetes/helm/istio/charts/pilot/values.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/values.yaml
@@ -15,7 +15,7 @@ traceSampling: 1.0
 # if protocol sniffing is enabled for outbound. Default to true.
 enableProtocolSniffingForOutbound: true
 # if protocol sniffing is enabled for inbound. Default to true.
-enableProtocolSniffingForInbound: true
+enableProtocolSniffingForInbound: false
 # Resources for a small pilot install
 resources:
   requests:

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -180,7 +180,7 @@ var (
 
 	EnableProtocolSniffingForInbound = env.RegisterBoolVar(
 		"PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND",
-		true,
+		false,
 		"If enabled, protocol sniffing will be used for inbound listeners whose port protocol is not specified or unsupported",
 	)
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -172,16 +172,16 @@ var (
 			"and will be removed in the near future.",
 	)
 
-	EnableProtocolSniffing = env.RegisterBoolVar(
-		"PILOT_ENABLE_PROTOCOL_SNIFFING",
+	EnableProtocolSniffingForOutbound = env.RegisterBoolVar(
+		"PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND",
 		true,
-		"If enabled, protocol sniffing will be used on ports whose port protocol is not specified or unsupported",
+		"If enabled, protocol sniffing will be used for outbound listeners whose port protocol is not specified or unsupported",
 	)
 
 	EnableProtocolSniffingForInbound = env.RegisterBoolVar(
 		"PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND",
 		true,
-		"If enabled, protocol sniffing will be used for inbound listeners",
+		"If enabled, protocol sniffing will be used for inbound listeners whose port protocol is not specified or unsupported",
 	)
 
 	ScopePushes = env.RegisterBoolVar(

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -73,7 +73,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 		}
 
 		p := protocol.Parse(servers[0].Port.Protocol)
-		listenerProtocol := plugin.ModelProtocolToListenerProtocol(node, p)
+		listenerProtocol := plugin.ModelProtocolToListenerProtocol(node, p, core.TrafficDirection_OUTBOUND)
 		if p.IsHTTP() {
 			// We have a list of HTTP servers on this port. Build a single listener for the server port.
 			// We only need to look at the first server in the list as the merge logic

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -112,7 +112,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 	listenerPort := 0
 	useSniffing := false
 	var err error
-	if util.IsProtocolSniffingEnabledForNode(node) &&
+	if util.IsProtocolSniffingEnabledForOutbound(node) &&
 		!strings.HasPrefix(routeName, model.UnixAddressPrefix) {
 		index := strings.IndexRune(routeName, ':')
 		if index != -1 {

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -364,7 +364,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(
 			}
 
 			pluginParams := &plugin.InputParams{
-				ListenerProtocol:           plugin.ModelProtocolToListenerProtocol(node, endpoint.ServicePort.Protocol),
+				ListenerProtocol: plugin.ModelProtocolToListenerProtocol(node, endpoint.ServicePort.Protocol,
+					core.TrafficDirection_INBOUND),
 				DeprecatedListenerCategory: networking.EnvoyFilter_DeprecatedListenerMatch_SIDECAR_INBOUND,
 				Env:                        env,
 				Node:                       node,
@@ -447,7 +448,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(
 			// Validation ensures that the protocol specified in Sidecar.ingress
 			// is always a valid known protocol
 			pluginParams := &plugin.InputParams{
-				ListenerProtocol:           plugin.ModelProtocolToListenerProtocol(node, listenPort.Protocol),
+				ListenerProtocol: plugin.ModelProtocolToListenerProtocol(node, listenPort.Protocol,
+					core.TrafficDirection_INBOUND),
 				DeprecatedListenerCategory: networking.EnvoyFilter_DeprecatedListenerMatch_SIDECAR_INBOUND,
 				Env:                        env,
 				Node:                       node,
@@ -659,7 +661,7 @@ type outboundListenerEntry struct {
 }
 
 func protocolName(node *model.Proxy, p protocol.Instance) string {
-	switch plugin.ModelProtocolToListenerProtocol(node, p) {
+	switch plugin.ModelProtocolToListenerProtocol(node, p, core.TrafficDirection_OUTBOUND) {
 	case plugin.ListenerProtocolHTTP:
 		return "HTTP"
 	case plugin.ListenerProtocolTCP:
@@ -795,7 +797,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 
 				// The listener protocol is determined by the protocol of egress listener port.
 				pluginParams := &plugin.InputParams{
-					ListenerProtocol:           plugin.ModelProtocolToListenerProtocol(node, listenPort.Protocol),
+					ListenerProtocol: plugin.ModelProtocolToListenerProtocol(node, listenPort.Protocol,
+						core.TrafficDirection_OUTBOUND),
 					DeprecatedListenerCategory: networking.EnvoyFilter_DeprecatedListenerMatch_SIDECAR_OUTBOUND,
 					Env:                        env,
 					Node:                       node,
@@ -854,7 +857,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 
 					// The listener protocol is determined by the protocol of service port.
 					pluginParams := &plugin.InputParams{
-						ListenerProtocol:           plugin.ModelProtocolToListenerProtocol(node, servicePort.Protocol),
+						ListenerProtocol: plugin.ModelProtocolToListenerProtocol(node, servicePort.Protocol,
+							core.TrafficDirection_OUTBOUND),
 						DeprecatedListenerCategory: networking.EnvoyFilter_DeprecatedListenerMatch_SIDECAR_OUTBOUND,
 						Env:                        env,
 						Node:                       node,

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1027,7 +1027,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 			return false, nil
 		}
 
-		if !util.IsProtocolSniffingEnabledForNode(node) {
+		if !util.IsProtocolSniffingEnabledForOutbound(node) {
 			if pluginParams.Service != nil {
 				if !(*currentListenerEntry).servicePort.Protocol.IsHTTP() {
 					outboundListenerConflict{
@@ -1054,7 +1054,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 		rdsName = listenerOpts.bind // use the UDS as a rds name
 	} else {
 		if pluginParams.ListenerProtocol == plugin.ListenerProtocolAuto &&
-			util.IsProtocolSniffingEnabledForNode(node) && listenerOpts.bind != actualWildcard && pluginParams.Service != nil {
+			util.IsProtocolSniffingEnabledForOutbound(node) && listenerOpts.bind != actualWildcard && pluginParams.Service != nil {
 			rdsName = fmt.Sprintf("%s:%d", pluginParams.Service.Hostname, pluginParams.Port.Port)
 		} else {
 			rdsName = fmt.Sprintf("%d", pluginParams.Port.Port)
@@ -1141,7 +1141,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 			return false, nil
 		}
 
-		if !util.IsProtocolSniffingEnabledForNode(node) {
+		if !util.IsProtocolSniffingEnabledForOutbound(node) {
 			// Check for port collisions between TCP/TLS and HTTP (or unknown). If
 			// configured correctly, TCP/TLS ports may not collide. We'll
 			// need to do additional work to find out if there is a
@@ -1215,7 +1215,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 		}
 
 		// Check if conflict happens
-		if util.IsProtocolSniffingEnabledForNode(node) && currentListenerEntry != nil {
+		if util.IsProtocolSniffingEnabledForOutbound(node) && currentListenerEntry != nil {
 			// Build HTTP listener. If current listener entry is using HTTP or protocol sniffing,
 			// append the service. Otherwise (TCP), change current listener to use protocol sniffing.
 			if currentListenerEntry.protocol.IsHTTP() {
@@ -1236,7 +1236,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 		}
 
 		// Check if conflict happens
-		if util.IsProtocolSniffingEnabledForNode(node) && currentListenerEntry != nil {
+		if util.IsProtocolSniffingEnabledForOutbound(node) && currentListenerEntry != nil {
 			// Build TCP listener. If current listener entry is using HTTP, add a new TCP filter chain
 			// If current listener is using protocol sniffing, merge the TCP filter chains.
 			if currentListenerEntry.protocol.IsHTTP() {

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -305,7 +305,7 @@ func (builder *ListenerBuilder) buildVirtualInboundListener(
 	actualWildcard, _ := getActualWildcardAndLocalHost(node)
 	// add an extra listener that binds to the port that is the recipient of the iptables redirect
 	filterChains := newInboundPassthroughFilterChains(env, node)
-	if util.IsProtocolSniffingEnabledForNode(node) {
+	if util.IsProtocolSniffingEnabledForInbound(node) {
 		filterChains = append(filterChains, newHTTPPassThroughFilterChain(configgen, env, node, push)...)
 	}
 	builder.virtualInboundListener = &xdsapi.Listener{

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -15,9 +15,12 @@
 package v1alpha3
 
 import (
+	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"istio.io/istio/pilot/pkg/features"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
@@ -182,6 +185,9 @@ func prepareListeners(t *testing.T) []*v2.Listener {
 }
 
 func TestVirtualInboundListenerBuilder(t *testing.T) {
+	_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name) }()
+
 	// prepare
 	t.Helper()
 	listeners := prepareListeners(t)
@@ -224,6 +230,8 @@ func TestVirtualInboundListenerBuilder(t *testing.T) {
 }
 
 func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
+	_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name) }()
 	// prepare
 	t.Helper()
 	listeners := prepareListeners(t)

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -153,8 +153,8 @@ var (
 )
 
 func TestInboundListenerConfigProxyV13(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffing.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffing.Name) }()
+	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
 
 	for _, p := range []*model.Proxy{&proxy13, &proxy13HTTP10} {
 		testInboundListenerConfigV13(t, p,
@@ -169,8 +169,8 @@ func TestInboundListenerConfigProxyV13(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_HTTPWithCurrentUnknownV13(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffing.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffing.Name) }()
+	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
 
 	// The oldest service port is unknown.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
@@ -181,8 +181,8 @@ func TestOutboundListenerConflict_HTTPWithCurrentUnknownV13(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_WellKnowPortsV13(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffing.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffing.Name) }()
+	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
 
 	// The oldest service port is unknown.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
@@ -195,8 +195,8 @@ func TestOutboundListenerConflict_WellKnowPortsV13(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_TCPWithCurrentUnknownV13(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffing.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffing.Name) }()
+	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
 
 	// The oldest service port is unknown.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
@@ -207,8 +207,8 @@ func TestOutboundListenerConflict_TCPWithCurrentUnknownV13(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_UnknownWithCurrentTCPV13(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffing.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffing.Name) }()
+	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
 
 	// The oldest service port is TCP.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
@@ -219,8 +219,8 @@ func TestOutboundListenerConflict_UnknownWithCurrentTCPV13(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_UnknownWithCurrentHTTPV13(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffing.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffing.Name) }()
+	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
 
 	// The oldest service port is TCP.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
@@ -231,8 +231,8 @@ func TestOutboundListenerConflict_UnknownWithCurrentHTTPV13(t *testing.T) {
 }
 
 func TestOutboundListenerRouteV13(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffing.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffing.Name) }()
+	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
 
 	testOutboundListenerRouteV13(t,
 		buildService("test1.com", "1.2.3.4", "unknown", tnow.Add(1*time.Second)),
@@ -241,8 +241,8 @@ func TestOutboundListenerRouteV13(t *testing.T) {
 }
 
 func TestOutboundListenerConfig_WithSidecarV13(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffing.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffing.Name) }()
+	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
 
 	// Add a service and verify it's config
 	services := []*model.Service{

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -153,8 +153,8 @@ var (
 )
 
 func TestInboundListenerConfigProxyV13(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
+	_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name) }()
 
 	for _, p := range []*model.Proxy{&proxy13, &proxy13HTTP10} {
 		testInboundListenerConfigV13(t, p,

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -62,7 +62,7 @@ func ModelProtocolToListenerProtocol(node *model.Proxy, p protocol.Instance,
 				p = protocol.TCP
 			}
 		case core.TrafficDirection_OUTBOUND:
-			if !util.IsProtocolSniffingEnabledForNode(node) {
+			if !util.IsProtocolSniffingEnabledForOutbound(node) {
 				p = protocol.TCP
 			}
 		default:

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -17,6 +17,7 @@ package plugin
 import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 
@@ -51,10 +52,22 @@ const (
 )
 
 // ModelProtocolToListenerProtocol converts from a config.Protocol to its corresponding plugin.ListenerProtocol
-func ModelProtocolToListenerProtocol(node *model.Proxy, p protocol.Instance) ListenerProtocol {
+func ModelProtocolToListenerProtocol(node *model.Proxy, p protocol.Instance,
+	trafficDirection core.TrafficDirection) ListenerProtocol {
 	// If protocol sniffing is not enabled, the default value is TCP
-	if !util.IsProtocolSniffingEnabledForNode(node) && p == protocol.Unsupported {
-		p = protocol.TCP
+	if p == protocol.Unsupported {
+		switch trafficDirection {
+		case core.TrafficDirection_INBOUND:
+			if !util.IsProtocolSniffingEnabledForInbound(node) {
+				p = protocol.TCP
+			}
+		case core.TrafficDirection_OUTBOUND:
+			if !util.IsProtocolSniffingEnabledForNode(node) {
+				p = protocol.TCP
+			}
+		default:
+			// should not reach here
+		}
 	}
 
 	switch p {
@@ -66,11 +79,7 @@ func ModelProtocolToListenerProtocol(node *model.Proxy, p protocol.Instance) Lis
 	case protocol.UDP:
 		return ListenerProtocolUnknown
 	default:
-		if util.IsProtocolSniffingEnabledForNode(node) {
-			return ListenerProtocolAuto
-		}
-
-		return ListenerProtocolUnknown
+		return ListenerProtocolAuto
 	}
 }
 

--- a/pilot/pkg/networking/plugin/plugin_test.go
+++ b/pilot/pkg/networking/plugin/plugin_test.go
@@ -1,0 +1,149 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"os"
+	"testing"
+
+	"istio.io/istio/pilot/pkg/features"
+
+	"istio.io/istio/pkg/config/protocol"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+
+	"istio.io/istio/pilot/pkg/model"
+)
+
+var (
+	proxy = &model.Proxy{
+		Type:        model.SidecarProxy,
+		IPAddresses: []string{"1.1.1.1"},
+		ID:          "v0.default",
+		DNSDomain:   "default.example.org",
+		Metadata: map[string]string{
+			model.NodeMetadataConfigNamespace: "not-default",
+			"ISTIO_VERSION":                   "1.3",
+		},
+		IstioVersion:    &model.IstioVersion{Major: 1, Minor: 3},
+		ConfigNamespace: "not-default",
+	}
+)
+
+func TestModelProtocolToListenerProtocol(t *testing.T) {
+	tests := []struct {
+		name                       string
+		node                       *model.Proxy
+		protocol                   protocol.Instance
+		direction                  core.TrafficDirection
+		sniffingEnabledForInbound  bool
+		sniffingEnabledForOutbound bool
+		want                       ListenerProtocol
+	}{
+		{
+			"TCP to TCP",
+			proxy,
+			protocol.TCP,
+			core.TrafficDirection_INBOUND,
+			true,
+			true,
+			ListenerProtocolTCP,
+		},
+		{
+			"HTTP to HTTP",
+			proxy,
+			protocol.HTTP,
+			core.TrafficDirection_INBOUND,
+			true,
+			true,
+			ListenerProtocolHTTP,
+		},
+		{
+			"MySQL to TCP",
+			proxy,
+			protocol.MySQL,
+			core.TrafficDirection_INBOUND,
+			true,
+			true,
+			ListenerProtocolTCP,
+		},
+		{
+			"Inbound unknown to Auto",
+			proxy,
+			protocol.Unsupported,
+			core.TrafficDirection_INBOUND,
+			true,
+			true,
+			ListenerProtocolAuto,
+		},
+		{
+			"Outbound unknown to Auto",
+			proxy,
+			protocol.Unsupported,
+			core.TrafficDirection_OUTBOUND,
+			true,
+			true,
+			ListenerProtocolAuto,
+		},
+		{
+			"Inbound unknown to TCP",
+			proxy,
+			protocol.Unsupported,
+			core.TrafficDirection_INBOUND,
+			false,
+			true,
+			ListenerProtocolTCP,
+		},
+		{
+			"Outbound unknown to Auto (disable sniffing for inbound)",
+			proxy,
+			protocol.Unsupported,
+			core.TrafficDirection_OUTBOUND,
+			false,
+			true,
+			ListenerProtocolAuto,
+		}, {
+			"Inbound unknown to Auto (disable sniffing for outbound)",
+			proxy,
+			protocol.Unsupported,
+			core.TrafficDirection_INBOUND,
+			true,
+			false,
+			ListenerProtocolAuto,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.sniffingEnabledForInbound {
+				_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
+			} else {
+				_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "false")
+			}
+			if tt.sniffingEnabledForOutbound {
+				_ = os.Setenv(features.EnableProtocolSniffing.Name, "true")
+			} else {
+				_ = os.Setenv(features.EnableProtocolSniffing.Name, "false")
+			}
+
+			if got := ModelProtocolToListenerProtocol(tt.node, tt.protocol, tt.direction); got != tt.want {
+				t.Errorf("ModelProtocolToListenerProtocol() = %v, want %v", got, tt.want)
+			}
+
+			_ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name)
+			_ = os.Unsetenv(features.EnableProtocolSniffing.Name)
+		})
+	}
+}

--- a/pilot/pkg/networking/plugin/plugin_test.go
+++ b/pilot/pkg/networking/plugin/plugin_test.go
@@ -133,9 +133,9 @@ func TestModelProtocolToListenerProtocol(t *testing.T) {
 				_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "false")
 			}
 			if tt.sniffingEnabledForOutbound {
-				_ = os.Setenv(features.EnableProtocolSniffing.Name, "true")
+				_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
 			} else {
-				_ = os.Setenv(features.EnableProtocolSniffing.Name, "false")
+				_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "false")
 			}
 
 			if got := ModelProtocolToListenerProtocol(tt.node, tt.protocol, tt.direction); got != tt.want {
@@ -143,7 +143,7 @@ func TestModelProtocolToListenerProtocol(t *testing.T) {
 			}
 
 			_ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name)
-			_ = os.Unsetenv(features.EnableProtocolSniffing.Name)
+			_ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name)
 		})
 	}
 }

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -278,8 +278,8 @@ func IsXDSMarshalingToAnyEnabled(node *model.Proxy) bool {
 }
 
 // IsProtocolSniffingEnabled checks whether protocol sniffing is enabled.
-func IsProtocolSniffingEnabledForNode(node *model.Proxy) bool {
-	return features.EnableProtocolSniffing.Get() && IsIstioVersionGE13(node)
+func IsProtocolSniffingEnabledForOutbound(node *model.Proxy) bool {
+	return features.EnableProtocolSniffingForOutbound.Get() && IsIstioVersionGE13(node)
 }
 
 func IsProtocolSniffingEnabledForInbound(node *model.Proxy) bool {
@@ -287,7 +287,7 @@ func IsProtocolSniffingEnabledForInbound(node *model.Proxy) bool {
 }
 
 func IsProtocolSniffingEnabledForPort(node *model.Proxy, port *model.Port) bool {
-	return IsProtocolSniffingEnabledForNode(node) && port.Protocol.IsUnsupported()
+	return IsProtocolSniffingEnabledForOutbound(node) && port.Protocol.IsUnsupported()
 }
 
 // ResolveHostsInNetworksConfig will go through the Gateways addresses for all

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -38,7 +38,8 @@ import (
 
 // TestLDS using isolated namespaces
 func TestLDSIsolated(t *testing.T) {
-
+	_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name) }()
 	_, tearDown := initLocalPilotTestEnv(t)
 	defer tearDown()
 
@@ -457,6 +458,8 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 
 // TestLDS using default sidecar in root namespace
 func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
+	_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
+	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name) }()
 	server, tearDown := util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
 		args.Plugins = bootstrap.DefaultPlugins
 		args.Config.FileDir = env.IstioSrc + "/tests/testdata/networking/envoyfilter-without-service"


### PR DESCRIPTION
Add protocol sniffing flag for inbound listener. Before there was a PR for adding flag for virtual inbound listener. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
