### PR TITLE
Update istio/proxy SHA to HEAD of istio/proxy:release-1.3

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "cd3fd800f5d75b4fea8a5da0212766402bfeecf1"
+		"lastStableSHA": "48bc83d8f0582fc060ef76d5aa3d75400e739d9e"
 	},
 	{
                 "_comment": "",


### PR DESCRIPTION
Update `istio/proxy` SHA to pick up https://github.com/istio/proxy/pull/2416, which in turn picked up https://github.com/istio/envoy/pull/102.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
