### PR TITLE
added kubernetes_sd_configs parameter to values.yaml and configmap

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -180,6 +180,13 @@ data:
     - job_name: 'kubernetes-service-endpoints'
       kubernetes_sd_configs:
       - role: endpoints
+{{- if .Values.configmap.kubernetes_sd_configs.namespaces }}
+        namespaces:
+          names:
+{{- range $i, $ns := .Values.configmap.kubernetes_sd_configs.namespaces }}
+          - {{ $ns }}
+{{- end }}
+{{- end }}
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
         action: keep
@@ -209,6 +216,13 @@ data:
     - job_name: 'kubernetes-pods'
       kubernetes_sd_configs:
       - role: pod
+{{- if .Values.configmap.kubernetes_sd_configs.namespaces }}
+        namespaces:
+          names:
+{{- range $i, $ns := .Values.configmap.kubernetes_sd_configs.namespaces }}
+          - {{ $ns }}
+{{- end }}
+{{- end }}
       relabel_configs:  # If first two labels are present, pod should be scraped  by the istio-secure job.
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
@@ -247,6 +261,13 @@ data:
         insecure_skip_verify: true  # prometheus does not support secure naming.
       kubernetes_sd_configs:
       - role: pod
+  {{- if .Values.configmap.kubernetes_sd_configs.namespaces }}
+        namespaces:
+          names:
+  {{- range $i, $ns := .Values.configmap.kubernetes_sd_configs.namespaces }}
+          - {{ $ns }}
+  {{- end }}
+  {{- end }}
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -58,3 +58,7 @@ service:
 
 security:
   enabled: true
+
+configmap:
+  kubernetes_sd_configs:
+    namespaces: []


### PR DESCRIPTION
Please provide a description for what this PR is for.
This PR allows users that install Istio via helm to limit Prometheus kubernetes service discovery specifying namespaces they want Prometheus scrapes from.
If no options are specified, the default behaviour would be the same as it is today (scapes all the metrics from annotated applications).
It solves issue https://github.com/istio/istio/issues/16968

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[x] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
