### PR TITLE
improve Pilot metrics

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -595,7 +595,6 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 	if con.CDSWatch {
 		err := s.pushCds(con, pushEv.push, currentVersion)
 		if err != nil {
-			proxiesConvergeDelayCdsErrors.Record(time.Since(pushEv.start).Seconds())
 			return err
 		}
 	}
@@ -603,21 +602,18 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 	if len(con.Clusters) > 0 {
 		err := s.pushEds(pushEv.push, con, currentVersion, nil)
 		if err != nil {
-			proxiesConvergeDelayEdsErrors.Record(time.Since(pushEv.start).Seconds())
 			return err
 		}
 	}
 	if con.LDSWatch {
 		err := s.pushLds(con, pushEv.push, currentVersion)
 		if err != nil {
-			proxiesConvergeDelayLdsErrors.Record(time.Since(pushEv.start).Seconds())
 			return err
 		}
 	}
 	if len(con.Routes) > 0 {
 		err := s.pushRoute(con, pushEv.push, currentVersion)
 		if err != nil {
-			proxiesConvergeDelayRdsErrors.Record(time.Since(pushEv.start).Seconds())
 			return err
 		}
 	}

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -595,6 +595,7 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 	if con.CDSWatch {
 		err := s.pushCds(con, pushEv.push, currentVersion)
 		if err != nil {
+			proxiesConvergeDelayCdsErrors.Record(time.Since(pushEv.start).Seconds())
 			return err
 		}
 	}
@@ -602,18 +603,21 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 	if len(con.Clusters) > 0 {
 		err := s.pushEds(pushEv.push, con, currentVersion, nil)
 		if err != nil {
+			proxiesConvergeDelayEdsErrors.Record(time.Since(pushEv.start).Seconds())
 			return err
 		}
 	}
 	if con.LDSWatch {
 		err := s.pushLds(con, pushEv.push, currentVersion)
 		if err != nil {
+			proxiesConvergeDelayLdsErrors.Record(time.Since(pushEv.start).Seconds())
 			return err
 		}
 	}
 	if len(con.Routes) > 0 {
 		err := s.pushRoute(con, pushEv.push, currentVersion)
 		if err != nil {
+			proxiesConvergeDelayRdsErrors.Record(time.Since(pushEv.start).Seconds())
 			return err
 		}
 	}

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -51,10 +51,10 @@ func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, v
 	pushStart := time.Now()
 	defer func() {
 		if err != nil {
-			proxiesConvergeDelayCdsErrors.Record(time.Since(pushStart).Seconds())
-		} else {
-			proxiesConvergeDelayCds.Record(time.Since(pushStart).Seconds())
+			cdsPushErrTime.Record(time.Since(pushStart).Seconds())
+			return
 		}
+		cdsPushTime.Record(time.Since(pushStart).Seconds())
 	}()
 	rawClusters := s.generateRawClusters(con.modelNode, push)
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -643,10 +643,10 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 	pushStart := time.Now()
 	defer func() {
 		if err != nil {
-			proxiesConvergeDelayEdsErrors.Record(time.Since(pushStart).Seconds())
-		} else {
-			proxiesConvergeDelayEds.Record(time.Since(pushStart).Seconds())
+			edsPushErrTime.Record(time.Since(pushStart).Seconds())
+			return
 		}
+		edsPushTime.Record(time.Since(pushStart).Seconds())
 	}()
 	loadAssignments := make([]*xdsapi.ClusterLoadAssignment, 0)
 	endpoints := 0

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -29,10 +29,10 @@ func (s *DiscoveryServer) pushLds(con *XdsConnection, push *model.PushContext, v
 	pushStart := time.Now()
 	defer func() {
 		if err != nil {
-			proxiesConvergeDelayLdsErrors.Record(time.Since(pushStart).Seconds())
-		} else {
-			proxiesConvergeDelayLds.Record(time.Since(pushStart).Seconds())
+			ldsPushErrTime.Record(time.Since(pushStart).Seconds())
+			return
 		}
+		ldsPushTime.Record(time.Since(pushStart).Seconds())
 	}()
 
 	rawListeners := s.generateRawListeners(con, push)

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -102,6 +102,22 @@ var (
 	rdsSendErrPushes  = pushes.With(typeTag.Value("rds_senderr"))
 	rdsBuildErrPushes = pushes.With(typeTag.Value("rds_builderr"))
 
+	pushTime = monitoring.NewDistribution(
+		"pilot_xds_push_time",
+		"Total time Pilot takes to push lds, rds, cds and eds.",
+		[]float64{1, 3, 5, 10, 20, 30, 50, 100},
+		monitoring.WithLabels(typeTag),
+	)
+
+	cdsPushTime    = pushTime.With(typeTag.Value("cds"))
+	cdsPushErrTime = pushTime.With(typeTag.Value("cds_pusherr"))
+	edsPushTime    = pushTime.With(typeTag.Value("eds"))
+	edsPushErrTime = pushTime.With(typeTag.Value("eds_pusherr"))
+	ldsPushTime    = pushTime.With(typeTag.Value("lds"))
+	ldsPushErrTime = pushTime.With(typeTag.Value("lds_pusherr"))
+	rdsPushTime    = pushTime.With(typeTag.Value("rds"))
+	rdsPushErrTime = pushTime.With(typeTag.Value("rds_pusherr"))
+
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesQueueTime = monitoring.NewDistribution(
 		"pilot_proxy_queue_time",
@@ -114,12 +130,8 @@ var (
 		"pilot_proxy_convergence_time",
 		"Delay between config change and all proxies converging.",
 		[]float64{1, 3, 5, 10, 20, 30, 50, 100},
-		monitoring.WithLabels(typeTag, errTag),
+		monitoring.WithLabels(errTag),
 	)
-	proxiesConvergeDelayCds = proxiesConvergeDelay.With(typeTag.Value("cds"))
-	proxiesConvergeDelayEds = proxiesConvergeDelay.With(typeTag.Value("eds"))
-	proxiesConvergeDelayRds = proxiesConvergeDelay.With(typeTag.Value("rds"))
-	proxiesConvergeDelayLds = proxiesConvergeDelay.With(typeTag.Value("lds"))
 
 	proxiesConvergeDelayCdsErrors = proxiesConvergeDelay.With(errTag.Value("cds"))
 	proxiesConvergeDelayEdsErrors = proxiesConvergeDelay.With(errTag.Value("eds"))
@@ -174,6 +186,7 @@ func init() {
 		xdsClients,
 		xdsResponseWriteTimeouts,
 		pushes,
+		pushTime,
 		proxiesConvergeDelay,
 		proxiesQueueTime,
 		pushContextErrors,

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -114,7 +114,13 @@ var (
 		"pilot_proxy_convergence_time",
 		"Delay between config change and all proxies converging.",
 		[]float64{1, 3, 5, 10, 20, 30, 50, 100},
+		monitoring.WithLabels(typeTag, errTag),
 	)
+	proxiesConvergeDelayCds = proxiesConvergeDelay.With(typeTag.Value("cds"))
+	proxiesConvergeDelayEds = proxiesConvergeDelay.With(typeTag.Value("eds"))
+	proxiesConvergeDelayRds = proxiesConvergeDelay.With(typeTag.Value("rds"))
+	proxiesConvergeDelayLds = proxiesConvergeDelay.With(typeTag.Value("lds"))
+
 	proxiesConvergeDelayCdsErrors = proxiesConvergeDelay.With(errTag.Value("cds"))
 	proxiesConvergeDelayEdsErrors = proxiesConvergeDelay.With(errTag.Value("eds"))
 	proxiesConvergeDelayRdsErrors = proxiesConvergeDelay.With(errTag.Value("rds"))
@@ -170,10 +176,6 @@ func init() {
 		pushes,
 		proxiesConvergeDelay,
 		proxiesQueueTime,
-		proxiesConvergeDelayCdsErrors,
-		proxiesConvergeDelayEdsErrors,
-		proxiesConvergeDelayRdsErrors,
-		proxiesConvergeDelayLdsErrors,
 		pushContextErrors,
 		totalXDSInternalErrors,
 		inboundUpdates,

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -104,19 +104,15 @@ var (
 
 	pushTime = monitoring.NewDistribution(
 		"pilot_xds_push_time",
-		"Total time Pilot takes to push lds, rds, cds and eds.",
-		[]float64{1, 3, 5, 10, 20, 30, 50, 100},
+		"Total time in second Pilot takes to push lds, rds, cds and eds.",
+		[]float64{.01, .1, 1, 3, 5, 10, 20, 30},
 		monitoring.WithLabels(typeTag),
 	)
 
-	cdsPushTime    = pushTime.With(typeTag.Value("cds"))
-	cdsPushErrTime = pushTime.With(typeTag.Value("cds_pusherr"))
-	edsPushTime    = pushTime.With(typeTag.Value("eds"))
-	edsPushErrTime = pushTime.With(typeTag.Value("eds_pusherr"))
-	ldsPushTime    = pushTime.With(typeTag.Value("lds"))
-	ldsPushErrTime = pushTime.With(typeTag.Value("lds_pusherr"))
-	rdsPushTime    = pushTime.With(typeTag.Value("rds"))
-	rdsPushErrTime = pushTime.With(typeTag.Value("rds_pusherr"))
+	cdsPushTime = pushTime.With(typeTag.Value("cds"))
+	edsPushTime = pushTime.With(typeTag.Value("eds"))
+	ldsPushTime = pushTime.With(typeTag.Value("lds"))
+	rdsPushTime = pushTime.With(typeTag.Value("rds"))
 
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesQueueTime = monitoring.NewDistribution(
@@ -130,13 +126,7 @@ var (
 		"pilot_proxy_convergence_time",
 		"Delay between config change and all proxies converging.",
 		[]float64{1, 3, 5, 10, 20, 30, 50, 100},
-		monitoring.WithLabels(errTag),
 	)
-
-	proxiesConvergeDelayCdsErrors = proxiesConvergeDelay.With(errTag.Value("cds"))
-	proxiesConvergeDelayEdsErrors = proxiesConvergeDelay.With(errTag.Value("eds"))
-	proxiesConvergeDelayRdsErrors = proxiesConvergeDelay.With(errTag.Value("rds"))
-	proxiesConvergeDelayLdsErrors = proxiesConvergeDelay.With(errTag.Value("lds"))
 
 	pushContextErrors = monitoring.NewSum(
 		"pilot_xds_push_context_errors",

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -31,10 +31,10 @@ func (s *DiscoveryServer) pushRoute(con *XdsConnection, push *model.PushContext,
 	pushStart := time.Now()
 	defer func() {
 		if err != nil {
-			proxiesConvergeDelayRdsErrors.Record(time.Since(pushStart).Seconds())
-		} else {
-			proxiesConvergeDelayRds.Record(time.Since(pushStart).Seconds())
+			rdsPushErrTime.Record(time.Since(pushStart).Seconds())
+			return
 		}
+		rdsPushTime.Record(time.Since(pushStart).Seconds())
 	}()
 	rawRoutes := s.generateRawRoutes(con, push)
 	if s.DebugConfigs {


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR does three things:

1.  move `proxiesConvergeDelay` metrics inside push function with a defer function call. This ensures we won't miss a report each time we're pushing the config. With current code I find metrics reporting is missing upon the first push(e.g. https://github.com/istio/istio/blob/master/pilot/pkg/proxy/envoy/v2/ads.go#L308)

2. add `proxiesConvergeDelayCds`, `proxiesConvergeDelayEds`, `proxiesConvergeDelayLds`, `proxiesConvergeDelayRds` to report time delay of a successful xDS push(current code only records metrics when error occurs). I'm adding this metrics because there was one case during our load test showing a very slow RDS push(we reported it with https://github.com/istio/istio/pull/16688 and the issue was fixed by https://github.com/istio/istio/pull/16702). And our team is also building alert rule based on push delay(e.g. alert if push speed is too slow, even if it is succeeded)

3. fix `proxiesConvergeDelay` metric label. The current code misses label definition when the metric is defined, which makes the cds/lds/eds/rds push reporting the same metrics:
```
# HELP pilot_proxy_convergence_time Delay between config change and all proxies converging.
# TYPE pilot_proxy_convergence_time histogram
pilot_proxy_convergence_time_bucket{le="1"} 4
pilot_proxy_convergence_time_bucket{le="3"} 6
pilot_proxy_convergence_time_bucket{le="5"} 6
pilot_proxy_convergence_time_bucket{le="10"} 6
pilot_proxy_convergence_time_bucket{le="20"} 6
pilot_proxy_convergence_time_bucket{le="30"} 6
pilot_proxy_convergence_time_bucket{le="50"} 7
pilot_proxy_convergence_time_bucket{le="100"} 7
pilot_proxy_convergence_time_bucket{le="+Inf"} 7
pilot_proxy_convergence_time_sum 51.14014323100001
pilot_proxy_convergence_time_count 7
```
With this PR, the metrics looks like this for total push delay(https://github.com/istio/istio/blob/master/pilot/pkg/proxy/envoy/v2/ads.go#L624):
```
pilot_proxy_convergence_time_bucket{err="",type="",le="1"} 0
pilot_proxy_convergence_time_bucket{err="",type="",le="3"} 0
pilot_proxy_convergence_time_bucket{err="",type="",le="5"} 0
pilot_proxy_convergence_time_bucket{err="",type="",le="10"} 0
pilot_proxy_convergence_time_bucket{err="",type="",le="20"} 0
pilot_proxy_convergence_time_bucket{err="",type="",le="30"} 0
pilot_proxy_convergence_time_bucket{err="",type="",le="50"} 0
pilot_proxy_convergence_time_bucket{err="",type="",le="100"} 1
pilot_proxy_convergence_time_bucket{err="",type="",le="+Inf"} 1
pilot_proxy_convergence_time_sum{err="",type=""} 74.550786954
pilot_proxy_convergence_time_count{err="",type=""} 1
```
and looks like this for each xDS push delay:
```
pilot_proxy_convergence_time_bucket{err="",type="cds",le="1"} 2
pilot_proxy_convergence_time_bucket{err="",type="cds",le="3"} 2
pilot_proxy_convergence_time_bucket{err="",type="cds",le="5"} 2
pilot_proxy_convergence_time_bucket{err="",type="cds",le="10"} 2
pilot_proxy_convergence_time_bucket{err="",type="cds",le="20"} 2
pilot_proxy_convergence_time_bucket{err="",type="cds",le="30"} 2
pilot_proxy_convergence_time_bucket{err="",type="cds",le="50"} 2
pilot_proxy_convergence_time_bucket{err="",type="cds",le="100"} 2
pilot_proxy_convergence_time_bucket{err="",type="cds",le="+Inf"} 2
pilot_proxy_convergence_time_sum{err="",type="cds"} 0.342288341
pilot_proxy_convergence_time_count{err="",type="cds"} 2
pilot_proxy_convergence_time_bucket{err="",type="eds",le="1"} 6
pilot_proxy_convergence_time_bucket{err="",type="eds",le="3"} 7
pilot_proxy_convergence_time_bucket{err="",type="eds",le="5"} 7
pilot_proxy_convergence_time_bucket{err="",type="eds",le="10"} 8
pilot_proxy_convergence_time_bucket{err="",type="eds",le="20"} 8
pilot_proxy_convergence_time_bucket{err="",type="eds",le="30"} 8
pilot_proxy_convergence_time_bucket{err="",type="eds",le="50"} 8
pilot_proxy_convergence_time_bucket{err="",type="eds",le="100"} 8
pilot_proxy_convergence_time_bucket{err="",type="eds",le="+Inf"} 8
pilot_proxy_convergence_time_sum{err="",type="eds"} 7.649225395999999
pilot_proxy_convergence_time_count{err="",type="eds"} 8
pilot_proxy_convergence_time_bucket{err="",type="lds",le="1"} 2
pilot_proxy_convergence_time_bucket{err="",type="lds",le="3"} 2
pilot_proxy_convergence_time_bucket{err="",type="lds",le="5"} 2
pilot_proxy_convergence_time_bucket{err="",type="lds",le="10"} 2
pilot_proxy_convergence_time_bucket{err="",type="lds",le="20"} 2
pilot_proxy_convergence_time_bucket{err="",type="lds",le="30"} 2
pilot_proxy_convergence_time_bucket{err="",type="lds",le="50"} 2
pilot_proxy_convergence_time_bucket{err="",type="lds",le="100"} 2
pilot_proxy_convergence_time_bucket{err="",type="lds",le="+Inf"} 2
pilot_proxy_convergence_time_sum{err="",type="lds"} 0.546226119
pilot_proxy_convergence_time_count{err="",type="lds"} 2
pilot_proxy_convergence_time_bucket{err="",type="rds",le="1"} 0
pilot_proxy_convergence_time_bucket{err="",type="rds",le="3"} 0
pilot_proxy_convergence_time_bucket{err="",type="rds",le="5"} 0
pilot_proxy_convergence_time_bucket{err="",type="rds",le="10"} 0
pilot_proxy_convergence_time_bucket{err="",type="rds",le="20"} 0
pilot_proxy_convergence_time_bucket{err="",type="rds",le="30"} 0
pilot_proxy_convergence_time_bucket{err="",type="rds",le="50"} 2
pilot_proxy_convergence_time_bucket{err="",type="rds",le="100"} 2
pilot_proxy_convergence_time_bucket{err="",type="rds",le="+Inf"} 2
pilot_proxy_convergence_time_sum{err="",type="rds"} 80.653288679
pilot_proxy_convergence_time_count{err="",type="rds"} 2
```



And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
