### PR TITLE
use kiali 1.4 so it can pick up patches

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -5,7 +5,7 @@ enabled: false # Note that if using the demo or demo-auth yaml when installing v
 replicaCount: 1
 hub: quay.io/kiali
 image: kiali
-tag: v1.4.0
+tag: v1.4
 contextPath: /kiali # The root context path to access the Kiali UI.
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Based on recommendation from kiali team and what we have done in 1.2.

[ ] Configuration Infrastructure
[ ] Docs
[x ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
