### PR TITLE
Propagate configured cert paths into the bootstrap template

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -46,6 +46,7 @@ import (
 	"istio.io/istio/pilot/pkg/proxy"
 	envoyDiscovery "istio.io/istio/pilot/pkg/proxy/envoy"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
@@ -408,7 +409,19 @@ var (
 
 			log.Infof("PilotSAN %#v", pilotSAN)
 
-			envoyProxy := envoy.NewProxy(proxyConfig, role.ServiceNode(), proxyLogLevel, proxyComponentLogLevel, pilotSAN, role.IPAddresses, dnsRefreshRate, opts)
+			clientCert := bootstrap.ProxyCert{
+				CertChain:  tlsClientCertChain,
+				PrivateKey: tlsClientKey,
+				CACerts:    tlsClientRootCert,
+			}
+
+			serverCert := bootstrap.ProxyCert{
+				CertChain:  tlsServerCertChain,
+				PrivateKey: tlsServerKey,
+				CACerts:    tlsServerRootCert,
+			}
+
+			envoyProxy := envoy.NewProxy(proxyConfig, role.ServiceNode(), proxyLogLevel, proxyComponentLogLevel, pilotSAN, role.IPAddresses, dnsRefreshRate, clientCert, serverCert, opts)
 			agent := envoy.NewAgent(envoyProxy, envoy.DefaultRetry, features.TerminationDrainDuration())
 			watcher := envoy.NewWatcher(tlsCertsToWatch, agent.ConfigCh())
 

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -258,9 +258,22 @@ func TestGolden(t *testing.T) {
 				localEnv = append(localEnv, k+"="+v)
 			}
 
+			clientCert := ProxyCert{
+				CertChain: "/etc/cert/client-chain.pem",
+				PrivateKey: "/etc/cert/client-key.pem",
+				CACerts: "/etc/cert/client-ca.pem",
+			}
+		
+			serverCert := ProxyCert{
+				CertChain: "/etc/cert/server-chain.pem",
+				PrivateKey: "/etc/cert/server-key.pem",
+				CACerts: "/etc/cert/server-ca.pem",
+			}
+
 			fn, err := writeBootstrapForPlatform(cfg, "sidecar~1.2.3.4~foo~bar", 0, []string{
 				"spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"}, c.opts, localEnv,
-				[]string{"10.3.3.3", "10.4.4.4", "10.5.5.5", "10.6.6.6", "10.4.4.4"}, "60s", &fakePlatform{})
+				[]string{"10.3.3.3", "10.4.4.4", "10.5.5.5", "10.6.6.6", "10.4.4.4"}, "60s",
+				clientCert, serverCert, &fakePlatform{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -209,16 +209,16 @@
             "tls_certificates": [
               {
                 "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
+                  "filename": "/etc/certs/client-chain.pem"
                 },
                 "private_key": {
-                  "filename": "/etc/certs/key.pem"
+                  "filename": "/etc/certs/client-key.pem"
                 }
               }
             ],
             "validation_context": {
               "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
+                "filename": "/etc/certs/client-ca.pem"
               },
               "verify_subject_alt_name": [
                 "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -209,16 +209,16 @@
             "tls_certificates": [
               {
                 "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
+                  "filename": "/etc/certs/client-chain.pem"
                 },
                 "private_key": {
-                  "filename": "/etc/certs/key.pem"
+                  "filename": "/etc/certs/client-key.pem"
                 }
               }
             ],
             "validation_context": {
               "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
+                "filename": "/etc/certs/client-ca.pem"
               },
               "verify_subject_alt_name": [
                 "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -231,16 +231,16 @@
             "tls_certificates": [
               {
                 "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
+                  "filename": "/etc/certs/client-chain.pem"
                 },
                 "private_key": {
-                  "filename": "/etc/certs/key.pem"
+                  "filename": "/etc/certs/client-key.pem"
                 }
               }
             ],
             "validation_context": {
               "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
+                "filename": "/etc/certs/client-ca.pem"
               },
               "verify_subject_alt_name": [
                 "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -48,11 +48,15 @@ type envoy struct {
 	opts           map[string]interface{}
 	nodeIPs        []string
 	dnsRefreshRate string
+
+	clientCert bootstrap.ProxyCert
+	serverCert bootstrap.ProxyCert
 }
 
 // NewProxy creates an instance of the proxy control commands
 func NewProxy(config meshconfig.ProxyConfig, node string, logLevel string,
-	componentLogLevel string, pilotSAN []string, nodeIPs []string, dnsRefreshRate string, opts map[string]interface{}) Proxy {
+	componentLogLevel string, pilotSAN []string, nodeIPs []string, dnsRefreshRate string,
+	clientCert bootstrap.ProxyCert, serverCert bootstrap.ProxyCert, opts map[string]interface{}) Proxy {
 	// inject tracing flag for higher levels
 	var args []string
 	if logLevel != "" {
@@ -70,6 +74,9 @@ func NewProxy(config meshconfig.ProxyConfig, node string, logLevel string,
 		nodeIPs:        nodeIPs,
 		dnsRefreshRate: dnsRefreshRate,
 		opts:           opts,
+
+		clientCert: clientCert,
+		serverCert: serverCert,
 	}
 }
 
@@ -122,7 +129,7 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 		fname = drainFile
 	} else {
 		out, err := bootstrap.WriteBootstrap(
-			&e.config, e.node, epoch, e.pilotSAN, e.opts, os.Environ(), e.nodeIPs, e.dnsRefreshRate)
+			&e.config, e.node, epoch, e.pilotSAN, e.opts, os.Environ(), e.nodeIPs, e.dnsRefreshRate, e.clientCert, e.serverCert)
 		if err != nil {
 			log.Errora("Failed to generate bootstrap config: ", err)
 			os.Exit(1) // Prevent infinite loop attempting to write the file, let k8s/systemd report

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/pkg/config/mesh"
 )
 
@@ -31,6 +32,18 @@ func TestEnvoyArgs(t *testing.T) {
 	opts["sds_uds_path"] = "udspath"
 	opts["sds_token_path"] = "tokenpath"
 
+	clientCert := bootstrap.ProxyCert{
+		CertChain: "/etc/cert/client-chain.pem",
+		PrivateKey: "/etc/cert/client-key.pem",
+		CACerts: "/etc/cert/client-ca.pem",
+	}
+
+	serverCert := bootstrap.ProxyCert{
+		CertChain: "/etc/cert/server-chain.pem",
+		PrivateKey: "/etc/cert/server-key.pem",
+		CACerts: "/etc/cert/server-ca.pem",
+	}
+
 	test := &envoy{
 		config:         proxyConfig,
 		node:           "my-node",
@@ -38,6 +51,9 @@ func TestEnvoyArgs(t *testing.T) {
 		nodeIPs:        []string{"10.75.2.9", "192.168.11.18"},
 		dnsRefreshRate: "60s",
 		opts:           opts,
+
+		clientCert: clientCert,
+		serverCert: serverCert,
 	}
 
 	testProxy := NewProxy(
@@ -48,6 +64,8 @@ func TestEnvoyArgs(t *testing.T) {
 		nil,
 		[]string{"10.75.2.9", "192.168.11.18"},
 		"60s",
+		clientCert,
+		serverCert,
 		opts,
 	)
 	if !reflect.DeepEqual(testProxy, test) {

--- a/tools/hyperistio/hyperistio.go
+++ b/tools/hyperistio/hyperistio.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pilot/pkg/proxy/envoy"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	agent "istio.io/istio/pkg/bootstrap"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/test/env"
@@ -123,7 +124,12 @@ func startEnvoy() error {
 		DrainDuration:    types.DurationProto(30 * time.Second), // crash if 0
 		StatNameLength:   189,
 	}
-	cfgF, err := agent.WriteBootstrap(cfg, "sidecar~127.0.0.2~a~a", 1, []string{}, nil, os.Environ(), []string{}, "60s")
+	cert := agent.ProxyCert{
+		CertChain:  constants.DefaultCertChain,
+		PrivateKey: constants.DefaultKey,
+		CACerts:    constants.DefaultRootCert,
+	}
+	cfgF, err := agent.WriteBootstrap(cfg, "sidecar~127.0.0.2~a~a", 1, []string{}, nil, os.Environ(), []string{}, "60s", cert, cert)
 	if err != nil {
 		return err
 	}

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -304,16 +304,16 @@
             "tls_certificates": [
               {
                 "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
+                  "filename": "{{ .clientCert.CertChain}}"
                 },
                 "private_key": {
-                  "filename": "/etc/certs/key.pem"
+                  "filename": "{{ .clientCert.PrivateKey }}"
                 }
               }
             ],
             "validation_context": {
               "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
+                "filename": "{{ .clientCert.CACerts }}"
               },
               "verify_subject_alt_name": [
                 {{- range $a, $s := .pilot_SAN }}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Continuing on from #11984, this change passes the configured cert paths down to the bootstrap template. The hardcoded paths for the pilot certs have been replaced by the configured client certs. The defaults remain the same, so any users that do not set the `ISTIO_META_`-based cert config env vars will not see any changes.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
