### PR TITLE
Fix race condition in controller test

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -173,10 +173,8 @@ func newFakeController(t *testing.T) (*Controller, *FakeXdsUpdater) {
 		stop:             make(chan struct{}),
 	})
 	_ = c.AppendInstanceHandler(func(instance *model.ServiceInstance, event model.Event) {
-		t.Log("Instance event received")
 	})
 	_ = c.AppendServiceHandler(func(service *model.Service, event model.Event) {
-		t.Log("Service event received")
 	})
 	c.Env = &model.Environment{
 		Mesh: &meshconfig.MeshConfig{

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -162,7 +162,7 @@ func newLocalController(t *testing.T) (*Controller, *FakeXdsUpdater) {
 	return ctl, fx
 }
 
-func newFakeController(t *testing.T) (*Controller, *FakeXdsUpdater) {
+func newFakeController(_ *testing.T) (*Controller, *FakeXdsUpdater) {
 	fx := NewFakeXDS()
 	clientSet := fake.NewSimpleClientset()
 	c := NewController(clientSet, Options{
@@ -172,10 +172,8 @@ func newFakeController(t *testing.T) (*Controller, *FakeXdsUpdater) {
 		XDSUpdater:       fx,
 		stop:             make(chan struct{}),
 	})
-	_ = c.AppendInstanceHandler(func(instance *model.ServiceInstance, event model.Event) {
-	})
-	_ = c.AppendServiceHandler(func(service *model.Service, event model.Event) {
-	})
+	_ = c.AppendInstanceHandler(func(instance *model.ServiceInstance, event model.Event) {})
+	_ = c.AppendServiceHandler(func(service *model.Service, event model.Event) {})
 	c.Env = &model.Environment{
 		Mesh: &meshconfig.MeshConfig{
 			MixerCheckServer: "mixer",


### PR DESCRIPTION
See failure https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/17005/racetest_istio/211 from #17005

The problem is you cannot call `t.Log` after a test is complete.