### PR TITLE
Turn on race test for native integ in presubmit

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -105,7 +105,7 @@ test.integration.%.kube.presubmit: | $(JUNIT_REPORT)
 # Generate presubmit integration test targets for each component in local environment.
 test.integration.%.local.presubmit: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
-	$(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... \
+	$(GO) test -p 1 ${T} -race ./tests/integration/$(subst .,/,$*)/... \
 	--istio.test.env native --istio.test.select -postsubmit,-flaky \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))
 


### PR DESCRIPTION
This was accidentally added as postsubmit only, which means we just break stuff and don't care (for example https://github.com/istio/istio/pull/16963, which means this PR should fail until that is merged). We should have this enabled for presubmit as well