### PR TITLE
Fix multicluster values name

### DIFF
--- a/tests/e2e/framework/multicluster.go
+++ b/tests/e2e/framework/multicluster.go
@@ -112,7 +112,7 @@ func (k *KubeInfo) generateRemoteIstio(dst string, useAutoInject bool, proxyHub,
 
 	// Set the cluster id
 	config := strings.Split(k.RemoteKubeConfig, "/")
-	helmSetContent += " --set global.multicluster.clusterName=" + config[len(config)-1]
+	helmSetContent += " --set global.multiCluster.clusterName=" + config[len(config)-1]
 
 	// Enabling access log because some tests (e.g. TestGrpc) are validating
 	// based on the pods logs


### PR DESCRIPTION
This was broken in https://github.com/istio/istio/pull/16957/files when the value was update to match `values.yaml` but the usage wasn't fixed here.

Fixes https://github.com/istio/istio/issues/17023