### PR TITLE
Fallback to struct when generating SDS config

### DIFF
--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -171,7 +171,7 @@ func ConstructgRPCCallCredentials(tokenFileName, headerKey string) []*core.GrpcS
 				FromPlugin: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin{
 					Name: FileBasedMetadataPlugName,
 					ConfigType: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_Config{
-					Config: util.MessageToStruct(config)},
+						Config: util.MessageToStruct(config)},
 				},
 			},
 		},

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -131,7 +131,7 @@ func constructLocalChannelCredConfig() *core.GrpcService_GoogleGrpc_ChannelCrede
 	}
 }
 
-func constructSdsConfigHelper(metaConfig *v2alpha.FileBasedMetadataConfig) *core.ConfigSource {
+func constructSdsConfigHelper(metaConfig *v2alpha.FileBasedMetadataConfig) *core.ConfigSource { // nolint:interfacer
 	return &core.ConfigSource{
 		InitialFetchTimeout: features.InitialFetchTimeout,
 		ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{


### PR DESCRIPTION
Please provide a description for what this PR is for.
There is a Any type field in the call credential config which is within SDS config. This Any type does not support deterministic marshalling. Therefore when multiple clusters and listeners contain identical SDS config. The config serialization could return different result. When Envoy receives SDS config with such Any type, Envoy will hash the SDS config as key to register SDS client. Due to non-deterministic marshalling, Envoy could register two SDS clients for identical SDS config, and creates two SDS subscription streams to Citadel agent.

With type Any in SDS config, we still see two SDS clients sometimes. This indicates that Envoy creates two SDS clients for identical SDS config. Fallback to use struct to avoid extra SDS push over multiple connections.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

https://github.com/istio/istio/issues/16974