### PR TITLE
Implement v1beta1 authz policy conversion

### DIFF
--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -46,7 +46,8 @@ type AuthorizationPolicies struct {
 	// Maps from namespace to the v1beta1 Authorization policies.
 	namespaceToV1beta1Policies map[string][]Config
 
-	// v1beta1 policy in root namespace applies to all workloads.
+	// The name of the root namespace. Policy in the root namespace applies to workloads in all
+	// namespaces. Only used for v1beta1 Authorization policy.
 	rootNamespace string
 }
 

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -45,6 +45,9 @@ type AuthorizationPolicies struct {
 
 	// Maps from namespace to the v1beta1 Authorization policies.
 	namespaceToV1beta1Policies map[string][]Config
+
+	// v1beta1 policy in root namespace applies to all workloads.
+	rootNamespace string
 }
 
 // GetAuthorizationPolicies gets the authorization policies in the mesh.
@@ -52,6 +55,7 @@ func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) 
 	policy := &AuthorizationPolicies{
 		namespaceToV1alpha1Policies: map[string]*RolesAndBindings{},
 		namespaceToV1beta1Policies:  map[string][]Config{},
+		rootNamespace:               env.Mesh.GetRootNamespace(),
 	}
 
 	rbacConfig := env.IstioConfigStore.ClusterRbacConfig()
@@ -78,6 +82,7 @@ func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) 
 	if err != nil {
 		return nil, err
 	}
+	sortConfigByCreationTime(policies)
 	policy.addAuthorizationPolicies(policies)
 
 	return policy, nil
@@ -135,19 +140,30 @@ func (policy *AuthorizationPolicies) ListServiceRoleBindings(ns string) map[stri
 	return rolesAndBindings.Bindings
 }
 
-// ListAuthorizationPolicies returns the AuthorizationPolicy for the workload in the given namespace.
-func (policy *AuthorizationPolicies) ListAuthorizationPolicies(ns string, workloadLabels labels.Collection) []Config {
+// ListAuthorizationPolicies returns the AuthorizationPolicy for the workload in root namespace and the config namespace.
+func (policy *AuthorizationPolicies) ListAuthorizationPolicies(configNamespace string,
+	workloadLabels labels.Collection) []Config {
 	if policy == nil {
 		return nil
 	}
 
-	var ret []Config
+	var namespaces []string
+	if policy.rootNamespace != "" {
+		namespaces = append(namespaces, policy.rootNamespace)
+	}
+	// To prevent duplicate policies in case root namespace equals proxy's namespace.
+	if configNamespace != policy.rootNamespace {
+		namespaces = append(namespaces, configNamespace)
+	}
 
-	for _, config := range policy.namespaceToV1beta1Policies[ns] {
-		spec := config.Spec.(*authpb.AuthorizationPolicy)
-		selector := labels.Instance(spec.GetSelector().GetMatchLabels())
-		if workloadLabels.IsSupersetOf(selector) {
-			ret = append(ret, config)
+	var ret []Config
+	for _, ns := range namespaces {
+		for _, config := range policy.namespaceToV1beta1Policies[ns] {
+			spec := config.Spec.(*authpb.AuthorizationPolicy)
+			selector := labels.Instance(spec.GetSelector().GetMatchLabels())
+			if workloadLabels.IsSupersetOf(selector) {
+				ret = append(ret, config)
+			}
 		}
 	}
 

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -79,7 +79,7 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 		return
 	}
 
-	builder := authz_builder.NewBuilder(in.ServiceInstance, in.Node.WorkloadLabels,
+	builder := authz_builder.NewBuilder(in.ServiceInstance, in.Node.WorkloadLabels, in.Node.ConfigNamespace,
 		in.Push.AuthzPolicies, util.IsXDSMarshalingToAnyEnabled(in.Node))
 	if builder == nil {
 		return

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -15,13 +15,9 @@
 package builder
 
 import (
-	"fmt"
-
 	tcp_filter "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	http_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
 	http_filter "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	tcp_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rbac/v2"
-	envoy_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -40,8 +36,7 @@ var (
 // Builder wraps all needed information for building the RBAC filter for a service.
 type Builder struct {
 	isXDSMarshalingToAnyEnabled bool
-	v1alpha1Generator           policy.Generator
-	v1beta1Generator            policy.Generator
+	generator                   policy.Generator
 }
 
 // NewBuilder creates a builder instance that can be used to build corresponding RBAC filter config.
@@ -68,7 +63,7 @@ func NewBuilder(serviceInstance *model.ServiceInstance, workloadLabels labels.Co
 	}
 
 	if policies.IsRBACEnabled(serviceHostname, serviceNamespace) {
-		builder.v1alpha1Generator = v1alpha1.NewGenerator(serviceMetadata, policies, isGlobalPermissiveEnabled)
+		builder.generator = v1alpha1.NewGenerator(serviceMetadata, policies, isGlobalPermissiveEnabled)
 	} else {
 		rbacLog.Debugf("v1alpha1 RBAC policy disabled for service %s", serviceHostname)
 	}
@@ -76,13 +71,13 @@ func NewBuilder(serviceInstance *model.ServiceInstance, workloadLabels labels.Co
 	// TODO: support policy in root namespace.
 	matchedPolicies := policies.ListAuthorizationPolicies(serviceNamespace, workloadLabels)
 	if len(matchedPolicies) > 0 {
-		builder.v1beta1Generator = v1beta1.NewGenerator(matchedPolicies)
+		builder.generator = v1beta1.NewGenerator(matchedPolicies)
 	} else {
 		rbacLog.Debugf("v1beta1 authorization policies disabled for workload %v in %s",
 			workloadLabels, serviceNamespace)
 	}
 
-	if builder.v1alpha1Generator == nil && builder.v1beta1Generator == nil {
+	if builder.generator == nil {
 		return nil
 	}
 
@@ -95,7 +90,7 @@ func (b *Builder) BuildHTTPFilter() *http_filter.HttpFilter {
 		return nil
 	}
 
-	rbacConfig := b.generate(false /* forTCPFilter */)
+	rbacConfig := b.generator.Generate(false /* forTCPFilter */)
 	if rbacConfig == nil {
 		return nil
 	}
@@ -120,7 +115,7 @@ func (b *Builder) BuildTCPFilter() *tcp_filter.Filter {
 
 	// The build function always return the config for HTTP filter, we need to extract the
 	// generated rules and set it in the config for TCP filter.
-	config := b.generate(true /* forTCPFilter */)
+	config := b.generator.Generate(true /* forTCPFilter */)
 	if config == nil {
 		return nil
 	}
@@ -141,41 +136,4 @@ func (b *Builder) BuildTCPFilter() *tcp_filter.Filter {
 
 	rbacLog.Debugf("built tcp filter config: %v", tcpConfig)
 	return &tcpConfig
-}
-
-func (b *Builder) generate(forTCPFilter bool) *http_config.RBAC {
-	var v1alpha1Config *http_config.RBAC
-	if b.v1alpha1Generator != nil {
-		v1alpha1Config = b.v1alpha1Generator.Generate(forTCPFilter)
-		rbacLog.Debugf("generated filter config from v1alpha1 policy: %v", v1alpha1Config)
-	}
-
-	var v1beta1Config *http_config.RBAC
-	if b.v1beta1Generator != nil {
-		v1beta1Config = b.v1beta1Generator.Generate(forTCPFilter)
-		rbacLog.Debugf("generated filter config from v1beta1 policy: %v", v1beta1Config)
-	}
-
-	if v1alpha1Config == nil && v1beta1Config == nil {
-		rbacLog.Errorf("No RBAC filter config generator available")
-		return nil
-	} else if v1alpha1Config == nil {
-		return v1beta1Config
-	} else if v1beta1Config == nil {
-		return v1alpha1Config
-	}
-
-	if v1alpha1Config.Rules == nil {
-		v1alpha1Config.Rules = &envoy_rbac.RBAC{}
-	}
-	if v1alpha1Config.Rules.Policies == nil {
-		v1alpha1Config.Rules.Policies = map[string]*envoy_rbac.Policy{}
-	}
-	// Only need to merge rules, the shadow rules is not supported in v1beta1.
-	for k, v := range v1beta1Config.GetRules().GetPolicies() {
-		name := fmt.Sprintf("authz-v1beta1-merged[%s]", k)
-		v1alpha1Config.Rules.Policies[name] = v
-	}
-	rbacLog.Debugf("merged v1beta1 to v1alpha1 config: %v", v1alpha1Config)
-	return v1alpha1Config
 }

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -103,7 +103,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 			policies: []*model.Config{
 				policy.SimpleAuthzPolicy("authz-bar", "a"),
 			},
-			wantPolicies: []string{"authz-bar"},
+			wantPolicies: []string{"authz-bar[0]"},
 		},
 		{
 			name: "v1alpha1 and v1beta1",
@@ -113,7 +113,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 				policy.SimpleBinding("binding-1", "a", "role-1"),
 				policy.SimpleAuthzPolicy("authz-bar", "a"),
 			},
-			wantPolicies: []string{"role-1", "authz-v1beta1-merged[authz-bar]"},
+			wantPolicies: []string{"authz-bar[0]"},
 		},
 	}
 

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -102,8 +102,9 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 			name: "v1beta1 only",
 			policies: []*model.Config{
 				policy.SimpleAuthzPolicy("authz-bar", "a"),
+				policy.SimpleAuthzPolicy("authz-foo", "a"),
 			},
-			wantPolicies: []string{"authz-bar[0]"},
+			wantPolicies: []string{"authz-bar[0]", "authz-foo[0]"},
 		},
 		{
 			name: "v1alpha1 and v1beta1",
@@ -151,6 +152,9 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 								if _, found := rbacConfig.GetRules().GetPolicies()[want]; !found {
 									t.Errorf("got rules with policies %v but want %v", rbacConfig.GetRules().GetPolicies(), want)
 								}
+							}
+							if len(tc.wantPolicies) != len(rbacConfig.GetRules().GetPolicies()) {
+								t.Errorf("got %d policies but want %d", len(rbacConfig.GetRules().GetPolicies()), len(tc.wantPolicies))
 							}
 						}
 					}

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -119,7 +119,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		p := policy.NewAuthzPolicies(tc.policies, t)
-		b := NewBuilder(service, nil, p, tc.isXDSMarshalingToAnyEnabled)
+		b := NewBuilder(service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
 
 		got := b.BuildHTTPFilter()
 		t.Run(tc.name, func(t *testing.T) {
@@ -206,7 +206,7 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		p := policy.NewAuthzPolicies(tc.policies, t)
-		b := NewBuilder(service, nil, p, tc.isXDSMarshalingToAnyEnabled)
+		b := NewBuilder(service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
 
 		t.Run(tc.name, func(t *testing.T) {
 			got := b.BuildTCPFilter()

--- a/pilot/pkg/security/authz/model/helper.go
+++ b/pilot/pkg/security/authz/model/helper.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	istio_rbac "istio.io/api/rbac/v1alpha1"
+	security "istio.io/api/security/v1beta1"
 )
 
 func permissionTag(tag string) string {
@@ -114,6 +115,16 @@ func fullSubject(tag string) *istio_rbac.Subject {
 		NotIps:        []string{"not-ips-" + tag},
 		Properties: map[string]string{
 			"property-" + tag: "value-" + tag,
+		},
+	}
+}
+
+func newCondition(key string) *security.Condition {
+	return &security.Condition{
+		Key: key,
+		Values: []string{
+			fmt.Sprintf("value-%s-1", key),
+			fmt.Sprintf("value-%s-2", key),
 		},
 	}
 }

--- a/pilot/pkg/security/authz/model/helper.go
+++ b/pilot/pkg/security/authz/model/helper.go
@@ -50,8 +50,8 @@ func fullPermission(tag string) Permission {
 		NotPaths:   []string{"not-paths-" + tag},
 		Methods:    []string{"methods-" + tag},
 		NotMethods: []string{"not-methods-" + tag},
-		Ports:      []int32{1},
-		NotPorts:   []int32{2},
+		Ports:      []string{"1"},
+		NotPorts:   []string{"2"},
 		Constraints: []KeyValues{
 			{
 				"constraint-" + tag: []string{"value1-" + tag, "value2-" + tag},

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -161,7 +161,7 @@ func NewModel(role *istio_rbac.ServiceRole, bindings []*istio_rbac.ServiceRoleBi
 	return m
 }
 
-// NewModel constructs a Model from a single v1beta1 Rule.
+// NewModel constructs a Model from v1beta1 Rule.
 func NewModelFromV1beta1(rule *security.Rule) *Model {
 	m := &Model{}
 
@@ -189,6 +189,11 @@ func NewModelFromV1beta1(rule *security.Rule) *Model {
 			m.Principals = append(m.Principals, principal)
 		}
 	}
+	if len(rule.From) == 0 {
+		m.Principals = []Principal{{
+			AllowAll: true,
+		}}
+	}
 
 	for _, to := range rule.To {
 		if operation := to.Operation; operation != nil {
@@ -201,6 +206,11 @@ func NewModelFromV1beta1(rule *security.Rule) *Model {
 			}
 			m.Permissions = append(m.Permissions, permission)
 		}
+	}
+	if len(rule.To) == 0 {
+		m.Permissions = []Permission{{
+			AllowAll: true,
+		}}
 	}
 
 	return m

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -20,6 +20,7 @@ import (
 	envoy_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
 
 	istio_rbac "istio.io/api/rbac/v1alpha1"
+	security "istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model"
 	istiolog "istio.io/pkg/log"
 )
@@ -121,8 +122,8 @@ func NewModel(role *istio_rbac.ServiceRole, bindings []*istio_rbac.ServiceRoleBi
 		permission.NotPaths = accessRule.NotPaths
 		permission.Methods = accessRule.Methods
 		permission.NotMethods = accessRule.NotMethods
-		permission.Ports = accessRule.Ports
-		permission.NotPorts = accessRule.NotPorts
+		permission.Ports = convertPortsToString(accessRule.Ports)
+		permission.NotPorts = convertPortsToString(accessRule.NotPorts)
 
 		constraints := KeyValues{}
 		for _, constraint := range accessRule.Constraints {
@@ -154,6 +155,51 @@ func NewModel(role *istio_rbac.ServiceRole, bindings []*istio_rbac.ServiceRoleBi
 			principal.Properties = []KeyValues{property}
 
 			m.Principals = append(m.Principals, principal)
+		}
+	}
+
+	return m
+}
+
+// NewModel constructs a Model from a single v1beta1 Rule.
+func NewModelFromV1beta1(rule *security.Rule) *Model {
+	m := &Model{}
+
+	conditionsForPrincipal := make([]KeyValues, 0)
+	conditionsForPermission := make([]KeyValues, 0)
+	for _, when := range rule.When {
+		if keySupportedForPrincipal(when.Key) {
+			conditionsForPrincipal = append(conditionsForPrincipal, KeyValues{when.Key: when.Values})
+		} else if keySupportedForPermission(when.Key) {
+			conditionsForPermission = append(conditionsForPermission, KeyValues{when.Key: when.Values})
+		} else {
+			rbacLog.Errorf("ignored unsupported condition: %v", when)
+		}
+	}
+
+	for _, from := range rule.From {
+		if source := from.Source; source != nil {
+			principal := Principal{
+				IPs:               source.IpBlocks,
+				Names:             source.Principals,
+				Namespaces:        source.Namespaces,
+				RequestPrincipals: source.RequestPrincipals,
+				Properties:        conditionsForPrincipal,
+			}
+			m.Principals = append(m.Principals, principal)
+		}
+	}
+
+	for _, to := range rule.To {
+		if operation := to.Operation; operation != nil {
+			permission := Permission{
+				Methods:     operation.Methods,
+				Hosts:       operation.Hosts,
+				Ports:       operation.Ports,
+				Paths:       operation.Paths,
+				Constraints: conditionsForPermission,
+			}
+			m.Permissions = append(m.Permissions, permission)
 		}
 	}
 

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -168,9 +168,9 @@ func NewModelFromV1beta1(rule *security.Rule) *Model {
 	conditionsForPrincipal := make([]KeyValues, 0)
 	conditionsForPermission := make([]KeyValues, 0)
 	for _, when := range rule.When {
-		if keySupportedForPrincipal(when.Key) {
+		if isSupportedPrincipal(when.Key) {
 			conditionsForPrincipal = append(conditionsForPrincipal, KeyValues{when.Key: when.Values})
-		} else if keySupportedForPermission(when.Key) {
+		} else if isSupportedPermission(when.Key) {
 			conditionsForPermission = append(conditionsForPermission, KeyValues{when.Key: when.Values})
 		} else {
 			rbacLog.Errorf("ignored unsupported condition: %v", when)

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 
 	istio_rbac "istio.io/api/rbac/v1alpha1"
-
+	security "istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -119,6 +119,186 @@ func TestNewModel(t *testing.T) {
 	}
 	if !reflect.DeepEqual(*got, want) {
 		t.Errorf("got %v but want %v", *got, want)
+	}
+}
+
+func TestNewModelFromV1beta1(t *testing.T) {
+	testCases := []struct {
+		name string
+		rule *security.Rule
+		want Model
+	}{
+		{
+			name: "only from",
+			rule: &security.Rule{
+				From: []*security.Rule_From{
+					{
+						Source: &security.Source{
+							Principals: []string{"principal"},
+						},
+					},
+				},
+			},
+			want: Model{
+				Principals: []Principal{
+					{
+						Names:      []string{"principal"},
+						Properties: []KeyValues{},
+					},
+				},
+				Permissions: []Permission{
+					{
+						AllowAll: true,
+					},
+				},
+			},
+		},
+		{
+			name: "only to",
+			rule: &security.Rule{
+				To: []*security.Rule_To{
+					{
+						Operation: &security.Operation{
+							Hosts: []string{"host"},
+						},
+					},
+				},
+			},
+			want: Model{
+				Principals: []Principal{
+					{
+						AllowAll: true,
+					},
+				},
+				Permissions: []Permission{
+					{
+						Hosts:       []string{"host"},
+						Constraints: []KeyValues{},
+					},
+				},
+			},
+		},
+		{
+			name: "full rule",
+			rule: &security.Rule{
+				From: []*security.Rule_From{
+					{
+						Source: &security.Source{
+							Principals:        []string{"p1", "p2"},
+							RequestPrincipals: []string{"rp1", "rp2"},
+							IpBlocks:          []string{"1.1.1.1", "2.2.2.2"},
+							Namespaces:        []string{"ns1", "ns2"},
+						},
+					},
+					{
+						Source: &security.Source{
+							Principals: []string{"p3"},
+						},
+					},
+				},
+				To: []*security.Rule_To{
+					{
+						Operation: &security.Operation{
+							Hosts:   []string{"h1", "h2"},
+							Ports:   []string{"10", "20"},
+							Paths:   []string{"/p1", "/p2"},
+							Methods: []string{"m1", "m2"},
+						},
+					},
+					{
+						Operation: &security.Operation{
+							Hosts: []string{"h3"},
+						},
+					},
+				},
+				When: []*security.Condition{
+					newCondition(attrRequestHeader),
+					newCondition(attrSrcIP),
+					newCondition(attrSrcNamespace),
+					newCondition(attrSrcUser),
+					newCondition(attrSrcPrincipal),
+					newCondition(attrRequestPrincipal),
+					newCondition(attrRequestAudiences),
+					newCondition(attrRequestPresenter),
+					newCondition(attrRequestClaims),
+					newCondition(attrRequestClaimGroups),
+					newCondition(attrDestIP),
+					newCondition(attrDestPort),
+					newCondition(attrDestLabel),     // Should be ignored.
+					newCondition(attrDestName),      // Should be ignored.
+					newCondition(attrDestNamespace), // Should be ignored.
+					newCondition(attrDestUser),      // Should be ignored.
+					newCondition(attrConnSNI),
+				},
+			},
+			want: Model{
+				Permissions: []Permission{
+					{
+						Hosts:   []string{"h1", "h2"},
+						Paths:   []string{"/p1", "/p2"},
+						Methods: []string{"m1", "m2"},
+						Ports:   []string{"10", "20"},
+						Constraints: []KeyValues{
+							{"destination.ip": []string{"value-destination.ip-1", "value-destination.ip-2"}},
+							{"destination.port": []string{"value-destination.port-1", "value-destination.port-2"}},
+							{"connection.sni": []string{"value-connection.sni-1", "value-connection.sni-2"}},
+						},
+					},
+					{
+						Hosts: []string{"h3"},
+						Constraints: []KeyValues{
+							{"destination.ip": []string{"value-destination.ip-1", "value-destination.ip-2"}},
+							{"destination.port": []string{"value-destination.port-1", "value-destination.port-2"}},
+							{"connection.sni": []string{"value-connection.sni-1", "value-connection.sni-2"}},
+						},
+					},
+				},
+				Principals: []Principal{
+					{
+						Names:             []string{"p1", "p2"},
+						Namespaces:        []string{"ns1", "ns2"},
+						IPs:               []string{"1.1.1.1", "2.2.2.2"},
+						RequestPrincipals: []string{"rp1", "rp2"},
+						Properties: []KeyValues{
+							{"request.headers": []string{"value-request.headers-1", "value-request.headers-2"}},
+							{"source.ip": []string{"value-source.ip-1", "value-source.ip-2"}},
+							{"source.namespace": []string{"value-source.namespace-1", "value-source.namespace-2"}},
+							{"source.user": []string{"value-source.user-1", "value-source.user-2"}},
+							{"source.principal": []string{"value-source.principal-1", "value-source.principal-2"}},
+							{"request.auth.principal": []string{"value-request.auth.principal-1", "value-request.auth.principal-2"}},
+							{"request.auth.audiences": []string{"value-request.auth.audiences-1", "value-request.auth.audiences-2"}},
+							{"request.auth.presenter": []string{"value-request.auth.presenter-1", "value-request.auth.presenter-2"}},
+							{"request.auth.claims": []string{"value-request.auth.claims-1", "value-request.auth.claims-2"}},
+							{"request.auth.claims[groups]": []string{"value-request.auth.claims[groups]-1", "value-request.auth.claims[groups]-2"}},
+						},
+					},
+					{
+						Names: []string{"p3"},
+						Properties: []KeyValues{
+							{"request.headers": []string{"value-request.headers-1", "value-request.headers-2"}},
+							{"source.ip": []string{"value-source.ip-1", "value-source.ip-2"}},
+							{"source.namespace": []string{"value-source.namespace-1", "value-source.namespace-2"}},
+							{"source.user": []string{"value-source.user-1", "value-source.user-2"}},
+							{"source.principal": []string{"value-source.principal-1", "value-source.principal-2"}},
+							{"request.auth.principal": []string{"value-request.auth.principal-1", "value-request.auth.principal-2"}},
+							{"request.auth.audiences": []string{"value-request.auth.audiences-1", "value-request.auth.audiences-2"}},
+							{"request.auth.presenter": []string{"value-request.auth.presenter-1", "value-request.auth.presenter-2"}},
+							{"request.auth.claims": []string{"value-request.auth.claims-1", "value-request.auth.claims-2"}},
+							{"request.auth.claims[groups]": []string{"value-request.auth.claims[groups]-1", "value-request.auth.claims[groups]-2"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewModelFromV1beta1(tc.rule)
+			if !reflect.DeepEqual(*got, tc.want) {
+				t.Errorf("got %+v\nbut want %+v", *got, tc.want)
+			}
+		})
 	}
 }
 

--- a/pilot/pkg/security/authz/model/permission.go
+++ b/pilot/pkg/security/authz/model/permission.go
@@ -38,6 +38,7 @@ type Permission struct {
 	Ports       []string
 	NotPorts    []string
 	Constraints []KeyValues
+	AllowAll    bool
 }
 
 // Match returns True if the calling service's attributes and/or labels match to the ServiceRole constraints.
@@ -127,6 +128,11 @@ func (permission *Permission) Generate(forTCPFilter bool) (*envoy_rbac.Permissio
 		return nil, err
 	}
 	pg := permissionGenerator{}
+
+	if permission.AllowAll {
+		pg.append(permissionAny(true))
+		return pg.andPermissions(), nil
+	}
 
 	if len(permission.Hosts) > 0 {
 		permission := permissionForKeyValues(hostHeader, permission.Hosts)

--- a/pilot/pkg/security/authz/model/permission.go
+++ b/pilot/pkg/security/authz/model/permission.go
@@ -199,7 +199,8 @@ func (permission *Permission) Generate(forTCPFilter bool) (*envoy_rbac.Permissio
 	return pg.andPermissions(), nil
 }
 
-func keySupportedForPermission(key string) bool {
+// isSupportedPermission returns true if the key is supported to be used in permission.
+func isSupportedPermission(key string) bool {
 	switch {
 	case key == attrDestIP:
 	case key == attrDestPort:

--- a/pilot/pkg/security/authz/model/permission_test.go
+++ b/pilot/pkg/security/authz/model/permission_test.go
@@ -316,7 +316,7 @@ func TestPermission_Generate(t *testing.T) {
 		{
 			name: "permission with ports",
 			permission: &Permission{
-				Ports: []int32{80, 90},
+				Ports: []string{"80", "90"},
 			},
 			wantYAML: `
         andRules:
@@ -329,7 +329,7 @@ func TestPermission_Generate(t *testing.T) {
 		{
 			name: "permission with notPorts",
 			permission: &Permission{
-				NotPorts: []int32{80, 90},
+				NotPorts: []string{"80", "90"},
 			},
 			wantYAML: `
         andRules:

--- a/pilot/pkg/security/authz/model/permission_test.go
+++ b/pilot/pkg/security/authz/model/permission_test.go
@@ -209,6 +209,17 @@ func TestPermission_Generate(t *testing.T) {
           - any: true`,
 		},
 		{
+			name: "allowAll permission",
+			permission: &Permission{
+				Hosts:    []string{"ignored"},
+				AllowAll: true,
+			},
+			wantYAML: `
+        andRules:
+          rules:
+          - any: true`,
+		},
+		{
 			name: "permission with hosts",
 			permission: &Permission{
 				Hosts: []string{"host-1", "host-2"},

--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -175,7 +175,8 @@ func (principal *Principal) Generate(forTCPFilter bool) (*envoy_rbac.Principal, 
 	return pg.andPrincipals(), nil
 }
 
-func keySupportedForPrincipal(key string) bool {
+// isSupportedPrincipal returns true if the key is supported to be used in principal.
+func isSupportedPrincipal(key string) bool {
 	switch {
 	case attrSrcIP == key:
 	case attrSrcNamespace == key:

--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -30,18 +30,18 @@ import (
 )
 
 type Principal struct {
-	User          string // For backward-compatible only.
-	Names         []string
-	NotNames      []string
-	Group         string // For backward-compatible only.
-	Groups        []string
-	NotGroups     []string
-	Namespaces    []string
-	NotNamespaces []string
-	IPs           []string
-	NotIPs        []string
+	User              string // For backward-compatible only.
+	Names             []string
+	NotNames          []string
+	Group             string // For backward-compatible only.
+	Groups            []string
+	NotGroups         []string
+	Namespaces        []string
+	NotNamespaces     []string
+	IPs               []string
+	NotIPs            []string
 	RequestPrincipals []string
-	Properties    []KeyValues
+	Properties        []KeyValues
 }
 
 // ValidateForTCP checks if the principal is valid for TCP filter. A principal is not valid for TCP

--- a/pilot/pkg/security/authz/model/principal_test.go
+++ b/pilot/pkg/security/authz/model/principal_test.go
@@ -97,6 +97,17 @@ func TestPrincipal_Generate(t *testing.T) {
               any: true`,
 		},
 		{
+			name: "allowAll principal",
+			principal: &Principal{
+				Names:    []string{"ignored"},
+				AllowAll: true,
+			},
+			wantYAML: `
+        andIds:
+          ids:
+          - any: true`,
+		},
+		{
 			name: "principal with user",
 			principal: &Principal{
 				User: "user-1",
@@ -162,6 +173,31 @@ func TestPrincipal_Generate(t *testing.T) {
                     value:
                       stringMatch:
                         exact: name-2`,
+		},
+		{
+			name: "principal with requestPrincipal",
+			principal: &Principal{
+				RequestPrincipals: []string{"id-1", "id-2"},
+			},
+			wantYAML: `
+        andIds:
+          ids:
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      exact: id-1
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      exact: id-2`,
 		},
 		{
 			name: "principal with group",

--- a/pilot/pkg/security/authz/policy/helper.go
+++ b/pilot/pkg/security/authz/policy/helper.go
@@ -177,6 +177,13 @@ func SimpleAuthzPolicy(name string, namespace string) *model.Config {
 							},
 						},
 					},
+					To: []*authpb.Rule_To{
+						{
+							Operation: &authpb.Operation{
+								Methods: []string{"GET"},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
@@ -15,13 +15,16 @@
 package v1beta1
 
 import (
+	"fmt"
+
 	http_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
 	envoy_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
 
-	istiolog "istio.io/pkg/log"
-
+	istio_rbac "istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model"
+	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
 	"istio.io/istio/pilot/pkg/security/authz/policy"
+	istiolog "istio.io/pkg/log"
 )
 
 var (
@@ -47,8 +50,23 @@ func (g *v1beta1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 	}
 
 	for _, config := range g.policies {
-		// TODO(yangminzhu): Implement the full authorization v1beta1 policy.
-		rbac.Policies[config.Name] = &envoy_rbac.Policy{}
+		spec := config.Spec.(*istio_rbac.AuthorizationPolicy)
+		for i, rule := range spec.Rules {
+			if p := g.generatePolicy(rule, forTCPFilter); p != nil {
+				name := fmt.Sprintf("%s[%d]", config.Name, i)
+				rbac.Policies[name] = p
+				rbacLog.Debugf("generated policy %s for rule", name)
+			}
+		}
 	}
 	return &http_config.RBAC{Rules: rbac}
+}
+
+func (g *v1beta1Generator) generatePolicy(rule *istio_rbac.Rule, forTCPFilter bool) *envoy_rbac.Policy {
+	if rule == nil {
+		return nil
+	}
+
+	m := authz_model.NewModelFromV1beta1(rule)
+	return m.Generate(nil, forTCPFilter)
 }

--- a/tests/integration/security/rbac/testdata/v1beta1-override-v1alpha1.yaml.tmpl
+++ b/tests/integration/security/rbac/testdata/v1beta1-override-v1alpha1.yaml.tmpl
@@ -1,0 +1,54 @@
+# Enable istio RBAC
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ClusterRbacConfig
+metadata:
+  name: default
+spec:
+  mode: 'ON_WITH_INCLUSION'
+  inclusion:
+    namespaces: ["{{ .Namespace }}"]
+---
+
+# For all services in the namespace:
+# * Allow requests at path "/path-v1alpha1".
+# * Deny any other requests by default.
+
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: viewer
+spec:
+  rules:
+  - services: ["*"]
+    paths: ["/path-v1alpha1"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: viewer-binding
+spec:
+  subjects:
+  - user: "*"
+  roleRef:
+    kind: ServiceRole
+    name: "viewer"
+---
+
+# For workload b:
+# * Allow requests at path "/path-v1beta1".
+# * Deny any other requests by default.
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: viewer
+spec:
+  selector:
+    matchLabels:
+      "app": "b"
+  rules:
+  - to:
+    - operation:
+        paths: ["/path-v1beta1"]
+---

--- a/tests/integration/security/rbac/v1beta1_test.go
+++ b/tests/integration/security/rbac/v1beta1_test.go
@@ -1,0 +1,107 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rbac
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/pkg/test/util/tmpl"
+	"istio.io/istio/tests/integration/security/util/connection"
+)
+
+// TestV1Beta1_OverrideV1alpha1 tests v1beta1 authorization overrides the v1alpha1 RBAC policy for
+// a given workload.
+func TestV1Beta1_OverrideV1alpha1(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "v1beta1-override-v1alpha1",
+				Inject: true,
+			})
+			ports := []echo.Port{
+				{
+					Name:        "http",
+					Protocol:    protocol.HTTP,
+					ServicePort: 80,
+				},
+			}
+
+			var a, b, c echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, echo.Config{
+					Service:   "a",
+					Namespace: ns,
+					Ports:     ports,
+					Galley:    g,
+					Pilot:     p,
+				}).
+				With(&b, echo.Config{
+					Service:   "b",
+					Namespace: ns,
+					Ports:     ports,
+					Galley:    g,
+					Pilot:     p,
+				}).
+				With(&c, echo.Config{
+					Service:   "c",
+					Namespace: ns,
+					Ports:     ports,
+					Galley:    g,
+					Pilot:     p,
+				}).
+				BuildOrFail(t)
+
+			newTestCase := func(target echo.Instance, path string, expectAllowed bool) TestCase {
+				return TestCase{
+					Request: connection.Checker{
+						From: a,
+						Options: echo.CallOptions{
+							Target:   target,
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Path:     path,
+						},
+					},
+					ExpectAllowed: expectAllowed,
+				}
+			}
+			cases := []TestCase{
+				newTestCase(b, "/path-v1alpha1", false),
+				newTestCase(b, "/path-v1beta1", true),
+				newTestCase(c, "/path-v1alpha1", true),
+				newTestCase(c, "/path-v1beta1", false),
+			}
+
+			args := map[string]string{
+				"Namespace": ns.Name(),
+			}
+			policies := tmpl.EvaluateAllOrFail(t, args,
+				file.AsStringOrFail(t, rbacClusterConfigTmpl),
+				file.AsStringOrFail(t, "testdata/v1beta1-override-v1alpha1.yaml.tmpl"))
+			g.ApplyConfigOrFail(t, ns, policies...)
+			defer g.DeleteConfigOrFail(t, ns, policies...)
+
+			RunRBACTest(t, cases)
+		})
+}

--- a/tests/integration/security/rbac/v1beta1_test.go
+++ b/tests/integration/security/rbac/v1beta1_test.go
@@ -17,7 +17,6 @@ package rbac
 import (
 	"testing"
 
-	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -26,6 +25,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/tmpl"
+	"istio.io/istio/tests/integration/security/util"
 	"istio.io/istio/tests/integration/security/util/connection"
 )
 
@@ -39,37 +39,12 @@ func TestV1Beta1_OverrideV1alpha1(t *testing.T) {
 				Prefix: "v1beta1-override-v1alpha1",
 				Inject: true,
 			})
-			ports := []echo.Port{
-				{
-					Name:        "http",
-					Protocol:    protocol.HTTP,
-					ServicePort: 80,
-				},
-			}
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, echo.Config{
-					Service:   "a",
-					Namespace: ns,
-					Ports:     ports,
-					Galley:    g,
-					Pilot:     p,
-				}).
-				With(&b, echo.Config{
-					Service:   "b",
-					Namespace: ns,
-					Ports:     ports,
-					Galley:    g,
-					Pilot:     p,
-				}).
-				With(&c, echo.Config{
-					Service:   "c",
-					Namespace: ns,
-					Ports:     ports,
-					Galley:    g,
-					Pilot:     p,
-				}).
+				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, util.EchoConfig("c", ns, false, nil, g, p)).
 				BuildOrFail(t)
 
 			newTestCase := func(target echo.Instance, path string, expectAllowed bool) TestCase {


### PR DESCRIPTION
Please provide a description for what this PR is for.

for https://github.com/istio/istio/issues/12394

1. for a given workload, use v1beta1 policy if there is any, otherwise fallback to v1alpha1
1. support policy in root namespace
1. use proxy config namespace instead of service namespace
1. basic e2e tests that verifies the v1beta1 policy is overriding the v1alpha1 policy

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
