### PR TITLE
Turn of GO111MODULE when fetching dependency

### DIFF
--- a/prow/mason_lib.sh
+++ b/prow/mason_lib.sh
@@ -24,9 +24,8 @@ function mason_cleanup() {
 }
 
 function get_resource() {
-  go get istio.io/test-infra/boskos/cmd/mason_client
-  # TODO: Remove once submitted
-  # go install istio.io/test-infra/boskos/cmd/mason_client
+  # Turn off modules, otherwise the go.mod file will be updated
+  GO111MODULE=off go get istio.io/test-infra/boskos/cmd/mason_client
   local type="${1}"
   local owner="${2}"
   local info_path="${3}"


### PR DESCRIPTION
Running this command tampers with the go.mod, which then causes tests to
1) use the wrong versions of things 2) fail to actually resolve those
versions properly

Needed before we can upgrade to go 1.13
(https://github.com/istio/istio/issues/16635)

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
