### PR TITLE
Fix misnamed nolint comment

### DIFF
--- a/mixer/pkg/protobuf/yaml/dynamic/handler.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/handler.go
@@ -154,7 +154,7 @@ func (h *Handler) connect() (err error) {
 	if err != nil {
 		return err
 	}
-	opts = append(opts, grpc.WithBalancerName(roundrobin.Name)) // nolint:staticheck
+	opts = append(opts, grpc.WithBalancerName(roundrobin.Name)) // nolint:staticcheck
 	if h.conn, err = grpc.Dial(h.connConfig.GetAddress(), opts...); err != nil {
 		handlerLog.Errorf("Unable to connect to:%s %v", h.connConfig.GetAddress(), err)
 		return errors.WithStack(err)


### PR DESCRIPTION
linter was giving a warning about this. I assume that means it treated it as a blanked `// nolint` comment, since it did fail to lint when I just removed the comment