### PR TITLE
Replace references to 'NameSpace' with the correct 'Namespace'

### DIFF
--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const secretName string = "testSecretName"
-const secretNameSpace string = "istio-system"
+const secretNamespace string = "istio-system"
 
 var testCreateControllerCalled int32
 var testDeleteControllerCalled int32
@@ -49,7 +49,7 @@ func createMultiClusterSecret(k8s *fake.Clientset) error {
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
-			Namespace: secretNameSpace,
+			Namespace: secretNamespace,
 			Labels: map[string]string{
 				MultiClusterSecretLabel: "true",
 			},
@@ -59,14 +59,14 @@ func createMultiClusterSecret(k8s *fake.Clientset) error {
 
 	data["testRemoteCluster"] = []byte("Test")
 	secret.Data = data
-	_, err := k8s.CoreV1().Secrets(secretNameSpace).Create(&secret)
+	_, err := k8s.CoreV1().Secrets(secretNamespace).Create(&secret)
 	return err
 }
 
 func deleteMultiClusterSecret(k8s *fake.Clientset) error {
 	var immediate int64
 
-	return k8s.CoreV1().Secrets(secretNameSpace).Delete(
+	return k8s.CoreV1().Secrets(secretNamespace).Delete(
 		secretName, &metav1.DeleteOptions{GracePeriodSeconds: &immediate})
 }
 
@@ -103,7 +103,7 @@ func Test_SecretController(t *testing.T) {
 
 	// Start the secret controller and sleep to allow secret process to start.
 	err := StartSecretController(
-		clientset, testCreateController, testDeleteController, secretNameSpace)
+		clientset, testCreateController, testDeleteController, secretNamespace)
 	if err != nil {
 		t.Fatalf("Could not start secret controller: %v", err)
 	}

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher.go
@@ -52,8 +52,8 @@ const (
 	// The ID/name for the k8sKey in kubernetes tls secret.
 	tlsScrtKey = "tls.key"
 
-	// IngressSecretNameSpace the namespace of kubernetes secrets to watch.
-	ingressSecretNameSpace = "INGRESS_GATEWAY_NAMESPACE"
+	// IngressSecretNamespace the namespace of kubernetes secrets to watch.
+	ingressSecretNamespace = "INGRESS_GATEWAY_NAMESPACE"
 
 	// IngressGatewaySdsCaSuffix is the suffix of the sds resource name for root CA. All resource
 	// names for ingress gateway root certs end with "-cacert".
@@ -152,7 +152,7 @@ func (sf *SecretFetcher) Run(ch chan struct{}) {
 	cache.WaitForCacheSync(ch, sf.scrtController.HasSynced)
 }
 
-var namespaceVar = env.RegisterStringVar(ingressSecretNameSpace, "", "")
+var namespaceVar = env.RegisterStringVar(ingressSecretNamespace, "", "")
 
 // InitWithKubeClient initializes SecretFetcher to watch kubernetes secrets.
 func (sf *SecretFetcher) InitWithKubeClient(core corev1.CoreV1Interface) { // nolint:interfacer

--- a/security/tests/integration/certificateRotationTest/certificate_rotation_test.go
+++ b/security/tests/integration/certificateRotationTest/certificate_rotation_test.go
@@ -44,7 +44,7 @@ var (
 
 func TestCertificateRotation(t *testing.T) {
 	// Create Istio CA with short lifetime certificates
-	initialSecret, err := integration.WaitForSecretExist(testEnv.ClientSet, testEnv.NameSpace, "istio.default",
+	initialSecret, err := integration.WaitForSecretExist(testEnv.ClientSet, testEnv.Namespace, "istio.default",
 		secretWaitTime)
 	if err != nil {
 		t.Error(err)
@@ -63,7 +63,7 @@ func TestCertificateRotation(t *testing.T) {
 			term *= 2
 		}
 
-		secret, err := integration.WaitForSecretExist(testEnv.ClientSet, testEnv.NameSpace, "istio.default",
+		secret, err := integration.WaitForSecretExist(testEnv.ClientSet, testEnv.Namespace, "istio.default",
 			secretWaitTime)
 		if err != nil {
 			continue

--- a/security/tests/integration/istio_ca_cert_rotation_env.go
+++ b/security/tests/integration/istio_ca_cert_rotation_env.go
@@ -30,7 +30,7 @@ type (
 		name      string
 		comps     []framework.Component
 		ClientSet *kubernetes.Clientset
-		NameSpace string
+		Namespace string
 		Hub       string
 		Tag       string
 	}
@@ -57,7 +57,7 @@ func NewCertRotationTestEnv(name, kubeConfig, hub, tag string) *CertRotationTest
 	return &CertRotationTestEnv{
 		name:      name,
 		ClientSet: clientset,
-		NameSpace: namespace,
+		Namespace: namespace,
 		Hub:       hub,
 		Tag:       tag,
 	}
@@ -76,7 +76,7 @@ func (env *CertRotationTestEnv) GetComponents() []framework.Component {
 		env.comps = []framework.Component{
 			NewKubernetesPod(
 				env.ClientSet,
-				env.NameSpace,
+				env.Namespace,
 				citadelSelfSignedShortTTL,
 				fmt.Sprintf("%s/citadel:%s", env.Hub, env.Tag),
 				[]string{
@@ -102,9 +102,9 @@ func (env *CertRotationTestEnv) Bringup() error {
 // Cleanup() is being called in framework.TearDown()
 func (env *CertRotationTestEnv) Cleanup() error {
 	log.Infof("cleaning up environment...")
-	err := deleteTestNamespace(env.ClientSet, env.NameSpace)
+	err := deleteTestNamespace(env.ClientSet, env.Namespace)
 	if err != nil {
-		retErr := fmt.Errorf("failed to delete the namespace: %v error: %v", env.NameSpace, err)
+		retErr := fmt.Errorf("failed to delete the namespace: %v error: %v", env.Namespace, err)
 		log.Errorf("%v", retErr)
 		return retErr
 	}

--- a/security/tests/integration/istio_ca_node_agent_env.go
+++ b/security/tests/integration/istio_ca_node_agent_env.go
@@ -32,7 +32,7 @@ type (
 		name      string
 		comps     []framework.Component
 		ClientSet *kubernetes.Clientset
-		NameSpace string
+		Namespace string
 		Hub       string
 		Tag       string
 	}
@@ -62,7 +62,7 @@ func NewNodeAgentTestEnv(name, kubeConfig, hub, tag string) *NodeAgentTestEnv {
 	return &NodeAgentTestEnv{
 		ClientSet: clientset,
 		name:      name,
-		NameSpace: namespace,
+		Namespace: namespace,
 		Hub:       hub,
 		Tag:       tag,
 	}
@@ -81,7 +81,7 @@ func (env *NodeAgentTestEnv) GetComponents() []framework.Component {
 		env.comps = []framework.Component{
 			NewKubernetesPod(
 				env.ClientSet,
-				env.NameSpace,
+				env.Namespace,
 				citadelWithGivenCertificate,
 				fmt.Sprintf("%v/citadel-test:%v", env.Hub, env.Tag),
 				[]string{},
@@ -89,7 +89,7 @@ func (env *NodeAgentTestEnv) GetComponents() []framework.Component {
 			),
 			NewKubernetesService(
 				env.ClientSet,
-				env.NameSpace,
+				env.Namespace,
 				"istio-citadel",
 				coreV1.ServiceTypeClusterIP,
 				8060,
@@ -102,7 +102,7 @@ func (env *NodeAgentTestEnv) GetComponents() []framework.Component {
 			),
 			NewKubernetesPod(
 				env.ClientSet,
-				env.NameSpace,
+				env.Namespace,
 				nodeAgent,
 				fmt.Sprintf("%v/node-agent-test:%v", env.Hub, env.Tag),
 				[]string{},
@@ -110,7 +110,7 @@ func (env *NodeAgentTestEnv) GetComponents() []framework.Component {
 			),
 			NewKubernetesService(
 				env.ClientSet,
-				env.NameSpace,
+				env.Namespace,
 				nodeAgentService,
 				coreV1.ServiceTypeLoadBalancer,
 				8080,
@@ -134,9 +134,9 @@ func (env *NodeAgentTestEnv) Bringup() error {
 // Cleanup() is being called in framework.TearDown()
 func (env *NodeAgentTestEnv) Cleanup() error {
 	log.Infof("cleaning up environment...")
-	err := deleteTestNamespace(env.ClientSet, env.NameSpace)
+	err := deleteTestNamespace(env.ClientSet, env.Namespace)
 	if err != nil {
-		retErr := fmt.Errorf("failed to delete namespace: %v error: %v", env.NameSpace, err)
+		retErr := fmt.Errorf("failed to delete namespace: %v error: %v", env.Namespace, err)
 		log.Errorf("%v", retErr)
 		return retErr
 	}
@@ -145,5 +145,5 @@ func (env *NodeAgentTestEnv) Cleanup() error {
 
 // GetNodeAgentIPAddress returns the external LoadBalancer IP address of the service
 func (env *NodeAgentTestEnv) GetNodeAgentIPAddress() (string, error) {
-	return getServiceExternalIPAddress(env.ClientSet, env.NameSpace, "node-agent-service")
+	return getServiceExternalIPAddress(env.ClientSet, env.Namespace, "node-agent-service")
 }

--- a/security/tests/integration/istio_ca_secret_env.go
+++ b/security/tests/integration/istio_ca_secret_env.go
@@ -34,7 +34,7 @@ type (
 		name      string
 		comps     []framework.Component
 		ClientSet *kubernetes.Clientset
-		NameSpace string
+		Namespace string
 		Hub       string
 		Tag       string
 	}
@@ -57,7 +57,7 @@ func NewSecretTestEnv(name, kubeConfig, hub, tag string) *SecretTestEnv {
 	return &SecretTestEnv{
 		ClientSet: clientset,
 		name:      name,
-		NameSpace: namespace,
+		Namespace: namespace,
 		Hub:       hub,
 		Tag:       tag,
 	}
@@ -76,7 +76,7 @@ func (env *SecretTestEnv) GetComponents() []framework.Component {
 		env.comps = []framework.Component{
 			NewKubernetesPod(
 				env.ClientSet,
-				env.NameSpace,
+				env.Namespace,
 				citadelSelfSigned,
 				fmt.Sprintf("%v/citadel:%v", env.Hub, env.Tag),
 				[]string{
@@ -101,9 +101,9 @@ func (env *SecretTestEnv) Bringup() error {
 // Cleanup() is being called in framework.TearDown()
 func (env *SecretTestEnv) Cleanup() error {
 	log.Infof("cleaning up environment...")
-	err := deleteTestNamespace(env.ClientSet, env.NameSpace)
+	err := deleteTestNamespace(env.ClientSet, env.Namespace)
 	if err != nil {
-		retErr := fmt.Errorf("failed to delete namespace: %v error: %v", env.NameSpace, err)
+		retErr := fmt.Errorf("failed to delete namespace: %v error: %v", env.Namespace, err)
 		log.Errorf("%v", retErr)
 		return retErr
 	}

--- a/security/tests/integration/secretCreationTest/secret_creation_test.go
+++ b/security/tests/integration/secretCreationTest/secret_creation_test.go
@@ -38,7 +38,7 @@ var (
 
 func TestSecretCreation(t *testing.T) {
 	// Test the existence of istio.default secret.
-	s, err := integration.WaitForSecretExist(testEnv.ClientSet, testEnv.NameSpace, "istio.default", secretWaitTime)
+	s, err := integration.WaitForSecretExist(testEnv.ClientSet, testEnv.Namespace, "istio.default", secretWaitTime)
 	if err != nil {
 		t.Error(err)
 	}
@@ -49,14 +49,14 @@ func TestSecretCreation(t *testing.T) {
 	}
 
 	// Delete the istio.default secret immediately
-	if err := integration.DeleteSecret(testEnv.ClientSet, testEnv.NameSpace, "istio.default"); err != nil {
+	if err := integration.DeleteSecret(testEnv.ClientSet, testEnv.Namespace, "istio.default"); err != nil {
 		t.Error(err)
 	}
 
 	t.Log(`secret "istio.default" has been deleted`)
 
 	// Test that the deleted secret is re-created properly.
-	if _, err := integration.WaitForSecretExist(testEnv.ClientSet, testEnv.NameSpace, "istio.default",
+	if _, err := integration.WaitForSecretExist(testEnv.ClientSet, testEnv.Namespace, "istio.default",
 		secretWaitTime); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Cleanup PR that changes refs to `NameSpace` with the correct `Namespace`

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
