### PR TITLE
Expose node agent INGRESS_GATEWAY_FALLBACK_SECRET and SECRET_WATCHER_RESYNC_PERIOD as Helm configurations

### DIFF
--- a/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
+++ b/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
@@ -4,12 +4,18 @@
 enabled: false
 image: node-agent-k8s
 env:
-  # name of authentication provider.
+  # Name of authentication provider.
   CA_PROVIDER: ""
   # CA endpoint.
   CA_ADDR: ""  
-  # names of authentication provider's plugins.
+  # Names of authentication provider's plugins.
   PLUGINS: ""
+  # The agent will retrieve secrets from the API server with the frequency
+  # specified in this configuration.
+  SECRET_WATCHER_RESYNC_PERIOD: ""
+  # When a secret cannot be found with the expected suffix in the ingress namespace
+  # a secret with this name will be used instead as a fallback.
+  INGRESS_GATEWAY_FALLBACK_SECRET: "gateway-fallback"
 nodeSelector: {}
 tolerations: []
 

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher.go
@@ -68,14 +68,16 @@ const (
 )
 
 var (
-	// TODO(JimmyCYJ): Configure these two env variables in Helm
+	secretFetcherLog = log.RegisterScope("secretFetcherLog", "secret fetcher debugging", 0)
 	// secretControllerResyncPeriod specifies the time period in seconds that secret controller
 	// resyncs to API server.
 	// example value format like "30s"
-	secretControllerResyncPeriod = env.RegisterStringVar("SECRET_WATCHER_RESYNC_PERIOD", "", "").Get()
+	secretControllerResyncPeriod = env.RegisterStringVar("SECRET_WATCHER_RESYNC_PERIOD", "",
+		"Interval at which the agent will retrieve secrets from the API server").Get()
+
 	// ingressFallbackSecret specifies the name of fallback secret for ingress gateway.
-	ingressFallbackSecret = env.RegisterStringVar("INGRESS_GATEWAY_FALLBACK_SECRET", "gateway-fallback", "").Get()
-	secretFetcherLog      = log.RegisterScope("secretFetcherLog", "secret fetcher debugging", 0)
+	ingressFallbackSecret = env.RegisterStringVar("INGRESS_GATEWAY_FALLBACK_SECRET", "gateway-fallback",
+		"Secret to be used in the case that agent cannot find seret with expected suffix in ingress namespace").Get()
 )
 
 // SecretFetcher fetches secret via watching k8s secrets or sending CSR to CA.


### PR DESCRIPTION
Expose `SECRET_WATCHER_RESYNC_PERIOD` and `INGRESS_GATEWAY_FALLBACK_SECRET` as Helm configurations.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
