### PR TITLE
Mark stats_filter_test as custom setup

### DIFF
--- a/tests/integration/telemetry/stats/prometheus/stats_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/stats_filter_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pkg/test/framework/label"
+
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/bookinfo"
 	"istio.io/istio/pkg/test/framework/components/environment"
@@ -134,6 +136,7 @@ func TestStatsFilter(t *testing.T) {
 func TestMain(m *testing.M) {
 	framework.NewSuite("stats_filter_test", m).
 		RequireEnvironment(environment.Kube).
+		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(getIstioInstance(), setupConfig)).
 		Setup(testSetup).
 		Run()


### PR DESCRIPTION
https://github.com/istio/istio/pull/16917/files broke new installer tests because it relies on custom setup I think (maybe there is another reason it fails though.. not sure if it requires mixer to be disabled or not)