### PR TITLE
listener: h2 sniffing for outbound listener

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1102,6 +1102,14 @@ func setUpstreamProtocol(node *model.Proxy, cluster *apiv2.Cluster, port *model.
 
 	if (util.IsProtocolSniffingEnabledForInboundPort(node, port) && direction == model.TrafficDirectionInbound) ||
 		(util.IsProtocolSniffingEnabledForOutboundPort(node, port) && direction == model.TrafficDirectionOutbound) {
+		// setup http2 protocol options for upstream connection.
+		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{
+			// Envoy default value of 100 is too low for data path.
+			MaxConcurrentStreams: &types.UInt32Value{
+				Value: 1073741824,
+			},
+		}
+
 		// Use downstream protocol. If the incoming traffic use HTTP 1.1, the
 		// upstream cluster will use HTTP 1.1, if incoming traffic use HTTP2,
 		// the upstream cluster will use HTTP2.

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -135,10 +135,13 @@ const (
 	// Used in xds config. Metavalue bind to this key is used by pilot as xds server but not by envoy.
 	// So the meta data can be erased when pushing to envoy.
 	PilotMetaKey = "pilot_meta"
+
+	// TODO(yxue): separate h2c vs h2
+	H2Protocol = "h2"
 )
 
 var (
-	applicationProtocols = []string{"http/1.1", "http/1.0"}
+	applicationProtocols = []string{"http/1.0", "http/1.1"}
 
 	// EnvoyJSONLogFormat12 map of values for envoy json based access logs for Istio 1.2
 	EnvoyJSONLogFormat12 = &google_protobuf.Struct{
@@ -1273,6 +1276,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 
 			// Support HTTP/1.0, HTTP/1.1 and HTTP/2
 			opt.match.ApplicationProtocols = append(opt.match.ApplicationProtocols, applicationProtocols...)
+			// TODO(yxue): merge applicationProtocols and H2Protocol when sniffing is enabled for inbound
+			opt.match.ApplicationProtocols = append(opt.match.ApplicationProtocols, H2Protocol)
 		}
 
 		listenerOpts.filterChainOpts = append(listenerOpts.filterChainOpts, opts...)
@@ -2135,6 +2140,7 @@ func mergeFilterChains(httpFilterChain, tcpFilterChain []*listener.FilterChain) 
 		}
 
 		fc.FilterChainMatch.ApplicationProtocols = append(fc.FilterChainMatch.ApplicationProtocols, applicationProtocols...)
+		fc.FilterChainMatch.ApplicationProtocols = append(fc.FilterChainMatch.ApplicationProtocols, H2Protocol)
 		newFilterChan = append(newFilterChan, fc)
 
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -584,7 +584,7 @@ func testOutboundListenerConflictV13(t *testing.T, services ...*model.Service) {
 			}
 		}
 
-		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2])
+		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2], model.TrafficDirectionOutbound)
 		if len(listeners[0].ListenerFilters) != 2 ||
 			listeners[0].ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
 			listeners[0].ListenerFilters[1].Name != "envoy.listener.http_inspector" {
@@ -611,7 +611,7 @@ func testOutboundListenerConflictV13(t *testing.T, services ...*model.Service) {
 			t.Fatalf("expected http filter chain, found %s", listeners[0].FilterChains[1].Filters[0].Name)
 		}
 
-		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2])
+		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2], model.TrafficDirectionOutbound)
 		if len(listeners[0].ListenerFilters) != 2 ||
 			listeners[0].ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
 			listeners[0].ListenerFilters[1].Name != "envoy.listener.http_inspector" {
@@ -636,8 +636,8 @@ func testInboundListenerConfigV13(t *testing.T, proxy *model.Proxy, services ...
 		t.Fatalf("expectd %d filter chains, %d http filter chains and %d tcp filter chain", 4, 2, 2)
 	}
 
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0])
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1])
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0], model.TrafficDirectionInbound)
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1], model.TrafficDirectionInbound)
 }
 
 func testInboundListenerConfigWithSidecarV13(t *testing.T, proxy *model.Proxy, services ...*model.Service) {
@@ -675,8 +675,8 @@ func testInboundListenerConfigWithSidecarV13(t *testing.T, proxy *model.Proxy, s
 		t.Fatalf("expectd %d filter chains, %d http filter chains and %d tcp filter chain", 4, 2, 2)
 	}
 
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0])
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1])
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0], model.TrafficDirectionInbound)
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1], model.TrafficDirectionInbound)
 }
 
 func testInboundListenerConfigWithSidecarWithoutServicesV13(t *testing.T, proxy *model.Proxy) {
@@ -714,8 +714,8 @@ func testInboundListenerConfigWithSidecarWithoutServicesV13(t *testing.T, proxy 
 		t.Fatalf("expectd %d filter chains, %d http filter chains and %d tcp filter chain", 4, 2, 2)
 	}
 
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0])
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1])
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0], model.TrafficDirectionInbound)
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1], model.TrafficDirectionInbound)
 }
 
 func testInboundListenerConfigWithoutServiceV13(t *testing.T, proxy *model.Proxy) {
@@ -727,12 +727,21 @@ func testInboundListenerConfigWithoutServiceV13(t *testing.T, proxy *model.Proxy
 	}
 }
 
-func verifyHTTPFilterChainMatch(t *testing.T, fc *listener.FilterChain) {
+func verifyHTTPFilterChainMatch(t *testing.T, fc *listener.FilterChain, direction model.TrafficDirection) {
 	t.Helper()
-	if len(fc.FilterChainMatch.ApplicationProtocols) != 2 ||
-		fc.FilterChainMatch.ApplicationProtocols[0] != "http/1.1" ||
-		fc.FilterChainMatch.ApplicationProtocols[1] != "http/1.0" {
-		t.Fatalf("expected %d application protocols, [http/1.1, http/1.0]", 3)
+	if direction == model.TrafficDirectionInbound &&
+		(len(fc.FilterChainMatch.ApplicationProtocols) != 2 ||
+			fc.FilterChainMatch.ApplicationProtocols[0] != "http/1.0" ||
+			fc.FilterChainMatch.ApplicationProtocols[1] != "http/1.1") {
+		t.Fatalf("expected %d application protocols, [http/1.0, http/1.1]", 2)
+	}
+
+	if direction == model.TrafficDirectionOutbound &&
+		(len(fc.FilterChainMatch.ApplicationProtocols) != 3 ||
+			fc.FilterChainMatch.ApplicationProtocols[0] != "http/1.0" ||
+			fc.FilterChainMatch.ApplicationProtocols[1] != "http/1.1" ||
+			fc.FilterChainMatch.ApplicationProtocols[2] != "h2") {
+		t.Fatalf("expected %d application protocols, [http/1.0, http/1.1, h2]", 3)
 	}
 }
 
@@ -810,7 +819,7 @@ func testOutboundListenerConfigWithSidecarV13(t *testing.T, services ...*model.S
 			t.Fatalf("expected tcp filter chain, found %s", l.FilterChains[1].Filters[0].Name)
 		}
 
-		verifyHTTPFilterChainMatch(t, l.FilterChains[3])
+		verifyHTTPFilterChainMatch(t, l.FilterChains[3], model.TrafficDirectionOutbound)
 
 		if len(l.ListenerFilters) != 2 ||
 			l.ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
@@ -840,7 +849,7 @@ func testOutboundListenerConfigWithSidecarV13(t *testing.T, services ...*model.S
 		}
 	}
 
-	verifyHTTPFilterChainMatch(t, l.FilterChains[1])
+	verifyHTTPFilterChainMatch(t, l.FilterChains[1], model.TrafficDirectionOutbound)
 	if len(l.ListenerFilters) != 2 ||
 		l.ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
 		l.ListenerFilters[1].Name != "envoy.listener.http_inspector" {

--- a/tests/integration/pilot/protocol_sniffing_test.go
+++ b/tests/integration/pilot/protocol_sniffing_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package protocolsniffing
+package pilot
 
 import (
 	"fmt"
@@ -21,54 +21,23 @@ import (
 
 	"istio.io/pkg/log"
 
-	"istio.io/istio/pkg/test/framework/resource"
-
-	"istio.io/istio/pkg/test/framework/components/galley"
-	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/pilot"
-
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
-	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/tests/integration/security/util/connection"
 )
 
-var (
-	i istio.Instance
-	g galley.Instance
-	p pilot.Instance
-)
-
-func TestMain(m *testing.M) {
-	framework.
-		NewSuite("protocolsniffing_test", m).
-		SetupOnEnv(environment.Kube, istio.Setup(&i, nil)).
-		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
-				return err
-			}
-			return nil
-		}).
-		Run()
-}
-
-func TestOutbound(t *testing.T) {
+func TestOutboundSniffing(t *testing.T) {
 	framework.NewTest(t).Run(func(ctx framework.TestContext) {
-		doTest(t, ctx)
+		runTest(t, ctx)
 	})
 }
 
-func doTest(t *testing.T, ctx framework.TestContext) {
+func runTest(t *testing.T, ctx framework.TestContext) {
 	ns := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "protocolsniffing",
 		Inject: true,

--- a/tests/integration/pilot/protocolsniffing/main_test.go
+++ b/tests/integration/pilot/protocolsniffing/main_test.go
@@ -1,0 +1,158 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocolsniffing
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/pkg/log"
+
+	"istio.io/istio/pkg/test/framework/resource"
+
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/tests/integration/security/util/connection"
+)
+
+var (
+	i istio.Instance
+	g galley.Instance
+	p pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("protocolsniffing_test", m).
+		SetupOnEnv(environment.Kube, istio.Setup(&i, nil)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+}
+
+func TestOutbound(t *testing.T) {
+	framework.NewTest(t).Run(func(ctx framework.TestContext) {
+		doTest(t, ctx)
+	})
+}
+
+func doTest(t *testing.T, ctx framework.TestContext) {
+	ns := namespace.NewOrFail(t, ctx, namespace.Config{
+		Prefix: "protocolsniffing",
+		Inject: true,
+	})
+
+	ports := []echo.Port{
+		{
+			Name:     "foo",
+			Protocol: protocol.HTTP,
+		},
+		{
+			Name:     "http",
+			Protocol: protocol.HTTP,
+		},
+		{
+			Name:     "bar",
+			Protocol: protocol.TCP,
+		},
+		{
+			Name:     "tcp",
+			Protocol: protocol.TCP,
+		},
+		{
+			Name:     "baz",
+			Protocol: protocol.GRPC,
+		},
+		{
+			Name:     "grpc",
+			Protocol: protocol.GRPC,
+		},
+	}
+
+	var from, to echo.Instance
+	echoboot.NewBuilderOrFail(t, ctx).
+		With(&from, echo.Config{
+			Service:   "from",
+			Namespace: ns,
+			Ports:     ports,
+			Galley:    g,
+			Pilot:     p,
+		}).
+		With(&to, echo.Config{
+			Service:   "to",
+			Namespace: ns,
+			Ports:     ports,
+			Galley:    g,
+			Pilot:     p,
+		}).
+		BuildOrFail(ctx)
+
+	from.WaitUntilCallableOrFail(t, to)
+	log.Infof("%s app ready: %s", ctx.Name(), from.Config().Service)
+
+	testCases := []struct {
+		portName string
+		scheme   scheme.Instance
+	}{
+		{"foo", scheme.HTTP},
+		{"http", scheme.HTTP},
+		{"baz", scheme.GRPC},
+		{"grpc", scheme.GRPC},
+	}
+
+	for _, tc := range testCases {
+		connChecker := connection.Checker{
+			From: from,
+			Options: echo.CallOptions{
+				Target:   to,
+				PortName: tc.portName,
+				Scheme:   tc.scheme,
+			},
+			ExpectSuccess: true,
+		}
+		subTestName := fmt.Sprintf(
+			"%s->%s:%s",
+			from.Config().Service,
+			to.Config().Service,
+			connChecker.Options.PortName)
+
+		t.Run(subTestName,
+			func(t *testing.T) {
+				retry.UntilSuccessOrFail(t, connChecker.Check,
+					retry.Delay(time.Second),
+					retry.Timeout(10*time.Second))
+			})
+	}
+}


### PR DESCRIPTION
Add `h2` to the ALPN match to support sniffing for H2 and GRPC traffic.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
