### PR TITLE
Set Citadel spiffe trust domain for all root certs

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -423,9 +423,10 @@ func createCA(client corev1.CoreV1Interface) *ca.IstioCA {
 	var caOpts *ca.IstioCAOptions
 	var err error
 
+	spiffe.SetTrustDomain(spiffe.DetermineTrustDomain(opts.trustDomain, true))
+
 	if opts.selfSignedCA {
 		log.Info("Use self-signed certificate as the CA certificate")
-		spiffe.SetTrustDomain(spiffe.DetermineTrustDomain(opts.trustDomain, true))
 		// Abort after 20 minutes.
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
 		defer cancel()


### PR DESCRIPTION
Right now Citadel will only set the SPIFFE trust domain when using self-signed certs. However in multi-cluster scenarios, my organization at Microsoft wants to use intermediate certificates scoped to a trust domain that bubble up to the same root authority. Each trust domain could then be used in RBAC scenarios to identify the cluster.

I have tested this by creating a custom Citadel build and deploying it in my multi cluster setup. Trust Domains with RBAC work as expected.

Without this change, Istio is non-functional with trust domains and custom certs.

Fixes: #17093

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
