### PR TITLE
Add PodSecurityPolicy yaml files for SDS

### DIFF
--- a/samples/security/psp/all-pods-psp.yaml
+++ b/samples/security/psp/all-pods-psp.yaml
@@ -1,0 +1,49 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: istio-sds-uds
+spec:
+  # Protect the unix domain socket from unauthorized modification
+  allowedHostPaths:
+    - pathPrefix: "/var/run/sds"
+      readOnly: true
+  # Allow the istio sidecar injector to work
+  allowedCapabilities:
+    - NET_ADMIN
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+    - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: istio-sds-uds
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - istio-sds-uds
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-sds-uds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-sds-uds
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts

--- a/samples/security/psp/all-pods-psp.yaml
+++ b/samples/security/psp/all-pods-psp.yaml
@@ -1,3 +1,5 @@
+# For details about using this yaml file, please refer to:
+# https://istio.io/docs/tasks/security/auth-sds/#increasing-security-with-pod-security-policies
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -24,7 +26,7 @@ spec:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: istio-sds-uds
+  name: istio-sds-uds-psp
 rules:
   - apiGroups:
       - extensions
@@ -38,11 +40,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-sds-uds
+  name: istio-sds-uds-psp
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-sds-uds
+  name: istio-sds-uds-psp
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group

--- a/samples/security/psp/citadel-agent-psp.yaml
+++ b/samples/security/psp/citadel-agent-psp.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: istio-nodeagent
+spec:
+  allowedHostPaths:
+    - pathPrefix: "/var/run/sds"
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+    - '*'
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: istio-nodeagent
+  namespace: istio-system
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - istio-nodeagent
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: istio-nodeagent
+  namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: istio-nodeagent
+subjects:
+  - kind: ServiceAccount
+    name: istio-nodeagent-service-account
+    namespace: istio-system

--- a/samples/security/psp/citadel-agent-psp.yaml
+++ b/samples/security/psp/citadel-agent-psp.yaml
@@ -1,3 +1,5 @@
+# For details about using this yaml file, please refer to:
+# https://istio.io/docs/tasks/security/auth-sds/#increasing-security-with-pod-security-policies
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -19,7 +21,7 @@ spec:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: istio-nodeagent
+  name: istio-nodeagent-istio-system-psp
   namespace: istio-system
 rules:
   - apiGroups:
@@ -34,12 +36,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istio-nodeagent
+  name: istio-nodeagent-istio-system-psp
   namespace: istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: istio-nodeagent
+  name: istio-nodeagent-istio-system-psp
 subjects:
   - kind: ServiceAccount
     name: istio-nodeagent-service-account


### PR DESCRIPTION
This is a UX fix that adds example Pod Security Policy yaml files to the repo for users to apply more conveniently.
For more info: https://istio.io/docs/tasks/security/auth-sds/#increasing-security-with-pod-security-policies

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
