### PR TITLE
Update go-control-plane to use golang/protobuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/cactus/go-statsd-client v3.1.1+incompatible
 	github.com/cenkalti/backoff v2.0.0+incompatible
+	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
@@ -46,7 +47,7 @@ require (
 	github.com/duosecurity/duo_api_golang v0.0.0-20190308151101-6c680f768e74 // indirect
 	github.com/elazarl/go-bindata-assetfs v1.0.0 // indirect
 	github.com/emicklei/go-restful v2.9.3+incompatible
-	github.com/envoyproxy/go-control-plane v0.8.7-0.20190821215049-f062b07a671a
+	github.com/envoyproxy/go-control-plane v0.9.0
 	github.com/evanphx/json-patch v4.2.0+incompatible
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/stackerr v0.0.0-20150612192056-c2fcf88613f4 // indirect
@@ -62,7 +63,7 @@ require (
 	github.com/gocql/gocql v0.0.0-20190423091413-b99afaf3b163 // indirect
 	github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/golang/protobuf v1.3.1
+	github.com/golang/protobuf v1.3.2
 	github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f
 	github.com/google/cel-go v0.2.0
 	github.com/google/go-cmp v0.3.0
@@ -116,7 +117,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/pquerna/cachecontrol v0.0.0-20180306154005-525d0eb5f91d // indirect
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
-	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
+	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/prometheus/common v0.4.0
 	github.com/prometheus/prom2json v1.2.1
 	github.com/ryanuber/go-glob v0.0.0-20160226084822-572520ed46db // indirect
@@ -145,7 +146,7 @@ require (
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135
 	google.golang.org/api v0.8.0
-	google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873
+	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
 	google.golang.org/grpc v1.23.0
 	gopkg.in/d4l3k/messagediff.v1 v1.2.1
 	gopkg.in/ini.v1 v1.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/cenkalti/backoff v2.0.0+incompatible h1:5IIPUHhlnUZbcHQsQou5k1Tn58nJk
 github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
+github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible h1:C29Ae4G5GtYyYMm1aztcyj/J5ckgJm2zwdDajFbx1NY=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
@@ -153,10 +155,10 @@ github.com/elazarl/goproxy/ext v0.0.0-20190630181448-f1e96bc0f4c5 h1:/VMZdsbv0B1
 github.com/elazarl/goproxy/ext v0.0.0-20190630181448-f1e96bc0f4c5/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v2.9.3+incompatible h1:2OwhVdhtzYUp5P5wuGsVDPagKSRd9JK72sJCHVCXh5g=
 github.com/emicklei/go-restful v2.9.3+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/envoyproxy/go-control-plane v0.8.7-0.20190821215049-f062b07a671a h1:SaBXBWjRmig9yVB49C6TcbDtbZTbhuFLod7YiGjuFxQ=
-github.com/envoyproxy/go-control-plane v0.8.7-0.20190821215049-f062b07a671a/go.mod h1:XB9+ce7x+IrsjgIVnRnql0O61gj/np0/bGDfhJI3sCU=
-github.com/envoyproxy/protoc-gen-validate v0.0.0-20190405222122-d6164de49109 h1:FNgqGzbOm637YKRbYGKb9cqGo8i50++w/LWvMau7jrw=
-github.com/envoyproxy/protoc-gen-validate v0.0.0-20190405222122-d6164de49109/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/envoyproxy/go-control-plane v0.9.0 h1:67WMNTvGrl7V1dWdKCeTwxDr7nio9clKoTlLhwIPnT4=
+github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
+github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.0.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -219,6 +221,8 @@ github.com/golang/protobuf v1.3.0 h1:kbxbvI4Un1LUWKxufD+BiE6AEExYYgkQLQmLFqA1LFk
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0aZrsoHpLJlZsBrGMFWbgLDGnPZk=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
@@ -482,6 +486,8 @@ github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f h1:BVwpUVJ
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
+github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275 h1:PnBWHBf+6L0jOqq0gIVUe6Yk0/QMZ640k6NvkxcBf+8=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.2.0 h1:kUZDBDTdBVBYBj5Tmh2NZLlF60mfjA27rM34b+cVwNU=
@@ -652,8 +658,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190508220229-2d0786266e9c h1:hDn6jm7snBX2O7+EeTk6Q4WXJfKt7MWgtiCCRi1rBoY=
-golang.org/x/sys v0.0.0-20190508220229-2d0786266e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f h1:25KHgbfyiSm6vwQLbM3zZIe1v9p/3ea4Rz+nnM5K/i4=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -704,6 +708,8 @@ google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb h1:i1Ppqkc3WQXikh8
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 h1:nfPFGzJkUDX6uBmpN/pSw7MbOAWegH5QDQuoXFHedLg=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
+google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=

--- a/istioctl/pkg/auth/cluster.go
+++ b/istioctl/pkg/auth/cluster.go
@@ -21,7 +21,7 @@ import (
 	"text/tabwriter"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 
 	"istio.io/pkg/log"
 )

--- a/istioctl/pkg/util/clusters/wrapper.go
+++ b/istioctl/pkg/util/clusters/wrapper.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 )
 
 // Wrapper is a wrapper around the Envoy Clusters

--- a/istioctl/pkg/util/configdump/bootstrap.go
+++ b/istioctl/pkg/util/configdump/bootstrap.go
@@ -16,7 +16,7 @@ package configdump
 
 import (
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	proto "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 )
 
 // GetBootstrapConfigDump retrieves the bootstrap config dump from the ConfigDump
@@ -26,7 +26,7 @@ func (w *Wrapper) GetBootstrapConfigDump() (*adminapi.BootstrapConfigDump, error
 		return nil, err
 	}
 	bootstrapDump := &adminapi.BootstrapConfigDump{}
-	err = proto.UnmarshalAny(&bootstrapDumpAny, bootstrapDump)
+	err = ptypes.UnmarshalAny(&bootstrapDumpAny, bootstrapDump)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/bootstrap_test.go
+++ b/istioctl/pkg/util/configdump/bootstrap_test.go
@@ -17,7 +17,7 @@ package configdump
 import (
 	"testing"
 
-	proto "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/any"
 )
 
 func TestWrapper_GetBootstrapConfigDump(t *testing.T) {
@@ -48,7 +48,7 @@ func TestWrapper_GetBootstrapConfigDump(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := setupWrapper(t)
 			if tt.noBootstrap {
-				w.Configs = []*proto.Any{}
+				w.Configs = []*any.Any{}
 			}
 			if tt.noConfigs {
 				w.Configs = nil

--- a/istioctl/pkg/util/configdump/cluster.go
+++ b/istioctl/pkg/util/configdump/cluster.go
@@ -18,7 +18,7 @@ import (
 	"sort"
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	proto "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 )
 
 // GetDynamicClusterDump retrieves a cluster dump with just dynamic active clusters in it
@@ -47,7 +47,7 @@ func (w *Wrapper) GetClusterConfigDump() (*adminapi.ClustersConfigDump, error) {
 		return nil, err
 	}
 	clusterDump := &adminapi.ClustersConfigDump{}
-	err = proto.UnmarshalAny(&clusterDumpAny, clusterDump)
+	err = ptypes.UnmarshalAny(&clusterDumpAny, clusterDump)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/cluster_test.go
+++ b/istioctl/pkg/util/configdump/cluster_test.go
@@ -19,7 +19,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	proto "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/any"
 )
 
 func setupWrapper(t *testing.T) *Wrapper {
@@ -61,7 +61,7 @@ func TestWrapper_GetClusterConfigDump(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := setupWrapper(t)
 			if tt.noCluster {
-				w.Configs = []*proto.Any{}
+				w.Configs = []*any.Any{}
 			}
 			if tt.noConfigs {
 				w.Configs = nil
@@ -120,7 +120,7 @@ func TestWrapper_GetDynamicClusterDump(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := setupWrapper(t)
 			if tt.noCluster {
-				w.Configs = []*proto.Any{}
+				w.Configs = []*any.Any{}
 			}
 			got, err := w.GetDynamicClusterDump(tt.stripVersion)
 			if (err != nil) != tt.wantErr {

--- a/istioctl/pkg/util/configdump/listener.go
+++ b/istioctl/pkg/util/configdump/listener.go
@@ -18,7 +18,7 @@ import (
 	"sort"
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	proto "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 )
 
 // GetDynamicListenerDump retrieves a listener dump with just dynamic active listeners in it
@@ -47,7 +47,7 @@ func (w *Wrapper) GetListenerConfigDump() (*adminapi.ListenersConfigDump, error)
 		return nil, err
 	}
 	listenerDump := &adminapi.ListenersConfigDump{}
-	err = proto.UnmarshalAny(&listenerDumpAny, listenerDump)
+	err = ptypes.UnmarshalAny(&listenerDumpAny, listenerDump)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/listener_test.go
+++ b/istioctl/pkg/util/configdump/listener_test.go
@@ -17,7 +17,7 @@ package configdump
 import (
 	"testing"
 
-	proto "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/any"
 )
 
 func TestWrapper_GetListenerConfigDump(t *testing.T) {
@@ -50,7 +50,7 @@ func TestWrapper_GetListenerConfigDump(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := setupWrapper(t)
 			if tt.noListener {
-				w.Configs = []*proto.Any{}
+				w.Configs = []*any.Any{}
 			}
 			if tt.noConfigs {
 				w.Configs = nil
@@ -110,7 +110,7 @@ func TestWrapper_GetDynamicListenerDump(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := setupWrapper(t)
 			if tt.noListener {
-				w.Configs = []*proto.Any{}
+				w.Configs = []*any.Any{}
 			}
 			got, err := w.GetDynamicListenerDump(tt.stripVersion)
 			if (err != nil) != tt.wantErr {

--- a/istioctl/pkg/util/configdump/route.go
+++ b/istioctl/pkg/util/configdump/route.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	proto "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 )
 
 // GetLastUpdatedDynamicRouteTime retrieves the LastUpdated timestamp of the
@@ -34,7 +34,7 @@ func (w *Wrapper) GetLastUpdatedDynamicRouteTime() (*time.Time, error) {
 	lastUpdated := time.Unix(0, 0) // get the oldest possible timestamp
 	for i := range drc {
 		if drc[i].LastUpdated != nil {
-			if drLastUpdated, err := proto.TimestampFromProto(drc[i].LastUpdated); err != nil {
+			if drLastUpdated, err := ptypes.Timestamp(drc[i].LastUpdated); err != nil {
 				return nil, err
 			} else if drLastUpdated.After(lastUpdated) {
 				lastUpdated = drLastUpdated
@@ -73,7 +73,7 @@ func (w *Wrapper) GetRouteConfigDump() (*adminapi.RoutesConfigDump, error) {
 		return nil, err
 	}
 	routeDump := &adminapi.RoutesConfigDump{}
-	err = proto.UnmarshalAny(&routeDumpAny, routeDump)
+	err = ptypes.UnmarshalAny(&routeDumpAny, routeDump)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/route_test.go
+++ b/istioctl/pkg/util/configdump/route_test.go
@@ -17,7 +17,7 @@ package configdump
 import (
 	"testing"
 
-	proto "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/any"
 )
 
 func TestWrapper_GetRouteConfigDump(t *testing.T) {
@@ -48,7 +48,7 @@ func TestWrapper_GetRouteConfigDump(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := setupWrapper(t)
 			if tt.noRoute {
-				w.Configs = []*proto.Any{}
+				w.Configs = []*any.Any{}
 			}
 			if tt.noConfigs {
 				w.Configs = nil
@@ -105,7 +105,7 @@ func TestWrapper_GetDynamicRouteDump(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := setupWrapper(t)
 			if tt.noRoute {
-				w.Configs = []*proto.Any{}
+				w.Configs = []*any.Any{}
 			}
 			got, err := w.GetDynamicRouteDump(tt.stripVersion)
 			if (err != nil) != tt.wantErr {

--- a/istioctl/pkg/util/configdump/secret.go
+++ b/istioctl/pkg/util/configdump/secret.go
@@ -16,7 +16,7 @@ package configdump
 
 import (
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	proto "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 )
 
 // GetSecretsConfigDump retrieves a secret dump from a config dump wrapper
@@ -26,7 +26,7 @@ func (w *Wrapper) GetSecretConfigDump() (*adminapi.SecretsConfigDump, error) {
 		return nil, err
 	}
 	secretDump := &adminapi.SecretsConfigDump{}
-	err = proto.UnmarshalAny(&secretDumpAny, secretDump)
+	err = ptypes.UnmarshalAny(&secretDumpAny, secretDump)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/util.go
+++ b/istioctl/pkg/util/configdump/util.go
@@ -17,7 +17,7 @@ package configdump
 import (
 	"fmt"
 
-	proto "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/any"
 )
 
 type configTypeURL string
@@ -32,15 +32,15 @@ const (
 )
 
 // getSection takes a TypeURL and returns the types.Any from the config dump corresponding to that URL
-func (w *Wrapper) getSection(sectionTypeURL configTypeURL) (proto.Any, error) {
-	var dumpAny proto.Any
+func (w *Wrapper) getSection(sectionTypeURL configTypeURL) (any.Any, error) {
+	var dumpAny any.Any
 	for _, conf := range w.Configs {
 		if conf.TypeUrl == string(sectionTypeURL) {
 			dumpAny = *conf
 		}
 	}
 	if dumpAny.TypeUrl == "" {
-		return proto.Any{}, fmt.Errorf("config dump has no route %s", sectionTypeURL)
+		return any.Any{}, fmt.Errorf("config dump has no route %s", sectionTypeURL)
 	}
 
 	return dumpAny, nil

--- a/istioctl/pkg/util/configdump/wrapper.go
+++ b/istioctl/pkg/util/configdump/wrapper.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/gogo/protobuf/jsonpb"
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )

--- a/istioctl/pkg/util/proto/messageslice.go
+++ b/istioctl/pkg/util/proto/messageslice.go
@@ -17,8 +17,8 @@ package proto
 import (
 	"bytes"
 
-	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb"
 )
 
 // MessageSlice allows us to marshal slices of protobuf messages like clusters/listeners/routes/endpoints correctly

--- a/istioctl/pkg/writer/compare/cluster.go
+++ b/istioctl/pkg/writer/compare/cluster.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/pmezard/go-difflib/difflib"
 )
 

--- a/istioctl/pkg/writer/compare/listener.go
+++ b/istioctl/pkg/writer/compare/listener.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/pmezard/go-difflib/difflib"
 )
 

--- a/istioctl/pkg/writer/compare/route.go
+++ b/istioctl/pkg/writer/compare/route.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/pmezard/go-difflib/difflib"
 )
 

--- a/istioctl/pkg/writer/envoy/clusters/clusters.go
+++ b/istioctl/pkg/writer/envoy/clusters/clusters.go
@@ -24,7 +24,7 @@ import (
 	"text/tabwriter"
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	"istio.io/istio/istioctl/pkg/util/clusters"
 	protio "istio.io/istio/istioctl/pkg/util/proto"

--- a/istioctl/pkg/writer/envoy/configdump/configdump.go
+++ b/istioctl/pkg/writer/envoy/configdump/configdump.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 
 	"istio.io/istio/istioctl/pkg/util/configdump"
 	sdscompare "istio.io/istio/istioctl/pkg/writer/compare/sds"

--- a/mixer/test/client/dynamic_attribute/dynamic_attribute_test.go
+++ b/mixer/test/client/dynamic_attribute/dynamic_attribute_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
-	"github.com/gogo/protobuf/types"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"google.golang.org/grpc"
 
 	"istio.io/istio/mixer/test/client/env"
@@ -191,10 +191,10 @@ func TestDynamicAttribute(t *testing.T) {
 				Endpoints: []*endpoint.LocalityLbEndpoints{{
 					LbEndpoints: []*endpoint.LbEndpoint{{
 						Metadata: &core.Metadata{
-							FilterMetadata: map[string]*types.Struct{
+							FilterMetadata: map[string]*structpb.Struct{
 								"istio": {
-									Fields: map[string]*types.Value{
-										"uid": {Kind: &types.Value_StringValue{StringValue: "pod1.ns2"}},
+									Fields: map[string]*structpb.Value{
+										"uid": {Kind: &structpb.Value_StringValue{StringValue: "pod1.ns2"}},
 									},
 								},
 							},

--- a/mixer/test/client/dynamic_listener/dynamic_listener_test.go
+++ b/mixer/test/client/dynamic_listener/dynamic_listener_test.go
@@ -23,15 +23,16 @@ import (
 	"time"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
-	"github.com/gogo/protobuf/types"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"google.golang.org/grpc"
 
 	mpb "istio.io/api/mixer/v1"
@@ -120,7 +121,7 @@ func (hasher) ID(*core.Node) string {
 }
 
 func makeListener(s *env.TestSetup, key string) *v2.Listener {
-	mxServiceConfig, err := util.MessageToStruct(&mccpb.ServiceConfig{
+	mxServiceConfig, err := conversion.MessageToStruct(&mccpb.ServiceConfig{
 		MixerAttributes: &mpb.Attributes{
 			Attributes: map[string]*mpb.Attributes_AttributeValue{
 				"key": {Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: key}},
@@ -129,13 +130,13 @@ func makeListener(s *env.TestSetup, key string) *v2.Listener {
 	if err != nil {
 		panic(err)
 	}
-	mxConf, err := util.MessageToStruct(env.GetDefaultHTTPServerConf())
+	mxConf, err := conversion.MessageToStruct(env.GetDefaultHTTPServerConf())
 	if err != nil {
 		panic(err)
 	}
 
 	manager := &hcm.HttpConnectionManager{
-		CodecType:  hcm.AUTO,
+		CodecType:  hcm.HttpConnectionManager_AUTO,
 		StatPrefix: "http",
 		RouteSpecifier: &hcm.HttpConnectionManager_RouteConfig{
 			RouteConfig: &v2.RouteConfiguration{
@@ -148,18 +149,18 @@ func makeListener(s *env.TestSetup, key string) *v2.Listener {
 						Action: &route.Route_Route{Route: &route.RouteAction{
 							ClusterSpecifier: &route.RouteAction_Cluster{Cluster: "backend"},
 						}},
-						PerFilterConfig: map[string]*types.Struct{
+						PerFilterConfig: map[string]*structpb.Struct{
 							"mixer": mxServiceConfig,
 						}}}}}}},
 		HttpFilters: []*hcm.HttpFilter{{
 			Name:       "mixer",
 			ConfigType: &hcm.HttpFilter_Config{mxConf},
 		}, {
-			Name: util.Router,
+			Name: wellknown.Router,
 		}},
 	}
 
-	pbst, err := util.MessageToStruct(manager)
+	pbst, err := conversion.MessageToStruct(manager)
 	if err != nil {
 		panic(err)
 	}
@@ -171,7 +172,7 @@ func makeListener(s *env.TestSetup, key string) *v2.Listener {
 			PortSpecifier: &core.SocketAddress_PortValue{PortValue: uint32(s.Ports().ServerProxyPort)}}}},
 		FilterChains: []*listener.FilterChain{{
 			Filters: []*listener.Filter{{
-				Name:       util.HTTPConnectionManager,
+				Name:       wellknown.HTTPConnectionManager,
 				ConfigType: &listener.Filter_Config{pbst},
 			}},
 		}},

--- a/mixer/test/client/gateway/gateway_test.go
+++ b/mixer/test/client/gateway/gateway_test.go
@@ -21,14 +21,14 @@ import (
 	"testing"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"google.golang.org/grpc"
 
@@ -309,14 +309,14 @@ func makeListener(port uint16, route string) (*v2.Listener, *hcm.HttpConnectionM
 				Address:       "127.0.0.1",
 				PortSpecifier: &core.SocketAddress_PortValue{PortValue: uint32(port)}}}},
 		}, &hcm.HttpConnectionManager{
-			CodecType:  hcm.AUTO,
+			CodecType:  hcm.HttpConnectionManager_AUTO,
 			StatPrefix: route,
 			RouteSpecifier: &hcm.HttpConnectionManager_Rds{
 				Rds: &hcm.Rds{RouteConfigName: route, ConfigSource: &core.ConfigSource{
 					ConfigSourceSpecifier: &core.ConfigSource_Ads{Ads: &core.AggregatedConfigSource{}},
 				}},
 			},
-			HttpFilters: []*hcm.HttpFilter{{Name: util.Router}},
+			HttpFilters: []*hcm.HttpFilter{{Name: wellknown.Router}},
 		}
 }
 
@@ -332,7 +332,7 @@ func makeSnapshot(s *env.TestSetup, t *testing.T) cache.Snapshot {
 	}
 	clientManager.HttpFilters = append(clientMutable.FilterChains[0].HTTP, clientManager.HttpFilters...)
 	clientListener.FilterChains = []*listener.FilterChain{{Filters: []*listener.Filter{{
-		Name:       util.HTTPConnectionManager,
+		Name:       wellknown.HTTPConnectionManager,
 		ConfigType: &listener.Filter_TypedConfig{TypedConfig: pilotutil.MessageToAny(clientManager)},
 	}}}}
 

--- a/mixer/test/client/pilotplugin/pilotplugin_test.go
+++ b/mixer/test/client/pilotplugin/pilotplugin_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"google.golang.org/grpc"
 
@@ -400,14 +400,14 @@ func makeListener(port uint16, route string) (*v2.Listener, *hcm.HttpConnectionM
 				Address:       "127.0.0.1",
 				PortSpecifier: &core.SocketAddress_PortValue{PortValue: uint32(port)}}}},
 		}, &hcm.HttpConnectionManager{
-			CodecType:  hcm.AUTO,
+			CodecType:  hcm.HttpConnectionManager_AUTO,
 			StatPrefix: route,
 			RouteSpecifier: &hcm.HttpConnectionManager_Rds{
 				Rds: &hcm.Rds{RouteConfigName: route, ConfigSource: &core.ConfigSource{
 					ConfigSourceSpecifier: &core.ConfigSource_Ads{Ads: &core.AggregatedConfigSource{}},
 				}},
 			},
-			HttpFilters: []*hcm.HttpFilter{{Name: util.Router}},
+			HttpFilters: []*hcm.HttpFilter{{Name: wellknown.Router}},
 		}
 }
 
@@ -425,7 +425,7 @@ func makeSnapshot(s *env.TestSetup, t *testing.T) cache.Snapshot {
 	}
 	serverManager.HttpFilters = append(serverMutable.FilterChains[0].HTTP, serverManager.HttpFilters...)
 	serverListener.FilterChains = []*listener.FilterChain{{Filters: []*listener.Filter{{
-		Name:       util.HTTPConnectionManager,
+		Name:       wellknown.HTTPConnectionManager,
 		ConfigType: &listener.Filter_TypedConfig{TypedConfig: pilotutil.MessageToAny(serverManager)},
 	}}}}
 
@@ -435,7 +435,7 @@ func makeSnapshot(s *env.TestSetup, t *testing.T) cache.Snapshot {
 	}
 	clientManager.HttpFilters = append(clientMutable.FilterChains[0].HTTP, clientManager.HttpFilters...)
 	clientListener.FilterChains = []*listener.FilterChain{{Filters: []*listener.Filter{{
-		Name:       util.HTTPConnectionManager,
+		Name:       wellknown.HTTPConnectionManager,
 		ConfigType: &listener.Filter_TypedConfig{TypedConfig: pilotutil.MessageToAny(clientManager)},
 	}}}}
 

--- a/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
+++ b/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
@@ -20,15 +20,15 @@ import (
 	"testing"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"google.golang.org/grpc"
 
@@ -404,14 +404,14 @@ func makeListener(port uint16, route string) (*v2.Listener, *hcm.HttpConnectionM
 				Name: "envoy.listener.tls_inspector",
 			}},
 		}, &hcm.HttpConnectionManager{
-			CodecType:  hcm.AUTO,
+			CodecType:  hcm.HttpConnectionManager_AUTO,
 			StatPrefix: route,
 			RouteSpecifier: &hcm.HttpConnectionManager_Rds{
 				Rds: &hcm.Rds{RouteConfigName: route, ConfigSource: &core.ConfigSource{
 					ConfigSourceSpecifier: &core.ConfigSource_Ads{Ads: &core.AggregatedConfigSource{}},
 				}},
 			},
-			HttpFilters: []*hcm.HttpFilter{{Name: util.Router}},
+			HttpFilters: []*hcm.HttpFilter{{Name: wellknown.Router}},
 		}
 }
 
@@ -430,7 +430,7 @@ func makeSnapshot(s *env.TestSetup, t *testing.T) cache.Snapshot {
 	serverManager.HttpFilters = append(serverMutable.FilterChains[0].HTTP, serverManager.HttpFilters...)
 	serverListener.FilterChains = []*listener.FilterChain{{
 		Filters: []*listener.Filter{{
-			Name:       util.HTTPConnectionManager,
+			Name:       wellknown.HTTPConnectionManager,
 			ConfigType: &listener.Filter_TypedConfig{TypedConfig: pilotutil.MessageToAny(serverManager)},
 		}},
 		// turn on mTLS on downstream
@@ -456,7 +456,7 @@ func makeSnapshot(s *env.TestSetup, t *testing.T) cache.Snapshot {
 	}
 	clientManager.HttpFilters = append(clientMutable.FilterChains[0].HTTP, clientManager.HttpFilters...)
 	clientListener.FilterChains = []*listener.FilterChain{{Filters: []*listener.Filter{{
-		Name:       util.HTTPConnectionManager,
+		Name:       wellknown.HTTPConnectionManager,
 		ConfigType: &listener.Filter_TypedConfig{TypedConfig: pilotutil.MessageToAny(clientManager)},
 	}}}}
 

--- a/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
+++ b/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"google.golang.org/grpc"
 
@@ -234,7 +234,7 @@ func makeListener(port uint16, cluster string) *v2.Listener {
 			Address:       "127.0.0.1",
 			PortSpecifier: &core.SocketAddress_PortValue{PortValue: uint32(port)}}}},
 		FilterChains: []*listener.FilterChain{{Filters: []*listener.Filter{{
-			Name: util.TCPProxy,
+			Name: wellknown.TCPProxy,
 			ConfigType: &listener.Filter_TypedConfig{
 				TypedConfig: pilotutil.MessageToAny(&tcp_proxy.TcpProxy{
 					StatPrefix:       "tcp",

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -52,7 +52,7 @@ import (
 	"istio.io/istio/pkg/config/validation"
 	"istio.io/istio/pkg/envoy"
 	"istio.io/istio/pkg/spiffe"
-	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
 const trustworthyJWTPath = "/var/run/secrets/tokens/istio-token"
@@ -293,7 +293,7 @@ var (
 				return err
 			}
 
-			if out, err := protomarshal.ToYAML(&proxyConfig); err != nil {
+			if out, err := gogoprotomarshal.ToYAML(&proxyConfig); err != nil {
 				log.Infof("Failed to serialize to YAML: %v", err)
 			} else {
 				log.Infof("Effective config: %s", out)

--- a/pilot/cmd/pilot-agent/status/util/listeners.go
+++ b/pilot/cmd/pilot-agent/status/util/listeners.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	admin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/cmd/pilot-agent/status/util/server_info.go
+++ b/pilot/cmd/pilot-agent/status/util/server_info.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	admin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/hashicorp/go-multierror"
 )
 

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -31,7 +31,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schemas"
-	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
 // ConvertObject converts an IstioObject k8s-style object to the
@@ -87,7 +87,7 @@ func ConvertObjectFromUnstructured(schema schema.Instance, un *unstructured.Unst
 
 // ConvertConfig translates Istio config to k8s config JSON
 func ConvertConfig(schema schema.Instance, cfg model.Config) (IstioObject, error) {
-	spec, err := protomarshal.ToJSONMap(cfg.Spec)
+	spec, err := gogoprotomarshal.ToJSONMap(cfg.Spec)
 	if err != nil {
 		return nil, err
 	}

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -17,7 +17,7 @@ package features
 import (
 	"time"
 
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 
 	"istio.io/pkg/env"
 )
@@ -96,7 +96,7 @@ var (
 			"a response to the config requested by Envoy, the Envoy will move on with the init phase. "+
 			"This prevents envoy from getting stuck waiting on config during startup.",
 	)
-	InitialFetchTimeout = types.DurationProto(initialFetchTimeoutVar.Get())
+	InitialFetchTimeout = ptypes.DurationProto(initialFetchTimeoutVar.Get())
 
 	terminationDrainDurationVar = env.RegisterIntVar(
 		"TERMINATION_DRAIN_DURATION_SECONDS",

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -22,9 +22,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/gogo/protobuf/jsonpb"
-	"github.com/gogo/protobuf/types"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/golang/protobuf/jsonpb"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
@@ -312,7 +312,7 @@ func GetNetworkView(node *Proxy) map[string]bool {
 
 // ParseMetadata parses the opaque Metadata from an Envoy Node into string key-value pairs.
 // Any non-string values are ignored.
-func ParseMetadata(metadata *types.Struct) map[string]string {
+func ParseMetadata(metadata *structpb.Struct) map[string]string {
 	if metadata == nil {
 		return nil
 	}
@@ -320,7 +320,7 @@ func ParseMetadata(metadata *types.Struct) map[string]string {
 	res := make(map[string]string, len(fields))
 	for k, v := range fields {
 		switch s := v.GetKind().(type) {
-		case *types.Value_StringValue:
+		case *structpb.Value_StringValue:
 			res[k] = s.StringValue
 		default:
 			// Some fields are not simple strings, dump these to json strings.

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -20,8 +20,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gogo/protobuf/jsonpb"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/jsonpb"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
 
 	"istio.io/istio/pkg/config/labels"
@@ -145,13 +145,13 @@ func TestParseMetadata(t *testing.T) {
 	}
 }
 
-func mapToStruct(msg map[string]interface{}) (*types.Struct, error) {
+func mapToStruct(msg map[string]interface{}) (*structpb.Struct, error) {
 	b, err := json.Marshal(msg)
 	if err != nil {
 		return nil, err
 	}
 
-	pbs := &types.Struct{}
+	pbs := &structpb.Struct{}
 	if err := jsonpb.Unmarshal(bytes.NewBuffer(b), pbs); err != nil {
 		return nil, err
 	}

--- a/pilot/pkg/model/conversion_test.go
+++ b/pilot/pkg/model/conversion_test.go
@@ -29,7 +29,7 @@ import (
 
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schemas"
-	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
 func TestApplyJSON(t *testing.T) {
@@ -50,7 +50,7 @@ func TestApplyJSON(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("[%v]", i), func(tt *testing.T) {
 			var got meshconfig.MeshConfig
-			err := protomarshal.ApplyJSON(c.in, &got)
+			err := gogoprotomarshal.ApplyJSON(c.in, &got)
 			if err != nil {
 				if !c.wantErr {
 					tt.Fatalf("got unexpected error: %v", err)
@@ -189,7 +189,7 @@ patterns:
 		},
 	}
 
-	gotJSON, err := protomarshal.ToJSON(msg)
+	gotJSON, err := gogoprotomarshal.ToJSON(msg)
 	if err != nil {
 		t.Errorf("ToJSON failed: %v", err)
 	}
@@ -197,7 +197,7 @@ patterns:
 		t.Errorf("ToJSON failed: \ngot %s, \nwant %s", gotJSON, strings.Join(strings.Fields(wantJSON), ""))
 	}
 
-	if _, err = protomarshal.ToJSON(nil); err == nil {
+	if _, err = gogoprotomarshal.ToJSON(nil); err == nil {
 		t.Error("should produce an error")
 	}
 
@@ -209,7 +209,7 @@ patterns:
 		t.Errorf("FromYAML failed: got %+v want %+v", spew.Sdump(gotFromJSON), spew.Sdump(msg))
 	}
 
-	gotYAML, err := protomarshal.ToYAML(msg)
+	gotYAML, err := gogoprotomarshal.ToYAML(msg)
 	if err != nil {
 		t.Errorf("ToYAML failed: %v", err)
 	}
@@ -217,7 +217,7 @@ patterns:
 		t.Errorf("ToYAML failed: \ngot %+v \nwant %+v", spew.Sdump(gotYAML), spew.Sdump(wantYAML))
 	}
 
-	if _, err = protomarshal.ToYAML(nil); err == nil {
+	if _, err = gogoprotomarshal.ToYAML(nil); err == nil {
 		t.Error("should produce an error")
 	}
 
@@ -233,7 +233,7 @@ patterns:
 		t.Errorf("should produce an error")
 	}
 
-	gotJSONMap, err := protomarshal.ToJSONMap(msg)
+	gotJSONMap, err := gogoprotomarshal.ToJSONMap(msg)
 	if err != nil {
 		t.Errorf("ToJSONMap failed: %v", err)
 	}
@@ -241,7 +241,7 @@ patterns:
 		t.Errorf("ToJSONMap failed: \ngot %vwant %v", spew.Sdump(gotJSONMap), spew.Sdump(wantJSONMap))
 	}
 
-	if _, err = protomarshal.ToJSONMap(nil); err == nil {
+	if _, err = gogoprotomarshal.ToJSONMap(nil); err == nil {
 		t.Error("should produce an error")
 	}
 
@@ -324,7 +324,7 @@ trafficPolicy:
 		t.Errorf("FromYAML should have failed using Schema with bad MessageName")
 	}
 
-	gotJSON, err := protomarshal.ToJSON(msg)
+	gotJSON, err := gogoprotomarshal.ToJSON(msg)
 	if err != nil {
 		t.Errorf("ToJSON failed: %v", err)
 	}
@@ -332,7 +332,7 @@ trafficPolicy:
 		t.Errorf("ToJSON failed: got %s, want %s", gotJSON, wantJSON)
 	}
 
-	if _, err = protomarshal.ToJSON(nil); err == nil {
+	if _, err = gogoprotomarshal.ToJSON(nil); err == nil {
 		t.Error("should produce an error")
 	}
 
@@ -344,7 +344,7 @@ trafficPolicy:
 		t.Errorf("FromYAML failed: got %+v want %+v", spew.Sdump(gotFromJSON), spew.Sdump(msg))
 	}
 
-	gotYAML, err := protomarshal.ToYAML(msg)
+	gotYAML, err := gogoprotomarshal.ToYAML(msg)
 	if err != nil {
 		t.Errorf("ToYAML failed: %v", err)
 	}
@@ -352,7 +352,7 @@ trafficPolicy:
 		t.Errorf("ToYAML failed: got %+v want %+v", spew.Sdump(gotYAML), spew.Sdump(wantYAML))
 	}
 
-	if _, err = protomarshal.ToYAML(nil); err == nil {
+	if _, err = gogoprotomarshal.ToYAML(nil); err == nil {
 		t.Error("should produce an error")
 	}
 
@@ -368,7 +368,7 @@ trafficPolicy:
 		t.Errorf("should produce an error")
 	}
 
-	gotJSONMap, err := protomarshal.ToJSONMap(msg)
+	gotJSONMap, err := gogoprotomarshal.ToJSONMap(msg)
 	if err != nil {
 		t.Errorf("ToJSONMap failed: %v", err)
 	}
@@ -376,7 +376,7 @@ trafficPolicy:
 		t.Errorf("ToJSONMap failed: \ngot %vwant %v", spew.Sdump(gotJSONMap), spew.Sdump(wantJSONMap))
 	}
 
-	if _, err = protomarshal.ToJSONMap(nil); err == nil {
+	if _, err = gogoprotomarshal.ToJSONMap(nil); err == nil {
 		t.Error("should produce an error")
 	}
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -31,7 +31,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 
 	authn "istio.io/api/authentication/v1alpha1"
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -20,12 +20,15 @@ import (
 	"strings"
 
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	v2Cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/wrappers"
+
+	"istio.io/istio/pkg/util/gogo"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -67,7 +70,7 @@ var (
 		// this value to 3, however that has shown to be insufficient during periods of pod churn (e.g. rolling updates),
 		// where multiple endpoints in a cluster are terminated. In these scenarios the circuit breaker can kick
 		// in before Pilot is able to deliver an updated endpoint list to Envoy, leading to client-facing 503s.
-		MaxRetries: &types.UInt32Value{Value: 1024},
+		MaxRetries: &wrappers.UInt32Value{Value: 1024},
 	}
 )
 
@@ -390,7 +393,7 @@ func buildLocalityLbEndpoints(env *model.Environment, proxyNetworkView map[strin
 					Address: host,
 				},
 			},
-			LoadBalancingWeight: &types.UInt32Value{
+			LoadBalancingWeight: &wrappers.UInt32Value{
 				Value: 1,
 			},
 		}
@@ -411,7 +414,7 @@ func buildLocalityLbEndpoints(env *model.Environment, proxyNetworkView map[strin
 		localityLbEndpoints = append(localityLbEndpoints, &endpoint.LocalityLbEndpoints{
 			Locality:    util.ConvertLocality(locality),
 			LbEndpoints: eps,
-			LoadBalancingWeight: &types.UInt32Value{
+			LoadBalancingWeight: &wrappers.UInt32Value{
 				Value: weight,
 			},
 		})
@@ -784,20 +787,20 @@ func applyConnectionPool(env *model.Environment, cluster *apiv2.Cluster, setting
 	if settings.Http != nil {
 		if settings.Http.Http2MaxRequests > 0 {
 			// Envoy only applies MaxRequests in HTTP/2 clusters
-			threshold.MaxRequests = &types.UInt32Value{Value: uint32(settings.Http.Http2MaxRequests)}
+			threshold.MaxRequests = &wrappers.UInt32Value{Value: uint32(settings.Http.Http2MaxRequests)}
 		}
 		if settings.Http.Http1MaxPendingRequests > 0 {
 			// Envoy only applies MaxPendingRequests in HTTP/1.1 clusters
-			threshold.MaxPendingRequests = &types.UInt32Value{Value: uint32(settings.Http.Http1MaxPendingRequests)}
+			threshold.MaxPendingRequests = &wrappers.UInt32Value{Value: uint32(settings.Http.Http1MaxPendingRequests)}
 		}
 
 		if settings.Http.MaxRequestsPerConnection > 0 {
-			cluster.MaxRequestsPerConnection = &types.UInt32Value{Value: uint32(settings.Http.MaxRequestsPerConnection)}
+			cluster.MaxRequestsPerConnection = &wrappers.UInt32Value{Value: uint32(settings.Http.MaxRequestsPerConnection)}
 		}
 
 		// FIXME: zero is a valid value if explicitly set, otherwise we want to use the default
 		if settings.Http.MaxRetries > 0 {
-			threshold.MaxRetries = &types.UInt32Value{Value: uint32(settings.Http.MaxRetries)}
+			threshold.MaxRetries = &wrappers.UInt32Value{Value: uint32(settings.Http.MaxRetries)}
 		}
 
 		idleTimeout = settings.Http.IdleTimeout
@@ -805,11 +808,11 @@ func applyConnectionPool(env *model.Environment, cluster *apiv2.Cluster, setting
 
 	if settings.Tcp != nil {
 		if settings.Tcp.ConnectTimeout != nil {
-			cluster.ConnectTimeout = util.GogoDurationToDuration(settings.Tcp.ConnectTimeout)
+			cluster.ConnectTimeout = gogo.DurationToProtoDuration(settings.Tcp.ConnectTimeout)
 		}
 
 		if settings.Tcp.MaxConnections > 0 {
-			threshold.MaxConnections = &types.UInt32Value{Value: uint32(settings.Tcp.MaxConnections)}
+			threshold.MaxConnections = &wrappers.UInt32Value{Value: uint32(settings.Tcp.MaxConnections)}
 		}
 
 		applyTCPKeepalive(env, cluster, settings)
@@ -820,7 +823,7 @@ func applyConnectionPool(env *model.Environment, cluster *apiv2.Cluster, setting
 	}
 
 	if idleTimeout != nil {
-		idleTimeoutDuration := util.GogoDurationToDuration(idleTimeout)
+		idleTimeoutDuration := gogo.DurationToProtoDuration(idleTimeout)
 		cluster.CommonHttpProtocolOptions = &core.HttpProtocolOptions{IdleTimeout: idleTimeoutDuration}
 	}
 }
@@ -859,15 +862,15 @@ func applyTCPKeepalive(env *model.Environment, cluster *apiv2.Cluster, settings 
 
 	// If any of the TCP keepalive options are not set, skip them from the config so that OS defaults are used.
 	if keepaliveProbes > 0 {
-		upstreamConnectionOptions.TcpKeepalive.KeepaliveProbes = &types.UInt32Value{Value: keepaliveProbes}
+		upstreamConnectionOptions.TcpKeepalive.KeepaliveProbes = &wrappers.UInt32Value{Value: keepaliveProbes}
 	}
 
 	if keepaliveTime != nil {
-		upstreamConnectionOptions.TcpKeepalive.KeepaliveTime = &types.UInt32Value{Value: uint32(keepaliveTime.Seconds)}
+		upstreamConnectionOptions.TcpKeepalive.KeepaliveTime = &wrappers.UInt32Value{Value: uint32(keepaliveTime.Seconds)}
 	}
 
 	if keepaliveInterval != nil {
-		upstreamConnectionOptions.TcpKeepalive.KeepaliveInterval = &types.UInt32Value{Value: uint32(keepaliveInterval.Seconds)}
+		upstreamConnectionOptions.TcpKeepalive.KeepaliveInterval = &wrappers.UInt32Value{Value: uint32(keepaliveInterval.Seconds)}
 	}
 
 	cluster.UpstreamConnectionOptions = upstreamConnectionOptions
@@ -881,19 +884,19 @@ func applyOutlierDetection(cluster *apiv2.Cluster, outlier *networking.OutlierDe
 
 	out := &v2Cluster.OutlierDetection{}
 	if outlier.BaseEjectionTime != nil {
-		out.BaseEjectionTime = outlier.BaseEjectionTime
+		out.BaseEjectionTime = gogo.DurationToProtoDuration(outlier.BaseEjectionTime)
 	}
 	if outlier.ConsecutiveErrors > 0 {
 		// Only listen to gateway errors, see https://github.com/istio/api/pull/617
-		out.EnforcingConsecutiveGatewayFailure = &types.UInt32Value{Value: uint32(100)} // defaults to 0
-		out.EnforcingConsecutive_5Xx = &types.UInt32Value{Value: uint32(0)}             // defaults to 100
-		out.ConsecutiveGatewayFailure = &types.UInt32Value{Value: uint32(outlier.ConsecutiveErrors)}
+		out.EnforcingConsecutiveGatewayFailure = &wrappers.UInt32Value{Value: uint32(100)} // defaults to 0
+		out.EnforcingConsecutive_5Xx = &wrappers.UInt32Value{Value: uint32(0)}             // defaults to 100
+		out.ConsecutiveGatewayFailure = &wrappers.UInt32Value{Value: uint32(outlier.ConsecutiveErrors)}
 	}
 	if outlier.Interval != nil {
-		out.Interval = outlier.Interval
+		out.Interval = gogo.DurationToProtoDuration(outlier.Interval)
 	}
 	if outlier.MaxEjectionPercent > 0 {
-		out.MaxEjectionPercent = &types.UInt32Value{Value: uint32(outlier.MaxEjectionPercent)}
+		out.MaxEjectionPercent = &wrappers.UInt32Value{Value: uint32(outlier.MaxEjectionPercent)}
 	}
 
 	cluster.OutlierDetection = out
@@ -930,9 +933,12 @@ func applyLoadBalancer(cluster *apiv2.Cluster, lb *networking.LoadBalancerSettin
 	// rejected by Envoy.
 
 	// Original destination service discovery must be used with the original destination load balancer.
-	if cluster.GetClusterDiscoveryType().Equal(&apiv2.Cluster_Type{Type: apiv2.Cluster_ORIGINAL_DST}) {
-		cluster.LbPolicy = lbPolicyClusterProvided(proxy)
-		return
+	switch t := cluster.ClusterDiscoveryType.(type) {
+	case *apiv2.Cluster_Type:
+		if t.Type == apiv2.Cluster_ORIGINAL_DST {
+			cluster.LbPolicy = lbPolicyClusterProvided(proxy)
+			return
+		}
 	}
 
 	// Redis protocol must be defaulted with MAGLEV to benefit from client side sharding.
@@ -959,9 +965,9 @@ func applyLoadBalancer(cluster *apiv2.Cluster, lb *networking.LoadBalancerSettin
 		// TODO MinimumRingSize is an int, and zero could potentially be a valid value
 		// unable to distinguish between set and unset case currently GregHanson
 		// 1024 is the default value for envoy
-		minRingSize := &types.UInt64Value{Value: 1024}
+		minRingSize := &wrappers.UInt64Value{Value: 1024}
 		if consistentHash.MinimumRingSize != 0 {
-			minRingSize = &types.UInt64Value{Value: consistentHash.GetMinimumRingSize()}
+			minRingSize = &wrappers.UInt64Value{Value: consistentHash.GetMinimumRingSize()}
 		}
 		cluster.LbPolicy = apiv2.Cluster_RING_HASH
 		cluster.LbConfig = &apiv2.Cluster_RingHashLbConfig_{
@@ -1094,7 +1100,7 @@ func setUpstreamProtocol(node *model.Proxy, cluster *apiv2.Cluster, port *model.
 	if port.Protocol.IsHTTP2() {
 		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{
 			// Envoy default value of 100 is too low for data path.
-			MaxConcurrentStreams: &types.UInt32Value{
+			MaxConcurrentStreams: &wrappers.UInt32Value{
 				Value: 1073741824,
 			},
 		}
@@ -1123,7 +1129,7 @@ func buildBlackHoleCluster(env *model.Environment) *apiv2.Cluster {
 	cluster := &apiv2.Cluster{
 		Name:                 util.BlackHoleCluster,
 		ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_STATIC},
-		ConnectTimeout:       util.GogoDurationToDuration(env.Mesh.ConnectTimeout),
+		ConnectTimeout:       gogo.DurationToProtoDuration(env.Mesh.ConnectTimeout),
 		LbPolicy:             apiv2.Cluster_ROUND_ROBIN,
 	}
 	return cluster
@@ -1135,7 +1141,7 @@ func buildDefaultPassthroughCluster(env *model.Environment, proxy *model.Proxy) 
 	cluster := &apiv2.Cluster{
 		Name:                 util.PassthroughCluster,
 		ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_ORIGINAL_DST},
-		ConnectTimeout:       util.GogoDurationToDuration(env.Mesh.ConnectTimeout),
+		ConnectTimeout:       gogo.DurationToProtoDuration(env.Mesh.ConnectTimeout),
 		LbPolicy:             lbPolicyClusterProvided(proxy),
 	}
 	passthroughSettings := &networking.ConnectionPoolSettings{
@@ -1158,7 +1164,7 @@ func buildDefaultCluster(env *model.Environment, name string, discoveryType apiv
 
 	if discoveryType == apiv2.Cluster_STRICT_DNS {
 		cluster.DnsLookupFamily = apiv2.Cluster_V4_ONLY
-		dnsRate := util.GogoDurationToDuration(env.Mesh.DnsRefreshRate)
+		dnsRate := gogo.DurationToProtoDuration(env.Mesh.DnsRefreshRate)
 		cluster.DnsRefreshRate = dnsRate
 		if util.IsIstioVersionGE13(proxy) && features.RespectDNSTTL.Get() {
 			cluster.RespectDnsTtl = true

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -933,7 +933,7 @@ func applyLoadBalancer(cluster *apiv2.Cluster, lb *networking.LoadBalancerSettin
 	// rejected by Envoy.
 
 	// Original destination service discovery must be used with the original destination load balancer.
-	switch t := cluster.ClusterDiscoveryType.(type) {
+	switch t := cluster.GetClusterDiscoveryType().(type) {
 	case *apiv2.Cluster_Type:
 		if t.Type == apiv2.Cluster_ORIGINAL_DST {
 			cluster.LbPolicy = lbPolicyClusterProvided(proxy)

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1111,7 +1111,7 @@ func setUpstreamProtocol(node *model.Proxy, cluster *apiv2.Cluster, port *model.
 		// setup http2 protocol options for upstream connection.
 		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{
 			// Envoy default value of 100 is too low for data path.
-			MaxConcurrentStreams: &types.UInt32Value{
+			MaxConcurrentStreams: &wrappers.UInt32Value{
 				Value: 1073741824,
 			},
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -22,10 +22,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+
 	"istio.io/istio/pilot/pkg/networking/util"
 
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	. "github.com/onsi/gomega"
@@ -206,7 +208,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 
 			// Verify that the values were set correctly.
 			g.Expect(commonHTTPProtocolOptions.IdleTimeout).To(Not(BeNil()))
-			g.Expect(*commonHTTPProtocolOptions.IdleTimeout).To(Equal(time.Duration(15000000000)))
+			g.Expect(commonHTTPProtocolOptions.IdleTimeout).To(Equal(ptypes.DurationProto(time.Duration(15000000000))))
 		})
 	}
 }
@@ -395,7 +397,7 @@ func TestBuildGatewayClustersWithRingHashLb(t *testing.T) {
 	g.Expect(cluster.LbPolicy).To(Equal(apiv2.Cluster_RING_HASH))
 	g.Expect(cluster.GetRingHashLbConfig().GetMinimumRingSize().GetValue()).To(Equal(uint64(2)))
 	g.Expect(cluster.Name).To(Equal("outbound|8080||*.example.org"))
-	g.Expect(cluster.ConnectTimeout.Nanoseconds()).To(Equal(int64(10000000001)))
+	g.Expect(cluster.ConnectTimeout).To(Equal(ptypes.DurationProto(time.Duration(10000000001))))
 }
 
 func TestBuildGatewayClustersWithRingHashLbDefaultMinRingSize(t *testing.T) {
@@ -428,7 +430,7 @@ func TestBuildGatewayClustersWithRingHashLbDefaultMinRingSize(t *testing.T) {
 	g.Expect(cluster.LbPolicy).To(Equal(apiv2.Cluster_RING_HASH))
 	g.Expect(cluster.GetRingHashLbConfig().GetMinimumRingSize().GetValue()).To(Equal(uint64(1024)))
 	g.Expect(cluster.Name).To(Equal("outbound|8080||*.example.org"))
-	g.Expect(cluster.ConnectTimeout.Nanoseconds()).To(Equal(int64(10000000001)))
+	g.Expect(cluster.ConnectTimeout).To(Equal(ptypes.DurationProto(time.Duration(10000000001))))
 }
 
 func newTestEnvironment(serviceDiscovery model.ServiceDiscovery, mesh meshconfig.MeshConfig, configStore model.IstioConfigStore) *model.Environment {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/google/go-cmp/cmp"
 
 	networking "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/deprecated.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/deprecated.go
@@ -19,10 +19,12 @@ import (
 	"strings"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	xdslistener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+
+	"istio.io/istio/pkg/util/gogo"
 
 	networking "istio.io/api/networking/v1alpha3"
 
@@ -212,7 +214,7 @@ func deprecatedInsertHTTPFilter(listenerName string, filterChain *xdslistener.Fi
 	envoyFilter *networking.EnvoyFilter_Filter, isXDSMarshalingToAnyEnabled bool) {
 	filter := &http_conn.HttpFilter{
 		Name:       envoyFilter.FilterName,
-		ConfigType: &http_conn.HttpFilter_Config{Config: envoyFilter.FilterConfig},
+		ConfigType: &http_conn.HttpFilter_Config{Config: gogo.StructToProtoStruct(envoyFilter.FilterConfig)},
 	}
 
 	position := networking.EnvoyFilter_InsertPosition_FIRST
@@ -267,7 +269,7 @@ func deprecatedInsertNetworkFilter(listenerName string, filterChain *xdslistener
 	envoyFilter *networking.EnvoyFilter_Filter) {
 	filter := &xdslistener.Filter{
 		Name:       envoyFilter.FilterName,
-		ConfigType: &xdslistener.Filter_Config{Config: envoyFilter.FilterConfig},
+		ConfigType: &xdslistener.Filter_Config{Config: gogo.StructToProtoStruct(envoyFilter.FilterConfig)},
 	}
 
 	position := networking.EnvoyFilter_InsertPosition_FIRST

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -20,12 +20,13 @@ import (
 	"testing"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	fault "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/fault/v2"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/types"
@@ -423,11 +424,11 @@ func TestApplyListenerPatches(t *testing.T) {
 	faultFilterIn := &fault.HTTPFault{
 		UpstreamCluster: "foobar",
 	}
-	faultFilterInAny, _ := types.MarshalAny(faultFilterIn)
+	faultFilterInAny, _ := ptypes.MarshalAny(faultFilterIn)
 	faultFilterOut := &fault.HTTPFault{
 		UpstreamCluster: "scooby",
 	}
-	faultFilterOutAny, _ := types.MarshalAny(faultFilterOut)
+	faultFilterOutAny, _ := ptypes.MarshalAny(faultFilterOut)
 	sidecarInboundIn := []*xdsapi.Listener{
 		{
 			Name: "12345",

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/proto"
 
 	networking "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/google/go-cmp/cmp"
 
 	networking "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/hashicorp/go-multierror"
 
@@ -356,10 +356,10 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 			httpOpts: &httpListenerOpts{
 				rds:              routeName,
 				useRemoteAddress: true,
-				direction:        http_conn.EGRESS, // viewed as from gateway to internal
+				direction:        http_conn.HttpConnectionManager_Tracing_EGRESS, // viewed as from gateway to internal
 				connectionManager: &http_conn.HttpConnectionManager{
 					// Forward client cert if connection is mTLS
-					ForwardClientCertDetails: http_conn.SANITIZE_SET,
+					ForwardClientCertDetails: http_conn.HttpConnectionManager_SANITIZE_SET,
 					SetCurrentClientCertDetails: &http_conn.HttpConnectionManager_SetCurrentClientCertDetails{
 						Subject: proto.BoolTrue,
 						Cert:    true,
@@ -391,10 +391,10 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 		httpOpts: &httpListenerOpts{
 			rds:              routeName,
 			useRemoteAddress: true,
-			direction:        http_conn.EGRESS, // viewed as from gateway to internal
+			direction:        http_conn.HttpConnectionManager_Tracing_EGRESS, // viewed as from gateway to internal
 			connectionManager: &http_conn.HttpConnectionManager{
 				// Forward client cert if connection is mTLS
-				ForwardClientCertDetails: http_conn.SANITIZE_SET,
+				ForwardClientCertDetails: http_conn.HttpConnectionManager_SANITIZE_SET,
 				SetCurrentClientCertDetails: &http_conn.HttpConnectionManager_SetCurrentClientCertDetails{
 					Subject: proto.BoolTrue,
 					Cert:    true,

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -18,10 +18,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	"github.com/gogo/protobuf/types"
 
 	networking "istio.io/api/networking/v1alpha3"
 
@@ -605,9 +604,9 @@ func TestCreateGatewayHTTPFilterChainOpts(t *testing.T) {
 				httpOpts: &httpListenerOpts{
 					rds:              "some-route",
 					useRemoteAddress: true,
-					direction:        http_conn.EGRESS,
+					direction:        http_conn.HttpConnectionManager_Tracing_EGRESS,
 					connectionManager: &http_conn.HttpConnectionManager{
-						ForwardClientCertDetails: http_conn.SANITIZE_SET,
+						ForwardClientCertDetails: http_conn.HttpConnectionManager_SANITIZE_SET,
 						SetCurrentClientCertDetails: &http_conn.HttpConnectionManager_SetCurrentClientCertDetails{
 							Subject: proto.BoolTrue,
 							Cert:    true,
@@ -638,9 +637,7 @@ func TestCreateGatewayHTTPFilterChainOpts(t *testing.T) {
 			result: &filterChainOpts{
 				sniHosts: []string{"example.org"},
 				tlsContext: &auth.DownstreamTlsContext{
-					RequireClientCertificate: &types.BoolValue{
-						Value: true,
-					},
+					RequireClientCertificate: proto.BoolTrue,
 					CommonTlsContext: &auth.CommonTlsContext{
 						TlsCertificates: []*auth.TlsCertificate{
 							{
@@ -671,9 +668,9 @@ func TestCreateGatewayHTTPFilterChainOpts(t *testing.T) {
 				httpOpts: &httpListenerOpts{
 					rds:              "some-route",
 					useRemoteAddress: true,
-					direction:        http_conn.EGRESS,
+					direction:        http_conn.HttpConnectionManager_Tracing_EGRESS,
 					connectionManager: &http_conn.HttpConnectionManager{
-						ForwardClientCertDetails: http_conn.SANITIZE_SET,
+						ForwardClientCertDetails: http_conn.HttpConnectionManager_SANITIZE_SET,
 						SetCurrentClientCertDetails: &http_conn.HttpConnectionManager_SetCurrentClientCertDetails{
 							Subject: proto.BoolTrue,
 							Cert:    true,
@@ -702,9 +699,7 @@ func TestCreateGatewayHTTPFilterChainOpts(t *testing.T) {
 			result: &filterChainOpts{
 				sniHosts: []string{"example.org", "test.org"},
 				tlsContext: &auth.DownstreamTlsContext{
-					RequireClientCertificate: &types.BoolValue{
-						Value: true,
-					},
+					RequireClientCertificate: proto.BoolTrue,
 					CommonTlsContext: &auth.CommonTlsContext{
 						TlsCertificates: []*auth.TlsCertificate{
 							{
@@ -735,9 +730,9 @@ func TestCreateGatewayHTTPFilterChainOpts(t *testing.T) {
 				httpOpts: &httpListenerOpts{
 					rds:              "some-route",
 					useRemoteAddress: true,
-					direction:        http_conn.EGRESS,
+					direction:        http_conn.HttpConnectionManager_Tracing_EGRESS,
 					connectionManager: &http_conn.HttpConnectionManager{
-						ForwardClientCertDetails: http_conn.SANITIZE_SET,
+						ForwardClientCertDetails: http_conn.HttpConnectionManager_SANITIZE_SET,
 						SetCurrentClientCertDetails: &http_conn.HttpConnectionManager_SetCurrentClientCertDetails{
 							Subject: proto.BoolTrue,
 							Cert:    true,
@@ -766,9 +761,7 @@ func TestCreateGatewayHTTPFilterChainOpts(t *testing.T) {
 			result: &filterChainOpts{
 				sniHosts: []string{"*.example.org", "example.org"},
 				tlsContext: &auth.DownstreamTlsContext{
-					RequireClientCertificate: &types.BoolValue{
-						Value: true,
-					},
+					RequireClientCertificate: proto.BoolTrue,
 					CommonTlsContext: &auth.CommonTlsContext{
 						TlsCertificates: []*auth.TlsCertificate{
 							{
@@ -799,9 +792,9 @@ func TestCreateGatewayHTTPFilterChainOpts(t *testing.T) {
 				httpOpts: &httpListenerOpts{
 					rds:              "some-route",
 					useRemoteAddress: true,
-					direction:        http_conn.EGRESS,
+					direction:        http_conn.HttpConnectionManager_Tracing_EGRESS,
 					connectionManager: &http_conn.HttpConnectionManager{
-						ForwardClientCertDetails: http_conn.SANITIZE_SET,
+						ForwardClientCertDetails: http_conn.HttpConnectionManager_SANITIZE_SET,
 						SetCurrentClientCertDetails: &http_conn.HttpConnectionManager_SetCurrentClientCertDetails{
 							Subject: proto.BoolTrue,
 							Cert:    true,

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 
 	networking "istio.io/api/networking/v1alpha3"
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 
 	meshapi "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -24,16 +24,19 @@ import (
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	accesslogconfig "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
-	google_protobuf "github.com/gogo/protobuf/types"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+
+	"istio.io/istio/pkg/util/gogo"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -144,59 +147,59 @@ var (
 	applicationProtocols = []string{"http/1.0", "http/1.1"}
 
 	// EnvoyJSONLogFormat12 map of values for envoy json based access logs for Istio 1.2
-	EnvoyJSONLogFormat12 = &google_protobuf.Struct{
-		Fields: map[string]*google_protobuf.Value{
-			"start_time":                        {Kind: &google_protobuf.Value_StringValue{StringValue: "%START_TIME%"}},
-			"method":                            {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(:METHOD)%"}},
-			"path":                              {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"}},
-			"protocol":                          {Kind: &google_protobuf.Value_StringValue{StringValue: "%PROTOCOL%"}},
-			"response_code":                     {Kind: &google_protobuf.Value_StringValue{StringValue: "%RESPONSE_CODE%"}},
-			"response_flags":                    {Kind: &google_protobuf.Value_StringValue{StringValue: "%RESPONSE_FLAGS%"}},
-			"bytes_received":                    {Kind: &google_protobuf.Value_StringValue{StringValue: "%BYTES_RECEIVED%"}},
-			"bytes_sent":                        {Kind: &google_protobuf.Value_StringValue{StringValue: "%BYTES_SENT%"}},
-			"duration":                          {Kind: &google_protobuf.Value_StringValue{StringValue: "%DURATION%"}},
-			"upstream_service_time":             {Kind: &google_protobuf.Value_StringValue{StringValue: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"}},
-			"x_forwarded_for":                   {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(X-FORWARDED-FOR)%"}},
-			"user_agent":                        {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(USER-AGENT)%"}},
-			"request_id":                        {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(X-REQUEST-ID)%"}},
-			"authority":                         {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(:AUTHORITY)%"}},
-			"upstream_host":                     {Kind: &google_protobuf.Value_StringValue{StringValue: "%UPSTREAM_HOST%"}},
-			"upstream_cluster":                  {Kind: &google_protobuf.Value_StringValue{StringValue: "%UPSTREAM_CLUSTER%"}},
-			"upstream_local_address":            {Kind: &google_protobuf.Value_StringValue{StringValue: "%UPSTREAM_LOCAL_ADDRESS%"}},
-			"downstream_local_address":          {Kind: &google_protobuf.Value_StringValue{StringValue: "%DOWNSTREAM_LOCAL_ADDRESS%"}},
-			"downstream_remote_address":         {Kind: &google_protobuf.Value_StringValue{StringValue: "%DOWNSTREAM_REMOTE_ADDRESS%"}},
-			"requested_server_name":             {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQUESTED_SERVER_NAME%"}},
-			"istio_policy_status":               {Kind: &google_protobuf.Value_StringValue{StringValue: "%DYNAMIC_METADATA(istio.mixer:status)%"}},
-			"upstream_transport_failure_reason": {Kind: &google_protobuf.Value_StringValue{StringValue: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"}},
+	EnvoyJSONLogFormat12 = &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"start_time":                        {Kind: &structpb.Value_StringValue{StringValue: "%START_TIME%"}},
+			"method":                            {Kind: &structpb.Value_StringValue{StringValue: "%REQ(:METHOD)%"}},
+			"path":                              {Kind: &structpb.Value_StringValue{StringValue: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"}},
+			"protocol":                          {Kind: &structpb.Value_StringValue{StringValue: "%PROTOCOL%"}},
+			"response_code":                     {Kind: &structpb.Value_StringValue{StringValue: "%RESPONSE_CODE%"}},
+			"response_flags":                    {Kind: &structpb.Value_StringValue{StringValue: "%RESPONSE_FLAGS%"}},
+			"bytes_received":                    {Kind: &structpb.Value_StringValue{StringValue: "%BYTES_RECEIVED%"}},
+			"bytes_sent":                        {Kind: &structpb.Value_StringValue{StringValue: "%BYTES_SENT%"}},
+			"duration":                          {Kind: &structpb.Value_StringValue{StringValue: "%DURATION%"}},
+			"upstream_service_time":             {Kind: &structpb.Value_StringValue{StringValue: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"}},
+			"x_forwarded_for":                   {Kind: &structpb.Value_StringValue{StringValue: "%REQ(X-FORWARDED-FOR)%"}},
+			"user_agent":                        {Kind: &structpb.Value_StringValue{StringValue: "%REQ(USER-AGENT)%"}},
+			"request_id":                        {Kind: &structpb.Value_StringValue{StringValue: "%REQ(X-REQUEST-ID)%"}},
+			"authority":                         {Kind: &structpb.Value_StringValue{StringValue: "%REQ(:AUTHORITY)%"}},
+			"upstream_host":                     {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_HOST%"}},
+			"upstream_cluster":                  {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_CLUSTER%"}},
+			"upstream_local_address":            {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_LOCAL_ADDRESS%"}},
+			"downstream_local_address":          {Kind: &structpb.Value_StringValue{StringValue: "%DOWNSTREAM_LOCAL_ADDRESS%"}},
+			"downstream_remote_address":         {Kind: &structpb.Value_StringValue{StringValue: "%DOWNSTREAM_REMOTE_ADDRESS%"}},
+			"requested_server_name":             {Kind: &structpb.Value_StringValue{StringValue: "%REQUESTED_SERVER_NAME%"}},
+			"istio_policy_status":               {Kind: &structpb.Value_StringValue{StringValue: "%DYNAMIC_METADATA(istio.mixer:status)%"}},
+			"upstream_transport_failure_reason": {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"}},
 		},
 	}
 
 	// EnvoyJSONLogFormat13 map of values for envoy json based access logs for Istio 1.3 onwards
-	EnvoyJSONLogFormat13 = &google_protobuf.Struct{
-		Fields: map[string]*google_protobuf.Value{
-			"start_time":                        {Kind: &google_protobuf.Value_StringValue{StringValue: "%START_TIME%"}},
-			"route_name":                        {Kind: &google_protobuf.Value_StringValue{StringValue: "%ROUTE_NAME%"}},
-			"method":                            {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(:METHOD)%"}},
-			"path":                              {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"}},
-			"protocol":                          {Kind: &google_protobuf.Value_StringValue{StringValue: "%PROTOCOL%"}},
-			"response_code":                     {Kind: &google_protobuf.Value_StringValue{StringValue: "%RESPONSE_CODE%"}},
-			"response_flags":                    {Kind: &google_protobuf.Value_StringValue{StringValue: "%RESPONSE_FLAGS%"}},
-			"bytes_received":                    {Kind: &google_protobuf.Value_StringValue{StringValue: "%BYTES_RECEIVED%"}},
-			"bytes_sent":                        {Kind: &google_protobuf.Value_StringValue{StringValue: "%BYTES_SENT%"}},
-			"duration":                          {Kind: &google_protobuf.Value_StringValue{StringValue: "%DURATION%"}},
-			"upstream_service_time":             {Kind: &google_protobuf.Value_StringValue{StringValue: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"}},
-			"x_forwarded_for":                   {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(X-FORWARDED-FOR)%"}},
-			"user_agent":                        {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(USER-AGENT)%"}},
-			"request_id":                        {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(X-REQUEST-ID)%"}},
-			"authority":                         {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQ(:AUTHORITY)%"}},
-			"upstream_host":                     {Kind: &google_protobuf.Value_StringValue{StringValue: "%UPSTREAM_HOST%"}},
-			"upstream_cluster":                  {Kind: &google_protobuf.Value_StringValue{StringValue: "%UPSTREAM_CLUSTER%"}},
-			"upstream_local_address":            {Kind: &google_protobuf.Value_StringValue{StringValue: "%UPSTREAM_LOCAL_ADDRESS%"}},
-			"downstream_local_address":          {Kind: &google_protobuf.Value_StringValue{StringValue: "%DOWNSTREAM_LOCAL_ADDRESS%"}},
-			"downstream_remote_address":         {Kind: &google_protobuf.Value_StringValue{StringValue: "%DOWNSTREAM_REMOTE_ADDRESS%"}},
-			"requested_server_name":             {Kind: &google_protobuf.Value_StringValue{StringValue: "%REQUESTED_SERVER_NAME%"}},
-			"istio_policy_status":               {Kind: &google_protobuf.Value_StringValue{StringValue: "%DYNAMIC_METADATA(istio.mixer:status)%"}},
-			"upstream_transport_failure_reason": {Kind: &google_protobuf.Value_StringValue{StringValue: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"}},
+	EnvoyJSONLogFormat13 = &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"start_time":                        {Kind: &structpb.Value_StringValue{StringValue: "%START_TIME%"}},
+			"route_name":                        {Kind: &structpb.Value_StringValue{StringValue: "%ROUTE_NAME%"}},
+			"method":                            {Kind: &structpb.Value_StringValue{StringValue: "%REQ(:METHOD)%"}},
+			"path":                              {Kind: &structpb.Value_StringValue{StringValue: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"}},
+			"protocol":                          {Kind: &structpb.Value_StringValue{StringValue: "%PROTOCOL%"}},
+			"response_code":                     {Kind: &structpb.Value_StringValue{StringValue: "%RESPONSE_CODE%"}},
+			"response_flags":                    {Kind: &structpb.Value_StringValue{StringValue: "%RESPONSE_FLAGS%"}},
+			"bytes_received":                    {Kind: &structpb.Value_StringValue{StringValue: "%BYTES_RECEIVED%"}},
+			"bytes_sent":                        {Kind: &structpb.Value_StringValue{StringValue: "%BYTES_SENT%"}},
+			"duration":                          {Kind: &structpb.Value_StringValue{StringValue: "%DURATION%"}},
+			"upstream_service_time":             {Kind: &structpb.Value_StringValue{StringValue: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"}},
+			"x_forwarded_for":                   {Kind: &structpb.Value_StringValue{StringValue: "%REQ(X-FORWARDED-FOR)%"}},
+			"user_agent":                        {Kind: &structpb.Value_StringValue{StringValue: "%REQ(USER-AGENT)%"}},
+			"request_id":                        {Kind: &structpb.Value_StringValue{StringValue: "%REQ(X-REQUEST-ID)%"}},
+			"authority":                         {Kind: &structpb.Value_StringValue{StringValue: "%REQ(:AUTHORITY)%"}},
+			"upstream_host":                     {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_HOST%"}},
+			"upstream_cluster":                  {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_CLUSTER%"}},
+			"upstream_local_address":            {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_LOCAL_ADDRESS%"}},
+			"downstream_local_address":          {Kind: &structpb.Value_StringValue{StringValue: "%DOWNSTREAM_LOCAL_ADDRESS%"}},
+			"downstream_remote_address":         {Kind: &structpb.Value_StringValue{StringValue: "%DOWNSTREAM_REMOTE_ADDRESS%"}},
+			"requested_server_name":             {Kind: &structpb.Value_StringValue{StringValue: "%REQUESTED_SERVER_NAME%"}},
+			"istio_policy_status":               {Kind: &structpb.Value_StringValue{StringValue: "%DYNAMIC_METADATA(istio.mixer:status)%"}},
+			"upstream_transport_failure_reason": {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"}},
 		},
 	}
 )
@@ -216,7 +219,7 @@ func buildAccessLog(node *model.Proxy, fl *accesslogconfig.FileAccessLog, env *m
 			Format: formatString,
 		}
 	case meshconfig.MeshConfig_JSON:
-		var jsonLog *google_protobuf.Struct
+		var jsonLog *structpb.Struct
 		// TODO potential optimization to avoid recomputing the user provided format for every listener
 		// mesh AccessLogFormat field could change so need a way to have a cached value that can be cleared
 		// on changes
@@ -224,15 +227,13 @@ func buildAccessLog(node *model.Proxy, fl *accesslogconfig.FileAccessLog, env *m
 			jsonFields := map[string]string{}
 			err := json.Unmarshal([]byte(env.Mesh.AccessLogFormat), &jsonFields)
 			if err == nil {
-				jsonLog = &google_protobuf.Struct{
-					Fields: make(map[string]*google_protobuf.Value, len(jsonFields)),
+				jsonLog = &structpb.Struct{
+					Fields: make(map[string]*structpb.Value, len(jsonFields)),
 				}
-				fmt.Println(jsonFields)
 				for key, value := range jsonFields {
-					jsonLog.Fields[key] = &google_protobuf.Value{Kind: &google_protobuf.Value_StringValue{StringValue: value}}
+					jsonLog.Fields[key] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: value}}
 				}
 			} else {
-				fmt.Println(env.Mesh.AccessLogFormat)
 				log.Errorf("error parsing provided json log format, default log format will be used: %v", err)
 			}
 		}
@@ -488,12 +489,12 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPListenerOptsForPort
 			pluginParams.Push, pluginParams.ServiceInstance, clusterName),
 		rds:              "", // no RDS for inbound traffic
 		useRemoteAddress: false,
-		direction:        http_conn.INGRESS,
+		direction:        http_conn.HttpConnectionManager_Tracing_INGRESS,
 		connectionManager: &http_conn.HttpConnectionManager{
 			// Append and forward client cert to backend.
-			ForwardClientCertDetails: http_conn.APPEND_FORWARD,
+			ForwardClientCertDetails: http_conn.HttpConnectionManager_APPEND_FORWARD,
 			SetCurrentClientCertDetails: &http_conn.HttpConnectionManager_SetCurrentClientCertDetails{
-				Subject: &google_protobuf.BoolValue{Value: true},
+				Subject: proto.BoolTrue,
 				Uri:     true,
 				Dns:     true,
 			},
@@ -941,7 +942,7 @@ func (configgen *ConfigGeneratorImpl) buildHTTPProxy(env *model.Environment, nod
 		return nil
 	}
 
-	traceOperation := http_conn.EGRESS
+	traceOperation := http_conn.HttpConnectionManager_Tracing_EGRESS
 	listenAddress := actualLocalHostAddress
 
 	httpOpts := &core.Http1ProtocolOptions{
@@ -1069,7 +1070,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 		// which is an internal address, so that trusted headers are not sanitized. This helps to retain the timeout headers
 		// such as "x-envoy-upstream-rq-timeout-ms" set by the calling application.
 		useRemoteAddress: features.UseRemoteAddress.Get(),
-		direction:        http_conn.EGRESS,
+		direction:        http_conn.HttpConnectionManager_Tracing_EGRESS,
 		rds:              rdsName,
 	}
 
@@ -1642,13 +1643,13 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 	copy(filters, httpFilters)
 
 	if httpOpts.addGRPCWebFilter {
-		filters = append(filters, &http_conn.HttpFilter{Name: xdsutil.GRPCWeb})
+		filters = append(filters, &http_conn.HttpFilter{Name: wellknown.GRPCWeb})
 	}
 
 	filters = append(filters,
-		&http_conn.HttpFilter{Name: xdsutil.CORS},
-		&http_conn.HttpFilter{Name: xdsutil.Fault},
-		&http_conn.HttpFilter{Name: xdsutil.Router},
+		&http_conn.HttpFilter{Name: wellknown.CORS},
+		&http_conn.HttpFilter{Name: wellknown.Fault},
+		&http_conn.HttpFilter{Name: wellknown.Router},
 	)
 
 	if httpOpts.connectionManager == nil {
@@ -1656,7 +1657,7 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 	}
 
 	connectionManager := httpOpts.connectionManager
-	connectionManager.CodecType = http_conn.AUTO
+	connectionManager.CodecType = http_conn.HttpConnectionManager_AUTO
 	connectionManager.AccessLog = []*accesslog.AccessLog{}
 	connectionManager.HttpFilters = filters
 	connectionManager.StatPrefix = httpOpts.statPrefix
@@ -1673,11 +1674,11 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 
 	idleTimeout, err := time.ParseDuration(node.Metadata[model.NodeMetadataIdleTimeout])
 	if idleTimeout > 0 && err == nil {
-		connectionManager.IdleTimeout = &idleTimeout
+		connectionManager.IdleTimeout = ptypes.DurationProto(idleTimeout)
 	}
 
-	notimeout := 0 * time.Second
-	connectionManager.StreamIdleTimeout = &notimeout
+	notimeout := ptypes.DurationProto(0 * time.Second)
+	connectionManager.StreamIdleTimeout = notimeout
 
 	if httpOpts.rds != "" {
 		rds := &http_conn.HttpConnectionManager_Rds{
@@ -1702,7 +1703,7 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 		}
 
 		acc := &accesslog.AccessLog{
-			Name: xdsutil.FileAccessLog,
+			Name: wellknown.FileAccessLog,
 		}
 
 		buildAccessLog(node, fl, env)
@@ -1731,7 +1732,7 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 		}
 
 		acc := &accesslog.AccessLog{
-			Name: xdsutil.HTTPGRPCAccessLog,
+			Name: wellknown.HTTPGRPCAccessLog,
 		}
 
 		if util.IsXDSMarshalingToAnyEnabled(node) {
@@ -1779,8 +1780,8 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 		}
 	}
 	if needTLSInspector || opts.needHTTPInspector {
-		listenerFiltersMap[xdsutil.TlsInspector] = true
-		listenerFilters = append(listenerFilters, &listener.ListenerFilter{Name: xdsutil.TlsInspector})
+		listenerFiltersMap[wellknown.TlsInspector] = true
+		listenerFilters = append(listenerFilters, &listener.ListenerFilter{Name: wellknown.TlsInspector})
 	}
 
 	if opts.needHTTPInspector {
@@ -1856,7 +1857,7 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 	}
 
 	if util.IsIstioVersionGE13(opts.proxy) {
-		listener.ListenerFiltersTimeout = util.GogoDurationToDuration(opts.env.Mesh.ProtocolDetectionTimeout)
+		listener.ListenerFiltersTimeout = gogo.DurationToProtoDuration(opts.env.Mesh.ProtocolDetectionTimeout)
 		if listener.ListenerFiltersTimeout != nil {
 			listener.ContinueOnListenerFiltersTimeout = true
 		}
@@ -1893,7 +1894,7 @@ func appendListenerFallthroughRoute(l *xdsapi.Listener, opts *buildListenerOpts,
 		}
 
 		tcpFilter := &listener.Filter{
-			Name: xdsutil.TCPProxy,
+			Name: wellknown.TCPProxy,
 		}
 		tcpProxy := &tcp_proxy.TcpProxy{
 			StatPrefix:       util.PassthroughCluster,
@@ -1956,7 +1957,7 @@ func buildCompleteFilterChain(pluginParams *plugin.InputParams, mutable *plugin.
 			opt.httpOpts.statPrefix = mutable.Listener.Name
 			httpConnectionManagers[i] = buildHTTPConnectionManager(pluginParams.Node, opts.env, opt.httpOpts, chain.HTTP)
 			filter := &listener.Filter{
-				Name: xdsutil.HTTPConnectionManager,
+				Name: wellknown.HTTPConnectionManager,
 			}
 			if util.IsXDSMarshalingToAnyEnabled(pluginParams.Node) {
 				filter.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(httpConnectionManagers[i])}
@@ -2183,13 +2184,13 @@ func appendListenerFilters(filters []*listener.ListenerFilter) []*listener.Liste
 	hasHTTPInspector := false
 
 	for _, f := range filters {
-		hasTLSInspector = hasTLSInspector || f.Name == xdsutil.TlsInspector
+		hasTLSInspector = hasTLSInspector || f.Name == wellknown.TlsInspector
 		hasHTTPInspector = hasHTTPInspector || f.Name == envoyListenerHTTPInspector
 	}
 
 	if !hasTLSInspector {
 		filters =
-			append(filters, &listener.ListenerFilter{Name: xdsutil.TlsInspector})
+			append(filters, &listener.ListenerFilter{Name: wellknown.TlsInspector})
 	}
 
 	if !hasHTTPInspector {

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -23,7 +23,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -22,12 +22,13 @@ import (
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
-	"github.com/gogo/protobuf/proto"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 
 	networking "istio.io/api/networking/v1alpha3"
 
@@ -526,7 +527,7 @@ func testOutboundListenerRouteV13(t *testing.T, services ...*model.Service) {
 	}
 
 	f := l.FilterChains[1].Filters[0]
-	cfg, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+	cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 	rds := cfg.Fields["rds"].GetStructValue().Fields["route_config_name"].GetStringValue()
 	if rds != "8080" {
 		t.Fatalf("expect routes %s, found %s", "8080", rds)
@@ -537,7 +538,7 @@ func testOutboundListenerRouteV13(t *testing.T, services ...*model.Service) {
 		t.Fatalf("expect listener %s", "1.2.3.4_8080")
 	}
 	f = l.FilterChains[1].Filters[0]
-	cfg, _ = xdsutil.MessageToStruct(f.GetTypedConfig())
+	cfg, _ = conversion.MessageToStruct(f.GetTypedConfig())
 	rds = cfg.Fields["rds"].GetStructValue().Fields["route_config_name"].GetStringValue()
 	if rds != "test1.com:8080" {
 		t.Fatalf("expect routes %s, found %s", "test1.com:8080", rds)
@@ -548,7 +549,7 @@ func testOutboundListenerRouteV13(t *testing.T, services ...*model.Service) {
 		t.Fatalf("expect listener %s", "3.4.5.6_8080")
 	}
 	f = l.FilterChains[1].Filters[0]
-	cfg, _ = xdsutil.MessageToStruct(f.GetTypedConfig())
+	cfg, _ = conversion.MessageToStruct(f.GetTypedConfig())
 	rds = cfg.Fields["rds"].GetStructValue().Fields["route_config_name"].GetStringValue()
 	if rds != "test3.com:8080" {
 		t.Fatalf("expect routes %s, found %s", "test3.com:8080", rds)
@@ -592,7 +593,7 @@ func testOutboundListenerConflictV13(t *testing.T, services ...*model.Service) {
 		}
 
 		f := listeners[0].FilterChains[2].Filters[0]
-		cfg, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+		cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 		rds := cfg.Fields["rds"].GetStructValue().Fields["route_config_name"].GetStringValue()
 		expect := fmt.Sprintf("%d", oldestService.Ports[0].Port)
 		if rds != expect {
@@ -1018,7 +1019,7 @@ func testOutboundListenerConfigWithSidecar(t *testing.T, services ...*model.Serv
 		t.Fatalf("expected HTTP listener on port 9000, found TCP\n%v", l)
 	} else {
 		f := l.FilterChains[0].Filters[0]
-		cfg, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+		cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 		if useRemoteAddress, exists := cfg.Fields["use_remote_address"]; exists {
 			if exists && useRemoteAddress.GetBoolValue() {
 				t.Fatalf("expected useRemoteAddress false, found true %v", l)
@@ -1061,7 +1062,7 @@ func testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t *testing.T, ser
 		t.Fatalf("expected HTTP listener on port 9000, found TCP\n%v", l)
 	} else {
 		f := l.FilterChains[0].Filters[0]
-		cfg, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+		cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 		if useRemoteAddress, exists := cfg.Fields["use_remote_address"]; exists {
 			if !exists || !useRemoteAddress.GetBoolValue() {
 				t.Fatalf("expected useRemoteAddress true, found false %v", l)
@@ -1170,7 +1171,7 @@ func verifyOutboundTCPListenerHostname(t *testing.T, l *xdsapi.Listener, hostnam
 	}
 	f := fc.Filters[0]
 	expectedStatPrefix := fmt.Sprintf("outbound|8080||%s", hostname)
-	cfg, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+	cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 	statPrefix := cfg.Fields["stat_prefix"].GetStringValue()
 	if statPrefix != expectedStatPrefix {
 		t.Fatalf("expected listener to contain stat_prefix %s, found %s", expectedStatPrefix, statPrefix)
@@ -1188,7 +1189,7 @@ func verifyInboundHTTPListenerServerName(t *testing.T, l *xdsapi.Listener) {
 	}
 	f := fc.Filters[0]
 	expectedServerName := "istio-envoy"
-	cfg, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+	cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 	serverName := cfg.Fields["server_name"].GetStringValue()
 	if serverName != expectedServerName {
 		t.Fatalf("expected listener to contain server_name %s, found %s", expectedServerName, serverName)
@@ -1207,7 +1208,7 @@ func verifyInboundEnvoyListenerNumber(t *testing.T, l *xdsapi.Listener) {
 		}
 
 		f := fc.Filters[0]
-		cfg, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+		cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 		hf := cfg.Fields["http_filters"].GetListValue()
 		if len(hf.Values) != 4 {
 			t.Fatalf("expected %d http filters, found %d", 4, len(hf.Values))
@@ -1230,7 +1231,7 @@ func verifyInboundHTTPListenerCertDetails(t *testing.T, l *xdsapi.Listener) {
 		t.Fatalf("expected %d filters, found %d", 1, len(fc.Filters))
 	}
 	f := fc.Filters[0]
-	cfg, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+	cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 	forwardDetails, expected := cfg.Fields["forward_client_cert_details"].GetStringValue(), "APPEND_FORWARD"
 	if forwardDetails != expected {
 		t.Fatalf("expected listener to contain forward_client_cert_details %s, found %s", expected, forwardDetails)
@@ -1255,7 +1256,7 @@ func verifyInboundHTTPListenerNormalizePath(t *testing.T, l *xdsapi.Listener) {
 		t.Fatalf("expected 1 filter, found %d", len(fc.Filters))
 	}
 	f := fc.Filters[0]
-	cfg, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+	cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 	actual := cfg.Fields["normalize_path"].GetBoolValue()
 	if actual != true {
 		t.Errorf("expected HTTP listener with normalize_path set to true, found false")
@@ -1267,7 +1268,7 @@ func verifyInboundHTTP10(t *testing.T, http10Expected bool, l *xdsapi.Listener) 
 	for _, fc := range l.FilterChains {
 		for _, f := range fc.Filters {
 			if f.Name == "envoy.http_connection_manager" {
-				cfg, _ := xdsutil.MessageToStruct(f.GetTypedConfig())
+				cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 				httpProtocolOptionsField := cfg.Fields["http_protocol_options"]
 				if http10Expected && httpProtocolOptionsField == nil {
 					t.Error("expected http_protocol_options for http_connection_manager, found nil")
@@ -1322,11 +1323,11 @@ func buildAllListeners(p plugin.Plugin, sidecarConfig *model.Config, services ..
 func getFilterConfig(filter *listener.Filter, out proto.Message) error {
 	switch c := filter.ConfigType.(type) {
 	case *listener.Filter_Config:
-		if err := util.StructToMessage(c.Config, out); err != nil {
+		if err := conversion.StructToMessage(c.Config, out); err != nil {
 			return err
 		}
 	case *listener.Filter_TypedConfig:
-		if err := types.UnmarshalAny(c.TypedConfig, out); err != nil {
+		if err := ptypes.UnmarshalAny(c.TypedConfig, out); err != nil {
 			return err
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -20,8 +20,8 @@ import (
 	"sort"
 
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/gogo/protobuf/types"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/golang/protobuf/ptypes/wrappers"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -88,7 +88,7 @@ func applyLocalityWeight(
 				// the load balancing weight for a locality is divided by the sum of the weights of all localities
 				for index, originalWeight := range destLocMap {
 					weight := float64(originalWeight*weight) / float64(totalWeight)
-					loadAssignment.Endpoints[index].LoadBalancingWeight = &types.UInt32Value{
+					loadAssignment.Endpoints[index].LoadBalancingWeight = &wrappers.UInt32Value{
 						Value: uint32(math.Ceil(weight)),
 					}
 				}

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -20,7 +20,7 @@ import (
 
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/gogo/protobuf/types"
 	. "github.com/onsi/gomega"
 

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -18,14 +18,16 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	accesslogconfig "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	mongo_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/mongo_proxy/v2"
 	mysql_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/mysql_proxy/v1alpha1"
 	redis_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/redis_proxy/v2"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes"
 
 	networking "istio.io/api/networking/v1alpha3"
 
@@ -60,14 +62,15 @@ func setAccessLog(env *model.Environment, node *model.Proxy, config *tcp_proxy.T
 		}
 
 		acc := &accesslog.AccessLog{
-			Name: xdsutil.FileAccessLog,
+			Name: wellknown.FileAccessLog,
 		}
 		buildAccessLog(node, fl, env)
 
 		if util.IsXDSMarshalingToAnyEnabled(node) {
 			acc.ConfigType = &accesslog.AccessLog_TypedConfig{TypedConfig: util.MessageToAny(fl)}
 		} else {
-			acc.ConfigType = &accesslog.AccessLog_Config{Config: util.MessageToStruct(fl)}
+			c, _ := conversion.MessageToStruct(fl)
+			acc.ConfigType = &accesslog.AccessLog_Config{Config: c}
 		}
 
 		config.AccessLog = append(config.AccessLog, acc)
@@ -83,7 +86,7 @@ func setAccessLogAndBuildTCPFilter(env *model.Environment, node *model.Proxy, co
 	setAccessLog(env, node, config)
 
 	tcpFilter := &listener.Filter{
-		Name: xdsutil.TCPProxy,
+		Name: wellknown.TCPProxy,
 	}
 	if util.IsXDSMarshalingToAnyEnabled(node) {
 		tcpFilter.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(config)}
@@ -106,7 +109,7 @@ func buildOutboundNetworkFiltersWithSingleDestination(env *model.Environment, no
 
 	idleTimeout, err := time.ParseDuration(node.Metadata[model.NodeMetadataIdleTimeout])
 	if idleTimeout > 0 && err == nil {
-		tcpProxy.IdleTimeout = &idleTimeout
+		tcpProxy.IdleTimeout = ptypes.DurationProto(idleTimeout)
 	}
 
 	tcpFilter := setAccessLogAndBuildTCPFilter(env, node, tcpProxy)
@@ -131,7 +134,7 @@ func buildOutboundNetworkFiltersWithWeightedClusters(env *model.Environment, nod
 
 	idleTimeout, err := time.ParseDuration(node.Metadata[model.NodeMetadataIdleTimeout])
 	if idleTimeout > 0 && err == nil {
-		proxyConfig.IdleTimeout = &idleTimeout
+		proxyConfig.IdleTimeout = ptypes.DurationProto(idleTimeout)
 	}
 
 	for _, route := range routes {
@@ -203,7 +206,7 @@ func buildMongoFilter(statPrefix string, isXDSMarshalingToAnyEnabled bool) *list
 	}
 
 	out := &listener.Filter{
-		Name: xdsutil.MongoProxy,
+		Name: wellknown.MongoProxy,
 	}
 	if isXDSMarshalingToAnyEnabled {
 		out.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(mongoProxy)}
@@ -237,7 +240,7 @@ func buildRedisFilter(statPrefix, clusterName string, isXDSMarshalingToAnyEnable
 		LatencyInMicros: true,       // redis latency stats are captured in micro seconds which is typically the case.
 		StatPrefix:      statPrefix, // redis stats are prefixed with redis.<statPrefix> by Envoy
 		Settings: &redis_proxy.RedisProxy_ConnPoolSettings{
-			OpTimeout: &redisOpTimeout, // TODO: Make this user configurable
+			OpTimeout: ptypes.DurationProto(redisOpTimeout), // TODO: Make this user configurable
 		},
 		PrefixRoutes: &redis_proxy.RedisProxy_PrefixRoutes{
 			CatchAllRoute: &redis_proxy.RedisProxy_PrefixRoutes_Route{
@@ -247,7 +250,7 @@ func buildRedisFilter(statPrefix, clusterName string, isXDSMarshalingToAnyEnable
 	}
 
 	out := &listener.Filter{
-		Name: xdsutil.RedisProxy,
+		Name: wellknown.RedisProxy,
 	}
 	if isXDSMarshalingToAnyEnabled {
 		out.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(redisProxy)}
@@ -265,7 +268,7 @@ func buildMySQLFilter(statPrefix string, isXDSMarshalingToAnyEnabled bool) *list
 	}
 
 	out := &listener.Filter{
-		Name: xdsutil.MySQLProxy,
+		Name: wellknown.MySQLProxy,
 	}
 
 	if isXDSMarshalingToAnyEnabled {

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -17,10 +17,10 @@ package v1alpha3
 import (
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	redis_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/redis_proxy/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
-	"github.com/gogo/protobuf/types"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes"
 )
 
 func TestBuildRedisFilter(t *testing.T) {
@@ -30,7 +30,7 @@ func TestBuildRedisFilter(t *testing.T) {
 	}
 	if config, ok := redisFilter.ConfigType.(*listener.Filter_TypedConfig); ok {
 		redisProxy := redis_proxy.RedisProxy{}
-		if err := types.UnmarshalAny(config.TypedConfig, &redisProxy); err != nil {
+		if err := ptypes.UnmarshalAny(config.TypedConfig, &redisProxy); err != nil {
 			t.Errorf("unmarshal failed: %v", err)
 		}
 		if redisProxy.StatPrefix != "redis" {

--- a/pilot/pkg/networking/core/v1alpha3/route/retry/retry_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/retry/retry_test.go
@@ -18,7 +18,8 @@ import (
 	"testing"
 	"time"
 
-	protoTypes "github.com/gogo/protobuf/types"
+	gogoTypes "github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 	. "github.com/onsi/gomega"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -57,18 +58,16 @@ func TestRetryWithAllFieldsSet(t *testing.T) {
 	// Create a route with a retry policy with zero attempts configured.
 	route := networking.HTTPRoute{
 		Retries: &networking.HTTPRetry{
-			Attempts: 2,
-			RetryOn:  "some,fake,conditions",
-			PerTryTimeout: &protoTypes.Duration{
-				Seconds: 3,
-			},
+			Attempts:      2,
+			RetryOn:       "some,fake,conditions",
+			PerTryTimeout: gogoTypes.DurationProto(time.Second * 3),
 		},
 	}
 
 	policy := retry.ConvertPolicy(route.Retries)
 	g.Expect(policy).To(Not(BeNil()))
 	g.Expect(policy.RetryOn).To(Equal("some,fake,conditions"))
-	g.Expect(*policy.PerTryTimeout).To(Equal(time.Second * 3))
+	g.Expect(policy.PerTryTimeout).To(Equal(ptypes.DurationProto(time.Second * 3)))
 	g.Expect(policy.NumRetries.Value).To(Equal(uint32(2)))
 	g.Expect(policy.RetriableStatusCodes).To(Equal(make([]uint32, 0)))
 	g.Expect(policy.RetryPriority).To(BeNil())

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -21,13 +21,20 @@ import (
 	"strings"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	xdsfault "github.com/envoyproxy/go-control-plane/envoy/config/filter/fault/v2"
 	xdshttpfault "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/fault/v2"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
-	"github.com/gogo/protobuf/types"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/duration"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/wrappers"
+
+	"istio.io/istio/pkg/proto"
+	"istio.io/istio/pkg/util/gogo"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/pkg/log"
@@ -340,9 +347,9 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		// add a name to the route
 	}
 	if util.IsXDSMarshalingToAnyEnabled(node) {
-		out.TypedPerFilterConfig = make(map[string]*types.Any)
+		out.TypedPerFilterConfig = make(map[string]*any.Any)
 	} else {
-		out.PerFilterConfig = make(map[string]*types.Struct)
+		out.PerFilterConfig = make(map[string]*structpb.Struct)
 	}
 
 	if redirect := in.Redirect; redirect != nil {
@@ -378,16 +385,16 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		}
 
 		if in.Timeout != nil {
-			d := util.GogoDurationToDuration(in.Timeout)
+			d := gogo.DurationToProtoDuration(in.Timeout)
 			// timeout
 			action.Timeout = d
 			action.MaxGrpcTimeout = d
 		} else {
 			// if no timeout is specified, disable timeouts. This is easier
 			// to reason about than assuming some defaults.
-			d := 0 * time.Second
-			action.Timeout = &d
-			action.MaxGrpcTimeout = &d
+			d := ptypes.DurationProto(0 * time.Second)
+			action.Timeout = d
+			action.MaxGrpcTimeout = d
 		}
 
 		out.Action = &route.Route_Route{Route: action}
@@ -425,7 +432,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		// TODO: eliminate this logic and use the total_weight option in envoy route
 		weighted := make([]*route.WeightedCluster_ClusterWeight, 0)
 		for _, dst := range in.Route {
-			weight := &types.UInt32Value{Value: uint32(dst.Weight)}
+			weight := &wrappers.UInt32Value{Value: uint32(dst.Weight)}
 			if dst.Weight == 0 {
 				// Ignore 0 weighted clusters if there are other clusters in the route.
 				// But if this is the only cluster in the route, then add it as a cluster with weight 100
@@ -529,14 +536,13 @@ func (b SortHeaderValueOption) Swap(i, j int) {
 // translateAppendHeaders translates headers
 func translateAppendHeaders(headers map[string]string, appendFlag bool) []*core.HeaderValueOption {
 	headerValueOptionList := make([]*core.HeaderValueOption, 0, len(headers))
-	appendValue := &types.BoolValue{Value: appendFlag}
 	for key, value := range headers {
 		headerValueOptionList = append(headerValueOptionList, &core.HeaderValueOption{
 			Header: &core.HeaderValue{
 				Key:   key,
 				Value: value,
 			},
-			Append: appendValue,
+			Append: &wrappers.BoolValue{Value: appendFlag},
 		})
 	}
 	sort.Stable(SortHeaderValueOption(headerValueOptionList))
@@ -571,7 +577,7 @@ func translateRouteMatch(in *networking.HTTPMatchRequest) *route.RouteMatch {
 		}
 	}
 
-	out.CaseSensitive = &types.BoolValue{Value: !in.IgnoreUriCase}
+	out.CaseSensitive = &wrappers.BoolValue{Value: !in.IgnoreUriCase}
 
 	if in.Method != nil {
 		matcher := translateHeaderMatch(HeaderMethod, in.Method)
@@ -607,7 +613,7 @@ func translateQueryParamMatch(name string, in *networking.StringMatch) route.Que
 		out.Value = m.Exact
 	case *networking.StringMatch_Regex:
 		out.Value = m.Regex
-		out.Regex = &types.BoolValue{Value: true}
+		out.Regex = proto.BoolTrue
 	}
 
 	return out
@@ -653,7 +659,7 @@ func translateCORSPolicy(in *networking.CorsPolicy, _ *model.Proxy) *route.CorsP
 		},
 	}
 
-	out.AllowCredentials = in.AllowCredentials
+	out.AllowCredentials = gogo.BoolToProtoBool(in.AllowCredentials)
 	out.AllowHeaders = strings.Join(in.AllowHeaders, ",")
 	out.AllowMethods = strings.Join(in.AllowMethods, ",")
 	out.ExposeHeaders = strings.Join(in.ExposeHeaders, ",")
@@ -692,7 +698,7 @@ func getRouteOperation(in *route.Route, vsName string, port int) string {
 
 // BuildDefaultHTTPInboundRoute builds a default inbound route.
 func BuildDefaultHTTPInboundRoute(node *model.Proxy, clusterName string, operation string) *route.Route {
-	notimeout := 0 * time.Second
+	notimeout := ptypes.DurationProto(0 * time.Second)
 
 	val := &route.Route{
 		Match: translateRouteMatch(nil),
@@ -702,8 +708,8 @@ func BuildDefaultHTTPInboundRoute(node *model.Proxy, clusterName string, operati
 		Action: &route.Route_Route{
 			Route: &route.RouteAction{
 				ClusterSpecifier: &route.RouteAction_Cluster{Cluster: clusterName},
-				Timeout:          &notimeout,
-				MaxGrpcTimeout:   &notimeout,
+				Timeout:          notimeout,
+				MaxGrpcTimeout:   notimeout,
 			},
 		},
 	}
@@ -758,9 +764,8 @@ func translateFault(in *networking.HTTPFaultInjection) *xdshttpfault.HTTPFault {
 		}
 		switch d := in.Delay.HttpDelayType.(type) {
 		case *networking.HTTPFaultInjection_Delay_FixedDelay:
-			delayDuration := util.GogoDurationToDuration(d.FixedDelay)
 			out.Delay.FaultDelaySecifier = &xdsfault.FaultDelay_FixedDelay{
-				FixedDelay: delayDuration,
+				FixedDelay: gogo.DurationToProtoDuration(d.FixedDelay),
 			}
 		default:
 			log.Warnf("Exponential faults are not yet supported")
@@ -825,12 +830,15 @@ func consistentHashToHashPolicy(consistentHash *networking.LoadBalancerSettings_
 		}
 	case *networking.LoadBalancerSettings_ConsistentHashLB_HttpCookie:
 		cookie := consistentHash.GetHttpCookie()
-
+		var ttl *duration.Duration
+		if cookie.GetTtl() != nil {
+			ttl = ptypes.DurationProto(*cookie.GetTtl())
+		}
 		return &route.RouteAction_HashPolicy{
 			PolicySpecifier: &route.RouteAction_HashPolicy_Cookie_{
 				Cookie: &route.RouteAction_HashPolicy_Cookie{
 					Name: cookie.GetName(),
-					Ttl:  cookie.GetTtl(),
+					Ttl:  ttl,
 					Path: cookie.GetPath(),
 				},
 			},

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -681,6 +681,8 @@ func getRouteOperation(in *route.Route, vsName string, port int) string {
 		case *route.RouteMatch_Path:
 			path = m.GetPath()
 		case *route.RouteMatch_Regex:
+			// Migration tracked in https://github.com/istio/istio/issues/17127
+			//nolint: staticcheck
 			path = m.GetRegex()
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/onsi/gomega"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -111,7 +112,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_Cookie_{
 				Cookie: &envoyroute.RouteAction_HashPolicy_Cookie{
 					Name: "hash-cookie",
-					Ttl:  &ttl,
+					Ttl:  ptypes.DurationProto(ttl),
 				},
 			},
 		}

--- a/pilot/pkg/networking/plugin/health/health.go
+++ b/pilot/pkg/networking/plugin/health/health.go
@@ -19,10 +19,10 @@ import (
 	"reflect"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	hcfilter "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/health_check/v2"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
@@ -42,10 +42,10 @@ func NewPlugin() plugin.Plugin {
 func buildHealthCheckFilter(probe *model.Probe, isXDSMarshalingToAnyEnabled bool) *http_conn.HttpFilter {
 	config := &hcfilter.HealthCheck{
 		PassThroughMode: proto.BoolTrue,
-		Headers: []*envoy_api_v2_route.HeaderMatcher{
+		Headers: []*route.HeaderMatcher{
 			{
 				Name:                 ":path",
-				HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_ExactMatch{ExactMatch: probe.Path},
+				HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{ExactMatch: probe.Path},
 			},
 		},
 	}

--- a/pilot/pkg/networking/plugin/health/health_test.go
+++ b/pilot/pkg/networking/plugin/health/health_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	hcfilter "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/health_check/v2"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 
@@ -53,10 +53,10 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 						ConfigType: &http_conn.HttpFilter_TypedConfig{
 							TypedConfig: util.MessageToAny(&hcfilter.HealthCheck{
 								PassThroughMode: proto.BoolTrue,
-								Headers: []*envoy_api_v2_route.HeaderMatcher{
+								Headers: []*route.HeaderMatcher{
 									{
 										Name:                 ":path",
-										HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_ExactMatch{ExactMatch: "/health"},
+										HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{ExactMatch: "/health"},
 									},
 								},
 							}),
@@ -82,10 +82,10 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 						ConfigType: &http_conn.HttpFilter_TypedConfig{
 							TypedConfig: util.MessageToAny(&hcfilter.HealthCheck{
 								PassThroughMode: proto.BoolTrue,
-								Headers: []*envoy_api_v2_route.HeaderMatcher{
+								Headers: []*route.HeaderMatcher{
 									{
 										Name:                 ":path",
-										HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_ExactMatch{ExactMatch: "/health"},
+										HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{ExactMatch: "/health"},
 									},
 								},
 							}),
@@ -119,10 +119,10 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 						ConfigType: &http_conn.HttpFilter_TypedConfig{
 							TypedConfig: util.MessageToAny(&hcfilter.HealthCheck{
 								PassThroughMode: proto.BoolTrue,
-								Headers: []*envoy_api_v2_route.HeaderMatcher{
+								Headers: []*route.HeaderMatcher{
 									{
 										Name:                 ":path",
-										HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_ExactMatch{ExactMatch: "/ready"},
+										HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{ExactMatch: "/ready"},
 									},
 								},
 							}),
@@ -133,10 +133,10 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 						ConfigType: &http_conn.HttpFilter_TypedConfig{
 							TypedConfig: util.MessageToAny(&hcfilter.HealthCheck{
 								PassThroughMode: proto.BoolTrue,
-								Headers: []*envoy_api_v2_route.HeaderMatcher{
+								Headers: []*route.HeaderMatcher{
 									{
 										Name:                 ":path",
-										HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_ExactMatch{ExactMatch: "/live"},
+										HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{ExactMatch: "/live"},
 									},
 								},
 							}),
@@ -171,10 +171,10 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 						ConfigType: &http_conn.HttpFilter_TypedConfig{
 							TypedConfig: util.MessageToAny(&hcfilter.HealthCheck{
 								PassThroughMode: proto.BoolTrue,
-								Headers: []*envoy_api_v2_route.HeaderMatcher{
+								Headers: []*route.HeaderMatcher{
 									{
 										Name:                 ":path",
-										HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_ExactMatch{ExactMatch: "/health"},
+										HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{ExactMatch: "/health"},
 									},
 								},
 							}),

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -587,6 +587,23 @@ func init() {
 	proto.RegisterType((*mccpb.HttpClientConfig)(nil), "istio.mixer.v1.config.client.HttpClientConfig")
 	proto.RegisterMapType(map[string]*mccpb.ServiceConfig(nil), "istio.mixer.v1.config.client.HttpClientConfig.ServiceConfigsEntry")
 	proto.RegisterType((*mccpb.TcpClientConfig)(nil), "istio.mixer.v1.config.client.TcpClientConfig")
+
+	proto.RegisterType((*mpb.Attributes)(nil), "istio.mixer.v1.Attributes")
+	proto.RegisterMapType(map[string]*mpb.Attributes_AttributeValue(nil), "istio.mixer.v1.Attributes.AttributesEntry")
+	proto.RegisterType((*mpb.Attributes_AttributeValue)(nil), "istio.mixer.v1.Attributes.AttributeValue")
+	proto.RegisterType((*mpb.Attributes_StringMap)(nil), "istio.mixer.v1.Attributes.StringMap")
+	proto.RegisterMapType(map[string]string(nil), "istio.mixer.v1.Attributes.StringMap.EntriesEntry")
+	proto.RegisterType((*mpb.CompressedAttributes)(nil), "istio.mixer.v1.CompressedAttributes")
+	proto.RegisterMapType(map[int32]bool(nil), "istio.mixer.v1.CompressedAttributes.BoolsEntry")
+	proto.RegisterMapType(map[int32][]byte(nil), "istio.mixer.v1.CompressedAttributes.BytesEntry")
+	proto.RegisterMapType(map[int32]float64(nil), "istio.mixer.v1.CompressedAttributes.DoublesEntry")
+	proto.RegisterMapType(map[int32]time.Duration(nil), "istio.mixer.v1.CompressedAttributes.DurationsEntry")
+	proto.RegisterMapType(map[int32]int64(nil), "istio.mixer.v1.CompressedAttributes.Int64sEntry")
+	proto.RegisterMapType(map[int32]mpb.StringMap(nil), "istio.mixer.v1.CompressedAttributes.StringMapsEntry")
+	proto.RegisterMapType(map[int32]int32(nil), "istio.mixer.v1.CompressedAttributes.StringsEntry")
+	proto.RegisterMapType(map[int32]time.Time(nil), "istio.mixer.v1.CompressedAttributes.TimestampsEntry")
+	proto.RegisterType((*mpb.StringMap)(nil), "istio.mixer.v1.StringMap")
+	proto.RegisterMapType(map[int32]int32(nil), "istio.mixer.v1.StringMap.EntriesEntry")
 }
 
 func buildInboundTCPFilter(mesh *meshconfig.MeshConfig, attrs attributes, node *model.Proxy) *listener.Filter {

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -579,12 +579,13 @@ func buildOutboundTCPFilter(mesh *meshconfig.MeshConfig, attrsIn attributes, nod
 // XDS protos use golang/protobuf, but the istio APIs use gogo protos. This means the golang/protobuf
 // backend needs to register the mixer client filter protos.
 func init() {
+	//nolint: lll
 	proto.RegisterEnum("istio.mixer.v1.config.client.NetworkFailPolicy_FailPolicy", mccpb.NetworkFailPolicy_FailPolicy_name, mccpb.NetworkFailPolicy_FailPolicy_value)
 	proto.RegisterType((*mccpb.NetworkFailPolicy)(nil), "istio.mixer.v1.config.client.NetworkFailPolicy")
 	proto.RegisterType((*mccpb.ServiceConfig)(nil), "istio.mixer.v1.config.client.ServiceConfig")
 	proto.RegisterType((*mccpb.TransportConfig)(nil), "istio.mixer.v1.config.client.TransportConfig")
 	proto.RegisterType((*mccpb.HttpClientConfig)(nil), "istio.mixer.v1.config.client.HttpClientConfig")
-	proto.RegisterMapType((map[string]*mccpb.ServiceConfig)(nil), "istio.mixer.v1.config.client.HttpClientConfig.ServiceConfigsEntry")
+	proto.RegisterMapType(map[string]*mccpb.ServiceConfig(nil), "istio.mixer.v1.config.client.HttpClientConfig.ServiceConfigsEntry")
 	proto.RegisterType((*mccpb.TcpClientConfig)(nil), "istio.mixer.v1.config.client.TcpClientConfig")
 }
 

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -16,9 +16,9 @@ package plugin
 
 import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 
 	networking "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/networking/plugin/plugin_test.go
+++ b/pilot/pkg/networking/plugin/plugin_test.go
@@ -22,7 +22,7 @@ import (
 
 	"istio.io/istio/pkg/config/protocol"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	"istio.io/istio/pilot/pkg/model"
 )

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -24,14 +24,18 @@ import (
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
-	"github.com/gogo/protobuf/proto"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	pstruct "github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/wrappers"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/pkg/log"
@@ -101,7 +105,7 @@ func ConvertAddressToCidr(addr string) *core.CidrRange {
 
 	cidr := &core.CidrRange{
 		AddressPrefix: addr,
-		PrefixLen: &types.UInt32Value{
+		PrefixLen: &wrappers.UInt32Value{
 			Value: getMaxCidrPrefix(addr),
 		},
 	}
@@ -169,7 +173,7 @@ func lbWeightNormalize(endpoints []*endpoint.LbEndpoint) []*endpoint.LbEndpoint 
 	out := make([]*endpoint.LbEndpoint, len(endpoints))
 	for i, ep := range endpoints {
 		weight := float64(ep.GetLoadBalancingWeight().GetValue()*maxLoadBalancingWeight) / float64(totalLbEndpointsNum)
-		ep.LoadBalancingWeight = &types.UInt32Value{
+		ep.LoadBalancingWeight = &wrappers.UInt32Value{
 			Value: uint32(math.Ceil(weight)),
 		}
 		out[i] = ep
@@ -197,7 +201,7 @@ func LocalityLbWeightNormalize(endpoints []*endpoint.LocalityLbEndpoints) []*end
 	out := make([]*endpoint.LocalityLbEndpoints, len(endpoints))
 	for i, localityLbEndpoint := range endpoints {
 		weight := float64(localityLbEndpoint.GetLoadBalancingWeight().GetValue()*maxLoadBalancingWeight) / float64(totalLbEndpointsNum)
-		localityLbEndpoint.LoadBalancingWeight = &types.UInt32Value{
+		localityLbEndpoint.LoadBalancingWeight = &wrappers.UInt32Value{
 			Value: uint32(math.Ceil(weight)),
 		}
 		out[i] = localityLbEndpoint
@@ -209,16 +213,26 @@ func LocalityLbWeightNormalize(endpoints []*endpoint.LocalityLbEndpoints) []*end
 // GetByAddress returns a listener by its address
 // TODO(mostrowski): consider passing map around to save iteration.
 func GetByAddress(listeners []*xdsapi.Listener, addr core.Address) *xdsapi.Listener {
-	for _, listener := range listeners {
-		if listener != nil && listener.Address.Equal(addr) {
-			return listener
+	for _, l := range listeners {
+		if l != nil && proto.Equal(l.Address, &addr) {
+			return l
 		}
 	}
 	return nil
 }
 
 // MessageToAny converts from proto message to proto Any
-func MessageToAny(msg proto.Message) *types.Any {
+func MessageToAny(msg proto.Message) *any.Any {
+	s, err := ptypes.MarshalAny(msg)
+	if err != nil {
+		log.Error(err.Error())
+		return nil
+	}
+	return s
+}
+
+// MessageToGogoAny converts from proto message to gogo Any
+func MessageToGogoAny(msg proto.Message) *types.Any {
 	s, err := types.MarshalAny(msg)
 	if err != nil {
 		log.Error(err.Error())
@@ -228,11 +242,11 @@ func MessageToAny(msg proto.Message) *types.Any {
 }
 
 // MessageToStruct converts from proto message to proto Struct
-func MessageToStruct(msg proto.Message) *types.Struct {
-	s, err := util.MessageToStruct(msg)
+func MessageToStruct(msg proto.Message) *pstruct.Struct {
+	s, err := conversion.MessageToStruct(msg)
 	if err != nil {
 		log.Error(err.Error())
-		return &types.Struct{}
+		return &pstruct.Struct{}
 	}
 	return s
 }
@@ -432,7 +446,7 @@ func cloneLocalityLbEndpoints(endpoints []*endpoint.LocalityLbEndpoints) []*endp
 	for _, ep := range endpoints {
 		clone := *ep
 		if ep.LoadBalancingWeight != nil {
-			clone.LoadBalancingWeight = &types.UInt32Value{
+			clone.LoadBalancingWeight = &wrappers.UInt32Value{
 				Value: ep.GetLoadBalancingWeight().GetValue(),
 			}
 		}
@@ -446,11 +460,11 @@ func cloneLocalityLbEndpoints(endpoints []*endpoint.LocalityLbEndpoints) []*endp
 // to generate attributes for policy and telemetry.
 func BuildConfigInfoMetadata(config model.ConfigMeta) *core.Metadata {
 	return &core.Metadata{
-		FilterMetadata: map[string]*types.Struct{
+		FilterMetadata: map[string]*pstruct.Struct{
 			IstioMetadataKey: {
-				Fields: map[string]*types.Value{
+				Fields: map[string]*pstruct.Value{
 					"config": {
-						Kind: &types.Value_StringValue{
+						Kind: &pstruct.Value_StringValue{
 							StringValue: fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s", config.Group, config.Version, config.Namespace, config.Type, config.Name),
 						},
 					},
@@ -473,28 +487,28 @@ func IsHTTPFilterChain(filterChain *listener.FilterChain) bool {
 // MergeAnyWithStruct merges a given struct into the given Any typed message by dynamically inferring the
 // type of Any, converting the struct into the inferred type, merging the two messages, and then
 // marshaling the merged message back into Any.
-func MergeAnyWithStruct(any *types.Any, pbStruct *types.Struct) (*types.Any, error) {
+func MergeAnyWithStruct(a *any.Any, pbStruct *pstruct.Struct) (*any.Any, error) {
 	// Assuming that Pilot is compiled with this type [which should always be the case]
 	var err error
-	var x types.DynamicAny
+	var x ptypes.DynamicAny
 
 	// First get an object of type used by this message
-	if err = types.UnmarshalAny(any, &x); err != nil {
+	if err = ptypes.UnmarshalAny(a, &x); err != nil {
 		return nil, err
 	}
 
 	// Create a typed copy. We will convert the user's struct to this type
 	temp := proto.Clone(x.Message)
 	temp.Reset()
-	if err = xdsutil.StructToMessage(pbStruct, temp); err != nil {
+	if err = conversion.StructToMessage(pbStruct, temp); err != nil {
 		return nil, err
 	}
 
 	// Merge the two typed protos
 	proto.Merge(x.Message, temp)
-	var retVal *types.Any
+	var retVal *any.Any
 	// Convert the merged proto back to any
-	if retVal, err = types.MarshalAny(x.Message); err != nil {
+	if retVal, err = ptypes.MarshalAny(x.Message); err != nil {
 		return nil, err
 	}
 
@@ -503,26 +517,26 @@ func MergeAnyWithStruct(any *types.Any, pbStruct *types.Struct) (*types.Any, err
 
 // MergeAnyWithAny merges a given any typed message into the given Any typed message by dynamically inferring the
 // type of Any
-func MergeAnyWithAny(dst *types.Any, src *types.Any) (*types.Any, error) {
+func MergeAnyWithAny(dst *any.Any, src *any.Any) (*any.Any, error) {
 	// Assuming that Pilot is compiled with this type [which should always be the case]
 	var err error
-	var dstX, srcX types.DynamicAny
+	var dstX, srcX ptypes.DynamicAny
 
 	// get an object of type used by this message
-	if err = types.UnmarshalAny(dst, &dstX); err != nil {
+	if err = ptypes.UnmarshalAny(dst, &dstX); err != nil {
 		return nil, err
 	}
 
 	// get an object of type used by this message
-	if err = types.UnmarshalAny(src, &srcX); err != nil {
+	if err = ptypes.UnmarshalAny(src, &srcX); err != nil {
 		return nil, err
 	}
 
 	// Merge the two typed protos
 	proto.Merge(dstX.Message, srcX.Message)
-	var retVal *types.Any
+	var retVal *any.Any
 	// Convert the merged proto back to dst
-	if retVal, err = types.MarshalAny(dstX.Message); err != nil {
+	if retVal, err = ptypes.MarshalAny(dstX.Message); err != nil {
 		return nil, err
 	}
 

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -20,14 +20,19 @@ import (
 	"time"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/wrappers"
 
-	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/types"
+	proto2 "istio.io/istio/pkg/proto"
+
+	"github.com/golang/protobuf/proto"
 	"gopkg.in/d4l3k/messagediff.v1"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -50,7 +55,7 @@ func TestConvertAddressToCidr(t *testing.T) {
 			"1.2.3.4",
 			&core.CidrRange{
 				AddressPrefix: "1.2.3.4",
-				PrefixLen: &types.UInt32Value{
+				PrefixLen: &wrappers.UInt32Value{
 					Value: 32,
 				},
 			},
@@ -60,7 +65,7 @@ func TestConvertAddressToCidr(t *testing.T) {
 			"1.2.3.4/16",
 			&core.CidrRange{
 				AddressPrefix: "1.2.3.4",
-				PrefixLen: &types.UInt32Value{
+				PrefixLen: &wrappers.UInt32Value{
 					Value: 16,
 				},
 			},
@@ -70,7 +75,7 @@ func TestConvertAddressToCidr(t *testing.T) {
 			"2001:db8::",
 			&core.CidrRange{
 				AddressPrefix: "2001:db8::",
-				PrefixLen: &types.UInt32Value{
+				PrefixLen: &wrappers.UInt32Value{
 					Value: 128,
 				},
 			},
@@ -80,7 +85,7 @@ func TestConvertAddressToCidr(t *testing.T) {
 			"2001:db8::/64",
 			&core.CidrRange{
 				AddressPrefix: "2001:db8::",
-				PrefixLen: &types.UInt32Value{
+				PrefixLen: &wrappers.UInt32Value{
 					Value: 64,
 				},
 			},
@@ -394,11 +399,11 @@ func TestBuildConfigInfoMetadata(t *testing.T) {
 				Type:      "destination-rule",
 			},
 			&core.Metadata{
-				FilterMetadata: map[string]*types.Struct{
+				FilterMetadata: map[string]*structpb.Struct{
 					IstioMetadataKey: {
-						Fields: map[string]*types.Value{
+						Fields: map[string]*structpb.Value{
 							"config": {
-								Kind: &types.Value_StringValue{
+								Kind: &structpb.Value_StringValue{
 									StringValue: "/apis/networking.istio.io/v1alpha3/namespaces/default/destination-rule/svcA",
 								},
 							},
@@ -450,7 +455,7 @@ func buildFakeCluster() *v2.Cluster {
 						SubZone: "subzone1",
 					},
 					LbEndpoints: []*endpoint.LbEndpoint{},
-					LoadBalancingWeight: &types.UInt32Value{
+					LoadBalancingWeight: &wrappers.UInt32Value{
 						Value: 1,
 					},
 					Priority: 0,
@@ -462,7 +467,7 @@ func buildFakeCluster() *v2.Cluster {
 						SubZone: "subzone2",
 					},
 					LbEndpoints: []*endpoint.LbEndpoint{},
-					LoadBalancingWeight: &types.UInt32Value{
+					LoadBalancingWeight: &wrappers.UInt32Value{
 						Value: 1,
 					},
 					Priority: 0,
@@ -559,13 +564,13 @@ func TestGetByAddress(t *testing.T) {
 
 func TestMergeAnyWithStruct(t *testing.T) {
 	inHCM := &http_conn.HttpConnectionManager{
-		CodecType:  http_conn.HTTP1,
+		CodecType:  http_conn.HttpConnectionManager_HTTP1,
 		StatPrefix: "123",
 		HttpFilters: []*http_conn.HttpFilter{
 			{
 				Name: "filter1",
 				ConfigType: &http_conn.HttpFilter_TypedConfig{
-					TypedConfig: &types.Any{},
+					TypedConfig: &any.Any{},
 				},
 			},
 		},
@@ -575,12 +580,12 @@ func TestMergeAnyWithStruct(t *testing.T) {
 	inAny := MessageToAny(inHCM)
 
 	// listener.go sets this to 0
-	newTimeout := 5 * time.Minute
+	newTimeout := ptypes.DurationProto(5 * time.Minute)
 	userHCM := &http_conn.HttpConnectionManager{
-		AddUserAgent:      &types.BoolValue{Value: true},
-		IdleTimeout:       &newTimeout,
-		StreamIdleTimeout: &newTimeout,
-		UseRemoteAddress:  &types.BoolValue{Value: true},
+		AddUserAgent:      proto2.BoolTrue,
+		IdleTimeout:       newTimeout,
+		StreamIdleTimeout: newTimeout,
+		UseRemoteAddress:  proto2.BoolTrue,
 		XffNumTrustedHops: 5,
 		ServerName:        "foobar",
 		HttpFilters: []*http_conn.HttpFilter{
@@ -607,7 +612,7 @@ func TestMergeAnyWithStruct(t *testing.T) {
 	}
 
 	outHCM := http_conn.HttpConnectionManager{}
-	if err = types.UnmarshalAny(outAny, &outHCM); err != nil {
+	if err = ptypes.UnmarshalAny(outAny, &outHCM); err != nil {
 		t.Errorf("Failed to unmarshall outAny to outHCM: %v", err)
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -25,7 +25,8 @@ import (
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
@@ -132,7 +133,7 @@ func (s *DiscoveryServer) configDump(conn *XdsConnection) (*adminapi.ConfigDump,
 	for _, cs := range clusters {
 		dynamicActiveClusters = append(dynamicActiveClusters, &adminapi.ClustersConfigDump_DynamicCluster{Cluster: cs})
 	}
-	clustersAny, err := types.MarshalAny(&adminapi.ClustersConfigDump{
+	clustersAny, err := ptypes.MarshalAny(&adminapi.ClustersConfigDump{
 		VersionInfo:           versionInfo(),
 		DynamicActiveClusters: dynamicActiveClusters,
 	})
@@ -145,7 +146,7 @@ func (s *DiscoveryServer) configDump(conn *XdsConnection) (*adminapi.ConfigDump,
 	for _, cs := range listeners {
 		dynamicActiveListeners = append(dynamicActiveListeners, &adminapi.ListenersConfigDump_DynamicListener{Listener: cs})
 	}
-	listenersAny, err := types.MarshalAny(&adminapi.ListenersConfigDump{
+	listenersAny, err := ptypes.MarshalAny(&adminapi.ListenersConfigDump{
 		VersionInfo:            versionInfo(),
 		DynamicActiveListeners: dynamicActiveListeners,
 	})
@@ -154,22 +155,22 @@ func (s *DiscoveryServer) configDump(conn *XdsConnection) (*adminapi.ConfigDump,
 	}
 
 	routes := s.generateRawRoutes(conn, s.globalPushContext())
-	routeConfigAny, _ := types.MarshalAny(&adminapi.RoutesConfigDump{})
+	routeConfigAny, _ := ptypes.MarshalAny(&adminapi.RoutesConfigDump{})
 	if len(routes) > 0 {
 		dynamicRouteConfig := []*adminapi.RoutesConfigDump_DynamicRouteConfig{}
 		for _, rs := range routes {
 			dynamicRouteConfig = append(dynamicRouteConfig, &adminapi.RoutesConfigDump_DynamicRouteConfig{RouteConfig: rs})
 		}
-		routeConfigAny, err = types.MarshalAny(&adminapi.RoutesConfigDump{DynamicRouteConfigs: dynamicRouteConfig})
+		routeConfigAny, err = ptypes.MarshalAny(&adminapi.RoutesConfigDump{DynamicRouteConfigs: dynamicRouteConfig})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	bootstrapAny, _ := types.MarshalAny(&adminapi.BootstrapConfigDump{})
+	bootstrapAny, _ := ptypes.MarshalAny(&adminapi.BootstrapConfigDump{})
 	// The config dump must have all configs with connections specified in
 	// https://www.envoyproxy.io/docs/envoy/latest/api-v2/admin/v2alpha/config_dump.proto
-	configDump := &adminapi.ConfigDump{Configs: []*types.Any{bootstrapAny, clustersAny, listenersAny, routeConfigAny}}
+	configDump := &adminapi.ConfigDump{Configs: []*any.Any{bootstrapAny, clustersAny, listenersAny, routeConfigAny}}
 	return configDump, nil
 }
 

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 
 	"istio.io/istio/pilot/pkg/model"
 )
@@ -39,7 +39,7 @@ func (conn *XdsConnection) clusters(response []*xdsapi.Cluster) *xdsapi.Discover
 	}
 
 	for _, c := range response {
-		cc, _ := types.MarshalAny(c)
+		cc, _ := ptypes.MarshalAny(c)
 		out.Resources = append(out.Resources, cc)
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/cds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/cds_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/env"
-	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 	"istio.io/istio/tests/util"
 )
 
@@ -42,7 +42,7 @@ func TestCDS(t *testing.T) {
 		return
 	}
 
-	strResponse, _ := protomarshal.ToJSONWithIndent(res, " ")
+	strResponse, _ := gogoprotomarshal.ToJSONWithIndent(res, " ")
 	_ = ioutil.WriteFile(env.IstioOut+"/cdsv2_sidecar.json", []byte(strResponse), 0644)
 
 	t.Log("CDS response", strResponse)

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 
 	authn "istio.io/api/authentication/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -280,7 +280,7 @@ func getConfigDump(t *testing.T, s *v2.DiscoveryServer, proxyID string, wantCode
 		return nil
 	}
 	got := &configdump.Wrapper{}
-	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+	if err := got.UnmarshalJSON(rr.Body.Bytes()); err != nil {
 		t.Fatalf(err.Error())
 	}
 	return got

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -21,9 +21,11 @@ import (
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/gogo/protobuf/types"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	"github.com/golang/protobuf/ptypes"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/wrappers"
 
 	networkingapi "istio.io/api/networking/v1alpha3"
 
@@ -118,7 +120,7 @@ func buildEnvoyLbEndpoint(uid string, family model.AddressFamily, address string
 		epWeight = 1
 	}
 	ep := &endpoint.LbEndpoint{
-		LoadBalancingWeight: &types.UInt32Value{
+		LoadBalancingWeight: &wrappers.UInt32Value{
 			Value: epWeight,
 		},
 		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
@@ -148,7 +150,7 @@ func networkEndpointToEnvoyEndpoint(e *model.NetworkEndpoint) (*endpoint.LbEndpo
 		epWeight = 1
 	}
 	ep := &endpoint.LbEndpoint{
-		LoadBalancingWeight: &types.UInt32Value{
+		LoadBalancingWeight: &wrappers.UInt32Value{
 			Value: epWeight,
 		},
 		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
@@ -172,19 +174,19 @@ func endpointMetadata(uid string, network string) *core.Metadata {
 	}
 
 	metadata := &core.Metadata{
-		FilterMetadata: map[string]*types.Struct{
+		FilterMetadata: map[string]*structpb.Struct{
 			util.IstioMetadataKey: {
-				Fields: map[string]*types.Value{},
+				Fields: map[string]*structpb.Value{},
 			},
 		},
 	}
 
 	if uid != "" {
-		metadata.FilterMetadata[util.IstioMetadataKey].Fields["uid"] = &types.Value{Kind: &types.Value_StringValue{StringValue: uid}}
+		metadata.FilterMetadata[util.IstioMetadataKey].Fields["uid"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: uid}}
 	}
 
 	if network != "" {
-		metadata.FilterMetadata[util.IstioMetadataKey].Fields["network"] = &types.Value{Kind: &types.Value_StringValue{StringValue: network}}
+		metadata.FilterMetadata[util.IstioMetadataKey].Fields["network"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: network}}
 	}
 
 	return metadata
@@ -367,7 +369,7 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 		for _, ep := range locEps[i].LbEndpoints {
 			weight += ep.LoadBalancingWeight.GetValue()
 		}
-		locEps[i].LoadBalancingWeight = &types.UInt32Value{
+		locEps[i].LoadBalancingWeight = &wrappers.UInt32Value{
 			Value: weight,
 		}
 	}
@@ -823,7 +825,7 @@ func endpointDiscoveryResponse(loadAssignments []*xdsapi.ClusterLoadAssignment, 
 		Nonce:       nonce(),
 	}
 	for _, loadAssignment := range loadAssignments {
-		resource, _ := types.MarshalAny(loadAssignment)
+		resource, _ := ptypes.MarshalAny(loadAssignment)
 		out.Resources = append(out.Resources, resource)
 	}
 
@@ -874,7 +876,7 @@ func buildLocalityLbEndpointsFromShards(
 		for _, ep := range locLbEps.LbEndpoints {
 			weight += ep.LoadBalancingWeight.GetValue()
 		}
-		locLbEps.LoadBalancingWeight = &types.UInt32Value{
+		locLbEps.LoadBalancingWeight = &wrappers.UInt32Value{
 			Value: weight,
 		}
 		locEps = append(locEps, locLbEps)

--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -19,10 +19,10 @@ import (
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	proto "github.com/gogo/protobuf/types"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
@@ -154,9 +154,9 @@ func verifySplitHorizonResponse(t *testing.T, network string, sidecarID string, 
 	}
 	defer cancel()
 
-	metadata := &proto.Struct{Fields: map[string]*proto.Value{
-		"ISTIO_VERSION": {Kind: &proto.Value_StringValue{StringValue: "1.3"}},
-		"NETWORK":       {Kind: &proto.Value_StringValue{StringValue: network}},
+	metadata := &structpb.Struct{Fields: map[string]*structpb.Value{
+		"ISTIO_VERSION": {Kind: &structpb.Value_StringValue{StringValue: "1.3"}},
+		"NETWORK":       {Kind: &structpb.Value_StringValue{StringValue: network}},
 	}}
 
 	err = sendCDSReqWithMetadata(sidecarID, metadata, edsstr)
@@ -290,7 +290,7 @@ func initRegistry(server *bootstrap.Server, clusterNum int, gatewaysIP []string,
 	}
 }
 
-func sendCDSReqWithMetadata(node string, metadata *proto.Struct, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) error {
+func sendCDSReqWithMetadata(node string, metadata *structpb.Struct, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) error {
 	err := edsstr.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
 		Node: &core.Node{
@@ -305,7 +305,7 @@ func sendCDSReqWithMetadata(node string, metadata *proto.Struct, edsstr ads.Aggr
 	return nil
 }
 
-func sendEDSReqWithMetadata(clusters []string, node string, metadata *proto.Struct,
+func sendEDSReqWithMetadata(clusters []string, node string, metadata *structpb.Struct,
 	edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) error {
 	err := edsstr.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 
 	"istio.io/api/mesh/v1alpha1"
 

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -17,8 +17,8 @@ package v2
 import (
 	"net"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/gogo/protobuf/types"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	"github.com/golang/protobuf/ptypes/wrappers"
 
 	"istio.io/api/mesh/v1alpha1"
 
@@ -73,7 +73,7 @@ func EndpointsByNetworkFilter(endpoints []*endpoint.LocalityLbEndpoints, conn *X
 			epNetwork := istioMetadata(lbEp, "network")
 			if epNetwork == network {
 				// This is a local endpoint
-				lbEp.LoadBalancingWeight = &types.UInt32Value{
+				lbEp.LoadBalancingWeight = &wrappers.UInt32Value{
 					Value: uint32(multiples),
 				}
 				lbEndpoints = append(lbEndpoints, lbEp)
@@ -116,7 +116,7 @@ func EndpointsByNetworkFilter(endpoints []*endpoint.LocalityLbEndpoints, conn *X
 									Address: epAddr,
 								},
 							},
-							LoadBalancingWeight: &types.UInt32Value{
+							LoadBalancingWeight: &wrappers.UInt32Value{
 								Value: w,
 							},
 						}
@@ -161,11 +161,11 @@ func istioMetadata(ep *endpoint.LbEndpoint, key string) string {
 }
 
 func createLocalityLbEndpoints(base *endpoint.LocalityLbEndpoints, lbEndpoints []*endpoint.LbEndpoint) *endpoint.LocalityLbEndpoints {
-	var weight *types.UInt32Value
+	var weight *wrappers.UInt32Value
 	if len(lbEndpoints) == 0 {
 		weight = nil
 	} else {
-		weight = &types.UInt32Value{}
+		weight = &wrappers.UInt32Value{}
 		for _, lbEp := range lbEndpoints {
 			weight.Value += lbEp.GetLoadBalancingWeight().Value
 		}

--- a/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
@@ -18,9 +18,10 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/gogo/protobuf/types"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/wrappers"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
@@ -430,7 +431,7 @@ func testEndpoints() []*endpoint.LocalityLbEndpoints {
 	return []*endpoint.LocalityLbEndpoints{
 		{
 			LbEndpoints: lbEndpoints,
-			LoadBalancingWeight: &types.UInt32Value{
+			LoadBalancingWeight: &wrappers.UInt32Value{
 				Value: uint32(len(lbEndpoints)),
 			},
 		},
@@ -453,16 +454,16 @@ func createLbEndpoints(lbEpsInfo []*LbEpInfo) []*endpoint.LbEndpoint {
 				},
 			},
 			Metadata: &core.Metadata{
-				FilterMetadata: map[string]*types.Struct{
+				FilterMetadata: map[string]*structpb.Struct{
 					"istio": {
-						Fields: map[string]*types.Value{
+						Fields: map[string]*structpb.Value{
 							"network": {
-								Kind: &types.Value_StringValue{
+								Kind: &structpb.Value_StringValue{
 									StringValue: lbEpInfo.network,
 								},
 							},
 							"uid": {
-								Kind: &types.Value_StringValue{
+								Kind: &structpb.Value_StringValue{
 									StringValue: "kubernetes://dummy",
 								},
 							},

--- a/pilot/pkg/proxy/envoy/v2/init_test.go
+++ b/pilot/pkg/proxy/envoy/v2/init_test.go
@@ -25,24 +25,26 @@ import (
 	"net"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+
+	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
+
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	proto "github.com/gogo/protobuf/types"
+	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
-
 	"istio.io/istio/pilot/pkg/model"
-	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
 )
 
-var nodeMetadata = &proto.Struct{Fields: map[string]*proto.Value{
-	"ISTIO_VERSION": {Kind: &proto.Value_StringValue{StringValue: "1.3"}}, // actual value doesn't matter
+var nodeMetadata = &structpb.Struct{Fields: map[string]*structpb.Value{
+	"ISTIO_VERSION": {Kind: &structpb.Value_StringValue{StringValue: "1.3"}}, // actual value doesn't matter
 }}
 
 // Extract cluster load assignment from a discovery response.
@@ -54,7 +56,7 @@ func getLoadAssignment(res1 *xdsapi.DiscoveryResponse) (*xdsapi.ClusterLoadAssig
 		return nil, errors.New("Invalid resource typeURL" + res1.Resources[0].TypeUrl)
 	}
 	cla := &xdsapi.ClusterLoadAssignment{}
-	err := cla.Unmarshal(res1.Resources[0].Value)
+	err := ptypes.UnmarshalAny(res1.Resources[0], cla)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +174,7 @@ func sendEDSNack(_ []string, node string, edsstr ads.AggregatedDiscoveryService_
 			Metadata: nodeMetadata,
 		},
 		TypeUrl:     v2.EndpointType,
-		ErrorDetail: &rpc.Status{Message: "NOPE!"},
+		ErrorDetail: &status.Status{Message: "NOPE!"},
 	})
 	if err != nil {
 		return fmt.Errorf("EDS NACK failed: %s", err)
@@ -222,7 +224,7 @@ func sendLDSReqWithLabels(node string, ldsstr ads.AggregatedDiscoveryService_Str
 		return err
 	}
 
-	nodeMetadata.Fields[model.NodeMetadataLabels] = &proto.Value{Kind: &proto.Value_StringValue{StringValue: string(data)}}
+	nodeMetadata.Fields[model.NodeMetadataLabels] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: string(data)}}
 	// Not influence other cases
 	defer delete(nodeMetadata.Fields, model.NodeMetadataLabels)
 
@@ -248,7 +250,7 @@ func sendLDSNack(node string, ldsstr ads.AggregatedDiscoveryService_StreamAggreg
 			Metadata: nodeMetadata,
 		},
 		TypeUrl:     v2.ListenerType,
-		ErrorDetail: &rpc.Status{Message: "NOPE!"}})
+		ErrorDetail: &status.Status{Message: "NOPE!"}})
 	if err != nil {
 		return fmt.Errorf("LDS NACK failed: %s", err)
 	}
@@ -280,7 +282,7 @@ func sendRDSNack(node string, _ []string, nonce string, rdsstr ads.AggregatedDis
 			Metadata: nodeMetadata,
 		},
 		TypeUrl:     v2.RouteType,
-		ErrorDetail: &rpc.Status{Message: "NOPE!"}})
+		ErrorDetail: &status.Status{Message: "NOPE!"}})
 	if err != nil {
 		return fmt.Errorf("RDS NACK failed: %s", err)
 	}
@@ -310,7 +312,7 @@ func sendCDSNack(node string, edsstr ads.AggregatedDiscoveryService_StreamAggreg
 			Id:       node,
 			Metadata: nodeMetadata,
 		},
-		ErrorDetail: &rpc.Status{Message: "NOPE!"},
+		ErrorDetail: &status.Status{Message: "NOPE!"},
 		TypeUrl:     v2.ClusterType})
 	if err != nil {
 		return fmt.Errorf("CDS NACK failed: %s", err)

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 
 	"istio.io/istio/pilot/pkg/model"
 )
@@ -76,7 +76,7 @@ func ldsDiscoveryResponse(ls []*xdsapi.Listener, version string) *xdsapi.Discove
 			totalXDSInternalErrors.Increment()
 			continue
 		}
-		lr, _ := types.MarshalAny(ll)
+		lr, _ := ptypes.MarshalAny(ll)
 		resp.Resources = append(resp.Resources, lr)
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -19,18 +19,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+
+	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
+
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdsapi_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	xdsapi_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/labels"
-	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 
 	testenv "istio.io/istio/mixer/test/client/env"
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
-	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
@@ -331,7 +334,7 @@ func TestLDS(t *testing.T) {
 			return
 		}
 
-		strResponse, _ := protomarshal.ToJSONWithIndent(res, " ")
+		strResponse, _ := gogoprotomarshal.ToJSONWithIndent(res, " ")
 		_ = ioutil.WriteFile(env.IstioOut+"/ldsv2_sidecar.json", []byte(strResponse), 0644)
 
 		if len(res.Resources) == 0 {
@@ -356,7 +359,7 @@ func TestLDS(t *testing.T) {
 			t.Fatal("Failed to receive LDS", err)
 		}
 
-		strResponse, _ := protomarshal.ToJSONWithIndent(res, " ")
+		strResponse, _ := gogoprotomarshal.ToJSONWithIndent(res, " ")
 
 		_ = ioutil.WriteFile(env.IstioOut+"/ldsv2_gateway.json", []byte(strResponse), 0644)
 
@@ -566,7 +569,7 @@ func expectLuaFilter(t *testing.T, l *xdsapi.Listener, expected bool) {
 			t.Fatalf("Expected Http Connection Manager Config Filter_TypedConfig, found %T", filter.ConfigType)
 		}
 		connectionManagerCfg := xdsapi_http_connection_manager.HttpConnectionManager{}
-		err := connectionManagerCfg.Unmarshal(httpCfg.TypedConfig.GetValue())
+		err := ptypes.UnmarshalAny(httpCfg.TypedConfig, &connectionManagerCfg)
 		if err != nil {
 			t.Fatalf("Could not deserialize http connection manager config: %v", err)
 		}

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -18,11 +18,12 @@ import (
 	"fmt"
 	"time"
 
+	"istio.io/istio/pkg/util/protomarshal"
+
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/util/protomarshal"
 )
 
 func (s *DiscoveryServer) pushRoute(con *XdsConnection, push *model.PushContext, version string) error {
@@ -76,7 +77,7 @@ func routeDiscoveryResponse(rs []*xdsapi.RouteConfiguration, version string) *xd
 		Nonce:       nonce(),
 	}
 	for _, rc := range rs {
-		rr, _ := types.MarshalAny(rc)
+		rr, _ := ptypes.MarshalAny(rc)
 		resp.Resources = append(resp.Resources, rr)
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/rds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/rds_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/env"
-	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 	"istio.io/istio/tests/util"
 )
 
@@ -70,7 +70,7 @@ func TestRDS(t *testing.T) {
 				t.Fatal("Failed to receive RDS", err)
 			}
 
-			strResponse, _ := protomarshal.ToJSONWithIndent(res, " ")
+			strResponse, _ := gogoprotomarshal.ToJSONWithIndent(res, " ")
 			_ = ioutil.WriteFile(env.IstioOut+fmt.Sprintf("/rdsv2/%s_%d.json", tt.name, idx), []byte(strResponse), 0644)
 			if len(res.Resources) == 0 {
 				t.Fatal("No response")

--- a/pilot/pkg/security/authn/v1alpha1/model.go
+++ b/pilot/pkg/security/authn/v1alpha1/model.go
@@ -15,10 +15,29 @@
 package v1alpha1
 
 import (
+	"github.com/golang/protobuf/proto"
+
 	authn "istio.io/api/authentication/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 )
+
+// XDS protos use golang/protobuf, but the istio APIs use gogo protos. This means the golang/protobuf
+// backend needs to register the authn filter protos.
+func init() {
+	proto.RegisterEnum("istio.authentication.v1alpha1.PrincipalBinding", authn.PrincipalBinding_name, authn.PrincipalBinding_value)
+	proto.RegisterEnum("istio.authentication.v1alpha1.MutualTls_Mode", authn.MutualTls_Mode_name, authn.MutualTls_Mode_value)
+	proto.RegisterType((*authn.StringMatch)(nil), "istio.authentication.v1alpha1.StringMatch")
+	proto.RegisterType((*authn.MutualTls)(nil), "istio.authentication.v1alpha1.MutualTls")
+	proto.RegisterType((*authn.Jwt)(nil), "istio.authentication.v1alpha1.Jwt")
+	proto.RegisterType((*authn.Jwt_TriggerRule)(nil), "istio.authentication.v1alpha1.Jwt.TriggerRule")
+	proto.RegisterType((*authn.PeerAuthenticationMethod)(nil), "istio.authentication.v1alpha1.PeerAuthenticationMethod")
+	proto.RegisterType((*authn.OriginAuthenticationMethod)(nil), "istio.authentication.v1alpha1.OriginAuthenticationMethod")
+	proto.RegisterType((*authn.Policy)(nil), "istio.authentication.v1alpha1.Policy")
+	proto.RegisterType((*authn.TargetSelector)(nil), "istio.authentication.v1alpha1.TargetSelector")
+	proto.RegisterMapType((map[string]string)(nil), "istio.authentication.v1alpha1.TargetSelector.LabelsEntry")
+	proto.RegisterType((*authn.PortSelector)(nil), "istio.authentication.v1alpha1.PortSelector")
+}
 
 // GetConsolidateAuthenticationPolicy returns the v1alpha1 authentication policy for workload specified by
 // hostname (or label selector if specified) and port, if defined.

--- a/pilot/pkg/security/authn/v1alpha1/model.go
+++ b/pilot/pkg/security/authn/v1alpha1/model.go
@@ -35,7 +35,7 @@ func init() {
 	proto.RegisterType((*authn.OriginAuthenticationMethod)(nil), "istio.authentication.v1alpha1.OriginAuthenticationMethod")
 	proto.RegisterType((*authn.Policy)(nil), "istio.authentication.v1alpha1.Policy")
 	proto.RegisterType((*authn.TargetSelector)(nil), "istio.authentication.v1alpha1.TargetSelector")
-	proto.RegisterMapType((map[string]string)(nil), "istio.authentication.v1alpha1.TargetSelector.LabelsEntry")
+	proto.RegisterMapType(map[string]string(nil), "istio.authentication.v1alpha1.TargetSelector.LabelsEntry")
 	proto.RegisterType((*authn.PortSelector)(nil), "istio.authentication.v1alpha1.PortSelector")
 }
 

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -18,15 +18,16 @@ import (
 	"crypto/sha1"
 	"fmt"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	ldsv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoy_jwt "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/jwt_authn/v2alpha"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/empty"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	authn_v1alpha1 "istio.io/api/authentication/v1alpha1"
 	authn_filter "istio.io/api/envoy/config/filter/http/authn/v2alpha1"
@@ -166,7 +167,7 @@ func convertToEnvoyJwtConfig(policyJwts []*authn_v1alpha1.Jwt) *envoy_jwt.JwtAut
 				},
 				Requires: &envoy_jwt.JwtRequirement{
 					RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-						AllowMissingOrFailed: &types.Empty{},
+						AllowMissingOrFailed: &empty.Empty{},
 					},
 				},
 			},
@@ -400,7 +401,7 @@ func (a v1alpha1PolicyApplier) InboundFilterChain(sdsUdsPath string, meta map[st
 				ListenerFilters: []*ldsv2.ListenerFilter{
 					{
 						Name:       xdsutil.TlsInspector,
-						ConfigType: &ldsv2.ListenerFilter_Config{Config: &types.Struct{}},
+						ConfigType: &ldsv2.ListenerFilter_Config{Config: &structpb.Struct{}},
 					},
 				},
 			},

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -20,14 +20,15 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoy_jwt "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/jwt_authn/v2alpha"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	protobuf "github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/empty"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	authn "istio.io/api/authentication/v1alpha1"
 	authn_filter "istio.io/api/envoy/config/filter/http/authn/v2alpha1"
@@ -308,7 +309,7 @@ func TestConvertPolicyToJwtConfig(t *testing.T) {
 						},
 						Requires: &envoy_jwt.JwtRequirement{
 							RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-								AllowMissingOrFailed: &types.Empty{},
+								AllowMissingOrFailed: &empty.Empty{},
 							},
 						},
 					},
@@ -372,7 +373,7 @@ func TestConvertPolicyToJwtConfig(t *testing.T) {
 						},
 						Requires: &envoy_jwt.JwtRequirement{
 							RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-								AllowMissingOrFailed: &types.Empty{},
+								AllowMissingOrFailed: &empty.Empty{},
 							},
 						},
 					},
@@ -851,7 +852,7 @@ func TestOnInboundFilterChains(t *testing.T) {
 					ListenerFilters: []*listener.ListenerFilter{
 						{
 							Name:       "envoy.listener.tls_inspector",
-							ConfigType: &listener.ListenerFilter_Config{&types.Struct{}},
+							ConfigType: &listener.ListenerFilter_Config{&structpb.Struct{}},
 						},
 					},
 				},

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -20,7 +20,7 @@ import (
 
 	http_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
 	tcp_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rbac/v2"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 
 	istio_rbac "istio.io/api/rbac/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
@@ -140,7 +140,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 					rbacConfig := &http_config.RBAC{}
 					if got.GetConfig() == nil {
 						t.Errorf("want struct config when isXDSMarshalingToAnyEnabled is false")
-					} else if err := util.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
+					} else if err := conversion.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
 						t.Errorf("failed to convert struct to message: %s", err)
 					} else {
 						if len(tc.wantPolicies) == 0 {
@@ -226,7 +226,7 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 				rbacConfig := &tcp_config.RBAC{}
 				if got.GetConfig() == nil {
 					t.Errorf("want struct config when isXDSMarshalingToAnyEnabled is false")
-				} else if err := util.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
+				} else if err := conversion.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
 					t.Errorf("failed to convert struct to message: %s", err)
 				} else {
 					if rbacConfig.StatPrefix != authz_model.RBACTCPFilterStatPrefix {

--- a/pilot/pkg/security/authz/model/matcher/cidr.go
+++ b/pilot/pkg/security/authz/model/matcher/cidr.go
@@ -19,8 +19,8 @@ import (
 	"net"
 	"strings"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/gogo/protobuf/types"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
 // CidrRange converts a CIDR or a single IP string to a corresponding CidrRange. For a single IP
@@ -55,6 +55,6 @@ func CidrRange(v string) (*core.CidrRange, error) {
 
 	return &core.CidrRange{
 		AddressPrefix: address,
-		PrefixLen:     &types.UInt32Value{Value: uint32(prefixLen)},
+		PrefixLen:     &wrappers.UInt32Value{Value: uint32(prefixLen)},
 	}, nil
 }

--- a/pilot/pkg/security/authz/model/matcher/cidr_test.go
+++ b/pilot/pkg/security/authz/model/matcher/cidr_test.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/gogo/protobuf/types"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func TestCidrRange(t *testing.T) {
@@ -50,7 +50,7 @@ func TestCidrRange(t *testing.T) {
 			V:    "192.168.0.0/16",
 			Expect: &core.CidrRange{
 				AddressPrefix: "192.168.0.0",
-				PrefixLen:     &types.UInt32Value{Value: 16},
+				PrefixLen:     &wrappers.UInt32Value{Value: 16},
 			},
 		},
 		{
@@ -63,7 +63,7 @@ func TestCidrRange(t *testing.T) {
 			V:    "192.168.0.0",
 			Expect: &core.CidrRange{
 				AddressPrefix: "192.168.0.0",
-				PrefixLen:     &types.UInt32Value{Value: 32},
+				PrefixLen:     &wrappers.UInt32Value{Value: 32},
 			},
 		},
 		{
@@ -71,7 +71,7 @@ func TestCidrRange(t *testing.T) {
 			V:    "2001:abcd:85a3::8a2e:370:1234",
 			Expect: &core.CidrRange{
 				AddressPrefix: "2001:abcd:85a3::8a2e:370:1234",
-				PrefixLen:     &types.UInt32Value{Value: 128},
+				PrefixLen:     &wrappers.UInt32Value{Value: 128},
 			},
 		},
 	}

--- a/pilot/pkg/security/authz/model/matcher/header.go
+++ b/pilot/pkg/security/authz/model/matcher/header.go
@@ -17,7 +17,7 @@ package matcher
 import (
 	"strings"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 )
 
 // HeaderMatcher converts a key, value string pair to a corresponding HeaderMatcher.

--- a/pilot/pkg/security/authz/model/matcher/header_test.go
+++ b/pilot/pkg/security/authz/model/matcher/header_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 )
 
 func TestHeaderMatcher(t *testing.T) {

--- a/pilot/pkg/security/authz/model/permission.go
+++ b/pilot/pkg/security/authz/model/permission.go
@@ -19,8 +19,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoy_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
 	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 

--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -19,8 +19,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoy_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
 	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -17,10 +17,11 @@ package model
 import (
 	"sync"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/config/grpc_credential/v2alpha"
-	"github.com/gogo/protobuf/types"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_config_grpc_credential_v2alpha "github.com/envoyproxy/go-control-plane/envoy/config/grpc_credential/v2alpha"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -158,7 +159,7 @@ func ConstructValidationContext(rootCAFilePath string, subjectAltNames []string)
 // ConstructgRPCCallCredentials is used to construct SDS config which is only available from 1.1
 func ConstructgRPCCallCredentials(tokenFileName, headerKey string) []*core.GrpcService_GoogleGrpc_CallCredentials {
 	// If k8s sa jwt token file exists, envoy only handles plugin credentials.
-	config := &v2alpha.FileBasedMetadataConfig{
+	config := &envoy_config_grpc_credential_v2alpha.FileBasedMetadataConfig{
 		SecretData: &core.DataSource{
 			Specifier: &core.DataSource_Filename{
 				Filename: tokenFileName,
@@ -198,16 +199,16 @@ var fileBasedMetadataConfigAnyMap sync.Map
 // returns different result. Once SDS config differs, Envoy will create multiple SDS clients to fetch
 // same SDS resource. To solve this problem, we use findOrMarshalFileBasedMetadataConfig so that
 // FileBasedMetadataConfig is marshaled once, and is reused in all SDS configs.
-func findOrMarshalFileBasedMetadataConfig(tokenFileName, headerKey string, fbMetadata *v2alpha.FileBasedMetadataConfig) *types.Any {
+func findOrMarshalFileBasedMetadataConfig(tokenFileName, headerKey string, fbMetadata *envoy_config_grpc_credential_v2alpha.FileBasedMetadataConfig) *any.Any {
 	key := fbMetadataAnyKey{
 		tokenFileName: tokenFileName,
 		headerKey:     headerKey,
 	}
 	if v, found := fileBasedMetadataConfigAnyMap.Load(key); found {
-		marshalAny := v.(types.Any)
+		marshalAny := v.(any.Any)
 		return &marshalAny
 	}
-	any, _ := types.MarshalAny(fbMetadata)
+	any, _ := ptypes.MarshalAny(fbMetadata)
 	fileBasedMetadataConfigAnyMap.Store(key, *any)
 	return any
 }

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -19,15 +19,15 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/config/grpc_credential/v2alpha"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_config_grpc_credential_v2alpha "github.com/envoyproxy/go-control-plane/envoy/config/grpc_credential/v2alpha"
 
 	"istio.io/istio/pilot/pkg/features"
 )
 
 func TestConstructSdsSecretConfig(t *testing.T) {
-	trustworthyMetaConfig := &v2alpha.FileBasedMetadataConfig{
+	trustworthyMetaConfig := &envoy_config_grpc_credential_v2alpha.FileBasedMetadataConfig{
 		SecretData: &core.DataSource{
 			Specifier: &core.DataSource_Filename{
 				Filename: K8sSATrustworthyJwtFileName,
@@ -166,7 +166,7 @@ func constructLocalChannelCredConfig() *core.GrpcService_GoogleGrpc_ChannelCrede
 	}
 }
 
-func constructsdsconfighelper(tokenFileName, headerKey string, metaConfig *v2alpha.FileBasedMetadataConfig) *core.ConfigSource {
+func constructsdsconfighelper(tokenFileName, headerKey string, metaConfig *envoy_config_grpc_credential_v2alpha.FileBasedMetadataConfig) *core.ConfigSource {
 	any := findOrMarshalFileBasedMetadataConfig(tokenFileName, headerKey, metaConfig)
 	return &core.ConfigSource{
 		InitialFetchTimeout: features.InitialFetchTimeout,

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pilot/tools/debug/pilot_cli.go
+++ b/pilot/tools/debug/pilot_cli.go
@@ -63,7 +63,7 @@ import (
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
@@ -73,7 +73,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
-	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
@@ -175,7 +175,7 @@ func configTypeToTypeURL(configType string) string {
 
 func (p PodInfo) makeRequest(configType string) *xdsapi.DiscoveryRequest {
 	return &xdsapi.DiscoveryRequest{
-		Node: &envoy_api_v2_core1.Node{
+		Node: &core1.Node{
 			Id: p.makeNodeID(),
 		},
 		TypeUrl: configTypeToTypeURL(configType)}
@@ -308,7 +308,7 @@ func main() {
 		log.Errorf("Failed to get Xds response for %v. Error: %v", *resources, err)
 		return
 	}
-	strResponse, _ := protomarshal.ToJSONWithIndent(resp, " ")
+	strResponse, _ := gogoprotomarshal.ToJSONWithIndent(resp, " ")
 	if outputFile == nil || *outputFile == "" {
 		fmt.Printf("%v\n", strResponse)
 	} else if err := ioutil.WriteFile(*outputFile, []byte(strResponse), 0644); err != nil {

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -29,8 +29,9 @@ import (
 	"time"
 
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
 
@@ -687,15 +688,15 @@ func storeKeepalive(tcpKeepalive *networking.ConnectionPoolSettings_TCPSettings_
 	}
 
 	if tcpKeepalive.Probes > 0 {
-		upstreamConnectionOptions.TcpKeepalive.KeepaliveProbes = &types.UInt32Value{Value: tcpKeepalive.Probes}
+		upstreamConnectionOptions.TcpKeepalive.KeepaliveProbes = &wrappers.UInt32Value{Value: tcpKeepalive.Probes}
 	}
 
 	if tcpKeepalive.Time != nil && tcpKeepalive.Time.Seconds > 0 {
-		upstreamConnectionOptions.TcpKeepalive.KeepaliveTime = &types.UInt32Value{Value: uint32(tcpKeepalive.Time.Seconds)}
+		upstreamConnectionOptions.TcpKeepalive.KeepaliveTime = &wrappers.UInt32Value{Value: uint32(tcpKeepalive.Time.Seconds)}
 	}
 
 	if tcpKeepalive.Interval != nil && tcpKeepalive.Interval.Seconds > 0 {
-		upstreamConnectionOptions.TcpKeepalive.KeepaliveInterval = &types.UInt32Value{Value: uint32(tcpKeepalive.Interval.Seconds)}
+		upstreamConnectionOptions.TcpKeepalive.KeepaliveInterval = &wrappers.UInt32Value{Value: uint32(tcpKeepalive.Interval.Seconds)}
 	}
 	upstreamConnectionOptionsStr := convertToJSON(upstreamConnectionOptions)
 	if upstreamConnectionOptionsStr == "" {

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -23,19 +23,19 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	v1 "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	v2 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 	tracev2 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/type/matcher"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
+	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	"github.com/ghodss/yaml"
-	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb"
 	diff "gopkg.in/d4l3k/messagediff.v1"
 
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
-	ocv1 "istio.io/gogo-genproto/opencensus/proto/trace/v1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/bootstrap/platform"
 	"istio.io/istio/pkg/test/env"
@@ -166,15 +166,15 @@ func TestGolden(t *testing.T) {
 			check: func(got *v2.Bootstrap, t *testing.T) {
 				cfg := got.Tracing.Http.GetConfig()
 				sdMsg := tracev2.OpenCensusConfig{}
-				if err := util.StructToMessage(cfg, &sdMsg); err != nil {
+				if err := conversion.StructToMessage(cfg, &sdMsg); err != nil {
 					t.Fatalf("unable to parse: %v %v", cfg, err)
 				}
 
 				want := tracev2.OpenCensusConfig{
-					TraceConfig: &ocv1.TraceConfig{
-						Sampler: &ocv1.TraceConfig_ConstantSampler{
-							ConstantSampler: &ocv1.ConstantSampler{
-								Decision: ocv1.ConstantSampler_ALWAYS_PARENT,
+					TraceConfig: &v1.TraceConfig{
+						Sampler: &v1.TraceConfig_ConstantSampler{
+							ConstantSampler: &v1.ConstantSampler{
+								Decision: v1.ConstantSampler_ALWAYS_PARENT,
 							},
 						},
 						MaxNumberOfAttributes:    200,
@@ -355,7 +355,7 @@ func TestGolden(t *testing.T) {
 	}
 }
 
-func checkListStringMatcher(t *testing.T, got *matcher.ListStringMatcher, want string, typ string) {
+func checkListStringMatcher(t *testing.T, got *envoy_type_matcher.ListStringMatcher, want string, typ string) {
 	var patterns []string
 	for _, pattern := range got.GetPatterns() {
 		var pat string

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -365,6 +365,8 @@ func checkListStringMatcher(t *testing.T, got *envoy_type_matcher.ListStringMatc
 		case "suffix":
 			pat = pattern.GetSuffix()
 		case "regexp":
+			// Migration tracked in https://github.com/istio/istio/issues/17127
+			//nolint: staticcheck
 			pat = pattern.GetRegex()
 		}
 

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -19,7 +19,7 @@ import (
 	"regexp"
 
 	"cloud.google.com/go/compute/metadata"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	"istio.io/pkg/log"
 )

--- a/pkg/bootstrap/platform/platform.go
+++ b/pkg/bootstrap/platform/platform.go
@@ -15,7 +15,7 @@
 package platform
 
 import (
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 )
 
 // Environment provides information for the platform on which the bootstrapping

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -24,7 +24,7 @@ import (
 
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/validation"
-	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
 // DefaultProxyConfig for individual proxies
@@ -82,7 +82,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 // input YAML with defaults applied to omitted configuration values.
 func ApplyMeshConfigDefaults(yaml string) (*meshconfig.MeshConfig, error) {
 	out := DefaultMeshConfig()
-	if err := protomarshal.ApplyYAML(yaml, &out); err != nil {
+	if err := gogoprotomarshal.ApplyYAML(yaml, &out); err != nil {
 		return nil, multierror.Prefix(err, "failed to convert to proto.")
 	}
 
@@ -95,11 +95,11 @@ func ApplyMeshConfigDefaults(yaml string) (*meshconfig.MeshConfig, error) {
 	// Re-apply defaults to ProxyConfig if they were defined in the
 	// original input MeshConfig.ProxyConfig.
 	if prevDefaultConfig != nil {
-		origProxyConfigYAML, err := protomarshal.ToYAML(prevDefaultConfig)
+		origProxyConfigYAML, err := gogoprotomarshal.ToYAML(prevDefaultConfig)
 		if err != nil {
 			return nil, multierror.Prefix(err, "failed to re-encode default proxy config")
 		}
-		if err := protomarshal.ApplyYAML(origProxyConfigYAML, out.DefaultConfig); err != nil {
+		if err := gogoprotomarshal.ApplyYAML(origProxyConfigYAML, out.DefaultConfig); err != nil {
 			return nil, multierror.Prefix(err, "failed to convert to proto.")
 		}
 	}
@@ -122,7 +122,7 @@ func EmptyMeshNetworks() meshconfig.MeshNetworks {
 // input YAML.
 func LoadMeshNetworksConfig(yaml string) (*meshconfig.MeshNetworks, error) {
 	out := EmptyMeshNetworks()
-	if err := protomarshal.ApplyYAML(yaml, &out); err != nil {
+	if err := gogoprotomarshal.ApplyYAML(yaml, &out); err != nil {
 		return nil, multierror.Prefix(err, "failed to convert to proto.")
 	}
 

--- a/pkg/config/schema/instance.go
+++ b/pkg/config/schema/instance.go
@@ -23,7 +23,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"istio.io/istio/pkg/config/validation"
-	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
 // Instance provides description of the configuration schema and its key function
@@ -74,7 +74,7 @@ func (i *Instance) FromJSON(js string) (proto.Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = protomarshal.ApplyJSON(js, pb); err != nil {
+	if err = gogoprotomarshal.ApplyJSON(js, pb); err != nil {
 		return nil, err
 	}
 	return pb, nil
@@ -86,7 +86,7 @@ func (i *Instance) FromYAML(yml string) (proto.Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = protomarshal.ApplyYAML(yml, pb); err != nil {
+	if err = gogoprotomarshal.ApplyYAML(yml, pb); err != nil {
 		return nil, err
 	}
 	return pb, nil

--- a/pkg/config/schemas/schemas_test.go
+++ b/pkg/config/schemas/schemas_test.go
@@ -32,7 +32,7 @@ import (
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/test/config"
-	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
 const (
@@ -60,7 +60,7 @@ func TestApplyJSON(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("[%v]", i), func(tt *testing.T) {
 			var got meshAPI.MeshConfig
-			err := protomarshal.ApplyJSON(c.in, &got)
+			err := gogoprotomarshal.ApplyJSON(c.in, &got)
 			if err != nil {
 				if !c.wantErr {
 					tt.Fatalf("got unexpected error: %v", err)
@@ -199,7 +199,7 @@ patterns:
 		},
 	}
 
-	gotJSON, err := protomarshal.ToJSON(msg)
+	gotJSON, err := gogoprotomarshal.ToJSON(msg)
 	if err != nil {
 		t.Errorf("ToJSON failed: %v", err)
 	}
@@ -207,7 +207,7 @@ patterns:
 		t.Errorf("ToJSON failed: \ngot %s, \nwant %s", gotJSON, strings.Join(strings.Fields(wantJSON), ""))
 	}
 
-	if _, err = protomarshal.ToJSON(nil); err == nil {
+	if _, err = gogoprotomarshal.ToJSON(nil); err == nil {
 		t.Error("should produce an error")
 	}
 
@@ -219,7 +219,7 @@ patterns:
 		t.Errorf("FromYAML failed: got %+v want %+v", spew.Sdump(gotFromJSON), spew.Sdump(msg))
 	}
 
-	gotYAML, err := protomarshal.ToYAML(msg)
+	gotYAML, err := gogoprotomarshal.ToYAML(msg)
 	if err != nil {
 		t.Errorf("ToYAML failed: %v", err)
 	}
@@ -227,7 +227,7 @@ patterns:
 		t.Errorf("ToYAML failed: \ngot %+v \nwant %+v", spew.Sdump(gotYAML), spew.Sdump(wantYAML))
 	}
 
-	if _, err = protomarshal.ToYAML(nil); err == nil {
+	if _, err = gogoprotomarshal.ToYAML(nil); err == nil {
 		t.Error("should produce an error")
 	}
 
@@ -243,7 +243,7 @@ patterns:
 		t.Errorf("should produce an error")
 	}
 
-	gotJSONMap, err := protomarshal.ToJSONMap(msg)
+	gotJSONMap, err := gogoprotomarshal.ToJSONMap(msg)
 	if err != nil {
 		t.Errorf("ToJSONMap failed: %v", err)
 	}
@@ -251,7 +251,7 @@ patterns:
 		t.Errorf("ToJSONMap failed: \ngot %vwant %v", spew.Sdump(gotJSONMap), spew.Sdump(wantJSONMap))
 	}
 
-	if _, err = protomarshal.ToJSONMap(nil); err == nil {
+	if _, err = gogoprotomarshal.ToJSONMap(nil); err == nil {
 		t.Error("should produce an error")
 	}
 
@@ -334,7 +334,7 @@ trafficPolicy:
 		t.Errorf("FromYAML should have failed using Schema with bad MessageName")
 	}
 
-	gotJSON, err := protomarshal.ToJSON(msg)
+	gotJSON, err := gogoprotomarshal.ToJSON(msg)
 	if err != nil {
 		t.Errorf("ToJSON failed: %v", err)
 	}
@@ -342,7 +342,7 @@ trafficPolicy:
 		t.Errorf("ToJSON failed: got %s, want %s", gotJSON, wantJSON)
 	}
 
-	if _, err = protomarshal.ToJSON(nil); err == nil {
+	if _, err = gogoprotomarshal.ToJSON(nil); err == nil {
 		t.Error("should produce an error")
 	}
 
@@ -354,7 +354,7 @@ trafficPolicy:
 		t.Errorf("FromYAML failed: got %+v want %+v", spew.Sdump(gotFromJSON), spew.Sdump(msg))
 	}
 
-	gotYAML, err := protomarshal.ToYAML(msg)
+	gotYAML, err := gogoprotomarshal.ToYAML(msg)
 	if err != nil {
 		t.Errorf("ToYAML failed: %v", err)
 	}
@@ -362,7 +362,7 @@ trafficPolicy:
 		t.Errorf("ToYAML failed: got %+v want %+v", spew.Sdump(gotYAML), spew.Sdump(wantYAML))
 	}
 
-	if _, err = protomarshal.ToYAML(nil); err == nil {
+	if _, err = gogoprotomarshal.ToYAML(nil); err == nil {
 		t.Error("should produce an error")
 	}
 
@@ -378,7 +378,7 @@ trafficPolicy:
 		t.Errorf("should produce an error")
 	}
 
-	gotJSONMap, err := protomarshal.ToJSONMap(msg)
+	gotJSONMap, err := gogoprotomarshal.ToJSONMap(msg)
 	if err != nil {
 		t.Errorf("ToJSONMap failed: %v", err)
 	}
@@ -386,7 +386,7 @@ trafficPolicy:
 		t.Errorf("ToJSONMap failed: \ngot %vwant %v", spew.Sdump(gotJSONMap), spew.Sdump(wantJSONMap))
 	}
 
-	if _, err = protomarshal.ToJSONMap(nil); err == nil {
+	if _, err = gogoprotomarshal.ToJSONMap(nil); err == nil {
 		t.Error("should produce an error")
 	}
 

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	xdsUtil "github.com/envoyproxy/go-control-plane/pkg/util"
+	xdsUtil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3212,7 +3212,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: `envoy filter: unknown field "foo" in v2.Cluster`},
+		}, error: `envoy filter: unknown field "foo" in envoy_api_v2.Cluster`},
 		{name: "happy config", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{

--- a/pkg/proto/types.go
+++ b/pkg/proto/types.go
@@ -15,17 +15,17 @@
 package proto
 
 import (
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
 var (
 	// BoolTrue is a bool true pointer of types.BoolValue.
-	BoolTrue = &types.BoolValue{
+	BoolTrue = &wrappers.BoolValue{
 		Value: true,
 	}
 
 	// BoolFalse is a bool false pointer of types.BoolValue.
-	BoolFalse = &types.BoolValue{
+	BoolFalse = &wrappers.BoolValue{
 		Value: false,
 	}
 )

--- a/pkg/test/deployment/util.go
+++ b/pkg/test/deployment/util.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 
 	"istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"

--- a/pkg/test/envoy/admin_util.go
+++ b/pkg/test/envoy/admin_util.go
@@ -26,7 +26,7 @@ import (
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
 	routeApi "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 
 	"istio.io/istio/istioctl/pkg/util/configdump"
 )

--- a/pkg/test/framework/components/echo/common/envoy.go
+++ b/pkg/test/framework/components/echo/common/envoy.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/util/retry"

--- a/pkg/test/framework/components/echo/common/envoy_test.go
+++ b/pkg/test/framework/components/echo/common/envoy_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test"

--- a/pkg/test/framework/components/echo/docker/sidecar.go
+++ b/pkg/test/framework/components/echo/docker/sidecar.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/gogo/protobuf/jsonpb"
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 
 	"istio.io/istio/pkg/test"

--- a/pkg/test/framework/components/echo/docker/sidecar.go
+++ b/pkg/test/framework/components/echo/docker/sidecar.go
@@ -23,7 +23,7 @@ import (
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/docker"
@@ -53,7 +53,7 @@ func newSidecar(container *docker.Container) (*sidecar, error) {
 		for _, c := range cfg.Configs {
 			if c.TypeUrl == "type.googleapis.com/envoy.admin.v2alpha.BootstrapConfigDump" {
 				cd := envoyAdmin.BootstrapConfigDump{}
-				if err := types.UnmarshalAny(c, &cd); err != nil {
+				if err := ptypes.UnmarshalAny(c, &cd); err != nil {
 					return false, err
 				}
 

--- a/pkg/test/framework/components/echo/docker/workload.go
+++ b/pkg/test/framework/components/echo/docker/workload.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
 

--- a/pkg/test/framework/components/echo/kube/sidecar.go
+++ b/pkg/test/framework/components/echo/kube/sidecar.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/ptypes"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -59,7 +59,7 @@ func newSidecar(pod kubeCore.Pod, accessor *kube.Accessor) (*sidecar, error) {
 		for _, c := range cfg.Configs {
 			if c.TypeUrl == "type.googleapis.com/envoy.admin.v2alpha.BootstrapConfigDump" {
 				cd := envoyAdmin.BootstrapConfigDump{}
-				if err := types.UnmarshalAny(c, &cd); err != nil {
+				if err := ptypes.UnmarshalAny(c, &cd); err != nil {
 					return false, err
 				}
 

--- a/pkg/test/framework/components/echo/kube/sidecar.go
+++ b/pkg/test/framework/components/echo/kube/sidecar.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
-	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 
 	"istio.io/istio/pkg/test"

--- a/pkg/test/util/structpath/instance.go
+++ b/pkg/test/util/structpath/instance.go
@@ -23,10 +23,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb"
 
-	messagediff "gopkg.in/d4l3k/messagediff.v1"
+	"gopkg.in/d4l3k/messagediff.v1"
 
 	"istio.io/istio/pkg/test"
 

--- a/pkg/util/gogo/conversion.go
+++ b/pkg/util/gogo/conversion.go
@@ -40,6 +40,9 @@ func AnyToProtoAny(gogo *types.Any) *any.Any {
 }
 
 func BoolToProtoBool(gogo *types.BoolValue) *wrappers.BoolValue {
+	if gogo == nil {
+		return nil
+	}
 	if gogo.Value {
 		return proto.BoolTrue
 	}
@@ -52,5 +55,4 @@ func DurationToProtoDuration(gogo *types.Duration) *duration.Duration {
 	}
 	x := duration.Duration(*gogo)
 	return &x
-	//return ptypes.DurationProto(*util.GogoDurationToDuration(gogo))
 }

--- a/pkg/util/gogo/conversion.go
+++ b/pkg/util/gogo/conversion.go
@@ -1,0 +1,56 @@
+package gogo
+
+import (
+	"bytes"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
+
+	gogojsonpb "github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/golang/protobuf/ptypes/wrappers"
+
+	"istio.io/istio/pkg/proto"
+)
+
+func StructToProtoStruct(gogo *types.Struct) *structpb.Struct {
+	if gogo == nil {
+		return nil
+	}
+	buf := &bytes.Buffer{}
+	if err := (&gogojsonpb.Marshaler{OrigName: true}).Marshal(buf, gogo); err != nil {
+		return nil
+	}
+
+	pbs := &structpb.Struct{}
+	if err := jsonpb.Unmarshal(buf, pbs); err != nil {
+		return nil
+	}
+	return pbs
+}
+
+func AnyToProtoAny(gogo *types.Any) *any.Any {
+	if gogo == nil {
+		return nil
+	}
+	x := any.Any(*gogo)
+	return &x
+}
+
+func BoolToProtoBool(gogo *types.BoolValue) *wrappers.BoolValue {
+	if gogo.Value {
+		return proto.BoolTrue
+	}
+	return proto.BoolFalse
+}
+
+func DurationToProtoDuration(gogo *types.Duration) *duration.Duration {
+	if gogo == nil {
+		return nil
+	}
+	x := duration.Duration(*gogo)
+	return &x
+	//return ptypes.DurationProto(*util.GogoDurationToDuration(gogo))
+}

--- a/pkg/util/gogoprotomarshal/protomarshal.go
+++ b/pkg/util/gogoprotomarshal/protomarshal.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package protomarshal
+package gogoprotomarshal
 
 import (
 	"encoding/json"
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
 
 	"istio.io/pkg/log"
 )

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -27,9 +27,9 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	authapi "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	sds "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -280,18 +280,18 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			if discReq.VersionInfo != "" && s.st.SecretExist(conID, resourceName, token, discReq.VersionInfo) {
 				sdsServiceLog.Debugf("%s received SDS ACK from proxy %q, version info %q, "+
 					"error details %s\n", conIDresourceNamePrefix, discReq.Node.Id, discReq.VersionInfo,
-					discReq.ErrorDetail.GoString())
+					discReq.ErrorDetail)
 				continue
 			}
 
 			if firstRequestFlag {
 				sdsServiceLog.Debugf("%s received first SDS request from proxy %q, version info "+
 					"%q, error details %s\n", conIDresourceNamePrefix, discReq.Node.Id, discReq.VersionInfo,
-					discReq.ErrorDetail.GoString())
+					discReq.ErrorDetail)
 			} else {
 				sdsServiceLog.Debugf("%s received SDS request from proxy %q, version info %q, "+
 					"error details %s\n", conIDresourceNamePrefix, discReq.Node.Id, discReq.VersionInfo,
-					discReq.ErrorDetail.GoString())
+					discReq.ErrorDetail)
 			}
 
 			// In ingress gateway agent mode, if the first SDS request is received but kubernetes secret is not ready,
@@ -599,7 +599,7 @@ func sdsDiscoveryResponse(s *model.SecretItem, conID, resourceName string) (*xds
 		}
 	}
 
-	ms, err := types.MarshalAny(secret)
+	ms, err := ptypes.MarshalAny(secret)
 	if err != nil {
 		sdsServiceLog.Errorf("%s failed to mashal secret for proxy: %v", conIDresourceNamePrefix, err)
 		return nil, err

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -26,11 +26,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/genproto/googleapis/rpc/status"
+
 	api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	authapi "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	sds "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	"github.com/gogo/protobuf/types"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -665,7 +667,7 @@ func testSDSStreamUpdateFailures(stream sds.SecretDiscoveryService_StreamSecrets
 
 	// Send third request and simulate the scenario that the second push causes secret update failure.
 	// The version info and response nonce in the third request should match the second request.
-	req.ErrorDetail = &rpc.Status{
+	req.ErrorDetail = &status.Status{
 		Code:    int32(rpc.INTERNAL),
 		Message: "fake error",
 	}
@@ -759,7 +761,7 @@ func TestStreamSecretsUpdateFailures(t *testing.T) {
 
 func verifySDSSResponse(resp *api.DiscoveryResponse, expectedPrivateKey []byte, expectedCertChain []byte) error {
 	var pb authapi.Secret
-	if err := types.UnmarshalAny(resp.Resources[0], &pb); err != nil {
+	if err := ptypes.UnmarshalAny(resp.Resources[0], &pb); err != nil {
 		return fmt.Errorf("unmarshalAny SDS response failed: %v", err)
 	}
 
@@ -789,7 +791,7 @@ func verifySDSSResponse(resp *api.DiscoveryResponse, expectedPrivateKey []byte, 
 
 func verifySDSSResponseForRootCert(t *testing.T, resp *api.DiscoveryResponse, expectedRootCert []byte) {
 	var pb authapi.Secret
-	if err := types.UnmarshalAny(resp.Resources[0], &pb); err != nil {
+	if err := ptypes.UnmarshalAny(resp.Resources[0], &pb); err != nil {
 		t.Fatalf("UnmarshalAny SDS response failed: %v", err)
 	}
 

--- a/security/pkg/testing/sdsc/sdsclient.go
+++ b/security/pkg/testing/sdsc/sdsclient.go
@@ -21,13 +21,14 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+
 	"istio.io/pkg/log"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	authapi "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	sds "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
@@ -151,7 +152,7 @@ func ValidateResponse(response *xdsapi.DiscoveryResponse) error {
 		return fmt.Errorf("unexpected resource size in the response, %v ", response.Resources)
 	}
 	var pb authapi.Secret
-	if err := types.UnmarshalAny(response.Resources[0], &pb); err != nil {
+	if err := ptypes.UnmarshalAny(response.Resources[0], &pb); err != nil {
 		return fmt.Errorf("unmarshalAny SDS response failed: %v", err)
 	}
 	return nil

--- a/tests/integration/pilot/envoyfilter/main_test.go
+++ b/tests/integration/pilot/envoyfilter/main_test.go
@@ -25,8 +25,10 @@ import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdscore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
@@ -282,14 +284,14 @@ func checkHTTPFilter(resp *xdsapi.DiscoveryResponse) (success bool, e error) {
 	// check for hcm, http filters
 	for _, fc := range listenerToCheck.FilterChains {
 		for _, networkFilter := range fc.Filters {
-			if networkFilter.Name == util.HTTPConnectionManager {
+			if networkFilter.Name == wellknown.HTTPConnectionManager {
 				hcm := &http_conn.HttpConnectionManager{}
 				if networkFilter.GetTypedConfig() != nil {
-					if err := types.UnmarshalAny(networkFilter.GetTypedConfig(), hcm); err != nil {
+					if err := ptypes.UnmarshalAny(networkFilter.GetTypedConfig(), hcm); err != nil {
 						return false, fmt.Errorf("failed to unmarshall HCM (Any) from 1.1.1.1_80 listener: %v", err)
 					}
 				} else {
-					if err := util.StructToMessage(networkFilter.GetConfig(), hcm); err != nil {
+					if err := conversion.StructToMessage(networkFilter.GetConfig(), hcm); err != nil {
 						return false, fmt.Errorf("failed to unmarshall HCM (Struct) from 1.1.1.1_80 listener: %v", err)
 					}
 				}

--- a/tests/integration/pilot/envoyfilter/main_test.go
+++ b/tests/integration/pilot/envoyfilter/main_test.go
@@ -22,8 +22,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/pkg/util"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdscore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"

--- a/tests/integration/security/authn/permissive/permissive_test.go
+++ b/tests/integration/security/authn/permissive/permissive_test.go
@@ -22,11 +22,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+
 	"istio.io/istio/tests/integration/security/util"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/gogo/protobuf/types"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -117,7 +118,7 @@ spec:
 					var errs []error
 					for _, r := range resp.Resources {
 						foo := &xdsapi.Listener{}
-						err := types.UnmarshalAny(r, foo)
+						err := ptypes.UnmarshalAny(r, foo)
 						if err != nil {
 							errs = append(errs, err)
 							continue

--- a/tests/integration/security/authn/permissive/permissive_test.go
+++ b/tests/integration/security/authn/permissive/permissive_test.go
@@ -25,7 +25,7 @@ import (
 	"istio.io/istio/tests/integration/security/util"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/istio/pkg/test/framework"


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/16871

go-control-plane switched over to golang/protobuf (from gogo/proto). This PR migrates all usages over to golang/protobuf. There is some amount of pain here due to istio apis using gogo still.