### PR TITLE
Fix the release grab when rc collides with latest

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -39,7 +39,7 @@ fi
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
   ISTIO_VERSION=$(curl -L -s https://api.github.com/repos/istio/istio/releases | \
                   grep tag_name | sed "s/ *\"tag_name\": *\"\\(.*\\)\",*/\\1/" | \
-                  sort -t"." -k 1,1 -k 2,2 -k 3,3 -k 4,4 | tail -n 1)
+                  grep -v "rc\.[0-9]$" | sort -t"." -k 1,1 -k 2,2 -k 3,3 -k 4,4 | tail -n 1)
 fi
 
 if [ "x${ISTIO_VERSION}" = "x" ] ; then


### PR DESCRIPTION
Please provide a description for what this PR is for.
The shell script provided for retrieving latest version was not working properly when the latest version number match a prereleased -rc 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
