### PR TITLE
ca.go: delete useless break in select statement

### DIFF
--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -143,7 +143,6 @@ func NewSelfSignedIstioCAOptions(ctx context.Context, caCertTTL, certTTL, maxCer
 			case <-ticker.C:
 				if caSecret, scrtErr = client.Secrets(namespace).Get(CASecret, metav1.GetOptions{}); scrtErr == nil {
 					log.Infof("Citadel successfully loaded the secret.")
-					break
 				}
 			case <-ctx.Done():
 				log.Errorf("Secret waiting thread is terminated.")


### PR DESCRIPTION

Please provide a description for what this PR is for.
Delete useless break in code, it is ambiguity.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
