### PR TITLE
WIP: install: deploy ingressgateway as DaemonSet when "daemonsetEnabled: true"

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/autoscale.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/autoscale.yaml
@@ -1,6 +1,7 @@
 {{- range $key, $spec := .Values }}
 {{- if ne $key "enabled" }}
 {{- if and $spec.enabled $spec.autoscaleEnabled $spec.autoscaleMin $spec.autoscaleMax }}
+{{- if not $spec.daemonsetEnabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -26,6 +27,7 @@ spec:
         name: cpu
         targetAverageUtilization: {{ $spec.cpu.targetAverageUtilization }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -4,14 +4,18 @@
 
 {{- $labels := merge (dict "release" $.Release.Name "chart" (include "gateway.chart" $) "heritage" $.Release.Service) $spec.labels }}
 apiVersion: apps/v1
+{{- if not $spec.daemonsetEnabled }}
 kind: Deployment
+{{- else }}
+kind: DaemonSet
+{{- end }}
 metadata:
   name: {{ $key }}
   namespace: {{ $spec.namespace | default $.Release.Namespace }}
   labels:
 {{ $labels | toYaml | indent 4 }}
 spec:
-{{- if not $spec.autoscaleEnabled }}
+{{- if and (not $spec.autoscaleEnabled) (not $spec.daemonsetEnabled) }}
 {{- if $spec.replicaCount }}
   replicas: {{ $spec.replicaCount }}
 {{- else }}
@@ -23,10 +27,17 @@ spec:
       {{- range $key, $val := $spec.labels }}
       {{ $key }}: {{ $val }}
       {{- end }}
+  {{- if not $spec.daemonsetEnabled }}
   strategy:
     rollingUpdate:
       maxSurge: {{ $spec.rollingMaxSurge }}
       maxUnavailable: {{ $spec.rollingMaxUnavailable }}
+  {{- else }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ $spec.rollingMaxUnavailable }}
+  {{- end }}
   template:
     metadata:
       labels:
@@ -238,7 +249,11 @@ spec:
           - name: ISTIO_META_WORKLOAD_NAME
             value: {{ $key }}
           - name: ISTIO_META_OWNER
+            {{- if not $spec.daemonsetEnabled }}
             value: kubernetes://api/apps/v1/namespaces/{{ $spec.namespace | default $.Release.Namespace }}/deployments/{{ $key }}
+            {{- else }}
+            value: kubernetes://api/apps/v1/namespaces/{{ $spec.namespace | default $.Release.Namespace }}/daemonsets/{{ $key }}
+            {{- end }}
           {{- if $spec.sds }}
           {{- if $spec.sds.enabled }}
           - name: ISTIO_META_USER_SDS

--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -32,7 +32,8 @@ istio-ingressgateway:
   autoscaleEnabled: true
   autoscaleMin: 1
   autoscaleMax: 5
-  # specify replicaCount when autoscaleEnabled: false
+  # daemonsetEnabled: false #change to true to deploy as "kind: DaemonSet" otherwise "kind: Deployment"
+  # specify replicaCount when autoscaleEnabled: false and daemonsetEnabled: false
   # replicaCount: 1
   rollingMaxSurge: 100%
   rollingMaxUnavailable: 25%


### PR DESCRIPTION
Please provide a description for what this PR is for.

Makes `kind` of istio-ingressgateway pod template configurable for deploying as `DaemonSet` via Helm values. 

* if `gateways.istio-ingressgateway.daemonsetEnabled` is `false` or `nil`, istio-ingressgateway is deployed as `Deployment` as usual
  * and its `HorizontalPodAutoscaler` is also deployed
* if `gateways.istio-ingressgateway.daemonsetEnabled` is `true`, istio-ingressgateway is deployed as `DaemonSet` with `updateStrategy` field
  * and its `HorizontalPodAutoscaler` is NOT deployed

I think this flag is useful when "externalTrafficPolicy" is set to "Local".
How is it ?

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
