### PR TITLE
Remove deprecated envoy flag

### DIFF
--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -45,7 +45,6 @@ func (s *TestSetup) newEnvoy() (envoy.Instance, error) {
 	options := []envoy.Option{
 		envoy.ConfigPath(confPath),
 		envoy.DrainDuration(1 * time.Second),
-		envoy.AllowUnknownFields(true),
 	}
 	if s.stress {
 		options = append(options, envoy.Concurrency(10))

--- a/pkg/envoy/instance_test.go
+++ b/pkg/envoy/instance_test.go
@@ -194,7 +194,6 @@ func TestCommandLineArgs(t *testing.T) {
 			envoy.ServiceNode("mynode"),
 			envoy.DrainDuration(drainDuration),
 			envoy.ParentShutdownDuration(parentShutdownDuration),
-			envoy.AllowUnknownFields(true),
 		),
 	})
 	g.Expect(i.Epoch()).To(Equal(envoy.Epoch(1)))

--- a/pkg/envoy/options.go
+++ b/pkg/envoy/options.go
@@ -605,22 +605,6 @@ var parentShutdownDurationValidator = registerFlagValidator(&flagValidator{
 	},
 })
 
-// AllowUnknownFields sets the --allow-unknown-fields flag, which disables validation of
-// protobuf configurations for unknown fields
-func AllowUnknownFields(allow bool) Option {
-	var v *flagValidator
-	if allow {
-		v = allowUnknownFieldsValidator
-	}
-
-	return &genericOption{
-		v:     v,
-		value: "",
-	}
-}
-
-var allowUnknownFieldsValidator = registerBoolFlagValidator("--allow-unknown-fields")
-
 func registerBoolFlagValidator(flagName string) *flagValidator {
 	return registerFlagValidator(&flagValidator{
 		flagName: FlagName(flagName),

--- a/pkg/envoy/options_test.go
+++ b/pkg/envoy/options_test.go
@@ -161,16 +161,6 @@ func TestGoodOptions(t *testing.T) {
 			expectedArgs: []string{"--config-yaml", "{}", "--parent-shutdown-time-s", "15"},
 			options:      envoy.Options{envoy.ConfigYaml("{}"), envoy.ParentShutdownDuration(15 * time.Second)},
 		},
-		{
-			name:         "allow-unknown-fields:true",
-			expectedArgs: []string{"--config-yaml", "{}", "--allow-unknown-fields"},
-			options:      envoy.Options{envoy.ConfigYaml("{}"), envoy.AllowUnknownFields(true)},
-		},
-		{
-			name:         "allow-unknown-fields:false",
-			expectedArgs: []string{"--config-yaml", "{}"},
-			options:      envoy.Options{envoy.ConfigYaml("{}"), envoy.AllowUnknownFields(false)},
-		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
--allow-unknown-fields has been deprecated for a while. The flag isn't really necessary anymore, since reject-unknown-dynamic-fields is false by default


Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
