### PR TITLE
Deflake metrics expiration test

### DIFF
--- a/mixer/adapter/prometheus/prometheus_test.go
+++ b/mixer/adapter/prometheus/prometheus_test.go
@@ -532,11 +532,11 @@ func TestMetricExpiration(t *testing.T) {
 		checkWaitTime    time.Duration
 	}{
 		{"No expiration", metricInfos{counter}, metricInsts{counterVal}, metricInsts{}, nil, 0},
-		{"Single metric expiration (counter)", metricInfos{counter}, metricInsts{counterVal}, metricInsts{}, testPolicy, 100 * time.Millisecond},
-		{"Single metric expiration (counter, alt policy)", metricInfos{counter}, metricInsts{counterVal}, metricInsts{}, altPolicy, 100 * time.Millisecond},
-		{"Single metric expiration (gauge)", metricInfos{gaugeWithLabels}, metricInsts{gaugeWithLabelsVal}, metricInsts{}, testPolicy, 100 * time.Millisecond},
-		{"Single metric expiration (histogram)", metricInfos{histogram}, metricInsts{histogramVal}, metricInsts{}, testPolicy, 100 * time.Millisecond},
-		{"Preserve non-stale metrics", metricInfos{counter}, metricInsts{counterVal}, metricInsts{counterVal2}, testPolicy, 100 * time.Millisecond},
+		{"Single metric expiration (counter)", metricInfos{counter}, metricInsts{counterVal}, metricInsts{}, testPolicy, 200 * time.Millisecond},
+		{"Single metric expiration (counter, alt policy)", metricInfos{counter}, metricInsts{counterVal}, metricInsts{}, altPolicy, 200 * time.Millisecond},
+		{"Single metric expiration (gauge)", metricInfos{gaugeWithLabels}, metricInsts{gaugeWithLabelsVal}, metricInsts{}, testPolicy, 200 * time.Millisecond},
+		{"Single metric expiration (histogram)", metricInfos{histogram}, metricInsts{histogramVal}, metricInsts{}, testPolicy, 200 * time.Millisecond},
+		{"Preserve non-stale metrics", metricInfos{counter}, metricInsts{counterVal}, metricInsts{counterVal2}, testPolicy, 200 * time.Millisecond},
 	}
 
 	f := newBuilder(&testServer{})


### PR DESCRIPTION
Running with `docker --cpus=1` this passes 100% of the time now; before it failed 100% of the time. Not the best fix.. but it seems to work

Fixes https://github.com/istio/istio/issues/17182