### PR TITLE
Add service.type and service.loadBalancerIP for kiali service

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/service.yaml
@@ -3,15 +3,30 @@ kind: Service
 metadata:
   name: kiali
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $val := .Values.service.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   labels:
     app: {{ template "kiali.name" . }}
     chart: {{ template "kiali.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  type: {{ .Values.service.type }}
   ports:
-  - name: http-kiali
+  - name: {{ .Values.service.name }}
+    targetPort: 20001
     protocol: TCP
-    port: 20001
+    port: {{ .Values.service.externalPort }}
   selector:
     app: kiali
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
+  {{if .Values.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+    {{range $rangeList := .Values.service.loadBalancerSourceRanges}}
+    - {{ $rangeList }}
+    {{end}}
+  {{end}}

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -62,3 +62,11 @@ security:
   enabled: false
   cert_file: /kiali-cert/cert-chain.pem
   private_key_file: /kiali-cert/key.pem
+
+service:
+  annotations: {}
+  name: http-kiali
+  type: ClusterIP
+  externalPort: 20001
+  loadBalancerIP:
+  loadBalancerSourceRanges: []


### PR DESCRIPTION
Current users login kiali dashboard by ingress.
After adding this pr, we can login it by NodePort service or
loadBalancerIP.

[x] Installation
