### PR TITLE
Trim local filepaths from go binaries

### DIFF
--- a/bin/gobuild.sh
+++ b/bin/gobuild.sh
@@ -67,5 +67,6 @@ done < "${BUILDINFO}"
 time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
         ${V} "${GOBUILDFLAGS_ARRAY[@]}" ${GCFLAGS:+-gcflags "${GCFLAGS}"} \
         -o "${OUT}" \
+        -trimpath \
         -pkgdir="${GOPKG}/${BUILD_GOOS}_${BUILD_GOARCH}" \
         -ldflags "${LDFLAGS} ${LD_EXTRAFLAGS}" "${BUILDPATH}"


### PR DESCRIPTION
Currently all builds have local filepaths in the binaries. We can pass
-trimpath to strip these, which will get us closer to reproducible
builds.

For https://github.com/istio/istio/issues/16635
