### PR TITLE
add metadata to analyzers, use it to trim required resources

### DIFF
--- a/galley/pkg/config/analysis/analyzer.go
+++ b/galley/pkg/config/analysis/analyzer.go
@@ -14,41 +14,89 @@
 
 package analysis
 
-import "istio.io/istio/galley/pkg/config/scope"
+import (
+	"istio.io/istio/galley/pkg/config/collection"
+	"istio.io/istio/galley/pkg/config/scope"
+)
 
 // Analyzer is an interface for analyzing configuration.
 type Analyzer interface {
-	Name() string
+	Metadata() Metadata
 	Analyze(c Context)
 }
 
+// Metadata represents metadata for an analyzer
+type Metadata struct {
+	name            string
+	collectionsUsed map[collection.Name]bool
+}
+
+// NewMetadata creates a new Metadata object
+func NewMetadata(name string, collectionsUsed collection.Names) Metadata {
+	cu := make(map[collection.Name]bool)
+	for _, c := range collectionsUsed {
+		cu[c] = true
+	}
+	return Metadata{
+		name:            name,
+		collectionsUsed: cu,
+	}
+}
+
+// Name of the analyzer this metadata is for
+func (m Metadata) Name() string {
+	return m.name
+}
+
+// CollectionsUsed registers the collections accessed by the analyzer this metadata is for
+func (m Metadata) CollectionsUsed() map[collection.Name]bool {
+	return m.collectionsUsed
+}
+
 type combinedAnalyzers struct {
-	name      string
+	metadata  Metadata
 	analyzers []Analyzer
 }
 
 // Combine multiple analyzers into a single one.
+// For collections used, use the union of the component analyzers
 func Combine(name string, analyzers ...Analyzer) Analyzer {
 	return &combinedAnalyzers{
-		name:      name,
+		metadata:  NewMetadata(name, combineCollectionsUsed(analyzers)),
 		analyzers: analyzers,
 	}
 }
 
-// Name implements Analyzer
-func (c *combinedAnalyzers) Name() string {
-	return c.name
+// Metadata implements Analyzer
+func (c *combinedAnalyzers) Metadata() Metadata {
+	return c.metadata
 }
 
 // Analyze implements Analyzer
 func (c *combinedAnalyzers) Analyze(ctx Context) {
 	for _, a := range c.analyzers {
-		scope.Analysis.Debugf("Started analyzer %q...", a.Name())
+		scope.Analysis.Debugf("Started analyzer %q...", a.Metadata().Name())
 		if ctx.Canceled() {
-			scope.Analysis.Debugf("Analyzer %q has been cancelled...", c.Name())
+			scope.Analysis.Debugf("Analyzer %q has been cancelled...", c.Metadata().Name())
 			return
 		}
 		a.Analyze(ctx)
-		scope.Analysis.Debugf("Completed analyzer %q...", a.Name())
+		scope.Analysis.Debugf("Completed analyzer %q...", a.Metadata().Name())
 	}
+}
+
+func combineCollectionsUsed(analyzers []Analyzer) collection.Names {
+	collectionSet := make(map[collection.Name]bool)
+	for _, a := range analyzers {
+		for c := range a.Metadata().CollectionsUsed() {
+			collectionSet[c] = true
+		}
+	}
+
+	rc := make([]collection.Name, len(collectionSet))
+	for k := range collectionSet {
+		rc = append(rc, k)
+	}
+
+	return rc
 }

--- a/galley/pkg/config/analysis/analyzer_test.go
+++ b/galley/pkg/config/analysis/analyzer_test.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/galley/pkg/config/analysis/diag"
+	"istio.io/istio/galley/pkg/config/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/testing/data"
+)
+
+type analyzer struct {
+	inputs collection.Names
+	ran    bool
+}
+
+// Metadata implements Analyzer
+func (a *analyzer) Metadata() Metadata {
+	return Metadata{
+		Name:   "",
+		Inputs: a.inputs,
+	}
+}
+
+// Analyze implements Analyzer
+func (a *analyzer) Analyze(ctx Context) {
+	a.ran = true
+}
+
+type context struct{}
+
+func (ctx *context) Report(c collection.Name, t diag.Message)                   {}
+func (ctx *context) Find(c collection.Name, name resource.Name) *resource.Entry { return nil }
+func (ctx *context) Exists(c collection.Name, name resource.Name) bool          { return false }
+func (ctx *context) ForEach(c collection.Name, fn IteratorFn)                   {}
+func (ctx *context) Canceled() bool                                             { return false }
+
+func TestCombinedAnalyzer(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	a1 := &analyzer{inputs: collection.Names{data.Collection1}}
+	a2 := &analyzer{inputs: collection.Names{data.Collection2}}
+
+	a := Combine("combined", a1, a2)
+	g.Expect(a.Metadata().Inputs).To(ConsistOf(data.Collection1, data.Collection2))
+
+	a.Analyze(&context{})
+	g.Expect(a1.ran).To(BeTrue())
+	g.Expect(a2.ran).To(BeTrue())
+}

--- a/galley/pkg/config/analysis/analyzers/auth/servicerolebindings.go
+++ b/galley/pkg/config/analysis/analyzers/auth/servicerolebindings.go
@@ -19,6 +19,7 @@ import (
 
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/processor/metadata"
 	"istio.io/istio/galley/pkg/config/resource"
 )
@@ -28,9 +29,13 @@ type ServiceRoleBindingAnalyzer struct{}
 
 var _ analysis.Analyzer = &ServiceRoleBindingAnalyzer{}
 
-// Name implements Analyzer
-func (s *ServiceRoleBindingAnalyzer) Name() string {
-	return "auth.ServiceRoleBindingAnalyzer"
+// Metadata implements Analyzer
+func (s *ServiceRoleBindingAnalyzer) Metadata() analysis.Metadata {
+	return analysis.NewMetadata("auth.ServiceRoleBindingAnalyzer",
+		collection.Names{
+			metadata.IstioRbacV1Alpha1Serviceroles,
+			metadata.IstioRbacV1Alpha1Servicerolebindings,
+		})
 }
 
 // Analyze implements Analyzer

--- a/galley/pkg/config/analysis/analyzers/auth/servicerolebindings.go
+++ b/galley/pkg/config/analysis/analyzers/auth/servicerolebindings.go
@@ -31,11 +31,13 @@ var _ analysis.Analyzer = &ServiceRoleBindingAnalyzer{}
 
 // Metadata implements Analyzer
 func (s *ServiceRoleBindingAnalyzer) Metadata() analysis.Metadata {
-	return analysis.NewMetadata("auth.ServiceRoleBindingAnalyzer",
-		collection.Names{
+	return analysis.Metadata{
+		Name: "auth.ServiceRoleBindingAnalyzer",
+		Inputs: collection.Names{
 			metadata.IstioRbacV1Alpha1Serviceroles,
 			metadata.IstioRbacV1Alpha1Servicerolebindings,
-		})
+		},
+	}
 }
 
 // Analyze implements Analyzer

--- a/galley/pkg/config/analysis/analyzers/virtualservice/destinations.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/destinations.go
@@ -32,6 +32,8 @@ var (
 // DestinationAnalyzer checks the destinations associated with each virtual service
 type DestinationAnalyzer struct{}
 
+var _ analysis.Analyzer = &DestinationAnalyzer{}
+
 type hostAndSubset struct {
 	host   resource.Name
 	subset string
@@ -39,13 +41,15 @@ type hostAndSubset struct {
 
 // Metadata implements Analyzer
 func (da *DestinationAnalyzer) Metadata() analysis.Metadata {
-	return analysis.NewMetadata("virtualservice.DestinationAnalyzer",
-		collection.Names{
+	return analysis.Metadata{
+		Name: "virtualservice.DestinationAnalyzer",
+		Inputs: collection.Names{
 			metadata.IstioNetworkingV1Alpha3SyntheticServiceentries,
 			metadata.IstioNetworkingV1Alpha3Serviceentries,
 			metadata.IstioNetworkingV1Alpha3Virtualservices,
 			metadata.IstioNetworkingV1Alpha3Destinationrules,
-		})
+		},
+	}
 }
 
 // Analyze implements Analyzer

--- a/galley/pkg/config/analysis/analyzers/virtualservice/destinations.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/destinations.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/processor/metadata"
 	"istio.io/istio/galley/pkg/config/resource"
 )
@@ -36,9 +37,15 @@ type hostAndSubset struct {
 	subset string
 }
 
-// Name implements Analyzer
-func (da *DestinationAnalyzer) Name() string {
-	return "virtualservice.DestinationAnalyzer"
+// Metadata implements Analyzer
+func (da *DestinationAnalyzer) Metadata() analysis.Metadata {
+	return analysis.NewMetadata("virtualservice.DestinationAnalyzer",
+		collection.Names{
+			metadata.IstioNetworkingV1Alpha3SyntheticServiceentries,
+			metadata.IstioNetworkingV1Alpha3Serviceentries,
+			metadata.IstioNetworkingV1Alpha3Virtualservices,
+			metadata.IstioNetworkingV1Alpha3Destinationrules,
+		})
 }
 
 // Analyze implements Analyzer

--- a/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
@@ -31,11 +31,13 @@ var _ analysis.Analyzer = &GatewayAnalyzer{}
 
 // Metadata implements Analyzer
 func (s *GatewayAnalyzer) Metadata() analysis.Metadata {
-	return analysis.NewMetadata("virtualservice.GatewayAnalyzer",
-		collection.Names{
+	return analysis.Metadata{
+		Name: "virtualservice.GatewayAnalyzer",
+		Inputs: collection.Names{
 			metadata.IstioNetworkingV1Alpha3Gateways,
 			metadata.IstioNetworkingV1Alpha3Virtualservices,
-		})
+		},
+	}
 }
 
 // Analyze implements Analyzer

--- a/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
@@ -19,6 +19,7 @@ import (
 
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/processor/metadata"
 	"istio.io/istio/galley/pkg/config/resource"
 )
@@ -28,9 +29,13 @@ type GatewayAnalyzer struct{}
 
 var _ analysis.Analyzer = &GatewayAnalyzer{}
 
-// Name implements Analyzer
-func (s *GatewayAnalyzer) Name() string {
-	return "virtualservice.GatewayAnalyzer"
+// Metadata implements Analyzer
+func (s *GatewayAnalyzer) Metadata() analysis.Metadata {
+	return analysis.NewMetadata("virtualservice.GatewayAnalyzer",
+		collection.Names{
+			metadata.IstioNetworkingV1Alpha3Gateways,
+			metadata.IstioNetworkingV1Alpha3Virtualservices,
+		})
 }
 
 // Analyze implements Analyzer

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -37,6 +37,11 @@ import (
 
 const domainSuffix = "svc.local"
 
+// Patch table
+var (
+	apiserverNew = apiserver.New
+)
+
 // SourceAnalyzer handles local analysis of k8s and file based event sources
 type SourceAnalyzer struct {
 	m                    *schema.Metadata
@@ -126,7 +131,7 @@ func (sa *SourceAnalyzer) AddRunningKubeSource(k client.Interfaces) {
 		Client:    k,
 		Resources: filteredResources,
 	}
-	src := apiserver.New(o)
+	src := apiserverNew(o)
 
 	sa.sources = append(sa.sources, src)
 }
@@ -152,5 +157,6 @@ func getUpstreamCollections(analyzer analysis.Analyzer, xformProviders transform
 			upstreamCollections[in] = true
 		}
 	}
+
 	return upstreamCollections
 }

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -14,6 +14,7 @@
 package local
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -24,21 +25,28 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/processor/metadata"
+	"istio.io/istio/galley/pkg/config/source/kube/apiserver"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/k8smeta"
 	"istio.io/istio/galley/pkg/testing/mock"
 )
 
 type testAnalyzer struct {
-	fn func(analysis.Context)
+	fn              func(analysis.Context)
+	collectionsUsed collection.Names
 }
 
-// Name implements SampleAnalyzer
-func (a *testAnalyzer) Name() string {
-	return "testAnalyzer"
+var blankTestAnalyzer = &testAnalyzer{
+	fn:              func(_ analysis.Context) {},
+	collectionsUsed: []collection.Name{},
 }
 
-// Analyze implements SampleAnalyzer
+// Metadata implements Analyzer
+func (a *testAnalyzer) Metadata() analysis.Metadata {
+	return analysis.NewMetadata("testAnalyzer", a.collectionsUsed)
+}
+
+// Analyze implements Analyzer
 func (a *testAnalyzer) Analyze(ctx analysis.Context) {
 	a.fn(ctx)
 }
@@ -48,10 +56,9 @@ func TestAbortWithNoSources(t *testing.T) {
 
 	cancel := make(chan struct{})
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), nil)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankTestAnalyzer)
 	_, err := sa.Analyze(cancel)
 	g.Expect(err).To(Not(BeNil()))
-
 }
 
 func TestAnalyzersRun(t *testing.T) {
@@ -80,7 +87,7 @@ func TestAddRunningKubeSource(t *testing.T) {
 
 	mk := mock.NewKube()
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), nil)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankTestAnalyzer)
 
 	sa.AddRunningKubeSource(mk)
 	g.Expect(sa.sources).To(HaveLen(1))
@@ -89,7 +96,7 @@ func TestAddRunningKubeSource(t *testing.T) {
 func TestAddFileKubeSource(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), nil)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankTestAnalyzer)
 
 	tmpfile, err := ioutil.TempFile("", "")
 	if err != nil {
@@ -106,4 +113,36 @@ func TestAddFileKubeSource(t *testing.T) {
 
 	sa.AddFileKubeSource([]string{tmpfile.Name()}, "")
 	g.Expect(sa.sources).To(HaveLen(1))
+}
+
+func TestResourceFiltering(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Set up mock apiServer so we can peek at the options it gets started with
+	prevApiserverNew := apiserverNew
+	defer func() { apiserverNew = prevApiserverNew }()
+	var recordedOptions apiserver.Options
+	apiserverNew = func(o apiserver.Options) *apiserver.Source {
+		recordedOptions = o
+		return nil
+	}
+
+	usedCollection := k8smeta.K8SCoreV1Services
+	dummyAnalyzer := &testAnalyzer{
+		fn:              func(_ analysis.Context) {},
+		collectionsUsed: []collection.Name{usedCollection},
+	}
+	mk := mock.NewKube()
+
+	sa := NewSourceAnalyzer(metadata.MustGet(), dummyAnalyzer)
+	sa.AddRunningKubeSource(mk)
+
+	// All but the used collection should be disabled
+	for _, r := range recordedOptions.Resources {
+		if r.Collection.Name == k8smeta.K8SCoreV1Services {
+			g.Expect(r.Disabled).To(BeFalse(), fmt.Sprintf("%s should not be disabled", r.Collection.Name))
+		} else {
+			g.Expect(r.Disabled).To(BeTrue(), fmt.Sprintf("%s should be disabled", r.Collection.Name))
+		}
+	}
 }

--- a/galley/pkg/config/analysis/metadata.go
+++ b/galley/pkg/config/analysis/metadata.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import "istio.io/istio/galley/pkg/config/collection"
+
+// Metadata represents metadata for an analyzer
+type Metadata struct {
+	Name   string
+	Inputs collection.Names
+}

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -42,8 +42,8 @@ func (a *analyzerMock) Analyze(c analysis.Context) {
 }
 
 // Name implements Analyzer
-func (a *analyzerMock) Name() string {
-	return ""
+func (a *analyzerMock) Metadata() analysis.Metadata {
+	return analysis.NewMetadata("", collection.Names{})
 }
 
 func TestAnalyzeAndDistributeSnapshots(t *testing.T) {

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -43,7 +43,10 @@ func (a *analyzerMock) Analyze(c analysis.Context) {
 
 // Name implements Analyzer
 func (a *analyzerMock) Metadata() analysis.Metadata {
-	return analysis.NewMetadata("", collection.Names{})
+	return analysis.Metadata{
+		Name:   "",
+		Inputs: collection.Names{},
+	}
 }
 
 func TestAnalyzeAndDistributeSnapshots(t *testing.T) {

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -52,9 +52,8 @@ istioctl experimental analyze -k a.yaml b.yaml
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// These scopes are pretty verbose at the default log level and significantly clutter terminal output,
 			// so we adjust them here to avoid that.
-			loggingOptions.SetOutputLevel("analysis", log.DebugLevel)
-			loggingOptions.SetOutputLevel("processing", log.DebugLevel)
-			loggingOptions.SetOutputLevel("source", log.DebugLevel)
+			loggingOptions.SetOutputLevel("processing", log.ErrorLevel)
+			loggingOptions.SetOutputLevel("source", log.ErrorLevel)
 			if err := log.Configure(loggingOptions); err != nil {
 				return err
 			}

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -52,8 +52,9 @@ istioctl experimental analyze -k a.yaml b.yaml
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// These scopes are pretty verbose at the default log level and significantly clutter terminal output,
 			// so we adjust them here to avoid that.
-			loggingOptions.SetOutputLevel("processing", log.ErrorLevel)
-			loggingOptions.SetOutputLevel("source", log.ErrorLevel)
+			loggingOptions.SetOutputLevel("analysis", log.DebugLevel)
+			loggingOptions.SetOutputLevel("processing", log.DebugLevel)
+			loggingOptions.SetOutputLevel("source", log.DebugLevel)
 			if err := log.Configure(loggingOptions); err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR does the following:

1. Analyzers now return a structured Metadata object instead of just their name, including fields that list what resources they need. 
2. When getting data from Kubernetes, we trim out any resources we don't need for a significant performance improvement. (See https://github.com/istio/istio/issues/17036)

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
