### PR TITLE
CNI gate is failing because of trimpath

### DIFF
--- a/bin/gobuild.sh
+++ b/bin/gobuild.sh
@@ -63,6 +63,7 @@ while read -r line; do
     LD_EXTRAFLAGS="${LD_EXTRAFLAGS} -X ${line}"
 done < "${BUILDINFO}"
 
+go version
 # forgoing -i (incremental build) because it will be deprecated by tool chain.
 time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
         ${V} "${GOBUILDFLAGS_ARRAY[@]}" ${GCFLAGS:+-gcflags "${GCFLAGS}"} \


### PR DESCRIPTION
Need to determine the go version in use in the CNI implementation.

The CNI implementation has multiple nested containers, and want to eliminate
the possibility that golang 1.12 is being used in CNI in some way.

This will be reverted once a determination has been made.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
