### PR TITLE
Pin versions of package in Dockerfile

### DIFF
--- a/bin/dockerfile_versions_update.sh
+++ b/bin/dockerfile_versions_update.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# WARNING: DO NOT EDIT, THIS FILE IS PROBABLY A COPY
-#
-# The original version of this file is located in the https://github.com/istio/common-files repo.
-# If you're looking at this file in a different repo and want to make a change, please go to the
-# common-files repo, make the change there and check it in. Then come back to this repo and run
-# "make updatecommon".
-
 # Copyright 2019 Istio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/dockerfile_versions_update.sh
+++ b/bin/dockerfile_versions_update.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# WARNING: DO NOT EDIT, THIS FILE IS PROBABLY A COPY
+#
+# The original version of this file is located in the https://github.com/istio/common-files repo.
+# If you're looking at this file in a different repo and want to make a change, please go to the
+# common-files repo, make the change there and check it in. Then come back to this repo and run
+# "make updatecommon".
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}")" && pwd )"
+ROOTDIR=$(dirname "${SCRIPTPATH}")
+cd "${ROOTDIR}"|| exit
+
+# shellcheck disable=SC2044
+for df in $(find "${ROOTDIR}" -path "${ROOTDIR}/vendor" -prune -o -name 'Dockerfile*'); do
+  if [ "" != "$(grep -E -w "apt-get" "${df}")" ]
+  then
+    BASE="$(grep -E "FROM" "${df}" | cut -d ' ' -f2)"
+    URL_CHECK=""
+    PATTERN="<h1>Package: "
+    EXTRACTION='s/.*(\([^)].*\)).*$/\1/'
+    case $BASE in
+      "ubuntu:bionic")
+        URL_CHECK="https://packages.ubuntu.com/bionic/PACKAGE"
+        ;;
+      "ubuntu:xenial")
+        URL_CHECK="https://packages.ubuntu.com/xenial/PACKAGE"
+        ;;
+      "debian:9-slim")
+        URL_CHECK="https://packages.debian.org/stretch/PACKAGE"
+        ;;
+      *)
+        echo "this base dockerfile image is not supported for version recommendation!"
+        ;;
+    esac
+    # First sed makes a start/stop pattern, grep check lines without apt install / # clean
+    # last seds trim spaces and remaining ampersands
+    sed -n -e '/apt-get install/,/&&/ p' < "${df}" | grep -E -v "apt-get " | sed -e 's/ \\$//' | sed -e 's/ &&//' | while read -r PACKAGE_VERSION; do
+      PACKAGE="$( echo "$PACKAGE_VERSION" | cut -d '=' -f1 )"
+      VERSION="$( echo "$PACKAGE_VERSION" | cut -d '=' -f2 )"
+      URL="${URL_CHECK//PACKAGE/${PACKAGE}}"
+      # The last cut command makes sure there is no comment in the version
+      # e.g. 7.58.0-2ubuntu3.8 and others
+      NEW_VERSION="$( curl -sfL "$URL" | grep -E "${PATTERN}" | sed -e "${EXTRACTION}" | cut -d " " -f1 )"
+      if [ "${NEW_VERSION}" != "${VERSION}" ] ; then
+        echo "Update ${df} ${PACKAGE} version from ${VERSION} to ${NEW_VERSION}"
+      fi
+    done
+  fi
+done

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -8,22 +8,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 # If you occasionally need something on the container do
 # sudo apt-get update && apt-get whichever
 
-# hadolint ignore=DL3005,DL3008
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-      ca-certificates \
-      curl \
-      iptables \
-      iproute2 \
-      iputils-ping \
-      knot-dnsutils \
-      netcat \
-      tcpdump \
-      net-tools \
-      lsof \
-      linux-tools-generic \
-      sudo \
-   && update-ca-certificates \
-   && apt-get upgrade -y \
+      ca-certificates=20180409 \
+      curl=7.58.0-2ubuntu3.8 \
+      iproute2=4.15.0-2ubuntu1 \
+      iptables=1.6.1-2ubuntu2 \
+      iputils-ping=3:20161105-1ubuntu2 \
+      knot-dnsutils=2.6.5-3 \
+      libexpat1=2.2.5-3ubuntu0.2 \
+      linux-tools-generic=4.15.0.64.66 \
+      lsof=4.89+dfsg-0.1 \
+      net-tools=1.60+git20161116.90da8a0-1ubuntu1 \
+      netcat=1.10-41.1 \
+      sudo=1.8.21p2-3ubuntu1 \
+      tcpdump=4.9.2-3 \
    && apt-get clean \
+   && update-ca-certificates \
    && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old

--- a/docker/Dockerfile.bionic_debug
+++ b/docker/Dockerfile.bionic_debug
@@ -6,21 +6,21 @@ FROM ubuntu:bionic
 # If you occasionally need something on the container do
 # sudo apt-get update && apt-get whichever
 
-# hadolint ignore=DL3005,DL3008
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-      curl \
-      iptables \
-      iproute2 \
-      iputils-ping \
-      knot-dnsutils \
-      netcat \
-      tcpdump \
-      net-tools \
-      lsof \
-      sudo && \
-      apt-get upgrade -y && \
-      apt-get clean -y && \
+      curl=7.58.0-2ubuntu3.8 \
+      iproute2=4.15.0-2ubuntu1 \
+      iptables=1.6.1-2ubuntu2 \
+      iputils-ping=3:20161105-1ubuntu2 \
+      knot-dnsutils=2.6.5-3 \
+      libexpat1=2.2.5-3ubuntu0.2 \
+      linux-tools-generic=4.15.0.64.66 \
+      lsof=4.89+dfsg-0.1 \
+      net-tools=1.60+git20161116.90da8a0-1ubuntu1 \
+      netcat=1.10-41.1 \
+      sudo=1.8.21p2-3ubuntu1 \
+      tcpdump=4.9.2-3 \
+      && apt-get clean -y && \
       rm -rf /var/cache/debconf/* /var/lib/apt/lists/* \
         /var/log/* /tmp/*  /var/tmp/*
 

--- a/docker/Dockerfile.deb_debug
+++ b/docker/Dockerfile.deb_debug
@@ -6,19 +6,18 @@ FROM debian:9-slim
 # Do not add more stuff to this list that isn't small or critically useful.
 # If you occasionally need something on the container do
 # sudo apt-get update && apt-get whichever
-# hadolint ignore=DL3005,DL3008
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-      curl \
-      iptables \
-      iproute2 \
-      iputils-ping \
-      knot-dnsutils \
-      netcat \
-      tcpdump \
-      net-tools \
-      lsof \
-      sudo &&  apt-get upgrade -y && \
+      curl=7.52.1-5+deb9u9 \
+      iproute2=4.9.0-1+deb9u1 \
+      iptables=1.6.0+snapshot20161117-6 \
+      iputils-ping=3:20161105-1 \
+      knot-dnsutils=2.4.0-3+deb9u1 \
+      lsof=4.89+dfsg-0.1 \
+      net-tools=1.60+git20161116.90da8a0-1 \
+      netcat=1.10-41 \
+      sudo=1.8.19p1-2.1 \
+      tcpdump=4.9.2-1~deb9u1 && \
       apt-get clean -y && \
       rm -rf /var/cache/debconf/* /var/lib/apt/lists/* \
         /var/log/* /tmp/*  /var/tmp/*

--- a/docker/Dockerfile.xenial_debug
+++ b/docker/Dockerfile.xenial_debug
@@ -8,21 +8,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 # If you occasionally need something on the container do
 # sudo apt-get update && apt-get whichever
 
-# hadolint ignore=DL3005,DL3008
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-      ca-certificates \
-      curl \
-      iptables \
-      iproute2 \
-      iputils-ping \
-      knot-dnsutils \
-      netcat \
-      tcpdump \
-      net-tools \
-      lsof \
-      linux-tools-generic \
-      sudo \
-   && apt-get upgrade -y \
+      ca-certificates=20170717~16.04.1 \
+      curl=7.47.0-1ubuntu2.14 \
+      iproute2=4.3.0-1ubuntu3 \
+      iptables=1.6.0-2ubuntu3 \
+      iputils-ping=3:20121221-5ubuntu2 \
+      knot-dnsutils=2.1.1-1build1 \
+      linux-tools-generic=4.4.0.164.172 \
+      lsof=4.89+dfsg-0.1 \
+      net-tools=1.60-26ubuntu1 \
+      netcat=1.10-41 \
+      sudo=1.8.16-0ubuntu1.7 \
+      tcpdump=4.9.2-0ubuntu0.16.04.1 \
    && apt-get clean \
    && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old


### PR DESCRIPTION
As it is recommended by Dockerfile good practices (and reported by Dockerfile linter as DL3005 and DL3008).

We're going back and forth on this topic (should we pin, vs apt-get update / upgrade).
Full chain security might require that we pin in order to insure traceability of software versions shipped during a release. But we would need, during the release process to have a tool that would provide latest version of everything. It is a goal of a companion script `bin/dockerfile_versions_update.sh` that would make such suggestions.

The only alternative that I can see to that approach would be to update the version automatically during the execution of the Makefile for docker targets (using a slightly modified version of the script that would generate updated Dockerfile instead of advising updates), and then produce a manifest that should be shipped somewhere (the docker image itself?) for traceability purpose.

Let's continue that discussion here, @johnma14 & @sdake : any thoughts & suggestions?

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
