### PR TITLE
Enforce correct metadata for analyzers via unit tests

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -22,11 +22,16 @@ import (
 )
 
 // All returns all analyzers
-func All() analysis.Analyzer {
-	return analysis.Combine("all",
+func All() []analysis.Analyzer {
+	return []analysis.Analyzer{
 		&virtualservice.GatewayAnalyzer{},
 		&virtualservice.DestinationAnalyzer{},
 		&auth.ServiceRoleBindingAnalyzer{},
 		&injection.Analyzer{},
-	)
+	}
+}
+
+// AllCombined returns all analyzers combined as one
+func AllCombined() analysis.Analyzer {
+	return analysis.Combine("all", All()...)
 }

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -15,6 +15,7 @@
 package analyzers
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -26,6 +27,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 	"istio.io/istio/galley/pkg/config/analysis/local"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/processor/metadata"
 )
 
@@ -90,21 +92,67 @@ var testGrid = []testCase{
 
 // TestAnalyzers allows for table-based testing of Analyzers.
 func TestAnalyzers(t *testing.T) {
+	requestedInputsByAnalyzer := make(map[string]map[collection.Name]struct{})
+
+	// For each test case, verify we get the expected messages as output
 	for _, testCase := range testGrid {
 		testCase := testCase // Capture range variable so subtests work correctly
 		t.Run(testCase.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
 			sa := local.NewSourceAnalyzer(metadata.MustGet(), testCase.analyzer)
+
+			// Set up a hook to record which collections are accessed by each analyzer
+			analyzerName := testCase.analyzer.Metadata().Name
+			sa.SetCollectionReporter(func(col collection.Name) {
+				if _, ok := requestedInputsByAnalyzer[analyzerName]; !ok {
+					requestedInputsByAnalyzer[analyzerName] = make(map[collection.Name]struct{})
+				}
+				requestedInputsByAnalyzer[analyzerName][col] = struct{}{}
+			})
+
 			sa.AddFileKubeSource(testCase.inputFiles, "")
 			cancel := make(chan struct{})
+
 			msgs, err := sa.Analyze(cancel)
 			if err != nil {
 				t.Fatalf("Error running analysis on testcase %s: %v", testCase.name, err)
 			}
+
 			actualMsgs := extractFields(msgs)
 			g.Expect(actualMsgs).To(ConsistOf(testCase.expected))
 		})
+	}
+
+	// Verify that the collections actually accessed during testing actually match
+	// the collections declared as inputs for each of the analyzers
+	t.Run("CheckMetadataInputs", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		for _, a := range All() {
+			analyzerName := a.Metadata().Name
+			requestedInputs := make([]collection.Name, 0)
+			for col := range requestedInputsByAnalyzer[analyzerName] {
+				requestedInputs = append(requestedInputs, col)
+			}
+
+			g.Expect(a.Metadata().Inputs).To(ConsistOf(requestedInputs), fmt.Sprintf(
+				"Metadata inputs for analyzer %q don't match actual collections accessed during testing. "+
+					"Either the metadata is wrong or the test cases for the analyzer are insufficient.", analyzerName))
+		}
+	})
+}
+
+func TestAnalyzersHaveUniqueNames(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	existingNames := make(map[string]struct{})
+	for _, a := range All() {
+		n := a.Metadata().Name
+		_, ok := existingNames[n]
+		g.Expect(ok).To(BeFalse(), fmt.Sprintf("Analyzer name %q is used more than once. "+
+			"Analyzers should be registered in All() exactly once and have a unique name.", n))
+
+		existingNames[n] = struct{}{}
 	}
 }
 

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -100,16 +100,16 @@ func TestAnalyzers(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			sa := local.NewSourceAnalyzer(metadata.MustGet(), testCase.analyzer)
-
 			// Set up a hook to record which collections are accessed by each analyzer
 			analyzerName := testCase.analyzer.Metadata().Name
-			sa.SetCollectionReporter(func(col collection.Name) {
+			cr := func(col collection.Name) {
 				if _, ok := requestedInputsByAnalyzer[analyzerName]; !ok {
 					requestedInputsByAnalyzer[analyzerName] = make(map[collection.Name]struct{})
 				}
 				requestedInputsByAnalyzer[analyzerName][col] = struct{}{}
-			})
+			}
+
+			sa := local.NewSourceAnalyzer(metadata.MustGet(), testCase.analyzer, cr)
 
 			sa.AddFileKubeSource(testCase.inputFiles, "")
 			cancel := make(chan struct{})

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -53,13 +53,12 @@ type SourceAnalyzer struct {
 	// Derived from the specified analyzer and transformer providers
 	inputCollections map[collection.Name]struct{}
 
-	// Hook function called whenever a collection is accessed through the AnalyzingDistributor's context.
-	collectionReporter func(collection.Name)
+	collectionReporter snapshotter.CollectionReporterFn
 }
 
 // NewSourceAnalyzer creates a new SourceAnalyzer with no sources. Use the Add*Source methods to add sources in ascending precedence order,
 // then execute Analyze to perform the analysis
-func NewSourceAnalyzer(m *schema.Metadata, analyzer analysis.Analyzer, cr func(collection.Name)) *SourceAnalyzer {
+func NewSourceAnalyzer(m *schema.Metadata, analyzer analysis.Analyzer, cr snapshotter.CollectionReporterFn) *SourceAnalyzer {
 	//collectionReporter hook function defaults to no-op
 	if cr == nil {
 		cr = func(collection.Name) {}

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -59,7 +59,7 @@ func TestAbortWithNoSources(t *testing.T) {
 
 	cancel := make(chan struct{})
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankTestAnalyzer)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankTestAnalyzer, nil)
 	_, err := sa.Analyze(cancel)
 	g.Expect(err).To(Not(BeNil()))
 }
@@ -77,7 +77,7 @@ func TestAnalyzersRun(t *testing.T) {
 		},
 	}
 
-	sa := NewSourceAnalyzer(metadata.MustGet(), a)
+	sa := NewSourceAnalyzer(metadata.MustGet(), a, nil)
 	sa.AddFileKubeSource([]string{}, "")
 
 	msgs, err := sa.Analyze(cancel)
@@ -90,7 +90,7 @@ func TestAddRunningKubeSource(t *testing.T) {
 
 	mk := mock.NewKube()
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankTestAnalyzer)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankTestAnalyzer, nil)
 
 	sa.AddRunningKubeSource(mk)
 	g.Expect(sa.sources).To(HaveLen(1))
@@ -99,7 +99,7 @@ func TestAddRunningKubeSource(t *testing.T) {
 func TestAddFileKubeSource(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankTestAnalyzer)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankTestAnalyzer, nil)
 
 	tmpfile, err := ioutil.TempFile("", "")
 	if err != nil {
@@ -137,7 +137,7 @@ func TestResourceFiltering(t *testing.T) {
 	}
 	mk := mock.NewKube()
 
-	sa := NewSourceAnalyzer(metadata.MustGet(), dummyAnalyzer)
+	sa := NewSourceAnalyzer(metadata.MustGet(), dummyAnalyzer, nil)
 	sa.AddRunningKubeSource(mk)
 
 	// All but the used collection should be disabled

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -37,7 +37,7 @@ type AnalyzingDistributor struct {
 	snapshotsMu   sync.RWMutex
 	lastSnapshots map[string]*Snapshot
 
-	// Hook function called whenever a collection is accessed
+	// Hook function called whenever a collection is accessed through the AnalyzingDistributor's context
 	collectionReporter func(collection.Name)
 }
 
@@ -47,20 +47,19 @@ const defaultSnapshotGroup = "default"
 const syntheticSnapshotGroup = "syntheticServiceEntry"
 
 // NewAnalyzingDistributor returns a new instance of AnalyzingDistributor.
-func NewAnalyzingDistributor(u StatusUpdater, a analysis.Analyzer, d Distributor) *AnalyzingDistributor {
+func NewAnalyzingDistributor(u StatusUpdater, a analysis.Analyzer, d Distributor, cr func(collection.Name)) *AnalyzingDistributor {
+	//collectionReport hook function defaults to no-op
+	if cr == nil {
+		cr = func(collection.Name) {}
+	}
+
 	return &AnalyzingDistributor{
 		updater:            u,
 		analyzer:           a,
 		distributor:        d,
 		lastSnapshots:      make(map[string]*Snapshot),
-		collectionReporter: func(collection.Name) {}, // No-op unless SetCollectionReporter specifies otherwise
+		collectionReporter: cr,
 	}
-}
-
-// SetCollectionReporter adds a hook that gets called whenever a collection is accessed
-// through the AnalyzingDistributor's context.
-func (d *AnalyzingDistributor) SetCollectionReporter(fn func(collection.Name)) {
-	d.collectionReporter = fn
 }
 
 // Distribute implements snapshotter.Distributor

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -24,6 +24,9 @@ import (
 	"istio.io/istio/galley/pkg/config/scope"
 )
 
+// CollectionReporterFn is a hook function called whenever a collection is accessed through the AnalyzingDistributor's context
+type CollectionReporterFn func(collection.Name)
+
 // AnalyzingDistributor is an snapshotter. Distributor implementation that will perform analysis on a snapshot before
 // publishing. It will update the CRD status with the analysis results.
 type AnalyzingDistributor struct {
@@ -37,8 +40,7 @@ type AnalyzingDistributor struct {
 	snapshotsMu   sync.RWMutex
 	lastSnapshots map[string]*Snapshot
 
-	// Hook function called whenever a collection is accessed through the AnalyzingDistributor's context
-	collectionReporter func(collection.Name)
+	collectionReporter CollectionReporterFn
 }
 
 var _ Distributor = &AnalyzingDistributor{}
@@ -47,7 +49,7 @@ const defaultSnapshotGroup = "default"
 const syntheticSnapshotGroup = "syntheticServiceEntry"
 
 // NewAnalyzingDistributor returns a new instance of AnalyzingDistributor.
-func NewAnalyzingDistributor(u StatusUpdater, a analysis.Analyzer, d Distributor, cr func(collection.Name)) *AnalyzingDistributor {
+func NewAnalyzingDistributor(u StatusUpdater, a analysis.Analyzer, d Distributor, cr CollectionReporterFn) *AnalyzingDistributor {
 	//collectionReport hook function defaults to no-op
 	if cr == nil {
 		cr = func(collection.Name) {}
@@ -139,7 +141,7 @@ type context struct {
 	sn                 *Snapshot
 	cancelCh           chan struct{}
 	messages           diag.Messages
-	collectionReporter func(collection.Name)
+	collectionReporter CollectionReporterFn
 }
 
 var _ analysis.Context = &context{}

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -55,7 +55,7 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 	u := &updaterMock{}
 	a := &analyzerMock{}
 	d := NewInMemoryDistributor()
-	ad := NewAnalyzingDistributor(u, a, d)
+	ad := NewAnalyzingDistributor(u, a, d, nil)
 
 	sDefault := getTestSnapshot("a", "b")
 	sSynthetic := getTestSnapshot("c")

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -22,6 +22,8 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 	"istio.io/istio/galley/pkg/config/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/pkg/mcp/snapshot"
 )
 
@@ -31,7 +33,8 @@ type updaterMock struct{}
 func (u *updaterMock) Update(messages diag.Messages) {}
 
 type analyzerMock struct {
-	analyzeCalls []*Snapshot
+	analyzeCalls       []*Snapshot
+	collectionToAccess collection.Name
 }
 
 // Analyze implements Analyzer
@@ -39,6 +42,8 @@ func (a *analyzerMock) Analyze(c analysis.Context) {
 	ctx := *c.(*context)
 
 	a.analyzeCalls = append(a.analyzeCalls, ctx.sn)
+
+	ctx.Exists(a.collectionToAccess, resource.NewName("", ""))
 }
 
 // Name implements Analyzer
@@ -53,9 +58,17 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	u := &updaterMock{}
-	a := &analyzerMock{}
+	a := &analyzerMock{
+		collectionToAccess: data.Collection1,
+	}
 	d := NewInMemoryDistributor()
-	ad := NewAnalyzingDistributor(u, a, d, nil)
+
+	var collectionAccessed collection.Name
+	cr := func(col collection.Name) {
+		collectionAccessed = col
+	}
+
+	ad := NewAnalyzingDistributor(u, a, d, cr)
 
 	sDefault := getTestSnapshot("a", "b")
 	sSynthetic := getTestSnapshot("c")
@@ -73,6 +86,9 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 	// Assert we triggered only once analysis, with the expected combination of snapshots
 	sCombined := getTestSnapshot("a", "b", "c")
 	g.Eventually(func() []*Snapshot { return a.analyzeCalls }).Should(ConsistOf(sCombined))
+
+	// Verify the collection reporter hook was called
+	g.Expect(collectionAccessed).To(Equal(a.collectionToAccess))
 }
 
 func getTestSnapshot(names ...string) *Snapshot {

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -64,7 +64,7 @@ istioctl experimental analyze -k a.yaml b.yaml
 			}
 			cancel := make(chan struct{})
 
-			sa := local.NewSourceAnalyzer(metadata.MustGet(), analyzers.All())
+			sa := local.NewSourceAnalyzer(metadata.MustGet(), analyzers.AllCombined())
 
 			// We use the "namespace" arg that's provided as part of root istioctl as a flag for specifying what namespace to use
 			// for file resources that don't have one specified.

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -64,7 +64,7 @@ istioctl experimental analyze -k a.yaml b.yaml
 			}
 			cancel := make(chan struct{})
 
-			sa := local.NewSourceAnalyzer(metadata.MustGet(), analyzers.AllCombined())
+			sa := local.NewSourceAnalyzer(metadata.MustGet(), analyzers.AllCombined(), nil)
 
 			// We use the "namespace" arg that's provided as part of root istioctl as a flag for specifying what namespace to use
 			// for file resources that don't have one specified.


### PR DESCRIPTION
Enforce correct metadata for analyzers via unit tests

This updates the testing framework for analyzers to check / enforce that the right collections have been declared as inputs in metadata. Also adds some light plumbing to make this possible. 

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
