### PR TITLE
Revert "CNI gate is failing because of trimpath"

### DIFF
--- a/bin/gobuild.sh
+++ b/bin/gobuild.sh
@@ -63,7 +63,6 @@ while read -r line; do
     LD_EXTRAFLAGS="${LD_EXTRAFLAGS} -X ${line}"
 done < "${BUILDINFO}"
 
-go version
 # forgoing -i (incremental build) because it will be deprecated by tool chain.
 time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
         ${V} "${GOBUILDFLAGS_ARRAY[@]}" ${GCFLAGS:+-gcflags "${GCFLAGS}"} \


### PR DESCRIPTION
Reverts istio/istio#17229

cni uses istio/istio's e2e tests directly.  It was found that the CNI image in use was using golang 1.12.9, and it is not the buildtools container.  https://github.com/istio/test-infra/pull/1829