### PR TITLE
apply localityLbSetting to sni-dnat clusters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -16,7 +16,6 @@ package v1alpha3
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/bootstrap/auth"
 	"strconv"
 	"strings"
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -98,9 +98,9 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(env *model.Environment, prox
 
 	switch proxy.Type {
 	case model.SidecarProxy:
-		outboundClusters = envoyfilter.ApplyClusterPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, proxy, push, outboundClusters)
 		// apply load balancer setting fot cluster endpoints
 		applyLocalityLBSetting(proxy.Locality, outboundClusters, env.Mesh.LocalityLbSetting)
+		outboundClusters = envoyfilter.ApplyClusterPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, proxy, push, outboundClusters)
 		// Let ServiceDiscovery decide which IP and Port are used for management if
 		// there are multiple IPs
 		managementPorts := make([]*model.Port, 0)
@@ -118,9 +118,9 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(env *model.Environment, prox
 		if proxy.Type == model.Router && proxy.GetRouterMode() == model.SniDnatRouter {
 			outboundClusters = append(outboundClusters, configgen.buildOutboundSniDnatClusters(env, proxy, push)...)
 		}
-		outboundClusters = envoyfilter.ApplyClusterPatches(networking.EnvoyFilter_GATEWAY, proxy, push, outboundClusters)
 		// apply load balancer setting fot cluster endpoints
 		applyLocalityLBSetting(proxy.Locality, outboundClusters, env.Mesh.LocalityLbSetting)
+		outboundClusters = envoyfilter.ApplyClusterPatches(networking.EnvoyFilter_GATEWAY, proxy, push, outboundClusters)
 		clusters = outboundClusters
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -75,7 +75,7 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 			clusterIndex: 0,
 		}, {
 			direction:    model.TrafficDirectionInbound,
-			clusterIndex: 1,
+			clusterIndex: 3,
 		},
 	}
 	settings := []*networking.ConnectionPoolSettings{
@@ -803,7 +803,7 @@ func TestStatNamePattern(t *testing.T) {
 		})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(clusters[0].AltStatName).To(Equal("*.example.org_default_8080"))
-	g.Expect(clusters[1].AltStatName).To(Equal("LocalService_*.example.org"))
+	g.Expect(clusters[3].AltStatName).To(Equal("LocalService_*.example.org"))
 }
 
 func TestSidecarLocalityLB(t *testing.T) {
@@ -931,7 +931,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 
 	g.Expect(err).NotTo(HaveOccurred())
 
-	for i := 0; i < 2; i++ {
+	for _, i := range []int{0, 3} {
 		cluster := clusters[i]
 		if cluster.CommonLbConfig == nil {
 			t.Errorf("CommonLbConfig should be set for cluster %+v", cluster)
@@ -977,7 +977,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 
 	g.Expect(err).NotTo(HaveOccurred())
 
-	for i := 0; i < 2; i++ {
+	for _, i := range []int{0, 3} {
 		if clusters[i].CommonLbConfig == nil {
 			t.Fatalf("CommonLbConfig should be set for cluster %+v", clusters[i])
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -75,7 +75,7 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 			clusterIndex: 0,
 		}, {
 			direction:    model.TrafficDirectionInbound,
-			clusterIndex: 3,
+			clusterIndex: 1,
 		},
 	}
 	settings := []*networking.ConnectionPoolSettings{
@@ -142,7 +142,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 			clusterIndex: 0,
 		}, {
 			direction:    model.TrafficDirectionInbound,
-			clusterIndex: 3,
+			clusterIndex: 1,
 		},
 	}
 	settings := &networking.ConnectionPoolSettings{
@@ -803,7 +803,7 @@ func TestStatNamePattern(t *testing.T) {
 		})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(clusters[0].AltStatName).To(Equal("*.example.org_default_8080"))
-	g.Expect(clusters[3].AltStatName).To(Equal("LocalService_*.example.org"))
+	g.Expect(clusters[1].AltStatName).To(Equal("LocalService_*.example.org"))
 }
 
 func TestLocalityLB(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -926,7 +926,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 					MinHealthPercent:  10,
 				},
 			},
-		}, map[string]string{model.NodeMetadataRouterMode: string(model.SniDnatRouter)},
+		}, &model.NodeMetadata{RouterMode: string(model.SniDnatRouter)},
 		model.MaxIstioVersion)
 
 	g.Expect(err).NotTo(HaveOccurred())
@@ -972,7 +972,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 					MinHealthPercent:  10,
 				},
 			},
-		}, map[string]string{model.NodeMetadataRouterMode: string(model.SniDnatRouter)},
+		}, &model.NodeMetadata{RouterMode: string(model.SniDnatRouter)},
 		model.MaxIstioVersion)
 
 	g.Expect(err).NotTo(HaveOccurred())

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -142,7 +142,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 			clusterIndex: 0,
 		}, {
 			direction:    model.TrafficDirectionInbound,
-			clusterIndex: 1,
+			clusterIndex: 3,
 		},
 	}
 	settings := &networking.ConnectionPoolSettings{


### PR DESCRIPTION
Please provide a description for what this PR is for.

When debuging Replicated control planes multi-clusters, we found the locality loadbalancer not take effect. Actually we did not set it for sni-dnat clusters at all.


cc @venilnoronha  

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
