### PR TITLE
Add ability to customise Prometheus global configuration

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -11,7 +11,9 @@ metadata:
 data:
   prometheus.yml: |-
     global:
-      scrape_interval: {{ .Values.scrapeInterval }}
+{{- if .Values.global_config }}
+{{ toYaml .Values.global_config | indent 6 }}
+{{- end }}
     scrape_configs:
 
     - job_name: 'istio-mesh'

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -31,8 +31,11 @@ tolerations: []
 podAntiAffinityLabelSelector: []
 podAntiAffinityTermLabelSelector: []
 
-# Controls the frequency of prometheus scraping
-scrapeInterval: 15s
+# Global Prometheus configuration
+# This is placed under the global: key in prometheus.yml. Named global_config to avoid
+# issues with .Values.global.
+global_config:
+  scrapeInterval: 15s
 
 contextPath: /prometheus
 

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -35,7 +35,7 @@ podAntiAffinityTermLabelSelector: []
 # This is placed under the global: key in prometheus.yml. Named global_config to avoid
 # issues with .Values.global.
 global_config:
-  scrapeInterval: 15s
+  scrape_interval: 15s
 
 contextPath: /prometheus
 

--- a/install/kubernetes/helm/istio/test-values/values-e2e.yaml
+++ b/install/kubernetes/helm/istio/test-values/values-e2e.yaml
@@ -16,7 +16,8 @@ global:
     mode: REGISTRY_ONLY
 
 prometheus:
-  scrapeInterval: 5s
+  global_config:
+    scrape_interval: 5s
 
 gateways:
   istio-ingressgateway:


### PR DESCRIPTION
Please provide a description for what this PR is for.

This adds the ability to customise the global configuration for the bundled Prometheus server. Specifically I was attempting to address the ability to add `external_labels` as we run a federated setup but by making it more generic users can customise as required.

An example additional values.yaml file would contain:

```
global_config:
  scrapeInterval: 15s
  external_labels:
    - foo: bar
```

Key is named global_config to avoid conflict with .Values.global.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
