### PR TITLE
fix(prom tests): use new EnvoyFilter API for v2 configs

### DIFF
--- a/tests/integration/telemetry/stats/prometheus/testdata/metadata_exchange_filter.yaml
+++ b/tests/integration/telemetry/stats/prometheus/testdata/metadata_exchange_filter.yaml
@@ -3,37 +3,21 @@ kind: EnvoyFilter
 metadata:
   name: metadata-exchange
 spec:
-  filters:
-    - filterConfig:
-        configuration: envoy.wasm.metadata_exchange
-        vm_config:
-          code:
-            inline_string: envoy.wasm.metadata_exchange
-          vm: envoy.wasm.vm.null
-      filterName: envoy.wasm
-      filterType: HTTP
-      listenerMatch:
-        listenerProtocol: HTTP
-        listenerType: SIDECAR_INBOUND
-    - filterConfig:
-        configuration: envoy.wasm.metadata_exchange
-        vm_config:
-          code:
-            inline_string: envoy.wasm.metadata_exchange
-          vm: envoy.wasm.vm.null
-      filterName: envoy.wasm
-      filterType: HTTP
-      listenerMatch:
-        listenerProtocol: HTTP
-        listenerType: SIDECAR_OUTBOUND
-    - filterConfig:
-        configuration: envoy.wasm.metadata_exchange
-        vm_config:
-          code:
-            inline_string: envoy.wasm.metadata_exchange
-          vm: envoy.wasm.vm.null
-      filterName: envoy.wasm
-      filterType: HTTP
-      listenerMatch:
-        listenerProtocol: HTTP
-        listenerType: GATEWAY
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: ANY # inbound, outbound, and gateway
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.wasm
+          config:
+            configuration: envoy.wasm.metadata_exchange
+            vm_config:
+              vm: envoy.wasm.vm.null
+              code:
+                inline_string: envoy.wasm.metadata_exchange

--- a/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
+++ b/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
@@ -3,49 +3,27 @@ kind: EnvoyFilter
 metadata:
   name: stats-filter
 spec:
-  filters:
-    - filterConfig:
-        configuration: |
-          {
-            "debug": "false",
-            "stat_prefix": "istio",
-          }
-        vm_config:
-          code:
-            inline_string: envoy.wasm.stats
-          vm: envoy.wasm.vm.null
-      filterName: envoy.wasm
-      filterType: HTTP
-      listenerMatch:
-        listenerProtocol: HTTP
-        listenerType: GATEWAY
-    - filterConfig:
-        configuration: |
-          {
-            "debug": "false",
-            "stat_prefix": "istio",
-          }
-        vm_config:
-          code:
-            inline_string: envoy.wasm.stats
-          vm: envoy.wasm.vm.null
-      filterName: envoy.wasm
-      filterType: HTTP
-      listenerMatch:
-        listenerProtocol: HTTP
-        listenerType: SIDECAR_INBOUND
-    - filterConfig:
-        configuration: |
-          {
-            "debug": "false",
-            "stat_prefix": "istio",
-          }
-        vm_config:
-          code:
-            inline_string: envoy.wasm.stats
-          vm: envoy.wasm.vm.null
-      filterName: envoy.wasm
-      filterType: HTTP
-      listenerMatch:
-        listenerProtocol: HTTP
-        listenerType: SIDECAR_OUTBOUND
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: ANY # inbound, outbound, and gateway
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.wasm
+          config:
+            configuration: |
+              {
+                "debug": "false",
+                "stat_prefix": "istio",
+              }
+            vm_config:
+              vm: envoy.wasm.vm.null
+              code:
+                inline_string: envoy.wasm.stats


### PR DESCRIPTION
This PR updates the parts of the EnvoyFilter API being used for configuring in-proxy telemetry. With this PR, we move away from the deprecated model for support in that API.

See also: https://github.com/istio/proxy/pull/2427, https://github.com/istio/proxy/pull/2428

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
