### PR TITLE
Make distroless the default

### DIFF
--- a/docker/Dockerfile.kubectl
+++ b/docker/Dockerfile.kubectl
@@ -2,8 +2,8 @@
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 # This container should only contain kubectl.  Hard-coding to use Linux K8s 1.13.10 version.
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.13.10/bin/linux/amd64/kubectl /usr/bin/kubectl

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
+++ b/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
@@ -17,10 +17,6 @@
 package contextgraph
 
 import (
-	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
-)
-
-import (
 	"flag"
 	"fmt"
 	"io"
@@ -34,10 +30,14 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
+
+	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
+
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+
 	gstatus "google.golang.org/grpc/status"
 )
 

--- a/mixer/docker/Dockerfile.mixer
+++ b/mixer/docker/Dockerfile.mixer
@@ -1,10 +1,10 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
 # No tag available https://hub.docker.com/_/scratch?tab=description
 # hadolint ignore=DL3006
-FROM scratch as default
+FROM scratch as ubuntu
 # obtained from debian ca-certs deb using fetch_cacerts.sh
 ADD ca-certificates.tgz /
 

--- a/mixer/docker/Dockerfile.mixer_codegen
+++ b/mixer/docker/Dockerfile.mixer_codegen
@@ -1,10 +1,10 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
 # No tag available https://hub.docker.com/_/scratch?tab=description
 # hadolint ignore=DL3006
-FROM scratch as default
+FROM scratch as ubuntu
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/mixer/docker/Dockerfile.test_policybackend
+++ b/mixer/docker/Dockerfile.test_policybackend
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/mixer/test/listbackend/cmd/Dockerfile
+++ b/mixer/test/listbackend/cmd/Dockerfile
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
 # No tag available https://hub.docker.com/_/scratch?tab=description
 # hadolint ignore=DL3006
-FROM scratch as default
+FROM scratch as ubuntu
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/mixer/test/prometheus/cmd/Dockerfile
+++ b/mixer/test/prometheus/cmd/Dockerfile
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
 # No tag available https://hub.docker.com/_/scratch?tab=description
 # hadolint ignore=DL3006
-FROM scratch as default
+FROM scratch as ubuntu
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -1,8 +1,8 @@
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 ARG proxy_version
 ARG istio_version

--- a/pilot/docker/Dockerfile.proxy_init
+++ b/pilot/docker/Dockerfile.proxy_init
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
 # ISTIO_VERSION is used to specify the version of the release
 ARG BASE_VERSION=latest
 
- # The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+ # The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 COPY istio-iptables.sh /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/istio-iptables.sh"]
@@ -14,10 +14,10 @@ ENTRYPOINT ["/usr/local/bin/istio-iptables.sh"]
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/cc:latest as distroless
 
-COPY --from=default /sbin/xtables-multi /sbin/iptables* /sbin/ip6tables* /sbin/ip /sbin/
-COPY --from=default /usr/lib/x86_64-linux-gnu/xtables/ /usr/lib/x86_64-linux-gnu/xtables
-COPY --from=default /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu
-COPY --from=default /etc/iproute2 /etc/iproute2
+COPY --from=ubuntu /sbin/xtables-multi /sbin/iptables* /sbin/ip6tables* /sbin/ip /sbin/
+COPY --from=ubuntu /usr/lib/x86_64-linux-gnu/xtables/ /usr/lib/x86_64-linux-gnu/xtables
+COPY --from=ubuntu /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu
+COPY --from=ubuntu /etc/iproute2 /etc/iproute2
 
 COPY istio-iptables /usr/local/bin/istio-iptables
 ENTRYPOINT ["/usr/local/bin/istio-iptables"]

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -1,8 +1,8 @@
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 ARG proxy_version
 ARG istio_version

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 # Add CA certificates for SSL connections.
 # obtained from debian ca-certs deb using fetch_cacerts.sh

--- a/pkg/test/framework/components/echo/kube/sidecar.go
+++ b/pkg/test/framework/components/echo/kube/sidecar.go
@@ -164,7 +164,7 @@ func (s *sidecar) ListenersOrFail(t test.Failer) *envoyAdmin.Listeners {
 
 func (s *sidecar) adminRequest(path string, out proto.Message) error {
 	// Exec onto the pod and make a curl request to the admin port, writing
-	command := fmt.Sprintf("curl http://127.0.0.1:%d/%s", proxyAdminPort, path)
+	command := fmt.Sprintf("pilot-agent request GET %s", path)
 	response, err := s.accessor.Exec(s.podNamespace, s.podName, proxyContainerName, command)
 	if err != nil {
 		return fmt.Errorf("failed exec on pod %s/%s: %v. Command: %s. Output:\n%s",

--- a/pkg/test/framework/components/echo/kube/sidecar.go
+++ b/pkg/test/framework/components/echo/kube/sidecar.go
@@ -35,7 +35,6 @@ import (
 
 const (
 	proxyContainerName = "istio-proxy"
-	proxyAdminPort     = 15000
 )
 
 var _ echo.Sidecar = &sidecar{}

--- a/prow/e2e-kind-suite.sh
+++ b/prow/e2e-kind-suite.sh
@@ -54,7 +54,7 @@ function build_kind_images() {
 
 	# If a variant is specified, load those images as well.
 	# We should load non-variant images as well for things like `app` which do not use variants
-	if [[ "${VARIANT:-}" != "distroless" ]] && [[ "${VARIANT:-}" != "" ]]; then
+	if [[ "${VARIANT:-}" != "" ]]; then
 	  docker images "${HUB}/*:${TAG}-${VARIANT}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 -P16 kind --loglevel debug --name istio-testing load docker-image
   fi
 }
@@ -88,7 +88,11 @@ for ((i=1; i<=$#; i++)); do
         --timeout) ((i++)); E2E_TIMEOUT=${!i}
         continue
         ;;
-        --variant) ((i++)); VARIANT="${!i}"
+        --variant) ((i++));
+          # Distroless is the default, so if set as variant we don't need to add the suffix
+          if [[ "${!i}" != "distroless" ]]; then
+            VARIANT="${!i}"
+          fi
         continue
         ;;
     esac
@@ -123,8 +127,7 @@ fi
 if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
    cni_run_daemon_kind
 fi
-
 time ISTIO_DOCKER_HUB=$HUB \
   E2E_ARGS="${E2E_ARGS[*]}" \
   JUNIT_E2E_XML="${ARTIFACTS}/junit.xml" \
-  make with_junit_report TARGET="${SINGLE_TEST}" ${VARIANT:+ VARIANT="${VARIANT}"} ${E2E_TIMEOUT:+ E2E_TIMEOUT="${E2E_TIMEOUT}"}
+  echo make with_junit_report TARGET="${SINGLE_TEST}" ${VARIANT:+ VARIANT="${VARIANT}"} ${E2E_TIMEOUT:+ E2E_TIMEOUT="${E2E_TIMEOUT}"}

--- a/prow/e2e-kind-suite.sh
+++ b/prow/e2e-kind-suite.sh
@@ -39,10 +39,14 @@ set -x
 source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
 
+
 function build_kind_images() {
+  if [[ -n "${VARIANT:-}" ]]; then
+    export DOCKER_BUILD_VARIANTS="${VARIANT}"
+  fi
   # Build just the images needed for the tests
   for image in pilot proxyv2 proxy_init app test_policybackend mixer citadel galley sidecar_injector kubectl node-agent-k8s; do
-    DOCKER_BUILD_VARIANTS="${VARIANT:-default}" make docker.${image}
+    make docker.${image}
   done
 	# Archived local images and load it into KinD's docker daemon
 	# Kubernetes in KinD can only access local images from its docker daemon.
@@ -50,7 +54,7 @@ function build_kind_images() {
 
 	# If a variant is specified, load those images as well.
 	# We should load non-variant images as well for things like `app` which do not use variants
-	if [[ "${VARIANT:-}" != "" ]]; then
+	if [[ "${VARIANT:-}" != "distroless" ]] && [[ "${VARIANT:-}" != "" ]]; then
 	  docker images "${HUB}/*:${TAG}-${VARIANT}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 -P16 kind --loglevel debug --name istio-testing load docker-image
   fi
 }

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -77,7 +77,7 @@ make init
 
 if [[ $HUB == *"istio-testing"* ]]; then
   # upload images
-  time ISTIO_DOCKER_HUB="${HUB}" make docker.push HUB="${HUB}" TAG="${TAG}" DOCKER_BUILD_VARIANTS="${VARIANT:-default}"
+  time ISTIO_DOCKER_HUB="${HUB}" make docker.push HUB="${HUB}" TAG="${TAG}" DOCKER_BUILD_VARIANTS="${VARIANT:-distroless}"
 fi
 
 if [[ "${SETUP_CLUSTER:-true}" == true ]]; then

--- a/release/gcb/docker_tag_push_lib.sh
+++ b/release/gcb/docker_tag_push_lib.sh
@@ -148,11 +148,11 @@ function set_image_vars() {
   TAR_NAME="${BASE_NAME%.*}"
   IMAGE_NAME="${TAR_NAME%.*}"
   VARIANT_NAME=""
-  #check if it is a build variant (e.g. sidecar_injector-distroless)
+  #check if it is a build variant (e.g. sidecar_injector-ubuntu)
   case "${IMAGE_NAME}" in
-    *-distroless)
-      # in case of a distroless tar file, we remove the "-distroless" from the image name
-      VARIANT_NAME="-distroless"
+    *-ubuntu)
+      # in case of a ubuntu tar file, we remove the "-ubuntu" from the image name
+      VARIANT_NAME="-ubuntu"
       IMAGE_NAME="${IMAGE_NAME%${VARIANT_NAME}}"
       ;;
   esac

--- a/release/gcb/gcb_lib.sh
+++ b/release/gcb/gcb_lib.sh
@@ -95,7 +95,7 @@ function make_istio() {
   rm -r "${ISTIO_OUT}/docker" || true
   BUILD_DOCKER_TARGETS=(docker.save)
 
-  CB_BRANCH=${BRANCH} DEBUG=0 ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} HUB=${REL_DOCKER_HUB} DOCKER_BUILD_VARIANTS="default distroless" make "${BUILD_DOCKER_TARGETS[@]}"
+  CB_BRANCH=${BRANCH} DEBUG=0 ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} HUB=${REL_DOCKER_HUB} DOCKER_BUILD_VARIANTS="ubuntu distroless" make "${BUILD_DOCKER_TARGETS[@]}"
 
   # preserve the source from the root of the code
   pushd "${ROOT}/../../../.." || exit

--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -20,12 +20,12 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go
 
 
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
 # No tag available https://hub.docker.com/_/scratch?tab=description
 # hadolint ignore=DL3006
-FROM scratch as default
+FROM scratch as ubuntu
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/security/docker/Dockerfile.citadel
+++ b/security/docker/Dockerfile.citadel
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 # obtained from debian ca-certs deb using fetch_cacerts.sh
 ADD ca-certificates.tgz /

--- a/security/docker/Dockerfile.citadel-test
+++ b/security/docker/Dockerfile.citadel-test
@@ -1,8 +1,8 @@
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 COPY istio_ca /usr/local/bin/istio_ca
 COPY istio_ca.crt /usr/local/bin/istio_ca.crt

--- a/security/docker/Dockerfile.node-agent
+++ b/security/docker/Dockerfile.node-agent
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/security/docker/Dockerfile.node-agent-k8s
+++ b/security/docker/Dockerfile.node-agent-k8s
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/security/docker/Dockerfile.node-agent-test
+++ b/security/docker/Dockerfile.node-agent-test
@@ -1,8 +1,8 @@
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 COPY node_agent /usr/local/bin/node_agent
 

--- a/security/docker/Dockerfile.sdsclient
+++ b/security/docker/Dockerfile.sdsclient
@@ -1,8 +1,8 @@
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 COPY sdsclient /
 RUN chmod 755 /sdsclient

--- a/sidecar-injector/docker/Dockerfile.sidecar_injector
+++ b/sidecar-injector/docker/Dockerfile.sidecar_injector
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=ubuntu
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM docker.io/istio/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
+FROM docker.io/istio/base:${BASE_VERSION} as ubuntu
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -79,6 +79,9 @@ func TestCoreDumpGenerated(t *testing.T) {
 	if strings.Contains(os.Getenv("TEST_ENV"), "minikube") {
 		t.Skipf("Skipping %s in minikube environment", t.Name())
 	}
+	if os.Getenv("ENABLE_KUBECTL_CP") != "true " {
+		t.Skipf("Skipping %s, kubectl cp not enabled", t.Name())
+	}
 	// Simplest way to create out of process core file.
 	crashContainer := "istio-proxy"
 	crashProgPath := "/tmp/crashing_program"

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -266,9 +266,9 @@ docker.base: docker/Dockerfile.base
 # 4. This rule runs $(BUILD_PRE) prior to any docker build and only if specified as a dependency variable
 # 5. This rule finally runs docker build passing $(BUILD_ARGS) to docker if they are specified as a dependency variable
 
-# DOCKER_BUILD_VARIANTS ?=default distroless
-DOCKER_BUILD_VARIANTS ?=default
-DEFAULT_DISTRIBUTION=default
+# DOCKER_BUILD_VARIANTS ?=ubuntu distroless
+DOCKER_BUILD_VARIANTS ?=distroless
+DEFAULT_DISTRIBUTION=distroless
 DOCKER_RULE=$(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time (mkdir -p $(DOCKER_BUILD_TOP)/$@ && cp -r $^ $(DOCKER_BUILD_TOP)/$@ && cd $(DOCKER_BUILD_TOP)/$@ && $(BUILD_PRE) docker build $(BUILD_ARGS) --build-arg BASE_DISTRIBUTION=$(VARIANT) -t $(HUB)/$(subst docker.,,$@):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) -f Dockerfile$(suffix $@) . ); )
 
 # This target will package all docker images used in test and release, without re-building

--- a/tools/packaging/deb/Dockerfile
+++ b/tools/packaging/deb/Dockerfile
@@ -3,7 +3,7 @@
 # ISTIO_VERSION is used to specify the version of the release
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
+# The following section is used as base image if BASE_DISTRIBUTION=ubuntu
 FROM docker.io/istio/base:${BASE_VERSION}
 
 # hadolint ignore=DL3006


### PR DESCRIPTION
Currently we ship our images with a ubuntu base. This has caused a bit of pain with security vulnerabilities and large image sizes. The environments WG has agreed to transition to distroless as the default for Istio 1.4.