### PR TITLE
Support for e2e-dashboard using kind

### DIFF
--- a/prow/config/metrics/aggregated-metrics-reader.yaml
+++ b/prow/config/metrics/aggregated-metrics-reader.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:aggregated-metrics-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]

--- a/prow/config/metrics/auth-delegator.yaml
+++ b/prow/config/metrics/auth-delegator.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/prow/config/metrics/auth-reader.yaml
+++ b/prow/config/metrics/auth-reader.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/prow/config/metrics/metrics-apiservice.yaml
+++ b/prow/config/metrics/metrics-apiservice.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100

--- a/prow/config/metrics/metrics-server-deployment.yaml
+++ b/prow/config/metrics/metrics-server-deployment.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        k8s-app: metrics-server
+    spec:
+      serviceAccountName: metrics-server
+      volumes:
+      # mount in tmp so we can safely use from-scratch images and/or read-only containers
+      - name: tmp-dir
+        emptyDir: {}
+      containers:
+      - name: metrics-server
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.2
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: tmp-dir
+          mountPath: /tmp
+

--- a/prow/config/metrics/metrics-server-service.yaml
+++ b/prow/config/metrics/metrics-server-service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/name: "Metrics-server"
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443

--- a/prow/config/metrics/resource-reader.yaml
+++ b/prow/config/metrics/resource-reader.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/prow/e2e-dashboard.sh
+++ b/prow/e2e-dashboard.sh
@@ -29,4 +29,4 @@ set -x
 
 # Run tests with auth disabled
 #echo 'Running dashboard e2e tests'
-./prow/e2e-suite.sh --single_test e2e_dashboard
+prow/e2e-kind-suite.sh --single_test e2e_dashboard

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -145,6 +145,8 @@ function setup_kind_cluster() {
 
   KUBECONFIG="$(kind get kubeconfig-path --name="istio-testing")"
   export KUBECONFIG
+
+  kubectl apply -f ./prow/config/metrics
 }
 
 function cni_run_daemon_kind() {

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -112,6 +112,10 @@ func performanceQueryFilterFn(queries []string) []string {
 			continue
 		}
 
+		// cAdvisor does not expose this metrics, and we don't have kubelet in kind
+		if strings.Contains(qry, "container_fs_usage_bytes") {
+			continue
+		}
 		ret = append(ret, qry)
 	}
 
@@ -270,6 +274,10 @@ func mixerQueryFilterFn(queries []string) []string {
 		if strings.Contains(query, "grpc_code!=") {
 			continue
 		}
+		// cAdvisor does not expose this metrics, and we don't have kubelet in kind
+		if strings.Contains(query, "container_fs_usage_bytes") {
+			continue
+		}
 		filtered = append(filtered, query)
 	}
 	return filtered
@@ -325,6 +333,10 @@ func pilotQueryFilterFn(queries []string) []string {
 		if strings.Contains(query, "_virt_services") {
 			continue
 		}
+		// cAdvisor does not expose this metrics, and we don't have kubelet in kind
+		if strings.Contains(query, "container_fs_usage_bytes") {
+			continue
+		}
 		filtered = append(filtered, query)
 	}
 	return filtered
@@ -369,6 +381,11 @@ func galleyQueryFilterFn(queries []string) []string {
 		if strings.Contains(query, "runtime_strategy_timer_max_time_reached_total") {
 			continue
 		}
+
+		// cAdvisor does not expose this metrics, and we don't have kubelet in kind
+		if strings.Contains(query, "container_fs_usage_bytes") {
+			continue
+		}
 		filtered = append(filtered, query)
 	}
 	return filtered
@@ -400,6 +417,10 @@ func citadelQueryFilterFn(queries []string) []string {
 			continue
 		}
 		if strings.Contains(query, "authentication_failure_count") {
+			continue
+		}
+		// cAdvisor does not expose this metrics, and we don't have kubelet in kind
+		if strings.Contains(query, "container_fs_usage_bytes") {
 			continue
 		}
 		filtered = append(filtered, query)


### PR DESCRIPTION
Kind did not work for the e2e-dashboard test as we didn't have a metrics
server installed. Kind doesn't have addons like minikube, so we resort
to manually installing it ourselves. Unfortunately, it seems we lose a
single metric, the container fs usage, so I removed it -- not sure if
there is a better alternative.

[x] Policies and Telemetry