### PR TITLE
Correct CoreDNS config and prevent race condition

### DIFF
--- a/install/kubernetes/helm/istio/charts/istiocoredns/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/istiocoredns/templates/configmap.yaml
@@ -15,8 +15,10 @@ data:
           health
           {{ if eq -1 (semver  .Values.coreDNSTag  | (semver "1.4.0").Compare) }}
           # Removed support for the proxy plugin: https://coredns.io/2019/03/03/coredns-1.4.0-release/
-          grpc . 127.0.0.1:8053
-          forward . /etc/resolv.conf
+          grpc global 127.0.0.1:8053
+          forward . /etc/resolv.conf {
+            except global
+          }
           {{ else }}
           proxy global 127.0.0.1:8053 {
             protocol grpc insecure


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fixes: https://github.com/istio/istio/issues/17290 the config had a race condition/wrong domain config the `.global` domain was always sent to `/etc/resolv.conf` which cloudn't resolve the request.

CC @hzxuzhonghu 

With this change the requests get resolved correctly:

```bash
root@details-v1-c5b5f496d-p2lhb:/opt/microservices# dig httpbin.bar.global

; <<>> DiG 9.10.3-P4-Debian <<>> httpbin.bar.global
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 55198
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;httpbin.bar.global.		IN	A

;; ANSWER SECTION:
httpbin.bar.global.	30	IN	A	127.255.0.2

;; Query time: 3 msec
;; SERVER: 10.7.240.10#53(10.7.240.10)
;; WHEN: Sat Sep 21 07:40:10 UTC 2019
;; MSG SIZE  rcvd: 81
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
