### PR TITLE
Recover panics from patching envoyfilters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
+
 	"istio.io/pkg/log"
 
 	networking "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
+	"istio.io/pkg/log"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -30,8 +31,17 @@ import (
 )
 
 // ApplyListenerPatches applies patches to LDS output
-func ApplyListenerPatches(patchContext networking.EnvoyFilter_PatchContext,
-	proxy *model.Proxy, push *model.PushContext, listeners []*xdsapi.Listener, skipAdds bool) []*xdsapi.Listener {
+func ApplyListenerPatches(
+	patchContext networking.EnvoyFilter_PatchContext,
+	proxy *model.Proxy,
+	push *model.PushContext,
+	listeners []*xdsapi.Listener,
+	skipAdds bool) (out []*xdsapi.Listener) {
+	defer util.HandleCrash(func() {
+		log.Errorf("listeners patch caused panic, so the patches did not take effect")
+	})
+	// In case the patches cause panic, use the listeners generated before to reduce the influence.
+	out = listeners
 
 	envoyFilterWrappers := push.EnvoyFilters(proxy)
 	return doListenerListOperation(proxy, patchContext, envoyFilterWrappers, listeners, skipAdds)

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -24,11 +24,20 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/pkg/log"
 )
 
-func ApplyRouteConfigurationPatches(patchContext networking.EnvoyFilter_PatchContext,
-	proxy *model.Proxy, push *model.PushContext,
-	routeConfiguration *xdsapi.RouteConfiguration) *xdsapi.RouteConfiguration {
+func ApplyRouteConfigurationPatches(
+	patchContext networking.EnvoyFilter_PatchContext,
+	proxy *model.Proxy,
+	push *model.PushContext,
+	routeConfiguration *xdsapi.RouteConfiguration) (out *xdsapi.RouteConfiguration) {
+	defer util.HandleCrash(func() {
+		log.Errorf("listeners patch caused panic, so the patches did not take effect")
+	})
+	// In case the patches cause panic, use the route generated before to reduce the influence.
+	out = routeConfiguration
 
 	envoyFilterWrappers := push.EnvoyFilters(proxy)
 	for _, efw := range envoyFilterWrappers {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -550,10 +550,12 @@ func logPanic(r interface{}) {
 	log.Errorf("Observed a panic: %#v (%v)\n%s", r, r, stacktrace)
 }
 
-// HandleCrash catches the crash and calls additional handler.
-func HandleCrash(handler func()) {
+// HandleCrash catches the crash and calls additional handlers.
+func HandleCrash(handlers ...func()) {
 	if r := recover(); r != nil {
 		logPanic(r)
-		handler()
+		for _, handler := range handlers {
+			handler()
+		}
 	}
 }

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -620,3 +620,32 @@ func TestMergeAnyWithStruct(t *testing.T) {
 		t.Errorf("Merged HCM does not match the expected output")
 	}
 }
+
+func TestHandleCrash(t *testing.T) {
+	defer func() {
+		if x := recover(); x != nil {
+			t.Errorf("Expected no panic ")
+		}
+	}()
+
+	defer HandleCrash()
+	panic("test")
+}
+
+func TestCustomHandleCrash(t *testing.T) {
+	ch := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case <-ch:
+			t.Logf("crash handler called")
+		case <-time.After(1 * time.Second):
+			t.Errorf("Custom handler not called")
+		}
+	}()
+
+	defer HandleCrash(func() {
+		ch <- struct{}{}
+	})
+
+	panic("test")
+}

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -15,7 +15,6 @@
 package v2
 
 import (
-	"fmt"
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -75,14 +74,11 @@ func (s *DiscoveryServer) generateRawClusters(node *model.Proxy, push *model.Pus
 
 	for _, c := range rawClusters {
 		if err := c.Validate(); err != nil {
-			retErr := fmt.Errorf("CDS: Generated invalid cluster for node %v: %v", node, err)
 			adsLog.Errorf("CDS: Generated invalid cluster for node:%s: %v, %v", node.ID, err, c)
 			cdsBuildErrPushes.Increment()
 			totalXDSInternalErrors.Increment()
 			// Generating invalid clusters is a bug.
-			// Panic instead of trying to recover from that, since we can't
-			// assume anything about the state.
-			panic(retErr.Error())
+			// Instead of panic, which will break down the whole cluster. Just ignore it here, let envoy process it.
 		}
 	}
 	return rawClusters

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -15,7 +15,6 @@
 package v2
 
 import (
-	"fmt"
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -51,13 +50,10 @@ func (s *DiscoveryServer) generateRawListeners(con *XdsConnection, push *model.P
 
 	for _, l := range rawListeners {
 		if err := l.Validate(); err != nil {
-			retErr := fmt.Errorf("LDS: Generated invalid listener for node %v: %v", con.modelNode, err)
 			adsLog.Errorf("LDS: Generated invalid listener for node:%s: %v, %v", con.modelNode.ID, err, l)
 			ldsBuildErrPushes.Increment()
 			// Generating invalid listeners is a bug.
-			// Panic instead of trying to recover from that, since we can't
-			// assume anything about the state.
-			panic(retErr.Error())
+			// Instead of panic, which will break down the whole cluster. Just ignore it here, let envoy process it.
 		}
 	}
 	return rawListeners

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -15,7 +15,6 @@
 package v2
 
 import (
-	"fmt"
 	"time"
 
 	"istio.io/istio/pkg/util/protomarshal"
@@ -58,13 +57,10 @@ func (s *DiscoveryServer) generateRawRoutes(con *XdsConnection, push *model.Push
 	// Now validate each route
 	for _, r := range rawRoutes {
 		if err := r.Validate(); err != nil {
-			retErr := fmt.Errorf("RDS: Generated invalid route %s for node %v: %v", r.Name, con.modelNode, err)
 			adsLog.Errorf("RDS: Generated invalid routes for route:%s for node:%v: %v, %v", r.Name, con.modelNode.ID, err, r)
 			rdsBuildErrPushes.Increment()
 			// Generating invalid routes is a bug.
-			// Panic instead of trying to recover from that, since we can't
-			// assume anything about the state.
-			panic(retErr.Error())
+			// Instead of panic, which will break down the whole cluster. Just ignore it here, let envoy process it.
 		}
 	}
 	return rawRoutes


### PR DESCRIPTION
Please provide a description for what this PR is for.

This is to fix when user create an invalid envoyfilter, it could cause pilot crash, which lead to the whole cluster down.

Fixes: #17266

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
