### PR TITLE
Verify go version before build

### DIFF
--- a/bin/gobuild.sh
+++ b/bin/gobuild.sh
@@ -63,6 +63,14 @@ while read -r line; do
     LD_EXTRAFLAGS="${LD_EXTRAFLAGS} -X ${line}"
 done < "${BUILDINFO}"
 
+# verify go version before build
+# NB. this was copied verbatim from Kubernetes hack
+minimum_go_version=go1.13 # supported patterns: go1.x, go1.x.x (x should be a number)
+IFS=" " read -ra go_version <<< "$(${GOBINARY} version)"
+if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
+    echo "Warning: Detected that you are using a low version of GO. Istio requires ${minimum_go_version} or greater."
+fi
+
 # forgoing -i (incremental build) because it will be deprecated by tool chain.
 time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
         ${V} "${GOBUILDFLAGS_ARRAY[@]}" ${GCFLAGS:+-gcflags "${GCFLAGS}"} \


### PR DESCRIPTION
Please provide a description for what this PR is for.
Since #17213 has been merged, but `-trimpath` is not a valid parameter for go1.12.
This PR adds the check for the go version.

For go1.12.5, the error like:
```
flag provided but not defined: -trimpath
```


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
