### PR TITLE
enhance envoy readiness probe

### DIFF
--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -131,7 +131,7 @@ func (p *Probe) pingVirtualListeners() error {
 	for _, vport := range vports {
 		_, err := net.Dial("tcp", fmt.Sprintf("%s:%d", p.LocalHostAddr, vport))
 		if err != nil {
-			return fmt.Errorf("Listener on port %d is still not listening: %v", vport, err)
+			return fmt.Errorf("listener on port %d is still not listening: %v", vport, err)
 		}
 	}
 

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -129,9 +129,12 @@ func (p *Probe) pingVirtualListeners() error {
 		return err
 	}
 	for _, vport := range vports {
-		_, err := net.Dial("tcp", fmt.Sprintf("%s:%d", p.LocalHostAddr, vport))
+		con, err := net.Dial("tcp", fmt.Sprintf("%s:%d", p.LocalHostAddr, vport))
 		if err != nil {
 			return fmt.Errorf("listener on port %d is still not listening: %v", vport, err)
+		}
+		if con != nil {
+			con.Close()
 		}
 	}
 

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -34,6 +34,7 @@ var (
 	goodStats      = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1"
 	liveServerInfo = &admin.ServerInfo{State: admin.ServerInfo_LIVE}
 	initServerInfo = &admin.ServerInfo{State: admin.ServerInfo_INITIALIZING}
+	emptyListeners = &admin.Listeners{}
 	listeners      = admin.Listeners{
 		ListenerStatuses: []*admin.ListenerStatus{
 			{
@@ -59,10 +60,6 @@ func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {
 	server := createAndStartServer(stats, liveServerInfo)
 	defer server.Close()
 	probe := Probe{AdminPort: 1234}
-
-	// Listen on Virtual Listener port.
-	l, _ := net.Listen("tcp", ":15006")
-	defer l.Close()
 
 	err := probe.Check()
 
@@ -105,10 +102,6 @@ func TestEnvoyStatsCompleteAndRejectedCDS(t *testing.T) {
 	defer server.Close()
 	probe := Probe{AdminPort: 1234}
 
-	// Listen on Virtual Listener port.
-	l, _ := net.Listen("tcp", ":15006")
-	defer l.Close()
-
 	err := probe.Check()
 
 	g.Expect(err).NotTo(HaveOccurred())
@@ -121,10 +114,6 @@ func TestEnvoyStatsCompleteAndRejectedLDS(t *testing.T) {
 	server := createAndStartServer(stats, liveServerInfo)
 	defer server.Close()
 	probe := Probe{AdminPort: 1234}
-
-	// Listen on Virtual Listener port.
-	l, _ := net.Listen("tcp", ":15006")
-	defer l.Close()
 
 	err := probe.Check()
 
@@ -172,11 +161,6 @@ func TestEnvoyCheckSucceedsIfStatsCleared(t *testing.T) {
 
 	// trigger the state change
 	server = createAndStartServer(goodStats, liveServerInfo)
-
-	// Listen on Virtual Listener port.
-	l, _ := net.Listen("tcp", ":15006")
-	defer l.Close()
-
 	err = probe.Check()
 	server.Close()
 	g.Expect(err).NotTo(HaveOccurred())
@@ -246,6 +230,13 @@ func createDefaultFuncMap(statsToReturn string, serverInfo proto.Message) map[st
 
 			// Send response to be tested
 			rw.Write([]byte(infoJSON))
+		},
+		"/listeners": func(rw http.ResponseWriter, _ *http.Request) {
+			jsonm := &jsonpb.Marshaler{Indent: "  "}
+			listenerJSON, _ := jsonm.MarshalToString(emptyListeners)
+
+			// Send response to be tested
+			rw.Write([]byte(listenerJSON))
 		},
 	}
 }

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -208,7 +208,7 @@ func TestEnvoyInitializingWithVirtualInboundListener(t *testing.T) {
 	g.Expect(err).To(HaveOccurred())
 
 	// Listen on Virtual Listener port.
-	l, err := net.Listen("tcp", ":15006")
+	l, _ := net.Listen("tcp", ":15006")
 	defer l.Close()
 
 	err = probe.Check()

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -34,6 +34,7 @@ var (
 	goodStats      = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1"
 	liveServerInfo = &admin.ServerInfo{State: admin.ServerInfo_LIVE}
 	initServerInfo = &admin.ServerInfo{State: admin.ServerInfo_INITIALIZING}
+	emptyListeners = &admin.Listeners{}
 	listeners      = admin.Listeners{
 		ListenerStatuses: []*admin.ListenerStatus{
 			{
@@ -203,6 +204,16 @@ func TestEnvoyInitializingWithVirtualInboundListener(t *testing.T) {
 
 	err := probe.Check()
 
+	// Check should fail because listener is not listening yet.
+	g.Expect(err).To(HaveOccurred())
+
+	// Listen on Virtual Listener port.
+	l, err := net.Listen("tcp", ":15006")
+	defer l.Close()
+
+	err = probe.Check()
+
+	// Check should succeed now.
 	g.Expect(err).ToNot(HaveOccurred())
 }
 
@@ -219,6 +230,13 @@ func createDefaultFuncMap(statsToReturn string, serverInfo proto.Message) map[st
 
 			// Send response to be tested
 			rw.Write([]byte(infoJSON))
+		},
+		"/listeners": func(rw http.ResponseWriter, _ *http.Request) {
+			jsonm := &jsonpb.Marshaler{Indent: "  "}
+			listenerJSON, _ := jsonm.MarshalToString(emptyListeners)
+
+			// Send response to be tested
+			rw.Write([]byte(listenerJSON))
 		},
 	}
 }

--- a/pilot/cmd/pilot-agent/status/util/listeners.go
+++ b/pilot/cmd/pilot-agent/status/util/listeners.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/pkg/model"
-	networking "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 )
 
 var (
@@ -68,27 +67,6 @@ func GetInboundListeningPorts(localHostAddr string, adminPort uint16, nodeType m
 	}
 
 	return ports, buf.String(), nil
-}
-
-// GetVirtualListenerPorts returns ports of Istio's traffic capture listeners.
-func GetVirtualListenerPorts(localHostAddr string, adminPort uint16) ([]uint16, error) {
-	buf, err := doHTTPGet(fmt.Sprintf("http://%s:%d/listeners?format=json", localHostAddr, adminPort))
-	if err != nil {
-		return nil, multierror.Prefix(err, "failed retrieving Envoy listeners:")
-	}
-
-	listeners := &admin.Listeners{}
-	if err := jsonpb.Unmarshal(buf, listeners); err != nil {
-		return nil, fmt.Errorf("failed parsing Envoy listeners %s: %s", buf, err)
-	}
-	ports := make([]uint16, 0)
-	for _, l := range listeners.ListenerStatuses {
-		if l.Name == networking.VirtualOutboundListenerName || l.Name == networking.VirtualInboundListenerName {
-			ports = append(ports, uint16(l.LocalAddress.GetSocketAddress().GetPortValue()))
-		}
-
-	}
-	return ports, nil
 }
 
 func isLocalListener(l string) bool {

--- a/pilot/cmd/pilot-agent/status/util/listeners.go
+++ b/pilot/cmd/pilot-agent/status/util/listeners.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/pkg/model"
+	networking "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 )
 
 var (
@@ -67,6 +68,27 @@ func GetInboundListeningPorts(localHostAddr string, adminPort uint16, nodeType m
 	}
 
 	return ports, buf.String(), nil
+}
+
+// GetVirtualListenerPorts returns ports of Istio's traffic capture listeners.
+func GetVirtualListenerPorts(localHostAddr string, adminPort uint16) ([]uint16, error) {
+	buf, err := doHTTPGet(fmt.Sprintf("http://%s:%d/listeners?format=json", localHostAddr, adminPort))
+	if err != nil {
+		return nil, multierror.Prefix(err, "failed retrieving Envoy listeners:")
+	}
+
+	listeners := &admin.Listeners{}
+	if err := jsonpb.Unmarshal(buf, listeners); err != nil {
+		return nil, fmt.Errorf("failed parsing Envoy listeners %s: %s", buf, err)
+	}
+	ports := make([]uint16, 0)
+	for _, l := range listeners.ListenerStatuses {
+		if l.Name == networking.VirtualOutboundListenerName || l.Name == networking.VirtualInboundListenerName {
+			ports = append(ports, uint16(l.LocalAddress.GetSocketAddress().GetPortValue()))
+		}
+
+	}
+	return ports, nil
 }
 
 func isLocalListener(l string) bool {


### PR DESCRIPTION
Currently we are checking the Server State to be "Live" before we mark Envoy ready. However, Envoy starts listenining on the listener sockets, after it has changed the server state to "Live". So technically there is a small period of gap between it declaring "Live" and it listens on the ports. This PR pings the virtual listeners to actually confirm they are listening before marking Envoy ready.

Relevant conversation in Envoy  https://github.com/envoyproxy/envoy/issues/8321

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
