### PR TITLE
Skip mixer config on virtual when mixer is disable

### DIFF
--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -230,6 +230,9 @@ func (mixerplugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.Mut
 
 // OnVirtualListener implements the Plugin interface method.
 func (mixerplugin) OnVirtualListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	if in.Env.Mesh.MixerCheckServer == "" && in.Env.Mesh.MixerReportServer == "" {
+		return nil
+	}
 	if in.ListenerProtocol == plugin.ListenerProtocolTCP {
 		attrs := createOutboundListenerAttributes(in)
 		tcpFilter := buildOutboundTCPFilter(in.Env.Mesh, attrs, in.Node, in.Service)

--- a/tests/integration/pilot/sidecar_api_test.go
+++ b/tests/integration/pilot/sidecar_api_test.go
@@ -105,10 +105,9 @@ func validateListenersNoConfig(t *testing.T, response *structpath.Instance) {
 			Select("{.resources[?(@.address.socketAddress.portValue==15001)]}").
 			Equals("virtualOutbound", "{.name}").
 			Equals("0.0.0.0", "{.address.socketAddress.address}").
-			Equals("mixer", "{.filterChains[1].filters[0].name}").
-			Equals("envoy.tcp_proxy", "{.filterChains[1].filters[1].name}").
-			Equals("PassthroughCluster", "{.filterChains[1].filters[1].typedConfig.cluster}").
-			Equals("PassthroughCluster", "{.filterChains[1].filters[1].typedConfig.statPrefix}").
+			Equals("envoy.tcp_proxy", "{.filterChains[1].filters[0].name}").
+			Equals("PassthroughCluster", "{.filterChains[1].filters[0].typedConfig.cluster}").
+			Equals("PassthroughCluster", "{.filterChains[1].filters[0].typedConfig.statPrefix}").
 			Equals(true, "{.useOriginalDst}").
 			CheckOrFail(t)
 	})


### PR DESCRIPTION
Currently we send mixer client config for inbound listeners even if
mixer is disabled. This change adds the same filtering that we add to
other listeners.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
