### PR TITLE
authz: fix the policy name in generated filter config

### DIFF
--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -104,7 +104,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 				policy.SimpleAuthzPolicy("authz-bar", "a"),
 				policy.SimpleAuthzPolicy("authz-foo", "a"),
 			},
-			wantPolicies: []string{"authz-bar[0]", "authz-foo[0]"},
+			wantPolicies: []string{"ns[a]-policy[authz-bar]-rule[0]", "ns[a]-policy[authz-foo]-rule[0]"},
 		},
 		{
 			name: "v1alpha1 and v1beta1",
@@ -114,7 +114,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 				policy.SimpleBinding("binding-1", "a", "role-1"),
 				policy.SimpleAuthzPolicy("authz-bar", "a"),
 			},
-			wantPolicies: []string{"authz-bar[0]"},
+			wantPolicies: []string{"ns[a]-policy[authz-bar]-rule[0]"},
 		},
 	}
 

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
@@ -53,7 +53,7 @@ func (g *v1beta1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 		spec := config.Spec.(*istio_rbac.AuthorizationPolicy)
 		for i, rule := range spec.Rules {
 			if p := g.generatePolicy(rule, forTCPFilter); p != nil {
-				name := fmt.Sprintf("%s[%d]", config.Name, i)
+				name := fmt.Sprintf("ns[%s]-policy[%s]-rule[%d]", config.Namespace, config.Name, i)
 				rbac.Policies[name] = p
 				rbacLog.Debugf("generated policy %s for rule", name)
 			}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Include the namespace of the policy in the generated filter config, otherwise one policy will be overridden if there are two policies with the same name in root namespace and normal namespace.

For #12394

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
