### PR TITLE
feat(platform meta): Update GCP platform metadata to capture GCE instance id

### DIFF
--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -25,9 +25,10 @@ import (
 )
 
 const (
-	GCPProject  = "gcp_project"
-	GCPCluster  = "gcp_cluster_name"
-	GCPLocation = "gcp_cluster_location"
+	GCPProject    = "gcp_project"
+	GCPCluster    = "gcp_gke_cluster_name"
+	GCPLocation   = "gcp_location"
+	GCEInstanceID = "gcp_gce_instance_id"
 )
 
 var (
@@ -55,6 +56,7 @@ type gcpEnv struct {
 	projectIDFn        metadataFn
 	locationFn         metadataFn
 	clusterNameFn      metadataFn
+	instanceIDFn       metadataFn
 }
 
 // NewGCP returns a platform environment customized for Google Cloud Platform.
@@ -66,6 +68,7 @@ func NewGCP() Environment {
 		projectIDFn:        metadata.ProjectID,
 		locationFn:         clusterLocationFn,
 		clusterNameFn:      clusterNameFn,
+		instanceIDFn:       metadata.InstanceID,
 	}
 }
 
@@ -87,6 +90,9 @@ func (e *gcpEnv) Metadata() map[string]string {
 	}
 	if cn, err := e.clusterNameFn(); err == nil {
 		md[GCPCluster] = cn
+	}
+	if id, err := e.instanceIDFn(); err == nil {
+		md[GCEInstanceID] = id
 	}
 	return md
 }

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -28,6 +28,7 @@ func TestMetadata(t *testing.T) {
 		projectIDFn   metadataFn
 		locationFn    metadataFn
 		clusterNameFn metadataFn
+		instanceIDFn  metadataFn
 		want          map[string]string
 	}{
 		{
@@ -36,6 +37,7 @@ func TestMetadata(t *testing.T) {
 			func() (string, error) { return "pid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instance", nil },
 			map[string]string{},
 		},
 		{
@@ -44,7 +46,8 @@ func TestMetadata(t *testing.T) {
 			func() (string, error) { return "pid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
-			map[string]string{GCPProject: "pid", GCPLocation: "location", GCPCluster: "cluster"},
+			func() (string, error) { return "instance", nil },
+			map[string]string{GCPProject: "pid", GCPLocation: "location", GCPCluster: "cluster", GCEInstanceID: "instance"},
 		},
 		{
 			"project id error",
@@ -52,7 +55,8 @@ func TestMetadata(t *testing.T) {
 			func() (string, error) { return "", errors.New("error") },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
-			map[string]string{GCPLocation: "location", GCPCluster: "cluster"},
+			func() (string, error) { return "instance", nil },
+			map[string]string{GCPLocation: "location", GCPCluster: "cluster", GCEInstanceID: "instance"},
 		},
 		{
 			"location error",
@@ -60,7 +64,8 @@ func TestMetadata(t *testing.T) {
 			func() (string, error) { return "pid", nil },
 			func() (string, error) { return "location", errors.New("error") },
 			func() (string, error) { return "cluster", nil },
-			map[string]string{GCPProject: "pid", GCPCluster: "cluster"},
+			func() (string, error) { return "instance", nil },
+			map[string]string{GCPProject: "pid", GCPCluster: "cluster", GCEInstanceID: "instance"},
 		},
 		{
 			"cluster name error",
@@ -68,13 +73,24 @@ func TestMetadata(t *testing.T) {
 			func() (string, error) { return "pid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", errors.New("error") },
-			map[string]string{GCPProject: "pid", GCPLocation: "location"},
+			func() (string, error) { return "instance", nil },
+			map[string]string{GCPProject: "pid", GCPLocation: "location", GCEInstanceID: "instance"},
+			//map[string]string{GCPProject: "pid", GCPLocation: "location"},
+		},
+		{
+			"instance id error",
+			func() bool { return true },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "", errors.New("error") },
+			map[string]string{GCPProject: "pid", GCPLocation: "location", GCPCluster: "cluster"},
 		},
 	}
 
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			mg := gcpEnv{tt.shouldFill, tt.projectIDFn, tt.locationFn, tt.clusterNameFn}
+			mg := gcpEnv{tt.shouldFill, tt.projectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceIDFn}
 			got := mg.Metadata()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Unexpected generated metadata: want %v got %v", tt.want, got)


### PR DESCRIPTION
This PR updates the `pkg/bootstrap/platform` package to include more metadata about potential GCP runtime envs. In particular, it adds a new metadata field for capturing the GCE instance ID for a proxy.

As part of this addition, a few of the platform metadata fields for GCP are renamed:
- `gcp_cluster_name` --> `gcp_gke_cluster_name`
- `gcp_cluster_location` --> `gcp_location` 

This work is part of the larger effort to support more environments than just k8s with the new extensibility framework. This will allow SD extensions, for instance, to assign telemetry to a GCE MR (no `gcp_gke_cluster_name` value will be set in the metadata).

See also: https://github.com/istio/istio/issues/17081

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ x ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
