### PR TITLE
Import proxy with experimental wasm/mixerv2 support.

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "815bb9ccc3fd259e3a9b6ac5fdae0420aaa09ab2"
+		"lastStableSHA": "dc3aafe38c5af924462e09e471a8a8804c0395f5"
 	},
 	{
                 "_comment": "",


### PR DESCRIPTION
Update istio/proxy which contains @jplevyak's experimental support for running MixerV2 in WASM.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
