### PR TITLE
injector: add new injectedAnnotations to support PSP

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/values.yaml
@@ -43,3 +43,17 @@ rewriteAppHTTPProbe: false
 neverInjectSelector: []
 
 alwaysInjectSelector: []
+
+# injectedAnnotations are additional annotations that will be added to the pod spec after injection
+# This is primarily to support PSP annotations. For example, if you defined a PSP with the annotations:
+#
+# annotations:
+#   apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+#   apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+#
+# The PSP controller would add corresponding annotations to the pod spec for each container. However, this happens before
+# the inject adds additional containers, so we must specify them explicitly here. With the above example, we could specify:
+# injectedAnnotations:
+#   container.apparmor.security.beta.kubernetes.io/istio-init: runtime/default
+#   container.apparmor.security.beta.kubernetes.io/istio-proxy: runtime/default
+injectedAnnotations: {}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -22,4 +22,8 @@ data:
 {{ toYaml .Values.sidecarInjectorWebhook.neverInjectSelector | trim | indent 6 }}
     template: |-
 {{ .Files.Get "files/injection-template.yaml" | trim | indent 6 }}
+    injectedAnnotations:
+    {{- range $key, $val := .Values.sidecarInjectorWebhook.injectedAnnotations }}
+      "{{ $key }}": "{{ $val }}"
+    {{- end }}
 {{- end }}

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -289,6 +289,10 @@ type Config struct {
 	// It's an array of label selectors, that will be OR'ed, meaning we will iterate
 	// over it and stop at the first match
 	AlwaysInjectSelector []metav1.LabelSelector `json:"alwaysInjectSelector"`
+
+	// InjectedAnnotations are additional annotations that will be added to the pod spec after injection
+	// This is primarily to support PSP annotations.
+	InjectedAnnotations map[string]string `json:"injectedAnnotations"`
 }
 
 func validateCIDRList(cidrs string) error {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite_template.yaml
@@ -1,23 +1,28 @@
-rewriteAppHTTPProbe: true
-initContainers:
-- name: istio-init
-  image: example.com/init:latest
-containers:
-- name: istio-proxy
-  image: example.com/proxy:latest
-  args:
-    - --statusPort
-    - 15020
-imagePullSecrets:
-- name: istio-image-pull-secrets
-volumes:
-- emptyDir:
-    medium: Memory
-  name: istio-envoy
-- name: istio-certs
-  secret:
-    {{ if eq .Spec.ServiceAccountName "" -}}
-    secretName: istio.default
-    {{ else -}}
-    secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
-    {{ end -}}
+policy: enabled
+alwaysInjectSelector: []
+neverInjectSelector: []
+injectedAnnotations: {}
+template: |-
+  rewriteAppHTTPProbe: true
+  initContainers:
+  - name: istio-init
+    image: example.com/init:latest
+  containers:
+  - name: istio-proxy
+    image: example.com/proxy:latest
+    args:
+      - --statusPort
+      - 15020
+  imagePullSecrets:
+  - name: istio-image-pull-secrets
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - name: istio-certs
+    secret:
+      {{ if eq .Spec.ServiceAccountName "" -}}
+      secretName: istio.default
+      {{ else -}}
+      secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+      {{ end -}}

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation_template.yaml
@@ -1,23 +1,28 @@
-rewriteAppHTTPProbe: false
-initContainers:
-- name: istio-init
-  image: example.com/init:latest
-containers:
-- name: istio-proxy
-  image: example.com/proxy:latest
-  args:
-    - --statusPort
-    - 15020
-imagePullSecrets:
-- name: istio-image-pull-secrets
-volumes:
-- emptyDir:
-    medium: Memory
-  name: istio-envoy
-- name: istio-certs
-  secret:
-    {{ if eq .Spec.ServiceAccountName "" -}}
-    secretName: istio.default
-    {{ else -}}
-    secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
-    {{ end -}}
+policy: enabled
+alwaysInjectSelector: []
+neverInjectSelector: []
+injectedAnnotations: {}
+template: |-
+  rewriteAppHTTPProbe: false
+  initContainers:
+  - name: istio-init
+    image: example.com/init:latest
+  containers:
+  - name: istio-proxy
+    image: example.com/proxy:latest
+    args:
+      - --statusPort
+      - 15020
+  imagePullSecrets:
+  - name: istio-image-pull-secrets
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - name: istio-certs
+    secret:
+      {{ if eq .Spec.ServiceAccountName "" -}}
+      secretName: istio.default
+      {{ else -}}
+      secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+      {{ end -}}

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_template.yaml
@@ -1,23 +1,28 @@
-rewriteAppHTTPProbe: true
-initContainers:
-- name: istio-init
-  image: example.com/init:latest
-containers:
-- name: istio-proxy
-  image: example.com/proxy:latest
-  args:
-    - --statusPort
-    - 15020
-imagePullSecrets:
-- name: istio-image-pull-secrets
-volumes:
-- emptyDir:
-    medium: Memory
-  name: istio-envoy
-- name: istio-certs
-  secret:
-    {{ if eq .Spec.ServiceAccountName "" -}}
-    secretName: istio.default
-    {{ else -}}
-    secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
-    {{ end -}}
+policy: enabled
+alwaysInjectSelector: []
+neverInjectSelector: []
+injectedAnnotations: {}
+template: |-
+  rewriteAppHTTPProbe: true
+  initContainers:
+  - name: istio-init
+    image: example.com/init:latest
+  containers:
+  - name: istio-proxy
+    image: example.com/proxy:latest
+    args:
+      - --statusPort
+      - 15020
+  imagePullSecrets:
+  - name: istio-image-pull-secrets
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - name: istio-certs
+    secret:
+      {{ if eq .Spec.ServiceAccountName "" -}}
+      secretName: istio.default
+      {{ else -}}
+      secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+      {{ end -}}

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite_template.yaml
@@ -1,19 +1,24 @@
-rewriteAppHTTPProbe: true
-initContainers:
-- name: istio-init
-  image: example.com/init:latest
-containers:
-- name: istio-proxy
-  image: example.com/proxy:latest
-  args:
-    - --statusPort
-    - 15020
-imagePullSecrets:
-- name: istio-image-pull-secrets
-volumes:
-- emptyDir:
-    medium: Memory
-  name: istio-envoy
-- name: istio-certs
-  secret:
-    secretName: istio.default
+policy: enabled
+alwaysInjectSelector: []
+neverInjectSelector: []
+injectedAnnotations: {}
+template: |-
+  rewriteAppHTTPProbe: true
+  initContainers:
+  - name: istio-init
+    image: example.com/init:latest
+  containers:
+  - name: istio-proxy
+    image: example.com/proxy:latest
+    args:
+      - --statusPort
+      - 15020
+  imagePullSecrets:
+  - name: istio-image-pull-secrets
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - name: istio-certs
+    secret:
+      secretName: istio.default

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
@@ -1,0 +1,73 @@
+ [
+  {
+    "op": "add",
+    "path": "/spec/initContainers/-",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/-",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "istio-envoy",
+      "emptyDir": {
+        "medium": "Memory"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "bar": "baz"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations/foo",
+    "value": "bar"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations/sidecar.istio.io~1status",
+    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels",
+    "value": {
+      "security.istio.io/mtlsReady": "true"
+    }
+  }
+]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.yaml
@@ -1,0 +1,12 @@
+metadata:
+  name: something
+spec:
+  initContainers:
+  - name: c0
+  - name: injected0
+  containers:
+  - name: c1
+  - name: injected1
+  volumes:
+  - name: v0
+  - name: injected2

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations_template.yaml
@@ -1,9 +1,10 @@
 policy: enabled
 alwaysInjectSelector: []
 neverInjectSelector: []
-injectedAnnotations: {}
+injectedAnnotations:
+  foo: bar
+  bar: baz
 template: |-
-  rewriteAppHTTPProbe: true
   initContainers:
   - name: istio-init
     image: example.com/init:latest

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_template.yaml
@@ -1,19 +1,24 @@
-initContainers:
-- name: istio-init
-  image: example.com/init:latest
-containers:
-- name: istio-proxy
-  image: example.com/proxy:latest
-imagePullSecrets:
-- name: istio-image-pull-secrets
-volumes:
-- emptyDir:
-    medium: Memory
-  name: istio-envoy
-- name: istio-certs
-  secret:
-    {{ if eq .Spec.ServiceAccountName "" -}}
-    secretName: istio.default
-    {{ else -}}
-    secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
-    {{ end -}}
+policy: enabled
+alwaysInjectSelector: []
+neverInjectSelector: []
+injectedAnnotations: {}
+template: |-
+  initContainers:
+  - name: istio-init
+    image: example.com/init:latest
+  containers:
+  - name: istio-proxy
+    image: example.com/proxy:latest
+  imagePullSecrets:
+  - name: istio-image-pull-secrets
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - name: istio-certs
+    secret:
+      {{ if eq .Spec.ServiceAccountName "" -}}
+      secretName: istio.default
+      {{ else -}}
+      secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+      {{ end -}}

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -461,7 +461,6 @@ func addLabels(target map[string]string, added map[string]string) []rfc6902Patch
 }
 
 func updateAnnotation(target map[string]string, added map[string]string) (patch []rfc6902PatchOperation) {
-	log.Errorf("howardjohn: added %v", added)
 	// To ensure deterministic patches, we sort the keys
 	var keys []string
 	for k := range added {

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -460,7 +461,16 @@ func addLabels(target map[string]string, added map[string]string) []rfc6902Patch
 }
 
 func updateAnnotation(target map[string]string, added map[string]string) (patch []rfc6902PatchOperation) {
-	for key, value := range added {
+	log.Errorf("howardjohn: added %v", added)
+	// To ensure deterministic patches, we sort the keys
+	var keys []string
+	for k := range added {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value := added[key]
 		if target == nil {
 			target = map[string]string{}
 			patch = append(patch, rfc6902PatchOperation{
@@ -665,6 +675,11 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 	}
 
 	annotations := map[string]string{annotation.SidecarStatus.Name: iStatus}
+
+	// Add all additional injected annotations
+	for k, v := range wh.sidecarConfig.InjectedAnnotations {
+		annotations[k] = v
+	}
 
 	patchBytes, err := createPatch(&pod, injectionStatus(&pod), annotations, spec)
 	if err != nil {


### PR DESCRIPTION
Add a new injectedAnnotations setting for the injector. Any annotations
here will be added to the final pod spec. This is required for PSPs to
work. See https://github.com/istio/istio/issues/17331 for details.

Note - a lot of changes here are to existing tests just to allow setting
all config options on the webhook rather than just the template.

Fixes https://github.com/istio/istio/issues/17331