### PR TITLE
add a link to the source of the echo client's main.go

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -51,6 +51,8 @@ To see its usage run:
 kubectl exec -it <test pod> -n <test namespace> -c app -- client -h
 ```
 
+or check [the source code](https://github.com/istio/istio/blob/master/pkg/test/echo/cmd/client/main.go).
+
 ## Adding New E2E Tests
 
 [demo_test.go](tests/bookinfo/demo_test.go) is a sample test that covers four cases: default routing, version routing, fault delay, and version migration.


### PR DESCRIPTION
To check the configuration options of client, there is no need to
run the image, the options are in the code.

There are no instructions how to run the test pod, what is the image,
so it is much simpler for the reader just to check the source code.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
