### PR TITLE
Remove dependencies to deprecated Galley code

### DIFF
--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -32,13 +32,13 @@ type MessageType struct {
 	template string
 }
 
-//Level returns the level of the MessageType
+// Level returns the level of the MessageType
 func (m *MessageType) Level() Level { return m.level }
 
-//Code returns the code of the MessageType
+// Code returns the code of the MessageType
 func (m *MessageType) Code() string { return m.code }
 
-//Template returns the message template used by the MessageType
+// Template returns the message template used by the MessageType
 func (m *MessageType) Template() string { return m.template }
 
 // Message is a specific diagnostic message
@@ -68,7 +68,8 @@ func (m *Message) toString(includeOrigin bool) string {
 	if includeOrigin && m.Origin != nil {
 		origin = "(" + m.Origin.FriendlyName() + ")"
 	}
-	return fmt.Sprintf("%v [%v]%s %s", m.Type.Level(), m.Type.Code(), origin, fmt.Sprintf(m.Type.Template(), m.Parameters...))
+	return fmt.Sprintf(
+		"%v [%v]%s %s", m.Type.Level(), m.Type.Code(), origin, fmt.Sprintf(m.Type.Template(), m.Parameters...))
 }
 
 // NewMessageType returns a new MessageType instance.

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -30,9 +30,9 @@ import (
 	"istio.io/istio/galley/pkg/config/processor/transforms"
 	"istio.io/istio/galley/pkg/config/schema"
 	"istio.io/istio/galley/pkg/config/scope"
+	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver"
 	"istio.io/istio/galley/pkg/config/source/kube/inmemory"
-	"istio.io/istio/galley/pkg/source/kube/client"
 )
 
 const domainSuffix = "svc.local"
@@ -59,7 +59,7 @@ type SourceAnalyzer struct {
 // NewSourceAnalyzer creates a new SourceAnalyzer with no sources. Use the Add*Source methods to add sources in ascending precedence order,
 // then execute Analyze to perform the analysis
 func NewSourceAnalyzer(m *schema.Metadata, analyzer analysis.Analyzer, cr snapshotter.CollectionReporterFn) *SourceAnalyzer {
-	//collectionReporter hook function defaults to no-op
+	// collectionReporter hook function defaults to no-op
 	if cr == nil {
 		cr = func(collection.Name) {}
 	}
@@ -122,7 +122,7 @@ func (sa *SourceAnalyzer) AddFileKubeSource(files []string, defaultNs string) er
 }
 
 // AddRunningKubeSource adds a source based on a running k8s cluster to the current SourceAnalyzer
-func (sa *SourceAnalyzer) AddRunningKubeSource(k client.Interfaces) {
+func (sa *SourceAnalyzer) AddRunningKubeSource(k kube.Interfaces) {
 	// As an optimization, filter out the resources we won't need for the current analysis.
 	// This matters because getting a snapshot from k8s is relatively time-expensive,
 	// so removing unnecessary resources makes a useful difference.

--- a/galley/pkg/config/processing/snapshotter/snapshotter.go
+++ b/galley/pkg/config/processing/snapshotter/snapshotter.go
@@ -21,10 +21,10 @@ import (
 
 	"istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/monitoring"
 	"istio.io/istio/galley/pkg/config/processing/snapshotter/strategy"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/scope"
-	"istio.io/istio/galley/pkg/runtime/monitoring"
 )
 
 // Snapshotter is a processor that handles input events and creates snapshotImpl collections.

--- a/galley/pkg/config/processing/snapshotter/strategy/debounce.go
+++ b/galley/pkg/config/processing/snapshotter/strategy/debounce.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	// TODO: Referencing this package directly, as duplicating it causes conflicts.
-	"istio.io/istio/galley/pkg/runtime/monitoring"
+	"istio.io/istio/galley/pkg/config/monitoring"
 )
 
 const (

--- a/galley/pkg/config/processing/snapshotter/strategy/debounce.go
+++ b/galley/pkg/config/processing/snapshotter/strategy/debounce.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	// TODO: Referencing this package directly, as duplicating it causes conflicts.
 	"istio.io/istio/galley/pkg/config/monitoring"
 )
 

--- a/galley/pkg/config/processing/snapshotter/strategy/immediate.go
+++ b/galley/pkg/config/processing/snapshotter/strategy/immediate.go
@@ -17,7 +17,7 @@ package strategy
 import (
 	"sync/atomic"
 
-	"istio.io/istio/galley/pkg/runtime/monitoring"
+	"istio.io/istio/galley/pkg/config/monitoring"
 )
 
 // Immediate is a snapshotting strategy for creating snapshots immediately, as events arrive.

--- a/galley/pkg/config/processor/transforms/serviceentry/transformer.go
+++ b/galley/pkg/config/processor/transforms/serviceentry/transformer.go
@@ -23,15 +23,16 @@ import (
 	coreV1 "k8s.io/api/core/v1"
 
 	networking "istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/monitoring"
 	"istio.io/istio/galley/pkg/config/processing"
 	"istio.io/istio/galley/pkg/config/processor/metadata"
 	"istio.io/istio/galley/pkg/config/processor/transforms/serviceentry/converter"
 	"istio.io/istio/galley/pkg/config/processor/transforms/serviceentry/pod"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/scope"
-	"istio.io/istio/galley/pkg/runtime/monitoring"
 )
 
 type serviceEntryTransformer struct {

--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -20,15 +20,16 @@ import (
 	"sync"
 	"time"
 
+	"istio.io/pkg/log"
+	"istio.io/pkg/timedfn"
+
+	"istio.io/istio/galley/pkg/config/monitoring"
 	"istio.io/istio/galley/pkg/runtime/groups"
-	"istio.io/istio/galley/pkg/runtime/monitoring"
 	"istio.io/istio/galley/pkg/runtime/processing"
 	"istio.io/istio/galley/pkg/runtime/projections/serviceentry"
 	"istio.io/istio/galley/pkg/runtime/publish"
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/galley/pkg/util"
-	"istio.io/pkg/log"
-	"istio.io/pkg/timedfn"
 )
 
 var scope = log.RegisterScope("runtime", "Galley runtime", 0)

--- a/galley/pkg/runtime/projections/serviceentry/handler.go
+++ b/galley/pkg/runtime/projections/serviceentry/handler.go
@@ -25,9 +25,10 @@ import (
 
 	mcp "istio.io/api/mcp/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+
+	"istio.io/istio/galley/pkg/config/monitoring"
 	"istio.io/istio/galley/pkg/metadata"
 	"istio.io/istio/galley/pkg/runtime/log"
-	"istio.io/istio/galley/pkg/runtime/monitoring"
 	"istio.io/istio/galley/pkg/runtime/processing"
 	"istio.io/istio/galley/pkg/runtime/projections/serviceentry/converter"
 	"istio.io/istio/galley/pkg/runtime/projections/serviceentry/pod"

--- a/galley/pkg/runtime/publish/strategy.go
+++ b/galley/pkg/runtime/publish/strategy.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 	"time"
 
+	"istio.io/istio/galley/pkg/config/monitoring"
 	"istio.io/istio/galley/pkg/runtime/log"
-	"istio.io/istio/galley/pkg/runtime/monitoring"
 	"istio.io/istio/galley/pkg/util"
 )
 

--- a/galley/pkg/runtime/state.go
+++ b/galley/pkg/runtime/state.go
@@ -25,10 +25,11 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	mcp "istio.io/api/mcp/v1alpha1"
+
+	"istio.io/istio/galley/pkg/config/monitoring"
 	"istio.io/istio/galley/pkg/metadata"
 	"istio.io/istio/galley/pkg/runtime/conversions"
 	"istio.io/istio/galley/pkg/runtime/log"
-	"istio.io/istio/galley/pkg/runtime/monitoring"
 	"istio.io/istio/galley/pkg/runtime/processing"
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/pkg/mcp/snapshot"

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -18,14 +18,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"istio.io/istio/galley/pkg/config/analysis/analyzers"
 	"istio.io/istio/galley/pkg/config/analysis/local"
 	"istio.io/istio/galley/pkg/config/processor/metadata"
-	"istio.io/istio/galley/pkg/source/kube/client"
+	cfgKube "istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
-
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -82,7 +82,7 @@ istioctl experimental analyze -k a.yaml b.yaml
 				if err != nil {
 					return err
 				}
-				k := client.NewKube(restConfig)
+				k := cfgKube.NewInterfaces(restConfig)
 
 				// If a default namespace to inject in files hasn't been explicitly defined already, use whatever is specified in the kube context
 				if selectedNamespace == "" {
@@ -103,8 +103,7 @@ istioctl experimental analyze -k a.yaml b.yaml
 					selectedNamespace = defaultNamespace
 				}
 
-				err := sa.AddFileKubeSource(files, selectedNamespace)
-				if err != nil {
+				if err = sa.AddFileKubeSource(files, selectedNamespace); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
- Move the monitoring package to be under pkg/config, as this was a shared component.
- Repoint config analysis code to use the code under pkg/config.