### PR TITLE
pilot: use downstream protocol and enable h2 for outbound

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -181,7 +181,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 				defaultCluster.AltStatName = altStatName(env.Mesh.OutboundClusterStatName, string(service.Hostname), "", proxy.DNSDomain, port)
 			}
 
-			setUpstreamProtocol(defaultCluster, port)
+			setUpstreamProtocol(proxy, defaultCluster, port, model.TrafficDirectionOutbound)
 			clusters = append(clusters, defaultCluster)
 
 			if destRule != nil {
@@ -214,7 +214,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 					if len(env.Mesh.OutboundClusterStatName) != 0 {
 						subsetCluster.AltStatName = altStatName(env.Mesh.OutboundClusterStatName, string(service.Hostname), subset.Name, proxy.DNSDomain, port)
 					}
-					setUpstreamProtocol(subsetCluster, port)
+					setUpstreamProtocol(proxy, subsetCluster, port, model.TrafficDirectionOutbound)
 
 					opts := buildClusterOpts{
 						env:             env,
@@ -517,7 +517,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(env *model.Environmen
 			localityLbEndpoints := buildInboundLocalityLbEndpoints(actualLocalHost, port.Port)
 			mgmtCluster := buildDefaultCluster(env, clusterName, apiv2.Cluster_STATIC, localityLbEndpoints,
 				model.TrafficDirectionInbound, proxy, nil)
-			setUpstreamProtocol(mgmtCluster, port)
+			setUpstreamProtocol(proxy, mgmtCluster, port, model.TrafficDirectionInbound)
 			clusters = append(clusters, mgmtCluster)
 		}
 	} else {
@@ -627,7 +627,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusterForPortOrUDS(pluginPara
 		localCluster.AltStatName = altStatName(pluginParams.Env.Mesh.InboundClusterStatName,
 			string(instance.Service.Hostname), "", pluginParams.Node.DNSDomain, instance.Endpoint.ServicePort)
 	}
-	setUpstreamProtocol(localCluster, instance.Endpoint.ServicePort)
+	setUpstreamProtocol(pluginParams.Node, localCluster, instance.Endpoint.ServicePort, model.TrafficDirectionInbound)
 	// call plugins
 	for _, p := range configgen.Plugins {
 		p.OnInboundCluster(pluginParams, localCluster)
@@ -1096,7 +1096,7 @@ func applyUpstreamTLSSettings(env *model.Environment, cluster *apiv2.Cluster, tl
 	}
 }
 
-func setUpstreamProtocol(cluster *apiv2.Cluster, port *model.Port) {
+func setUpstreamProtocol(node *model.Proxy, cluster *apiv2.Cluster, port *model.Port, direction model.TrafficDirection) {
 	if port.Protocol.IsHTTP2() {
 		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{
 			// Envoy default value of 100 is too low for data path.
@@ -1104,6 +1104,22 @@ func setUpstreamProtocol(cluster *apiv2.Cluster, port *model.Port) {
 				Value: 1073741824,
 			},
 		}
+	}
+
+	if (util.IsProtocolSniffingEnabledForInboundPort(node, port) && direction == model.TrafficDirectionInbound) ||
+		(util.IsProtocolSniffingEnabledForOutboundPort(node, port) && direction == model.TrafficDirectionOutbound) {
+		// setup http2 protocol options for upstream connection.
+		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{
+			// Envoy default value of 100 is too low for data path.
+			MaxConcurrentStreams: &types.UInt32Value{
+				Value: 1073741824,
+			},
+		}
+
+		// Use downstream protocol. If the incoming traffic use HTTP 1.1, the
+		// upstream cluster will use HTTP 1.1, if incoming traffic use HTTP2,
+		// the upstream cluster will use HTTP2.
+		cluster.ProtocolSelection = apiv2.Cluster_USE_DOWNSTREAM_PROTOCOL
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1111,7 +1111,7 @@ func setUpstreamProtocol(node *model.Proxy, cluster *apiv2.Cluster, port *model.
 		// setup http2 protocol options for upstream connection.
 		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{
 			// Envoy default value of 100 is too low for data path.
-			MaxConcurrentStreams: &types.UInt32Value{
+			MaxConcurrentStreams: &wrappers.UInt32Value{
 				Value: 1073741824,
 			},
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -75,7 +75,7 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 			clusterIndex: 0,
 		}, {
 			direction:    model.TrafficDirectionInbound,
-			clusterIndex: 3,
+			clusterIndex: 4,
 		},
 	}
 	settings := []*networking.ConnectionPoolSettings{
@@ -106,7 +106,7 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 						},
 					})
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(clusters)).To(Equal(6))
+				g.Expect(len(clusters)).To(Equal(8))
 				cluster := clusters[directionInfo.clusterIndex]
 				g.Expect(len(cluster.CircuitBreakers.Thresholds)).To(Equal(1))
 				thresholds := cluster.CircuitBreakers.Thresholds[0]
@@ -134,15 +134,37 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	directionInfos := []struct {
-		direction    model.TrafficDirection
-		clusterIndex int
+		direction                  model.TrafficDirection
+		clusterIndex               int
+		useDownStreamProtocol      bool
+		sniffingEnabledForInbound  bool
+		sniffingEnabledForOutbound bool
 	}{
 		{
-			direction:    model.TrafficDirectionOutbound,
-			clusterIndex: 0,
+			direction:                  model.TrafficDirectionOutbound,
+			clusterIndex:               0,
+			useDownStreamProtocol:      false,
+			sniffingEnabledForInbound:  false,
+			sniffingEnabledForOutbound: true,
 		}, {
-			direction:    model.TrafficDirectionInbound,
-			clusterIndex: 3,
+			direction:                  model.TrafficDirectionInbound,
+			clusterIndex:               4,
+			useDownStreamProtocol:      false,
+			sniffingEnabledForInbound:  false,
+			sniffingEnabledForOutbound: true,
+		}, {
+			direction:                  model.TrafficDirectionOutbound,
+			clusterIndex:               1,
+			useDownStreamProtocol:      true,
+			sniffingEnabledForInbound:  false,
+			sniffingEnabledForOutbound: true,
+		},
+		{
+			direction:                  model.TrafficDirectionInbound,
+			clusterIndex:               5,
+			useDownStreamProtocol:      true,
+			sniffingEnabledForInbound:  true,
+			sniffingEnabledForOutbound: true,
 		},
 	}
 	settings := &networking.ConnectionPoolSettings{
@@ -153,6 +175,12 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 	}
 
 	for _, directionInfo := range directionInfos {
+		if directionInfo.sniffingEnabledForInbound {
+			_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
+		} else {
+			_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "false")
+		}
+
 		settingsName := "default"
 		if settings != nil {
 			settingsName = "override"
@@ -167,10 +195,16 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 					},
 				})
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(len(clusters)).To(Equal(6))
+			g.Expect(len(clusters)).To(Equal(8))
 			cluster := clusters[directionInfo.clusterIndex]
 			g.Expect(cluster.CommonHttpProtocolOptions).To(Not(BeNil()))
 			commonHTTPProtocolOptions := cluster.CommonHttpProtocolOptions
+
+			if directionInfo.useDownStreamProtocol {
+				g.Expect(cluster.ProtocolSelection).To(Equal(apiv2.Cluster_USE_DOWNSTREAM_PROTOCOL))
+			} else {
+				g.Expect(cluster.ProtocolSelection).To(Equal(apiv2.Cluster_USE_CONFIGURED_PROTOCOL))
+			}
 
 			// Verify that the values were set correctly.
 			g.Expect(commonHTTPProtocolOptions.IdleTimeout).To(Not(BeNil()))
@@ -216,16 +250,23 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 
 	serviceDiscovery := &fakes.ServiceDiscovery{}
 
-	servicePort := &model.Port{
-		Name:     "default",
-		Port:     8080,
-		Protocol: protocol.HTTP,
+	servicePort := model.PortList{
+		&model.Port{
+			Name:     "default",
+			Port:     8080,
+			Protocol: protocol.HTTP,
+		},
+		&model.Port{
+			Name:     "auto",
+			Port:     9090,
+			Protocol: protocol.Unsupported,
+		},
 	}
 	service := &model.Service{
 		Hostname:    host.Name(serviceHostname),
 		Address:     "1.1.1.1",
 		ClusterVIPs: make(map[string]string),
-		Ports:       model.PortList{servicePort},
+		Ports:       servicePort,
 		Resolution:  serviceResolution,
 	}
 
@@ -235,7 +276,7 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 			Endpoint: model.NetworkEndpoint{
 				Address:     "192.168.1.1",
 				Port:        10001,
-				ServicePort: servicePort,
+				ServicePort: servicePort[0],
 				Locality:    "region1/zone1/subzone1",
 				LbWeight:    40,
 			},
@@ -245,7 +286,7 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 			Endpoint: model.NetworkEndpoint{
 				Address:     "192.168.1.2",
 				Port:        10001,
-				ServicePort: servicePort,
+				ServicePort: servicePort[0],
 				Locality:    "region1/zone1/subzone2",
 				LbWeight:    20,
 			},
@@ -255,9 +296,19 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 			Endpoint: model.NetworkEndpoint{
 				Address:     "192.168.1.3",
 				Port:        10001,
-				ServicePort: servicePort,
+				ServicePort: servicePort[0],
 				Locality:    "region2/zone1/subzone1",
 				LbWeight:    40,
+			},
+		},
+		{
+			Service: service,
+			Endpoint: model.NetworkEndpoint{
+				Address:     "192.168.1.1",
+				Port:        10001,
+				ServicePort: servicePort[1],
+				Locality:    "region1/zone1/subzone1",
+				LbWeight:    0,
 			},
 		},
 	}
@@ -340,7 +391,7 @@ func TestBuildGatewayClustersWithRingHashLb(t *testing.T) {
 		})
 	g.Expect(err).NotTo(HaveOccurred())
 
-	g.Expect(len(clusters)).To(Equal(3))
+	g.Expect(len(clusters)).To(Equal(4))
 
 	cluster := clusters[0]
 	g.Expect(cluster.LbPolicy).To(Equal(apiv2.Cluster_RING_HASH))
@@ -373,7 +424,7 @@ func TestBuildGatewayClustersWithRingHashLbDefaultMinRingSize(t *testing.T) {
 		})
 	g.Expect(err).NotTo(HaveOccurred())
 
-	g.Expect(len(clusters)).To(Equal(3))
+	g.Expect(len(clusters)).To(Equal(4))
 
 	cluster := clusters[0]
 	g.Expect(cluster.LbPolicy).To(Equal(apiv2.Cluster_RING_HASH))
@@ -401,7 +452,7 @@ func TestBuildSidecarClustersWithIstioMutualAndSNI(t *testing.T) {
 	clusters, err := buildSniTestClusters("foo.com")
 	g.Expect(err).NotTo(HaveOccurred())
 
-	g.Expect(len(clusters)).To(Equal(4))
+	g.Expect(len(clusters)).To(Equal(6))
 
 	cluster := clusters[1]
 	g.Expect(cluster.Name).To(Equal("outbound|8080|foobar|foo.example.org"))
@@ -410,7 +461,7 @@ func TestBuildSidecarClustersWithIstioMutualAndSNI(t *testing.T) {
 	clusters, err = buildSniTestClusters("")
 	g.Expect(err).NotTo(HaveOccurred())
 
-	g.Expect(len(clusters)).To(Equal(4))
+	g.Expect(len(clusters)).To(Equal(6))
 
 	cluster = clusters[1]
 	g.Expect(cluster.Name).To(Equal("outbound|8080|foobar|foo.example.org"))
@@ -461,9 +512,9 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 		nil, testMesh, destRule, envoyMetadata, model.MaxIstioVersion)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	g.Expect(clusters).To(HaveLen(7))
+	g.Expect(clusters).To(HaveLen(10))
 
-	expectedOutboundClusterCount := 2
+	expectedOutboundClusterCount := 4
 	actualOutboundClusterCount := 0
 
 	for _, c := range clusters {
@@ -526,7 +577,7 @@ func TestBuildSidecarClustersWithMeshWideTCPKeepalive(t *testing.T) {
 	// Do not set tcp_keepalive anywhere
 	clusters, err := buildTestClustersWithTCPKeepalive(None)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(len(clusters)).To(Equal(7))
+	g.Expect(len(clusters)).To(Equal(10))
 	cluster := clusters[1]
 	g.Expect(cluster.Name).To(Equal("outbound|8080|foobar|foo.example.org"))
 	// UpstreamConnectionOptions should be nil. TcpKeepalive is the only field in it currently.
@@ -535,7 +586,7 @@ func TestBuildSidecarClustersWithMeshWideTCPKeepalive(t *testing.T) {
 	// Set mesh wide default for tcp_keepalive.
 	clusters, err = buildTestClustersWithTCPKeepalive(Mesh)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(len(clusters)).To(Equal(7))
+	g.Expect(len(clusters)).To(Equal(10))
 	cluster = clusters[1]
 	g.Expect(cluster.Name).To(Equal("outbound|8080|foobar|foo.example.org"))
 	// KeepaliveTime should be set but rest should be nil.
@@ -546,7 +597,7 @@ func TestBuildSidecarClustersWithMeshWideTCPKeepalive(t *testing.T) {
 	// Set DestinationRule override for tcp_keepalive.
 	clusters, err = buildTestClustersWithTCPKeepalive(DestinationRule)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(len(clusters)).To(Equal(7))
+	g.Expect(len(clusters)).To(Equal(10))
 	cluster = clusters[1]
 	g.Expect(cluster.Name).To(Equal("outbound|8080|foobar|foo.example.org"))
 	// KeepaliveTime should be set but rest should be nil.
@@ -557,7 +608,7 @@ func TestBuildSidecarClustersWithMeshWideTCPKeepalive(t *testing.T) {
 	// Set DestinationRule override for tcp_keepalive with empty value.
 	clusters, err = buildTestClustersWithTCPKeepalive(DestinationRuleForOsDefault)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(len(clusters)).To(Equal(7))
+	g.Expect(len(clusters)).To(Equal(10))
 	cluster = clusters[1]
 	g.Expect(cluster.Name).To(Equal("outbound|8080|foobar|foo.example.org"))
 	// TcpKeepalive should be present but with nil values.
@@ -659,7 +710,7 @@ func TestClusterMetadata(t *testing.T) {
 		}
 	}
 
-	g.Expect(clustersWithMetadata).To(Equal(len(destRule.Subsets) + 2)) // outbound  outbound subsets  inbound
+	g.Expect(clustersWithMetadata).To(Equal(len(destRule.Subsets) + 6)) // outbound  outbound subsets  inbound
 
 	sniClusters, err := buildSniDnatTestClusters("test-sni")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -803,7 +854,7 @@ func TestStatNamePattern(t *testing.T) {
 		})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(clusters[0].AltStatName).To(Equal("*.example.org_default_8080"))
-	g.Expect(clusters[3].AltStatName).To(Equal("LocalService_*.example.org"))
+	g.Expect(clusters[4].AltStatName).To(Equal("LocalService_*.example.org"))
 }
 
 func TestSidecarLocalityLB(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -982,7 +982,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 
 	g.Expect(err).NotTo(HaveOccurred())
 
-	for _, i := range []int{0, 3} {
+	for _, i := range []int{0, 1, 4, 5} {
 		cluster := clusters[i]
 		if cluster.CommonLbConfig == nil {
 			t.Errorf("CommonLbConfig should be set for cluster %+v", cluster)
@@ -1028,7 +1028,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 
 	g.Expect(err).NotTo(HaveOccurred())
 
-	for _, i := range []int{0, 3} {
+	for _, i := range []int{0, 1, 4, 5} {
 		if clusters[i].CommonLbConfig == nil {
 			t.Fatalf("CommonLbConfig should be set for cluster %+v", clusters[i])
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -138,10 +138,13 @@ const (
 	// Used in xds config. Metavalue bind to this key is used by pilot as xds server but not by envoy.
 	// So the meta data can be erased when pushing to envoy.
 	PilotMetaKey = "pilot_meta"
+
+	// TODO(yxue): separate h2c vs h2
+	H2Protocol = "h2"
 )
 
 var (
-	applicationProtocols = []string{"http/1.1", "http/1.0"}
+	applicationProtocols = []string{"http/1.0", "http/1.1"}
 
 	// EnvoyJSONLogFormat12 map of values for envoy json based access logs for Istio 1.2
 	EnvoyJSONLogFormat12 = &structpb.Struct{
@@ -1274,6 +1277,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 
 			// Support HTTP/1.0, HTTP/1.1 and HTTP/2
 			opt.match.ApplicationProtocols = append(opt.match.ApplicationProtocols, applicationProtocols...)
+			// TODO(yxue): merge applicationProtocols and H2Protocol when sniffing is enabled for inbound
+			opt.match.ApplicationProtocols = append(opt.match.ApplicationProtocols, H2Protocol)
 		}
 
 		listenerOpts.filterChainOpts = append(listenerOpts.filterChainOpts, opts...)
@@ -2136,6 +2141,7 @@ func mergeFilterChains(httpFilterChain, tcpFilterChain []*listener.FilterChain) 
 		}
 
 		fc.FilterChainMatch.ApplicationProtocols = append(fc.FilterChainMatch.ApplicationProtocols, applicationProtocols...)
+		fc.FilterChainMatch.ApplicationProtocols = append(fc.FilterChainMatch.ApplicationProtocols, H2Protocol)
 		newFilterChan = append(newFilterChan, fc)
 
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -585,7 +585,7 @@ func testOutboundListenerConflictV13(t *testing.T, services ...*model.Service) {
 			}
 		}
 
-		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2])
+		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2], model.TrafficDirectionOutbound)
 		if len(listeners[0].ListenerFilters) != 2 ||
 			listeners[0].ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
 			listeners[0].ListenerFilters[1].Name != "envoy.listener.http_inspector" {
@@ -612,7 +612,7 @@ func testOutboundListenerConflictV13(t *testing.T, services ...*model.Service) {
 			t.Fatalf("expected http filter chain, found %s", listeners[0].FilterChains[1].Filters[0].Name)
 		}
 
-		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2])
+		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2], model.TrafficDirectionOutbound)
 		if len(listeners[0].ListenerFilters) != 2 ||
 			listeners[0].ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
 			listeners[0].ListenerFilters[1].Name != "envoy.listener.http_inspector" {
@@ -637,8 +637,8 @@ func testInboundListenerConfigV13(t *testing.T, proxy *model.Proxy, services ...
 		t.Fatalf("expectd %d filter chains, %d http filter chains and %d tcp filter chain", 4, 2, 2)
 	}
 
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0])
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1])
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0], model.TrafficDirectionInbound)
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1], model.TrafficDirectionInbound)
 }
 
 func testInboundListenerConfigWithSidecarV13(t *testing.T, proxy *model.Proxy, services ...*model.Service) {
@@ -676,8 +676,8 @@ func testInboundListenerConfigWithSidecarV13(t *testing.T, proxy *model.Proxy, s
 		t.Fatalf("expectd %d filter chains, %d http filter chains and %d tcp filter chain", 4, 2, 2)
 	}
 
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0])
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1])
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0], model.TrafficDirectionInbound)
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1], model.TrafficDirectionInbound)
 }
 
 func testInboundListenerConfigWithSidecarWithoutServicesV13(t *testing.T, proxy *model.Proxy) {
@@ -715,8 +715,8 @@ func testInboundListenerConfigWithSidecarWithoutServicesV13(t *testing.T, proxy 
 		t.Fatalf("expectd %d filter chains, %d http filter chains and %d tcp filter chain", 4, 2, 2)
 	}
 
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0])
-	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1])
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0], model.TrafficDirectionInbound)
+	verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1], model.TrafficDirectionInbound)
 }
 
 func testInboundListenerConfigWithoutServiceV13(t *testing.T, proxy *model.Proxy) {
@@ -728,12 +728,21 @@ func testInboundListenerConfigWithoutServiceV13(t *testing.T, proxy *model.Proxy
 	}
 }
 
-func verifyHTTPFilterChainMatch(t *testing.T, fc *listener.FilterChain) {
+func verifyHTTPFilterChainMatch(t *testing.T, fc *listener.FilterChain, direction model.TrafficDirection) {
 	t.Helper()
-	if len(fc.FilterChainMatch.ApplicationProtocols) != 2 ||
-		fc.FilterChainMatch.ApplicationProtocols[0] != "http/1.1" ||
-		fc.FilterChainMatch.ApplicationProtocols[1] != "http/1.0" {
-		t.Fatalf("expected %d application protocols, [http/1.1, http/1.0]", 3)
+	if direction == model.TrafficDirectionInbound &&
+		(len(fc.FilterChainMatch.ApplicationProtocols) != 2 ||
+			fc.FilterChainMatch.ApplicationProtocols[0] != "http/1.0" ||
+			fc.FilterChainMatch.ApplicationProtocols[1] != "http/1.1") {
+		t.Fatalf("expected %d application protocols, [http/1.0, http/1.1]", 2)
+	}
+
+	if direction == model.TrafficDirectionOutbound &&
+		(len(fc.FilterChainMatch.ApplicationProtocols) != 3 ||
+			fc.FilterChainMatch.ApplicationProtocols[0] != "http/1.0" ||
+			fc.FilterChainMatch.ApplicationProtocols[1] != "http/1.1" ||
+			fc.FilterChainMatch.ApplicationProtocols[2] != "h2") {
+		t.Fatalf("expected %d application protocols, [http/1.0, http/1.1, h2]", 3)
 	}
 }
 
@@ -811,7 +820,7 @@ func testOutboundListenerConfigWithSidecarV13(t *testing.T, services ...*model.S
 			t.Fatalf("expected tcp filter chain, found %s", l.FilterChains[1].Filters[0].Name)
 		}
 
-		verifyHTTPFilterChainMatch(t, l.FilterChains[3])
+		verifyHTTPFilterChainMatch(t, l.FilterChains[3], model.TrafficDirectionOutbound)
 
 		if len(l.ListenerFilters) != 2 ||
 			l.ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
@@ -841,7 +850,7 @@ func testOutboundListenerConfigWithSidecarV13(t *testing.T, services ...*model.S
 		}
 	}
 
-	verifyHTTPFilterChainMatch(t, l.FilterChains[1])
+	verifyHTTPFilterChainMatch(t, l.FilterChains[1], model.TrafficDirectionOutbound)
 	if len(l.ListenerFilters) != 2 ||
 		l.ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
 		l.ListenerFilters[1].Name != "envoy.listener.http_inspector" {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -309,6 +309,14 @@ func IsProtocolSniffingEnabledForPort(node *model.Proxy, port *model.Port) bool 
 	return IsProtocolSniffingEnabledForOutbound(node) && port.Protocol.IsUnsupported()
 }
 
+func IsProtocolSniffingEnabledForInboundPort(node *model.Proxy, port *model.Port) bool {
+	return IsProtocolSniffingEnabledForInbound(node) && port.Protocol.IsUnsupported()
+}
+
+func IsProtocolSniffingEnabledForOutboundPort(node *model.Proxy, port *model.Port) bool {
+	return IsProtocolSniffingEnabledForOutbound(node) && port.Protocol.IsUnsupported()
+}
+
 // ResolveHostsInNetworksConfig will go through the Gateways addresses for all
 // networks in the config and if it's not an IP address it will try to lookup
 // that hostname and replace it with the IP address in the config

--- a/tests/integration/pilot/protocol_sniffing_test.go
+++ b/tests/integration/pilot/protocol_sniffing_test.go
@@ -1,0 +1,127 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pilot
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/pkg/log"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/tests/integration/security/util/connection"
+)
+
+func TestOutboundSniffing(t *testing.T) {
+	framework.NewTest(t).Run(func(ctx framework.TestContext) {
+		runTest(t, ctx)
+	})
+}
+
+func runTest(t *testing.T, ctx framework.TestContext) {
+	ns := namespace.NewOrFail(t, ctx, namespace.Config{
+		Prefix: "protocolsniffing",
+		Inject: true,
+	})
+
+	ports := []echo.Port{
+		{
+			Name:     "foo",
+			Protocol: protocol.HTTP,
+		},
+		{
+			Name:     "http",
+			Protocol: protocol.HTTP,
+		},
+		{
+			Name:     "bar",
+			Protocol: protocol.TCP,
+		},
+		{
+			Name:     "tcp",
+			Protocol: protocol.TCP,
+		},
+		{
+			Name:     "baz",
+			Protocol: protocol.GRPC,
+		},
+		{
+			Name:     "grpc",
+			Protocol: protocol.GRPC,
+		},
+	}
+
+	var from, to echo.Instance
+	echoboot.NewBuilderOrFail(t, ctx).
+		With(&from, echo.Config{
+			Service:   "from",
+			Namespace: ns,
+			Ports:     ports,
+			Galley:    g,
+			Pilot:     p,
+		}).
+		With(&to, echo.Config{
+			Service:   "to",
+			Namespace: ns,
+			Ports:     ports,
+			Galley:    g,
+			Pilot:     p,
+		}).
+		BuildOrFail(ctx)
+
+	from.WaitUntilCallableOrFail(t, to)
+	log.Infof("%s app ready: %s", ctx.Name(), from.Config().Service)
+
+	testCases := []struct {
+		portName string
+		scheme   scheme.Instance
+	}{
+		{"foo", scheme.HTTP},
+		{"http", scheme.HTTP},
+		{"baz", scheme.GRPC},
+		{"grpc", scheme.GRPC},
+	}
+
+	for _, tc := range testCases {
+		connChecker := connection.Checker{
+			From: from,
+			Options: echo.CallOptions{
+				Target:   to,
+				PortName: tc.portName,
+				Scheme:   tc.scheme,
+			},
+			ExpectSuccess: true,
+		}
+		subTestName := fmt.Sprintf(
+			"%s->%s:%s",
+			from.Config().Service,
+			to.Config().Service,
+			connChecker.Options.PortName)
+
+		t.Run(subTestName,
+			func(t *testing.T) {
+				retry.UntilSuccessOrFail(t, connChecker.Check,
+					retry.Delay(time.Second),
+					retry.Timeout(10*time.Second))
+			})
+	}
+}


### PR DESCRIPTION
`use_downstream_protocol` for unnamed ports. 

When using Istio with named port, the HTTP/1.1 client can talk to HTTP/2 service without caring about if the service support h2c upgrade or not. If client sends HTTP over TLS, the traffic will be proxied by TCP proxy and ALPN negotiation will be done between client and service. When the Envoy listener receives HTTP/1.1 request in plain text, it could use HTTP/2 connection pool to proxy the request. 
After using protocol sniffing, if the client sends HTTP/1.1 over TLS, it’s the same as before. If the client sends HTTP/1.1 in plain text, the client doesn’t know which connection pool should be used for upstream connection because Envoy cannot infer the service information from the service port name. 

This is not a regression because currently if user use some random port name, HTTP/1.1 client **cannot** talk to HTTP2 service either.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
