### PR TITLE
authz: fix the config generation for condition in policy

### DIFF
--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -179,6 +179,50 @@ func TestNewModelFromV1beta1(t *testing.T) {
 			},
 		},
 		{
+			name: "one permission condition",
+			rule: &security.Rule{
+				When: []*security.Condition{
+					newCondition(attrDestIP),
+				},
+			},
+			want: Model{
+				Permissions: []Permission{
+					{
+						Constraints: []KeyValues{
+							{"destination.ip": []string{"value-destination.ip-1", "value-destination.ip-2"}},
+						},
+					},
+				},
+				Principals: []Principal{
+					{
+						AllowAll: true,
+					},
+				},
+			},
+		},
+		{
+			name: "one principal condition",
+			rule: &security.Rule{
+				When: []*security.Condition{
+					newCondition(attrRequestHeader),
+				},
+			},
+			want: Model{
+				Permissions: []Permission{
+					{
+						AllowAll: true,
+					},
+				},
+				Principals: []Principal{
+					{
+						Properties: []KeyValues{
+							{"request.headers": []string{"value-request.headers-1", "value-request.headers-2"}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "full rule",
 			rule: &security.Rule{
 				From: []*security.Rule_From{
@@ -296,7 +340,7 @@ func TestNewModelFromV1beta1(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewModelFromV1beta1(tc.rule)
 			if !reflect.DeepEqual(*got, tc.want) {
-				t.Errorf("got %+v\nbut want %+v", *got, tc.want)
+				t.Errorf("\n got %+v\nwant %+v", *got, tc.want)
 			}
 		})
 	}

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
@@ -55,7 +55,7 @@ func (g *v1beta1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 			if p := g.generatePolicy(rule, forTCPFilter); p != nil {
 				name := fmt.Sprintf("ns[%s]-policy[%s]-rule[%d]", config.Namespace, config.Name, i)
 				rbac.Policies[name] = p
-				rbacLog.Debugf("generated policy %s for rule", name)
+				rbacLog.Debugf("generated policy %s: %+v", name, p)
 			}
 		}
 	}
@@ -68,5 +68,6 @@ func (g *v1beta1Generator) generatePolicy(rule *istio_rbac.Rule, forTCPFilter bo
 	}
 
 	m := authz_model.NewModelFromV1beta1(rule)
+	rbacLog.Debugf("constructed internal model: %+v", m)
 	return m.Generate(nil, forTCPFilter)
 }


### PR DESCRIPTION
Please provide a description for what this PR is for.

For #12394

This PR fixes the bug that the condition is incorrectly skipped when `from` or `to` is not set in the policy.

Will add e2e tests in following PRs.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
