### PR TITLE
Add a namespace to the dummy validation rule

### DIFF
--- a/pkg/test/framework/components/istio/util.go
+++ b/pkg/test/framework/components/istio/util.go
@@ -29,6 +29,7 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: validation-readiness-dummy-rule
+  namespace: istio-system
 spec:
   match: request.headers["foo"] == "bar"
   actions:


### PR DESCRIPTION
So that it doesn't rely on user's configured namespace - this might
lead to an error if user's kubeconfig is pointing to a non-existent
namespace.