### PR TITLE
authz: add integration test

### DIFF
--- a/pilot/pkg/security/authz/builder/integration_test.go
+++ b/pilot/pkg/security/authz/builder/integration_test.go
@@ -1,0 +1,131 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	http_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
+
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/security/authz/policy"
+	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/util/protomarshal"
+)
+
+func TestBuildHTTPFilter(t *testing.T) {
+	testCases := []struct {
+		name     string
+		policies *model.AuthorizationPolicies
+		want     *http_config.RBAC
+	}{
+		{
+			name:     "v1beta1 all fields",
+			policies: getPolicies("testdata/v1beta1-all-fields-in.yaml", t),
+			want:     getProto("testdata/v1beta1-all-fields-out.yaml", t),
+		},
+		{
+			name:     "v1beta1 allow all",
+			policies: getPolicies("testdata/v1beta1-allow-all-in.yaml", t),
+			want:     getProto("testdata/v1beta1-allow-all-out.yaml", t),
+		},
+		{
+			name:     "v1beta1 deny all",
+			policies: getPolicies("testdata/v1beta1-deny-all-in.yaml", t),
+			want:     getProto("testdata/v1beta1-deny-all-out.yaml", t),
+		},
+		{
+			name:     "v1beta1 multiple policies",
+			policies: getPolicies("testdata/v1beta1-multiple-policies-in.yaml", t),
+			want:     getProto("testdata/v1beta1-multiple-policies-out.yaml", t),
+		},
+		{
+			name:     "v1beta1 not override v1alpha1",
+			policies: getPolicies("testdata/v1beta1-not-override-v1alpha1-in.yaml", t),
+			want:     getProto("testdata/v1beta1-not-override-v1alpha1-out.yaml", t),
+		},
+		{
+			name:     "v1beta1 override v1alpha1",
+			policies: getPolicies("testdata/v1beta1-override-v1alpha1-in.yaml", t),
+			want:     getProto("testdata/v1beta1-override-v1alpha1-out.yaml", t),
+		},
+		{
+			name:     "v1beta1 single policy",
+			policies: getPolicies("testdata/v1beta1-single-policy-in.yaml", t),
+			want:     getProto("testdata/v1beta1-single-policy-out.yaml", t),
+		},
+	}
+
+	httpbinLabels := map[string]string{
+		"app":     "httpbin",
+		"version": "v1",
+	}
+	service := newService("httpbin.foo.svc.cluster.local", httpbinLabels, t)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewBuilder(service, labels.Collection{httpbinLabels}, "foo", tc.policies, false)
+			if b == nil {
+				t.Fatalf("failed to create builder")
+			}
+			got := b.generator.Generate(false)
+
+			if !reflect.DeepEqual(got, tc.want) {
+				gotYaml, err := protomarshal.ToYAML(got)
+				if err != nil {
+					t.Fatalf("failed to convert to YAML: %v", err)
+				}
+				wantYaml, err := protomarshal.ToYAML(tc.want)
+				if err != nil {
+					t.Fatalf("failed to convert to YAML: %v", err)
+				}
+				t.Errorf("got:\n%s\nwant:\n%s\n", gotYaml, wantYaml)
+			}
+		})
+	}
+}
+
+func getPolicies(filename string, t *testing.T) *model.AuthorizationPolicies {
+	t.Helper()
+
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("failed to read input yaml file: %v", err)
+	}
+	c, _, err := crd.ParseInputs(string(data))
+	if err != nil {
+		t.Fatalf("failde to parse CRD: %v", err)
+	}
+	var configs []*model.Config
+	for i := range c {
+		configs = append(configs, &c[i])
+	}
+	return policy.NewAuthzPolicies(configs, t)
+}
+
+func getProto(filename string, t *testing.T) *http_config.RBAC {
+	t.Helper()
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("failed to read output yaml file: %v", err)
+	}
+	out := &http_config.RBAC{}
+	if err := protomarshal.ApplyYAML(string(data), out); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+	return out
+}

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-all-fields-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-all-fields-in.yaml
@@ -1,0 +1,48 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-1
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+    - from:
+        - source:
+            principals: ["principal", "principal-prefix-*", "*-suffix-principal", "*"]
+            requestPrincipals: ["requestPrincipals", "requestPrincipals-prefix-*", "*-suffix-requestPrincipals", "*"]
+            namespaces: ["ns", "ns-prefix-*", "*-ns-suffix", "*"]
+            ipBlocks: ["1.2.3.4", "5.6.0.0/16"]
+      to:
+        - operation:
+            methods: ["method", "method-prefix-*", "*-suffix-method", "*"]
+            hosts: ["exact.com", "*.suffix.com", "prefix.*", "*"]
+            ports: ["80", "90"]
+            paths: ["/exact", "/prefix/*", "*/suffix", "*"]
+      when:
+        - key: "request.headers[X-header]"
+          values: ["header", "header-prefix-*", "*-suffix-header", "*"]
+        - key: "source.ip"
+          values: ["10.10.10.10", "192.168.10.0/24"]
+        - key: "source.namespace"
+          values: ["ns", "ns-prefix-*", "*-ns-suffix", "*"]
+        - key: "source.principal"
+          values: ["principal", "principal-prefix-*", "*-suffix-principal", "*"]
+        - key: "request.auth.principal"
+          values: ["requestPrincipals", "requestPrincipals-prefix-*", "*-suffix-requestPrincipals", "*"]
+        - key: "request.auth.audiences"
+          values: ["audiences", "audiences-prefix-*", "*-suffix-audiences", "*"]
+        - key: "request.auth.presenter"
+          values: ["presenter", "presenter-prefix-*", "*-suffix-presenter", "*"]
+        - key: "request.auth.claims[iss]"
+          values: ["iss", "iss-prefix-*", "*-suffix-iss", "*"]
+        - key: "destination.ip"
+          values: ["10.10.10.10", "192.168.10.0/24"]
+        - key: "destination.port"
+          values: ["91", "92"]
+        - key: "connection.sni"
+          values: ["exact.com", "*.suffix.com", "prefix.*", "*"]
+        - key: "experimental.envoy.filters.a.b[c]"
+          values: ["exact", "prefix-*", "*-suffix", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-all-fields-out.yaml
@@ -1,0 +1,407 @@
+rules:
+  policies:
+    ns[foo]-policy[httpbin-1]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: exact.com
+                        name: :authority
+                    - header:
+                        name: :authority
+                        suffixMatch: .suffix.com
+                    - header:
+                        name: :authority
+                        prefixMatch: prefix.
+                    - header:
+                        name: :authority
+                        presentMatch: true
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: method
+                        name: :method
+                    - header:
+                        name: :method
+                        prefixMatch: method-prefix-
+                    - header:
+                        name: :method
+                        suffixMatch: -suffix-method
+                    - header:
+                        name: :method
+                        presentMatch: true
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: /exact
+                        name: :path
+                    - header:
+                        name: :path
+                        prefixMatch: /prefix/
+                    - header:
+                        name: :path
+                        suffixMatch: /suffix
+                    - header:
+                        name: :path
+                        presentMatch: true
+              - orRules:
+                  rules:
+                    - destinationPort: 80
+                    - destinationPort: 90
+              - orRules:
+                  rules:
+                    - destinationIp:
+                        addressPrefix: 10.10.10.10
+                        prefixLen: 32
+                    - destinationIp:
+                        addressPrefix: 192.168.10.0
+                        prefixLen: 24
+              - orRules:
+                  rules:
+                    - destinationPort: 91
+                    - destinationPort: 92
+              - orRules:
+                  rules:
+                    - requestedServerName:
+                        exact: exact.com
+                    - requestedServerName:
+                        suffix: .suffix.com
+                    - requestedServerName:
+                        prefix: prefix.
+                    - requestedServerName:
+                        regex: .*
+              - orRules:
+                  rules:
+                    - metadata:
+                        filter: envoy.filters.a.b
+                        path:
+                          - key: c
+                        value:
+                          stringMatch:
+                            exact: exact
+                    - metadata:
+                        filter: envoy.filters.a.b
+                        path:
+                          - key: c
+                        value:
+                          stringMatch:
+                            prefix: prefix-
+                    - metadata:
+                        filter: envoy.filters.a.b
+                        path:
+                          - key: c
+                        value:
+                          stringMatch:
+                            suffix: -suffix
+                    - metadata:
+                        filter: envoy.filters.a.b
+                        path:
+                          - key: c
+                        value:
+                          stringMatch:
+                            regex: .*
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: principal
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            prefix: principal-prefix-
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            suffix: -suffix-principal
+                    - any: true
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: requestPrincipals
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            prefix: requestPrincipals-prefix-
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            suffix: -suffix-requestPrincipals
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            regex: .*
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/ns/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/ns-prefix-.*/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/.*-ns-suffix/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/.*/.*
+              - orIds:
+                  ids:
+                    - sourceIp:
+                        addressPrefix: 1.2.3.4
+                        prefixLen: 32
+                    - sourceIp:
+                        addressPrefix: 5.6.0.0
+                        prefixLen: 16
+              - orIds:
+                  ids:
+                    - header:
+                        exactMatch: header
+                        name: X-header
+                    - header:
+                        name: X-header
+                        prefixMatch: header-prefix-
+                    - header:
+                        name: X-header
+                        suffixMatch: -suffix-header
+                    - header:
+                        name: X-header
+                        presentMatch: true
+              - orIds:
+                  ids:
+                    - sourceIp:
+                        addressPrefix: 10.10.10.10
+                        prefixLen: 32
+                    - sourceIp:
+                        addressPrefix: 192.168.10.0
+                        prefixLen: 24
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/ns/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/ns-prefix-.*/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/.*-ns-suffix/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/.*/.*
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: principal
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            prefix: principal-prefix-
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            suffix: -suffix-principal
+                    - any: true
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: requestPrincipals
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            prefix: requestPrincipals-prefix-
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            suffix: -suffix-requestPrincipals
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            regex: .*
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.audiences
+                        value:
+                          stringMatch:
+                            exact: audiences
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.audiences
+                        value:
+                          stringMatch:
+                            prefix: audiences-prefix-
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.audiences
+                        value:
+                          stringMatch:
+                            suffix: -suffix-audiences
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.audiences
+                        value:
+                          stringMatch:
+                            regex: .*
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.presenter
+                        value:
+                          stringMatch:
+                            exact: presenter
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.presenter
+                        value:
+                          stringMatch:
+                            prefix: presenter-prefix-
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.presenter
+                        value:
+                          stringMatch:
+                            suffix: -suffix-presenter
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.presenter
+                        value:
+                          stringMatch:
+                            regex: .*
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.claims
+                          - key: iss
+                        value:
+                          listMatch:
+                            oneOf:
+                              stringMatch:
+                                exact: iss
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.claims
+                          - key: iss
+                        value:
+                          listMatch:
+                            oneOf:
+                              stringMatch:
+                                prefix: iss-prefix-
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.claims
+                          - key: iss
+                        value:
+                          listMatch:
+                            oneOf:
+                              stringMatch:
+                                suffix: -suffix-iss
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.claims
+                          - key: iss
+                        value:
+                          listMatch:
+                            oneOf:
+                              stringMatch:
+                                regex: .*

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-allow-all-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-allow-all-in.yaml
@@ -1,0 +1,12 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-all
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+    - {}

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-allow-all-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-allow-all-out.yaml
@@ -1,0 +1,11 @@
+rules:
+  policies:
+    ns[foo]-policy[allow-all]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - any: true
+      principals:
+        - andIds:
+            ids:
+              - any: true

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-deny-all-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-deny-all-in.yaml
@@ -1,0 +1,10 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-all
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-deny-all-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-deny-all-out.yaml
@@ -1,0 +1,2 @@
+rules:
+  policies: {}

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-multiple-policies-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-multiple-policies-in.yaml
@@ -1,0 +1,109 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-1
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+  - to:
+    - operation:
+        methods: ["GET", "POST"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-2
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  rules:
+    - to:
+      - operation:
+          paths: ["/v1", "/v2"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-3
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      version: v1
+  rules:
+    - to:
+        - operation:
+            hosts: ["google.com", "httpbin.org"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-4
+  namespace: foo
+spec:
+  rules:
+    - to:
+        - operation:
+            ports: ["80", "90"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-5
+  namespace: foo
+spec:
+  rules:
+    - from:
+        - source:
+            principals: ["principals1", "principals2"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-6
+  namespace: foo
+spec:
+  rules:
+    - from:
+        - source:
+            requestPrincipals: ["requestPrincipals1", "requestPrincipals2"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-7
+  namespace: foo
+spec:
+  rules:
+    - from:
+        - source:
+            namespaces: ["namespaces1", "namespaces2"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-8
+  namespace: foo
+spec:
+  rules:
+    - from:
+        - source:
+            ipBlocks: ["1.2.3.4", "5.6.7.0/24"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-9
+  namespace: foo
+spec:
+  rules:
+    - when:
+        - key: "request.headers[X-abc]"
+          values: ["abc1", "abc2"]
+---

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-multiple-policies-out.yaml
@@ -1,0 +1,166 @@
+rules:
+  policies:
+    ns[foo]-policy[httpbin-1]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: GET
+                        name: :method
+                    - header:
+                        exactMatch: POST
+                        name: :method
+      principals:
+        - andIds:
+            ids:
+              - any: true
+    ns[foo]-policy[httpbin-2]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: /v1
+                        name: :path
+                    - header:
+                        exactMatch: /v2
+                        name: :path
+      principals:
+        - andIds:
+            ids:
+              - any: true
+    ns[foo]-policy[httpbin-3]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: google.com
+                        name: :authority
+                    - header:
+                        exactMatch: httpbin.org
+                        name: :authority
+      principals:
+        - andIds:
+            ids:
+              - any: true
+    ns[foo]-policy[httpbin-4]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - destinationPort: 80
+                    - destinationPort: 90
+      principals:
+        - andIds:
+            ids:
+              - any: true
+    ns[foo]-policy[httpbin-5]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - any: true
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: principals1
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: principals2
+    ns[foo]-policy[httpbin-6]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - any: true
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: requestPrincipals1
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: requestPrincipals2
+    ns[foo]-policy[httpbin-7]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - any: true
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/namespaces1/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/namespaces2/.*
+    ns[foo]-policy[httpbin-8]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - any: true
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - sourceIp:
+                        addressPrefix: 1.2.3.4
+                        prefixLen: 32
+                    - sourceIp:
+                        addressPrefix: 5.6.7.0
+                        prefixLen: 24
+    ns[foo]-policy[httpbin-9]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - any: true
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - header:
+                        exactMatch: abc1
+                        name: X-abc
+                    - header:
+                        exactMatch: abc2
+                        name: X-abc

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-not-override-v1alpha1-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-not-override-v1alpha1-in.yaml
@@ -1,0 +1,46 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-1
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+      foo: bar
+  rules:
+    - to:
+        - operation:
+            methods: ["GET"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ClusterRbacConfig
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  mode: 'ON'
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: httpbin
+  namespace: foo
+spec:
+  rules:
+    - services: ["*"]
+      paths: ["/v1alpha1"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: httpbin-binding
+  namespace: foo
+spec:
+  subjects:
+    - user: "*"
+  roleRef:
+    kind: ServiceRole
+    name: "httpbin"
+---

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-not-override-v1alpha1-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-not-override-v1alpha1-out.yaml
@@ -1,0 +1,15 @@
+rules:
+  policies:
+    httpbin:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: /v1alpha1
+                        name: :path
+      principals:
+        - andIds:
+            ids:
+              - any: true

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-override-v1alpha1-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-override-v1alpha1-in.yaml
@@ -1,0 +1,45 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-1
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+    - to:
+        - operation:
+            methods: ["GET"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ClusterRbacConfig
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  mode: 'ON'
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: httpbin
+  namespace: foo
+spec:
+  rules:
+    - services: ["*"]
+      paths: ["/v1alpha1"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: httpbin-binding
+  namespace: foo
+spec:
+  subjects:
+    - user: "*"
+  roleRef:
+    kind: ServiceRole
+    name: "httpbin"
+---

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-override-v1alpha1-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-override-v1alpha1-out.yaml
@@ -1,0 +1,15 @@
+rules:
+  policies:
+    ns[foo]-policy[httpbin-1]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: GET
+                        name: :method
+      principals:
+        - andIds:
+            ids:
+              - any: true

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-single-policy-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-single-policy-in.yaml
@@ -1,0 +1,60 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+    - from:
+        - source:
+            principals: ["rule[0]-from[0]-principal[1]", "rule[0]-from[0]-principal[2]"]
+            requestPrincipals: ["rule[0]-from[0]-requestPrincipal[1]", "rule[0]-from[0]-requestPrincipal[2]"]
+            namespaces: ["rule[0]-from[0]-ns[1]", "rule[0]-from[0]-ns[2]"]
+            ipBlocks: ["10.0.0.1", "10.0.0.2"]
+        - source:
+            principals: ["rule[0]-from[1]-principal[1]", "rule[0]-from[1]-principal[2]"]
+            requestPrincipals: ["rule[0]-from[1]-requestPrincipal[1]", "rule[0]-from[1]-requestPrincipal[2]"]
+            namespaces: ["rule[0]-from[1]-ns[1]", "rule[0]-from[1]-ns[2]"]
+            ipBlocks: ["10.0.1.1", "192.0.1.2"]
+      to:
+        - operation:
+            methods: ["rule[0]-to[0]-method[1]", "rule[0]-to[0]-method[2]"]
+            hosts: ["rule[0]-to[0]-host[1]", "rule[0]-to[0]-host[2]"]
+            ports: ["9001", "9002"]
+            paths: ["rule[0]-to[0]-path[1]", "rule[0]-to[0]-path[2]"]
+        - operation:
+            methods: ["rule[0]-to[1]-method[1]", "rule[0]-to[1]-method[2]"]
+            hosts: ["rule[0]-to[1]-host[1]", "rule[0]-to[1]-host[2]"]
+            ports: ["9011", "9012"]
+            paths: ["rule[0]-to[1]-path[1]", "rule[0]-to[1]-path[2]"]
+      when:
+        - key: "request.headers[X-header]"
+          values: ["header", "header-prefix-*", "*-suffix-header", "*"]
+        - key: "destination.ip"
+          values: ["10.10.10.10", "192.168.10.0/24"]
+    - from:
+        - source:
+            principals: ["rule[1]-from[0]-principal[1]", "rule[1]-from[0]-principal[2]"]
+            requestPrincipals: ["rule[1]-from[0]-requestPrincipal[1]", "rule[1]-from[0]-requestPrincipal[2]"]
+            namespaces: ["rule[1]-from[0]-ns[1]", "rule[1]-from[0]-ns[2]"]
+            ipBlocks: ["10.1.0.1", "10.1.0.2"]
+        - source:
+            principals: ["rule[1]-from[1]-principal[1]", "rule[1]-from[1]-principal[2]"]
+            requestPrincipals: ["rule[1]-from[1]-requestPrincipal[1]", "rule[1]-from[1]-requestPrincipal[2]"]
+            namespaces: ["rule[1]-from[1]-ns[1]", "rule[1]-from[1]-ns[2]"]
+            ipBlocks: ["10.1.1.1", "192.1.1.2"]
+      to:
+        - operation:
+            methods: ["rule[1]-to[0]-method[1]", "rule[1]-to[0]-method[2]"]
+            hosts: ["rule[1]-to[0]-host[1]", "rule[1]-to[0]-host[2]"]
+            ports: ["9101", "9102"]
+            paths: ["rule[1]-to[0]-path[1]", "rule[1]-to[0]-path[2]"]
+        - operation:
+            methods: ["rule[1]-to[1]-method[1]", "rule[1]-to[1]-method[2]"]
+            hosts: ["rule[1]-to[1]-host[1]", "rule[1]-to[1]-host[2]"]
+            ports: ["9111", "9112"]
+            paths: ["rule[1]-to[1]-path[1]", "rule[1]-to[1]-path[2]"]

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-single-policy-out.yaml
@@ -1,0 +1,404 @@
+rules:
+  policies:
+    ns[foo]-policy[httpbin]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[0]-to[0]-host[1]
+                        name: :authority
+                    - header:
+                        exactMatch: rule[0]-to[0]-host[2]
+                        name: :authority
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[0]-to[0]-method[1]
+                        name: :method
+                    - header:
+                        exactMatch: rule[0]-to[0]-method[2]
+                        name: :method
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[0]-to[0]-path[1]
+                        name: :path
+                    - header:
+                        exactMatch: rule[0]-to[0]-path[2]
+                        name: :path
+              - orRules:
+                  rules:
+                    - destinationPort: 9001
+                    - destinationPort: 9002
+              - orRules:
+                  rules:
+                    - destinationIp:
+                        addressPrefix: 10.10.10.10
+                        prefixLen: 32
+                    - destinationIp:
+                        addressPrefix: 192.168.10.0
+                        prefixLen: 24
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[0]-to[1]-host[1]
+                        name: :authority
+                    - header:
+                        exactMatch: rule[0]-to[1]-host[2]
+                        name: :authority
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[0]-to[1]-method[1]
+                        name: :method
+                    - header:
+                        exactMatch: rule[0]-to[1]-method[2]
+                        name: :method
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[0]-to[1]-path[1]
+                        name: :path
+                    - header:
+                        exactMatch: rule[0]-to[1]-path[2]
+                        name: :path
+              - orRules:
+                  rules:
+                    - destinationPort: 9011
+                    - destinationPort: 9012
+              - orRules:
+                  rules:
+                    - destinationIp:
+                        addressPrefix: 10.10.10.10
+                        prefixLen: 32
+                    - destinationIp:
+                        addressPrefix: 192.168.10.0
+                        prefixLen: 24
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: rule[0]-from[0]-principal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: rule[0]-from[0]-principal[2]
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: rule[0]-from[0]-requestPrincipal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: rule[0]-from[0]-requestPrincipal[2]
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/rule[0]-from[0]-ns[1]/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/rule[0]-from[0]-ns[2]/.*
+              - orIds:
+                  ids:
+                    - sourceIp:
+                        addressPrefix: 10.0.0.1
+                        prefixLen: 32
+                    - sourceIp:
+                        addressPrefix: 10.0.0.2
+                        prefixLen: 32
+              - orIds:
+                  ids:
+                    - header:
+                        exactMatch: header
+                        name: X-header
+                    - header:
+                        name: X-header
+                        prefixMatch: header-prefix-
+                    - header:
+                        name: X-header
+                        suffixMatch: -suffix-header
+                    - header:
+                        name: X-header
+                        presentMatch: true
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: rule[0]-from[1]-principal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: rule[0]-from[1]-principal[2]
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: rule[0]-from[1]-requestPrincipal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: rule[0]-from[1]-requestPrincipal[2]
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/rule[0]-from[1]-ns[1]/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/rule[0]-from[1]-ns[2]/.*
+              - orIds:
+                  ids:
+                    - sourceIp:
+                        addressPrefix: 10.0.1.1
+                        prefixLen: 32
+                    - sourceIp:
+                        addressPrefix: 192.0.1.2
+                        prefixLen: 32
+              - orIds:
+                  ids:
+                    - header:
+                        exactMatch: header
+                        name: X-header
+                    - header:
+                        name: X-header
+                        prefixMatch: header-prefix-
+                    - header:
+                        name: X-header
+                        suffixMatch: -suffix-header
+                    - header:
+                        name: X-header
+                        presentMatch: true
+    ns[foo]-policy[httpbin]-rule[1]:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[1]-to[0]-host[1]
+                        name: :authority
+                    - header:
+                        exactMatch: rule[1]-to[0]-host[2]
+                        name: :authority
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[1]-to[0]-method[1]
+                        name: :method
+                    - header:
+                        exactMatch: rule[1]-to[0]-method[2]
+                        name: :method
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[1]-to[0]-path[1]
+                        name: :path
+                    - header:
+                        exactMatch: rule[1]-to[0]-path[2]
+                        name: :path
+              - orRules:
+                  rules:
+                    - destinationPort: 9101
+                    - destinationPort: 9102
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[1]-to[1]-host[1]
+                        name: :authority
+                    - header:
+                        exactMatch: rule[1]-to[1]-host[2]
+                        name: :authority
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[1]-to[1]-method[1]
+                        name: :method
+                    - header:
+                        exactMatch: rule[1]-to[1]-method[2]
+                        name: :method
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[1]-to[1]-path[1]
+                        name: :path
+                    - header:
+                        exactMatch: rule[1]-to[1]-path[2]
+                        name: :path
+              - orRules:
+                  rules:
+                    - destinationPort: 9111
+                    - destinationPort: 9112
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: rule[1]-from[0]-principal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: rule[1]-from[0]-principal[2]
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: rule[1]-from[0]-requestPrincipal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: rule[1]-from[0]-requestPrincipal[2]
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/rule[1]-from[0]-ns[1]/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/rule[1]-from[0]-ns[2]/.*
+              - orIds:
+                  ids:
+                    - sourceIp:
+                        addressPrefix: 10.1.0.1
+                        prefixLen: 32
+                    - sourceIp:
+                        addressPrefix: 10.1.0.2
+                        prefixLen: 32
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: rule[1]-from[1]-principal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: rule[1]-from[1]-principal[2]
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: rule[1]-from[1]-requestPrincipal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: request.auth.principal
+                        value:
+                          stringMatch:
+                            exact: rule[1]-from[1]-requestPrincipal[2]
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/rule[1]-from[1]-ns[1]/.*
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/rule[1]-from[1]-ns[2]/.*
+              - orIds:
+                  ids:
+                    - sourceIp:
+                        addressPrefix: 10.1.1.1
+                        prefixLen: 32
+                    - sourceIp:
+                        addressPrefix: 192.1.1.2
+                        prefixLen: 32


### PR DESCRIPTION
Please provide a description for what this PR is for.

For #12394

This PR adds comprehensive integration tests for v1beta1 authorization conversion in Pilot, the test takes the v1beta1 custom resources as input, generate the Envoy RBAC filter config and then compare it with the golden output.

The following cases are covered:
- A single v1beta1 policy that sets all of its fields with exact, prefix and suffix match
- A simple allow all v1beta1 policy
- A simple deny all v1beta1 policy
- Multiple (9) different v1beta1 policies on same workload
- Both v1beta1 and v1alpha1 policy, the v1beta1 is used to override the v1alpha1
- Both v1beta1 and v1alpha1 policy, the v1beta1 is not used to override the v1alpha1
- A single v1beta1 policy that has multiple rules, from, to in the policy

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
