### PR TITLE
Respect labels form node matadata first

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -481,12 +481,20 @@ func (node *Proxy) SetServiceInstances(env *Environment) error {
 
 // SetWorkloadLabels will reset the proxy.WorkloadLabels if `force` = true,
 // otherwise only set it when it is nil.
-func (node *Proxy) SetWorkloadLabels(env *Environment, force bool) error {
+func (node *Proxy) SetWorkloadLabels(env *Environment) error {
 	// The WorkloadLabels is already parsed from Node metadata["LABELS"]
 	if node.WorkloadLabels != nil {
 		return nil
 	}
 
+	// TODO: remove WorkloadLabels and use node.Metadata.Labels directly
+	// First get the workload labels from node meta
+	if len(node.Metadata.Labels) > 0 {
+		node.WorkloadLabels = labels.Collection{node.Metadata.Labels}
+		return nil
+	}
+
+	// Fallback to calling GetProxyWorkloadLabels
 	l, err := env.GetProxyWorkloadLabels(node)
 	if err != nil {
 		log.Errorf("failed to get service proxy labels: %v", err)

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -200,14 +200,13 @@ type UpdateEvent struct {
 
 func newXdsConnection(peerAddr string, stream DiscoveryStream) *XdsConnection {
 	return &XdsConnection{
-		pushChannel:   make(chan *XdsEvent),
-		updateChannel: make(chan *UpdateEvent, 1),
-		PeerAddr:      peerAddr,
-		Clusters:      []string{},
-		Connect:       time.Now(),
-		stream:        stream,
-		LDSListeners:  []*xdsapi.Listener{},
-		RouteConfigs:  map[string]*xdsapi.RouteConfiguration{},
+		pushChannel:  make(chan *XdsEvent),
+		PeerAddr:     peerAddr,
+		Clusters:     []string{},
+		Connect:      time.Now(),
+		stream:       stream,
+		LDSListeners: []*xdsapi.Listener{},
+		RouteConfigs: map[string]*xdsapi.RouteConfiguration{},
 	}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -192,12 +192,6 @@ type XdsEvent struct {
 	done func()
 }
 
-// UpdateEvent represents a update request for the proxy.
-// This will trigger proxy specific attributes reset before each push.
-type UpdateEvent struct {
-	workloadLabel bool
-}
-
 func newXdsConnection(peerAddr string, stream DiscoveryStream) *XdsConnection {
 	return &XdsConnection{
 		pushChannel:  make(chan *XdsEvent),


### PR DESCRIPTION
As there are labels in NodeMetadata, we should only fallback to calling GetProxyWorkloadLabels when this field is empty. Which may happen on older sidecars or platforms other than k8s