### PR TITLE
fix: NodeAgent CrashLoopBackOff if enabled

### DIFF
--- a/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
+++ b/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
@@ -5,11 +5,12 @@ enabled: false
 image: node-agent-k8s
 env:
   # name of authentication provider.
-  CA_PROVIDER: ""
+  CA_PROVIDER: "Citadel"
   # CA endpoint.
-  CA_ADDR: ""  
+  CA_ADDR: "istio-citadel:8060"
   # names of authentication provider's plugins.
   PLUGINS: ""
+  VALID_TOKEN: true
 nodeSelector: {}
 tolerations: []
 

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -57,12 +57,6 @@ security:
 #
 nodeagent:
   enabled: false
-  image: node-agent-k8s
-  env:
-    CA_PROVIDER: "Citadel"
-    CA_ADDR: "istio-citadel:8060"
-    VALID_TOKEN: true
-
 
 #
 # addon grafana configuration

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -57,6 +57,12 @@ security:
 #
 nodeagent:
   enabled: false
+  image: node-agent-k8s
+  env:
+    CA_PROVIDER: "Citadel"
+    CA_ADDR: "istio-citadel:8060"
+    VALID_TOKEN: true
+
 
 #
 # addon grafana configuration


### PR DESCRIPTION
If nodeagent enabled in values.yml, by default it'll crashloop.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ x ] Configuration Infrastructure
[ ] Docs
[ x ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
