### PR TITLE
Add jobs resources to avoid forbidden by some policies

### DIFF
--- a/install/kubernetes/helm/istio-init/templates/job-crd-10.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-10.yaml
@@ -14,6 +14,10 @@ spec:
       - name: istio-init-crd-10
         image: "{{ .Values.global.hub }}/kubectl:{{ .Values.global.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+{{- if .Values.job.resources }}
+        resources:
+{{ toYaml .Values.job.resources | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: crd-10
           mountPath: /etc/istio/crd-10

--- a/install/kubernetes/helm/istio-init/templates/job-crd-11.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-11.yaml
@@ -14,6 +14,10 @@ spec:
       - name: istio-init-crd-11
         image: "{{ .Values.global.hub }}/kubectl:{{ .Values.global.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+{{- if .Values.job.resources }}
+        resources:
+{{ toYaml .Values.job.resources | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: crd-11
           mountPath: /etc/istio/crd-11

--- a/install/kubernetes/helm/istio-init/templates/job-crd-14.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-14.yaml
@@ -11,14 +11,18 @@ spec:
     spec:
       serviceAccountName: istio-init-service-account
       containers:
-        - name: istio-init-crd-14
-          image: "{{ .Values.global.hub }}/kubectl:{{ .Values.global.tag }}"
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-          volumeMounts:
-            - name: crd-14
-              mountPath: /etc/istio/crd-14
-              readOnly: true
-          command: ["kubectl",  "apply", "-f", "/etc/istio/crd-14/crd-14.yaml"]
+      - name: istio-init-crd-14
+        image: "{{ .Values.global.hub }}/kubectl:{{ .Values.global.tag }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+{{- if .Values.job.resources }}
+        resources:
+{{ toYaml .Values.job.resources | indent 10 }}
+{{- end }}
+        volumeMounts:
+          - name: crd-14
+            mountPath: /etc/istio/crd-14
+            readOnly: true
+        command: ["kubectl",  "apply", "-f", "/etc/istio/crd-14/crd-14.yaml"]
       volumes:
         - name: crd-14
           configMap:

--- a/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-10.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-10.yaml
@@ -15,6 +15,10 @@ spec:
       - name: istio-init-crd-certmanager-10
         image: "{{ .Values.global.hub }}/kubectl:{{ .Values.global.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+{{- if .Values.job.resources }}
+        resources:
+{{ toYaml .Values.job.resources | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: crd-certmanager-10
           mountPath: /etc/istio/crd-certmanager-10

--- a/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-11.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-11.yaml
@@ -15,6 +15,10 @@ spec:
       - name: istio-init-crd-certmanager-11
         image: "{{ .Values.global.hub }}/kubectl:{{ .Values.global.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+{{- if .Values.job.resources }}
+        resources:
+{{ toYaml .Values.job.resources | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: crd-certmanager-11
           mountPath: /etc/istio/crd-certmanager-11

--- a/install/kubernetes/helm/istio-init/values.yaml
+++ b/install/kubernetes/helm/istio-init/values.yaml
@@ -14,3 +14,12 @@ global:
 
 certmanager:
   enabled: false
+
+job:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi
+    limits:
+      cpu: 100m
+      memory: 200Mi


### PR DESCRIPTION

Unlimited resources are forbindden in some platform, I think we should add resources limit for jobs.

```console
[root@kebe-dev-m1 ~]# kubectl -n istio-system describe job istio-init-crd-10-1.3.0
....
Events:
  Type     Reason        Age                    From            Message
  ----     ------        ----                   ----            -------
  Warning  FailedCreate  3m48s (x41 over 4h3m)  job-controller  (combined from similar events): Error creating: pods "istio-init-crd-10-1.3.0-xhwv7" is forbidden: exceeded quota: best-effort, requested: pods=1, used: pods=0, limited: pods=0
```

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
