### PR TITLE
Fix nil dereference from #17449

### DIFF
--- a/galley/pkg/config/analysis/analyzers/auth/servicerolebindings.go
+++ b/galley/pkg/config/analysis/analyzers/auth/servicerolebindings.go
@@ -52,6 +52,11 @@ func (s *ServiceRoleBindingAnalyzer) analyzeRoleBinding(r *resource.Entry, ctx a
 	srb := r.Item.(*v1alpha1.ServiceRoleBinding)
 	ns, _ := r.Metadata.Name.InterpretAsNamespaceAndName()
 
+	// If no servicerole is defined at all, just skip. The field is required, but that should be enforced elsewhere.
+	if srb.RoleRef == nil {
+		return
+	}
+
 	if !ctx.Exists(metadata.IstioRbacV1Alpha1Serviceroles, resource.NewName(ns, srb.RoleRef.Name)) {
 		ctx.Report(metadata.IstioRbacV1Alpha1Servicerolebindings, msg.NewReferencedResourceNotFound(r, "service role", srb.RoleRef.Name))
 	}

--- a/galley/pkg/config/analysis/analyzers/testdata/servicerolebindings.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/servicerolebindings.yaml
@@ -26,3 +26,13 @@ spec:
     name: bogus-service-role  # Expected: validation error since this role does not exist
   subjects:
   - user: cluster.local/ns/default/sa/bookinfo-productpage
+---
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  name: test-binding
+spec:
+  mode: PERMISSIVE
+  # Expected: no validation error, skip if roleRef is missing
+  subjects:
+  - user: cluster.local/ns/default/sa/bookinfo-productpage


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/17449

Analyzers checking for referential integrity shouldn't be responsible for invalid or incorrectly defined resources, but do need to be robust and handle that case gracefully. 

We don't emit an error here because the assumption is that our other validation should catch it. (E.g. this wouldn't pass the webhook admission or `istioctl validate`). We do plan to integrate these analyzers with the single-object validators, so the customer experience is unified and consistent. See https://github.com/istio/istio/issues/16777 for more on that. 

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
