### PR TITLE
Tune pilot proxy convergence metric and fix comment

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -124,8 +124,8 @@ var (
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesConvergeDelay = monitoring.NewDistribution(
 		"pilot_proxy_convergence_time",
-		"Delay between config change and all proxies converging.",
-		[]float64{1, 3, 5, 10, 20, 30, 50, 100},
+		"Delay between config change and a proxy receiving all required configuration.",
+		[]float64{.1, .5, 1,  3, 5, 10, 20, 30},
 	)
 
 	pushContextErrors = monitoring.NewSum(

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -125,7 +125,7 @@ var (
 	proxiesConvergeDelay = monitoring.NewDistribution(
 		"pilot_proxy_convergence_time",
 		"Delay between config change and a proxy receiving all required configuration.",
-		[]float64{.1, .5, 1,  3, 5, 10, 20, 30},
+		[]float64{.1, .5, 1, 3, 5, 10, 20, 30},
 	)
 
 	pushContextErrors = monitoring.NewSum(


### PR DESCRIPTION
The comment was inaccurate, and the buckets are way to large. In most
cases the time is less than 1 second, so we can't report anything
useful. This allows us to be a little more granular.

[x] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Developer Infrastructure
