### PR TITLE
Exit pilot-agent on Envoy error

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,6 @@ github.com/emicklei/go-restful v2.8.1+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/emicklei/go-restful v2.9.3+incompatible h1:2OwhVdhtzYUp5P5wuGsVDPagKSRd9JK72sJCHVCXh5g=
 github.com/emicklei/go-restful v2.9.3+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful-swagger12 v0.0.0-20170926063155-7524189396c6/go.mod h1:qr0VowGBT4CS4Q8vFF8BSeKz34PuqKGxs/L0IAQA9DQ=
-github.com/envoyproxy/go-control-plane v0.9.0 h1:67WMNTvGrl7V1dWdKCeTwxDr7nio9clKoTlLhwIPnT4=
-github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191002184426-9d865299d2ff h1:c03aOTa9x9VOSKW5w0Mm9NeRPceC013YduuOudsHNlQ=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191002184426-9d865299d2ff/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=

--- a/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
+++ b/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
@@ -17,10 +17,6 @@
 package contextgraph
 
 import (
-	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
-)
-
-import (
 	"flag"
 	"fmt"
 	"io"
@@ -34,10 +30,14 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
+
+	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
+
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+
 	gstatus "google.golang.org/grpc/status"
 )
 

--- a/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
+++ b/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
@@ -17,6 +17,10 @@
 package contextgraph
 
 import (
+	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
+)
+
+import (
 	"flag"
 	"fmt"
 	"io"
@@ -30,14 +34,10 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
-
-	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
-
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-
 	gstatus "google.golang.org/grpc/status"
 )
 

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -433,7 +433,7 @@ var (
 
 			agent := envoy.NewAgent(envoyProxy, features.TerminationDrainDuration())
 
-			watcher := envoy.NewWatcher(tlsCertsToWatch, agent.ConfigCh())
+			watcher := envoy.NewWatcher(tlsCertsToWatch, agent.Restart)
 
 			go watcher.Run(ctx)
 

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -388,6 +388,7 @@ var (
 			if statusPort > 0 {
 				parsedPorts, err := parseApplicationPorts()
 				if err != nil {
+					cancel()
 					return err
 				}
 				localHostAddr := "127.0.0.1"
@@ -404,6 +405,7 @@ var (
 					NodeType:           role.Type,
 				})
 				if err != nil {
+					cancel()
 					return err
 				}
 				go waitForCompletion(ctx, statusServer.Run)

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -438,8 +438,7 @@ var (
 			// On SIGINT or SIGTERM, cancel the context, triggering a graceful shutdown
 			go cmd.WaitSignalFunc(cancel)
 
-			agent.Run(ctx)
-			return nil
+			return agent.Run(ctx)
 		},
 	}
 )

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -35,7 +35,7 @@ func WaitSignal(stop chan struct{}) {
 	_ = log.Sync()
 }
 
-// WaitSignal awaits for SIGINT or SIGTERM and calls the cancel function
+// WaitSignalFunc awaits for SIGINT or SIGTERM and calls the cancel function
 func WaitSignalFunc(cancel func()) {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -35,6 +35,15 @@ func WaitSignal(stop chan struct{}) {
 	_ = log.Sync()
 }
 
+// WaitSignal awaits for SIGINT or SIGTERM and calls the cancel function
+func WaitSignalFunc(cancel func()) {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+	cancel()
+	_ = log.Sync()
+}
+
 // AddFlags adds all command line flags to the given command.
 func AddFlags(rootCmd *cobra.Command) {
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)

--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -196,7 +196,7 @@ func (a *agent) reconcile() {
 	a.currentEpoch++
 
 	// buffer aborts to prevent blocking on failing proxy
-	abortCh := make(chan error)
+	abortCh := make(chan error, 1)
 
 	a.abortCh[a.currentEpoch] = abortCh
 	a.currentConfig = a.desiredConfig

--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -164,9 +164,8 @@ func (a *agent) Run(ctx context.Context) error {
 			if len(a.abortCh) == 0 {
 				log.Infof("All epoch aborted, exiting")
 				return status.err
-			} else {
-				log.Infof("Waiting for %d epochs to exit", len(a.abortCh))
 			}
+			log.Infof("Waiting for %d epochs to exit", len(a.abortCh))
 
 		case <-ctx.Done():
 			a.terminate()

--- a/pkg/envoy/watcher.go
+++ b/pkg/envoy/watcher.go
@@ -41,13 +41,11 @@ type Watcher interface {
 
 type watcher struct {
 	certs   []string
-	updates chan<- interface{}
+	updates func(interface{})
 }
 
 // NewWatcher creates a new watcher instance from a proxy agent and a set of monitored certificate file paths
-func NewWatcher(
-	certs []string,
-	updates chan<- interface{}) Watcher {
+func NewWatcher(certs []string, updates func(interface{})) Watcher {
 	return &watcher{
 		certs:   certs,
 		updates: updates,
@@ -68,7 +66,7 @@ func (w *watcher) Run(ctx context.Context) {
 func (w *watcher) SendConfig() {
 	h := sha256.New()
 	generateCertHash(h, w.certs)
-	w.updates <- h.Sum(nil)
+	w.updates(h.Sum(nil))
 }
 
 type watchFileEventsFn func(ctx context.Context, wch <-chan *fsnotify.FileEvent,

--- a/pkg/envoy/watcher_test.go
+++ b/pkg/envoy/watcher_test.go
@@ -32,7 +32,7 @@ type TestAgent struct {
 	configCh chan interface{}
 }
 
-func (ta *TestAgent) Restart(c interface{})  {
+func (ta *TestAgent) Restart(c interface{}) {
 	ta.configCh <- c
 }
 

--- a/pkg/envoy/watcher_test.go
+++ b/pkg/envoy/watcher_test.go
@@ -32,8 +32,8 @@ type TestAgent struct {
 	configCh chan interface{}
 }
 
-func (ta *TestAgent) ConfigCh() chan<- interface{} {
-	return ta.configCh
+func (ta *TestAgent) Restart(c interface{})  {
+	ta.configCh <- c
 }
 
 func (ta *TestAgent) Run(ctx context.Context) {
@@ -44,7 +44,7 @@ func TestRunSendConfig(t *testing.T) {
 	agent := &TestAgent{
 		configCh: make(chan interface{}),
 	}
-	watcher := NewWatcher([]string{"/random"}, agent.ConfigCh())
+	watcher := NewWatcher([]string{"/random"}, agent.Restart)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// watcher starts agent and schedules a config update


### PR DESCRIPTION
Consider a case where Envoy is going OOM.

* Envoy dies, but kubernetes still reports things are good and 2/2 ready.
Repeat a few times.
* At somepoint due to backoff, envoy is dead for 2 minutes. The readiness
probe won't fail for at least a minute, so there is 1min where traffic
is coming and we are not even attempting to handle it.

Meanwhile, the operator has no clue what is going on, because Kubernetes
doesn't know envoy is crashing

Alternatively, if we exit when envoy crashes:

* The readiness probe fails immediately
* The user can clearly see envoy is crashing
* Kubernetes handles backoff for us
* We don't have to handle the complexity.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
