### PR TITLE
Mark mixer policy test as flaky

### DIFF
--- a/tests/integration/mixer/policy/white_black_listing_test.go
+++ b/tests/integration/mixer/policy/white_black_listing_test.go
@@ -18,13 +18,15 @@ import (
 	"net/http"
 	"testing"
 
+	"istio.io/istio/pkg/test/framework/label"
+
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/bookinfo"
 	util "istio.io/istio/tests/integration/mixer"
 )
 
 func TestWhiteListing(t *testing.T) {
-	framework.Run(t, func(ctx framework.TestContext) {
+	framework.NewTest(t).Label(label.Flaky).Run(func(ctx framework.TestContext) {
 		// Verify you can access productpage right now.
 		util.SendTrafficAndWaitForExpectedStatus(ing, t, "Sending traffic...", "", 2, http.StatusOK)
 


### PR DESCRIPTION
This test fails 80% of the time:
https://testgrid.k8s.io/istio_istio#integ-mixer-k8s-tests_istio&exclude-non-failed-tests=&width=20

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
