### PR TITLE
Incremental PushContext initilization

### DIFF
--- a/pilot/pkg/config/clusterregistry/multicluster.go
+++ b/pilot/pkg/config/clusterregistry/multicluster.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/kube/secretcontroller"
 	"istio.io/pkg/log"
 )
@@ -148,6 +149,10 @@ func (m *Multicluster) ReloadNetworkLookup(meshNetworks *meshconfig.MeshNetworks
 
 func (m *Multicluster) updateHandler() {
 	if m.XDSUpdater != nil {
-		m.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true})
+		req := &model.PushRequest{
+			Full:               true,
+			ConfigTypesUpdated: map[string]struct{}{schemas.ServiceEntry.Type: {}},
+		}
+		m.XDSUpdater.ConfigUpdate(req)
 	}
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -232,7 +232,7 @@ func (first *PushRequest) Merge(other *PushRequest) *PushRequest {
 	}
 
 	// Merge the target namespaces
-	if len(first.NamespacesUpdated) > 0 && len(other.NamespacesUpdated) > 0 {
+	if len(first.NamespacesUpdated) > 0 || len(other.NamespacesUpdated) > 0 {
 		merged.NamespacesUpdated = make(map[string]struct{})
 		for update := range first.NamespacesUpdated {
 			merged.NamespacesUpdated[update] = struct{}{}
@@ -243,7 +243,7 @@ func (first *PushRequest) Merge(other *PushRequest) *PushRequest {
 	}
 
 	// Merge the config updates
-	if len(first.ConfigTypesUpdated) > 0 && len(other.ConfigTypesUpdated) > 0 {
+	if len(first.ConfigTypesUpdated) > 0 || len(other.ConfigTypesUpdated) > 0 {
 		merged.ConfigTypesUpdated = make(map[string]struct{})
 		for update := range first.ConfigTypesUpdated {
 			merged.ConfigTypesUpdated[update] = struct{}{}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -232,7 +232,7 @@ func (first *PushRequest) Merge(other *PushRequest) *PushRequest {
 	}
 
 	// Merge the target namespaces
-	if len(first.NamespacesUpdated) > 0 || len(other.NamespacesUpdated) > 0 {
+	if len(first.NamespacesUpdated) > 0 && len(other.NamespacesUpdated) > 0 {
 		merged.NamespacesUpdated = make(map[string]struct{})
 		for update := range first.NamespacesUpdated {
 			merged.NamespacesUpdated[update] = struct{}{}
@@ -243,7 +243,7 @@ func (first *PushRequest) Merge(other *PushRequest) *PushRequest {
 	}
 
 	// Merge the config updates
-	if len(first.ConfigTypesUpdated) > 0 || len(other.ConfigTypesUpdated) > 0 {
+	if len(first.ConfigTypesUpdated) > 0 && len(other.ConfigTypesUpdated) > 0 {
 		merged.ConfigTypesUpdated = make(map[string]struct{})
 		for update := range first.ConfigTypesUpdated {
 			merged.ConfigTypesUpdated[update] = struct{}{}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1425,35 +1425,35 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 	return MergeGateways(out...)
 }
 
-func (in *PushContext) copyInto(out *PushContext) {
+func (ps *PushContext) copyInto(out *PushContext) {
 	// service related
-	out.privateServicesByNamespace = in.privateServicesByNamespace
-	out.publicServices = in.publicServices
-	out.ServiceByHostnameAndNamespace = in.ServiceByHostnameAndNamespace
-	out.ServiceAccounts = in.ServiceAccounts
+	out.privateServicesByNamespace = ps.privateServicesByNamespace
+	out.publicServices = ps.publicServices
+	out.ServiceByHostnameAndNamespace = ps.ServiceByHostnameAndNamespace
+	out.ServiceAccounts = ps.ServiceAccounts
 
 	// virtualservice related
-	out.privateVirtualServicesByNamespace = in.privateVirtualServicesByNamespace
-	out.publicVirtualServices = in.publicVirtualServices
+	out.privateVirtualServicesByNamespace = ps.privateVirtualServicesByNamespace
+	out.publicVirtualServices = ps.publicVirtualServices
 
 	// destination rule related
-	out.namespaceLocalDestRules = in.namespaceLocalDestRules
-	out.namespaceExportedDestRules = in.namespaceExportedDestRules
-	out.allExportedDestRules = in.allExportedDestRules
+	out.namespaceLocalDestRules = ps.namespaceLocalDestRules
+	out.namespaceExportedDestRules = ps.namespaceExportedDestRules
+	out.allExportedDestRules = ps.allExportedDestRules
 
 	// sidecars
-	out.sidecarsByNamespace = in.sidecarsByNamespace
+	out.sidecarsByNamespace = ps.sidecarsByNamespace
 
 	// envoyfilters
-	out.envoyFiltersByNamespace = in.envoyFiltersByNamespace
+	out.envoyFiltersByNamespace = ps.envoyFiltersByNamespace
 
 	// gateways
-	out.gatewaysByNamespace = in.gatewaysByNamespace
-	out.allGateways = in.allGateways
+	out.gatewaysByNamespace = ps.gatewaysByNamespace
+	out.allGateways = ps.allGateways
 
 	// authz
-	out.AuthzPolicies = in.AuthzPolicies
+	out.AuthzPolicies = ps.AuthzPolicies
 
 	// authn
-	out.AuthnPolicies = in.AuthnPolicies
+	out.AuthnPolicies = ps.AuthnPolicies
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -711,7 +711,7 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 	ps.initDefaultExportMaps()
 
 	// create new or incremental update
-	if pushReq == nil || oldPushContext == nil || len(pushReq.ConfigTypesUpdated) == 0 {
+	if pushReq == nil || oldPushContext == nil || !oldPushContext.initDone || len(pushReq.ConfigTypesUpdated) == 0 {
 		if err := ps.createNewContext(env); err != nil {
 			return err
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -488,7 +488,7 @@ func newTestEnvironment(serviceDiscovery model.ServiceDiscovery, mesh meshconfig
 	}
 
 	env.PushContext = model.NewPushContext()
-	_ = env.PushContext.InitContext(env)
+	_ = env.PushContext.InitContext(env, nil, nil)
 
 	return env
 }

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -285,7 +285,7 @@ func TestApplyClusterPatches(t *testing.T) {
 	serviceDiscovery := &fakes.ServiceDiscovery{}
 	env := newTestEnvironment(serviceDiscovery, testMesh, buildEnvoyFilterConfigStore(configPatches))
 	push := model.NewPushContext()
-	push.InitContext(env)
+	push.InitContext(env, nil, nil)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ApplyClusterPatches(tc.patchContext, tc.proxy, push, tc.input)

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -85,7 +85,7 @@ func newTestEnvironment(serviceDiscovery model.ServiceDiscovery, mesh meshconfig
 	}
 
 	env.PushContext = model.NewPushContext()
-	_ = env.PushContext.InitContext(env)
+	_ = env.PushContext.InitContext(env, nil, nil)
 
 	return env
 }
@@ -645,7 +645,7 @@ func TestApplyListenerPatches(t *testing.T) {
 	serviceDiscovery := &fakes.ServiceDiscovery{}
 	env := newTestEnvironment(serviceDiscovery, testMesh, buildEnvoyFilterConfigStore(configPatches))
 	push := model.NewPushContext()
-	push.InitContext(env)
+	push.InitContext(env, nil, nil)
 
 	type args struct {
 		patchContext networking.EnvoyFilter_PatchContext

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
@@ -419,7 +419,7 @@ func TestApplyRouteConfigurationPatches(t *testing.T) {
 	serviceDiscovery := &fakes.ServiceDiscovery{}
 	env := newTestEnvironment(serviceDiscovery, testMesh, buildEnvoyFilterConfigStore(configPatches))
 	push := model.NewPushContext()
-	push.InitContext(env)
+	push.InitContext(env, nil, nil)
 
 	sidecarNode := &model.Proxy{Type: model.SidecarProxy, ConfigNamespace: "not-default"}
 	gatewayNode := &model.Proxy{Type: model.Router, ConfigNamespace: "not-default"}

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -971,7 +971,7 @@ func buildEnv(t *testing.T, gateways []pilot_model.Config, virtualServices []pil
 		Mesh:             &m,
 	}
 
-	if err := env.PushContext.InitContext(&env); err != nil {
+	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 		t.Fatalf("failed to init push context: %v", err)
 	}
 	return env

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -665,7 +665,7 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 
 	env := buildListenerEnvWithVirtualServices(services, virtualServices)
 
-	if err := env.PushContext.InitContext(&env); err != nil {
+	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 		t.Fatalf("failed to initialize push context")
 	}
 	if registryOnly {

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -70,7 +70,7 @@ func TestListenerBuilder(t *testing.T) {
 
 	env := buildListenerEnv(services)
 
-	if err := env.PushContext.InitContext(&env); err != nil {
+	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 		t.Fatalf("init push context error: %s", err.Error())
 	}
 	instances := make([]*model.ServiceInstance, len(services))
@@ -114,7 +114,7 @@ func TestVirtualListenerBuilder(t *testing.T) {
 	services := []*model.Service{service}
 
 	env := buildListenerEnv(services)
-	if err := env.PushContext.InitContext(&env); err != nil {
+	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 		t.Fatalf("init push context error: %s", err.Error())
 	}
 	instances := make([]*model.ServiceInstance, len(services))
@@ -161,7 +161,7 @@ func prepareListeners(t *testing.T) []*v2.Listener {
 	services := []*model.Service{service}
 
 	env := buildListenerEnv(services)
-	if err := env.PushContext.InitContext(&env); err != nil {
+	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 		t.Fatalf("init push context error: %s", err.Error())
 	}
 	instances := make([]*model.ServiceInstance, len(services))

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -445,7 +445,7 @@ func TestOutboundListenerForHeadlessServices(t *testing.T) {
 			serviceDiscovery.ServicesReturns(services, nil)
 			serviceDiscovery.InstancesByPortReturns(tt.instances, nil)
 			env.ServiceDiscovery = serviceDiscovery
-			if err := env.PushContext.InitContext(&env); err != nil {
+			if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 				t.Errorf("Failed to initialize push context: %v", err)
 			}
 
@@ -1367,7 +1367,7 @@ func buildAllListeners(p plugin.Plugin, sidecarConfig *model.Config, services ..
 
 	env := buildListenerEnv(services)
 
-	if err := env.PushContext.InitContext(&env); err != nil {
+	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 		return nil
 	}
 
@@ -1406,7 +1406,7 @@ func buildOutboundListeners(p plugin.Plugin, proxy *model.Proxy, sidecarConfig *
 		env = buildListenerEnv(services)
 	}
 
-	if err := env.PushContext.InitContext(&env); err != nil {
+	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 		return nil
 	}
 
@@ -1424,7 +1424,7 @@ func buildOutboundListeners(p plugin.Plugin, proxy *model.Proxy, sidecarConfig *
 func buildInboundListeners(p plugin.Plugin, proxy *model.Proxy, sidecarConfig *model.Config, services ...*model.Service) []*xdsapi.Listener {
 	configgen := NewConfigGenerator([]plugin.Plugin{p})
 	env := buildListenerEnv(services)
-	if err := env.PushContext.InitContext(&env); err != nil {
+	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 		return nil
 	}
 	instances := make([]*model.ServiceInstance, len(services))

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -194,7 +194,7 @@ func buildEnvForClustersWithDistribute(distribute []*meshconfig.LocalityLoadBala
 	}
 
 	env.PushContext = model.NewPushContext()
-	_ = env.PushContext.InitContext(env)
+	_ = env.PushContext.InitContext(env, nil, nil)
 	env.PushContext.SetDestinationRules([]model.Config{
 		{ConfigMeta: model.ConfigMeta{
 			Type:    schemas.DestinationRule.Type,
@@ -256,7 +256,7 @@ func buildEnvForClustersWithFailover() *model.Environment {
 	}
 
 	env.PushContext = model.NewPushContext()
-	_ = env.PushContext.InitContext(env)
+	_ = env.PushContext.InitContext(env, nil, nil)
 	env.PushContext.SetDestinationRules([]model.Config{
 		{ConfigMeta: model.ConfigMeta{
 			Type:    schemas.DestinationRule.Type,

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -243,7 +243,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 	// check works, since it assumes ClearCache is called (and as such PushContext
 	// is initialized)
 	// InitContext returns immediately if the context was already initialized.
-	err := s.globalPushContext().InitContext(s.Env)
+	err := s.globalPushContext().InitContext(s.Env, nil, nil)
 	if err != nil {
 		// Error accessing the data - log and close, maybe a different pilot replica
 		// has more luck

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -155,7 +155,13 @@ func NewDiscoveryServer(
 	}
 
 	// Flush cached discovery responses whenever services configuration change.
-	serviceHandler := func(*model.Service, model.Event) { out.clearCache(&model.PushRequest{Full: true}) }
+	serviceHandler := func(*model.Service, model.Event) {
+		pushReq := &model.PushRequest{
+			Full:               true,
+			ConfigTypesUpdated: map[string]struct{}{schemas.ServiceEntry.Type: {}},
+		}
+		out.clearCache(pushReq)
+	}
 	if err := ctl.AppendServiceHandler(serviceHandler); err != nil {
 		adsLog.Errorf("Append service handler failed: %v", err)
 		return nil
@@ -179,9 +185,11 @@ func NewDiscoveryServer(
 		// TODO: changes should not trigger a full recompute of LDS/RDS/CDS/EDS
 		// (especially mixerclient HTTP and quota)
 		configHandler := func(c model.Config, e model.Event) {
-			updateReq := &model.PushRequest{Full: true}
-			updateReq.ConfigTypesUpdated = map[string]struct{}{c.Type: {}}
-			out.clearCache(updateReq)
+			pushReq := &model.PushRequest{
+				Full:               true,
+				ConfigTypesUpdated: map[string]struct{}{c.Type: {}},
+			}
+			out.clearCache(pushReq)
 		}
 		for _, descriptor := range schemas.Istio {
 			configCache.RegisterEventHandler(descriptor.Type, configHandler)
@@ -245,16 +253,15 @@ func (s *DiscoveryServer) Push(req *model.PushRequest) {
 		return
 	}
 	// Reset the status during the push.
-	pc := s.globalPushContext()
-	if pc != nil {
-		pc.OnConfigChange()
+	oldPushContext := s.globalPushContext()
+	if oldPushContext != nil {
+		oldPushContext.OnConfigChange()
 	}
 	// PushContext is reset after a config change. Previous status is
 	// saved.
 	t0 := time.Now()
 	push := model.NewPushContext()
-	err := push.InitContext(s.Env)
-	if err != nil {
+	if err := push.InitContext(s.Env, oldPushContext, req); err != nil {
 		adsLog.Errorf("XDS: Failed to update services: %v", err)
 		// We can't push if we can't read the data - stick with previous version.
 		pushContextErrors.Increment()
@@ -307,8 +314,8 @@ func (s *DiscoveryServer) ClearCache() {
 
 // clearCache will clear all envoy caches. Called by service, instance and config handlers.
 // This will impact the performance, since envoy will need to recalculate.
-func (s *DiscoveryServer) clearCache(updateRequest *model.PushRequest) {
-	s.ConfigUpdate(updateRequest)
+func (s *DiscoveryServer) clearCache(pushRequest *model.PushRequest) {
+	s.ConfigUpdate(pushRequest)
 }
 
 // ConfigUpdate implements ConfigUpdater interface, used to request pushes.

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -85,17 +85,13 @@ func NewServiceDiscovery(callbacks model.ConfigStoreCache, store model.IstioConf
 	return c
 }
 
-// AppendServiceHandler is an over-complicated way to add the v1 cache invalidation.
-// In <0.8 pilot it is not usingthe event or service param.
-// Deprecated: post 0.8 we're planning to use direct interface
+// AppendServiceHandler adds service resource event handler
 func (d *ServiceEntryStore) AppendServiceHandler(f func(*model.Service, model.Event)) error {
 	d.serviceHandlers = append(d.serviceHandlers, f)
 	return nil
 }
 
-// AppendInstanceHandler is an over-complicated way to add the v1 cache invalidation.
-// In <0.8 pilot it is not usingthe event or service param.
-// Deprecated: post 0.8 we're planning to use direct interface
+// AppendInstanceHandler adds instance event handler.
 func (d *ServiceEntryStore) AppendInstanceHandler(f func(*model.ServiceInstance, model.Event)) error {
 	d.instanceHandlers = append(d.instanceHandlers, f)
 	return nil

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -821,7 +821,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 			}
 		}
 
-		log.Infof("Handle service %s in namespace %s", svc.Name, svc.Namespace)
+		log.Debugf("Handle service %s in namespace %s", svc.Name, svc.Namespace)
 
 		hostname := svc.Name + "." + svc.Namespace
 		ports := map[string]uint32{}


### PR DESCRIPTION
Based on @rshriram's pr #16076, to implement incremental push context init.  Basically it is to make use of the old push context as much as possible. For example,  if a service updated, only reinitialize its related configs, services and sidecarscopes. 

It is to improve the performance and scalability of the control plane. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
