### PR TITLE
ServiceEntry resolution strict validation 

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2352,8 +2352,9 @@ func ValidateServiceEntry(_, _ string, config proto.Message) (errs error) {
 			errs = appendErrors(errs, fmt.Errorf("invalid host %s", hostname))
 		} else {
 			errs = appendErrors(errs, ValidateWildcardDomain(hostname))
-			if strings.HasPrefix(hostname, "*") && serviceEntry.Resolution == networking.ServiceEntry_DNS {
-				errs = appendErrors(errs, fmt.Errorf("wildcard hostname %s must not be set DNS resolution", hostname))
+			if strings.HasPrefix(hostname, "*") && len(serviceEntry.Endpoints) == 0 &&
+				serviceEntry.Resolution == networking.ServiceEntry_DNS {
+				errs = appendErrors(errs, fmt.Errorf("wildcard hostname %s without endpoints must not be set DNS resolution", hostname))
 			}
 		}
 	}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2352,6 +2352,9 @@ func ValidateServiceEntry(_, _ string, config proto.Message) (errs error) {
 			errs = appendErrors(errs, fmt.Errorf("invalid host %s", hostname))
 		} else {
 			errs = appendErrors(errs, ValidateWildcardDomain(hostname))
+			if strings.HasPrefix(hostname, "*") && serviceEntry.Resolution == networking.ServiceEntry_DNS {
+				errs = appendErrors(errs, fmt.Errorf("wildcard hostname %s must not be set DNS resolution", hostname))
+			}
 		}
 	}
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3270,6 +3270,16 @@ func TestValidateServiceEntries(t *testing.T) {
 		},
 			valid: true},
 
+		{name: "discovery type DNS without endpoints, wildcard hostname", in: networking.ServiceEntry{
+			Hosts: []string{"*.google.com"},
+			Ports: []*networking.Port{
+				{Number: 80, Protocol: "http", Name: "http-valid1"},
+				{Number: 8080, Protocol: "http", Name: "http-valid2"},
+			},
+			Resolution: networking.ServiceEntry_DNS,
+		},
+			valid: false},
+
 		{name: "discovery type DNS, label mtlsReady", in: networking.ServiceEntry{
 			Hosts: []string{"*.google.com"},
 			Ports: []*networking.Port{


### PR DESCRIPTION
Validate serviceentry strictly, do not allow wildcard hostname with resolution set to DNS when there is no endpoints set. Otherwise, envoy will async dns resolve the wildcard hostname.

The below config is invalid:

```
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: external-svc-wildcard-example
 spec:
   hosts:
   - "*.bar.com"
   location: MESH_EXTERNAL
   ports:
   - number: 80
     name: http
     protocol: HTTP
   resolution: DNS
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
