### PR TITLE
fix statname pattern for cross namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/DataDog/datadog-go v2.2.0+incompatible
 	github.com/Masterminds/sprig v2.14.1+incompatible // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect
+	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/SAP/go-hdb v0.14.1 // indirect
 	github.com/SermoDigital/jose v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/DataDog/datadog-go v2.2.0+incompatible
 	github.com/Masterminds/sprig v2.14.1+incompatible // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect
-	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/SAP/go-hdb v0.14.1 // indirect
 	github.com/SermoDigital/jose v0.9.1 // indirect

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1294,7 +1294,6 @@ func TestAltStatName(t *testing.T) {
 		statPattern string
 		host        string
 		subsetName  string
-		dnsDomain   string
 		port        *model.Port
 		want        string
 	}{
@@ -1303,16 +1302,22 @@ func TestAltStatName(t *testing.T) {
 			"%SERVICE%",
 			"reviews.default.svc.cluster.local",
 			"",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default",
+		},
+		{
+			"Service only pattern",
+			"%SERVICE%",
+			"reviews.namespace1.svc.cluster.local",
+			"",
+			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
+			"reviews.namespace1",
 		},
 		{
 			"Service FQDN only pattern",
 			"%SERVICE_FQDN%",
 			"reviews.default.svc.cluster.local",
 			"",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default.svc.cluster.local",
 		},
@@ -1321,7 +1326,6 @@ func TestAltStatName(t *testing.T) {
 			"%SERVICE%_%SERVICE_PORT%",
 			"reviews.default.svc.cluster.local",
 			"",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default_7443",
 		},
@@ -1330,7 +1334,6 @@ func TestAltStatName(t *testing.T) {
 			"%SERVICE%_%SERVICE_PORT_NAME%",
 			"reviews.default.svc.cluster.local",
 			"",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default_grpc-svc",
 		},
@@ -1339,7 +1342,6 @@ func TestAltStatName(t *testing.T) {
 			"%SERVICE%_%SERVICE_PORT_NAME%_%SERVICE_PORT%",
 			"reviews.default.svc.cluster.local",
 			"",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default_grpc-svc_7443",
 		},
@@ -1348,7 +1350,6 @@ func TestAltStatName(t *testing.T) {
 			"%SERVICE_FQDN%_%SERVICE_PORT%",
 			"reviews.default.svc.cluster.local",
 			"",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default.svc.cluster.local_7443",
 		},
@@ -1357,7 +1358,6 @@ func TestAltStatName(t *testing.T) {
 			"%SERVICE_FQDN%_%SERVICE_PORT_NAME%",
 			"reviews.default.svc.cluster.local",
 			"",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default.svc.cluster.local_grpc-svc",
 		},
@@ -1366,7 +1366,6 @@ func TestAltStatName(t *testing.T) {
 			"%SERVICE_FQDN%_%SERVICE_PORT_NAME%_%SERVICE_PORT%",
 			"reviews.default.svc.cluster.local",
 			"",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default.svc.cluster.local_grpc-svc_7443",
 		},
@@ -1375,7 +1374,6 @@ func TestAltStatName(t *testing.T) {
 			"%SERVICE_FQDN%%SUBSET_NAME%_%SERVICE_PORT_NAME%_%SERVICE_PORT%",
 			"reviews.default.svc.cluster.local",
 			"",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default.svc.cluster.local_grpc-svc_7443",
 		},
@@ -1384,7 +1382,6 @@ func TestAltStatName(t *testing.T) {
 			"%SERVICE_FQDN%.%SUBSET_NAME%.%SERVICE_PORT_NAME%_%SERVICE_PORT%",
 			"reviews.default.svc.cluster.local",
 			"v1",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default.svc.cluster.local.v1.grpc-svc_7443",
 		},
@@ -1393,7 +1390,6 @@ func TestAltStatName(t *testing.T) {
 			"%SERVICE_FQDN%.%DUMMY%",
 			"reviews.default.svc.cluster.local",
 			"v1",
-			"default.svc.cluster.local",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			"reviews.default.svc.cluster.local.%DUMMY%",
 		},
@@ -1401,7 +1397,7 @@ func TestAltStatName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := altStatName(tt.statPattern, tt.host, tt.subsetName, tt.dnsDomain, tt.port)
+			got := altStatName(tt.statPattern, tt.host, tt.subsetName, tt.port)
 			if got != tt.want {
 				t.Errorf("Expected alt statname %s, but got %s", tt.want, got)
 			}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1306,7 +1306,7 @@ func TestAltStatName(t *testing.T) {
 			"reviews.default",
 		},
 		{
-			"Service only pattern",
+			"Service only pattern across namespace",
 			"%SERVICE%",
 			"reviews.namespace1.svc.cluster.local",
 			"",


### PR DESCRIPTION
Fixes a minor bug in stat name generation for cross namespace services.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
