### PR TITLE
Expose secret eviction duration as environment var

### DIFF
--- a/security/cmd/node_agent_k8s/main_test.go
+++ b/security/cmd/node_agent_k8s/main_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/istio/security/pkg/nodeagent/sds"
@@ -44,6 +45,15 @@ func TestValidateOptions(t *testing.T) {
 				workloadSdsCacheOptions.InitialBackoff = 120001
 			},
 			errorMsg: "initial backoff should be within range 10 to 120000",
+		},
+		{
+			name: "eviction duration too small",
+			setExtraOptions: func() {
+				workloadSdsCacheOptions.EvictionDuration = 1 * time.Hour
+				workloadSdsCacheOptions.SecretTTL = 2 * time.Hour
+				workloadSdsCacheOptions.SecretRefreshGraceDuration = 5 * time.Minute
+			},
+			errorMsg: "EvictionDuration is less than (TTL - GraceDuration), found: 1h0m0s < 1h55m0s",
 		},
 		{
 			name: "same path for workload SDS and ingress SDS",


### PR DESCRIPTION
Please provide a description for what this PR is for.

* Expose SecretEvictionDuration as env variable like other nodeagent params
* Ensure EvictionDuration > TTL - GraceRotationDuration otherwise
secrets are removed before they are refreshed

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
