### PR TITLE
warn if proxy version does not exist in metadata

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -592,8 +592,6 @@ func ParseServiceNodeWithMetadata(s string, metadata *NodeMetadata) (*Proxy, err
 		log.Warnf("Istio Version is not found in metadata, which may have undesirable side effects")
 	}
 	out.IstioVersion = ParseIstioVersion(metadata.IstioVersion)
-	
-
 	if len(metadata.Labels) > 0 {
 		out.WorkloadLabels = labels.Collection{metadata.Labels}
 	}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -590,9 +590,9 @@ func ParseServiceNodeWithMetadata(s string, metadata *NodeMetadata) (*Proxy, err
 	out.DNSDomain = parts[3]
 	if len(metadata.IstioVersion) == 0 {
 		log.Warnf("Istio Version is not found in metadata, which may have undesirable side effects")
-	} else {
-		out.IstioVersion = ParseIstioVersion(metadata.IstioVersion)
 	}
+	out.IstioVersion = ParseIstioVersion(metadata.IstioVersion)
+	
 
 	if len(metadata.Labels) > 0 {
 		out.WorkloadLabels = labels.Collection{metadata.Labels}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -588,7 +588,11 @@ func ParseServiceNodeWithMetadata(s string, metadata *NodeMetadata) (*Proxy, err
 
 	out.ID = parts[2]
 	out.DNSDomain = parts[3]
-	out.IstioVersion = ParseIstioVersion(metadata.IstioVersion)
+	if len(metadata.IstioVersion) == 0 {
+		log.Warnf("Istio Version is not found in metadata, which may have undesirable side effects")
+	} else {
+		out.IstioVersion = ParseIstioVersion(metadata.IstioVersion)
+	}
 
 	if len(metadata.Labels) > 0 {
 		out.WorkloadLabels = labels.Collection{metadata.Labels}


### PR DESCRIPTION
If Proxy version (ISTIO_VERSION) field in  metadata does not exist for example older version have ISTIO_PROXY_VERSION, pilot silently treats it as Max version and sends all the latest config which may have undesirable effects. This PR adds a warning log line so that we can identify this problem more easily.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
