### PR TITLE
Fix serialized field names for remote service config in gateway deployment

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -136,13 +136,13 @@ spec:
         {{- if $.Values.global.proxy.envoyMetricsService.enabled }}
           - --envoyMetricsService
           {{- with  $.Values.global.proxy.envoyMetricsService }}
-          - '{"address":"{{ .host }}:{{.port }}"{{ if .tlsSettings }},"tlsSettings":{{ .tlsSettings | toJson }}{{- end }}{{ if .tcpKeepalive }},"tcpKeepalive":{{ .tcpKeepalive | toJson }}{{- end }}}'
+          - '{"address":"{{ .host }}:{{.port }}"{{ if .tlsSettings }},"tls_settings":{{ .tlsSettings | toJson }}{{- end }}{{ if .tcpKeepalive }},"tcp_keepalive":{{ .tcpKeepalive | toJson }}{{- end }}}'
           {{- end }}
         {{- end}}
         {{- if $.Values.global.proxy.envoyAccessLogService.enabled }}
           - --envoyAccessLogService
           {{- with  $.Values.global.proxy.envoyAccessLogService }}
-          - '{"address":"{{ .host }}:{{.port }}"{{ if .tlsSettings }},"tlsSettings":{{ .tlsSettings | toJson }}{{- end }}{{ if .tcpKeepalive }},"tcpKeepalive":{{ .tcpKeepalive | toJson }}{{- end }}}'
+          - '{"address":"{{ .host }}:{{.port }}"{{ if .tlsSettings }},"tls_settings":{{ .tlsSettings | toJson }}{{- end }}{{ if .tcpKeepalive }},"tcp_keepalive":{{ .tcpKeepalive | toJson }}{{- end }}}'
           {{- end }}
         {{- end }}
           - --proxyAdminPort


### PR DESCRIPTION
Please provide a description for what this PR is for.

The gateway deployment template currently uses camel case for the TLS/keepalive fields in the `RemoteService` configs, but the serializer actually expects snake case.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
