### PR TITLE
Revert "enhance envoy readiness probe"

### DIFF
--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -34,7 +34,6 @@ var (
 	goodStats      = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1"
 	liveServerInfo = &admin.ServerInfo{State: admin.ServerInfo_LIVE}
 	initServerInfo = &admin.ServerInfo{State: admin.ServerInfo_INITIALIZING}
-	emptyListeners = &admin.Listeners{}
 	listeners      = admin.Listeners{
 		ListenerStatuses: []*admin.ListenerStatus{
 			{
@@ -204,16 +203,6 @@ func TestEnvoyInitializingWithVirtualInboundListener(t *testing.T) {
 
 	err := probe.Check()
 
-	// Check should fail because listener is not listening yet.
-	g.Expect(err).To(HaveOccurred())
-
-	// Listen on Virtual Listener port.
-	l, _ := net.Listen("tcp", ":15006")
-	defer l.Close()
-
-	err = probe.Check()
-
-	// Check should succeed now.
 	g.Expect(err).ToNot(HaveOccurred())
 }
 
@@ -230,13 +219,6 @@ func createDefaultFuncMap(statsToReturn string, serverInfo proto.Message) map[st
 
 			// Send response to be tested
 			rw.Write([]byte(infoJSON))
-		},
-		"/listeners": func(rw http.ResponseWriter, _ *http.Request) {
-			jsonm := &jsonpb.Marshaler{Indent: "  "}
-			listenerJSON, _ := jsonm.MarshalToString(emptyListeners)
-
-			// Send response to be tested
-			rw.Write([]byte(listenerJSON))
 		},
 	}
 }

--- a/pilot/cmd/pilot-agent/status/util/listeners.go
+++ b/pilot/cmd/pilot-agent/status/util/listeners.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/pkg/model"
-	networking "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 )
 
 var (
@@ -68,27 +67,6 @@ func GetInboundListeningPorts(localHostAddr string, adminPort uint16, nodeType m
 	}
 
 	return ports, buf.String(), nil
-}
-
-// GetVirtualListenerPorts returns ports of Istio's traffic capture listeners.
-func GetVirtualListenerPorts(localHostAddr string, adminPort uint16) ([]uint16, error) {
-	buf, err := doHTTPGet(fmt.Sprintf("http://%s:%d/listeners?format=json", localHostAddr, adminPort))
-	if err != nil {
-		return nil, multierror.Prefix(err, "failed retrieving Envoy listeners:")
-	}
-
-	listeners := &admin.Listeners{}
-	if err := jsonpb.Unmarshal(buf, listeners); err != nil {
-		return nil, fmt.Errorf("failed parsing Envoy listeners %s: %s", buf, err)
-	}
-	ports := make([]uint16, 0)
-	for _, l := range listeners.ListenerStatuses {
-		if l.Name == networking.VirtualOutboundListenerName || l.Name == networking.VirtualInboundListenerName {
-			ports = append(ports, uint16(l.LocalAddress.GetSocketAddress().GetPortValue()))
-		}
-
-	}
-	return ports, nil
 }
 
 func isLocalListener(l string) bool {


### PR DESCRIPTION
Reverts istio/istio#17310

Once this PR was merged all of our tests started failing ~75% of the time. I suspected this PR to be the root cause (due to timing), but couldn't reproduce locally (likely due to my machine being larger than prow?) and eventually somehow we got things fairly stable, so I figured it was a coincidence regarding the timing.

However, I started experiencing extremely high CPU usage by the proxy in master. What I saw was 20k connections open at startup, causing cascading failures to mixer. I am not 100% sure why this change caused this, but doing a binary search points to this as the culprit. Happens 100% of the time with this PR and 0% of the time with `HEAD^`