### PR TITLE
Update Jaeger version to 1.14

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
         prometheus.io/scrape: "true"
-        prometheus.io/port: "16686"
+        prometheus.io/port: "14269"
 {{- if .Values.contextPath }}
         prometheus.io/path: "{{ .Values.contextPath }}/metrics"
 {{- else }}
@@ -50,6 +50,10 @@ spec:
           ports:
             - containerPort: 9411
             - containerPort: 16686
+            - containerPort: 14250
+            - containerPort: 14267
+            - containerPort: 14268
+            - containerPort: 14269
             - containerPort: 5775
               protocol: UDP
             - containerPort: 6831
@@ -81,11 +85,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 16686
+              port: 14269
           readinessProbe:
             httpGet:
               path: /
-              port: 16686
+              port: 14269
 {{- if eq .Values.jaeger.spanStorageType "badger" }}
           volumeMounts:
           - name: data

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
@@ -25,11 +25,6 @@ spec:
         sidecar.istio.io/inject: "false"
         prometheus.io/scrape: "true"
         prometheus.io/port: "14269"
-{{- if .Values.contextPath }}
-        prometheus.io/path: "{{ .Values.contextPath }}/metrics"
-{{- else }}
-        prometheus.io/path: "/{{ .Values.provider }}/metrics"
-{{- end }}
 {{- if .Values.jaeger.podAnnotations }}
 {{ toYaml .Values.jaeger.podAnnotations | indent 8 }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
@@ -55,6 +55,10 @@ items:
       port: 14268
       targetPort: 14268
       protocol: TCP
+    - name: jaeger-collector-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
     selector:
       app: jaeger
     type: ClusterIP

--- a/install/kubernetes/helm/istio/charts/tracing/values.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/values.yaml
@@ -31,7 +31,7 @@ podAntiAffinityTermLabelSelector: []
 jaeger:
   hub: docker.io/jaegertracing
   image: all-in-one
-  tag: 1.12
+  tag: 1.14
   podAnnotations: {}
   memory:
     max_traces: 50000


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR updates the Jaeger version to 1.14 and changes the prometheus metrics and readiness probe port to use the admin endpoint.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
