### PR TITLE
galley: Add fsnotify support to file system source

### DIFF
--- a/galley/pkg/config/source/kube/fs/source.go
+++ b/galley/pkg/config/source/kube/fs/source.go
@@ -77,6 +77,10 @@ func (s *source) Start() {
 
 	c := make(chan appsignals.Signal, 1)
 	appsignals.Watch(c)
+	shut := make(chan os.Signal, 1)
+	if err := appsignals.FileTrigger(s.root, syscall.SIGUSR1, shut); err != nil {
+		scope.Source.Errorf("Unable to setup FileTrigger for %s: %v", s.root, err)
+	}
 	go func() {
 		s.reload()
 		s.s.Start()
@@ -88,6 +92,7 @@ func (s *source) Start() {
 					s.reload()
 				}
 			case <-done:
+				shut <- syscall.SIGTERM
 				return
 			}
 		}


### PR DESCRIPTION
We have been using galley with filesystem backend in the VM infrastructure for a while.
Fsnotify support is required to kick off the config reload routines, when config files
on the disk change. Currently, the fs backend requires explicit triggers for file system changes
by asking the user to issue a SIGUSR1. This PR chains fsnotify triggers to this path [triggering
a SIGUSR1 when the backing files change].

Signed-off-by: Shriram Rajagopalan <rshriram@tetrate.io>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure