### PR TITLE
Add LDAP support to Kiali Helm chart

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
 name: kiali
-version: 1.1.0
-appVersion: 1.1.0
+version: 1.4.0
+appVersion: 1.4.0
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
@@ -13,6 +13,12 @@ data:
     istio_namespace: {{ .Release.Namespace }}
     auth:
       strategy: {{ .Values.dashboard.auth.strategy }}
+{{- if eq .Values.dashboard.auth.strategy "ldap" }}
+      ldap:
+{{- with .Values.dashboard.auth.strategy.ldap }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- end }}
     server:
       port: 20001
 {{- if .Values.contextPath }}

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -48,7 +48,21 @@ ingress:
 
 dashboard:
   auth:
-    strategy: login # Can be anonymous, login, or openshift
+    strategy: login # Can be anonymous, login, openshift, or ldap
+    # ldap: # This is required to use the ldap strategy
+    #   ldap_base: "DC=example,DC=com"
+    #   ldap_bind_dn: "CN={USERID},OU=xyz,OU=Users,OU=Accounts,DC=example,DC=com"
+    #   ldap_group_filter: "(cn=%s)"
+    #   ldap_host: "ldap-service.ldap-namespace"
+    #   ldap_insecure_skip_verify: true
+    #   ldap_mail_id_key: "mail"
+    #   ldap_member_of_key: "memberOf"
+    #   ldap_port: 123
+    #   ldap_role_filter: ".*xyz.*"
+    #   ldap_search_filter: "(&(name={USERID}))"
+    #   ldap_use_ssl: false
+    #   ldap_user_filter: "(cn=%s)"
+    #   ldap_user_id_key: "cn"
   secretName: kiali # You must create a secret with this name - one is not provided out-of-box.
   viewOnlyMode: false # Bind the service account to a role with only read access
   grafanaURL:  # If you have Grafana installed and it is accessible to client browsers, then set this to its external URL. Kiali will redirect users to this URL when Grafana metrics are to be shown.


### PR DESCRIPTION
Kiali supports using LDAP for authentication but the current Helm chart didn't enable the LDAP settings to be added to the config map if the auth strategy was set to *ldap*. This pull request enbles the setting of the LDAP values.

Fixes https://github.com/istio/istio/issues/17077.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
