### PR TITLE
WIP (No-test) Generate secure naming for trust domain aliases.

### DIFF
--- a/galley/pkg/config/processor/transforms/serviceentry/pod/cache.go
+++ b/galley/pkg/config/processor/transforms/serviceentry/pod/cache.go
@@ -231,5 +231,5 @@ func getLocality(region, zone string) string {
 
 // kubeToIstioServiceAccount converts a K8s service account to an Istio service account
 func kubeToIstioServiceAccount(saname string, ns string) string {
-	return spiffe.MustGenSpiffeURI(ns, saname)
+	return spiffe.MustGenSpiffeURI("", ns, saname)
 }

--- a/galley/pkg/runtime/projections/serviceentry/pod/cache.go
+++ b/galley/pkg/runtime/projections/serviceentry/pod/cache.go
@@ -229,5 +229,5 @@ func getLocality(region, zone string) string {
 
 // kubeToIstioServiceAccount converts a K8s service account to an Istio service account
 func kubeToIstioServiceAccount(saname string, ns string) string {
-	return spiffe.MustGenSpiffeURI(ns, saname)
+	return spiffe.MustGenSpiffeURI("", ns, saname)
 }

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -73,6 +73,10 @@ spec:
 {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}
 {{- end }}
+{{- if .Values.global.trustDomainAliases }}
+          # Non-empty list will end with a comma.
+          - --trust-domain-aliases={{- range .Values.global.trustDomainAliases }}{{ . | quote }},{{- end }}
+{{- end }}
           - --keepaliveMaxServerConnectionAge
           - "{{ .Values.keepaliveMaxServerConnectionAge }}"
           ports:

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -124,6 +124,17 @@ data:
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
     trustDomain: {{ .Values.global.trustDomain | quote }}
 
+    #  The trust domain aliases represent the aliases of trust_domain.
+    #  For example, if we have
+    #  trustDomain: td1
+    #  trustDomainAliases: [“td2”, "td3"]
+    #  Any service with the identity "td1/ns/foo/sa/a-service-account", "td2/ns/foo/sa/a-service-account",
+    #  or "td3/ns/foo/sa/a-service-account" will be treated the same in the Istio mesh.
+    trustDomainAliases:
+      {{- range .Values.global.trustDomainAliases }}
+      - {{ . | quote }}
+      {{- end }}
+
     # If true, automatically configure client side mTLS settings to match the corresponding service's
     # server side mTLS authentication policy, when destination rule for that service does not specify
     # TLS settings.

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -464,6 +464,14 @@ global:
   #   else:  default dns domain
   trustDomain: ""
 
+  #  The trust domain aliases represent the aliases of trust_domain.
+  #  For example, if we have
+  #  trustDomain: td1
+  #  trustDomainAliases: [“td2”, "td3"]
+  #  Any service with the identity "td1/ns/foo/sa/a-service-account", "td2/ns/foo/sa/a-service-account",
+  #  or "td3/ns/foo/sa/a-service-account" will be treated the same in the Istio mesh.
+  trustDomainAliases: []
+
   # Mesh ID means Mesh Identifier. It should be unique within the scope where
   # meshes will interact with each other, but it is not required to be
   # globally/universally unique. For example, if any of the following are true,

--- a/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
+++ b/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
@@ -17,10 +17,6 @@
 package contextgraph
 
 import (
-	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
-)
-
-import (
 	"flag"
 	"fmt"
 	"io"
@@ -34,10 +30,14 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
+
+	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
+
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+
 	gstatus "google.golang.org/grpc/status"
 )
 

--- a/mixer/test/client/gateway/gateway_test.go
+++ b/mixer/test/client/gateway/gateway_test.go
@@ -242,10 +242,11 @@ func (mock) GetService(_ host.Name) (*model.Service, error) { return nil, nil }
 func (mock) InstancesByPort(_ *model.Service, _ int, _ labels.Collection) ([]*model.ServiceInstance, error) {
 	return nil, nil
 }
-func (mock) ManagementPorts(_ string) model.PortList                        { return nil }
-func (mock) Services() ([]*model.Service, error)                            { return nil, nil }
-func (mock) WorkloadHealthCheckInfo(_ string) model.ProbeList               { return nil }
-func (mock) GetIstioServiceAccounts(_ *model.Service, ports []int) []string { return nil }
+func (mock) ManagementPorts(_ string) model.PortList                              { return nil }
+func (mock) Services() ([]*model.Service, error)                                  { return nil, nil }
+func (mock) WorkloadHealthCheckInfo(_ string) model.ProbeList                     { return nil }
+func (mock) GetIstioServiceAccounts(_ *model.Service, ports []int) []string       { return nil }
+func (mock) GetIstioServiceAccountAliases(_ *model.Service, ports []int) []string { return nil }
 
 const (
 	id = "id"

--- a/mixer/test/client/pilotplugin/pilotplugin_test.go
+++ b/mixer/test/client/pilotplugin/pilotplugin_test.go
@@ -314,10 +314,11 @@ func (mock) GetService(_ host.Name) (*model.Service, error) { return nil, nil }
 func (mock) InstancesByPort(_ *model.Service, _ int, _ labels.Collection) ([]*model.ServiceInstance, error) {
 	return nil, nil
 }
-func (mock) ManagementPorts(_ string) model.PortList                        { return nil }
-func (mock) Services() ([]*model.Service, error)                            { return nil, nil }
-func (mock) WorkloadHealthCheckInfo(_ string) model.ProbeList               { return nil }
-func (mock) GetIstioServiceAccounts(_ *model.Service, ports []int) []string { return nil }
+func (mock) ManagementPorts(_ string) model.PortList                              { return nil }
+func (mock) Services() ([]*model.Service, error)                                  { return nil, nil }
+func (mock) WorkloadHealthCheckInfo(_ string) model.ProbeList                     { return nil }
+func (mock) GetIstioServiceAccounts(_ *model.Service, ports []int) []string       { return nil }
+func (mock) GetIstioServiceAccountAliases(_ *model.Service, ports []int) []string { return nil }
 
 const (
 	id = "id"

--- a/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
+++ b/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
@@ -323,10 +323,11 @@ func (mock) GetService(_ host.Name) (*model.Service, error) { return nil, nil }
 func (mock) InstancesByPort(_ *model.Service, _ int, _ labels.Collection) ([]*model.ServiceInstance, error) {
 	return nil, nil
 }
-func (mock) ManagementPorts(_ string) model.PortList                        { return nil }
-func (mock) Services() ([]*model.Service, error)                            { return nil, nil }
-func (mock) WorkloadHealthCheckInfo(_ string) model.ProbeList               { return nil }
-func (mock) GetIstioServiceAccounts(_ *model.Service, ports []int) []string { return nil }
+func (mock) ManagementPorts(_ string) model.PortList                              { return nil }
+func (mock) Services() ([]*model.Service, error)                                  { return nil, nil }
+func (mock) WorkloadHealthCheckInfo(_ string) model.ProbeList                     { return nil }
+func (mock) GetIstioServiceAccounts(_ *model.Service, ports []int) []string       { return nil }
+func (mock) GetIstioServiceAccountAliases(_ *model.Service, ports []int) []string { return nil }
 
 const (
 	id = "id"

--- a/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
+++ b/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
@@ -193,10 +193,11 @@ func (mock) GetService(_ host.Name) (*model.Service, error) { return nil, nil }
 func (mock) InstancesByPort(_ *model.Service, _ int, _ labels.Collection) ([]*model.ServiceInstance, error) {
 	return nil, nil
 }
-func (mock) ManagementPorts(_ string) model.PortList                        { return nil }
-func (mock) Services() ([]*model.Service, error)                            { return nil, nil }
-func (mock) WorkloadHealthCheckInfo(_ string) model.ProbeList               { return nil }
-func (mock) GetIstioServiceAccounts(_ *model.Service, ports []int) []string { return nil }
+func (mock) ManagementPorts(_ string) model.PortList                              { return nil }
+func (mock) Services() ([]*model.Service, error)                                  { return nil, nil }
+func (mock) WorkloadHealthCheckInfo(_ string) model.ProbeList                     { return nil }
+func (mock) GetIstioServiceAccounts(_ *model.Service, ports []int) []string       { return nil }
+func (mock) GetIstioServiceAccountAliases(_ *model.Service, ports []int) []string { return nil }
 
 const (
 	id = "id"

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -61,6 +61,7 @@ var (
 			}
 
 			spiffe.SetTrustDomain(spiffe.DetermineTrustDomain(serverArgs.Config.ControllerOptions.TrustDomain, hasKubeRegistry()))
+			spiffe.SetTrustDomainAliases(serverArgs.Config.ControllerOptions.TrustDomainAliases)
 
 			// Create the stop channel for all of the servers.
 			stop := make(chan struct{})
@@ -133,6 +134,8 @@ func init() {
 		"DNS domain suffix")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ControllerOptions.TrustDomain, "trust-domain", "",
 		"The domain serves to identify the system with spiffe")
+	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.Config.ControllerOptions.TrustDomainAliases, "trust-domain-aliases", nil,
+		"The aliases of the trust domain")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Service.Consul.ServerURL, "consulserverURL", "",
 		"URL for the Consul server")
 	discoveryCmd.PersistentFlags().DurationVar(&serverArgs.Service.Consul.Interval, "consulserverInterval", 2*time.Second,

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -257,10 +257,11 @@ type ProbeList []*Probe
 //      --> NetworkEndpoint(172.16.0.3:8888), Service(catalog.myservice.com), Labels(kitty=cat)
 //      --> NetworkEndpoint(172.16.0.4:8888), Service(catalog.myservice.com), Labels(kitty=cat)
 type ServiceInstance struct {
-	Endpoint       NetworkEndpoint `json:"endpoint,omitempty"`
-	Service        *Service        `json:"service,omitempty"`
-	Labels         labels.Instance `json:"labels,omitempty"`
-	ServiceAccount string          `json:"serviceaccount,omitempty"`
+	Endpoint              NetworkEndpoint `json:"endpoint,omitempty"`
+	Service               *Service        `json:"service,omitempty"`
+	Labels                labels.Instance `json:"labels,omitempty"`
+	ServiceAccount        string          `json:"serviceaccount,omitempty"`
+	ServiceAccountAliases []string        `json:"-"`
 }
 
 // GetLocality returns the availability zone from an instance. If service instance label for locality
@@ -328,6 +329,10 @@ type IstioEndpoint struct {
 
 	// ServiceAccount holds the associated service account.
 	ServiceAccount string
+
+	// ServiceAccountAliases are the aliases of the ServiceAccount.
+	// This concept is the same as trust domain aliases and trust domain.
+	ServiceAccountAliases []string
 
 	// Network holds the network where this endpoint is present
 	Network string
@@ -445,6 +450,10 @@ type ServiceDiscovery interface {
 	// the specified service hostname and ports.
 	// Deprecated - service account tracking moved to XdsServer, incremental.
 	GetIstioServiceAccounts(svc *Service, ports []int) []string
+
+	// GetIstioServiceAccountAliases returns a list of service account aliases looked up from
+	// the specified service hostname and ports.
+	GetIstioServiceAccountAliases(svc *Service, ports []int) []string
 }
 
 // Match returns true if port matches with authentication port selector criteria.

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -800,7 +800,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := conditionallyConvertToIstioMtls(tt.tls, tt.sans, tt.sni, tt.proxy)
+			got := conditionallyConvertToIstioMtls(tt.tls, tt.sans, nil, tt.sni, tt.proxy)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Expected locality empty result %#v, but got %#v", tt.want, got)
 			}

--- a/pilot/pkg/networking/core/v1alpha3/fakes/fake_service_discovery.gen.go
+++ b/pilot/pkg/networking/core/v1alpha3/fakes/fake_service_discovery.gen.go
@@ -138,6 +138,10 @@ func (fake *ServiceDiscovery) GetIstioServiceAccounts(arg1 *model.Service, arg2 
 	return fakeReturns.result1
 }
 
+func (fake *ServiceDiscovery) GetIstioServiceAccountAliases(svc *model.Service, ports []int) []string {
+	return nil
+}
+
 func (fake *ServiceDiscovery) GetIstioServiceAccountsCallCount() int {
 	fake.getIstioServiceAccountsMutex.RLock()
 	defer fake.getIstioServiceAccountsMutex.RUnlock()

--- a/pilot/pkg/proxy/envoy/infra_auth.go
+++ b/pilot/pkg/proxy/envoy/infra_auth.go
@@ -29,7 +29,7 @@ const (
 func GetSAN(ns string, identity string) string {
 
 	if ns != "" {
-		return spiffe.MustGenSpiffeURI(ns, identity)
+		return spiffe.MustGenSpiffeURI("", ns, identity)
 	}
 	return spiffe.GenCustomSpiffe(identity)
 }

--- a/pilot/pkg/proxy/envoy/v2/mem.go
+++ b/pilot/pkg/proxy/envoy/v2/mem.go
@@ -360,9 +360,13 @@ func (sd *MemServiceDiscovery) GetIstioServiceAccounts(svc *model.Service, ports
 	defer sd.mutex.Unlock()
 	if svc.Hostname == "world.default.svc.cluster.local" {
 		return []string{
-			spiffe.MustGenSpiffeURI("default", "serviceaccount1"),
-			spiffe.MustGenSpiffeURI("default", "serviceaccount2"),
+			spiffe.MustGenSpiffeURI("", "default", "serviceaccount1"),
+			spiffe.MustGenSpiffeURI("", "default", "serviceaccount2"),
 		}
 	}
 	return make([]string, 0)
+}
+
+func (sd *MemServiceDiscovery) GetIstioServiceAccountAliases(svc *model.Service, ports []int) []string {
+	return nil
 }

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -324,3 +324,12 @@ func (c *Controller) GetIstioServiceAccounts(svc *model.Service, ports []int) []
 	}
 	return nil
 }
+
+func (c *Controller) GetIstioServiceAccountAliases(svc *model.Service, ports []int) []string {
+	for _, r := range c.GetRegistries() {
+		if svcAccountAliases := r.GetIstioServiceAccountAliases(svc, ports); svcAccountAliases != nil {
+			return svcAccountAliases
+		}
+	}
+	return nil
+}

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -234,8 +234,12 @@ func (c *Controller) GetIstioServiceAccounts(svc *model.Service, ports []int) []
 	// Follow - https://goo.gl/Dt11Ct
 
 	return []string{
-		spiffe.MustGenSpiffeURI("default", "default"),
+		spiffe.MustGenSpiffeURI("", "default", "default"),
 	}
+}
+
+func (c *Controller) GetIstioServiceAccountAliases(svc *model.Service, ports []int) []string {
+	return nil
 }
 
 func (c *Controller) initCache() error {

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -268,3 +268,7 @@ func (d *ServiceEntryStore) GetIstioServiceAccounts(svc *model.Service, ports []
 	// service, with service instances, and dns.
 	return nil
 }
+
+func (d *ServiceEntryStore) GetIstioServiceAccountAliases(svc *model.Service, ports []int) []string {
+	return nil
+}

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -264,9 +264,13 @@ func (sd *ServiceDiscovery) WorkloadHealthCheckInfo(addr string) model.ProbeList
 func (sd *ServiceDiscovery) GetIstioServiceAccounts(svc *model.Service, ports []int) []string {
 	if svc.Hostname == "world.default.svc.cluster.local" {
 		return []string{
-			spiffe.MustGenSpiffeURI("default", "serviceaccount1"),
-			spiffe.MustGenSpiffeURI("default", "serviceaccount2"),
+			spiffe.MustGenSpiffeURI("", "default", "serviceaccount1"),
+			spiffe.MustGenSpiffeURI("", "default", "serviceaccount2"),
 		}
 	}
 	return make([]string, 0)
+}
+
+func (sd *ServiceDiscovery) GetIstioServiceAccountAliases(svc *model.Service, ports []int) []string {
+	return nil
 }

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -140,7 +140,7 @@ func setStatsOptions(opts map[string]interface{}, meta *model.NodeMetadata, node
 
 func defaultPilotSan() []string {
 	return []string{
-		spiffe.MustGenSpiffeURI("istio-system", "istio-pilot-service-account")}
+		spiffe.MustGenSpiffeURI("", "istio-system", "istio-pilot-service-account")}
 }
 
 func configFile(config string, epoch int) string {

--- a/pkg/spiffe/spiffe_test.go
+++ b/pkg/spiffe/spiffe_test.go
@@ -61,7 +61,7 @@ func TestGenSpiffeURI(t *testing.T) {
 	}
 	for id, tc := range testCases {
 		SetTrustDomain(tc.trustDomain)
-		got, err := GenSpiffeURI(tc.namespace, tc.serviceAccount)
+		got, err := GenSpiffeURI("", tc.namespace, tc.serviceAccount)
 		if tc.expectedError == "" && err != nil {
 			t.Errorf("teste case [%v] failed, error %v", id, tc)
 		}
@@ -107,7 +107,7 @@ func TestGetSetTrustDomain(t *testing.T) {
 }
 
 func TestMustGenSpiffeURI(t *testing.T) {
-	if nonsense := MustGenSpiffeURI("", ""); nonsense != "spiffe://cluster.local/ns//sa/" {
+	if nonsense := MustGenSpiffeURI("", "", ""); nonsense != "spiffe://cluster.local/ns//sa/" {
 		t.Errorf("Unexpected spiffe URI for empty namespace and service account: %s", nonsense)
 	}
 }

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -403,7 +403,7 @@ func (sc *SecretController) enableNamespaceRetroactive(namespace string) {
 }
 
 func (sc *SecretController) generateKeyAndCert(saName string, saNamespace string) ([]byte, []byte, error) {
-	id := spiffe.MustGenSpiffeURI(saNamespace, saName)
+	id := spiffe.MustGenSpiffeURI("", saNamespace, saName)
 	if sc.dnsNames != nil {
 		// Control plane components in same namespace.
 		if e, ok := sc.dnsNames[saName]; ok {

--- a/security/pkg/platform/gcp.go
+++ b/security/pkg/platform/gcp.go
@@ -86,7 +86,7 @@ func (ci *GcpClientImpl) GetServiceIdentity() (string, error) {
 		log.Errorf("Failed to get service account with error: %v", err)
 		return "", err
 	}
-	return spiffe.GenSpiffeURI("default", serviceAccount)
+	return spiffe.GenSpiffeURI("", "default", serviceAccount)
 }
 
 // GetAgentCredential returns the GCP JWT for the serivce account.

--- a/security/pkg/registry/kube/serviceaccount.go
+++ b/security/pkg/registry/kube/serviceaccount.go
@@ -79,7 +79,7 @@ func (c *ServiceAccountController) Run(stopCh chan struct{}) {
 }
 
 func getSpiffeID(sa *v1.ServiceAccount) string {
-	return spiffe.MustGenSpiffeURI(sa.GetNamespace(), sa.GetName())
+	return spiffe.MustGenSpiffeURI("", sa.GetNamespace(), sa.GetName())
 }
 
 func (c *ServiceAccountController) serviceAccountAdded(obj interface{}) {

--- a/security/tests/integration/kubernetes_utils.go
+++ b/security/tests/integration/kubernetes_utils.go
@@ -349,7 +349,7 @@ func ExamineSecret(secret *v1.Secret) error {
 		}
 	}
 
-	expectedID, err := spiffe.GenSpiffeURI(secret.GetNamespace(), "default")
+	expectedID, err := spiffe.GenSpiffeURI("", secret.GetNamespace(), "default")
 	if err != nil {
 		return err
 	}

--- a/tests/integration/security/util/secret/secret.go
+++ b/tests/integration/security/util/secret/secret.go
@@ -41,7 +41,7 @@ func Examine(secret *v1.Secret) error {
 		}
 	}
 
-	expectedID, err := spiffe.GenSpiffeURI(secret.GetNamespace(), "default")
+	expectedID, err := spiffe.GenSpiffeURI("", secret.GetNamespace(), "default")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
 Generate secure naming for trust domain aliases. Installing Istio with "cluster.local" trust domain and "td1" and "td2" aliases gives 
```
                "validation_context": {
                  "trusted_ca": {
                    "filename": "/etc/certs/root-cert.pem"
                  },
                  "verify_subject_alt_name": [
                    "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account",
                    "spiffe://td1/ns/istio-system/sa/istio-pilot-service-account",
                    "spiffe://td2/ns/istio-system/sa/istio-pilot-service-account"
                  ]
                },
```

More context: https://docs.google.com/document/d/1wzHUjYAR6qu3g_z58z0m34sIrEX8czfSbv0a48KvA4s

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
