### PR TITLE
Update status controller to use a subfield and structured status messages

### DIFF
--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -53,12 +53,12 @@ type Message struct {
 }
 
 // Unstructured returns this message as a JSON-style unstructured map
-func (m *Message) Unstructured() map[string]interface{} {
+func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	result["code"] = m.Type.Code()
-	result["level"] = m.Type.Level()
-	if m.Origin != nil {
+	result["level"] = string(m.Type.Level())
+	if includeOrigin && m.Origin != nil {
 		result["origin"] = m.Origin.FriendlyName()
 	}
 	result["message"] = fmt.Sprintf(m.Type.Template(), m.Parameters...)

--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -52,20 +52,24 @@ type Message struct {
 	Origin resource.Origin
 }
 
+// Unstructured returns this message as a JSON-style unstructured map
+func (m *Message) Unstructured() map[string]interface{} {
+	result := make(map[string]interface{})
+
+	result["code"] = m.Type.Code()
+	result["level"] = m.Type.Level()
+	if m.Origin != nil {
+		result["origin"] = m.Origin.FriendlyName()
+	}
+	result["message"] = fmt.Sprintf(m.Type.Template(), m.Parameters...)
+
+	return result
+}
+
 // String implements io.Stringer
 func (m *Message) String() string {
-	return m.toString(true)
-}
-
-// StatusString creates a short-form string version of this message, suitable for putting in status fields of
-// individual objects.
-func (m *Message) StatusString() string {
-	return m.toString(false)
-}
-
-func (m *Message) toString(includeOrigin bool) string {
 	origin := ""
-	if includeOrigin && m.Origin != nil {
+	if m.Origin != nil {
 		origin = "(" + m.Origin.FriendlyName() + ")"
 	}
 	return fmt.Sprintf(

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -41,5 +41,18 @@ func TestMessageWithOrigin_String(t *testing.T) {
 	m := NewMessage(mt, o, "Feta")
 
 	g.Expect(m.String()).To(Equal(`Error [IST-0042](toppings/cheese) Cheese type not found: "Feta"`))
-	g.Expect(m.StatusString()).To(Equal(`Error [IST-0042] Cheese type not found: "Feta"`))
+}
+
+func TestMessage_Unstructured(t *testing.T) {
+	g := NewGomegaWithT(t)
+	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
+	m := NewMessage(mt, nil, "Feta")
+
+	g.Expect(m.Unstructured(true)).To(Not(HaveKey("origin")))
+	g.Expect(m.Unstructured(false)).To(Not(HaveKey("origin")))
+
+	m = NewMessage(mt, testOrigin("toppings/cheese"), "Feta")
+
+	g.Expect(m.Unstructured(true)).To((HaveKey("origin")))
+	g.Expect(m.Unstructured(false)).To(Not(HaveKey("origin")))
 }

--- a/galley/pkg/config/source/kube/apiserver/status/controller.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller.go
@@ -102,7 +102,15 @@ func (c *ControllerImpl) Stop() {
 // UpdateResourceStatus is called by the source to relay the currently observed status of a resource.
 func (c *ControllerImpl) UpdateResourceStatus(
 	col collection.Name, name resource.Name, version resource.Version, status interface{}) {
-	c.state.setObserved(col, name, version, status)
+
+	// Extract the subfield this controller manages
+	statusMap, ok := status.(map[string]interface{})
+	if !ok {
+		// If the status field was something other than a map, treat it like it was empty
+		// for the purpose of "observed"
+	}
+
+	c.state.setObserved(col, name, version, statusMap[c.subfield])
 }
 
 // Report the given set of messages towards particular resources.

--- a/galley/pkg/config/source/kube/apiserver/status/controller.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller.go
@@ -104,11 +104,9 @@ func (c *ControllerImpl) UpdateResourceStatus(
 	col collection.Name, name resource.Name, version resource.Version, status interface{}) {
 
 	// Extract the subfield this controller manages
-	statusMap, ok := status.(map[string]interface{})
-	if !ok {
-		// If the status field was something other than a map, treat it like it was empty
-		// for the purpose of "observed"
-	}
+	// If the status field was something other than a map, treat it like it was an empty map
+	// for the purpose of "observed"
+	statusMap, _ := status.(map[string]interface{})
 
 	c.state.setObserved(col, name, version, statusMap[c.subfield])
 }

--- a/galley/pkg/config/source/kube/apiserver/status/controller.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller.go
@@ -47,13 +47,18 @@ type ControllerImpl struct {
 
 	// Wait group for synchronizing the exit of the background go routine.
 	wg sync.WaitGroup
+
+	// Subfield of status that this controller manages
+	subfield string
 }
 
 var _ Controller = &ControllerImpl{}
 
 // NewController returns a new instance of controller.
-func NewController() *ControllerImpl {
-	return &ControllerImpl{}
+func NewController(subfield string) *ControllerImpl {
+	return &ControllerImpl{
+		subfield: subfield,
+	}
 }
 
 // Start the controller. This will reset the internal state.
@@ -80,7 +85,7 @@ func (c *ControllerImpl) Start(p *rt.Provider, resources []schema.KubeResource) 
 	}
 
 	c.wg.Add(1)
-	go run(c.state, ifaces, &c.wg)
+	go run(c.state, c.subfield, ifaces, &c.wg)
 }
 
 // Stop the controller
@@ -127,7 +132,7 @@ func (c *ControllerImpl) Report(messages diag.Messages) {
 	c.state.applyMessages(msgs)
 }
 
-func run(state *state, ifaces map[collection.Name]dynamic.NamespaceableResourceInterface, wg *sync.WaitGroup) {
+func run(state *state, subfield string, ifaces map[collection.Name]dynamic.NamespaceableResourceInterface, wg *sync.WaitGroup) {
 mainloop:
 	for {
 		st, ok := state.dequeueWork()
@@ -157,10 +162,26 @@ mainloop:
 			continue mainloop
 		}
 
+		// Get the map of status objects. If it doesn't already exist, create it.
+		statusObj, ok := u.Object["status"]
+		if !ok {
+			statusObj = make(map[string]interface{})
+		}
+		statusMap, ok := statusObj.(map[string]interface{})
+		if !ok {
+			scope.Source.Warnf("Failed to parse the status field as a map. Previous status value will be discarded! Status value was: %v", statusObj)
+		}
+
+		// Update the status field (for the subfield this controller manages) to match desired status
+		// If there are no other subfields left, also delete the status field
 		if st.desiredStatus != nil {
-			u.Object["status"] = st.desiredStatus
+			statusMap[subfield] = st.desiredStatus
+			u.Object["status"] = statusMap
 		} else {
-			delete(u.Object, "status")
+			delete(statusMap, subfield)
+			if len(statusMap) == 0 {
+				delete(u.Object, "status")
+			}
 		}
 
 		_, err = iface.Namespace(ns).UpdateStatus(u, metav1.UpdateOptions{})

--- a/galley/pkg/config/source/kube/apiserver/status/controller_test.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -325,7 +326,7 @@ func setupClient() (*mock.Kube, *fake.FakeDynamicClient) {
 	return k, cl
 }
 
-func setupClientWithReactors(retVal *unstructured.Unstructured, updateErrVal error) (*mock.Kube, *fake.FakeDynamicClient) {
+func setupClientWithReactors(retVal runtime.Object, updateErrVal error) (*mock.Kube, *fake.FakeDynamicClient) {
 	k, cl := setupClient()
 
 	cl.ReactionChain = nil

--- a/galley/pkg/config/source/kube/apiserver/status/status.go
+++ b/galley/pkg/config/source/kube/apiserver/status/status.go
@@ -15,6 +15,7 @@
 package status
 
 import (
+	"reflect"
 	"sync"
 
 	"istio.io/istio/galley/pkg/config/resource"
@@ -87,5 +88,6 @@ func (r *status) isEnqueued() bool {
 }
 
 func (r *status) needsChange() bool {
-	return r.observedStatus != r.desiredStatus
+	// Status may be a slice, in which case equality isn't defined, so we use reflect.DeepEqual instead
+	return !reflect.DeepEqual(r.observedStatus, r.desiredStatus)
 }

--- a/galley/pkg/config/source/kube/apiserver/status/util.go
+++ b/galley/pkg/config/source/kube/apiserver/status/util.go
@@ -26,13 +26,9 @@ func toStatusValue(msgs diag.Messages) interface{} {
 
 	result := make([]interface{}, 0)
 	for _, m := range msgs {
-		u := m.Unstructured()
-
 		// For the purposes of status update, the origin field is redundant
 		// since we're attaching the message to the origin resource.
-		delete(u, "origin")
-
-		result = append(result, u)
+		result = append(result, m.Unstructured(false))
 	}
 
 	return result

--- a/galley/pkg/config/source/kube/apiserver/status/util.go
+++ b/galley/pkg/config/source/kube/apiserver/status/util.go
@@ -15,8 +15,6 @@
 package status
 
 import (
-	"strings"
-
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 )
 
@@ -26,13 +24,16 @@ func toStatusValue(msgs diag.Messages) interface{} {
 		return nil
 	}
 
-	var lines strings.Builder
-
-	// TODO: This should be structured, not just a string
+	result := make([]interface{}, 0)
 	for _, m := range msgs {
-		lines.WriteString(m.StatusString())
-		lines.WriteString("\n")
+		u := m.Unstructured()
+
+		// For the purposes of status update, the origin field is redundant
+		// since we're attaching the message to the origin resource.
+		delete(u, "origin")
+
+		result = append(result, u)
 	}
 
-	return lines.String()
+	return result
 }

--- a/galley/pkg/config/source/kube/apiserver/status/util.go
+++ b/galley/pkg/config/source/kube/apiserver/status/util.go
@@ -28,6 +28,7 @@ func toStatusValue(msgs diag.Messages) interface{} {
 
 	var lines strings.Builder
 
+	// TODO: This should be structured, not just a string
 	for _, m := range msgs {
 		lines.WriteString(m.StatusString())
 		lines.WriteString("\n")

--- a/galley/pkg/server/components/processing2.go
+++ b/galley/pkg/server/components/processing2.go
@@ -310,7 +310,7 @@ func (p *Processing2) createSourceAndStatusUpdater(resources schema.KubeResource
 
 		var statusCtl status.Controller
 		if p.args.EnableConfigAnalysis {
-			statusCtl = status.NewController()
+			statusCtl = status.NewController("validationMessages")
 		}
 
 		o := apiserver.Options{


### PR DESCRIPTION
1. Each status update controller instance is now responsible for managing a single subfield of the "status" subresource, so it isn't monopolizing the subresource for other use cases.
2. The validation messages in the status updates are now structured.

Before:
```
status:|
  Error [IST0101] Referenced gateway not found: "bogus-reviews-gateway-1"
  Error [IST0101] Referenced host not found: "reviews-bogus2"
  Error [IST0101] Referenced host+subset in destinationrule not found: "reviews-bogus2+v1"
  Error [IST0101] Referenced host+subset in destinationrule not found: "reviews+v1-bogus"
```

After:
```
status:
  validationMessages:
  - code: IST0101
    level: Error
    message: 'Referenced gateway not found: "bogus-reviews-gateway-1"'
  - code: IST0101
    level: Error
    message: 'Referenced host not found: "reviews-bogus2"'
  - code: IST0101
    level: Error
    message: 'Referenced host+subset in destinationrule not found: "reviews-bogus2+v1"'
  - code: IST0101
    level: Error
    message: 'Referenced host+subset in destinationrule not found: "reviews+v1-bogus"'
```

Solves https://github.com/istio/istio/issues/17454

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
