### PR TITLE
Disable sds_vault_flow for Istio 1.3

### DIFF
--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -39,6 +39,8 @@ func TestSdsVaultCaFlow(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			// Istio 1.3 uses Trustworthy JWT, which, unlike normal k8s JWT, is not
 			// recognized on Vault.
+			// https://github.com/istio/istio/issues/17561,
+		  // https://github.com/istio/istio/issues/17572.
 			t.Skip("skipped for Istio 1.3, which uses Trustworthy JWT")
 
 			istioCfg := istio.DefaultConfigOrFail(t, ctx)

--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -37,6 +37,9 @@ func TestSdsVaultCaFlow(t *testing.T) {
 	framework.NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
+			// Istio 1.3 uses Trustworthy JWT, which, unlike normal k8s JWT, is not
+			// recognized on Vault.
+			t.Skip("skipped for Istio 1.3, which uses Trustworthy JWT")
 
 			istioCfg := istio.DefaultConfigOrFail(t, ctx)
 

--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -40,8 +40,8 @@ func TestSdsVaultCaFlow(t *testing.T) {
 			// Istio 1.3 uses Trustworthy JWT, which, unlike normal k8s JWT, is not
 			// recognized on Vault.
 			// https://github.com/istio/istio/issues/17561,
-		  // https://github.com/istio/istio/issues/17572.
-			t.Skip("skipped for Istio 1.3, which uses Trustworthy JWT")
+			// https://github.com/istio/istio/issues/17572.
+			t.Skip("skipped for Istio versions using Trustworthy JWT, https://github.com/istio/istio/issues/17572")
 
 			istioCfg := istio.DefaultConfigOrFail(t, ctx)
 


### PR DESCRIPTION
Istio 1.3 uses Trustworthy JWT, which, unlike normal k8s JWT, is not recognized on Vault.

This PR is for the issue: https://github.com/istio/istio/issues/17561

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X] Security
[ X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
