### PR TITLE
explicitly use python3 to run perf benchmark script

### DIFF
--- a/prow/setup_perf_cluster_for_tests.sh
+++ b/prow/setup_perf_cluster_for_tests.sh
@@ -81,7 +81,7 @@ function export_metrics() {
     do
       echo "Running for $i min"
       sleep 1m
-      python prom.py http://localhost:8060 60 --no-aggregate >> "${perf_metrics}"
+      python3 prom.py http://localhost:8060 60 --no-aggregate >> "${perf_metrics}"
     done
 
     gsutil -q cp "${perf_metrics}" "gs://$CB_GCS_BUILD_PATH/perf_metrics.txt"


### PR DESCRIPTION
A related follow up fix for this PR: https://github.com/istio/tools/pull/404