### PR TITLE
Add labels to bookinfo serviceaccounts

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -13,6 +13,20 @@
 #   limitations under the License.
 
 ##################################################################################################
+# This file defines the services, service accounts, and deployments for the Bookinfo sample.
+#
+# To apply all 4 Bookinfo services, their corresponding service accounts, and deployments:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
+#
+# Alternatively, you can deploy any resource separately:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l service=reviews # reviews Service
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l account=reviews # reviews ServiceAccount
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l app=reviews,version=v3 # reviews-v3 Deployment
+##################################################################################################
+
+##################################################################################################
 # Details service
 ##################################################################################################
 apiVersion: v1

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -33,6 +33,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bookinfo-details
+  labels:
+    account: details
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -82,6 +84,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bookinfo-ratings
+  labels:
+    account: ratings
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -131,6 +135,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bookinfo-reviews
+  labels:
+    account: reviews
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -234,6 +240,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bookinfo-productpage
+  labels:
+    account: productpage
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Add labels so that the service accounts can be selectively applied, just like all the other resources in bookinfo.yaml. For example:
```
kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l account=reviews
```

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
