### PR TITLE
perf: don't sort XDS requests and avoid resize

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads_common_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common_test.go
@@ -15,6 +15,7 @@
 package v2
 
 import (
+	"strconv"
 	"testing"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -52,5 +53,27 @@ func TestProxyNeedsPush(t *testing.T) {
 				t.Fatalf("Got needs push = %v, expected %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func BenchmarkListEquals(b *testing.B) {
+	size := 100
+	var l []string
+	for i := 0; i < size; i++ {
+		l = append(l, strconv.Itoa(i))
+	}
+	var equal []string
+	for i := 0; i < size; i++ {
+		equal = append(equal, strconv.Itoa(i))
+	}
+	var notEqual []string
+	for i := 0; i < size; i++ {
+		notEqual = append(notEqual, strconv.Itoa(i))
+	}
+	notEqual[size-1] = "z"
+
+	for n := 0; n < b.N; n++ {
+		listEqualUnordered(l, equal)
+		listEqualUnordered(l, notEqual)
 	}
 }

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -848,7 +848,8 @@ func buildLocalityLbEndpointsFromShards(
 			locLbEps, found := localityEpMap[ep.Locality]
 			if !found {
 				locLbEps = &endpoint.LocalityLbEndpoints{
-					Locality: util.ConvertLocality(ep.Locality),
+					Locality:    util.ConvertLocality(ep.Locality),
+					LbEndpoints: make([]*endpoint.LbEndpoint, 0, len(endpoints)),
 				}
 				localityEpMap[ep.Locality] = locLbEps
 			}


### PR DESCRIPTION
* For high number of connections the sorting is taking 5% of pilot CPU.

Benchmarks show:
Before: BenchmarkListEquals-6              21976             53132 ns/op
6656 B/op        408 allocs/op

After: BenchmarkListEquals-6              50162             23798 ns/op
5696 B/op          5 allocs/op

* We are doing a ton of splice resizes for endpoints, when we know the
size of the list ahead of time

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
