### PR TITLE
extract BUILD_WITH_CONTAINER docker command into a script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,58 +28,11 @@
 # figure out all the tools you need in your environment to make that work.
 export BUILD_WITH_CONTAINER ?= 0
 
-LOCAL_ARCH := $(shell uname -m)
-ifeq ($(LOCAL_ARCH),x86_64)
-    TARGET_ARCH ?= amd64
-else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
-    TARGET_ARCH ?= arm64
-else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
-    TARGET_ARCH ?= arm
-else
-   $(error "This system's architecture $(LOCAL_ARCH) isn't recognized/supported")
-endif
-
-LOCAL_OS := $(shell uname)
-ifeq ($(LOCAL_OS),Linux)
-   TARGET_OS ?= linux
-   READLINK_FLAGS="-f"
-else ifeq ($(LOCAL_OS),Darwin)
-   TARGET_OS ?= darwin
-   READLINK_FLAGS=""
-else
-   $(error "This system's OS $(LOCAL_OS) isn't recognized/supported")
-endif
-
-REPO_ROOT = $(shell git rev-parse --show-toplevel)
-REPO_NAME = $(shell basename $(REPO_ROOT))
 TARGET_OUT ?= $(HOME)/istio_out/$(REPO_NAME)
 
 ifeq ($(BUILD_WITH_CONTAINER),1)
-CONTAINER_CLI ?= docker
-DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
-IMG ?= gcr.io/istio-testing/build-tools:2019-10-02T14-57-08
-UID = $(shell id -u)
-PWD = $(shell pwd)
-
-$(info Building with the build container: $(IMG).)
-
-# Determine the timezone across various platforms to pass into the
-# docker run operation. This operation assumes zoneinfo is within
-# the path of the file.
-TIMEZONE=`readlink $(READLINK_FLAGS) /etc/localtime | sed -e 's/^.*zoneinfo\///'`
-
-RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
-	-e IN_BUILD_CONTAINER="$(BUILD_WITH_CONTAINER)" \
-	-e TZ="$(TIMEZONE)" \
-	-e TARGET_ARCH="$(TARGET_ARCH)" \
-	-e TARGET_OS="$(TARGET_OS)" \
-	-v /etc/passwd:/etc/passwd:ro \
-	$(DOCKER_SOCKET_MOUNT) \
-	$(CONTAINER_OPTIONS) \
-	--mount type=bind,source="$(PWD)",destination="/work" \
-	--mount type=bind,source="$(TARGET_OUT)",destination="/targetout" \
-	--mount type=volume,source=home,destination="/home" \
-	-w /work $(IMG)
+$(info Building with the build container.)
+RUN = ./common/scripts/run-docker.sh
 else
 $(info Building with your local toolchain.)
 RUN =
@@ -94,5 +47,9 @@ MAKE = $(RUN) make --no-print-directory -e -f Makefile.core.mk
 default:
 	@mkdir -p $(TARGET_OUT)
 	@$(MAKE)
+
+shell:
+	@mkdir -p $(TARGET_OUT)
+	@$(RUN) /bin/bash
 
 .PHONY: default

--- a/common/scripts/run-docker.sh
+++ b/common/scripts/run-docker.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -ex
+
+istio_dir=$(git rev-parse --show-toplevel)
+repo_name=$(basename $istio_dir)
+target_out=$HOME/istio_out/$repo_name
+
+image="gcr.io/istio-testing/build-tools:latest"
+
+docker pull $image
+
+docker run -it --rm -u $(id -u) \
+    -u root \
+    --cap-add=NET_ADMIN \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /etc/passwd:/etc/passwd:ro \
+    $CONTAINER_OPTIONS \
+    -e WHAT=$WHAT \
+    --mount type=bind,source="$istio_dir",destination="/work" \
+    --mount type=bind,source="$target_out",destination="/targetout" \
+    --mount type=volume,source=home,destination="/home" \
+    -w /work $image $@
+

--- a/common/scripts/run-docker.sh
+++ b/common/scripts/run-docker.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -ex
 


### PR DESCRIPTION
Also adds `make shell` to drop the user to a bash prompt.

I've tested this manually fairly extensively. This is adapted from a
script I've been using since I started working with istio.

Not all make targets succeed, but they fail the same way after these changes
as they did before. Presumably those commands aren't being used by anyone,
or the people who use them know how to make them pass. Please advise if this
isn't enough.

resolves #17476 - all commands arguments to run-docker.sh are passed
into the container

resolves #17474 - only for the case of WHAT though, is there documentation on
other environment variables that can be passed to make?

Notable changes and omissions:

* I did not carry over TARGET_ARCH and TARGET_OS because they appear to
have no function.
* I did not carry over TZ because everything should be
UTC.
* Using `latest` tag for build-tools, I'm not sure the mechanism by
which the dated tag gets updated. Is that a manual process?
* Previously, CONTAINER_CLI, DOCKER_SOCKET_MOUNT, IMG, and TARGET_OUT
were overridable. What is the use case for doing that?
* I left off --sig-proxy=true which _helps_ #17476, but does not resolve
it fully. I believe it was causing problems because the entrypoint is
PID 1 which has some special rules for SIGINTs.

Put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[x] Developer Infrastructure
