### PR TITLE
Include headless service for security reachability e2e tests

### DIFF
--- a/tests/integration/security/reachability/automtls/reachability_test.go
+++ b/tests/integration/security/reachability/automtls/reachability_test.go
@@ -51,8 +51,7 @@ func TestReachabilityAuto(t *testing.T) {
 							return false
 						}
 
-						// Exclude headless->headless
-						return src != rctx.Headless || opts.Target != rctx.Headless
+						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						if src == rctx.Naked && opts.Target == rctx.Naked {
@@ -74,8 +73,7 @@ func TestReachabilityAuto(t *testing.T) {
 							return false
 						}
 
-						// Exclude headless->headless
-						return src != rctx.Headless || opts.Target != rctx.Headless
+						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						if src == rctx.Naked && opts.Target == rctx.Naked {
@@ -97,10 +95,6 @@ func TestReachabilityAuto(t *testing.T) {
 							return false
 						}
 
-						// Exclude calls to the headless TCP port.
-						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
-							return false
-						}
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
@@ -111,10 +105,6 @@ func TestReachabilityAuto(t *testing.T) {
 					ConfigFile: "global-mtls-off.yaml",
 					Namespace:  systemNM,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						// Exclude calls to the headless TCP port.
-						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
-							return false
-						}
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {

--- a/tests/integration/security/reachability/automtls/reachability_test.go
+++ b/tests/integration/security/reachability/automtls/reachability_test.go
@@ -91,11 +91,7 @@ func TestReachabilityAuto(t *testing.T) {
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
 						// Exclude calls to the naked app.
-						if opts.Target == rctx.Naked {
-							return false
-						}
-
-						return true
+						return opts.Target != rctx.Naked
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						return true

--- a/tests/integration/security/reachability/manualmtls/reachability_test.go
+++ b/tests/integration/security/reachability/manualmtls/reachability_test.go
@@ -92,11 +92,7 @@ func TestReachability(t *testing.T) {
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
 						// Exclude calls to the naked app.
-						if opts.Target == rctx.Naked {
-							return false
-						}
-
-						return true
+						return opts.Target != rctx.Naked
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						return true

--- a/tests/integration/security/reachability/manualmtls/reachability_test.go
+++ b/tests/integration/security/reachability/manualmtls/reachability_test.go
@@ -50,9 +50,7 @@ func TestReachability(t *testing.T) {
 						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
 							return false
 						}
-
-						// Exclude headless->headless
-						return src != rctx.Headless || opts.Target != rctx.Headless
+						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						if src == rctx.Naked && opts.Target == rctx.Naked {
@@ -74,8 +72,7 @@ func TestReachability(t *testing.T) {
 							return false
 						}
 
-						// Exclude headless->headless
-						return src != rctx.Headless || opts.Target != rctx.Headless
+						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						// When mTLS is in STRICT mode, DR's TLS settings are default to mTLS so the result would
@@ -99,10 +96,6 @@ func TestReachability(t *testing.T) {
 							return false
 						}
 
-						// Exclude calls to the headless TCP port.
-						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
-							return false
-						}
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
@@ -113,10 +106,6 @@ func TestReachability(t *testing.T) {
 					ConfigFile: "global-mtls-off.yaml",
 					Namespace:  systemNM,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						// Exclude calls to the headless TCP port.
-						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
-							return false
-						}
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {


### PR DESCRIPTION
Please provide a description for what this PR is for.

With PR https://github.com/istio/istio/pull/16845, mTLS should work with headless service (in default installation with `PILOT_ENABLE_HEADLESS_SERVICE` is on. This PR enable the reachability test for mTLS with headless service to confirm.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
