### PR TITLE
setup file trigger before start

### DIFF
--- a/galley/cmd/galley/cmd/server.go
+++ b/galley/cmd/galley/cmd/server.go
@@ -155,6 +155,8 @@ func serverCmd() *cobra.Command {
 		"Enable service discovery processing in Galley")
 	svr.PersistentFlags().BoolVar(&serverArgs.UseOldProcessor, "useOldProcessor", serverArgs.UseOldProcessor,
 		"Use the old processing pipeline for config processing")
+	svr.PersistentFlags().BoolVar(&serverArgs.WatchConfigFiles, "watchConfigFiles", serverArgs.WatchConfigFiles,
+		"Enable the Fsnotify for watching config source files on the disk and implicit signaling on a config change. Explicit signaling will still be enabled")
 	svr.PersistentFlags().BoolVar(&serverArgs.EnableConfigAnalysis, "enableAnalysis", serverArgs.EnableConfigAnalysis,
 		"Enable config analysis service")
 

--- a/galley/pkg/config/source/kube/fs/source.go
+++ b/galley/pkg/config/source/kube/fs/source.go
@@ -40,25 +40,27 @@ var (
 var nameDiscriminator int64
 
 type source struct {
-	mu   sync.Mutex
-	name string
-	s    *inmemory.KubeSource
-	root string
-	done chan struct{}
+	mu               sync.Mutex
+	name             string
+	s                *inmemory.KubeSource
+	root             string
+	done             chan struct{}
+	watchConfigFiles bool
 }
 
 var _ event.Source = &source{}
 
 // New returns a new filesystem based processor.Source.
-func New(root string, resources schema.KubeResources) (event.Source, error) {
+func New(root string, resources schema.KubeResources, watchConfigFiles bool) (event.Source, error) {
 	src := inmemory.NewKubeSource(resources)
 	name := fmt.Sprintf("fs-%d", nameDiscriminator)
 	nameDiscriminator++
 
 	s := &source{
-		name: name,
-		root: root,
-		s:    src,
+		name:             name,
+		root:             root,
+		s:                src,
+		watchConfigFiles: watchConfigFiles,
 	}
 
 	return s, nil
@@ -78,8 +80,10 @@ func (s *source) Start() {
 	c := make(chan appsignals.Signal, 1)
 	appsignals.Watch(c)
 	shut := make(chan os.Signal, 1)
-	if err := appsignals.FileTrigger(s.root, syscall.SIGUSR1, shut); err != nil {
-		scope.Source.Errorf("Unable to setup FileTrigger for %s: %v", s.root, err)
+	if s.watchConfigFiles {
+		if err := appsignals.FileTrigger(s.root, syscall.SIGUSR1, shut); err != nil {
+			scope.Source.Errorf("Unable to setup FileTrigger for %s: %v", s.root, err)
+		}
 	}
 	go func() {
 		s.reload()
@@ -92,7 +96,9 @@ func (s *source) Start() {
 					s.reload()
 				}
 			case <-done:
-				shut <- syscall.SIGTERM
+				if s.watchConfigFiles {
+					shut <- syscall.SIGTERM
+				}
 				return
 			}
 		}

--- a/galley/pkg/config/source/kube/fs/source.go
+++ b/galley/pkg/config/source/kube/fs/source.go
@@ -77,6 +77,10 @@ func (s *source) Start() {
 
 	c := make(chan appsignals.Signal, 1)
 	appsignals.Watch(c)
+	shut := make(chan os.Signal, 1)
+	if err := appsignals.FileTrigger(s.root, syscall.SIGUSR1, shut); err != nil {
+		scope.Source.Errorf("Unable to setup FileTrigger for %s: %v", s.root, err)
+	}
 	go func() {
 		s.reload()
 		s.s.Start()
@@ -88,6 +92,7 @@ func (s *source) Start() {
 					s.reload()
 				}
 			case <-done:
+				shut <- syscall.SIGTERM
 				return
 			}
 		}

--- a/galley/pkg/server/components/processing.go
+++ b/galley/pkg/server/components/processing.go
@@ -253,7 +253,7 @@ func (p *Processing) createSource(mesh meshconfig.Cache) (src runtime.Source, er
 	sourceSchema := p.getSourceSchema()
 
 	if p.args.ConfigPath != "" {
-		if src, err = fsNew(p.args.ConfigPath, sourceSchema, converterCfg); err != nil {
+		if src, err = fsNew(p.args.ConfigPath, sourceSchema, converterCfg, p.args.WatchConfigFiles); err != nil {
 			return
 		}
 	} else {

--- a/galley/pkg/server/components/processing2.go
+++ b/galley/pkg/server/components/processing2.go
@@ -279,7 +279,7 @@ func (p *Processing2) createSourceAndStatusUpdater(resources schema.KubeResource
 	src event.Source, updater snapshotter.StatusUpdater, err error) {
 
 	if p.args.ConfigPath != "" {
-		if src, err = fsNew2(p.args.ConfigPath, resources); err != nil {
+		if src, err = fsNew2(p.args.ConfigPath, resources, p.args.WatchConfigFiles); err != nil {
 			return
 		}
 		updater = &snapshotter.InMemoryStatusUpdater{}

--- a/galley/pkg/server/components/processing2_test.go
+++ b/galley/pkg/server/components/processing2_test.go
@@ -87,7 +87,7 @@ loop:
 			netListen = func(network, address string) (net.Listener, error) { return nil, e }
 		case 7:
 			args.ConfigPath = "aaa"
-			fsNew2 = func(_ string, _ schema.KubeResources) (event.Source, error) { return nil, e }
+			fsNew2 = func(_ string, _ schema.KubeResources, _ bool) (event.Source, error) { return nil, e }
 		default:
 			break loop
 

--- a/galley/pkg/server/components/processing_test.go
+++ b/galley/pkg/server/components/processing_test.go
@@ -49,7 +49,7 @@ loop:
 			return runtime.NewInMemorySource(), nil
 		}
 		newMeshConfigCache = func(path string) (meshconfig.Cache, error) { return meshconfig.NewInMemory(), nil }
-		fsNew = func(string, *schema.Instance, *converter.Config) (runtime.Source, error) {
+		fsNew = func(string, *schema.Instance, *converter.Config, bool) (runtime.Source, error) {
 			return runtime.NewInMemorySource(), nil
 		}
 		mcpMetricReporter = func(string) monitoring.Reporter {
@@ -78,7 +78,7 @@ loop:
 			newMeshConfigCache = func(path string) (meshconfig.Cache, error) { return nil, e }
 		case 4:
 			args.ConfigPath = "aaa"
-			fsNew = func(string, *schema.Instance, *converter.Config) (runtime.Source, error) { return nil, e }
+			fsNew = func(string, *schema.Instance, *converter.Config, bool) (runtime.Source, error) { return nil, e }
 		case 5:
 			args.DisableResourceReadyCheck = true
 			findSupportedResources = func(k client.Interfaces, specs []sourceSchema.ResourceSpec) ([]sourceSchema.ResourceSpec, error) {

--- a/galley/pkg/server/settings/args.go
+++ b/galley/pkg/server/settings/args.go
@@ -118,6 +118,10 @@ type Args struct { // nolint:maligned
 	// DEPRECATED
 	DisableResourceReadyCheck bool
 
+	// WatchConfigFiles if set to true, enables Fsnotify watcher for watching and signaling config file changes.
+	// Default is false
+	WatchConfigFiles bool
+
 	// keep-alive options for the MCP gRPC Server.
 	KeepAlive *keepalive.Options
 
@@ -159,6 +163,7 @@ func DefaultArgs() *Args {
 		EnableProfiling:             false,
 		PprofPort:                   9094,
 		UseOldProcessor:             false,
+		WatchConfigFiles:            false,
 		EnableConfigAnalysis:        false,
 		Liveness: probe.Options{
 			Path:           defaultLivenessProbeFilePath,

--- a/pkg/istiod/galley.go
+++ b/pkg/istiod/galley.go
@@ -267,7 +267,7 @@ func (p *GalleyServer) getServerGrpcOptions() []grpc.ServerOption {
 type GalleyCfgSourceFn func(resources schema.KubeResources) (src event.Source, err error)
 
 func (p *GalleyServer) createSource(resources schema.KubeResources) (src event.Source, err error) {
-	if src, err = fs2.New(p.args.ConfigPath, resources); err != nil {
+	if src, err = fs2.New(p.args.ConfigPath, resources, p.args.WatchConfigFiles); err != nil {
 		return
 	}
 	return


### PR DESCRIPTION
Taking over #17523 

We have been using galley with filesystem backend in the VM infrastructure for a while.
Fsnotify support is required to kick off the config reload routines, when config files
on the disk change. Currently, the fs backend requires explicit triggers for file system changes
by asking the user to issue a SIGUSR1. This PR chains fsnotify triggers to this path [triggering
a SIGUSR1 when the backing files change].
