### PR TITLE
log HTTP req/resp headers created by metadata exchange filter in ALS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/DataDog/datadog-go v2.2.0+incompatible
 	github.com/Masterminds/sprig v2.14.1+incompatible // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect
-	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/SAP/go-hdb v0.14.1 // indirect
 	github.com/SermoDigital/jose v0.9.1 // indirect
@@ -74,7 +73,6 @@ require (
 	github.com/google/cel-go v0.2.0
 	github.com/google/go-cmp v0.3.0
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gax-go v2.0.0+incompatible
 	github.com/googleapis/gax-go/v2 v2.0.5

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/DataDog/datadog-go v2.2.0+incompatible
 	github.com/Masterminds/sprig v2.14.1+incompatible // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect
+	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/SAP/go-hdb v0.14.1 // indirect
 	github.com/SermoDigital/jose v0.9.1 // indirect
@@ -73,6 +74,7 @@ require (
 	github.com/google/cel-go v0.2.0
 	github.com/google/go-cmp v0.3.0
 	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gax-go v2.0.0+incompatible
 	github.com/googleapis/gax-go/v2 v2.0.5

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -150,6 +150,12 @@ const (
 var (
 	applicationProtocols = []string{"http/1.0", "http/1.1"}
 
+	// Headers added by the metadata exchange filter
+	// We need to propagate these as part of access log service stream
+	// Logging them by default on the console may be an issue as the base64 encoded string is bound to be a big one.
+	// But end users can certainly configure it on their own via the meshConfig
+	envoyWasmHeadersToLog = []string{"envoy.wasm.metadata_exchange.upstream", "envoy.wasm.metadata_exchange.downstream"}
+
 	// EnvoyJSONLogFormat12 map of values for envoy json based access logs for Istio 1.2
 	EnvoyJSONLogFormat12 = &structpb.Struct{
 		Fields: map[string]*structpb.Value{
@@ -1740,6 +1746,8 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 					},
 				},
 			},
+			AdditionalRequestHeadersToLog:  envoyWasmHeadersToLog,
+			AdditionalResponseHeadersToLog: envoyWasmHeadersToLog,
 		}
 
 		acc := &accesslog.AccessLog{


### PR DESCRIPTION
We are sending two headers: envoy-wasm-metadata-upstream and envoy-wasm-metadata-downstream. These need to be logged as part of ALS. If these are not present, nothing will happen.