### PR TITLE
Make processing and source log levels Error by default in istioctl

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -25,7 +25,6 @@ import (
 	"istio.io/istio/galley/pkg/config/processor/metadata"
 	cfgKube "istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/pkg/kube"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -50,14 +49,6 @@ istioctl experimental analyze -k
 istioctl experimental analyze -k a.yaml b.yaml
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// These scopes are pretty verbose at the default log level and significantly clutter terminal output,
-			// so we adjust them here to avoid that.
-			loggingOptions.SetOutputLevel("processing", log.ErrorLevel)
-			loggingOptions.SetOutputLevel("source", log.ErrorLevel)
-			if err := log.Configure(loggingOptions); err != nil {
-				return err
-			}
-
 			files, err := gatherFiles(args)
 			if err != nil {
 				return err

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -54,8 +54,18 @@ var (
 	// Create a kubernetes.ExecClientSDS
 	clientExecSdsFactory = newSDSExecClient
 
-	loggingOptions = log.DefaultOptions()
+	loggingOptions = defaultLogOptions()
 )
+
+func defaultLogOptions() *log.Options {
+	o := log.DefaultOptions()
+
+	// These scopes are, by default, too chatty for command line use
+	o.SetOutputLevel("processing", log.ErrorLevel)
+	o.SetOutputLevel("source", log.ErrorLevel)
+
+	return o
+}
 
 // GetRootCmd returns the root of the cobra command-tree.
 func GetRootCmd(args []string) *cobra.Command {


### PR DESCRIPTION
`istioctl x analyze` invokes code that logs to the "processing" and "source" scopes, which are too chatty for command line use at the default Info log output level. Previously, we overrode this just for the analyze command, but this has the disadvantage of making it so that --log_output_levels can't be used to affect those scopes at runtime. 

This moves that defaulting up a level to root istioctl. If any other commands end up using code that logs these copes, they aren't going to want that verbosity either. And now you can use --log_output_levels to adjust them if you need to. 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
