### PR TITLE
Generate extra principals/users when trust domain aliases are used.

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -124,6 +124,17 @@ data:
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
     trustDomain: {{ .Values.global.trustDomain | quote }}
 
+    #  The trust domain aliases represent the aliases of trust_domain.
+    #  For example, if we have
+    #  trustDomain: td1
+    #  trustDomainAliases: [“td2”, "td3"]
+    #  Any service with the identity "td1/ns/foo/sa/a-service-account", "td2/ns/foo/sa/a-service-account",
+    #  or "td3/ns/foo/sa/a-service-account" will be treated the same in the Istio mesh.
+    trustDomainAliases:
+      {{- range .Values.global.trustDomainAliases }}
+      - {{ . | quote }}
+      {{- end }}
+
     # If true, automatically configure client side mTLS settings to match the corresponding service's
     # server side mTLS authentication policy, when destination rule for that service does not specify
     # TLS settings.

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -464,6 +464,14 @@ global:
   #   else:  default dns domain
   trustDomain: ""
 
+  #  The trust domain aliases represent the aliases of trust_domain.
+  #  For example, if we have
+  #  trustDomain: td1
+  #  trustDomainAliases: [“td2”, "td3"]
+  #  Any service with the identity "td1/ns/foo/sa/a-service-account", "td2/ns/foo/sa/a-service-account",
+  #  or "td3/ns/foo/sa/a-service-account" will be treated the same in the Istio mesh.
+  trustDomainAliases: []
+
   # Mesh ID means Mesh Identifier. It should be unique within the scope where
   # meshes will interact with each other, but it is not required to be
   # globally/universally unique. For example, if any of the following are true,

--- a/istioctl/pkg/auth/upgrader.go
+++ b/istioctl/pkg/auth/upgrader.go
@@ -151,7 +151,7 @@ func (ug *Upgrader) convert(authzPolicies *model.AuthorizationPolicies) error {
 			roleName := roleConfig.Name
 			if bindings, found := bindingsKeyList[roleName]; found {
 				role := roleConfig.Spec.(*rbac_v1alpha1.ServiceRole)
-				m := authz_model.NewModel(role, bindings)
+				m := authz_model.NewModelV1Alpha1("", nil, role, bindings)
 				err := ug.v1alpha1ModelTov1beta1Policy(m, ns)
 				if err != nil {
 					return err

--- a/istioctl/pkg/auth/upgrader.go
+++ b/istioctl/pkg/auth/upgrader.go
@@ -257,8 +257,8 @@ func convertBindingToSources(principals []authz_model.Principal) ([]*rbac_v1beta
 		from := rbac_v1beta1.Rule_From{
 			Source: &rbac_v1beta1.Source{},
 		}
-		if subject.User != "" {
-			from.Source.Principals = []string{subject.User}
+		if len(subject.Users) != 0 {
+			from.Source.Principals = subject.Users
 		}
 		if len(subject.Properties) == 0 {
 			ruleFrom = append(ruleFrom, &from)

--- a/istioctl/pkg/auth/upgrader.go
+++ b/istioctl/pkg/auth/upgrader.go
@@ -151,7 +151,7 @@ func (ug *Upgrader) convert(authzPolicies *model.AuthorizationPolicies) error {
 			roleName := roleConfig.Name
 			if bindings, found := bindingsKeyList[roleName]; found {
 				role := roleConfig.Spec.(*rbac_v1alpha1.ServiceRole)
-				m := authz_model.NewModelV1Alpha1("", nil, role, bindings)
+				m := authz_model.NewModelV1alpha1("", nil, role, bindings)
 				err := ug.v1alpha1ModelTov1beta1Policy(m, ns)
 				if err != nil {
 					return err

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -82,8 +82,8 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 	}
 
 	// TODO: Get trust domain from MeshConfig instead.
-	builder := authz_builder.NewBuilder(spiffe.GetTrustDomain(), in.Env.Mesh.TrustDomainAliases, in.ServiceInstance, in.Node.WorkloadLabels, in.Node.ConfigNamespace,
-		in.Push.AuthzPolicies, util.IsXDSMarshalingToAnyEnabled(in.Node))
+	builder := authz_builder.NewBuilder(spiffe.GetTrustDomain(), in.Env.Mesh.TrustDomainAliases, in.ServiceInstance,
+		in.Node.WorkloadLabels, in.Node.ConfigNamespace, in.Push.AuthzPolicies, util.IsXDSMarshalingToAnyEnabled(in.Node))
 	if builder == nil {
 		return
 	}

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	authz_builder "istio.io/istio/pilot/pkg/security/authz/builder"
+	"istio.io/istio/pkg/spiffe"
 )
 
 var (
@@ -80,7 +81,8 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 		return
 	}
 
-	builder := authz_builder.NewBuilder(in.Env.Mesh.TrustDomainAliases, in.ServiceInstance, in.Node.WorkloadLabels, in.Node.ConfigNamespace,
+	// TODO: Get trust domain from MeshConfig instead.
+	builder := authz_builder.NewBuilder(spiffe.GetTrustDomain(), in.Env.Mesh.TrustDomainAliases, in.ServiceInstance, in.Node.WorkloadLabels, in.Node.ConfigNamespace,
 		in.Push.AuthzPolicies, util.IsXDSMarshalingToAnyEnabled(in.Node))
 	if builder == nil {
 		return

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -24,11 +24,12 @@ package authz
 import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 
+	istiolog "istio.io/pkg/log"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	authz_builder "istio.io/istio/pilot/pkg/security/authz/builder"
-	istiolog "istio.io/pkg/log"
 )
 
 var (
@@ -79,7 +80,7 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 		return
 	}
 
-	builder := authz_builder.NewBuilder(in.ServiceInstance, in.Node.WorkloadLabels, in.Node.ConfigNamespace,
+	builder := authz_builder.NewBuilder(in.Env.Mesh.TrustDomainAliases, in.ServiceInstance, in.Node.WorkloadLabels, in.Node.ConfigNamespace,
 		in.Push.AuthzPolicies, util.IsXDSMarshalingToAnyEnabled(in.Node))
 	if builder == nil {
 		return

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -82,6 +82,7 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 	}
 
 	// TODO: Get trust domain from MeshConfig instead.
+	// https://github.com/istio/istio/issues/17873
 	builder := authz_builder.NewBuilder(spiffe.GetTrustDomain(), in.Env.Mesh.TrustDomainAliases, in.ServiceInstance,
 		in.Node.WorkloadLabels, in.Node.ConfigNamespace, in.Push.AuthzPolicies, util.IsXDSMarshalingToAnyEnabled(in.Node))
 	if builder == nil {

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -40,12 +40,12 @@ type Builder struct {
 }
 
 // NewBuilder creates a builder instance that can be used to build corresponding RBAC filter config.
-func NewBuilder(serviceInstance *model.ServiceInstance, workloadLabels labels.Collection, configNamespace string,
+func NewBuilder(trustDomainAliases []string, serviceInstance *model.ServiceInstance, workloadLabels labels.Collection, configNamespace string,
 	policies *model.AuthorizationPolicies, isXDSMarshalingToAnyEnabled bool) *Builder {
 	var generator policy.Generator
 
 	if p := policies.ListAuthorizationPolicies(configNamespace, workloadLabels); len(p) > 0 {
-		generator = v1beta1.NewGenerator(p)
+		generator = v1beta1.NewGenerator(trustDomainAliases, p)
 		rbacLog.Debugf("v1beta1 authorization enabled for workload %v in %s", workloadLabels, configNamespace)
 	} else {
 		if serviceInstance.Service == nil {
@@ -62,7 +62,7 @@ func NewBuilder(serviceInstance *model.ServiceInstance, workloadLabels labels.Co
 
 		serviceHostname := string(serviceInstance.Service.Hostname)
 		if policies.IsRBACEnabled(serviceHostname, serviceNamespace) {
-			generator = v1alpha1.NewGenerator(serviceMetadata, policies, policies.IsGlobalPermissiveEnabled())
+			generator = v1alpha1.NewGenerator(trustDomainAliases, serviceMetadata, policies, policies.IsGlobalPermissiveEnabled())
 			rbacLog.Debugf("v1alpha1 RBAC enabled for service %s", serviceHostname)
 		}
 	}

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -41,7 +41,8 @@ type Builder struct {
 }
 
 // NewBuilder creates a builder instance that can be used to build corresponding RBAC filter config.
-func NewBuilder(trustDomain string, trustDomainAliases []string, serviceInstance *model.ServiceInstance, workloadLabels labels.Collection, configNamespace string,
+func NewBuilder(trustDomain string, trustDomainAliases []string, serviceInstance *model.ServiceInstance,
+	workloadLabels labels.Collection, configNamespace string,
 	policies *model.AuthorizationPolicies, isXDSMarshalingToAnyEnabled bool) *Builder {
 	var generator policy.Generator
 

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -120,7 +120,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		p := policy.NewAuthzPolicies(tc.policies, t)
-		b := NewBuilder(service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
+		b := NewBuilder(nil, service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
 
 		got := b.BuildHTTPFilter()
 		t.Run(tc.name, func(t *testing.T) {
@@ -210,7 +210,7 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		p := policy.NewAuthzPolicies(tc.policies, t)
-		b := NewBuilder(service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
+		b := NewBuilder(nil, service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
 
 		t.Run(tc.name, func(t *testing.T) {
 			got := b.BuildTCPFilter()

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -120,7 +120,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		p := policy.NewAuthzPolicies(tc.policies, t)
-		b := NewBuilder(nil, service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
+		b := NewBuilder("cluster.local", nil, service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
 
 		got := b.BuildHTTPFilter()
 		t.Run(tc.name, func(t *testing.T) {
@@ -210,7 +210,7 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		p := policy.NewAuthzPolicies(tc.policies, t)
-		b := NewBuilder(nil, service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
+		b := NewBuilder("", nil, service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
 
 		t.Run(tc.name, func(t *testing.T) {
 			got := b.BuildTCPFilter()

--- a/pilot/pkg/security/authz/builder/integration_test.go
+++ b/pilot/pkg/security/authz/builder/integration_test.go
@@ -78,7 +78,7 @@ func TestBuildHTTPFilter(t *testing.T) {
 	service := newService("httpbin.foo.svc.cluster.local", httpbinLabels, t)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			b := NewBuilder(service, labels.Collection{httpbinLabels}, "foo", tc.policies, false)
+			b := NewBuilder(nil, service, labels.Collection{httpbinLabels}, "foo", tc.policies, false)
 			if b == nil {
 				t.Fatalf("failed to create builder")
 			}

--- a/pilot/pkg/security/authz/builder/integration_test.go
+++ b/pilot/pkg/security/authz/builder/integration_test.go
@@ -30,9 +30,11 @@ import (
 
 func TestBuildHTTPFilter(t *testing.T) {
 	testCases := []struct {
-		name     string
-		policies *model.AuthorizationPolicies
-		want     *http_config.RBAC
+		name               string
+		trustDomain        string
+		trustDomainAliases []string
+		policies           *model.AuthorizationPolicies
+		want               *http_config.RBAC
 	}{
 		{
 			name:     "v1beta1 all fields",
@@ -69,6 +71,20 @@ func TestBuildHTTPFilter(t *testing.T) {
 			policies: getPolicies("testdata/v1beta1-single-policy-in.yaml", t),
 			want:     getProto("testdata/v1beta1-single-policy-out.yaml", t),
 		},
+		{
+			name:               "v1beta1 trust domain aliases",
+			trustDomain:        "td1",
+			trustDomainAliases: []string{"cluster.local"},
+			policies:           getPolicies("testdata/v1beta1-simple-policy-td-aliases-in.yaml", t),
+			want:               getProto("testdata/v1beta1-simple-policy-td-aliases-out.yaml", t),
+		},
+		{
+			name:               "v1alpha1 trust domain aliases",
+			trustDomain:        "td1",
+			trustDomainAliases: []string{"cluster.local"},
+			policies:           getPolicies("testdata/v1alpha1-simple-policy-td-aliases-in.yaml", t),
+			want:               getProto("testdata/v1alpha1-simple-policy-td-aliases-out.yaml", t),
+		},
 	}
 
 	httpbinLabels := map[string]string{
@@ -78,7 +94,7 @@ func TestBuildHTTPFilter(t *testing.T) {
 	service := newService("httpbin.foo.svc.cluster.local", httpbinLabels, t)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			b := NewBuilder(nil, service, labels.Collection{httpbinLabels}, "foo", tc.policies, false)
+			b := NewBuilder(tc.trustDomain, tc.trustDomainAliases, service, labels.Collection{httpbinLabels}, "foo", tc.policies, false)
 			if b == nil {
 				t.Fatalf("failed to create builder")
 			}

--- a/pilot/pkg/security/authz/builder/integration_test.go
+++ b/pilot/pkg/security/authz/builder/integration_test.go
@@ -72,14 +72,21 @@ func TestBuildHTTPFilter(t *testing.T) {
 			want:     getProto("testdata/v1beta1-single-policy-out.yaml", t),
 		},
 		{
-			name:               "v1beta1 trust domain aliases",
+			name:               "v1beta1 one trust domain alias",
 			trustDomain:        "td1",
 			trustDomainAliases: []string{"cluster.local"},
 			policies:           getPolicies("testdata/v1beta1-simple-policy-td-aliases-in.yaml", t),
 			want:               getProto("testdata/v1beta1-simple-policy-td-aliases-out.yaml", t),
 		},
 		{
-			name:               "v1alpha1 trust domain aliases",
+			name:               "v1beta1 multiple trust domain aliases",
+			trustDomain:        "td1",
+			trustDomainAliases: []string{"cluster.local", "some-td"},
+			policies:           getPolicies("testdata/v1beta1-simple-policy-multiple-td-aliases-in.yaml", t),
+			want:               getProto("testdata/v1beta1-simple-policy-multiple-td-aliases-out.yaml", t),
+		},
+		{
+			name:               "v1alpha1 one trust domain alias",
 			trustDomain:        "td1",
 			trustDomainAliases: []string{"cluster.local"},
 			policies:           getPolicies("testdata/v1alpha1-simple-policy-td-aliases-in.yaml", t),

--- a/pilot/pkg/security/authz/builder/testdata/v1alpha1-simple-policy-td-aliases-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1alpha1-simple-policy-td-aliases-in.yaml
@@ -1,0 +1,30 @@
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ClusterRbacConfig
+metadata:
+  name: default
+spec:
+  mode: 'ON_WITH_INCLUSION'
+  inclusion:
+    namespaces: ["foo"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: httpbin-viewer
+  namespace: foo
+spec:
+  rules:
+    - services: ["httpbin.foo.svc.cluster.local"]
+      methods: ["GET"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: bind-httpbin-viewer
+  namespace: foo
+spec:
+  subjects:
+    - user: "cluster.local/ns/istio-system/sa/http-viewer"
+  roleRef:
+    kind: ServiceRole
+    name: httpbin-viewer

--- a/pilot/pkg/security/authz/builder/testdata/v1alpha1-simple-policy-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1alpha1-simple-policy-td-aliases-out.yaml
@@ -12,19 +12,19 @@ rules:
       principals:
         - andIds:
             ids:
-              - metadata:
-                  filter: istio_authn
-                  path:
-                    - key: source.principal
-                  value:
-                    stringMatch:
-                      exact: td1/ns/istio-system/sa/http-viewer
-        - andIds:
-            ids:
-              - metadata:
-                  filter: istio_authn
-                  path:
-                    - key: source.principal
-                  value:
-                    stringMatch:
-                      exact: cluster.local/ns/istio-system/sa/http-viewer
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: td1/ns/istio-system/sa/http-viewer
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: cluster.local/ns/istio-system/sa/http-viewer

--- a/pilot/pkg/security/authz/builder/testdata/v1alpha1-simple-policy-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1alpha1-simple-policy-td-aliases-out.yaml
@@ -1,0 +1,30 @@
+rules:
+  policies:
+    httpbin-viewer:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: GET
+                        name: :method
+      principals:
+        - andIds:
+            ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: source.principal
+                  value:
+                    stringMatch:
+                      exact: td1/ns/istio-system/sa/http-viewer
+        - andIds:
+            ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: source.principal
+                  value:
+                    stringMatch:
+                      exact: cluster.local/ns/istio-system/sa/http-viewer

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-not-override-v1alpha1-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-not-override-v1alpha1-out.yaml
@@ -12,4 +12,6 @@ rules:
       principals:
         - andIds:
             ids:
-              - any: true
+              - orIds:
+                  ids:
+                    - any: true

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-simple-policy-multiple-td-aliases-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-simple-policy-multiple-td-aliases-in.yaml
@@ -1,0 +1,17 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+    - from:
+        - source:
+            principals: ["cluster.local/ns/rule[0]/sa/from[0]-principal[0]"]
+        - source:
+            principals: ["some-td/ns/rule[0]/sa/from[1]-principal[0]", "cluster.local/ns/rule[0]/sa/from[1]-principal[1]"]
+            namespaces: ["rule[0]-from[1]-ns[0]"]

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-simple-policy-multiple-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-simple-policy-multiple-td-aliases-out.yaml
@@ -1,0 +1,88 @@
+rules:
+  policies:
+    ns[foo]-policy[httpbin]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - any: true
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: td1/ns/rule[0]/sa/from[0]-principal[0]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: cluster.local/ns/rule[0]/sa/from[0]-principal[0]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: some-td/ns/rule[0]/sa/from[0]-principal[0]
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: td1/ns/rule[0]/sa/from[1]-principal[0]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: cluster.local/ns/rule[0]/sa/from[1]-principal[0]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: some-td/ns/rule[0]/sa/from[1]-principal[0]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: td1/ns/rule[0]/sa/from[1]-principal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: cluster.local/ns/rule[0]/sa/from[1]-principal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: some-td/ns/rule[0]/sa/from[1]-principal[1]
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/rule[0]-from[1]-ns[0]/.*

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-simple-policy-td-aliases-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-simple-policy-td-aliases-in.yaml
@@ -1,0 +1,26 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+    - from:
+        - source:
+            principals: ["cluster.local/ns/rule[0]/sa/from[0]-principal[0]"]
+        - source:
+            principals: ["cluster.local/ns/rule[0]/sa/from[1]-principal[0]", "cluster.local/ns/rule[0]/sa/from[1]-principal[1]"]
+            namespaces: ["rule[0]-from[1]-ns[0]"]
+      to:
+        - operation:
+            methods: ["rule[0]-to[0]-method[0]"]
+    - from:
+        - source:
+            principals: ["cluster.local/ns/rule[1]/sa/from[0]-principal[0]"]
+      to:
+        - operation:
+            methods: ["rule[1]-to[0]-method[0]"]

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-simple-policy-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-simple-policy-td-aliases-out.yaml
@@ -1,0 +1,99 @@
+rules:
+  policies:
+    ns[foo]-policy[httpbin]-rule[0]:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[0]-to[0]-method[0]
+                        name: :method
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: td1/ns/rule[0]/sa/from[0]-principal[0]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: cluster.local/ns/rule[0]/sa/from[0]-principal[0]
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: td1/ns/rule[0]/sa/from[1]-principal[0]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: cluster.local/ns/rule[0]/sa/from[1]-principal[0]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: td1/ns/rule[0]/sa/from[1]-principal[1]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: cluster.local/ns/rule[0]/sa/from[1]-principal[1]
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .*/ns/rule[0]-from[1]-ns[0]/.*
+    ns[foo]-policy[httpbin]-rule[1]:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: rule[1]-to[0]-method[0]
+                        name: :method
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: td1/ns/rule[1]/sa/from[0]-principal[0]
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: cluster.local/ns/rule[1]/sa/from[0]-principal[0]

--- a/pilot/pkg/security/authz/model/helper.go
+++ b/pilot/pkg/security/authz/model/helper.go
@@ -63,7 +63,7 @@ func fullPermission(tag string) Permission {
 
 func fullPrincipal(tag string) Principal {
 	return Principal{
-		Users:         []string{"user-" + tag},
+		Users:         []string{"users-" + tag},
 		Names:         []string{"names-" + tag},
 		NotNames:      []string{"not-names-" + tag},
 		Group:         "group-" + tag,
@@ -103,7 +103,7 @@ func fullRule(tag string) *istio_rbac.AccessRule {
 
 func fullSubject(tag string) *istio_rbac.Subject {
 	return &istio_rbac.Subject{
-		User:          "user-" + tag,
+		User:          "users-" + tag,
 		Names:         []string{"names-" + tag},
 		NotNames:      []string{"not-names-" + tag},
 		Group:         "group-" + tag,

--- a/pilot/pkg/security/authz/model/helper.go
+++ b/pilot/pkg/security/authz/model/helper.go
@@ -38,7 +38,7 @@ func principalTag(tag string) string {
 
 func simplePrincipal(tag string) Principal {
 	return Principal{
-		User: principalTag(tag),
+		Users: []string{principalTag(tag)},
 	}
 }
 
@@ -63,7 +63,7 @@ func fullPermission(tag string) Permission {
 
 func fullPrincipal(tag string) Principal {
 	return Principal{
-		User:          "user-" + tag,
+		Users:         []string{"user-" + tag},
 		Names:         []string{"names-" + tag},
 		NotNames:      []string{"not-names-" + tag},
 		Group:         "group-" + tag,

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -35,7 +35,7 @@ const (
 	RBACTCPFilterStatPrefix = "tcp."
 
 	// attributes that could be used in both ServiceRoleBinding and ServiceRole.
-	attrRequestHeader = "request.headers" // header name is surrounded by brackets, e.g. "request.headers[Users-Agent]".
+	attrRequestHeader = "request.headers" // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
 
 	// attributes that could be used in a ServiceRoleBinding property.
 	attrSrcIP        = "source.ip"        // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
@@ -168,7 +168,7 @@ func NewModelV1Alpha1(trustDomain string, trustDomainAliases []string, role *ist
 }
 
 // NewModelV1beta1 constructs a Model from v1beta1 Rule.
-func NewModelFromV1beta1(trustDomain string, trustDomainAliases []string, rule *security.Rule) *Model {
+func NewModelV1beta1(trustDomain string, trustDomainAliases []string, rule *security.Rule) *Model {
 	m := &Model{}
 
 	conditionsForPrincipal := make([]KeyValues, 0)

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -289,11 +289,6 @@ func getPrincipalsIncludingAliases(trustDomain string, trustDomainAliases []stri
 		if trustDomainFromPrincipal == "" {
 			return principals
 		}
-		// If the current trust domain is the same as the one from the existing principal, there is nothing to do.
-		// NOTE: All |principals| must have the same trust domain.
-		if trustDomainFromPrincipal == trustDomain {
-			return principals
-		}
 		// Only generate configuration if the extracted trust domain from the policy is part of the trust domain aliases,
 		// or if the extracted/existing trust domain is "cluster.local", which is a pointer to the local trust domain
 		// and its aliases.

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -110,9 +110,9 @@ type Model struct {
 
 type KeyValues map[string][]string
 
-// NewModelV1Alpha1 constructs a Model from a single ServiceRole and a list of ServiceRoleBinding. The ServiceRole
+// NewModelV1alpha1 constructs a Model from a single ServiceRole and a list of ServiceRoleBinding. The ServiceRole
 // is converted to the permission and the ServiceRoleBinding is converted to the principal.
-func NewModelV1Alpha1(trustDomain string, trustDomainAliases []string, role *istio_rbac.ServiceRole, bindings []*istio_rbac.ServiceRoleBinding) *Model {
+func NewModelV1alpha1(trustDomain string, trustDomainAliases []string, role *istio_rbac.ServiceRole, bindings []*istio_rbac.ServiceRoleBinding) *Model {
 	m := &Model{}
 	for _, accessRule := range role.Rules {
 		var permission Permission
@@ -139,7 +139,7 @@ func NewModelV1Alpha1(trustDomain string, trustDomainAliases []string, role *ist
 		for _, subject := range binding.Subjects {
 			users := []string{}
 			if subject.User != "" {
-				users = getPrincipalsIncludingAliases(trustDomain, trustDomainAliases, []string{subject.User})
+				users = replaceTrustDomainAliases(trustDomain, trustDomainAliases, []string{subject.User})
 			}
 			principal := Principal{
 				Users:         users,
@@ -185,7 +185,7 @@ func NewModelV1beta1(trustDomain string, trustDomainAliases []string, rule *secu
 
 	for _, from := range rule.From {
 		if source := from.Source; source != nil {
-			names := getPrincipalsIncludingAliases(trustDomain, trustDomainAliases, source.Principals)
+			names := replaceTrustDomainAliases(trustDomain, trustDomainAliases, source.Principals)
 			principal := Principal{
 				IPs:               source.IpBlocks,
 				Names:             names,
@@ -273,31 +273,32 @@ func (m *Model) Generate(service *ServiceMetadata, forTCPFilter bool) *envoy_rba
 	return policy
 }
 
-// getPrincipalsIncludingAliases returns a list of users encoded in SPIFFE format with the local
-// trust domain and its aliases.
+// replaceTrustDomainAliases checks the existing principals and returns a list of new principals
+// with the current trust domain and its aliases.
 // For example, for a user "bar" in namespace "foo".
 // If the local trust domain is "td2" and its alias is "td1" (migrating from td1 to td2),
-// getPrincipalsIncludingAliases returns ["td2/ns/foo/sa/bar", "td2/ns/foo/sa/bar]].
-func getPrincipalsIncludingAliases(trustDomain string, trustDomainAliases []string, principals []string) []string {
+// replaceTrustDomainAliases returns ["td2/ns/foo/sa/bar", "td1/ns/foo/sa/bar]].
+// TODO(pitv2109): Put |trustDomain| and |trustDomainAliases| together. Do this and for other functions.
+func replaceTrustDomainAliases(trustDomain string, trustDomainAliases []string, principals []string) []string {
 	// If trust domain aliases are empty, return the existing principals.
 	if len(trustDomainAliases) == 0 {
 		return principals
 	}
 	principalsIncludingAliases := []string{}
 	for _, principal := range principals {
-		trustDomainFromPrincipal := extractTrustDomainFromAuthzPrincipal(principal)
+		trustDomainFromPrincipal := getTrustDomain(principal)
+		//TODO(pitlv2109): Handle * and prefix/suffix.
 		if trustDomainFromPrincipal == "" {
 			return principals
 		}
 		// Only generate configuration if the extracted trust domain from the policy is part of the trust domain aliases,
 		// or if the extracted/existing trust domain is "cluster.local", which is a pointer to the local trust domain
 		// and its aliases.
-		if !found(trustDomainFromPrincipal, trustDomainAliases) && trustDomainFromPrincipal != "cluster.local" {
-			continue
+		if found(trustDomainFromPrincipal, trustDomainAliases) || trustDomainFromPrincipal == "cluster.local" {
+			// Generate configuration for trust domain and trust domain aliases.
+			principalsIncludingAliases = append(principalsIncludingAliases, replaceTrustDomainInPrincipal(trustDomain, principal))
+			principalsIncludingAliases = append(principalsIncludingAliases, getPrincipalsForAliases(trustDomainAliases, principal)...)
 		}
-		// Generate configuration for trust domain and trust domain aliases.
-		principalsIncludingAliases = append(principalsIncludingAliases, getIdentityWithNewTrustDomain(trustDomain, principal))
-		principalsIncludingAliases = append(principalsIncludingAliases, getPrincipalsForAliases(trustDomainAliases, principal)...)
 	}
 	return principalsIncludingAliases
 }
@@ -307,7 +308,7 @@ func getPrincipalsIncludingAliases(trustDomain string, trustDomainAliases []stri
 func getPrincipalsForAliases(trustDomainAliases []string, principal string) []string {
 	principalsForAliases := []string{}
 	for _, tdAlias := range trustDomainAliases {
-		principalsForAliases = append(principalsForAliases, getIdentityWithNewTrustDomain(tdAlias, principal))
+		principalsForAliases = append(principalsForAliases, replaceTrustDomainInPrincipal(tdAlias, principal))
 	}
 	return principalsForAliases
 }

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -105,7 +105,7 @@ func TestNewModel(t *testing.T) {
 		},
 	}
 
-	got := NewModelV1Alpha1("", nil, role, []*istio_rbac.ServiceRoleBinding{binding1, binding2})
+	got := NewModelV1alpha1("", nil, role, []*istio_rbac.ServiceRoleBinding{binding1, binding2})
 	want := Model{
 		Permissions: []Permission{
 			fullPermission("perm-1"),
@@ -460,7 +460,7 @@ func TestModel_Generate(t *testing.T) {
 	}
 }
 
-func TestGetUsersIncludingAliases(t *testing.T) {
+func TestReplaceTrustDomainAliases(t *testing.T) {
 	type inStruct struct {
 		trustDomain        string
 		trustDomainAliases []string
@@ -496,7 +496,7 @@ func TestGetUsersIncludingAliases(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		got := getPrincipalsIncludingAliases(tc.in.trustDomain, tc.in.trustDomainAliases, tc.in.users)
+		got := replaceTrustDomainAliases(tc.in.trustDomain, tc.in.trustDomainAliases, tc.in.users)
 		if !reflect.DeepEqual(got, tc.expect) {
 			t.Errorf("%s failed. Expect: %s. Got: %s", tc.name, tc.expect, got)
 		}

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -123,7 +123,7 @@ func TestNewModel(t *testing.T) {
 	}
 }
 
-func TestNewModelFromV1beta1(t *testing.T) {
+func TestNewModelV1beta1(t *testing.T) {
 	testCases := []struct {
 		name string
 		rule *security.Rule
@@ -339,7 +339,7 @@ func TestNewModelFromV1beta1(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := NewModelFromV1beta1("", nil, tc.rule)
+			got := NewModelV1beta1("", nil, tc.rule)
 			if !reflect.DeepEqual(*got, tc.want) {
 				t.Errorf("\n got %+v\nwant %+v", *got, tc.want)
 			}

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -23,6 +23,7 @@ import (
 
 	istio_rbac "istio.io/api/rbac/v1alpha1"
 	security "istio.io/api/security/v1beta1"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -104,7 +105,7 @@ func TestNewModel(t *testing.T) {
 		},
 	}
 
-	got := NewModel(role, []*istio_rbac.ServiceRoleBinding{binding1, binding2})
+	got := NewModelV1Alpha1(nil, role, []*istio_rbac.ServiceRoleBinding{binding1, binding2})
 	want := Model{
 		Permissions: []Permission{
 			fullPermission("perm-1"),
@@ -338,7 +339,7 @@ func TestNewModelFromV1beta1(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := NewModelFromV1beta1(tc.rule)
+			got := NewModelFromV1beta1(nil, tc.rule)
 			if !reflect.DeepEqual(*got, tc.want) {
 				t.Errorf("\n got %+v\nwant %+v", *got, tc.want)
 			}
@@ -455,6 +456,52 @@ func TestModel_Generate(t *testing.T) {
 					}
 				}
 			}
+		}
+	}
+}
+
+func TestGetUsersIncludingAliases(t *testing.T) {
+	type inStruct struct {
+		trustDomainAliases []string
+		users              []string
+	}
+	testCases := []struct {
+		name   string
+		in     inStruct
+		expect []string
+	}{
+		{
+			name:   "No trust domain aliases",
+			in:     inStruct{nil, []string{"cluster.local/ns/foo/sa/bar"}},
+			expect: []string{"cluster.local/ns/foo/sa/bar"},
+		},
+		{
+			name:   "One trust domain alias, one principal",
+			in:     inStruct{[]string{"td1"}, []string{"cluster.local/ns/foo/sa/bar"}},
+			expect: []string{"cluster.local/ns/foo/sa/bar", "td1/ns/foo/sa/bar"},
+		},
+		{
+			name:   "One trust domain alias, two principals",
+			in:     inStruct{[]string{"td1"}, []string{"cluster.local/ns/foo/sa/bar", "cluster.local/ns/yyy/sa/zzz"}},
+			expect: []string{"cluster.local/ns/foo/sa/bar", "cluster.local/ns/yyy/sa/zzz", "td1/ns/foo/sa/bar", "td1/ns/yyy/sa/zzz"},
+		},
+		{
+			name:   "Two trust domain aliases, one principal",
+			in:     inStruct{[]string{"td1", "td2"}, []string{"cluster.local/ns/foo/sa/bar"}},
+			expect: []string{"cluster.local/ns/foo/sa/bar", "td1/ns/foo/sa/bar", "td2/ns/foo/sa/bar"},
+		},
+		{
+			name: "Two trust domain aliases, two principals",
+			in:   inStruct{[]string{"td1", "td2"}, []string{"cluster.local/ns/foo/sa/bar", "cluster.local/ns/yyy/sa/zzz"}},
+			expect: []string{"cluster.local/ns/foo/sa/bar", "cluster.local/ns/yyy/sa/zzz",
+				"td1/ns/foo/sa/bar", "td1/ns/yyy/sa/zzz", "td2/ns/foo/sa/bar", "td2/ns/yyy/sa/zzz"},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := getPrincipalsIncludingAliases(tc.in.trustDomainAliases, tc.in.users)
+		if !reflect.DeepEqual(got, tc.expect) {
+			t.Errorf("%s failed. Expect: %s. Got: %s", tc.name, tc.expect, got)
 		}
 	}
 }

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -105,7 +105,7 @@ func TestNewModel(t *testing.T) {
 		},
 	}
 
-	got := NewModelV1Alpha1(nil, role, []*istio_rbac.ServiceRoleBinding{binding1, binding2})
+	got := NewModelV1Alpha1("", nil, role, []*istio_rbac.ServiceRoleBinding{binding1, binding2})
 	want := Model{
 		Permissions: []Permission{
 			fullPermission("perm-1"),
@@ -339,7 +339,7 @@ func TestNewModelFromV1beta1(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := NewModelFromV1beta1(nil, tc.rule)
+			got := NewModelFromV1beta1("", nil, tc.rule)
 			if !reflect.DeepEqual(*got, tc.want) {
 				t.Errorf("\n got %+v\nwant %+v", *got, tc.want)
 			}
@@ -462,6 +462,7 @@ func TestModel_Generate(t *testing.T) {
 
 func TestGetUsersIncludingAliases(t *testing.T) {
 	type inStruct struct {
+		trustDomain        string
 		trustDomainAliases []string
 		users              []string
 	}
@@ -471,35 +472,31 @@ func TestGetUsersIncludingAliases(t *testing.T) {
 		expect []string
 	}{
 		{
-			name:   "No trust domain aliases",
-			in:     inStruct{nil, []string{"cluster.local/ns/foo/sa/bar"}},
+			name:   "No trust domain aliases (no change in trust domain)",
+			in:     inStruct{"cluster.local", nil, []string{"cluster.local/ns/foo/sa/bar"}},
 			expect: []string{"cluster.local/ns/foo/sa/bar"},
 		},
 		{
 			name:   "One trust domain alias, one principal",
-			in:     inStruct{[]string{"td1"}, []string{"cluster.local/ns/foo/sa/bar"}},
-			expect: []string{"cluster.local/ns/foo/sa/bar", "td1/ns/foo/sa/bar"},
+			in:     inStruct{"td2", []string{"td1"}, []string{"td1/ns/foo/sa/bar"}},
+			expect: []string{"td2/ns/foo/sa/bar", "td1/ns/foo/sa/bar"},
 		},
 		{
 			name:   "One trust domain alias, two principals",
-			in:     inStruct{[]string{"td1"}, []string{"cluster.local/ns/foo/sa/bar", "cluster.local/ns/yyy/sa/zzz"}},
-			expect: []string{"cluster.local/ns/foo/sa/bar", "cluster.local/ns/yyy/sa/zzz", "td1/ns/foo/sa/bar", "td1/ns/yyy/sa/zzz"},
-		},
-		{
-			name:   "Two trust domain aliases, one principal",
-			in:     inStruct{[]string{"td1", "td2"}, []string{"cluster.local/ns/foo/sa/bar"}},
-			expect: []string{"cluster.local/ns/foo/sa/bar", "td1/ns/foo/sa/bar", "td2/ns/foo/sa/bar"},
+			in:     inStruct{"td1", []string{"cluster.local"}, []string{"cluster.local/ns/foo/sa/bar", "cluster.local/ns/yyy/sa/zzz"}},
+			expect: []string{"td1/ns/foo/sa/bar", "cluster.local/ns/foo/sa/bar", "td1/ns/yyy/sa/zzz", "cluster.local/ns/yyy/sa/zzz"},
 		},
 		{
 			name: "Two trust domain aliases, two principals",
-			in:   inStruct{[]string{"td1", "td2"}, []string{"cluster.local/ns/foo/sa/bar", "cluster.local/ns/yyy/sa/zzz"}},
-			expect: []string{"cluster.local/ns/foo/sa/bar", "cluster.local/ns/yyy/sa/zzz",
-				"td1/ns/foo/sa/bar", "td1/ns/yyy/sa/zzz", "td2/ns/foo/sa/bar", "td2/ns/yyy/sa/zzz"},
+			in: inStruct{"td2", []string{"td1", "cluster.local"},
+				[]string{"cluster.local/ns/foo/sa/bar", "td1/ns/yyy/sa/zzz"}},
+			expect: []string{"td2/ns/foo/sa/bar", "td1/ns/foo/sa/bar", "cluster.local/ns/foo/sa/bar",
+				"td2/ns/yyy/sa/zzz", "td1/ns/yyy/sa/zzz", "cluster.local/ns/yyy/sa/zzz"},
 		},
 	}
 
 	for _, tc := range testCases {
-		got := getPrincipalsIncludingAliases(tc.in.trustDomainAliases, tc.in.users)
+		got := getPrincipalsIncludingAliases(tc.in.trustDomain, tc.in.trustDomainAliases, tc.in.users)
 		if !reflect.DeepEqual(got, tc.expect) {
 			t.Errorf("%s failed. Expect: %s. Got: %s", tc.name, tc.expect, got)
 		}

--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -30,7 +30,7 @@ import (
 )
 
 type Principal struct {
-	User              string // For backward-compatible only.
+	Users             []string // For backward-compatible only.
 	Names             []string
 	NotNames          []string
 	Group             string // For backward-compatible only.
@@ -89,8 +89,8 @@ func (principal *Principal) Generate(forTCPFilter bool) (*envoy_rbac.Principal, 
 		return pg.andPrincipals(), nil
 	}
 
-	if principal.User != "" {
-		principal := principalForKeyValue(attrSrcPrincipal, principal.User, forTCPFilter)
+	if len(principal.Users) != 0 {
+		principal := principalForKeyValues(attrSrcPrincipal, principal.Users, forTCPFilter)
 		pg.append(principal)
 	}
 

--- a/pilot/pkg/security/authz/model/principal_test.go
+++ b/pilot/pkg/security/authz/model/principal_test.go
@@ -115,13 +115,15 @@ func TestPrincipal_Generate(t *testing.T) {
 			wantYAML: `
         andIds:
           ids:
-          - metadata:
-              filter: istio_authn
-              path:
-              - key: source.principal
-              value:
-                stringMatch:
-                  exact: user-1`,
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      exact: user-1`,
 		},
 		{
 			name: "principal with names",

--- a/pilot/pkg/security/authz/model/principal_test.go
+++ b/pilot/pkg/security/authz/model/principal_test.go
@@ -54,7 +54,7 @@ func TestPrincipal_ValidateForTCP(t *testing.T) {
 		{
 			name: "good principal",
 			principal: &Principal{
-				User: "user",
+				Users: []string{"user"},
 				Properties: []KeyValues{
 					{
 						attrSrcNamespace: []string{"ns"},
@@ -110,7 +110,7 @@ func TestPrincipal_Generate(t *testing.T) {
 		{
 			name: "principal with user",
 			principal: &Principal{
-				User: "user-1",
+				Users: []string{"user-1"},
 			},
 			wantYAML: `
         andIds:

--- a/pilot/pkg/security/authz/model/util.go
+++ b/pilot/pkg/security/authz/model/util.go
@@ -109,3 +109,20 @@ func found(key string, list []string) bool {
 	}
 	return false
 }
+
+// getIdentityWithNewTrustDomain returns a new SPIFFE identity with the new trust domain.
+// The trust domain corresponds to the trust root of a system.
+// Refer to
+// [SPIFFE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)
+// In Istio, an identity is presented in the SPIFFE format, which is:
+// spiffe://<trust-domain>/ns/<some-namespace>/sa/<some-service-account>
+func getIdentityWithNewTrustDomain(trustDomain, spiffeIdentity string) (string, error) {
+	identityParts := strings.Split(spiffeIdentity, "/")
+	// A valid SPIFFE identity in authorization has no SPIFFE:// prefix.
+	// It is presented as <trust-domain>/ns/<some-namespace>/sa/<some-service-account>
+	if len(identityParts) != 5 {
+		rbacLog.Errorf("Wrong SPIFFE format found: %s", spiffeIdentity)
+		return "", fmt.Errorf("wrong SPIFFE format found: %s", spiffeIdentity)
+	}
+	return fmt.Sprintf("%s/%s", trustDomain, strings.Join(identityParts[1:], "/")), nil
+}

--- a/pilot/pkg/security/authz/model/util.go
+++ b/pilot/pkg/security/authz/model/util.go
@@ -110,13 +110,13 @@ func found(key string, list []string) bool {
 	return false
 }
 
-// getIdentityWithNewTrustDomain returns a new SPIFFE identity with the new trust domain.
+// replaceTrustDomainInPrincipal returns a new SPIFFE identity with the new trust domain.
 // The trust domain corresponds to the trust root of a system.
 // Refer to
 // [SPIFFE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)
 // In Istio authorization, an identity is presented in the format:
 // <trust-domain>/ns/<some-namespace>/sa/<some-service-account>
-func getIdentityWithNewTrustDomain(trustDomain, spiffeIdentity string) string {
+func replaceTrustDomainInPrincipal(trustDomain, spiffeIdentity string) string {
 	identityParts := strings.Split(spiffeIdentity, "/")
 	// A valid SPIFFE identity in authorization has no SPIFFE:// prefix.
 	// It is presented as <trust-domain>/ns/<some-namespace>/sa/<some-service-account>
@@ -133,7 +133,7 @@ func getIdentityWithNewTrustDomain(trustDomain, spiffeIdentity string) string {
 // In Istio authorization, an identity is presented in the format:
 // <trust-domain>/ns/<some-namespace>/sa/<some-service-account>
 // Therefore, for example, "cluster.local/ns/default/sa/bookinfo-ratings-v2" will return "cluster.local"
-func extractTrustDomainFromAuthzPrincipal(principal string) string {
+func getTrustDomain(principal string) string {
 	identityParts := strings.Split(principal, "/")
 	// A valid SPIFFE identity in authorization has no SPIFFE:// prefix.
 	// It is presented as <trust-domain>/ns/<some-namespace>/sa/<some-service-account>

--- a/pilot/pkg/security/authz/model/util.go
+++ b/pilot/pkg/security/authz/model/util.go
@@ -114,15 +114,32 @@ func found(key string, list []string) bool {
 // The trust domain corresponds to the trust root of a system.
 // Refer to
 // [SPIFFE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)
-// In Istio, an identity is presented in the SPIFFE format, which is:
-// spiffe://<trust-domain>/ns/<some-namespace>/sa/<some-service-account>
-func getIdentityWithNewTrustDomain(trustDomain, spiffeIdentity string) (string, error) {
+// In Istio authorization, an identity is presented in the format:
+// <trust-domain>/ns/<some-namespace>/sa/<some-service-account>
+func getIdentityWithNewTrustDomain(trustDomain, spiffeIdentity string) string {
 	identityParts := strings.Split(spiffeIdentity, "/")
 	// A valid SPIFFE identity in authorization has no SPIFFE:// prefix.
 	// It is presented as <trust-domain>/ns/<some-namespace>/sa/<some-service-account>
 	if len(identityParts) != 5 {
 		rbacLog.Errorf("Wrong SPIFFE format found: %s", spiffeIdentity)
-		return "", fmt.Errorf("wrong SPIFFE format found: %s", spiffeIdentity)
+		return ""
 	}
-	return fmt.Sprintf("%s/%s", trustDomain, strings.Join(identityParts[1:], "/")), nil
+	return fmt.Sprintf("%s/%s", trustDomain, strings.Join(identityParts[1:], "/"))
+}
+
+// The trust domain corresponds to the trust root of a system.
+// Refer to
+// [SPIFFE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)
+// In Istio authorization, an identity is presented in the format:
+// <trust-domain>/ns/<some-namespace>/sa/<some-service-account>
+// Therefore, for example, "cluster.local/ns/default/sa/bookinfo-ratings-v2" will return "cluster.local"
+func extractTrustDomainFromAuthzPrincipal(principal string) string {
+	identityParts := strings.Split(principal, "/")
+	// A valid SPIFFE identity in authorization has no SPIFFE:// prefix.
+	// It is presented as <trust-domain>/ns/<some-namespace>/sa/<some-service-account>
+	if len(identityParts) != 5 {
+		rbacLog.Errorf("Wrong SPIFFE format found: %s", principal)
+		return ""
+	}
+	return identityParts[0]
 }

--- a/pilot/pkg/security/authz/model/util_test.go
+++ b/pilot/pkg/security/authz/model/util_test.go
@@ -197,27 +197,27 @@ func TestExtractActualServiceAccount(t *testing.T) {
 	}
 }
 
-func TestGetIdentityWithNewTrustDomain(t *testing.T) {
+func TestReplaceTrustDomainInPrincipal(t *testing.T) {
 	cases := []struct {
 		trustDomainIn string
-		spiffeIn      string
+		principal     string
 		out           string
 	}{
-		{spiffeIn: "spiffe://cluster.local/ns/foo/sa/bar", out: ""},
-		{spiffeIn: "sa/test-sa/ns/default", out: ""},
-		{trustDomainIn: "td", spiffeIn: "cluster.local/ns/foo/sa/bar", out: "td/ns/foo/sa/bar"},
-		{trustDomainIn: "abc", spiffeIn: "xyz/ns/foo/sa/bar", out: "abc/ns/foo/sa/bar"},
+		{principal: "spiffe://cluster.local/ns/foo/sa/bar", out: ""},
+		{principal: "sa/test-sa/ns/default", out: ""},
+		{trustDomainIn: "td", principal: "cluster.local/ns/foo/sa/bar", out: "td/ns/foo/sa/bar"},
+		{trustDomainIn: "abc", principal: "xyz/ns/foo/sa/bar", out: "abc/ns/foo/sa/bar"},
 	}
 
 	for _, c := range cases {
-		got := getIdentityWithNewTrustDomain(c.trustDomainIn, c.spiffeIn)
+		got := replaceTrustDomainInPrincipal(c.trustDomainIn, c.principal)
 		if got != c.out {
 			t.Errorf("expect %s, but got %s", c.out, got)
 		}
 	}
 }
 
-func TestExtractTrustDomainFromAuthzPrincipal(t *testing.T) {
+func TestGetTrustDomain(t *testing.T) {
 	cases := []struct {
 		principal string
 		out       string
@@ -229,7 +229,7 @@ func TestExtractTrustDomainFromAuthzPrincipal(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		got := extractTrustDomainFromAuthzPrincipal(c.principal)
+		got := getTrustDomain(c.principal)
 		if got != c.out {
 			t.Errorf("expect %s, but got %s", c.out, got)
 		}

--- a/pilot/pkg/security/authz/model/util_test.go
+++ b/pilot/pkg/security/authz/model/util_test.go
@@ -202,21 +202,34 @@ func TestGetIdentityWithNewTrustDomain(t *testing.T) {
 		trustDomainIn string
 		spiffeIn      string
 		out           string
-		expectedError string
 	}{
-		{spiffeIn: "spiffe://cluster.local/ns/foo/sa/bar", expectedError: "wrong SPIFFE format found"},
-		{spiffeIn: "sa/test-sa/ns/default", expectedError: "wrong SPIFFE format found"},
+		{spiffeIn: "spiffe://cluster.local/ns/foo/sa/bar", out: ""},
+		{spiffeIn: "sa/test-sa/ns/default", out: ""},
 		{trustDomainIn: "td", spiffeIn: "cluster.local/ns/foo/sa/bar", out: "td/ns/foo/sa/bar"},
 		{trustDomainIn: "abc", spiffeIn: "xyz/ns/foo/sa/bar", out: "abc/ns/foo/sa/bar"},
 	}
 
 	for _, c := range cases {
-		got, err := getIdentityWithNewTrustDomain(c.trustDomainIn, c.spiffeIn)
-		if err != nil {
-			if !strings.Contains(err.Error(), c.expectedError) {
-				t.Fatalf("unexpected error: %v", err)
-			}
+		got := getIdentityWithNewTrustDomain(c.trustDomainIn, c.spiffeIn)
+		if got != c.out {
+			t.Errorf("expect %s, but got %s", c.out, got)
 		}
+	}
+}
+
+func TestExtractTrustDomainFromAuthzPrincipal(t *testing.T) {
+	cases := []struct {
+		principal string
+		out       string
+	}{
+		{principal: "spiffe://cluster.local/ns/foo/sa/bar", out: ""},
+		{principal: "sa/test-sa/ns/default", out: ""},
+		{principal: "cluster.local/ns/foo/sa/bar", out: "cluster.local"},
+		{principal: "xyz/ns/foo/sa/bar", out: "xyz"},
+	}
+
+	for _, c := range cases {
+		got := extractTrustDomainFromAuthzPrincipal(c.principal)
 		if got != c.out {
 			t.Errorf("expect %s, but got %s", c.out, got)
 		}

--- a/pilot/pkg/security/authz/model/util_test.go
+++ b/pilot/pkg/security/authz/model/util_test.go
@@ -196,3 +196,29 @@ func TestExtractActualServiceAccount(t *testing.T) {
 		}
 	}
 }
+
+func TestGetIdentityWithNewTrustDomain(t *testing.T) {
+	cases := []struct {
+		trustDomainIn string
+		spiffeIn      string
+		out           string
+		expectedError string
+	}{
+		{spiffeIn: "spiffe://cluster.local/ns/foo/sa/bar", expectedError: "wrong SPIFFE format found"},
+		{spiffeIn: "sa/test-sa/ns/default", expectedError: "wrong SPIFFE format found"},
+		{trustDomainIn: "td", spiffeIn: "cluster.local/ns/foo/sa/bar", out: "td/ns/foo/sa/bar"},
+		{trustDomainIn: "abc", spiffeIn: "xyz/ns/foo/sa/bar", out: "abc/ns/foo/sa/bar"},
+	}
+
+	for _, c := range cases {
+		got, err := getIdentityWithNewTrustDomain(c.trustDomainIn, c.spiffeIn)
+		if err != nil {
+			if !strings.Contains(err.Error(), c.expectedError) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+		if got != c.out {
+			t.Errorf("expect %s, but got %s", c.out, got)
+		}
+	}
+}

--- a/pilot/pkg/security/authz/policy/helper.go
+++ b/pilot/pkg/security/authz/policy/helper.go
@@ -125,7 +125,11 @@ func SimpleRole(name string, namespace string, service string) *model.Config {
 }
 
 func BindingTag(name string) string {
-	return fmt.Sprintf("UserFromBinding[%s]", name)
+	return fmt.Sprintf("cluster.local/ns/%s/sa/%s", name, name)
+}
+
+func BindingPrincipal(trustDomain, namespace, saName string) string {
+	return fmt.Sprintf("%s/ns/%s/sa/%s", trustDomain, namespace, saName)
 }
 
 func SimpleBinding(name string, namespace string, role string) *model.Config {

--- a/pilot/pkg/security/authz/policy/helper.go
+++ b/pilot/pkg/security/authz/policy/helper.go
@@ -124,11 +124,11 @@ func SimpleRole(name string, namespace string, service string) *model.Config {
 	}
 }
 
-func BindingTag(name string) string {
+func SimplePrincipal(name string) string {
 	return fmt.Sprintf("cluster.local/ns/%s/sa/%s", name, name)
 }
 
-func BindingPrincipal(trustDomain, namespace, saName string) string {
+func CustomPrincipal(trustDomain, namespace, saName string) string {
 	return fmt.Sprintf("%s/ns/%s/sa/%s", trustDomain, namespace, saName)
 }
 
@@ -142,7 +142,7 @@ func SimpleBinding(name string, namespace string, role string) *model.Config {
 		Spec: &istio_rbac.ServiceRoleBinding{
 			Subjects: []*istio_rbac.Subject{
 				{
-					User: BindingTag(name),
+					User: SimplePrincipal(name),
 				},
 			},
 			RoleRef: &istio_rbac.RoleRef{
@@ -216,6 +216,8 @@ func Verify(got *envoy_rbac.RBAC, want map[string][]string) error {
 			if !ok {
 				err = multierror.Append(err, fmt.Errorf("not found rule %q", key))
 			} else {
+				// FIXME(pitlv2109/yangmingzhu): This doesn't always work because |actualStr| might contain
+				// more stuff than |values| from |want|. Need to check both ways.
 				for _, value := range values {
 					if !strings.Contains(actualStr, value) {
 						err = multierror.Append(err, fmt.Errorf("not found %q in rule %q", value, key))

--- a/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1.go
+++ b/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1.go
@@ -116,6 +116,6 @@ func (g *v1alpha1Generator) generatePolicy(trustDomain string, trustDomainAliase
 		return nil
 	}
 
-	m := authz_model.NewModelV1Alpha1(trustDomain, trustDomainAliases, role, bindings)
+	m := authz_model.NewModelV1alpha1(trustDomain, trustDomainAliases, role, bindings)
 	return m.Generate(g.serviceMetadata, forTCPFilter)
 }

--- a/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1_test.go
+++ b/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1_test.go
@@ -255,9 +255,6 @@ func TestV1alpha1_TrustDomainAliases(t *testing.T) {
 			if !found {
 				t.Fatalf("key %s not found", role)
 			}
-			if len(policy.Principals) != len(tc.expectPrincipals) {
-				t.Fatalf("unexpected number of principals. Want %d, got %d", len(tc.expectPrincipals), len(policy.Principals))
-			}
 			principalsStr := spew.Sdump(policy.Principals)
 			for _, expectedPrincipal := range tc.expectPrincipals {
 				if !strings.Contains(principalsStr, expectedPrincipal) {

--- a/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1_test.go
+++ b/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1_test.go
@@ -174,7 +174,7 @@ func TestV1alpha1Generator_Generate(t *testing.T) {
 			if authzPolicies == nil {
 				t.Fatal("failed to create authz policies")
 			}
-			g := NewGenerator(nil, serviceFooInNamespaceA, authzPolicies, tc.isGlobalPermissiveEnabled)
+			g := NewGenerator("cluster.local", nil, serviceFooInNamespaceA, authzPolicies, tc.isGlobalPermissiveEnabled)
 			if g == nil {
 				t.Fatal("failed to create generator")
 			}
@@ -208,6 +208,7 @@ func TestV1alpha1_TrustDomainAliases(t *testing.T) {
 	testCases := []struct {
 		name               string
 		policies           []*model.Config
+		trustDomain        string
 		trustDomainAliases []string
 		expectPrincipals   []string
 	}{
@@ -217,6 +218,7 @@ func TestV1alpha1_TrustDomainAliases(t *testing.T) {
 				policy.SimpleRole(role, namespaceA, serviceFoo),
 				policy.SimpleBinding("binding", namespaceA, role),
 			},
+			trustDomain:        "cluster.local",
 			trustDomainAliases: nil,
 			expectPrincipals:   []string{policy.BindingPrincipal("cluster.local", "binding", "binding")},
 		},
@@ -226,11 +228,11 @@ func TestV1alpha1_TrustDomainAliases(t *testing.T) {
 				policy.SimpleRole(role, namespaceA, serviceFoo),
 				policy.SimpleBinding("binding", namespaceA, role),
 			},
-			trustDomainAliases: []string{"td1", "td2"},
+			trustDomain:        "td1",
+			trustDomainAliases: []string{"cluster.local"},
 			expectPrincipals: []string{
 				policy.BindingPrincipal("cluster.local", "binding", "binding"),
-				policy.BindingPrincipal("td1", "binding", "binding"),
-				policy.BindingPrincipal("td2", "binding", "binding")},
+				policy.BindingPrincipal("td1", "binding", "binding")},
 		},
 	}
 
@@ -240,7 +242,7 @@ func TestV1alpha1_TrustDomainAliases(t *testing.T) {
 			if authzPolicies == nil {
 				t.Fatal("failed to create authz policies")
 			}
-			g := NewGenerator(tc.trustDomainAliases, serviceFooInNamespaceA, authzPolicies, false)
+			g := NewGenerator(tc.trustDomain, tc.trustDomainAliases, serviceFooInNamespaceA, authzPolicies, false)
 			if g == nil {
 				t.Fatal("failed to create generator")
 			}

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
@@ -32,12 +32,14 @@ var (
 )
 
 type v1beta1Generator struct {
+	trustDomain        string
 	trustDomainAliases []string
 	policies           []model.Config
 }
 
-func NewGenerator(trustDomainAliases []string, policies []model.Config) policy.Generator {
+func NewGenerator(trustDomain string, trustDomainAliases []string, policies []model.Config) policy.Generator {
 	return &v1beta1Generator{
+		trustDomain:        trustDomain,
 		trustDomainAliases: trustDomainAliases,
 		policies:           policies,
 	}
@@ -54,7 +56,7 @@ func (g *v1beta1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 	for _, config := range g.policies {
 		spec := config.Spec.(*istio_rbac.AuthorizationPolicy)
 		for i, rule := range spec.Rules {
-			if p := g.generatePolicy(g.trustDomainAliases, rule, forTCPFilter); p != nil {
+			if p := g.generatePolicy(g.trustDomain, g.trustDomainAliases, rule, forTCPFilter); p != nil {
 				name := fmt.Sprintf("ns[%s]-policy[%s]-rule[%d]", config.Namespace, config.Name, i)
 				rbac.Policies[name] = p
 				rbacLog.Debugf("generated policy %s: %+v", name, p)
@@ -64,12 +66,12 @@ func (g *v1beta1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 	return &http_config.RBAC{Rules: rbac}
 }
 
-func (g *v1beta1Generator) generatePolicy(trustDomainAliases []string, rule *istio_rbac.Rule, forTCPFilter bool) *envoy_rbac.Policy {
+func (g *v1beta1Generator) generatePolicy(trustDomain string, trustDomainAliases []string, rule *istio_rbac.Rule, forTCPFilter bool) *envoy_rbac.Policy {
 	if rule == nil {
 		return nil
 	}
 
-	m := authz_model.NewModelFromV1beta1(trustDomainAliases, rule)
+	m := authz_model.NewModelFromV1beta1(trustDomain, trustDomainAliases, rule)
 	rbacLog.Debugf("constructed internal model: %+v", m)
 	return m.Generate(nil, forTCPFilter)
 }

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
@@ -32,12 +32,14 @@ var (
 )
 
 type v1beta1Generator struct {
-	policies []model.Config
+	trustDomainAliases []string
+	policies           []model.Config
 }
 
-func NewGenerator(policies []model.Config) policy.Generator {
+func NewGenerator(trustDomainAliases []string, policies []model.Config) policy.Generator {
 	return &v1beta1Generator{
-		policies: policies,
+		trustDomainAliases: trustDomainAliases,
+		policies:           policies,
 	}
 }
 
@@ -52,7 +54,7 @@ func (g *v1beta1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 	for _, config := range g.policies {
 		spec := config.Spec.(*istio_rbac.AuthorizationPolicy)
 		for i, rule := range spec.Rules {
-			if p := g.generatePolicy(rule, forTCPFilter); p != nil {
+			if p := g.generatePolicy(g.trustDomainAliases, rule, forTCPFilter); p != nil {
 				name := fmt.Sprintf("ns[%s]-policy[%s]-rule[%d]", config.Namespace, config.Name, i)
 				rbac.Policies[name] = p
 				rbacLog.Debugf("generated policy %s: %+v", name, p)
@@ -62,12 +64,12 @@ func (g *v1beta1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 	return &http_config.RBAC{Rules: rbac}
 }
 
-func (g *v1beta1Generator) generatePolicy(rule *istio_rbac.Rule, forTCPFilter bool) *envoy_rbac.Policy {
+func (g *v1beta1Generator) generatePolicy(trustDomainAliases []string, rule *istio_rbac.Rule, forTCPFilter bool) *envoy_rbac.Policy {
 	if rule == nil {
 		return nil
 	}
 
-	m := authz_model.NewModelFromV1beta1(rule)
+	m := authz_model.NewModelFromV1beta1(trustDomainAliases, rule)
 	rbacLog.Debugf("constructed internal model: %+v", m)
 	return m.Generate(nil, forTCPFilter)
 }

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
@@ -71,7 +71,7 @@ func (g *v1beta1Generator) generatePolicy(trustDomain string, trustDomainAliases
 		return nil
 	}
 
-	m := authz_model.NewModelFromV1beta1(trustDomain, trustDomainAliases, rule)
+	m := authz_model.NewModelV1beta1(trustDomain, trustDomainAliases, rule)
 	rbacLog.Debugf("constructed internal model: %+v", m)
 	return m.Generate(nil, forTCPFilter)
 }

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
@@ -63,7 +63,7 @@ func TestV1beta1Generator_Generate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := NewGenerator(nil, tc.policies)
+			g := NewGenerator("", nil, tc.policies)
 			if g == nil {
 				t.Fatal("failed to create generator")
 			}

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
@@ -63,7 +63,7 @@ func TestV1beta1Generator_Generate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := NewGenerator(tc.policies)
+			g := NewGenerator(nil, tc.policies)
 			if g == nil {
 				t.Fatal("failed to create generator")
 			}

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pilot/pkg/security/authz/policy"
 )
 
+// TODO(pitlv2109): Add unit tests with trust domain aliases.
 func TestV1beta1Generator_Generate(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -69,6 +69,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		SdsUdsPath:                        "",
 		EnableSdsTokenMount:               false,
 		TrustDomain:                       "",
+		TrustDomainAliases:                []string{},
 		DefaultServiceExportTo:            []string{"*"},
 		DefaultVirtualServiceExportTo:     []string{"*"},
 		DefaultDestinationRuleExportTo:    []string{"*"},


### PR DESCRIPTION
Generate extra principals/users when trust domain aliases are used. Only support first class fields, i.e. `user` in v1alpha1 and `principals` in v1beta1.

Sample RBAC config with trust domain "cluster.local" and "td1, td2" alias. 
```
{
                          "name": "envoy.filters.http.rbac",
                          "typed_config": {
                            "@type": "type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC",
                            "rules": {
                              "policies": {
                                "service-viewer": {
                                  "permissions": [
                                    {
                                      "and_rules": {
                                        "rules": [
                                          {
                                            "or_rules": {
                                              "rules": [
                                                {
                                                  "header": {
                                                    "name": ":method",
                                                    "exact_match": "GET"
                                                  }
                                                }
                                              ]
                                            }
                                          }
                                        ]
                                      }
                                    }
                                  ],
                                  "principals": [
                                    {
                                      "and_ids": {
                                        "ids": [
                                          {
                                            "metadata": {
                                              "filter": "istio_authn",
                                              "path": [
                                                {
                                                  "key": "source.principal"
                                                }
                                              ],
                                              "value": {
                                                "string_match": {
                                                  "exact": "cluster.local/ns/istio-system/sa/istio-galley-service-account"
                                                }
                                              }
                                            }
                                          }
                                        ]
                                      }
                                    },
                                    {
                                      "and_ids": {
                                        "ids": [
                                          {
                                            "metadata": {
                                              "filter": "istio_authn",
                                              "path": [
                                                {
                                                  "key": "source.principal"
                                                }
                                              ],
                                              "value": {
                                                "string_match": {
                                                  "exact": "td1/ns/istio-system/sa/istio-galley-service-account"
                                                }
                                              }
                                            }
                                          }
                                        ]
                                      }
                                    },
                                    {
                                      "and_ids": {
                                        "ids": [
                                          {
                                            "metadata": {
                                              "filter": "istio_authn",
                                              "path": [
                                                {
                                                  "key": "source.principal"
                                                }
                                              ],
                                              "value": {
                                                "string_match": {
                                                  "exact": "td2/ns/istio-system/sa/istio-galley-service-account"
                                                }
                                              }
                                            }
                                          }
                                        ]
                                      }
                                    }
                                  ]
                                }
                              }
                            }
                          }
                        }
```
