### PR TITLE
Align service resolution in converter with pilot

### DIFF
--- a/galley/pkg/config/processor/transforms/serviceentry/converter/instance.go
+++ b/galley/pkg/config/processor/transforms/serviceentry/converter/instance.go
@@ -48,8 +48,8 @@ func New(domain string, pods pod.Cache) *Instance {
 // ServiceEntry is passed as an argument (out) in order to enable object reuse in the future.
 func (i *Instance) Convert(service *resource.Entry, endpoints *resource.Entry, outMeta *resource.Metadata,
 	out *networking.ServiceEntry) error {
-	i.convertService(service, outMeta, out)
 	i.convertEndpoints(endpoints, outMeta, out)
+	i.convertService(service, outMeta, out)
 	return nil
 }
 
@@ -61,10 +61,17 @@ func (i *Instance) convertService(service *resource.Entry, outMeta *resource.Met
 	}
 
 	spec := service.Item.(*coreV1.ServiceSpec)
-
-	resolution := networking.ServiceEntry_STATIC
 	location := networking.ServiceEntry_MESH_INTERNAL
-	endpoints := convertExternalServiceEndpoints(spec, service.Metadata)
+	endpoints := out.Endpoints
+	if len(endpoints) == 0 {
+		endpoints = convertExternalServiceEndpoints(spec, service.Metadata)
+	}
+
+	var resolution networking.ServiceEntry_Resolution
+	// Resolution STATIC must have endpoints
+	if len(endpoints) != 0 {
+		resolution = networking.ServiceEntry_STATIC
+	}
 
 	// Check for an external service
 	externalName := ""
@@ -83,6 +90,10 @@ func (i *Instance) convertService(service *resource.Entry, outMeta *resource.Met
 		// Headless services should not be load balanced
 		resolution = networking.ServiceEntry_NONE
 	}
+	// Resolution NONE must not have endpoints
+	if resolution == networking.ServiceEntry_NONE && len(endpoints) != 0 {
+		resolution = networking.ServiceEntry_STATIC
+	}
 
 	ports := make([]*networking.Port, 0, len(spec.Ports))
 	for _, port := range spec.Ports {
@@ -93,7 +104,12 @@ func (i *Instance) convertService(service *resource.Entry, outMeta *resource.Met
 
 	// Store everything in the ServiceEntry.
 	out.Hosts = []string{host}
-	out.Addresses = []string{addr}
+	// CIDR addrs are only allowed for NONE/STATIC resolution types
+	if resolution != networking.ServiceEntry_DNS {
+		out.Addresses = []string{addr}
+	} else {
+		out.Addresses = []string{constants.UnspecifiedIP}
+	}
 	out.Resolution = resolution
 	out.Location = location
 	out.Ports = ports
@@ -108,7 +124,10 @@ func (i *Instance) convertService(service *resource.Entry, outMeta *resource.Met
 	outMeta.CreateTime = service.Metadata.CreateTime
 
 	// Update the annotations.
-	outMeta.Annotations = service.Metadata.Annotations.CloneOrCreate()
+	outMeta.Annotations = outMeta.Annotations.CloneOrCreate()
+	for k, v := range service.Metadata.Annotations {
+		outMeta.Annotations[k] = v
+	}
 
 	// Add an annotation for the version of the service resource.
 	outMeta.Annotations[annotation.AlphaNetworkingServiceVersion.Name] = string(service.Metadata.Version)

--- a/galley/pkg/config/processor/transforms/serviceentry/converter/instance.go
+++ b/galley/pkg/config/processor/transforms/serviceentry/converter/instance.go
@@ -48,6 +48,10 @@ func New(domain string, pods pod.Cache) *Instance {
 // ServiceEntry is passed as an argument (out) in order to enable object reuse in the future.
 func (i *Instance) Convert(service *resource.Entry, endpoints *resource.Entry, outMeta *resource.Metadata,
 	out *networking.ServiceEntry) error {
+	// we want to build the endpoints and then services
+	// as availability of endpoints can impact determining
+	// service resolution e.g STATIC service resolution
+	// must have endpoints
 	i.convertEndpoints(endpoints, outMeta, out)
 	i.convertService(service, outMeta, out)
 	return nil


### PR DESCRIPTION
This change aligns the service resolution selection logic with what
exist in pilot, this change only applies to converter that is used by
NewProcessor2.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
