### PR TITLE
Introduce a jitter into root cert rotator

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	enableJitterForRootCertRotator          = "ENABLE_JITTER_FOR_ROOT_CERT_ROTATOR"
+	enableJitterForRootCertRotator = "ENABLE_JITTER_FOR_ROOT_CERT_ROTATOR"
 )
 
 type cliOptions struct { // nolint: maligned
@@ -67,7 +67,7 @@ type cliOptions struct { // nolint: maligned
 	selfSignedCA                    bool
 	selfSignedCACertTTL             time.Duration
 	selfSignedRootCertCheckInterval time.Duration
-	enableJitterForRootCertRotator          bool
+	enableJitterForRootCertRotator  bool
 
 	workloadCertTTL    time.Duration
 	maxWorkloadCertTTL time.Duration
@@ -127,9 +127,9 @@ var (
 		LivenessProbeOptions: &probe.Options{},
 		enableJitterForRootCertRotator: env.RegisterBoolVar(enableJitterForRootCertRotator,
 			true,
-			"If true, set up a jitter to start root cert rotator. " +
-					"Jitter selects a backoff time in seconds to start root cert rotator, " +
-					"and the back off time is below root cert check interval.").Get(),
+			"If true, set up a jitter to start root cert rotator. "+
+				"Jitter selects a backoff time in seconds to start root cert rotator, "+
+				"and the back off time is below root cert check interval.").Get(),
 	}
 
 	rootCmd = &cobra.Command{

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -47,6 +47,10 @@ import (
 	"istio.io/pkg/version"
 )
 
+const (
+	enableJitterForRootCertRotator          = "ENABLE_JITTER_FOR_ROOT_CERT_ROTATOR"
+)
+
 type cliOptions struct { // nolint: maligned
 	// Comma separated string containing all listened namespaces
 	listenedNamespaces        string
@@ -63,6 +67,7 @@ type cliOptions struct { // nolint: maligned
 	selfSignedCA                    bool
 	selfSignedCACertTTL             time.Duration
 	selfSignedRootCertCheckInterval time.Duration
+	enableJitterForRootCertRotator          bool
 
 	workloadCertTTL    time.Duration
 	maxWorkloadCertTTL time.Duration
@@ -120,6 +125,11 @@ var (
 		loggingOptions:       log.DefaultOptions(),
 		ctrlzOptions:         ctrlz.DefaultOptions(),
 		LivenessProbeOptions: &probe.Options{},
+		enableJitterForRootCertRotator: env.RegisterBoolVar(enableJitterForRootCertRotator,
+			true,
+			"If true, set up a jitter to start root cert rotator. " +
+					"Jitter selects a backoff time in seconds to start root cert rotator, " +
+					"and the back off time is below root cert check interval.").Get(),
 	}
 
 	rootCmd = &cobra.Command{
@@ -447,10 +457,10 @@ func createCA(client corev1.CoreV1Interface) *ca.IstioCA {
 			opts.selfSignedRootCertCheckInterval = 1 * time.Minute
 		}
 		caOpts, err = ca.NewSelfSignedIstioCAOptions(ctx, opts.readSigningCertOnly,
-			opts.selfSignedCACertTTL,
-			opts.selfSignedRootCertCheckInterval, opts.workloadCertTTL,
-			opts.maxWorkloadCertTTL, spiffe.GetTrustDomain(), opts.dualUse,
-			opts.istioCaStorageNamespace, checkInterval, client, opts.rootCertFile)
+			opts.selfSignedCACertTTL, opts.selfSignedRootCertCheckInterval,
+			opts.workloadCertTTL, opts.maxWorkloadCertTTL, spiffe.GetTrustDomain(),
+			opts.dualUse, opts.istioCaStorageNamespace, checkInterval, client,
+			opts.rootCertFile, opts.enableJitterForRootCertRotator)
 		if err != nil {
 			fatalf("Failed to create a self-signed Citadel (error: %v)", err)
 		}

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	enableJitterForRootCertRotator = "ENABLE_JITTER_FOR_ROOT_CERT_ROTATOR"
+	enableJitterForRootCertRotator = "CITADEL_ENABLE_JITTER_FOR_ROOT_CERT_ROTATOR"
 )
 
 type cliOptions struct { // nolint: maligned

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -118,7 +118,7 @@ func appendRootCerts(pemCert []byte, rootCertFile string) ([]byte, error) {
 func NewSelfSignedIstioCAOptions(ctx context.Context, readSigningCertOnly bool,
 	caCertTTL, rootCertCheckInverval, certTTL, maxCertTTL time.Duration,
 	org string, dualUse bool, namespace string, readCertRetryInterval time.Duration,
-	client corev1.CoreV1Interface, rootCertFile string) (caOpts *IstioCAOptions, err error) {
+	client corev1.CoreV1Interface, rootCertFile string, enableJitter bool) (caOpts *IstioCAOptions, err error) {
 	// For the first time the CA is up, if readSigningCertOnly is unset,
 	// it generates a self-signed key/cert pair and write it to CASecret.
 	// For subsequent restart, CA will reads key/cert from CASecret.
@@ -154,6 +154,7 @@ func NewSelfSignedIstioCAOptions(ctx context.Context, readSigningCertOnly bool,
 			readSigningCertOnly: readSigningCertOnly,
 			org:                 org,
 			rootCertFile:        rootCertFile,
+			enableJitter:				 enableJitter,
 			client:              client,
 		},
 	}

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -154,7 +154,7 @@ func NewSelfSignedIstioCAOptions(ctx context.Context, readSigningCertOnly bool,
 			readSigningCertOnly: readSigningCertOnly,
 			org:                 org,
 			rootCertFile:        rootCertFile,
-			enableJitter:				 enableJitter,
+			enableJitter:        enableJitter,
 			client:              client,
 		},
 	}

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -99,10 +99,7 @@ func TestCreateSelfSignedIstioCAWithoutSecret(t *testing.T) {
 	readSigningCertOnly := false
 	rootCertCheckInverval := time.Hour
 
-	caopts, err := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly,
-		caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL,
-		org, false, caNamespace, -1, client.CoreV1(),
-		rootCertFile)
+	caopts, err := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly, caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL, org, false, caNamespace, -1, client.CoreV1(), rootCertFile, false)
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -190,10 +187,7 @@ func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 	readSigningCertOnly := false
 	rootCertCheckInverval := time.Hour
 
-	caopts, err := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly,
-		caCertTTL, rootCertCheckInverval, certTTL, maxCertTTL,
-		org, false, caNamespace, -1, client.CoreV1(),
-		rootCertFile)
+	caopts, err := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly, caCertTTL, rootCertCheckInverval, certTTL, maxCertTTL, org, false, caNamespace, -1, client.CoreV1(), rootCertFile, false)
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -262,10 +256,7 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 	expectedErr := "secret waiting thread is terminated"
 	ctx0, cancel0 := context.WithTimeout(context.Background(), time.Millisecond*50)
 	defer cancel0()
-	_, err := NewSelfSignedIstioCAOptions(ctx0, readSigningCertOnly, caCertTTL,
-		certTTL, rootCertCheckInverval, maxCertTTL,
-		org, false, caNamespace, time.Millisecond*10, client.CoreV1(),
-		rootCertFile)
+	_, err := NewSelfSignedIstioCAOptions(ctx0, readSigningCertOnly, caCertTTL, certTTL, rootCertCheckInverval, maxCertTTL, org, false, caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile, false)
 	if err == nil {
 		t.Errorf("Expected error, but succeeded.")
 	} else if err.Error() != expectedErr {
@@ -282,9 +273,7 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	defer cancel1()
-	caopts, err := NewSelfSignedIstioCAOptions(ctx1, readSigningCertOnly, caCertTTL,
-		certTTL, rootCertCheckInverval, maxCertTTL, org, false,
-		caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile)
+	caopts, err := NewSelfSignedIstioCAOptions(ctx1, readSigningCertOnly, caCertTTL, certTTL, rootCertCheckInverval, maxCertTTL, org, false, caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -99,7 +99,9 @@ func TestCreateSelfSignedIstioCAWithoutSecret(t *testing.T) {
 	readSigningCertOnly := false
 	rootCertCheckInverval := time.Hour
 
-	caopts, err := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly, caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL, org, false, caNamespace, -1, client.CoreV1(), rootCertFile, false)
+	caopts, err := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly,
+		caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL, org, false,
+		caNamespace, -1, client.CoreV1(), rootCertFile, false)
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -172,7 +174,8 @@ func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 	signingKeyPem := []byte(key1Pem)
 
 	client := fake.NewSimpleClientset()
-	initSecret := k8ssecret.BuildSecret("", CASecret, "default", nil, nil, nil, signingCertPem, signingKeyPem, istioCASecretType)
+	initSecret := k8ssecret.BuildSecret("", CASecret, "default",
+		nil, nil, nil, signingCertPem, signingKeyPem, istioCASecretType)
 	_, err := client.CoreV1().Secrets("default").Create(initSecret)
 	if err != nil {
 		t.Errorf("Failed to create secret (error: %s)", err)
@@ -187,7 +190,9 @@ func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 	readSigningCertOnly := false
 	rootCertCheckInverval := time.Hour
 
-	caopts, err := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly, caCertTTL, rootCertCheckInverval, certTTL, maxCertTTL, org, false, caNamespace, -1, client.CoreV1(), rootCertFile, false)
+	caopts, err := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly,
+		caCertTTL, rootCertCheckInverval, certTTL, maxCertTTL, org, false,
+		caNamespace, -1, client.CoreV1(), rootCertFile, false)
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -256,7 +261,9 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 	expectedErr := "secret waiting thread is terminated"
 	ctx0, cancel0 := context.WithTimeout(context.Background(), time.Millisecond*50)
 	defer cancel0()
-	_, err := NewSelfSignedIstioCAOptions(ctx0, readSigningCertOnly, caCertTTL, certTTL, rootCertCheckInverval, maxCertTTL, org, false, caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile, false)
+	_, err := NewSelfSignedIstioCAOptions(ctx0, readSigningCertOnly, caCertTTL, certTTL,
+		rootCertCheckInverval, maxCertTTL, org, false, caNamespace,
+		time.Millisecond*10, client.CoreV1(), rootCertFile, false)
 	if err == nil {
 		t.Errorf("Expected error, but succeeded.")
 	} else if err.Error() != expectedErr {
@@ -273,7 +280,9 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	defer cancel1()
-	caopts, err := NewSelfSignedIstioCAOptions(ctx1, readSigningCertOnly, caCertTTL, certTTL, rootCertCheckInverval, maxCertTTL, org, false, caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile, false)
+	caopts, err := NewSelfSignedIstioCAOptions(ctx1, readSigningCertOnly, caCertTTL,
+		certTTL, rootCertCheckInverval, maxCertTTL, org, false, caNamespace,
+		time.Millisecond*10, client.CoreV1(), rootCertFile, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -17,6 +17,7 @@ package ca
 import (
 	"bytes"
 	"encoding/base64"
+	"math/rand"
 	"time"
 
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -42,6 +43,7 @@ type SelfSignedCARootCertRotatorConfig struct {
 	readSigningCertOnly bool
 	org                 string
 	rootCertFile        string
+	enableJitter        bool
 	client              corev1.CoreV1Interface
 }
 
@@ -51,6 +53,7 @@ type SelfSignedCARootCertRotator struct {
 	configMapController *configmap.Controller
 	caSecretController  *controller.CaSecretController
 	config              *SelfSignedCARootCertRotatorConfig
+	backOffTime         time.Duration
 	ca                  *IstioCA
 }
 
@@ -64,11 +67,24 @@ func NewSelfSignedCARootCertRotator(config *SelfSignedCARootCertRotatorConfig,
 		config:              config,
 		ca:                  ca,
 	}
+	if config.enableJitter {
+		// Select a back off time in seconds, which is in the range of [0, rotator.config.CheckInterval).
+		backOffSeconds := int(time.Duration(rand.Int63n(int64(rotator.config.CheckInterval))).Seconds())
+		rotator.backOffTime = time.Duration(backOffSeconds) * time.Second
+		rootCertRotatorLog.Infof("Set up back off time %s to start rotator.", rotator.backOffTime.String())
+	} else {
+		rotator.backOffTime = time.Duration(0)
+	}
 	return rotator
 }
 
 // Run refreshes root certs and updates config map accordingly.
 func (rotator *SelfSignedCARootCertRotator) Run(rootCertRotatorChan chan struct{}) {
+	if rotator.config.enableJitter && rotator.backOffTime > time.Duration(0) {
+		rootCertRotatorLog.Infof("Jitter is enabled, wait %s before " +
+				"starting root cert rotator.", rotator.backOffTime.String())
+		time.Sleep(rotator.backOffTime)
+	}
 	ticker := time.NewTicker(rotator.config.CheckInterval)
 	for {
 		select {

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -80,7 +80,7 @@ func NewSelfSignedCARootCertRotator(config *SelfSignedCARootCertRotatorConfig,
 
 // Run refreshes root certs and updates config map accordingly.
 func (rotator *SelfSignedCARootCertRotator) Run(rootCertRotatorChan chan struct{}) {
-	if rotator.config.enableJitter && rotator.backOffTime > time.Duration(0) {
+	if rotator.config.enableJitter {
 		rootCertRotatorLog.Infof("Jitter is enabled, wait %s before "+
 			"starting root cert rotator.", rotator.backOffTime.String())
 		time.Sleep(rotator.backOffTime)

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -81,8 +81,8 @@ func NewSelfSignedCARootCertRotator(config *SelfSignedCARootCertRotatorConfig,
 // Run refreshes root certs and updates config map accordingly.
 func (rotator *SelfSignedCARootCertRotator) Run(rootCertRotatorChan chan struct{}) {
 	if rotator.config.enableJitter && rotator.backOffTime > time.Duration(0) {
-		rootCertRotatorLog.Infof("Jitter is enabled, wait %s before " +
-				"starting root cert rotator.", rotator.backOffTime.String())
+		rootCertRotatorLog.Infof("Jitter is enabled, wait %s before "+
+			"starting root cert rotator.", rotator.backOffTime.String())
 		time.Sleep(rotator.backOffTime)
 	}
 	ticker := time.NewTicker(rotator.config.CheckInterval)

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -34,17 +34,17 @@ import (
 var rootCertRotatorLog = log.RegisterScope("rootCertRotator", "Self-signed CA root cert rotator log", 0)
 
 type SelfSignedCARootCertRotatorConfig struct {
+	certInspector       certutil.CertUtil
+	caStorageNamespace  string
+	org                 string
+	rootCertFile        string
+	client              corev1.CoreV1Interface
 	CheckInterval       time.Duration
 	caCertTTL           time.Duration
 	retryInterval       time.Duration
-	certInspector       certutil.CertUtil
-	caStorageNamespace  string
 	dualUse             bool
 	readSigningCertOnly bool
-	org                 string
-	rootCertFile        string
 	enableJitter        bool
-	client              corev1.CoreV1Interface
 }
 
 // SelfSignedCARootCertRotator automatically checks self-signed signing root

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
@@ -33,6 +33,27 @@ import (
 
 const caNamespace = "default"
 
+// TestJitterConfiguration tests the setup of jitter
+func TestJitterConfiguration(t *testing.T) {
+	enableJitterOpts := getDefaultSelfSignedIstioCAOptions(nil)
+	enableJitterOpts.RotatorConfig.enableJitter = true
+	rotator0 := getRootCertRotator(enableJitterOpts)
+	if rotator0.backOffTime < time.Duration(0) {
+		t.Errorf("back off time should be zero or positive but got %v", rotator0.backOffTime)
+	}
+	if rotator0.backOffTime >= rotator0.config.CheckInterval {
+		t.Errorf("back off time should be shorter than rotation interval but got %v",
+			rotator0.backOffTime)
+	}
+
+	disableJitterOpts := getDefaultSelfSignedIstioCAOptions(nil)
+	disableJitterOpts.RotatorConfig.enableJitter = false
+	rotator1 := getRootCertRotator(disableJitterOpts)
+	if rotator1.backOffTime > time.Duration(0) {
+		t.Errorf("back off time should be negative but got %v", rotator1.backOffTime)
+	}
+}
+
 // TestRootCertRotatorWithoutRootCertSecret verifies that if root cert secret
 // does not exist, the rotator does not add new root cert.
 func TestRootCertRotatorWithoutRootCertSecret(t *testing.T) {
@@ -239,10 +260,7 @@ func getDefaultSelfSignedIstioCAOptions(client corev1.CoreV1Interface) *IstioCAO
 	readSigningCertOnly := false
 	rootCertCheckInverval := time.Hour
 
-	caopts, _ := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly,
-		caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL,
-		org, false, caNamespace, -1, client,
-		rootCertFile)
+	caopts, _ := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly, caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL, org, false, caNamespace, -1, client, rootCertFile, false)
 	return caopts
 }
 

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
@@ -260,7 +260,9 @@ func getDefaultSelfSignedIstioCAOptions(client corev1.CoreV1Interface) *IstioCAO
 	readSigningCertOnly := false
 	rootCertCheckInverval := time.Hour
 
-	caopts, _ := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly, caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL, org, false, caNamespace, -1, client, rootCertFile, false)
+	caopts, _ := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly,
+		caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL, org, false,
+		caNamespace, -1, client, rootCertFile, false)
 	return caopts
 }
 


### PR DESCRIPTION
Please provide a description for what this PR is for.
Introduce a jitter into root cert rotator, that sets up a backoff time when starting rotator. This is to prevent race condition when multiple Citadels are deployed and none of the Citadels is in read-only mode.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

#17059