### PR TITLE
Add the ability to fail tests when using an Envoy deprecated feature

### DIFF
--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -54,6 +54,7 @@ type instance struct {
 	env       *kubeEnv.Environment
 	workloads []*workload
 	grpcPort  uint16
+	ctx       resource.Context
 }
 
 func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err error) {
@@ -74,6 +75,7 @@ func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err erro
 	c := &instance{
 		env: env,
 		cfg: cfg,
+		ctx: ctx,
 	}
 	c.id = ctx.TrackResource(c)
 
@@ -221,7 +223,7 @@ func (c *instance) initialize(endpoints *kubeCore.Endpoints) error {
 	workloads := make([]*workload, 0)
 	for _, subset := range endpoints.Subsets {
 		for _, addr := range subset.Addresses {
-			workload, err := newWorkload(addr, c.cfg.Annotations, c.grpcPort, c.env.Accessor)
+			workload, err := newWorkload(addr, c.cfg.Annotations, c.grpcPort, c.env.Accessor, c.ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/test/framework/components/echo/kube/workload.go
+++ b/pkg/test/framework/components/echo/kube/workload.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/errors"
+	"istio.io/istio/pkg/test/framework/resource"
 
 	"github.com/hashicorp/go-multierror"
 
@@ -44,9 +46,11 @@ type workload struct {
 	forwarder kube.PortForwarder
 	sidecar   *sidecar
 	accessor  *kube.Accessor
+	ctx       resource.Context
 }
 
-func newWorkload(addr kubeCore.EndpointAddress, annotations echo.Annotations, grpcPort uint16, accessor *kube.Accessor) (*workload, error) {
+func newWorkload(addr kubeCore.EndpointAddress, annotations echo.Annotations, grpcPort uint16,
+	accessor *kube.Accessor, ctx resource.Context) (*workload, error) {
 	if addr.TargetRef == nil || addr.TargetRef.Kind != "Pod" {
 		return nil, fmt.Errorf("invalid TargetRef for endpoint %s: %v", addr.IP, addr.TargetRef)
 	}
@@ -86,6 +90,7 @@ func newWorkload(addr kubeCore.EndpointAddress, annotations echo.Annotations, gr
 		Instance:  c,
 		sidecar:   s,
 		accessor:  accessor,
+		ctx:       ctx,
 	}, nil
 }
 
@@ -96,7 +101,20 @@ func (w *workload) Close() (err error) {
 	if w.forwarder != nil {
 		err = multierror.Append(err, w.forwarder.Close()).ErrorOrNil()
 	}
+	if w.ctx.Settings().FailOnDeprecation && w.sidecar != nil {
+		err = multierror.Append(err, w.checkDeprecation()).ErrorOrNil()
+	}
 	return
+}
+
+func (w *workload) checkDeprecation() error {
+	logs, err := w.sidecar.Logs()
+	if err != nil {
+		return fmt.Errorf("could not get sidecar logs to inspect for deprecation messages: %v", err)
+	}
+
+	info := fmt.Sprintf("pod: %s/%s", w.pod.Namespace, w.pod.Name)
+	return errors.FindDeprecatedMessagesInEnvoyLog(logs, info)
 }
 
 func (w *workload) Address() string {

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -180,7 +180,7 @@ func DefaultConfig(ctx resource.Context) (Config, error) {
 		return Config{}, err
 	}
 
-	if s.Values, err = newHelmValues(deps); err != nil {
+	if s.Values, err = newHelmValues(ctx, deps); err != nil {
 		return Config{}, err
 	}
 
@@ -222,7 +222,7 @@ func checkFileExists(path string) error {
 	return nil
 }
 
-func newHelmValues(s *image.Settings) (map[string]string, error) {
+func newHelmValues(ctx resource.Context, s *image.Settings) (map[string]string, error) {
 	userValues, err := parseHelmValues()
 	if err != nil {
 		return nil, err
@@ -245,6 +245,13 @@ func newHelmValues(s *image.Settings) (map[string]string, error) {
 	if values[image.TagValuesKey] == image.LatestTag {
 		values[image.ImagePullPolicyValuesKey] = string(kubeCore.PullAlways)
 	}
+
+	// We need more information on Envoy logs to detect usage of any deprecated feature
+	if ctx.Settings().FailOnDeprecation {
+		values["global.proxy.logLevel"] = "debug"
+		values["global.proxy.componentLogLevel"] = "misc:debug"
+	}
+
 	return values, nil
 }
 

--- a/pkg/test/framework/core/flags.go
+++ b/pkg/test/framework/core/flags.go
@@ -44,6 +44,12 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 	}
 	s.Selector = f
 
+	if s.FailOnDeprecation && s.NoCleanup {
+		return nil,
+			fmt.Errorf("checking for deprecation occurs at cleanup level, thus flags -istio.test.nocleanup and" +
+				" -istio.test.deprecation_failure must not be used at the same time")
+	}
+
 	return s, nil
 }
 
@@ -63,4 +69,7 @@ func init() {
 
 	flag.StringVar(&settingsFromCommandLine.SelectorString, "istio.test.select", settingsFromCommandLine.SelectorString,
 		"Comma separated list of labels for selecting tests to run (e.g. 'foo,+bar-baz').")
+
+	flag.BoolVar(&settingsFromCommandLine.FailOnDeprecation, "istio.test.deprecation_failure", settingsFromCommandLine.FailOnDeprecation,
+		"Make tests fail if any usage of deprecated stuff (e.g. Envoy flags) is detected.")
 }

--- a/pkg/test/framework/core/settings.go
+++ b/pkg/test/framework/core/settings.go
@@ -47,6 +47,9 @@ type Settings struct {
 	// Indicates that the tests are running in CI Mode
 	CIMode bool
 
+	// Should the tests fail if usage of deprecated stuff (e.g. Envoy flags) is detected
+	FailOnDeprecation bool
+
 	// Local working directory root for creating temporary directories / files in. If left empty,
 	// os.TempDir() will be used.
 	BaseDir string
@@ -90,11 +93,12 @@ func DefaultSettings() *Settings {
 func (s *Settings) String() string {
 	result := ""
 
-	result += fmt.Sprintf("Environment:  %v\n", s.Environment)
-	result += fmt.Sprintf("TestID:       %s\n", s.TestID)
-	result += fmt.Sprintf("RunID:        %s\n", s.RunID.String())
-	result += fmt.Sprintf("NoCleanup:    %v\n", s.NoCleanup)
-	result += fmt.Sprintf("BaseDir:      %s\n", s.BaseDir)
-	result += fmt.Sprintf("Selector:     %v\n", s.Selector)
+	result += fmt.Sprintf("Environment:       %v\n", s.Environment)
+	result += fmt.Sprintf("TestID:            %s\n", s.TestID)
+	result += fmt.Sprintf("RunID:             %s\n", s.RunID.String())
+	result += fmt.Sprintf("NoCleanup:         %v\n", s.NoCleanup)
+	result += fmt.Sprintf("BaseDir:           %s\n", s.BaseDir)
+	result += fmt.Sprintf("Selector:          %v\n", s.Selector)
+	result += fmt.Sprintf("FailOnDeprecation: %v\n", s.FailOnDeprecation)
 	return result
 }

--- a/pkg/test/framework/errors/deprecations.go
+++ b/pkg/test/framework/errors/deprecations.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+type DeprecatedError struct {
+	msg string
+}
+
+func NewDeprecatedError(format string, args ...interface{}) error {
+	return &DeprecatedError{fmt.Sprintf(format, args...)}
+}
+
+func IsDeprecatedError(err error) bool {
+	_, ok := err.(*DeprecatedError)
+	return ok
+}
+
+func IsOrContainsDeprecatedError(err error) bool {
+	if IsDeprecatedError(err) {
+		return true
+	}
+
+	if m, ok := err.(*multierror.Error); ok {
+		for _, e := range m.Errors {
+			if IsDeprecatedError(e) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (de *DeprecatedError) Error() string {
+	return de.msg
+}
+
+// FindDeprecatedMessagesInEnvoyLog looks for deprecated messages in the `logs` parameter. If found, it will return
+// a DeprecatedError. Use `extraInfo` to pass additional info, like pod namespace/name, etc.
+func FindDeprecatedMessagesInEnvoyLog(logs, extraInfo string) error {
+	scanner := bufio.NewScanner(strings.NewReader(logs))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(strings.ToLower(line), "deprecated") {
+			if len(extraInfo) > 0 {
+				extraInfo = fmt.Sprintf(" (%s)", extraInfo)
+			}
+			return NewDeprecatedError("usage of deprecated stuff in Envoy%s: %s", extraInfo, line)
+		}
+	}
+
+	return nil
+}

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -101,7 +101,7 @@ func (s *scope) done(nocleanup bool) error {
 			scopes.Framework.Debugf("Begin cleaning up %s", name)
 			if e := c.Close(); e != nil {
 				scopes.Framework.Debugf("Error cleaning up %s: %v", name, e)
-				err = multierror.Append(e, err)
+				err = multierror.Append(err, e)
 			}
 			scopes.Framework.Debugf("Cleanup complete for %s", name)
 		}

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/environment/native"
 	"istio.io/istio/pkg/test/framework/core"
+	ferrors "istio.io/istio/pkg/test/framework/errors"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
@@ -209,6 +210,11 @@ func (s *Suite) run() (errLevel int) {
 
 		if err := rt.Close(); err != nil {
 			scopes.Framework.Errorf("Error during close: %v", err)
+			if rt.context.settings.FailOnDeprecation {
+				if ferrors.IsOrContainsDeprecatedError(err) {
+					errLevel = 1
+				}
+			}
 		}
 		rt = nil
 	}()

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/core"
+	"istio.io/istio/pkg/test/framework/errors"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
@@ -229,6 +230,11 @@ func (c *testContext) Done() {
 	scopes.Framework.Debugf("Begin cleaning up testContext: %q", c.id)
 	if err := c.scope.done(c.suite.settings.NoCleanup); err != nil {
 		c.Logf("error scope cleanup: %v", err)
+		if c.Settings().FailOnDeprecation {
+			if errors.IsOrContainsDeprecatedError(err) {
+				c.Error("Using deprecated Envoy features. Failing due to -istio.test.deprecation_failure flag.")
+			}
+		}
 	}
 	scopes.Framework.Debugf("Completed cleaning up testContext: %q", c.id)
 }


### PR DESCRIPTION
Through the flag `-istio.test.deprecation_failure`.

Currently it inspects proxy logs looking for deprecated
messages. This can be enhanced in the future to cover other
deprecations.