### PR TITLE
Replace go.uber.org/multierr with github.com/hashicorp/go-multierror

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,6 @@ require (
 	github.com/yuin/gopher-lua v0.0.0-20180316054350-84ea3a3c79b3 // indirect
 	go.opencensus.io v0.21.0
 	go.uber.org/atomic v1.4.0
-	go.uber.org/multierr v1.1.0
 	go.uber.org/zap v1.10.0
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,6 @@ github.com/emicklei/go-restful v2.8.1+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/emicklei/go-restful v2.9.3+incompatible h1:2OwhVdhtzYUp5P5wuGsVDPagKSRd9JK72sJCHVCXh5g=
 github.com/emicklei/go-restful v2.9.3+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful-swagger12 v0.0.0-20170926063155-7524189396c6/go.mod h1:qr0VowGBT4CS4Q8vFF8BSeKz34PuqKGxs/L0IAQA9DQ=
-github.com/envoyproxy/go-control-plane v0.9.0 h1:67WMNTvGrl7V1dWdKCeTwxDr7nio9clKoTlLhwIPnT4=
-github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191002184426-9d865299d2ff h1:c03aOTa9x9VOSKW5w0Mm9NeRPceC013YduuOudsHNlQ=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191002184426-9d865299d2ff/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=

--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -32,8 +32,8 @@ import (
 	"istio.io/istio/pkg/kube"
 
 	"github.com/ghodss/yaml"
+	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
-	"go.uber.org/multierr"
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/istioctl/pkg/util/handlers"
@@ -198,7 +198,7 @@ func setupParameters(sidecarTemplate, valuesConfig *string) (*meshconfig.MeshCon
 		}
 		var injectConfig inject.Config
 		if err := yaml.Unmarshal(injectionConfig, &injectConfig); err != nil {
-			return nil, multierr.Append(fmt.Errorf("loading --injectConfigFile"), err)
+			return nil, multierror.Append(err, fmt.Errorf("loading --injectConfigFile"))
 		}
 		*sidecarTemplate = injectConfig.Template
 	} else if *sidecarTemplate, err = getInjectConfigFromConfigMap(kubeconfig); err != nil {
@@ -224,20 +224,20 @@ func injectSideCarIntoDeployment(client kubernetes.Interface, deps []appsv1.Depl
 			dep.Name, dep.Namespace)
 		newDep, err := inject.IntoObject(sidecarTemplate, valuesConfig, meshConfig, &dep)
 		if err != nil {
-			errs = multierr.Append(fmt.Errorf("failed to update deployment %s.%s for service %s.%s due to %v",
-				dep.Name, dep.Namespace, svcName, svcNamespace, err), errs)
+			errs = multierror.Append(errs, fmt.Errorf("failed to update deployment %s.%s for service %s.%s due to %v",
+				dep.Name, dep.Namespace, svcName, svcNamespace, err))
 			continue
 		}
 		res, b := newDep.(*appsv1.Deployment)
 		if !b {
-			errs = multierr.Append(fmt.Errorf("failed to update deployment %s.%s for service %s.%s",
-				dep.Name, dep.Namespace, svcName, svcNamespace), errs)
+			errs = multierror.Append(errs, fmt.Errorf("failed to update deployment %s.%s for service %s.%s",
+				dep.Name, dep.Namespace, svcName, svcNamespace))
 			continue
 		}
 		if _, err :=
 			client.AppsV1().Deployments(svcNamespace).Update(res); err != nil {
-			errs = multierr.Append(fmt.Errorf("failed to update deployment %s.%s for service %s.%s due to %v",
-				dep.Name, dep.Namespace, svcName, svcNamespace, err), errs)
+			errs = multierror.Append(errs, fmt.Errorf("failed to update deployment %s.%s for service %s.%s due to %v",
+				dep.Name, dep.Namespace, svcName, svcNamespace, err))
 			continue
 
 		}
@@ -249,8 +249,8 @@ func injectSideCarIntoDeployment(client kubernetes.Interface, deps []appsv1.Depl
 			},
 		}
 		if _, err = client.AppsV1().Deployments(svcNamespace).UpdateStatus(d); err != nil {
-			errs = multierr.Append(fmt.Errorf("failed to update deployment %s.%s for service %s.%s due to %v",
-				dep.Name, dep.Namespace, svcName, svcNamespace, err), errs)
+			errs = multierror.Append(errs, fmt.Errorf("failed to update deployment %s.%s for service %s.%s due to %v",
+				dep.Name, dep.Namespace, svcName, svcNamespace, err))
 			continue
 		}
 		fmt.Fprintf(writer, "deployment %s.%s updated successfully with Istio sidecar injected.\n"+

--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -22,9 +22,8 @@ import (
 	"os"
 
 	"github.com/ghodss/yaml"
+	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
-
-	"go.uber.org/multierr"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/pkg/log"
@@ -75,8 +74,8 @@ func getMeshConfigFromConfigMap(kubeconfig, command string) (*meshconfig.MeshCon
 	}
 	cfg, err := mesh.ApplyMeshConfigDefaults(configYaml)
 	if err != nil {
-		err = multierr.Append(fmt.Errorf("istioctl version %s cannot parse mesh config. Install istioctl from the latest Istio release",
-			version.Info.Version), err)
+		err = multierror.Append(err, fmt.Errorf("istioctl version %s cannot parse mesh config.  Install istioctl from the latest Istio release",
+			version.Info.Version))
 	}
 	return cfg, err
 }
@@ -136,13 +135,13 @@ func getInjectConfigFromConfigMap(kubeconfig string) (string, error) {
 func validateFlags() error {
 	var err error
 	if inFilename != "" && emitTemplate {
-		err = multierr.Append(err, errors.New("--filename and --emitTemplate are mutually exclusive"))
+		err = multierror.Append(err, errors.New("--filename and --emitTemplate are mutually exclusive"))
 	}
 	if inFilename == "" && !emitTemplate {
-		err = multierr.Append(err, errors.New("filename not specified (see --filename or -f)"))
+		err = multierror.Append(err, errors.New("filename not specified (see --filename or -f)"))
 	}
 	if meshConfigFile == "" && meshConfigMapName == "" {
-		err = multierr.Append(err, errors.New("--meshConfigFile or --meshConfigMapName must be set"))
+		err = multierror.Append(err, errors.New("--meshConfigFile or --meshConfigMapName must be set"))
 	}
 	return err
 }
@@ -274,7 +273,7 @@ istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo.yaml \
 				}
 				var injectConfig inject.Config
 				if err := yaml.Unmarshal(injectionConfig, &injectConfig); err != nil {
-					return multierr.Append(fmt.Errorf("loading --injectConfigFile"), err)
+					return multierror.Append(err, fmt.Errorf("loading --injectConfigFile"))
 				}
 				sidecarTemplate = injectConfig.Template
 			} else if sidecarTemplate, err = getInjectConfigFromConfigMap(kubeconfig); err != nil {

--- a/istioctl/cmd/kubeinject_test.go
+++ b/istioctl/cmd/kubeinject_test.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -26,13 +27,13 @@ func TestKubeInject(t *testing.T) {
 		{ // case 0
 			configs:        []model.Config{},
 			args:           strings.Split("kube-inject", " "),
-			expectedOutput: "Error: filename not specified (see --filename or -f)\n",
+			expectedRegexp: regexp.MustCompile(`filename not specified \(see --filename or -f\)`),
 			wantException:  true,
 		},
 		{ // case 1
 			configs:        []model.Config{},
 			args:           strings.Split("kube-inject -f missing.yaml", " "),
-			expectedOutput: "Error: open missing.yaml: no such file or directory\n",
+			expectedRegexp: regexp.MustCompile(`open missing.yaml: no such file or directory`),
 			wantException:  true,
 		},
 		{ // case 2

--- a/istioctl/cmd/kubeuninject.go
+++ b/istioctl/cmd/kubeuninject.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
+	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
-	"go.uber.org/multierr"
 	"k8s.io/api/batch/v2alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +51,7 @@ func validateUninjectFlags() error {
 	var err error
 
 	if uninjectInFilename == "" {
-		err = multierr.Append(err, errors.New("filename not specified (see --filename or -f)"))
+		err = multierror.Append(err, errors.New("filename not specified (see --filename or -f)"))
 	}
 	return err
 }
@@ -71,7 +71,7 @@ func extractResourceFile(in io.Reader, out io.Writer) error {
 
 		obj, err := inject.FromRawToObject(raw)
 		if err != nil && !runtime.IsNotRegisteredError(err) {
-			return multierr.Append(fmt.Errorf("cannot parse YAML input"), err)
+			return multierror.Append(err, fmt.Errorf("cannot parse YAML input"))
 		}
 
 		var updated []byte
@@ -144,7 +144,7 @@ func removeDNSConfig(podDNSConfig *corev1.PodDNSConfig) {
 			} else {
 				podDNSConfig.Searches = podDNSConfig.Searches[:index]
 			}
-			//reset to 0
+			// reset to 0
 			index = 0
 			l = len(podDNSConfig.Searches)
 		} else {
@@ -233,7 +233,7 @@ func extractObject(in runtime.Object) (interface{}, error) {
 	}
 
 	metadata.Annotations = handleAnnotations(metadata.Annotations)
-	//skip uninjection for pods
+	// skip uninjection for pods
 	sidecarInjected := false
 	for _, c := range podSpec.Containers {
 		if c.Name == proxyContainerName {
@@ -284,7 +284,7 @@ kubectl get deployment -o yaml | istioctl experimental kube-uninject -f - | kube
 			if err = validateUninjectFlags(); err != nil {
 				return err
 			}
-			//get the resource content
+			// get the resource content
 			var reader io.Reader
 			if uninjectInFilename == "-" {
 				reader = os.Stdin

--- a/istioctl/cmd/kubeuninject_test.go
+++ b/istioctl/cmd/kubeuninject_test.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -27,13 +28,13 @@ func TestKubeUninject(t *testing.T) {
 		{ // case 0
 			configs:        []model.Config{},
 			args:           strings.Split("experimental kube-uninject", " "),
-			expectedOutput: "Error: filename not specified (see --filename or -f)\n",
+			expectedRegexp: regexp.MustCompile(`filename not specified \(see --filename or -f\)`),
 			wantException:  true,
 		},
 		{ // case 1
 			configs:        []model.Config{},
 			args:           strings.Split("experimental kube-uninject -f missing.yaml", " "),
-			expectedOutput: "Error: open missing.yaml: no such file or directory\n",
+			expectedRegexp: regexp.MustCompile(`open missing.yaml: no such file or directory`),
 			wantException:  true,
 		},
 		{ // case 2

--- a/istioctl/cmd/remove-from-mesh.go
+++ b/istioctl/cmd/remove-from-mesh.go
@@ -24,8 +24,8 @@ import (
 
 	"istio.io/istio/pkg/config/schemas"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
-	"go.uber.org/multierr"
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/istioctl/pkg/util/handlers"
@@ -152,13 +152,13 @@ func unInjectSideCarFromDeployment(client kubernetes.Interface, deps []appsv1.De
 		removeDNSConfig(podSpec.DNSConfig)
 		res, b := newDep.(*appsv1.Deployment)
 		if !b {
-			errs = multierr.Append(fmt.Errorf("failed to update deployment %q for service %q", depName, name), errs)
+			errs = multierror.Append(errs, fmt.Errorf("failed to update deployment %q for service %q", depName, name))
 			continue
 		}
 		res.Spec.Template.Spec = *podSpec
 		if _, err :=
 			client.AppsV1().Deployments(svcNamespace).Update(res); err != nil {
-			errs = multierr.Append(fmt.Errorf("failed to update deployment %q for service %q", depName, name), errs)
+			errs = multierror.Append(errs, fmt.Errorf("failed to update deployment %q for service %q", depName, name))
 			continue
 
 		}
@@ -170,7 +170,7 @@ func unInjectSideCarFromDeployment(client kubernetes.Interface, deps []appsv1.De
 			},
 		}
 		if _, err := client.AppsV1().Deployments(svcNamespace).UpdateStatus(d); err != nil {
-			errs = multierr.Append(fmt.Errorf("failed to update deployment %q for service %q", depName, name), errs)
+			errs = multierror.Append(errs, fmt.Errorf("failed to update deployment %q for service %q", depName, name))
 			continue
 		}
 		fmt.Fprintf(writer, "deployment %q updated successfully with Istio sidecar un-injected.\n", depName)

--- a/mixer/adapter/bypass/bypass.go
+++ b/mixer/adapter/bypass/bypass.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"go.uber.org/multierr"
+	"github.com/hashicorp/go-multierror"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
@@ -345,8 +345,7 @@ func (h *handler) Close() (err error) {
 	}
 
 	if h.conn != nil {
-		err2 := h.conn.Close()
-		err = multierr.Append(err, err2)
+		err = multierror.Append(err, h.conn.Close()).ErrorOrNil()
 	}
 
 	return

--- a/tests/e2e/tests/multicluster/split_horizon_test.go
+++ b/tests/e2e/tests/multicluster/split_horizon_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/multierr"
+	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/tests/e2e/framework"
 	"istio.io/istio/tests/util"
@@ -298,11 +298,11 @@ func (c *deployableConfig) Teardown() error {
 func (c *deployableConfig) TeardownNoDelay() error {
 	var err error
 	for _, yamlFile := range c.applied {
-		err = multierr.Append(err, util.KubeDelete(c.Namespace, yamlFile, c.kubeconfig))
+		err = multierror.Append(err, util.KubeDelete(c.Namespace, yamlFile, c.kubeconfig))
 	}
 	// Restore configs that was removed
 	for _, yaml := range c.removed {
-		err = multierr.Append(err, util.KubeApplyContents(c.Namespace, yaml, c.kubeconfig))
+		err = multierror.Append(err, util.KubeApplyContents(c.Namespace, yaml, c.kubeconfig))
 	}
 	c.applied = []string{}
 	return err
@@ -379,7 +379,7 @@ func (t *testConfig) Teardown() (err error) {
 	for _, ec := range t.extraConfig {
 		e := ec.Teardown()
 		if e != nil {
-			err = multierr.Append(err, e)
+			err = multierror.Append(err, e)
 		}
 	}
 	return


### PR DESCRIPTION
To keep consistency and drop one dependency. The latter seems to be way more
used in Istio code than the former.