### PR TITLE
Call JwksURI resolver when populating authN policy for push context

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -65,7 +65,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/proxy/envoy"
 	envoyv2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/consul"
@@ -968,7 +967,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 
 			go func() {
 				<-stop
-				authn_model.JwtKeyResolver.Close()
+				model.JwtKeyResolver.Close()
 
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -87,6 +87,9 @@ var (
 		"pilot_jwks_resolver_network_fetch_fail_total",
 		"Total number of failed network fetch by pilot jwks resolver",
 	)
+
+	// JwtKeyResolver resolves JWT public key and JwksURI.
+	JwtKeyResolver = NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 )
 
 // jwtPubKeyEntry is a single cached entry for jwt public key.

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -818,8 +818,10 @@ func (ps *PushContext) initAuthnPolicies(env *Environment) error {
 
 	for _, spec := range authNPolicies {
 		policy := spec.Spec.(*authn.Policy)
-		// Fill JwksURI if missing.
-		JwtKeyResolver.SetAuthenticationPolicyJwksURIs(policy)
+		// Fill JwksURI if missing. Ignoring error, as when it happens, jwksURI will be left empty
+		// and result in rejecting all request. This is acceptable behavior when JWT spec is not complete
+		// to run Jwt validation.
+		_ = JwtKeyResolver.SetAuthenticationPolicyJwksURIs(policy)
 
 		if len(policy.Targets) > 0 {
 			for _, dest := range policy.Targets {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -818,6 +818,9 @@ func (ps *PushContext) initAuthnPolicies(env *Environment) error {
 
 	for _, spec := range authNPolicies {
 		policy := spec.Spec.(*authn.Policy)
+		// Fill JwksURI if missing.
+		JwtKeyResolver.SetAuthenticationPolicyJwksURIs(policy)
+
 		if len(policy.Targets) > 0 {
 			for _, dest := range policy.Targets {
 				hostName := ResolveShortnameToFQDN(dest.Name, spec.ConfigMeta)

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -22,6 +22,7 @@ import (
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -268,6 +269,108 @@ func TestAuthNPolicies(t *testing.T) {
 		}
 	}
 
+}
+
+func TestJwtAuthNPolicy(t *testing.T) {
+	ms, err := test.StartNewServer()
+	defer ms.Stop()
+	if err != nil {
+		t.Fatal("failed to start a mock server")
+	}
+
+	ps := NewPushContext()
+	env := &Environment{Mesh: &meshconfig.MeshConfig{RootNamespace: "istio-system"}}
+	ps.Env = env
+	authNPolicies := map[string]*authn.Policy{
+		constants.DefaultAuthenticationPolicyName: {},
+
+		"jwt-with-jwks-uri": {
+			Targets: []*authn.TargetSelector{{
+				Name: "jwt-svc-1",
+			}},
+			Origins: []*authn.OriginAuthenticationMethod{{
+				Jwt: &authn.Jwt{
+					Issuer:  "http://abc",
+					JwksUri: "http://xyz",
+				},
+			}},
+		},
+		"jwt-without-jwks-uri": {
+			Targets: []*authn.TargetSelector{{
+				Name: "jwt-svc-2",
+			}},
+			Origins: []*authn.OriginAuthenticationMethod{{
+				Jwt: &authn.Jwt{
+					Issuer: ms.URL,
+				},
+			}},
+		},
+	}
+
+	configStore := newFakeStore()
+	for key, value := range authNPolicies {
+		cfg := Config{
+			ConfigMeta: ConfigMeta{
+				Name:      key,
+				Group:     "authentication",
+				Version:   "v1alpha2",
+				Domain:    "cluster.local",
+				Namespace: "default",
+			},
+			Spec: value,
+		}
+		if key == constants.DefaultAuthenticationPolicyName {
+			// Cluster-scoped policy
+			cfg.ConfigMeta.Type = schemas.AuthenticationMeshPolicy.Type
+			cfg.ConfigMeta.Namespace = NamespaceAll
+		} else {
+			cfg.ConfigMeta.Type = schemas.AuthenticationPolicy.Type
+		}
+		if _, err := configStore.Create(cfg); err != nil {
+			t.Error(err)
+		}
+	}
+
+	store := istioConfigStore{ConfigStore: configStore}
+	env.IstioConfigStore = &store
+	if err := ps.initAuthnPolicies(env); err != nil {
+		t.Fatalf("init authn policies failed: %v", err)
+	}
+
+	cases := []struct {
+		hostname        host.Name
+		namespace       string
+		port            Port
+		expectedJwksURI string
+	}{
+		{
+			hostname:        "jwt-svc-1.default.svc.cluster.local",
+			namespace:       "default",
+			port:            Port{Port: 80},
+			expectedJwksURI: "http://xyz",
+		},
+		{
+			hostname:        "jwt-svc-2.default.svc.cluster.local",
+			namespace:       "default",
+			port:            Port{Port: 80},
+			expectedJwksURI: ms.URL + "/oauth2/v3/certs",
+		},
+	}
+
+	for _, c := range cases {
+		ps.ServiceByHostnameAndNamespace[c.hostname] = map[string]*Service{"default": nil}
+	}
+
+	for i, c := range cases {
+		service := &Service{
+			Hostname:   c.hostname,
+			Attributes: ServiceAttributes{Namespace: c.namespace},
+		}
+
+		if got := ps.AuthenticationPolicyForWorkload(service, &c.port); got.GetOrigins()[0].GetJwt().GetJwksUri() != c.expectedJwksURI {
+			t.Errorf("%d. AuthenticationPolicyForWorkload for %s.%s:%v: got(%v) != want(%v)\n", i, c.hostname, c.namespace, c.port, got, c.expectedJwksURI)
+		}
+	}
 }
 
 func TestEnvoyFilters(t *testing.T) {

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -27,7 +27,6 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/schemas"
 )
@@ -173,7 +172,7 @@ func NewDiscoveryServer(
 	}
 
 	// Flush cached discovery responses when detecting jwt public key change.
-	authn_model.JwtKeyResolver.PushFunc = out.ClearCache
+	model.JwtKeyResolver.PushFunc = out.ClearCache
 
 	if configCache != nil {
 		// TODO: changes should not trigger a full recompute of LDS/RDS/CDS/EDS

--- a/pilot/pkg/security/authn/v1alpha1/model.go
+++ b/pilot/pkg/security/authn/v1alpha1/model.go
@@ -17,7 +17,6 @@ package v1alpha1
 import (
 	authn "istio.io/api/authentication/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
 )
 
 // GetConsolidateAuthenticationPolicy returns the v1alpha1 authentication policy for workload specified by
@@ -31,7 +30,7 @@ func GetConsolidateAuthenticationPolicy(store model.IstioConfigStore, serviceIns
 	config := store.AuthenticationPolicyForWorkload(service, labels, port)
 	if config != nil {
 		policy := config.Spec.(*authn.Policy)
-		if err := authn_model.JwtKeyResolver.SetAuthenticationPolicyJwksURIs(policy); err == nil {
+		if err := model.JwtKeyResolver.SetAuthenticationPolicyJwksURIs(policy); err == nil {
 			return policy
 		}
 	}

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -141,7 +141,7 @@ func convertToEnvoyJwtConfig(policyJwts []*authn_v1alpha1.Jwt) *envoy_jwt.JwtAut
 		jwtPubKey := policyJwt.Jwks
 		if jwtPubKey == "" {
 			var err error
-			jwtPubKey, err = authn_model.JwtKeyResolver.GetPublicKey(policyJwt.JwksUri)
+			jwtPubKey, err = model.JwtKeyResolver.GetPublicKey(policyJwt.JwksUri)
 			if err != nil {
 				log.Errorf("Failed to fetch jwt public key from %q: %s", policyJwt.JwksUri, err)
 			}
@@ -200,7 +200,7 @@ func convertToIstioJwtConfig(policyJwts []*authn_v1alpha1.Jwt) *istio_jwt.JwtAut
 		jwtPubKey := policyJwt.Jwks
 		if jwtPubKey == "" {
 			var err error
-			jwtPubKey, err = authn_model.JwtKeyResolver.GetPublicKey(policyJwt.JwksUri)
+			jwtPubKey, err = model.JwtKeyResolver.GetPublicKey(policyJwt.JwksUri)
 			if err != nil {
 				log.Errorf("Failed to fetch jwt public key from %q: %s", policyJwt.JwksUri, err)
 			}

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -54,9 +54,6 @@ const (
 	IngressGatewaySdsCaSuffix = "-cacert"
 )
 
-// JwtKeyResolver resolves JWT public key and JwksURI.
-var JwtKeyResolver = model.NewJwksResolver(model.JwtPubKeyEvictionDuration, model.JwtPubKeyRefreshInterval)
-
 // ConstructSdsSecretConfigForGatewayListener constructs SDS secret configuration for ingress gateway.
 func ConstructSdsSecretConfigForGatewayListener(name, sdsUdsPath string) *auth.SdsSecretConfig {
 	if name == "" || sdsUdsPath == "" {


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR fix the missing Jwks URI resolver call when switching to use authn policy from push context (https://github.com/istio/istio/pull/16716)

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
