### PR TITLE
Update release-builder SHA

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -31,11 +31,11 @@ fi
 # Old prow image does not set this, so needed explicitly here as this is not called through make
 export GO111MODULE=on
 
-DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-release}
-GCS_BUCKET=${GCS_BUCKET:-istio-prerelease/dev}
+DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
+GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=a873eb7c2b88222d649bc2df8f2ac8fb87990680
+BUILDER_SHA=14055a08b4438fbb3a2439a057a1a303a0fd5116
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha


### PR DESCRIPTION
There were a couple of issues with the old release builder. These have been fixed, and testing has been added to the release-builder image, so we have confidence that this will work now.