### PR TITLE
Small update to analysis README.md

### DIFF
--- a/galley/pkg/config/analysis/README.md
+++ b/galley/pkg/config/analysis/README.md
@@ -94,12 +94,7 @@ If your analyzer requires any new message types (meaning a unique template and e
             type: string
     ```
 
-1. Run `go generate`:
-
-    ```sh
-    cd galley/pkg/config/analysis/msg
-    REPO_ROOT=$(git rev-parse --show-toplevel) go generate
-    ```
+1. Run `BUILD_WITH_CONTAINER make gen`:
 
 1. Use the new type in your analyzer
 

--- a/galley/pkg/config/analysis/README.md
+++ b/galley/pkg/config/analysis/README.md
@@ -94,7 +94,7 @@ If your analyzer requires any new message types (meaning a unique template and e
             type: string
     ```
 
-1. Run `BUILD_WITH_CONTAINER make gen`:
+1. Run `BUILD_WITH_CONTAINER=1 make gen`:
 
 1. Use the new type in your analyzer
 

--- a/galley/pkg/config/analysis/README.md
+++ b/galley/pkg/config/analysis/README.md
@@ -98,7 +98,7 @@ If your analyzer requires any new message types (meaning a unique template and e
 
     ```sh
     cd galley/pkg/config/analysis/msg
-    go generate
+    REPO_ROOT=$(git rev-parse --show-toplevel) go generate
     ```
 
 1. Use the new type in your analyzer


### PR DESCRIPTION
go generate depends on $REPO_ROOT being defined (which normally comes from the Makefile). Without this environment variable defined, you see a confusing error.

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
