### PR TITLE
Start control plane with less privileges 

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -36,12 +36,13 @@ spec:
       securityContext:
         runAsUser: 1
         runAsNonRoot: true
-        readOnlyRootFilesystem: true
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
       containers:
         - name: galley
+          securityContext:
+            readOnlyRootFilesystem: true
 {{- if contains "/" .Values.image }}
           image: "{{ .Values.image }}"
 {{- else }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: istio-galley-service-account
+      securityContext:
+        runAsUser: 1
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
@@ -45,7 +49,7 @@ spec:
 {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
-          - containerPort: 443
+          - containerPort: 8443
           - containerPort: {{ .Values.global.monitoringPort }}
           - containerPort: 9901
           command:
@@ -53,10 +57,11 @@ spec:
           - server
           - --meshConfigFile=/etc/mesh-config/mesh
           - --livenessProbeInterval=1s
-          - --livenessProbePath=/healthliveness
-          - --readinessProbePath=/healthready
+          - --livenessProbePath=/tmp/healthliveness
+          - --readinessProbePath=/tmp/healthready
           - --readinessProbeInterval=1s
           - --deployment-namespace={{ .Release.Namespace }}
+          - --validation-port=8443
 {{- if $.Values.global.controlPlaneSecurityEnabled}}
           - --insecure=false
 {{- else }}
@@ -87,12 +92,14 @@ spec:
           - name: mesh-config
             mountPath: /etc/mesh-config
             readOnly: true
+          - name: tmp
+            mountPath: /tmp
           livenessProbe:
             exec:
               command:
                 - /usr/local/bin/galley
                 - probe
-                - --probe-path=/healthliveness
+                - --probe-path=/tmp/healthliveness
                 - --interval=10s
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -101,7 +108,7 @@ spec:
               command:
                 - /usr/local/bin/galley
                 - probe
-                - --probe-path=/healthready
+                - --probe-path=/tmp/healthready
                 - --interval=10s
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -121,6 +128,9 @@ spec:
       - name: mesh-config
         configMap:
           name: istio
+      - name: tmp
+        emptyDir:
+          medium: Memory
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
@@ -13,6 +13,7 @@ spec:
   ports:
   - port: 443
     name: https-validation
+    targetPort: 8443
   - port: {{ .Values.global.monitoringPort }}
     name: http-monitoring
   - port: 9901


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR changes the default helm settings to ensure that the control plane components are not running as root and therefore need less privileges and work better with PodSecurityPolicies.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
