### PR TITLE
Handle a missing statusPort setting for the injector as statusPort 0

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -146,7 +146,7 @@ containers:
   {{ end -}}
   - --controlPlaneAuthPolicy
   - "{{ annotation .ObjectMeta `sidecar.istio.io/controlPlaneAuthPolicy` .ProxyConfig.ControlPlaneAuthPolicy }}"
-{{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
+{{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" (valueOrDefault .Values.global.proxy.statusPort 0 )) `0`) }}
   - --statusPort
   - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"
   - --applicationPorts
@@ -247,7 +247,7 @@ containers:
     value: "{{ .Values.global.trustDomain }}"
   {{- end }}
   imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-  {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+  {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` (valueOrDefault .Values.global.proxy.statusPort 0 )) `0` }}
   readinessProbe:
     httpGet:
       path: /healthz/ready


### PR DESCRIPTION
Please provide a description for what this PR is for.

We create our own custom values files to enable specific settings and configure the proxy for our needs. The last time we forgot to set the `statusPort` (https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/values.yaml#L229) which resulted in the following error message at replicaSets:

```bash
  Type     Reason        Age               From                   Message
  ----     ------        ----              ----                   -------
  Warning  FailedCreate  30s               replicaset-controller  Error creating: Pod "test-v2-dummy-istio-dev-694589b8fc-zjz95" is invalid: spec.containers[1].readinessProbe.httpGet.port: Invalid value: "<nil>": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
  Warning  FailedCreate  30s               replicaset-controller  Error creating: Pod "test-v2-dummy-istio-dev-694589b8fc-66v7l" is invalid: spec.containers[1].readinessProbe.httpGet.port: Invalid value: "<nil>": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
  Warning  FailedCreate  30s               replicaset-controller  Error creating: Pod "test-v2-dummy-istio-dev-694589b8fc-nbnzh" is invalid: spec.containers[1].readinessProbe.httpGet.port: Invalid value: "<nil>": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
  Warning  FailedCreate  30s               replicaset-controller  Error creating: Pod "test-v2-dummy-istio-dev-694589b8fc-brztf" is invalid: spec.containers[1].readinessProbe.httpGet.port: Invalid value: "<nil>": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
  Warning  FailedCreate  30s               replicaset-controller  Error creating: Pod "test-v2-dummy-istio-dev-694589b8fc-x94gg" is invalid: spec.containers[1].readinessProbe.httpGet.port: Invalid value: "<nil>": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
  Warning  FailedCreate  30s               replicaset-controller  Error creating: Pod "test-v2-dummy-istio-dev-694589b8fc-kqc5b" is invalid: spec.containers[1].readinessProbe.httpGet.port: Invalid value: "<nil>": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
  Warning  FailedCreate  30s               replicaset-controller  Error creating: Pod "test-v2-dummy-istio-dev-694589b8fc-w5pzv" is invalid: spec.containers[1].readinessProbe.httpGet.port: Invalid value: "<nil>": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
  Warning  FailedCreate  29s               replicaset-controller  Error creating: Pod "test-v2-dummy-istio-dev-694589b8fc-sp7xp" is invalid: spec.containers[1].readinessProbe.httpGet.port: Invalid value: "<nil>": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
  Warning  FailedCreate  29s               replicaset-controller  Error creating: Pod "test-v2-dummy-istio-dev-694589b8fc-8ct25" is invalid: spec.containers[1].readinessProbe.httpGet.port: Invalid value: "<nil>": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
  Warning  FailedCreate  9s (x4 over 27s)  replicaset-controller  (combined from similar events): Error creating: Pod "test-v2-dummy-istio-dev-694589b8fc-c2tdj" is invalid: spec.containers[1].readinessProbe.httpGet.port: Invalid value: "<nil>": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
```

The error is not really helpful, since our test application has no `readinessProbe` we knew that the error must be in the injector template. I would prefer that a missing `statusPort` setting is handle as no `statusPort` (e.g. 0).

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[X] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
