### PR TITLE
Disable broken test TestMetricExpiration

### DIFF
--- a/mixer/adapter/prometheus/prometheus_test.go
+++ b/mixer/adapter/prometheus/prometheus_test.go
@@ -519,7 +519,7 @@ func TestComputeSha(t *testing.T) {
 }
 
 func TestMetricExpiration(t *testing.T) {
-
+	t.Skip("https://github.com/istio/istio/issues/17182")
 	testPolicy := expPolicy(50*time.Millisecond, 10*time.Millisecond)
 	altPolicy := expPolicy(50*time.Millisecond, 0)
 


### PR DESCRIPTION
Test has been failing for weeks with no attention from maintainers. This
is the most flaky test by a wide margin.

Tracked in https://github.com/istio/istio/issues/17182

[x] Policies and Telemetry