### PR TITLE
Add integ test for status update

### DIFF
--- a/galley/pkg/config/source/kube/apiserver/status/controller.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller.go
@@ -176,6 +176,7 @@ mainloop:
 		statusMap, ok := statusObj.(map[string]interface{})
 		if !ok {
 			scope.Source.Warnf("Failed to parse the status field as a map. Previous status value will be discarded! Status value was: %v", statusObj)
+			statusMap = make(map[string]interface{})
 		}
 
 		// Update the status field (for the subfield this controller manages) to match desired status

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -77,6 +77,9 @@ spec:
 {{- if $.Values.global.logging.level }}
           - --log_output_level={{ $.Values.global.logging.level }}
 {{- end}}
+{{- if .Values.enableAnalysis }}
+          - --enableAnalysis=true
+{{- end }}
           volumeMounts:
           - name: certs
             mountPath: /etc/certs

--- a/install/kubernetes/helm/istio/charts/galley/values.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/values.yaml
@@ -33,3 +33,6 @@ podAntiAffinityTermLabelSelector: []
 
 # Enable service discovery processing in Galley
 enableServiceDiscovery: false
+
+# Enable analysis and status update in Galley
+enableAnalysis: false

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -32,7 +32,10 @@ import (
 	kubeExtClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/dynamic"
 	kubeClient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	kubeClientCore "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -56,6 +59,7 @@ type Accessor struct {
 	ctl        *kubectl
 	set        *kubeClient.Clientset
 	extSet     *kubeExtClient.Clientset
+	dynClient  dynamic.Interface
 }
 
 // NewAccessor returns a new instance of an accessor.
@@ -78,14 +82,20 @@ func NewAccessor(kubeConfig string, baseWorkDir string) (*Accessor, error) {
 		return nil, err
 	}
 
+	dynClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
+	}
+
 	return &Accessor{
 		restConfig: restConfig,
 		ctl: &kubectl{
 			kubeConfig: kubeConfig,
 			baseDir:    baseWorkDir,
 		},
-		set:    set,
-		extSet: extSet,
+		set:       set,
+		extSet:    extSet,
+		dynClient: dynClient,
 	}, nil
 }
 
@@ -487,6 +497,16 @@ func (a *Accessor) GetNamespace(ns string) (*kubeApiCore.Namespace, error) {
 	}
 
 	return n, nil
+}
+
+// GetUnstructured returns an unstructured k8s resource object based on the provided schema, namespace, and name.
+func (a *Accessor) GetUnstructured(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+	u, err := a.dynClient.Resource(gvr).Namespace(namespace).Get(name, kubeApiMeta.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource %v of type %v: %v", name, gvr, err)
+	}
+
+	return u, nil
 }
 
 // ApplyContents applies the given config contents using kubectl.

--- a/tests/integration/galley/statusupdate/statusupdate_test.go
+++ b/tests/integration/galley/statusupdate/statusupdate_test.go
@@ -1,3 +1,16 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 package statusupdate
 
 import (

--- a/tests/integration/galley/statusupdate/statusupdate_test.go
+++ b/tests/integration/galley/statusupdate/statusupdate_test.go
@@ -1,0 +1,110 @@
+package statusupdate
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("statusupdate_test", m).
+		Label(label.CustomSetup).
+		SetupOnEnv(environment.Kube, istio.Setup(nil, setupConfig)).
+		Run()
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.Values["galley.enableAnalysis"] = "true"
+}
+
+const (
+	serviceRoleBindingYaml = `
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  name: service-role-binding
+  namespace: default
+spec:
+  mode: PERMISSIVE
+  roleRef:
+    kind: ServiceRole
+    name: service-role
+  subjects:
+  - user: '*'
+`
+	serviceRoleYaml = `
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRole
+metadata:
+  name: service-role
+  namespace: default
+spec:
+  rules:
+  - services: ["*"]
+`
+	namespace       = "default"
+	timeout         = "10s"
+	pollingInterval = "1s"
+)
+
+func TestStatusUpdate(t *testing.T) {
+	framework.NewTest(t).
+		// The status update implementation we're testing is kube-specific
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			g := NewGomegaWithT(t)
+
+			env := ctx.Environment().(*kube.Environment)
+
+			gvr := schema.GroupVersionResource{
+				Group:    "rbac.istio.io",
+				Version:  "v1alpha1",
+				Resource: "servicerolebindings",
+			}
+			name := "service-role-binding"
+
+			// Apply config that should generate a validation message
+			err := env.ApplyContents(namespace, serviceRoleBindingYaml)
+			defer func() { _ = env.DeleteContents(namespace, serviceRoleBindingYaml) }()
+
+			if err != nil {
+				t.Fatalf("Error applying serviceRoleBindingYaml for test scenario: %v", err)
+			}
+
+			// Verify we have the expected validation message
+			g.Eventually(func() string { return getStatus(t, env, gvr, namespace, name) }, timeout, pollingInterval).
+				Should(ContainSubstring(msg.ReferencedResourceNotFound.Code()))
+
+			// Apply config that should fix the problem and remove the validation message
+			err = env.ApplyContents("default", serviceRoleYaml)
+			defer func() { _ = env.DeleteContents(namespace, serviceRoleYaml) }()
+			if err != nil {
+				t.Fatalf("Error applying serviceRoleYaml for test scenario: %v", err)
+			}
+
+			//Verify the validation message disappears. (With "eventually" / timeout)
+			g.Eventually(func() string { return getStatus(t, env, gvr, namespace, name) }, timeout, pollingInterval).
+				Should(Not(ContainSubstring(msg.ReferencedResourceNotFound.Code())))
+		})
+}
+
+func getStatus(t *testing.T, env *kube.Environment, gvr schema.GroupVersionResource, namespace, name string) string {
+	u, err := env.GetUnstructured(gvr, namespace, name)
+	if err != nil {
+		t.Errorf("Couldn't get status for resource %v", name)
+	}
+	return fmt.Sprintf("%v", u.Object["status"])
+}


### PR DESCRIPTION
Add a basic integration test to cover Galley updating resource status with validation messages based on the analyzer framework.

Also adds a variable to the Galley helm chart for enabling analysis.

Also fix a minor bug in the status controller and add a test for it. 

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
