### PR TITLE
Add analyzer support for checking sidecar proxy mismatches with the i…

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -32,6 +32,7 @@ func All() []analysis.Analyzer {
 		&virtualservice.DestinationRuleAnalyzer{},
 		&auth.ServiceRoleBindingAnalyzer{},
 		&injection.Analyzer{},
+		&injection.VersionAnalyzer{},
 		&deprecation.FieldAnalyzer{},
 	}
 }

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -100,6 +100,16 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name: "istioInjectionVersionMismatch",
+		inputFiles: []string{
+			"testdata/injection-with-mismatched-sidecar.yaml",
+		},
+		analyzer: &injection.Analyzer{},
+		expected: []message{
+			{msg.IstioProxyVersionMismatch, "Pod/default/details-v1-68fbb76fc-cfqjd"},
+		},
+	},
+	{
 		name: "gatewayNoWorkload",
 		inputFiles: []string{
 			"testdata/gateway-no-workload.yaml",

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -106,7 +106,7 @@ var testGrid = []testCase{
 		},
 		analyzer: &injection.VersionAnalyzer{},
 		expected: []message{
-			{msg.IstioProxyVersionMismatch, "Pod/default/details-v1-pod"},
+			{msg.IstioProxyVersionMismatch, "Pod/enabled-namespace/details-v1-pod-old"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -104,9 +104,9 @@ var testGrid = []testCase{
 		inputFiles: []string{
 			"testdata/injection-with-mismatched-sidecar.yaml",
 		},
-		analyzer: &injection.Analyzer{},
+		analyzer: &injection.VersionAnalyzer{},
 		expected: []message{
-			{msg.IstioProxyVersionMismatch, "Pod/default/details-v1-68fbb76fc-cfqjd"},
+			{msg.IstioProxyVersionMismatch, "Pod/default/details-v1-pod"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/injection/injection-version.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection-version.go
@@ -22,8 +22,8 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/meta/metadata"
-	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/galley/pkg/config/resource"
 )
 
 // VersionAnalyzer checks the version of auto-injection configured with the running proxies on pods.

--- a/galley/pkg/config/analysis/analyzers/injection/injection-version.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection-version.go
@@ -1,0 +1,142 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package injection
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/galley/pkg/config/processor/metadata"
+	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/schema/collection"
+)
+
+// VersionAnalyzer checks the version of auto-injection configured with the running proxies on pods.
+type VersionAnalyzer struct{}
+
+var _ analysis.Analyzer = &VersionAnalyzer{}
+
+const injectorName = "sidecar-injector-webhook"
+const sidecarInjectorName = "sidecarInjectorWebhook"
+
+// podVersion is a helper struct for tracking a resource with its detected
+// proxy version.
+type podVersion struct {
+	Entry        *resource.Entry
+	ProxyVersion string
+}
+
+// Metadata implements Analyzer.
+func (a *VersionAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name: "injection.VersionAnalyzer",
+		Inputs: collection.Names{
+			metadata.K8SCoreV1Namespaces,
+			metadata.K8SCoreV1Pods,
+		},
+	}
+}
+
+// Analyze implements Analyzer.
+func (a *VersionAnalyzer) Analyze(c analysis.Context) {
+	injectedNamespaces := make(map[string]struct{})
+
+	// Collect the list of namespaces that have istio injection enabled.
+	c.ForEach(metadata.K8SCoreV1Namespaces, func(r *resource.Entry) bool {
+		if r.Metadata.Labels[injectionLabelName] == injectionLabelEnableValue {
+			injectedNamespaces[r.Metadata.Name.String()] = struct{}{}
+		}
+
+		return true
+	})
+
+	injectorVersions := make(map[string]struct{})
+	var podVersions []podVersion
+	c.ForEach(metadata.K8SCoreV1Pods, func(r *resource.Entry) bool {
+		pod := r.Item.(*v1.Pod)
+
+		// Check if this is a sidecar injector pod - if it is, note its version.
+		if v := tryReturnSidecarInjectorVersion(pod); v != "" {
+			injectorVersions[v] = struct{}{}
+		}
+
+		if _, ok := injectedNamespaces[pod.GetNamespace()]; !ok {
+			return true
+		}
+
+		for _, container := range pod.Spec.Containers {
+			if container.Name != istioProxyName {
+				continue
+			}
+			// Attempt to parse out the version of the proxy.
+			_, v := getContainerNameVersion(&container)
+			// We can't check anything without a version; skip the pod.
+			if v == "" {
+				continue
+			}
+			// Note the pod/version to check later after we've collected all injector versions.
+			podVersions = append(podVersions, podVersion{
+				Entry:        r,
+				ProxyVersion: v})
+
+		}
+
+		return true
+	})
+
+	for iv := range injectorVersions {
+		for _, pv := range podVersions {
+			if pv.ProxyVersion != iv {
+				c.Report(metadata.K8SCoreV1Pods, msg.NewIstioProxyVersionMismatch(pv.Entry, pv.ProxyVersion, iv))
+			}
+		}
+	}
+}
+
+// tryReturnSidecarInjectorVersion returns an empty string if the pod is not
+// the sidecar injector; otherwise the version of the injector image is
+// returned.
+func tryReturnSidecarInjectorVersion(p *v1.Pod) string {
+	if p.Labels["app"] != sidecarInjectorName {
+		return ""
+	}
+
+	for _, c := range p.Spec.Containers {
+		if c.Name != injectorName {
+			continue
+		}
+
+		_, v := getContainerNameVersion(&c)
+		return v
+	}
+
+	return ""
+}
+
+// getContainerNameVersion parses the name and version from a container image.
+// If the version is not specified or can't be found, version is the empty
+// string.
+func getContainerNameVersion(c *v1.Container) (image string, version string) {
+	parts := strings.Split(c.Image, ":")
+	if len(parts) != 2 {
+		return c.Image, ""
+	}
+	image = parts[0]
+	version = parts[1]
+	return
+}

--- a/galley/pkg/config/analysis/analyzers/injection/injection-version.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection-version.go
@@ -21,9 +21,9 @@ import (
 
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
-	"istio.io/istio/galley/pkg/config/processor/metadata"
+	"istio.io/istio/galley/pkg/config/meta/metadata"
 	"istio.io/istio/galley/pkg/config/resource"
-	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
 )
 
 // VersionAnalyzer checks the version of auto-injection configured with the running proxies on pods.

--- a/galley/pkg/config/analysis/analyzers/injection/injection.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection.go
@@ -38,6 +38,7 @@ const injectionLabelName = "istio-injection"
 const injectionLabelEnableValue = "enabled"
 
 const istioProxyName = "istio-proxy"
+const injectorName = "sidecar-injector-webhook"
 
 // Metadata implements Analyzer
 func (a *Analyzer) Metadata() analysis.Metadata {
@@ -67,7 +68,6 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 		if injectionLabel == "" {
 			// TODO: if Istio is installed with sidecarInjectorWebhook.enableNamespacesByDefault=true
 			// (in the istio-sidecar-injector configmap), we need to reverse this logic and treat this as an injected namespace
-
 			c.Report(metadata.K8SCoreV1Namespaces, msg.NewNamespaceNotInjected(r, r.Metadata.Name.String(), r.Metadata.Name.String()))
 			return true
 		}
@@ -82,8 +82,15 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 		return true
 	})
 
+	injectorVersions := make(map[string]bool)
+	var podVersions []podVersion
 	c.ForEach(metadata.K8SCoreV1Pods, func(r *resource.Entry) bool {
 		pod := r.Item.(*v1.Pod)
+
+		// Check if this is the sidecar injector pod - if it is, note its version
+		if v := tryReturnSidecarInjectorVersion(pod); v != "" {
+			injectorVersions[v] = true
+		}
 
 		if !injectedNamespaces[pod.GetNamespace()] {
 			return true
@@ -99,13 +106,49 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 
 		if proxyImage == "" {
 			c.Report(metadata.K8SCoreV1Pods, msg.NewPodMissingProxy(r, pod.Name, pod.GetNamespace()))
+		} else if parts := strings.Split(proxyImage, ":"); len(parts) == 2 {
+			// Note the pod/version to check later after we've collected all injector versions
+			podVersions = append(podVersions, podVersion{
+				Entry:        r,
+				ProxyVersion: parts[1]})
 		}
-
-		// TODO: if the pod is injected, check that it's using the right image. This would
-		// cover scenarios where Istio is upgraded but pods are not restarted.
-		// This is challenging because getting the expected image for the current version
-		// of Istio is non-trivial and non-standard across versions
 
 		return true
 	})
+
+	for iv := range injectorVersions {
+		for _, pv := range podVersions {
+			if pv.ProxyVersion != iv {
+				c.Report(metadata.K8SCoreV1Pods, msg.NewIstioProxyVersionMismatch(pv.Entry, pv.ProxyVersion, iv))
+			}
+		}
+	}
+}
+
+type podVersion struct {
+	Entry        *resource.Entry
+	ProxyVersion string
+}
+
+// tryReturnSidecarInjectorVersion returns an empty string if the pod is not
+// the sidecar injector; otherwise the version of the injector image is
+// returned.
+func tryReturnSidecarInjectorVersion(p *v1.Pod) string {
+	if p.Labels["app"] != "sidecarInjectorWebhook" {
+		return ""
+	}
+
+	for _, c := range p.Spec.Containers {
+		if c.Name != injectorName {
+			continue
+		}
+
+		parts := strings.Split(c.Image, ":")
+		if len(parts) != 2 {
+			continue
+		}
+		return parts[1]
+	}
+
+	return ""
 }

--- a/galley/pkg/config/analysis/analyzers/testdata/injection-with-mismatched-sidecar.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/injection-with-mismatched-sidecar.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   labels:
     app: sidecarInjectorWebhook
-  name: istio-sidecar-injector-6dcc9f86b-rln9t
+  name: istio-sidecar-injector-pod
   namespace: istio-system
 spec:
   containers:
@@ -23,7 +23,7 @@ kind: Pod
 metadata:
   labels:
     app: details
-  name: details-v1-68fbb76fc-cfqjd
+  name: details-v1-pod
   namespace: default
 spec:
   containers:

--- a/galley/pkg/config/analysis/analyzers/testdata/injection-with-mismatched-sidecar.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/injection-with-mismatched-sidecar.yaml
@@ -1,4 +1,4 @@
-# Injector is configured to inject 1.3.1, but we have a running pod with 1.3.0
+# Sidecar injector specifying 1.3.1 for image.
 apiVersion: v1
 kind: Pod
 metadata:
@@ -11,23 +11,63 @@ spec:
   - image: docker.io/istio/sidecar_injector:1.3.1
     name: sidecar-injector-webhook
 ---
+# Namespace 'enabled-namespace' has istio injection enabled, so will be enforced.
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
     istio-injection: enabled
-  name: default
+  name: enabled-namespace
 ---
+# Details-v1-pod-old is out of date and should get a warning.
 apiVersion: v1
 kind: Pod
 metadata:
   labels:
     app: details
-  name: details-v1-pod
-  namespace: default
+  name: details-v1-pod-old
+  namespace: enabled-namespace
 spec:
   containers:
   - image: docker.io/istio/examples-bookinfo-details-v1:1.15.0
     name: details
   - image: docker.io/istio/proxyv2:1.3.0
     name: istio-proxy
+---
+# Details-v1-pod-new is up to date, and should be ignored.
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: details
+  name: details-v1-pod-new
+  namespace: enabled-namespace
+spec:
+  containers:
+  - image: docker.io/istio/examples-bookinfo-details-v1:1.15.0
+    name: details
+  - image: docker.io/istio/proxyv2:1.3.1
+    name: istio-proxy
+---
+# Namespace 'default' does not have an explicit label, so no version checking should happen.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+# Details-v2-pod-old is out of date, but since istio-injection is not enabled on the namespace, 
+# no warning occurs.
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: details
+  name: details-v2-pod-old
+  namespace: default
+spec:
+  containers:
+  - image: docker.io/istio/examples-bookinfo-details-v2:1.15.0
+    name: details
+  - image: docker.io/istio/proxyv2:1.3.0
+    name: istio-proxy
+---

--- a/galley/pkg/config/analysis/analyzers/testdata/injection-with-mismatched-sidecar.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/injection-with-mismatched-sidecar.yaml
@@ -1,0 +1,33 @@
+# Injector is configured to inject 1.3.1, but we have a running pod with 1.3.0
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: sidecarInjectorWebhook
+  name: istio-sidecar-injector-6dcc9f86b-rln9t
+  namespace: istio-system
+spec:
+  containers:
+  - image: docker.io/istio/sidecar_injector:1.3.1
+    name: sidecar-injector-webhook
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: enabled
+  name: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: details
+  name: details-v1-68fbb76fc-cfqjd
+  namespace: default
+spec:
+  containers:
+  - image: docker.io/istio/examples-bookinfo-details-v1:1.15.0
+    name: details
+  - image: docker.io/istio/proxyv2:1.3.0
+    name: istio-proxy

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -40,6 +40,10 @@ var (
 	// GatewayPortNotOnWorkload defines a diag.MessageType for message "GatewayPortNotOnWorkload".
 	// Description: Unhandled gateway port
 	GatewayPortNotOnWorkload = diag.NewMessageType(diag.Warning, "IST0104", "The gateway refers to a port that is not exposed on the workload (pod selector %s; port %d)")
+
+	// IstioProxyVersionMismatch defines a diag.MessageType for message "IstioProxyVersionMismatch".
+	// Description: The version of the Istio proxy running on the pod does not match the version used by the istio injector.
+	IstioProxyVersionMismatch = diag.NewMessageType(diag.Warning, "IST0105", "The version of the Istio proxy running on the pod does not match the version used by the istio injector (pod version: %s; injector version: %s). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pod.")
 )
 
 // NewInternalError returns a new diag.Message based on InternalError.
@@ -115,6 +119,16 @@ func NewGatewayPortNotOnWorkload(entry *resource.Entry, selector string, port in
 		originOrNil(entry),
 		selector,
 		port,
+	)
+}
+
+// NewIstioProxyVersionMismatch returns a new diag.Message based on IstioProxyVersionMismatch.
+func NewIstioProxyVersionMismatch(entry *resource.Entry, proxyVersion string, injectionVersion string) diag.Message {
+	return diag.NewMessage(
+		IstioProxyVersionMismatch,
+		originOrNil(entry),
+		proxyVersion,
+		injectionVersion,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -80,3 +80,14 @@ messages:
         type: string
       - name: port
         type: int
+  
+  - name: "IstioProxyVersionMismatch"
+    code: IST0105
+    level: Warning
+    description: "The version of the Istio proxy running on the pod does not match the version used by the istio injector."
+    template: "The version of the Istio proxy running on the pod does not match the version used by the istio injector (pod version: %s; injector version: %s). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pod."
+    args:
+      - name: proxyVersion
+        type: string
+      - name: injectionVersion
+        type: string


### PR DESCRIPTION
…njector

Upon upgrading Istio, users must then upgrade all their sidecars (usually by redeploying to ensure the auto-injector runs again). It's easy to forget to do this (and not always easy to audit). Now, `istioctl experimental analyze -k` will check for the sidecar injector version and the version running on all pods, and will complain if they mismatch.

Note that currently, only proxies in workloads where auto-injection is enabled are checked.

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Here's an example of what it looks like when run on an Istio cluster running 1.3.1 with bookinfo running proxies from 1.3.0:
```
jsselman-macbookpro2:istio jsselman$ ~/go/out/darwin_amd64/release/istioctl experimental analyze -k
Warn [IST0105](Pod/default/reviews-v2-569796655b-7bxr2) The version of the Istio proxy running on the pod does not match the version used by the istio injector (pod version: 1.3.0; injector version: 1.3.1). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pod.
Warn [IST0105](Pod/default/ratings-v1-7bdfd65ccc-54l6r) The version of the Istio proxy running on the pod does not match the version used by the istio injector (pod version: 1.3.0; injector version: 1.3.1). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pod.
Warn [IST0105](Pod/default/reviews-v3-844bc59d88-4fnz5) The version of the Istio proxy running on the pod does not match the version used by the istio injector (pod version: 1.3.0; injector version: 1.3.1). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pod.
Warn [IST0105](Pod/default/productpage-v1-6c6c87ffff-lg2p2) The version of the Istio proxy running on the pod does not match the version used by the istio injector (pod version: 1.3.0; injector version: 1.3.1). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pod.
Warn [IST0105](Pod/default/reviews-v1-5c5b7b9f8d-lcxfk) The version of the Istio proxy running on the pod does not match the version used by the istio injector (pod version: 1.3.0; injector version: 1.3.1). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pod.
Warn [IST0105](Pod/default/details-v1-68fbb76fc-cfqjd) The version of the Istio proxy running on the pod does not match the version used by the istio injector (pod version: 1.3.0; injector version: 1.3.1). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pod.
```