### PR TITLE
Update `istioctl authn` tool to reflect autoMTLS

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -381,7 +381,7 @@ func EvaluateTLSState(clientMode *networking.TLSSettings, serverMode authn_alpha
 	const conflictState string = "CONFLICT"
 
 	if clientMode == nil {
-		// TLS settings was not set explicitely, pilot will try a setting that work well with the
+		// TLS settings was not set explicitly, pilot will try a setting that work well with the
 		// destination authN policy. We could use the separate state value (e.g AUTO) in the future.
 		return okState
 	}

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -374,16 +374,16 @@ func AnalyzeMTLSSettings(hostname host.Name, port *model.Port, authnPolicy *auth
 
 // EvaluateTLSState returns the conflict state (string) for the input client+server settings.
 // The output string could be:
-// - "AUTO": client TLS settings is not set, and will be automatically determined based on server mode.
 // - "OK": both client and server TLS settings are set correctly.
 // - "CONFLICT": both client and server TLS settings are set, but could be incompatible.
 func EvaluateTLSState(clientMode *networking.TLSSettings, serverMode authn_alpha1.MutualTLSMode) string {
 	const okState string = "OK"
 	const conflictState string = "CONFLICT"
-	const autoState string = "AUTO"
 
 	if clientMode == nil {
-		return autoState
+		// TLS settings was not set explicitely, pilot will try a setting that work well with the
+		// destination authN policy. We could use the separate state value (e.g AUTO) in the future.
+		return okState
 	}
 
 	if (serverMode == authn_alpha1.MTLSDisable && clientMode.GetMode() == networking.TLSSettings_DISABLE) ||

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 
 	"github.com/golang/protobuf/jsonpb"
 
@@ -251,7 +252,7 @@ type AuthenticationDebug struct {
 
 // Pretty to-string function for unit test log.
 func (p *AuthenticationDebug) String() string {
-	return fmt.Sprintf("%s:%d, authn=%q, dr=%q, server=%q, client=%q, status=%q", p.Host, p.Port, p.AuthenticationPolicyName,
+	return fmt.Sprintf("{%s:%d, authn=%q, dr=%q, server=%q, client=%q, status=%q}", p.Host, p.Port, p.AuthenticationPolicyName,
 		p.DestinationRuleName, p.ServerProtocol, p.ClientProtocol, p.TLSConflictStatus)
 }
 
@@ -336,7 +337,14 @@ func AnalyzeMTLSSettings(hostname host.Name, port *model.Port, authnPolicy *auth
 	output := []*AuthenticationDebug{}
 
 	clientTLSModes := collectTLSSettingsForPort(rule, port)
-	for ss, c := range clientTLSModes {
+	var subsets []string
+	for k := range clientTLSModes {
+		subsets = append(subsets, k)
+	}
+	sort.Strings(subsets)
+
+	for _, ss := range subsets {
+		c := clientTLSModes[ss]
 		info := baseDebugInfo
 		if c != nil {
 			info.ClientProtocol = c.GetMode().String()

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -292,7 +292,7 @@ func getConfigDump(t *testing.T, s *v2.DiscoveryServer, proxyID string, wantCode
 }
 
 // TestAuthenticationZ tests the /debug/authenticationz handle. Due to the limitation of the test setup,
-// this test convers only one simple scenario. See TestAnalyzeMTLSSettings for more
+// this test converts only one simple scenario. See TestAnalyzeMTLSSettings for more
 func TestAuthenticationZ(t *testing.T) {
 	t.Run("TestAuthenticationZ", func(t *testing.T) {
 		s, tearDown := initLocalPilotTestEnv(t)

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -19,12 +19,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
+	authn "istio.io/api/authentication/v1alpha1"
+	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/istioctl/pkg/util/configdump"
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
+	authn_alpha1 "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/tests/util"
 )
 
@@ -284,4 +289,437 @@ func getConfigDump(t *testing.T, s *v2.DiscoveryServer, proxyID string, wantCode
 		t.Fatalf(err.Error())
 	}
 	return got
+}
+
+// TestAuthenticationZ tests the /debug/authenticationz handle. Due to the limitation of the test setup,
+// this test convers only one simple scenario. See TestAnalyzeMTLSSettings for more
+func TestAuthenticationZ(t *testing.T) {
+	t.Run("TestAuthenticationZ", func(t *testing.T) {
+		s, tearDown := initLocalPilotTestEnv(t)
+		defer tearDown()
+
+		envoy, cancel, err := connectADS(util.MockPilotGrpcAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cancel()
+
+		// Make CDS/LDS/RDS requestst to make the proxy instance available.
+		if err := sendCDSReq(sidecarID(app3Ip, "dumpApp"), envoy); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendLDSReq(sidecarID(app3Ip, "dumpApp"), envoy); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendRDSReq(sidecarID(app3Ip, "dumpApp"), []string{"80", "8080"}, "", envoy); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adsReceive(envoy, 5*time.Second); err != nil {
+			t.Fatal("Recv failed", err)
+		}
+
+		got := getAuthenticationZ(t, s.EnvoyXdsServer, "dumpApp-644fc65469-96dza.testns")
+		expectedLen := 25
+		if len(got) != expectedLen {
+			t.Errorf("AuthenticationZ should have %d entries, got got %d", expectedLen, len(got))
+		}
+		for _, info := range got {
+			expectedStatus := "AUTO"
+			if info.Host == "mymongodb.somedomain" {
+				expectedStatus = "CONFLICT"
+			}
+			if info.TLSConflictStatus != expectedStatus {
+				t.Errorf("want TLS conflict status %q, got %v", expectedStatus, info)
+			}
+		}
+	})
+}
+
+func getAuthenticationZ(t *testing.T, s *v2.DiscoveryServer, proxyID string) []v2.AuthenticationDebug {
+	path := "/debug/authenticationz"
+	if proxyID != "" {
+		path += fmt.Sprintf("?proxyID=%v", proxyID)
+	}
+	req, err := http.NewRequest("GET", path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	authenticationz := http.HandlerFunc(s.Authenticationz)
+	authenticationz.ServeHTTP(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("authenticationz error with code %v", rr.Code)
+	}
+
+	got := []v2.AuthenticationDebug{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Error(err)
+	}
+	return got
+}
+
+func TestEvaluateTLSState(t *testing.T) {
+	testCases := []struct {
+		name     string
+		client   *networking.TLSSettings
+		server   authn_alpha1.MutualTLSMode
+		expected string
+	}{
+		{
+			name:     "Auto with mTLS disable",
+			client:   nil,
+			server:   authn_alpha1.MTLSDisable,
+			expected: "AUTO",
+		},
+		{
+			name:     "Auto with mTLS permissive",
+			client:   nil,
+			server:   authn_alpha1.MTLSPermissive,
+			expected: "AUTO",
+		},
+		{
+			name:     "Auto with mTLS STRICT",
+			client:   nil,
+			server:   authn_alpha1.MTLSStrict,
+			expected: "AUTO",
+		},
+		{
+			name: "OK with mTLS STRICT",
+			client: &networking.TLSSettings{
+				Mode: networking.TLSSettings_ISTIO_MUTUAL,
+			},
+			server:   authn_alpha1.MTLSStrict,
+			expected: "OK",
+		},
+		{
+			name: "OK with mTLS DISABLE",
+			client: &networking.TLSSettings{
+				Mode: networking.TLSSettings_DISABLE,
+			},
+			server:   authn_alpha1.MTLSDisable,
+			expected: "OK",
+		},
+		{
+			name: "OK: plaintext with mTLS PERMISSIVE",
+			client: &networking.TLSSettings{
+				Mode: networking.TLSSettings_DISABLE,
+			},
+			server:   authn_alpha1.MTLSPermissive,
+			expected: "OK",
+		},
+		{
+			name: "OK: ISTIO_MUTUAL with mTLS PERMISSIVE",
+			client: &networking.TLSSettings{
+				Mode: networking.TLSSettings_ISTIO_MUTUAL,
+			},
+			server:   authn_alpha1.MTLSPermissive,
+			expected: "OK",
+		},
+		{
+			name: "Conflict: plaintext with mTLS STRICT",
+			client: &networking.TLSSettings{
+				Mode: networking.TLSSettings_DISABLE,
+			},
+			server:   authn_alpha1.MTLSStrict,
+			expected: "CONFLICT",
+		},
+		{
+			name: "Conflict: (custom) mTLS with mTLS STRICT",
+			client: &networking.TLSSettings{
+				Mode: networking.TLSSettings_MUTUAL,
+			},
+			server:   authn_alpha1.MTLSStrict,
+			expected: "CONFLICT",
+		},
+		{
+			name: "Conflict: TLS simple with mTLS STRICT",
+			client: &networking.TLSSettings{
+				Mode: networking.TLSSettings_SIMPLE,
+			},
+			server:   authn_alpha1.MTLSStrict,
+			expected: "CONFLICT",
+		},
+		{
+			name: "Conflict: TLS simple with mTLS PERMISSIVE",
+			client: &networking.TLSSettings{
+				Mode: networking.TLSSettings_SIMPLE,
+			},
+			server:   authn_alpha1.MTLSPermissive,
+			expected: "CONFLICT",
+		},
+		{
+			name: "Conflict: (custom) mTLS with mTLS PERMISSIVE",
+			client: &networking.TLSSettings{
+				Mode: networking.TLSSettings_SIMPLE,
+			},
+			server:   authn_alpha1.MTLSPermissive,
+			expected: "CONFLICT",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := v2.EvaluateTLSState(tc.client, tc.server); got != tc.expected {
+				t.Errorf("EvaluateTLSState expected to be %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestAnalyzeMTLSSettings(t *testing.T) {
+	testCases := []struct {
+		name        string
+		authnPolicy *authn.Policy
+		destConfig  *model.Config
+		expected    []*v2.AuthenticationDebug
+	}{
+		{
+			name:        "No policy",
+			authnPolicy: nil,
+			destConfig:  nil,
+			expected: []*v2.AuthenticationDebug{
+				{
+					Host:                     "foo.default",
+					Port:                     8080,
+					AuthenticationPolicyName: "-",
+					DestinationRuleName:      "-",
+					ServerProtocol:           "DISABLE",
+					ClientProtocol:           "-",
+					TLSConflictStatus:        "AUTO",
+				},
+			},
+		},
+		{
+			name: "No DR",
+			authnPolicy: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{
+							Mtls: &authn.MutualTls{
+								Mode: authn.MutualTls_STRICT,
+							},
+						},
+					},
+				},
+			},
+			destConfig: nil,
+			expected: []*v2.AuthenticationDebug{
+				{
+					Host:                     "foo.default",
+					Port:                     8080,
+					AuthenticationPolicyName: "???",
+					DestinationRuleName:      "-",
+					ServerProtocol:           "STRICT",
+					ClientProtocol:           "-",
+					TLSConflictStatus:        "AUTO",
+				},
+			},
+		},
+		{
+			name: "DR without TLS Settings",
+			authnPolicy: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{
+							Mtls: &authn.MutualTls{
+								Mode: authn.MutualTls_STRICT,
+							},
+						},
+					},
+				},
+			},
+			destConfig: &model.Config{
+				ConfigMeta: model.ConfigMeta{
+					Name:      "some-rule",
+					Namespace: "default",
+				},
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{},
+				},
+			},
+			expected: []*v2.AuthenticationDebug{
+				{
+					Host:                     "foo.default",
+					Port:                     8080,
+					AuthenticationPolicyName: "???",
+					DestinationRuleName:      "some-rule/default",
+					ServerProtocol:           "STRICT",
+					ClientProtocol:           "-",
+					TLSConflictStatus:        "AUTO",
+				},
+			},
+		},
+		{
+			name: "DR with TLS Settings",
+			authnPolicy: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{
+							Mtls: &authn.MutualTls{
+								Mode: authn.MutualTls_STRICT,
+							},
+						},
+					},
+				},
+			},
+			destConfig: &model.Config{
+				ConfigMeta: model.ConfigMeta{
+					Name:      "some-rule",
+					Namespace: "default",
+				},
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						Tls: &networking.TLSSettings{
+							Mode: networking.TLSSettings_DISABLE,
+						},
+					},
+				},
+			},
+			expected: []*v2.AuthenticationDebug{
+				{
+					Host:                     "foo.default",
+					Port:                     8080,
+					AuthenticationPolicyName: "???",
+					DestinationRuleName:      "some-rule/default",
+					ServerProtocol:           "STRICT",
+					ClientProtocol:           "DISABLE",
+					TLSConflictStatus:        "CONFLICT",
+				},
+			},
+		},
+		{
+			name: "DR with port-specific TLS Settings",
+			authnPolicy: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{
+							Mtls: &authn.MutualTls{
+								Mode: authn.MutualTls_STRICT,
+							},
+						},
+					},
+				},
+			},
+			destConfig: &model.Config{
+				ConfigMeta: model.ConfigMeta{
+					Name:      "some-rule",
+					Namespace: "default",
+				},
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						Tls: &networking.TLSSettings{
+							Mode: networking.TLSSettings_DISABLE,
+						},
+						PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+							{
+								Port: &networking.PortSelector{
+									Number: 8080,
+								},
+								Tls: &networking.TLSSettings{
+									Mode: networking.TLSSettings_ISTIO_MUTUAL,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []*v2.AuthenticationDebug{
+				{
+					Host:                     "foo.default",
+					Port:                     8080,
+					AuthenticationPolicyName: "???",
+					DestinationRuleName:      "some-rule/default",
+					ServerProtocol:           "STRICT",
+					ClientProtocol:           "ISTIO_MUTUAL",
+					TLSConflictStatus:        "OK",
+				},
+			},
+		},
+		{
+			name: "DR with subset",
+			authnPolicy: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{
+							Mtls: &authn.MutualTls{
+								Mode: authn.MutualTls_STRICT,
+							},
+						},
+					},
+				},
+			},
+			destConfig: &model.Config{
+				ConfigMeta: model.ConfigMeta{
+					Name:      "some-rule",
+					Namespace: "default",
+				},
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						Tls: &networking.TLSSettings{
+							Mode: networking.TLSSettings_DISABLE,
+						},
+						PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+							{
+								Port: &networking.PortSelector{
+									Number: 8080,
+								},
+								Tls: &networking.TLSSettings{
+									Mode: networking.TLSSettings_ISTIO_MUTUAL,
+								},
+							},
+						},
+					},
+					Subsets: []*networking.Subset{
+						{
+							Name:   "foobar",
+							Labels: map[string]string{"foo": "bar"},
+							TrafficPolicy: &networking.TrafficPolicy{
+								PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+									{
+										Port: &networking.PortSelector{
+											Number: 8080,
+										},
+										Tls: &networking.TLSSettings{
+											Mode: networking.TLSSettings_SIMPLE,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []*v2.AuthenticationDebug{
+				{
+					Host:                     "foo.default",
+					Port:                     8080,
+					AuthenticationPolicyName: "???",
+					DestinationRuleName:      "some-rule/default",
+					ServerProtocol:           "STRICT",
+					ClientProtocol:           "ISTIO_MUTUAL",
+					TLSConflictStatus:        "OK",
+				},
+				{
+					Host:                     "foo.default|foobar",
+					Port:                     8080,
+					AuthenticationPolicyName: "???",
+					DestinationRuleName:      "some-rule/default",
+					ServerProtocol:           "STRICT",
+					ClientProtocol:           "SIMPLE",
+					TLSConflictStatus:        "CONFLICT",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			port := model.Port{
+				Port: 8080,
+			}
+			if got := v2.AnalyzeMTLSSettings(host.Name("foo.default"), &port, tc.authnPolicy, tc.destConfig); !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("EvaluateTLSState expected to be %+v, got %+v", tc.expected, got)
+			}
+		})
+	}
 }

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -324,7 +324,7 @@ func TestAuthenticationZ(t *testing.T) {
 			t.Errorf("AuthenticationZ should have %d entries, got got %d", expectedLen, len(got))
 		}
 		for _, info := range got {
-			expectedStatus := "AUTO"
+			expectedStatus := "OK"
 			if info.Host == "mymongodb.somedomain" {
 				expectedStatus = "CONFLICT"
 			}
@@ -369,19 +369,19 @@ func TestEvaluateTLSState(t *testing.T) {
 			name:     "Auto with mTLS disable",
 			client:   nil,
 			server:   authn_alpha1.MTLSDisable,
-			expected: "AUTO",
+			expected: "OK",
 		},
 		{
 			name:     "Auto with mTLS permissive",
 			client:   nil,
 			server:   authn_alpha1.MTLSPermissive,
-			expected: "AUTO",
+			expected: "OK",
 		},
 		{
 			name:     "Auto with mTLS STRICT",
 			client:   nil,
 			server:   authn_alpha1.MTLSStrict,
-			expected: "AUTO",
+			expected: "OK",
 		},
 		{
 			name: "OK with mTLS STRICT",
@@ -485,7 +485,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 					DestinationRuleName:      "-",
 					ServerProtocol:           "DISABLE",
 					ClientProtocol:           "-",
-					TLSConflictStatus:        "AUTO",
+					TLSConflictStatus:        "OK",
 				},
 			},
 		},
@@ -511,7 +511,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 					DestinationRuleName:      "-",
 					ServerProtocol:           "STRICT",
 					ClientProtocol:           "-",
-					TLSConflictStatus:        "AUTO",
+					TLSConflictStatus:        "OK",
 				},
 			},
 		},
@@ -545,7 +545,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 					DestinationRuleName:      "some-rule/default",
 					ServerProtocol:           "STRICT",
 					ClientProtocol:           "-",
-					TLSConflictStatus:        "AUTO",
+					TLSConflictStatus:        "OK",
 				},
 			},
 		},

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -153,6 +153,10 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 		Hostname: hostname,
 		Address:  "10.10.0.3",
 		Ports:    testPorts(0),
+		Attributes: model.ServiceAttributes{
+			Name:      "service3",
+			Namespace: "default",
+		},
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance(hostname, &model.ServiceInstance{
 		Endpoint: model.NetworkEndpoint{
@@ -178,6 +182,10 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 				Port:     80,
 				Protocol: protocol.HTTP,
 			}},
+		Attributes: model.ServiceAttributes{
+			Name:      "local",
+			Namespace: "default",
+		},
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance("local.default.svc.cluster.local", &model.ServiceInstance{
 		Endpoint: model.NetworkEndpoint{
@@ -198,6 +206,10 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 		Hostname: "service3.default.svc.cluster.local",
 		Address:  "10.10.0.1",
 		Ports:    testPorts(0),
+		Attributes: model.ServiceAttributes{
+			Name:      "service3",
+			Namespace: "default",
+		},
 	})
 
 	server.EnvoyXdsServer.MemRegistry.AddInstance("service3.default.svc.cluster.local", &model.ServiceInstance{
@@ -243,6 +255,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 				Protocol: protocol.HTTPS,
 			},
 		},
+		// TODO: set attribute for this service. It may affect TestLDSIsolated as we now having service defined in istio-system namespaces
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
 		Endpoint: model.NetworkEndpoint{

--- a/pilot/pkg/security/authn/v1alpha1/model.go
+++ b/pilot/pkg/security/authn/v1alpha1/model.go
@@ -66,3 +66,15 @@ func GetMutualTLSMode(policy *authn.Policy) MutualTLSMode {
 	}
 	return MTLSDisable
 }
+
+// String converts MutualTLSMode to human readable string for debugging.
+func (mode MutualTLSMode) String() string {
+	// declare an array of strings
+	names := [...]string{
+		"UNKNOWN",
+		"DISABLE",
+		"PERMISSIVE",
+		"STRICT"}
+
+	return names[mode]
+}

--- a/tests/testdata/config/authn.yaml
+++ b/tests/testdata/config/authn.yaml
@@ -1,0 +1,9 @@
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: default
+  namespace: default
+  domain: "cluster.local"
+spec:
+  peers:
+  - mtls: {}

--- a/tests/testdata/config/authn.yaml
+++ b/tests/testdata/config/authn.yaml
@@ -6,4 +6,5 @@ metadata:
   domain: "cluster.local"
 spec:
   peers:
-  - mtls: {}
+  - mtls:
+      mode: PERMISSIVE


### PR DESCRIPTION
As pilot now detects the client TLS settings, if it is not define in `DestinationRule` (related [PR for strict mode](https://github.com/istio/istio/pull/16657), permissive more is soon-to-come), it shouldn't show `CONFLICT` in that case. This PR change it to `AUTO`, indicate the settings is automatically determined.

It also include few other implementation changes and fixes:
- Use authn policy from push context.
- Display status for subset, if applicable (fix https://github.com/istio/istio/issues/17554)
- Change the display text for TLS mode (closer to enum description).
- Add some unit tests for `/debug/authenticationz` handler.

However, the tool cannot show the source (CRD name) of the authN policy. We need to change the data model for authN policy in the push context to carry that information. This will be taken care of in the next PR.

Issues:

https://github.com/istio/istio/issues/16586
https://github.com/istio/istio/issues/17554

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
