### PR TITLE
Allow skipping entire test suites, skip sds_vault_flow

### DIFF
--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -53,6 +53,7 @@ type mRunFn func() int
 // Suite allows the test author to specify suite-related metadata and do setup in a fluent-style, before commencing execution.
 type Suite struct {
 	testID string
+	skip   string
 	mRun   mRunFn
 	osExit func(int)
 	labels label.Set
@@ -82,6 +83,10 @@ func newSuite(testID string, fn mRunFn, osExit func(int), getSettingsFn func(str
 // Label all the tests in suite with the given labels
 func (s *Suite) Label(labels ...label.Instance) *Suite {
 	s.labels = s.labels.Add(labels...)
+	return s
+}
+func (s *Suite) Skip(reason string) *Suite {
+	s.skip = reason
 	return s
 }
 
@@ -176,6 +181,11 @@ func (s *Suite) run() (errLevel int) {
 	}
 
 	ctx := rt.suiteContext()
+
+	// Skip the test if its explicitly skipped
+	if s.skip != "" {
+		scopes.Framework.Infof("Skipping suite %q: %s", ctx.Settings().TestID, s.skip)
+	}
 
 	// Before starting, check whether the current set of labels & label selectors will ever allow us to run tests.
 	// if not, simply exit now.

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -85,6 +85,8 @@ func (s *Suite) Label(labels ...label.Instance) *Suite {
 	s.labels = s.labels.Add(labels...)
 	return s
 }
+
+// Skip marks a suite as skipped with the given reason. This will prevent any setup functions from occurring.
 func (s *Suite) Skip(reason string) *Suite {
 	s.skip = reason
 	return s
@@ -185,6 +187,7 @@ func (s *Suite) run() (errLevel int) {
 	// Skip the test if its explicitly skipped
 	if s.skip != "" {
 		scopes.Framework.Infof("Skipping suite %q: %s", ctx.Settings().TestID, s.skip)
+		return 0
 	}
 
 	// Before starting, check whether the current set of labels & label selectors will ever allow us to run tests.

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -55,6 +55,7 @@ func TestMain(m *testing.M) {
 	// with the certificates issued by the SDS Vault CA flow.
 	framework.NewSuite("sds_vault_flow_test", m).
 		Label(label.CustomSetup).
+		Skip("https://github.com/istio/istio/issues/17572").
 		// SDS requires Kubernetes 1.13
 		RequireEnvironmentVersion("1.13").
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).


### PR DESCRIPTION
The problem we are seeing is the sds_vault_flow is skipped, but the
failure from the test actually occurs during Istio setup, before the
test is skipped.

For example: https://prow.k8s.io/view/gcs/istio-prow/logs/integ-k8s-113_istio_postsubmit/229

[x] Security
[x] Test and Release
