### PR TITLE
cluster: filter service instances on the same port

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -414,7 +414,7 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 	clusters := configgen.BuildClusters(env, proxy, env.PushContext)
 	var err error
 	if len(env.PushContext.ProxyStatus[model.DuplicatedClusters.Name()]) > 0 {
-		err = fmt.Errorf("Duplicate clusters detected %#v", env.PushContext.ProxyStatus[model.DuplicatedClusters.Name()])
+		err = fmt.Errorf("duplicate clusters detected %#v", env.PushContext.ProxyStatus[model.DuplicatedClusters.Name()])
 	}
 	return clusters, err
 }


### PR DESCRIPTION
Filters services instances on the port while building inbound clusters when there are Pod has multiple IP addresses. This avoids building a inbound cluster on the same port and then later marking it as duplicate in normalizeCluster method.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Fixes #17632 https://github.com/istio/istio/issues/17632
