### PR TITLE
pilot: add units to metric descriptions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1184,7 +1184,6 @@ istio.io/operator v0.0.0-20190923170413-6e6db1228c1f/go.mod h1:zXW7+gecpItHqIChr
 istio.io/pkg v0.0.0-20190515193414-9332430ad747/go.mod h1:0EkPwmR0tESYjN4Ilq1D52nTBurXaQvny3r2VY4j4tw=
 istio.io/pkg v0.0.0-20190905225920-6d0bbfe3b229 h1:BOAXiysHton3DsQZu/+lMSZ3gD3VBv9RZ9psETyB+7o=
 istio.io/pkg v0.0.0-20190905225920-6d0bbfe3b229/go.mod h1:We4ZQuCbiiNfXge2GfOshBsyDXVwzFwP8703V5DcM14=
-istio.io/pkg v0.0.0-20190930134523-4e6e584aaaae h1:K1PEVkoopgAykTFEQ5IB13M5V1umz76N65qNy8VLJTA=
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711 h1:BblVYz/wE5WtBsD/Gvu54KyBUTJMflolzc5I2DTvh50=
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711/go.mod h1:TBhBqb1AWbBQbW3XRusr7n7E4v2+5ZY8r8sAMnyFC5A=
 k8s.io/apiextensions-apiserver v0.0.0-20190620085554-14e95df34f1f h1:+pHBUvIpLzm6H8VwRO+jMLcq5MIfaGq5xu/cBV676Ps=

--- a/go.sum
+++ b/go.sum
@@ -1184,6 +1184,7 @@ istio.io/operator v0.0.0-20190923170413-6e6db1228c1f/go.mod h1:zXW7+gecpItHqIChr
 istio.io/pkg v0.0.0-20190515193414-9332430ad747/go.mod h1:0EkPwmR0tESYjN4Ilq1D52nTBurXaQvny3r2VY4j4tw=
 istio.io/pkg v0.0.0-20190905225920-6d0bbfe3b229 h1:BOAXiysHton3DsQZu/+lMSZ3gD3VBv9RZ9psETyB+7o=
 istio.io/pkg v0.0.0-20190905225920-6d0bbfe3b229/go.mod h1:We4ZQuCbiiNfXge2GfOshBsyDXVwzFwP8703V5DcM14=
+istio.io/pkg v0.0.0-20190930134523-4e6e584aaaae h1:K1PEVkoopgAykTFEQ5IB13M5V1umz76N65qNy8VLJTA=
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711 h1:BblVYz/wE5WtBsD/Gvu54KyBUTJMflolzc5I2DTvh50=
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711/go.mod h1:TBhBqb1AWbBQbW3XRusr7n7E4v2+5ZY8r8sAMnyFC5A=
 k8s.io/apiextensions-apiserver v0.0.0-20190620085554-14e95df34f1f h1:+pHBUvIpLzm6H8VwRO+jMLcq5MIfaGq5xu/cBV676Ps=

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -117,14 +117,14 @@ var (
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesQueueTime = monitoring.NewDistribution(
 		"pilot_proxy_queue_time",
-		"Time in milliseconds, a proxy is in the push queue before being dequeued.",
+		"Time in seconds, a proxy is in the push queue before being dequeued.",
 		[]float64{.1, 1, 3, 5, 10, 20, 30},
 	)
 
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesConvergeDelay = monitoring.NewDistribution(
 		"pilot_proxy_convergence_time",
-		"Delay in milliseconds between config change and a proxy receiving all required configuration.",
+		"Delay in seconds between config change and a proxy receiving all required configuration.",
 		[]float64{.1, .5, 1, 3, 5, 10, 20, 30},
 	)
 

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -104,7 +104,7 @@ var (
 
 	pushTime = monitoring.NewDistribution(
 		"pilot_xds_push_time",
-		"Total time in second Pilot takes to push lds, rds, cds and eds.",
+		"Total time in seconds Pilot takes to push lds, rds, cds and eds.",
 		[]float64{.01, .1, 1, 3, 5, 10, 20, 30},
 		monitoring.WithLabels(typeTag),
 	)
@@ -117,14 +117,14 @@ var (
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesQueueTime = monitoring.NewDistribution(
 		"pilot_proxy_queue_time",
-		"Time a proxy is in the push queue before being dequeued.",
+		"Time in milliseconds, a proxy is in the push queue before being dequeued.",
 		[]float64{.1, 1, 3, 5, 10, 20, 30},
 	)
 
 	// only supported dimension is millis, unfortunately. default to unitdimensionless.
 	proxiesConvergeDelay = monitoring.NewDistribution(
 		"pilot_proxy_convergence_time",
-		"Delay between config change and a proxy receiving all required configuration.",
+		"Delay in milliseconds between config change and a proxy receiving all required configuration.",
 		[]float64{.1, .5, 1, 3, 5, 10, 20, 30},
 	)
 


### PR DESCRIPTION
Couple of metric descriptions in Pilot are missing units. This PR adds them,
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
