### PR TITLE
Fix trimpath issue

### DIFF
--- a/common/scripts/gobuild.sh
+++ b/common/scripts/gobuild.sh
@@ -73,13 +73,15 @@ done < "${BUILDINFO}"
 # verify go version before build
 # NB. this was copied verbatim from Kubernetes hack
 minimum_go_version=go1.13 # supported patterns: go1.x, go1.x.x (x should be a number)
+GO_VERSION_UPDATED=true
 IFS=" " read -ra go_version <<< "$(${GOBINARY} version)"
 if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
+    GO_VERSION_UPDATED=false
     echo "Warning: Detected that you are using an older version of the Go compiler. Istio requires ${minimum_go_version} or greater."
 fi
 
 OPTIMIZATION_FLAGS="-trimpath"
-if [ "${DEBUG}" == "1" ]; then
+if [[ "${DEBUG}" == "1" ]] || [[ "${GO_VERSION_UPDATED}" = false ]]; then
     OPTIMIZATION_FLAGS=""
 fi
 


### PR DESCRIPTION
Looks like the global --trimpath flag is not available before go 1.13

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X ] Test and Release
[ ] User Experience
[X ] Developer Infrastructure
