### PR TITLE
pilot: use transport socket in filter chains and clusters

### DIFF
--- a/istioctl/pkg/auth/listener.go
+++ b/istioctl/pkg/auth/listener.go
@@ -123,7 +123,13 @@ func ParseListener(listener *v2.Listener) *ParsedListener {
 	}
 
 	for _, fc := range listener.FilterChains {
-		parsedFC := &filterChain{tlsContext: fc.TlsContext}
+		tlsContext := &auth.DownstreamTlsContext{}
+		if fc.TransportSocket != nil && fc.TransportSocket.Name == "tls" {
+			ptypes.UnmarshalAny(fc.TransportSocket.GetTypedConfig(), tlsContext)
+		} else {
+			tlsContext = fc.TlsContext
+		}
+		parsedFC := &filterChain{tlsContext: tlsContext}
 		for _, filter := range fc.Filters {
 			switch filter.Name {
 			case "envoy.http_connection_manager":

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1623,11 +1623,12 @@ type filterChainOpts struct {
 	sniHosts         []string
 	destinationCIDRs []string
 	metadata         *core.Metadata
-	tlsContext       *auth.DownstreamTlsContext
-	httpOpts         *httpListenerOpts
-	match            *listener.FilterChainMatch
-	listenerFilters  []*listener.ListenerFilter
-	networkFilters   []*listener.Filter
+	// transportSocket  *core.TransportSocket
+	tlsContext      *auth.DownstreamTlsContext
+	httpOpts        *httpListenerOpts
+	match           *listener.FilterChainMatch
+	listenerFilters []*listener.ListenerFilter
+	networkFilters  []*listener.Filter
 }
 
 // buildListenerOpts are the options required to build a Listener
@@ -1846,7 +1847,7 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 		}
 		filterChains = append(filterChains, &listener.FilterChain{
 			FilterChainMatch: match,
-			TlsContext:       chain.tlsContext,
+			TransportSocket:  buildDownstreamTlsTransportSocket(chain.tlsContext),
 		})
 	}
 
@@ -2210,4 +2211,13 @@ func appendListenerFilters(filters []*listener.ListenerFilter) []*listener.Liste
 	}
 
 	return filters
+}
+
+func buildDownstreamTlsTransportSocket(tlsContext *auth.DownstreamTlsContext) *core.TransportSocket {
+	typedConfig, err := ptypes.MarshalAny(tlsContext)
+	if err == nil {
+		log.Errorf(err.Error())
+	}
+	transportSocket := &core.TransportSocket{Name: "tls", ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: typedConfig}}
+	return transportSocket
 }


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Context: envoyproxy/envoy#8098, transport socket support is already in Envoy for more than a year.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
