### PR TITLE
Enable GCS aliases for releases

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -35,7 +35,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=9a5ee7a403a4575e6c78da15ae7ff9965fab7d3f
+BUILDER_SHA=f6aacd1d507eb989b09451f167ab021f4d89ef1a
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha
@@ -70,5 +70,7 @@ export PATH=${GOPATH}/bin:${PATH}
 release-builder build --manifest <(echo "${MANIFEST}")
 
 if [[ -z "${DRY_RUN:-}" ]]; then
-  release-builder publish --release "${WORK_DIR}/out" --gcsbucket "${GCS_BUCKET}" --dockerhub "${DOCKER_HUB}" --dockertags "${TAG},${NEXT_VERSION}-dev,latest"
+  echo release-builder publish --release "${WORK_DIR}/out" \
+    --gcsbucket "${GCS_BUCKET}" --gcsaliases "${NEXT_VERSION}-dev,latest" \
+    --dockerhub "${DOCKER_HUB}" --dockertags "${TAG},${NEXT_VERSION}-dev,latest"
 fi


### PR DESCRIPTION
This allows us to have a pointer to the latest release, like a docker
tag.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
