### PR TITLE
Support standalone Istio certificate controller for DNS certificate provisioning

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -343,6 +343,7 @@ BINARIES:=./istioctl/cmd/istioctl \
   ./security/cmd/node_agent \
   ./security/cmd/node_agent_k8s \
   ./security/cmd/istio_ca \
+  ./security/cmd/chiron \
   ./security/tools/sdsclient \
   ./pkg/test/echo/cmd/client \
   ./pkg/test/echo/cmd/server \
@@ -351,7 +352,7 @@ BINARIES:=./istioctl/cmd/istioctl \
   ./tools/istio-iptables
 
 # List of binaries included in releases
-RELEASE_BINARIES:=pilot-discovery pilot-agent sidecar-injector mixc mixs mixgen node_agent node_agent_k8s istio_ca istioctl galley sdsclient
+RELEASE_BINARIES:=pilot-discovery pilot-agent sidecar-injector mixc mixs mixgen node_agent node_agent_k8s istio_ca istioctl galley sdsclient chiron
 
 .PHONY: build
 build: depend

--- a/install/kubernetes/helm/istio/charts/chiron/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/chiron/Chart.yaml
@@ -1,16 +1,11 @@
 apiVersion: v1
-name: istio
+name: chiron
 version: 1.1.0
 appVersion: 1.1.0
-tillerVersion: ">=2.7.2-0"
-description: Helm chart for all istio components
+tillerVersion: ">=2.7.2"
+description: Helm chart for chiron deployment
 keywords:
   - istio
-  - security
-  - sidecarInjectorWebhook
-  - mixer
-  - pilot
-  - galley
   - chiron
 sources:
   - http://github.com/istio/istio

--- a/install/kubernetes/helm/istio/charts/chiron/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/charts/chiron/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chiron.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chiron.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chiron.chart" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/install/kubernetes/helm/istio/charts/chiron/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/chiron/templates/clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-chiron-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "chiron.name" . }}
+    chart: {{ template "chiron.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "watch", "list", "update", "delete"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources:
+      - "certificatesigningrequests"
+      - "certificatesigningrequests/approval"
+      - "certificatesigningrequests/status"
+    verbs: ["update", "create", "get", "delete"]

--- a/install/kubernetes/helm/istio/charts/chiron/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/chiron/templates/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-chiron-role-binding-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "chiron.name" . }}
+    chart: {{ template "chiron.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-chiron-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-chiron-service-account
+    namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/helm/istio/charts/chiron/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/chiron/templates/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-chiron
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "chiron.name" . }}
+    chart: {{ template "chiron.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    istio: chiron
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      istio: chiron
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingMaxSurge }}
+      maxUnavailable: {{ .Values.rollingMaxUnavailable }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "chiron.name" . }}
+        chart: {{ template "chiron.chart" . }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        istio: chiron
+      annotations:
+        sidecar.istio.io/inject: "false"
+         {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: istio-chiron-service-account
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
+      containers:
+        - name: chiron
+{{- if contains "/" .Values.image }}
+          image: "{{ .Values.image }}"
+{{- else }}
+          image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          args:
+          - --enable-controller
+{{- if $.Values.global.logging.level }}
+          - --log_output_level={{ $.Values.global.logging.level }}
+{{- end}}
+          resources:
+{{- if .Values.resources }}
+{{ toYaml .Values.resources | indent 12 }}
+{{- else }}
+{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
+      {{- include "podAntiAffinity" . | indent 6 }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}

--- a/install/kubernetes/helm/istio/charts/chiron/templates/poddisruptionbudget.yaml
+++ b/install/kubernetes/helm/istio/charts/chiron/templates/poddisruptionbudget.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: istio-chiron
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "chiron.name" . }}
+    chart: {{ template "chiron.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    istio: chiron
+spec:
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+{{ include "podDisruptionBudget.spec" .Values.global.defaultPodDisruptionBudget }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "chiron.name" . }}
+      release: {{ .Release.Name }}
+      istio: chiron
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/chiron/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/chiron/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+metadata:
+  name: istio-chiron-service-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "chiron.name" . }}
+    chart: {{ template "chiron.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}

--- a/install/kubernetes/helm/istio/charts/chiron/values.yaml
+++ b/install/kubernetes/helm/istio/charts/chiron/values.yaml
@@ -1,0 +1,32 @@
+#
+# chiron configuration
+#
+enabled: false
+replicaCount: 1
+rollingMaxSurge: 100%
+rollingMaxUnavailable: 25%
+image: chiron
+nodeSelector: {}
+tolerations: []
+podAnnotations: {}
+
+# Specify the pod anti-affinity that allows you to constrain which nodes
+# your pod is eligible to be scheduled based on labels on pods that are
+# already running on the node rather than based on labels on nodes.
+# There are currently two types of anti-affinity:
+#    "requiredDuringSchedulingIgnoredDuringExecution"
+#    "preferredDuringSchedulingIgnoredDuringExecution"
+# which denote "hard" vs. "soft" requirements, you can define your values
+# in "podAntiAffinityLabelSelector" and "podAntiAffinityTermLabelSelector"
+# correspondingly.
+# For example:
+# podAntiAffinityLabelSelector:
+# - key: security
+#   operator: In
+#   values: S1,S2
+#   topologyKey: "kubernetes.io/hostname"
+# This pod anti-affinity rule says that the pod requires not to be scheduled
+# onto a node if that node is already running a pod with label having key
+# "security" and value "S1".
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -29,6 +29,9 @@ dependencies:
   - name: galley
     version: 1.1.0
     condition: galley.enabled
+  - name: chiron
+    version: 1.1.0
+    condition: chiron.enabled
   - name: kiali
     version: 1.1.0
     condition: kiali.enabled

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -29,6 +29,13 @@ galley:
   enabled: true
 
 #
+# chiron configuration, refer to charts/chiron/values.yaml
+# for detailed configuration
+#
+chiron:
+  enabled: false
+
+#
 # mixer configuration
 #
 # @see charts/mixer/values.yaml for all values

--- a/security/docker/Dockerfile.chiron
+++ b/security/docker/Dockerfile.chiron
@@ -1,0 +1,22 @@
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM docker.io/istio/base:${BASE_VERSION} as default
+
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+# hadolint ignore=DL3007
+FROM gcr.io/distroless/static:latest as distroless
+
+# This will build the final image based on either default or distroless from above
+# hadolint ignore=DL3006
+FROM ${BASE_DISTRIBUTION}
+
+# All containers need a /tmp directory
+WORKDIR /tmp/
+COPY chiron /usr/local/bin/chiron
+
+ENTRYPOINT [ "/usr/local/bin/chiron" ]

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -23,7 +23,7 @@ docker: build-linux docker.all
 
 # Add new docker targets to the end of the DOCKER_TARGETS list.
 DOCKER_TARGETS:=docker.pilot docker.proxy_debug docker.proxytproxy docker.proxyv2 docker.app docker.app_sidecar docker.test_policybackend \
-	docker.proxy_init docker.mixer docker.mixer_codegen docker.citadel docker.galley docker.sidecar_injector docker.kubectl docker.node-agent-k8s
+	docker.proxy_init docker.mixer docker.mixer_codegen docker.citadel docker.galley docker.sidecar_injector docker.kubectl docker.node-agent-k8s docker.chiron
 
 $(ISTIO_DOCKER) $(ISTIO_DOCKER_TAR):
 	mkdir -p $@
@@ -49,7 +49,7 @@ $(ISTIO_DOCKER)/node_agent.crt $(ISTIO_DOCKER)/node_agent.key: ${GEN_CERT} $(IST
 # 	cp $(ISTIO_OUT_LINUX)/$FILE $(ISTIO_DOCKER)/($FILE)
 DOCKER_FILES_FROM_ISTIO_OUT_LINUX:=client server \
                              pilot-discovery pilot-agent sidecar-injector mixs mixgen \
-                             istio_ca node_agent node_agent_k8s galley istio-iptables
+                             istio_ca node_agent node_agent_k8s galley istio-iptables chiron
 $(foreach FILE,$(DOCKER_FILES_FROM_ISTIO_OUT_LINUX), \
         $(eval $(ISTIO_DOCKER)/$(FILE): $(ISTIO_OUT_LINUX)/$(FILE) | $(ISTIO_DOCKER); cp $(ISTIO_OUT_LINUX)/$(FILE) $(ISTIO_DOCKER)/$(FILE)))
 
@@ -228,6 +228,11 @@ docker.citadel-test: security/docker/Dockerfile.citadel-test
 docker.citadel-test: $(ISTIO_DOCKER)/istio_ca
 docker.citadel-test: $(ISTIO_DOCKER)/istio_ca.crt
 docker.citadel-test: $(ISTIO_DOCKER)/istio_ca.key
+	$(DOCKER_RULE)
+
+docker.chiron: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
+docker.chiron: security/docker/Dockerfile.chiron
+docker.chiron: $(ISTIO_DOCKER)/chiron
 	$(DOCKER_RULE)
 
 docker.node-agent: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}


### PR DESCRIPTION
Istio certificate controller (Chiron) can run in the following modes. This PR is for the standalone mode.
- Pilot use Chiron (linked in Pilot) to provision DNS certificates.
- For the environment without Pilot, Chiron runs in its standalone mode.

Please provide a description for what this PR is for: https://github.com/istio/istio/issues/17061

Design documents:
[1]https://docs.google.com/document/d/1VHyBre8943USOx_YEVtA18KfEoGTmLT1iBHESO5bzcA/edit#heading=h.qex63c29z2to
[2] https://docs.google.com/document/d/1v8BxI07u-mby5f5rCruwF7odSXgb9G8-C9W5hQtSIAg/edit#heading=h.xw1gqgyqs5b

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
