### PR TITLE
Avoid excessive retries in tracing test

### DIFF
--- a/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
@@ -51,7 +51,7 @@ func TestClientTracing(t *testing.T) {
 			extraHeader := fmt.Sprintf("%s: %s", traceHeader, id)
 
 			retry.UntilSuccessOrFail(t, func() error {
-				util.VisitProductPage(ingress, /* time_out = */ 10, /* want_status = */ 200, t)
+				util.SendTraffic(ingress, t, "Sending traffic", url, extraHeader, 1)
 				traces, err := tracing.GetZipkinInstance().QueryTraces(100,
 					fmt.Sprintf("productpage.%s.svc.cluster.local:9080/productpage", bookinfoNsInst.Name()), fmt.Sprintf("guid:x-client-trace-id=%s", id))
 				if err != nil {

--- a/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
@@ -51,9 +51,7 @@ func TestClientTracing(t *testing.T) {
 			extraHeader := fmt.Sprintf("%s: %s", traceHeader, id)
 
 			retry.UntilSuccessOrFail(t, func() error {
-				// Send test traffic. QPS is restricted to 10, so this will send ~20secs worth of traffic.
-				// We want a multiple of 5secs worth of traffic, given default envoy flush times on the zipkin driver.
-				util.SendTraffic(ingress, t, "Sending traffic", url, extraHeader, 200)
+				util.VisitProductPage(ingress, /* time_out = */ 10, /* want_status = */ 200, t)
 				traces, err := tracing.GetZipkinInstance().QueryTraces(100,
 					fmt.Sprintf("productpage.%s.svc.cluster.local:9080/productpage", bookinfoNsInst.Name()), fmt.Sprintf("guid:x-client-trace-id=%s", id))
 				if err != nil {

--- a/tests/integration/telemetry/tracing/servertracing/tracing_test.go
+++ b/tests/integration/telemetry/tracing/servertracing/tracing_test.go
@@ -40,9 +40,7 @@ func TestProxyTracing(t *testing.T) {
 			bookinfoNsInst := tracing.GetBookinfoNamespaceInstance()
 
 			retry.UntilSuccessOrFail(t, func() error {
-				// Send test traffic. QPS is restricted to 10, so this will send ~20secs worth of traffic.
-				// We want a multiple of 5secs worth of traffic, given default envoy flush times on the zipkin driver.
-				util.SendTraffic(tracing.GetIngressInstance(), t, "Sending traffic", "", "", 200)
+				util.VisitProductPage(ingress, /* time_out = */ 10, /* want_status = */ 200, t)
 				traces, err := tracing.GetZipkinInstance().QueryTraces(100,
 					fmt.Sprintf("productpage.%s.svc.cluster.local:9080/productpage", bookinfoNsInst.Name()), "")
 				if err != nil {

--- a/tests/integration/telemetry/tracing/servertracing/tracing_test.go
+++ b/tests/integration/telemetry/tracing/servertracing/tracing_test.go
@@ -40,7 +40,7 @@ func TestProxyTracing(t *testing.T) {
 			bookinfoNsInst := tracing.GetBookinfoNamespaceInstance()
 
 			retry.UntilSuccessOrFail(t, func() error {
-				util.VisitProductPage(ingress, /* time_out = */ 10, /* want_status = */ 200, t)
+				util.SendTraffic(tracing.GetIngressInstance(), t, "Sending traffic", "", "", 1)
 				traces, err := tracing.GetZipkinInstance().QueryTraces(100,
 					fmt.Sprintf("productpage.%s.svc.cluster.local:9080/productpage", bookinfoNsInst.Name()), "")
 				if err != nil {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/16985

Both cases should sample at 100%. This PR limits the number of request to ensure that the sample rate is applied.