### PR TITLE
Remove proxy_debug image

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -52,7 +52,7 @@ esac
 export ISTIO_OUT=${ISTIO_OUT:-${ISTIO_BIN}}
 
 # Download Envoy debug and release binaries for Linux x86_64. They will be included in the
-# docker images created by Dockerfile.proxy and Dockerfile.proxy_debug.
+# docker images created by Dockerfile.proxyv2 and Dockerfile.proxytproxy.
 
 # Gets the download command supported by the system (currently either curl or wget)
 DOWNLOAD_COMMAND=""

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -53,33 +53,26 @@ var (
 // InitImageName returns the fully qualified image name for the istio
 // init image given a docker hub and tag and debug flag
 // This is used for testing only
-func InitImageName(hub string, tag string, _ bool) string {
+func InitImageName(hub string, tag string) string {
 	return hub + "/proxy_init:" + tag
 }
 
 // ProxyImageName returns the fully qualified image name for the istio
 // proxy image given a docker hub and tag and whether to use debug or not.
 // This is used for testing
-func ProxyImageName(hub string, tag string, debug bool) string {
+func ProxyImageName(hub string, tag string) string {
 	// Allow overriding the proxy image.
-	if debug {
-		return hub + "/proxy_debug:" + tag
-	}
 	return hub + "/proxyv2:" + tag
 }
 
 func TestImageName(t *testing.T) {
 	want := "docker.io/istio/proxy_init:latest"
-	if got := InitImageName("docker.io/istio", "latest", true); got != want {
+	if got := InitImageName("docker.io/istio", "latest"); got != want {
 		t.Errorf("InitImageName() failed: got %q want %q", got, want)
 	}
-	want = "docker.io/istio/proxy_debug:latest"
-	if got := ProxyImageName("docker.io/istio", "latest", true); got != want {
-		t.Errorf("ProxyImageName() failed: got %q want %q", got, want)
-	}
 	want = "docker.io/istio/proxyv2:latest"
-	if got := ProxyImageName("docker.io/istio", "latest", false); got != want {
-		t.Errorf("ProxyImageName(debug:false) failed: got %q want %q", got, want)
+	if got := ProxyImageName("docker.io/istio", "latest"); got != want {
+		t.Errorf("ProxyImageName() failed: got %q want %q", got, want)
 	}
 }
 
@@ -100,7 +93,6 @@ func TestIntoResourceFile(t *testing.T) {
 		readinessFailureThreshold    uint32
 		enableAuth                   bool
 		enableCoreDump               bool
-		debugMode                    bool
 		privileged                   bool
 		tproxy                       bool
 		podDNSSearchNamespaces       []string
@@ -556,8 +548,8 @@ func TestIntoResourceFile(t *testing.T) {
 			}
 
 			params := &Params{
-				InitImage:                    InitImageName(unitTestHub, unitTestTag, c.debugMode),
-				ProxyImage:                   ProxyImageName(unitTestHub, unitTestTag, c.debugMode),
+				InitImage:                    InitImageName(unitTestHub, unitTestTag),
+				ProxyImage:                   ProxyImageName(unitTestHub, unitTestTag),
 				ImagePullPolicy:              "IfNotPresent",
 				SDSEnabled:                   false,
 				Verbosity:                    DefaultVerbosity,
@@ -566,7 +558,6 @@ func TestIntoResourceFile(t *testing.T) {
 				EnableCoreDump:               c.enableCoreDump,
 				Privileged:                   c.privileged,
 				Mesh:                         &m,
-				DebugMode:                    c.debugMode,
 				IncludeIPRanges:              c.includeIPRanges,
 				ExcludeIPRanges:              c.excludeIPRanges,
 				IncludeInboundPorts:          c.includeInboundPorts,
@@ -678,8 +669,8 @@ func TestRewriteAppProbe(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			m := mesh.DefaultMeshConfig()
 			params := &Params{
-				InitImage:                    InitImageName(unitTestHub, unitTestTag, false),
-				ProxyImage:                   ProxyImageName(unitTestHub, unitTestTag, false),
+				InitImage:                    InitImageName(unitTestHub, unitTestTag),
+				ProxyImage:                   ProxyImageName(unitTestHub, unitTestTag),
 				ImagePullPolicy:              "IfNotPresent",
 				SidecarProxyUID:              DefaultSidecarProxyUID,
 				Version:                      "12345678",
@@ -895,8 +886,8 @@ func TestSkipUDPPorts(t *testing.T) {
 func newTestParams() *Params {
 	m := mesh.DefaultMeshConfig()
 	return &Params{
-		InitImage:           InitImageName(unitTestHub, unitTestTag, false),
-		ProxyImage:          ProxyImageName(unitTestHub, unitTestTag, false),
+		InitImage:           InitImageName(unitTestHub, unitTestTag),
+		ProxyImage:          ProxyImageName(unitTestHub, unitTestTag),
 		ImagePullPolicy:     "IfNotPresent",
 		SDSEnabled:          false,
 		Verbosity:           DefaultVerbosity,

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1570,8 +1570,8 @@ func testSideCarInjectorMetrics(t *testing.T, wh *Webhook) {
 func BenchmarkInjectServe(b *testing.B) {
 	mesh := mesh.DefaultMeshConfig()
 	params := &Params{
-		InitImage:           InitImageName(unitTestHub, unitTestTag, false),
-		ProxyImage:          ProxyImageName(unitTestHub, unitTestTag, false),
+		InitImage:           InitImageName(unitTestHub, unitTestTag),
+		ProxyImage:          ProxyImageName(unitTestHub, unitTestTag),
 		ImagePullPolicy:     "IfNotPresent",
 		Verbosity:           DefaultVerbosity,
 		SidecarProxyUID:     DefaultSidecarProxyUID,

--- a/samples/bookinfo/platform/consul/templates/bookinfo.sidecars.yaml.tmpl
+++ b/samples/bookinfo/platform/consul/templates/bookinfo.sidecars.yaml.tmpl
@@ -32,7 +32,7 @@ services:
       - -b
       - "9080"
   details-v1-sidecar:
-    image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
+    image: {PROXY_HUB}/proxyv2:{PROXY_TAG}
     network_mode: "container:consul_details-v1_1"
     entrypoint:
       - su
@@ -56,7 +56,7 @@ services:
       - -b
       - "9080"
   ratings-v1-sidecar:
-    image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
+    image: {PROXY_HUB}/proxyv2:{PROXY_TAG}
     network_mode: "container:consul_ratings-v1_1"
     entrypoint:
       - su
@@ -80,7 +80,7 @@ services:
       - -b
       - "9080"
   productpage-v1-sidecar:
-    image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
+    image: {PROXY_HUB}/proxyv2:{PROXY_TAG}
     network_mode: "container:consul_productpage-v1_1"
     entrypoint:
       - su
@@ -104,7 +104,7 @@ services:
       - -b
       - "9080"
   reviews-v1-sidecar:
-    image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
+    image: {PROXY_HUB}/proxyv2:{PROXY_TAG}
     network_mode: "container:consul_reviews-v1_1"
     entrypoint:
       - su
@@ -128,7 +128,7 @@ services:
       - -b
       - "9080"
   reviews-v2-sidecar:
-    image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
+    image: {PROXY_HUB}/proxyv2:{PROXY_TAG}
     network_mode: "container:consul_reviews-v2_1"
     entrypoint:
       - su
@@ -152,7 +152,7 @@ services:
       - -b
       - "9080"
   reviews-v3-sidecar:
-    image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
+    image: {PROXY_HUB}/proxyv2:{PROXY_TAG}
     network_mode: "container:consul_reviews-v3_1"
     entrypoint:
       - su


### PR DESCRIPTION
Having a duplicated dockerfile of proxyv2 makes it hard to keep things
in sync. Additionally, this makes `make docker` much slower since the
debug image is 1gb.

Developers who want to use the debug image can still do so with the
DEBUG_IMAGE flag.
