### PR TITLE
Conditionally add applicationPorts

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -149,8 +149,10 @@ containers:
 {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" (valueOrDefault .Values.global.proxy.statusPort 0 )) `0`) }}
   - --statusPort
   - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"
+  {{- if (annotation .ObjectMeta `readiness.status.sidecar.istio.io/applicationPorts` (applicationPorts .Spec.Containers))}}
   - --applicationPorts
   - "{{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/applicationPorts` (applicationPorts .Spec.Containers) }}"
+  {{- end }}
 {{- end }}
 {{- if .Values.global.trustDomain }}
   - --trust-domain={{ .Values.global.trustDomain }}


### PR DESCRIPTION
### Summary
Only add `--applicationPorts` command line argument when application ports are not empty.

### Why:
if a pod does not expose any ports for any of its containers, the list of applicationPorts is going to be empty and Proxy startup will fail.
The issue was observed in the following scenario:
![Screen Shot 2019-10-03 at 11 29 19 AM copy](https://user-images.githubusercontent.com/3926194/66430751-8deafb00-e9cf-11e9-9a64-09b761612aad.png)

```
Rendering '/etc/istio/proxy/config_template....'                                                                                │
│Rendering '/etc/istio/proxy/config_template...'                                                                                │
│2019-10-03T18:24:50.890391Z    info    FLAG: --applicationPorts="[--concurrency]"                                              │
│2019-10-03T18:24:50.890439Z    info    FLAG: --binaryPath="/usr/local/bin/envoy"                                               │
│2019-10-03T18:24:50.890445Z    info    FLAG: --concurrency="0"                                                                 │
│2019-10-03T18:24:50.890449Z    info    FLAG: --configPath="/etc/istio/proxy"                                                   │
```


```
    │2019-10-03T18:24:50.895786Z    info    pilot-agent is terminating                                                              │
    │2019-10-03T18:24:50.895810Z    error   strconv.ParseUint: parsing "--concurrency": invalid syntax
```



And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
