### PR TITLE
Keep authN policy config meta in the push context for istioctl authn tls-check tool

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1219,12 +1219,14 @@ func (ps *PushContext) initDestinationRules(env *Environment) error {
 // This replaces store.AuthenticationPolicyForWorkload
 func (ps *PushContext) AuthenticationPolicyForWorkload(service *Service, port *Port) (*authn.Policy, *ConfigMeta) {
 	// Match by Service hostname
-	if workloadPolicy, configMeta := authenticationPolicyForWorkload(ps.AuthnPolicies.policies[service.Hostname], port); workloadPolicy != nil {
+	if workloadPolicy, configMeta := authenticationPolicyForWorkload(
+		ps.AuthnPolicies.policies[service.Hostname], port); workloadPolicy != nil {
 		return workloadPolicy, configMeta
 	}
 
 	// Match by namespace
-	if workloadPolicy, configMeta := authenticationPolicyForWorkload(ps.AuthnPolicies.policies[host.Name(service.Attributes.Namespace)], port); workloadPolicy != nil {
+	if workloadPolicy, configMeta := authenticationPolicyForWorkload(
+		ps.AuthnPolicies.policies[host.Name(service.Attributes.Namespace)], port); workloadPolicy != nil {
 		return workloadPolicy, configMeta
 	}
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -944,9 +944,9 @@ func (ps *PushContext) initAuthnPolicies(env *Environment) error {
 		policies: map[host.Name][]*authnPolicyByPort{},
 	}
 
-	// golang pass every thing by value, so use the old school for loop to avoid make extra copies.
-	for i := 0; i < len(authNPolicies); i++ {
-		spec := &authNPolicies[i]
+	for idx := range authNPolicies {
+		// golang pass every thing by value, so do this to access to the config object by pointer.
+		spec := &authNPolicies[idx]
 		policy := spec.Spec.(*authn.Policy)
 		// Fill JwksURI if missing. Ignoring error, as when it happens, jwksURI will be left empty
 		// and result in rejecting all request. This is acceptable behavior when JWT spec is not complete

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -201,7 +201,8 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 			serviceMTLSMode := authn_v1alpha1_applier.MTLSUnknown
 			if !service.MeshExternal {
 				// Only need the authentication MTLS mode when service is not external.
-				serviceMTLSMode = authn_v1alpha1_applier.GetMutualTLSMode(push.AuthenticationPolicyForWorkload(service, port))
+				policy, _ := push.AuthenticationPolicyForWorkload(service, port)
+				serviceMTLSMode = authn_v1alpha1_applier.GetMutualTLSMode(policy)
 			}
 			clusters = append(clusters, defaultCluster)
 			destinationRule := castDestinationRuleOrDefault(destRule)

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -306,9 +306,9 @@ func (s *DiscoveryServer) Authenticationz(w http.ResponseWriter, req *http.Reque
 				continue
 			}
 			for _, p := range ss.Ports {
-				authnPolicy := s.globalPushContext().AuthenticationPolicyForWorkload(ss, p)
+				authnPolicy, authnMeta := s.globalPushContext().AuthenticationPolicyForWorkload(ss, p)
 				destConfig := s.globalPushContext().DestinationRule(mostRecentProxy, ss)
-				info = append(info, AnalyzeMTLSSettings(ss.Hostname, p, authnPolicy, destConfig)...)
+				info = append(info, AnalyzeMTLSSettings(ss.Hostname, p, authnPolicy, authnMeta, destConfig)...)
 			}
 		}
 		if b, err := json.MarshalIndent(info, "  ", "  "); err == nil {

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -38,11 +38,6 @@ const (
 	// configNameNotApplicable is used to represent the name of the authentication policy or
 	// destination rule when they are not specified.
 	configNameNotApplicable = "-"
-
-	// configNameUnknown is used to represent the name of the authentication policy when it is specified,
-	// but the information is not available to show. This is temporary, until we fix the push context to carry
-	// authN policy name.
-	configNameUnknown = "???"
 )
 
 // InitDebug initializes the debug handlers and adds a debug in-memory registry.

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -498,15 +498,21 @@ func TestEvaluateTLSState(t *testing.T) {
 }
 
 func TestAnalyzeMTLSSettings(t *testing.T) {
+	fakeConfigMeta := model.ConfigMeta{
+		Name:      "foo",
+		Namespace: "bar",
+	}
 	testCases := []struct {
 		name        string
 		authnPolicy *authn.Policy
+		authnMeta   *model.ConfigMeta
 		destConfig  *model.Config
 		expected    []*v2.AuthenticationDebug
 	}{
 		{
 			name:        "No policy",
 			authnPolicy: nil,
+			authnMeta:   nil,
 			destConfig:  nil,
 			expected: []*v2.AuthenticationDebug{
 				{
@@ -533,12 +539,13 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 					},
 				},
 			},
+			authnMeta:  &fakeConfigMeta,
 			destConfig: nil,
 			expected: []*v2.AuthenticationDebug{
 				{
 					Host:                     "foo.default",
 					Port:                     8080,
-					AuthenticationPolicyName: "???",
+					AuthenticationPolicyName: "foo/bar",
 					DestinationRuleName:      "-",
 					ServerProtocol:           "STRICT",
 					ClientProtocol:           "-",
@@ -559,6 +566,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 					},
 				},
 			},
+			authnMeta: &fakeConfigMeta,
 			destConfig: &model.Config{
 				ConfigMeta: model.ConfigMeta{
 					Name:      "some-rule",
@@ -572,7 +580,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 				{
 					Host:                     "foo.default",
 					Port:                     8080,
-					AuthenticationPolicyName: "???",
+					AuthenticationPolicyName: "foo/bar",
 					DestinationRuleName:      "some-rule/default",
 					ServerProtocol:           "STRICT",
 					ClientProtocol:           "-",
@@ -593,6 +601,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 					},
 				},
 			},
+			authnMeta: &fakeConfigMeta,
 			destConfig: &model.Config{
 				ConfigMeta: model.ConfigMeta{
 					Name:      "some-rule",
@@ -610,7 +619,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 				{
 					Host:                     "foo.default",
 					Port:                     8080,
-					AuthenticationPolicyName: "???",
+					AuthenticationPolicyName: "foo/bar",
 					DestinationRuleName:      "some-rule/default",
 					ServerProtocol:           "STRICT",
 					ClientProtocol:           "DISABLE",
@@ -631,6 +640,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 					},
 				},
 			},
+			authnMeta: &fakeConfigMeta,
 			destConfig: &model.Config{
 				ConfigMeta: model.ConfigMeta{
 					Name:      "some-rule",
@@ -658,7 +668,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 				{
 					Host:                     "foo.default",
 					Port:                     8080,
-					AuthenticationPolicyName: "???",
+					AuthenticationPolicyName: "foo/bar",
 					DestinationRuleName:      "some-rule/default",
 					ServerProtocol:           "STRICT",
 					ClientProtocol:           "ISTIO_MUTUAL",
@@ -679,6 +689,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 					},
 				},
 			},
+			authnMeta: &fakeConfigMeta,
 			destConfig: &model.Config{
 				ConfigMeta: model.ConfigMeta{
 					Name:      "some-rule",
@@ -724,7 +735,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 				{
 					Host:                     "foo.default",
 					Port:                     8080,
-					AuthenticationPolicyName: "???",
+					AuthenticationPolicyName: "foo/bar",
 					DestinationRuleName:      "some-rule/default",
 					ServerProtocol:           "STRICT",
 					ClientProtocol:           "ISTIO_MUTUAL",
@@ -733,7 +744,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 				{
 					Host:                     "foo.default|foobar",
 					Port:                     8080,
-					AuthenticationPolicyName: "???",
+					AuthenticationPolicyName: "foo/bar",
 					DestinationRuleName:      "some-rule/default",
 					ServerProtocol:           "STRICT",
 					ClientProtocol:           "SIMPLE",
@@ -748,7 +759,7 @@ func TestAnalyzeMTLSSettings(t *testing.T) {
 			port := model.Port{
 				Port: 8080,
 			}
-			if got := v2.AnalyzeMTLSSettings(host.Name("foo.default"), &port, tc.authnPolicy, tc.destConfig); !reflect.DeepEqual(got, tc.expected) {
+			if got := v2.AnalyzeMTLSSettings(host.Name("foo.default"), &port, tc.authnPolicy, tc.authnMeta, tc.destConfig); !reflect.DeepEqual(got, tc.expected) {
 				t.Errorf("EvaluateTLSState expected to be %+v, got %+v", tc.expected, got)
 			}
 		})

--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -28,6 +28,6 @@ func NewPolicyApplier(push *model.PushContext,
 	service := serviceInstance.Service
 	// TODO GregHanson add support for authn policy label matching
 	port := serviceInstance.Endpoint.ServicePort
-	authnPolicy := push.AuthenticationPolicyForWorkload(service, port)
+	authnPolicy, _ := push.AuthenticationPolicyForWorkload(service, port)
 	return v1alpha1.NewPolicyApplier(authnPolicy)
 }


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR follows https://github.com/istio/istio/pull/17624 to populate the policy (CRD) name to the `istioctl authn tls-check` output.

Related issues:
https://github.com/istio/istio/issues/16586
https://github.com/istio/istio/issues/17554

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
