### PR TITLE
fix(mesh id): ensure mesh id is available to gateways

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -241,12 +241,12 @@ spec:
             value: {{ $key }}
           - name: ISTIO_META_OWNER
             value: kubernetes://api/apps/v1/namespaces/{{ $spec.namespace | default $.Release.Namespace }}/deployments/{{ $key }}
-          {{- if .Values.global.meshID }}
+          {{- if $.Values.global.meshID }}
           - name: ISTIO_META_MESH_ID
-            value: "{{ .Values.global.meshID }}"
-          {{- else if .Values.global.trustDomain }}
+            value: "{{ $.Values.global.meshID }}"
+          {{- else if $.Values.global.trustDomain }}
           - name: ISTIO_META_MESH_ID
-            value: "{{ .Values.global.trustDomain }}"
+            value: "{{ $.Values.global.trustDomain }}"
           {{- end }}
           {{- if $spec.sds }}
           {{- if $spec.sds.enabled }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -241,6 +241,13 @@ spec:
             value: {{ $key }}
           - name: ISTIO_META_OWNER
             value: kubernetes://api/apps/v1/namespaces/{{ $spec.namespace | default $.Release.Namespace }}/deployments/{{ $key }}
+          {{- if .Values.global.meshID }}
+          - name: ISTIO_META_MESH_ID
+            value: "{{ .Values.global.meshID }}"
+          {{- else if .Values.global.trustDomain }}
+          - name: ISTIO_META_MESH_ID
+            value: "{{ .Values.global.trustDomain }}"
+          {{- end }}
           {{- if $spec.sds }}
           {{- if $spec.sds.enabled }}
           - name: ISTIO_META_USER_SDS


### PR DESCRIPTION
It looks like the update to add the ISTIO_META_MESH_ID env var to sidecar injection template did not also update the gateways. This PR fixes this particular gap.

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ X ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
