### PR TITLE
log a WARN instead of ERROR for errors processing kube yaml files

### DIFF
--- a/galley/pkg/config/source/kube/inmemory/kubesource.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource.go
@@ -194,7 +194,7 @@ func (s *KubeSource) parseContent(r schema.KubeResources, name, yamlText string)
 
 		r, err := s.parseChunk(r, chunk)
 		if err != nil {
-			scope.Source.Errorf("Error processing %s[%d]: %v", name, i, err)
+			scope.Source.Warnf("Error processing %s[%d]: %v", name, i, err)
 			scope.Source.Debugf("Offending Yaml chunk: %v", string(chunk))
 			continue
 		}

--- a/galley/pkg/source/fs/source.go
+++ b/galley/pkg/source/fs/source.go
@@ -273,7 +273,7 @@ func (s *source) parseFile(path string, data []byte) []*fileResource {
 		}
 		r, err := s.parseChunk(chunk)
 		if err != nil {
-			log.Scope.Errorf("Error processing %s[%d]: %v", path, i, err)
+			log.Scope.Warnf("Error processing %s[%d]: %v", path, i, err)
 			continue
 		}
 		if r == nil {


### PR DESCRIPTION
Change the output level from ERROR to WARN for errors processing kube yaml. 

This comes up often if `istioctl x analyze` is used on kube files that include kube resources that `istioctl x analyze` doesn't pay attention to, and adds confusing noise to the output.

Fixes https://github.com/istio/istio/issues/17684

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
