### PR TITLE
Update release-builder SHA

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -35,7 +35,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=f6aacd1d507eb989b09451f167ab021f4d89ef1a
+BUILDER_SHA=f57e69ecb55f8c7b9c61db7bbdaf2963c11301a5
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha
@@ -72,5 +72,5 @@ release-builder build --manifest <(echo "${MANIFEST}")
 if [[ -z "${DRY_RUN:-}" ]]; then
   release-builder publish --release "${WORK_DIR}/out" \
     --gcsbucket "${GCS_BUCKET}" --gcsaliases "${NEXT_VERSION}-dev,latest" \
-    --dockerhub "${DOCKER_HUB}" --dockertags "${TAG},${NEXT_VERSION}-dev,latest"
+    --dockerhub "${DOCKER_HUB}" --dockertags "${VERSION},${NEXT_VERSION}-dev,latest"
 fi


### PR DESCRIPTION
This fixes the license generation, and changes the docker tag to be the
version as expected, rather than git sha.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
