### PR TITLE
Display exit code during test cleanup

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -97,18 +97,19 @@ function clone_cni() {
 
 function check_kind() {
   echo "Checking KinD is installed..."
-  if ! kind --help > /dev/null; then
+  if ! command -v curl > /dev/null; then
     echo "Looks like KinD is not installed."
     exit 1
   fi
 }
 
 function cleanup_kind_cluster() {
-    kind export logs --name istio-testing "${ARTIFACTS}/kind"
-    if [[ -z "${SKIP_CLEANUP:-}" ]]; then
-      echo "Cleaning up kind cluster"
-      kind delete cluster --name=istio-testing
-    fi
+  echo "Test exited with exit code $?."
+  kind export logs --name istio-testing "${ARTIFACTS}/kind"
+  if [[ -z "${SKIP_CLEANUP:-}" ]]; then
+    echo "Cleaning up kind cluster"
+    kind delete cluster --name=istio-testing
+  fi
 }
 
 function setup_kind_cluster() {


### PR DESCRIPTION
Lately tests have been failing for what seems like no reason. Keeping
the exit code may help debug these a bit.

[x] Test and Release
