### PR TITLE
Add link to Galley design doc

### DIFF
--- a/galley/README.md
+++ b/galley/README.md
@@ -6,3 +6,5 @@ details of obtaining user configuration from the underlying platform. It contain
 Kubernetes CRD listeners for collecting configuration, an MCP protocol server
 implementation for distributing config, and a validation web-hook for pre-ingestion
 validation by Kubernetes API Server.
+
+[High-level design doc](https://docs.google.com/document/d/1GRLQ6bs2pzhURKQ871fgoagh8bkJkRYRFABgAuezK8s) *(Oct 2019)*


### PR DESCRIPTION
Add a link to the Galley design doc from the Galley README

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
