### PR TITLE
Wait for previous envoy to go live before hot restart

### DIFF
--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -83,6 +83,9 @@ func NewAgent(proxy Proxy, terminationDrainDuration time.Duration) Agent {
 
 // Proxy defines command interface for a proxy
 type Proxy interface {
+	// IsLive returns true if the server is up and running (i.e. past initialization).
+	IsLive() bool
+
 	// Run command for a config, epoch, and abort channel
 	Run(interface{}, int, <-chan error) error
 
@@ -119,18 +122,59 @@ type exitStatus struct {
 }
 
 func (a *agent) Restart(config interface{}) {
-	if !reflect.DeepEqual(a.currentConfig, config) {
-		a.mu.Lock()
-		defer a.mu.Unlock()
-		log.Infof("Received new config")
+	a.mu.Lock()
+	defer a.mu.Unlock()
 
-		a.currentConfig = config
+	if reflect.DeepEqual(a.currentConfig, config) {
+		// Same configuration - nothing to do.
+		return
+	}
 
-		// Increment the latest running epoch
-		a.currentEpoch++
-		abortCh := make(chan error, 1)
-		a.activeEpochs[a.currentEpoch] = abortCh
-		go a.runWait(a.currentConfig, a.currentEpoch, abortCh)
+	log.Infof("Received new config")
+
+	// Make sure the current epoch (if there is one) is live before performing a hot restart.
+	a.waitUntilLive()
+
+	// Increment the latest running epoch
+	a.currentEpoch++
+	a.currentConfig = config
+
+	// Add the new epoch to the map.
+	abortCh := make(chan error, 1)
+	a.activeEpochs[a.currentEpoch] = abortCh
+
+	go a.runWait(a.currentConfig, a.currentEpoch, abortCh)
+}
+
+// waitUntilLive waits for the current epoch (if there is one) to go live.
+func (a *agent) waitUntilLive() {
+	// Make sure there is a currently active epoch. If not, just return.
+	if a.currentEpoch < 0 {
+		log.Info("no previous epoch exists, starting now")
+		return
+	}
+
+	log.Infof("waiting for epoch %d to go live before performing a hot restart", a.currentEpoch)
+
+	interval := time.NewTicker(200 * time.Millisecond)
+	timer := time.NewTimer(5 * time.Second)
+
+	defer func() {
+		interval.Stop()
+		timer.Stop()
+	}()
+
+	for {
+		select {
+		case <-timer.C:
+			log.Warnf("timed out waiting for epoch %d to go live.", a.currentEpoch)
+			return
+		case <-interval.C:
+			if a.proxy.IsLive() {
+				// It's live!
+				return
+			}
+		}
 	}
 }
 

--- a/pkg/envoy/agent_test.go
+++ b/pkg/envoy/agent_test.go
@@ -159,7 +159,7 @@ func TestWaitForLive(t *testing.T) {
 	wg.Wait()
 
 	// An error threshold used for the time comparison. Should (hopefully) be enough to avoid flakes.
-	errThreshold := 500 * time.Millisecond
+	errThreshold := 1 * time.Second
 
 	// Verify that the second epoch is delayed until epoch 0 was live.
 	g.Expect(epoch1StartTime).Should(BeTemporally("~", expectedEpoch1StartTime, errThreshold))

--- a/pkg/envoy/agent_test.go
+++ b/pkg/envoy/agent_test.go
@@ -16,18 +16,33 @@ package envoy
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	. "github.com/onsi/gomega"
 )
 
 // TestProxy sample struct for proxy
 type TestProxy struct {
 	run     func(interface{}, int, <-chan error) error
 	cleanup func(int)
+	live    func() bool
 }
 
 func (tp TestProxy) Run(config interface{}, epoch int, stop <-chan error) error {
+	if tp.run == nil {
+		return nil
+	}
 	return tp.run(config, epoch, stop)
+}
+
+func (tp TestProxy) IsLive() bool {
+	if tp.live == nil {
+		return true
+	}
+	return tp.live()
 }
 
 func (tp TestProxy) Cleanup(epoch int) {
@@ -40,12 +55,9 @@ func (tp TestProxy) Cleanup(epoch int) {
 func TestStartExit(t *testing.T) {
 	ctx := context.Background()
 	done := make(chan struct{})
-	a := NewAgent(TestProxy{
-		func(config interface{}, i2 int, abort <-chan error) error { return nil },
-		func(i int) {}},
-		0)
+	a := NewAgent(TestProxy{}, 0)
 	go func() {
-		a.Run(ctx)
+		_ = a.Run(ctx)
 		done <- struct{}{}
 	}()
 	a.Restart("config")
@@ -84,8 +96,8 @@ func TestStartDrain(t *testing.T) {
 		}
 		return nil
 	}
-	a := NewAgent(TestProxy{start, nil}, -10*time.Second)
-	go a.Run(ctx)
+	a := NewAgent(TestProxy{run: start}, -10*time.Second)
+	go func() { _ = a.Run(ctx) }()
 	a.Restart(startConfig)
 	<-blockChan
 	cancel()
@@ -95,6 +107,62 @@ func TestStartDrain(t *testing.T) {
 	if proxiesStarted != wantProxiesStarted {
 		t.Errorf("expected %v proxies to be started, got %v", wantProxiesStarted, proxiesStarted)
 	}
+}
+
+// TestWaitForLive tests that a hot restart will not occur until after a previous epoch goes live.
+func TestWaitForLive(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The delay for the first epoch (i.e. epoch 0) to go "live"
+	delay := time.Second * 2
+	live := uint32(0)
+	var expectedEpoch1StartTime time.Time
+	var epoch1StartTime time.Time
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	start := func(config interface{}, epoch int, _ <-chan error) error {
+		switch epoch {
+		case 0:
+			// Epoch 0 has started, get the expected time that epoch 1 should start including the "live" delay.
+			expectedEpoch1StartTime = time.Now().Add(delay)
+			wg.Done()
+
+			// Add a short delay before reporting live.
+			time.Sleep(delay)
+			atomic.StoreUint32(&live, 1)
+		case 1:
+			// Epoch 1 has started, record the time.
+			epoch1StartTime = time.Now()
+			wg.Done()
+		}
+		<-ctx.Done()
+		return nil
+	}
+	isLive := func() bool {
+		return atomic.LoadUint32(&live) > 0
+	}
+	a := NewAgent(TestProxy{run: start, live: isLive}, -10*time.Second)
+	go func() { _ = a.Run(ctx) }()
+
+	// Start the first epoch.
+	a.Restart("config1")
+
+	// Start the second epoch, should wait until the first goes live.
+	a.Restart("config2")
+
+	// Wait for both to start.
+	wg.Wait()
+
+	// An error threshold used for the time comparison. Should (hopefully) be enough to avoid flakes.
+	errThreshold := 500 * time.Millisecond
+
+	// Verify that the second epoch is delayed until epoch 0 was live.
+	g.Expect(epoch1StartTime).Should(BeTemporally("~", expectedEpoch1StartTime, errThreshold))
 }
 
 // TestApplyTwice tests that scheduling the same config does not trigger a restart
@@ -109,9 +177,8 @@ func TestApplyTwice(t *testing.T) {
 		<-ctx.Done()
 		return nil
 	}
-	cleanup := func(epoch int) {}
-	a := NewAgent(TestProxy{start, cleanup}, -10*time.Second)
-	go a.Run(ctx)
+	a := NewAgent(TestProxy{run: start}, -10*time.Second)
+	go func() { _ = a.Run(ctx) }()
 	a.Restart(desired)
 	applyCount++
 	a.Restart(desired)
@@ -169,8 +236,8 @@ func TestStartTwiceStop(t *testing.T) {
 			cancel()
 		}
 	}
-	a := NewAgent(TestProxy{start, cleanup}, 0)
-	go a.Run(ctx)
+	a := NewAgent(TestProxy{run: start, cleanup: cleanup}, 0)
+	go func() { _ = a.Run(ctx) }()
 	a.Restart(desired0)
 	a.Restart(desired1)
 	a.Restart(desired2)
@@ -193,8 +260,8 @@ func TestRecovery(t *testing.T) {
 		<-ctx.Done()
 		return nil
 	}
-	a := NewAgent(TestProxy{start, func(_ int) {}}, 0)
-	go a.Run(ctx)
+	a := NewAgent(TestProxy{run: start}, 0)
+	go func() { _ = a.Run(ctx) }()
 	a.Restart(desired)
 
 	// make sure we don't try to reconcile twice

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"time"
 
+	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
 	"github.com/gogo/protobuf/types"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -78,6 +79,15 @@ func NewProxy(cfg ProxyConfig) Proxy {
 		ProxyConfig: cfg,
 		extraArgs:   args,
 	}
+}
+
+func (e *envoy) IsLive() bool {
+	adminPort := uint32(e.Config.ProxyAdminPort)
+	if info, err := GetServerInfo(adminPort); err == nil && info.State == envoyAdmin.ServerInfo_LIVE {
+		// It's live.
+		return true
+	}
+	return false
 }
 
 func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -83,10 +83,18 @@ func NewProxy(cfg ProxyConfig) Proxy {
 
 func (e *envoy) IsLive() bool {
 	adminPort := uint32(e.Config.ProxyAdminPort)
-	if info, err := GetServerInfo(adminPort); err == nil && info.State == envoyAdmin.ServerInfo_LIVE {
+	info, err := GetServerInfo(adminPort)
+	if err != nil {
+		log.Infof("failed retrieving server from Envoy on port %d: %v", adminPort, err)
+		return false
+	}
+
+	if info.State == envoyAdmin.ServerInfo_LIVE {
 		// It's live.
 		return true
 	}
+
+	log.Infof("envoy server not yet live, state: %s", info.State.String())
 	return false
 }
 


### PR DESCRIPTION
This addresses some issues seen with #17460. Specifically, we occasionally saw "previous envoy process is still initializing" in the logs, which was likely due to the slow start-up of pilot.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
