### PR TITLE
Re-enable analysis tests, add more debug logging

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -31,6 +31,8 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/meta/metadata"
 	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/galley/pkg/config/scope"
+	"istio.io/pkg/log"
 )
 
 type message struct {
@@ -187,8 +189,20 @@ var testGrid = []testCase{
 
 // TestAnalyzers allows for table-based testing of Analyzers.
 func TestAnalyzers(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/17617")
 	requestedInputsByAnalyzer := make(map[string]map[collection.Name]struct{})
+
+	// Temporarily make logging more verbose to debug https://github.com/istio/istio/issues/17617
+	oldSourceLevel := scope.Source.GetOutputLevel()
+	oldProcessingLevel := scope.Processing.GetOutputLevel()
+	oldAnalysisLevel := scope.Analysis.GetOutputLevel()
+	defer func() {
+		scope.Source.SetOutputLevel(oldSourceLevel)
+		scope.Processing.SetOutputLevel(oldProcessingLevel)
+		scope.Analysis.SetOutputLevel(oldAnalysisLevel)
+	}()
+	scope.Source.SetOutputLevel(log.DebugLevel)
+	scope.Processing.SetOutputLevel(log.DebugLevel)
+	scope.Analysis.SetOutputLevel(log.DebugLevel)
 
 	// For each test case, verify we get the expected messages as output
 	for _, testCase := range testGrid {

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -118,6 +118,7 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (diag.Messages, error) {
 	rt.Start()
 	defer rt.Stop()
 
+	scope.Analysis.Debugf("Waiting for analysis messages to be available...")
 	if updater.WaitForReport(cancel) {
 		return updater.Get(), nil
 	}

--- a/galley/pkg/config/collection/instance.go
+++ b/galley/pkg/config/collection/instance.go
@@ -41,6 +41,11 @@ func New(collection collection.Name) *Instance {
 	}
 }
 
+// Name of the collection
+func (c *Instance) Name() collection.Name {
+	return c.collection
+}
+
 // Get the instance with the given name
 func (c *Instance) Get(name resource.Name) *resource.Entry {
 	c.mu.RLock()

--- a/galley/pkg/config/processing/snapshotter/snapshotter.go
+++ b/galley/pkg/config/processing/snapshotter/snapshotter.go
@@ -172,10 +172,12 @@ func (sg *snapshotGroup) onSync(c *coll.Instance) {
 	if !synced[c] {
 		atomic.AddInt32(&sg.remaining, -1)
 		synced[c] = true
+		scope.Processing.Debugf("sg.onSync: %v fully synced, %d remaining", c.Name(), sg.remaining)
 	}
 
 	// proceed with triggering the strategy OnChange only after we've full synced every collection in a group.
 	if atomic.LoadInt32(&sg.remaining) <= 0 {
+		scope.Processing.Debugf("sg.onSync: all collections synced, proceeding with strategy.OnChange()")
 		sg.strategy.OnChange()
 	}
 }


### PR DESCRIPTION
This re-enables analysis logging, which was disabled to fix https://github.com/istio/istio/pull/17652.

We haven't been able to repro the flake so far, but this adds more logging that will hopefully give us some insight if/when it happens again. 

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
