### PR TITLE
Refactor to share constants and enum between different authN applier versions

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -198,7 +198,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 
 			setUpstreamProtocol(proxy, defaultCluster, port, model.TrafficDirectionOutbound)
 
-			serviceMTLSMode := authn_v1alpha1_applier.MTLSUnknown
+			serviceMTLSMode := authn_model.MTLSUnknown
 			if !service.MeshExternal {
 				// Only need the authentication MTLS mode when service is not external.
 				policy, _ := push.AuthenticationPolicyForWorkload(service, port)
@@ -325,7 +325,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(env *model.En
 					clusterMode:     SniDnatClusterMode,
 					direction:       model.TrafficDirectionOutbound,
 					proxy:           proxy,
-					serviceMTLSMode: authn_v1alpha1_applier.MTLSUnknown,
+					serviceMTLSMode: authn_model.MTLSUnknown,
 				}
 				applyTrafficPolicy(opts, proxy)
 				defaultCluster.Metadata = util.BuildConfigInfoMetadata(destRule.ConfigMeta)
@@ -347,7 +347,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(env *model.En
 						clusterMode:     SniDnatClusterMode,
 						direction:       model.TrafficDirectionOutbound,
 						proxy:           proxy,
-						serviceMTLSMode: authn_v1alpha1_applier.MTLSUnknown,
+						serviceMTLSMode: authn_model.MTLSUnknown,
 					}
 					applyTrafficPolicy(opts, proxy)
 
@@ -359,7 +359,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(env *model.En
 						clusterMode:     SniDnatClusterMode,
 						direction:       model.TrafficDirectionOutbound,
 						proxy:           proxy,
-						serviceMTLSMode: authn_v1alpha1_applier.MTLSUnknown,
+						serviceMTLSMode: authn_model.MTLSUnknown,
 					}
 					applyTrafficPolicy(opts, proxy)
 
@@ -714,10 +714,10 @@ func conditionallyConvertToIstioMtls(
 	serviceAccounts []string,
 	sni string,
 	proxy *model.Proxy,
-	serviceMTLSMode authn_v1alpha1_applier.MutualTLSMode,
+	serviceMTLSMode authn_model.MutualTLSMode,
 ) *networking.TLSSettings {
 	if tls == nil {
-		if serviceMTLSMode != authn_v1alpha1_applier.MTLSStrict {
+		if serviceMTLSMode != authn_model.MTLSStrict {
 			// Destination service is not in strict-mTLS mode, do nothing.
 			return nil
 		}
@@ -806,7 +806,7 @@ type buildClusterOpts struct {
 	clusterMode     ClusterMode
 	direction       model.TrafficDirection
 	proxy           *model.Proxy
-	serviceMTLSMode authn_v1alpha1_applier.MutualTLSMode
+	serviceMTLSMode authn_model.MutualTLSMode
 }
 
 func applyTrafficPolicy(opts buildClusterOpts, proxy *model.Proxy) {
@@ -1235,7 +1235,7 @@ func buildDefaultCluster(env *model.Environment, name string, discoveryType apiv
 		clusterMode:     DefaultClusterMode,
 		direction:       direction,
 		proxy:           proxy,
-		serviceMTLSMode: authn_v1alpha1_applier.MTLSUnknown,
+		serviceMTLSMode: authn_model.MTLSUnknown,
 	}
 	applyTrafficPolicy(opts, proxy)
 	return cluster

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -40,7 +40,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/fakes"
 	"istio.io/istio/pilot/pkg/networking/plugin"
-	authn_v1alpha1_applier "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
+	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
@@ -799,7 +799,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 		sans            []string
 		sni             string
 		proxy           *model.Proxy
-		serviceMTLSMode authn_v1alpha1_applier.MutualTLSMode
+		serviceMTLSMode authn_model.MutualTLSMode
 		want            *networking.TLSSettings
 	}{
 		{
@@ -808,7 +808,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffe://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			authn_v1alpha1_applier.MTLSUnknown,
+			authn_model.MTLSUnknown,
 			tlsSettings,
 		},
 		{
@@ -824,7 +824,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffe://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			authn_v1alpha1_applier.MTLSUnknown,
+			authn_model.MTLSUnknown,
 			&networking.TLSSettings{
 				Mode:              networking.TLSSettings_ISTIO_MUTUAL,
 				CaCertificates:    constants.DefaultRootCert,
@@ -844,7 +844,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 				TLSClientKey:       "/custom/key.pem",
 				TLSClientRootCert:  "/custom/root.pem",
 			}},
-			authn_v1alpha1_applier.MTLSUnknown,
+			authn_model.MTLSUnknown,
 			&networking.TLSSettings{
 				Mode:              networking.TLSSettings_ISTIO_MUTUAL,
 				CaCertificates:    "/custom/root.pem",
@@ -860,7 +860,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffee://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			authn_v1alpha1_applier.MTLSUnknown,
+			authn_model.MTLSUnknown,
 			nil,
 		},
 		{
@@ -869,7 +869,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffee://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			authn_v1alpha1_applier.MTLSDisable,
+			authn_model.MTLSDisable,
 			nil,
 		},
 		{
@@ -878,7 +878,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffee://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			authn_v1alpha1_applier.MTLSPermissive,
+			authn_model.MTLSPermissive,
 			nil,
 		},
 		{
@@ -887,7 +887,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffee://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			authn_v1alpha1_applier.MTLSStrict,
+			authn_model.MTLSStrict,
 			&networking.TLSSettings{
 				Mode:              networking.TLSSettings_ISTIO_MUTUAL,
 				CaCertificates:    constants.DefaultRootCert,

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -27,11 +27,11 @@ import (
 
 	authn "istio.io/api/authentication/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
-
 	"istio.io/istio/pilot/pkg/model"
 	networking_core "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/util"
 	authn_alpha1 "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
+	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pkg/config/host"
@@ -377,7 +377,7 @@ func AnalyzeMTLSSettings(hostname host.Name, port *model.Port, authnPolicy *auth
 // The output string could be:
 // - "OK": both client and server TLS settings are set correctly.
 // - "CONFLICT": both client and server TLS settings are set, but could be incompatible.
-func EvaluateTLSState(clientMode *networking.TLSSettings, serverMode authn_alpha1.MutualTLSMode) string {
+func EvaluateTLSState(clientMode *networking.TLSSettings, serverMode authn_model.MutualTLSMode) string {
 	const okState string = "OK"
 	const conflictState string = "CONFLICT"
 
@@ -387,9 +387,9 @@ func EvaluateTLSState(clientMode *networking.TLSSettings, serverMode authn_alpha
 		return okState
 	}
 
-	if (serverMode == authn_alpha1.MTLSDisable && clientMode.GetMode() == networking.TLSSettings_DISABLE) ||
-		(serverMode == authn_alpha1.MTLSStrict && clientMode.GetMode() == networking.TLSSettings_ISTIO_MUTUAL) ||
-		(serverMode == authn_alpha1.MTLSPermissive &&
+	if (serverMode == authn_model.MTLSDisable && clientMode.GetMode() == networking.TLSSettings_DISABLE) ||
+		(serverMode == authn_model.MTLSStrict && clientMode.GetMode() == networking.TLSSettings_ISTIO_MUTUAL) ||
+		(serverMode == authn_model.MTLSPermissive &&
 			(clientMode.GetMode() == networking.TLSSettings_ISTIO_MUTUAL || clientMode.GetMode() == networking.TLSSettings_DISABLE)) {
 		return okState
 	}

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -28,7 +28,7 @@ import (
 	"istio.io/istio/istioctl/pkg/util/configdump"
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
-	authn_alpha1 "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
+	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/tests/util"
 )
@@ -393,25 +393,25 @@ func TestEvaluateTLSState(t *testing.T) {
 	testCases := []struct {
 		name     string
 		client   *networking.TLSSettings
-		server   authn_alpha1.MutualTLSMode
+		server   authn_model.MutualTLSMode
 		expected string
 	}{
 		{
 			name:     "Auto with mTLS disable",
 			client:   nil,
-			server:   authn_alpha1.MTLSDisable,
+			server:   authn_model.MTLSDisable,
 			expected: "OK",
 		},
 		{
 			name:     "Auto with mTLS permissive",
 			client:   nil,
-			server:   authn_alpha1.MTLSPermissive,
+			server:   authn_model.MTLSPermissive,
 			expected: "OK",
 		},
 		{
 			name:     "Auto with mTLS STRICT",
 			client:   nil,
-			server:   authn_alpha1.MTLSStrict,
+			server:   authn_model.MTLSStrict,
 			expected: "OK",
 		},
 		{
@@ -419,7 +419,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_ISTIO_MUTUAL,
 			},
-			server:   authn_alpha1.MTLSStrict,
+			server:   authn_model.MTLSStrict,
 			expected: "OK",
 		},
 		{
@@ -427,7 +427,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_DISABLE,
 			},
-			server:   authn_alpha1.MTLSDisable,
+			server:   authn_model.MTLSDisable,
 			expected: "OK",
 		},
 		{
@@ -435,7 +435,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_DISABLE,
 			},
-			server:   authn_alpha1.MTLSPermissive,
+			server:   authn_model.MTLSPermissive,
 			expected: "OK",
 		},
 		{
@@ -443,7 +443,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_ISTIO_MUTUAL,
 			},
-			server:   authn_alpha1.MTLSPermissive,
+			server:   authn_model.MTLSPermissive,
 			expected: "OK",
 		},
 		{
@@ -451,7 +451,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_DISABLE,
 			},
-			server:   authn_alpha1.MTLSStrict,
+			server:   authn_model.MTLSStrict,
 			expected: "CONFLICT",
 		},
 		{
@@ -459,7 +459,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_MUTUAL,
 			},
-			server:   authn_alpha1.MTLSStrict,
+			server:   authn_model.MTLSStrict,
 			expected: "CONFLICT",
 		},
 		{
@@ -467,7 +467,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_SIMPLE,
 			},
-			server:   authn_alpha1.MTLSStrict,
+			server:   authn_model.MTLSStrict,
 			expected: "CONFLICT",
 		},
 		{
@@ -475,7 +475,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_SIMPLE,
 			},
-			server:   authn_alpha1.MTLSPermissive,
+			server:   authn_model.MTLSPermissive,
 			expected: "CONFLICT",
 		},
 		{
@@ -483,7 +483,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_SIMPLE,
 			},
-			server:   authn_alpha1.MTLSPermissive,
+			server:   authn_model.MTLSPermissive,
 			expected: "CONFLICT",
 		},
 	}

--- a/pilot/pkg/security/authn/v1alpha1/model.go
+++ b/pilot/pkg/security/authn/v1alpha1/model.go
@@ -19,7 +19,6 @@ import (
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 )
 
-
 // GetMutualTLSMode returns the mTLS mode for given. If the policy is nil, or doesn't define mTLS, it returns MTLSDisable.
 func GetMutualTLSMode(policy *authn.Policy) authn_model.MutualTLSMode {
 	if mTLSSetting := GetMutualTLS(policy); mTLSSetting != nil {

--- a/pilot/pkg/security/authn/v1alpha1/model.go
+++ b/pilot/pkg/security/authn/v1alpha1/model.go
@@ -16,44 +16,17 @@ package v1alpha1
 
 import (
 	authn "istio.io/api/authentication/v1alpha1"
+	authn_model "istio.io/istio/pilot/pkg/security/model"
 )
 
-// MutualTLSMode is the mutule TLS mode specified by authentication policy.
-type MutualTLSMode int
-
-const (
-	// MTLSUnknown is used to indicate the variable hasn't been initialized correctly (with the authentication policy).
-	MTLSUnknown MutualTLSMode = iota
-
-	// MTLSDisable if authentication policy disable mTLS.
-	MTLSDisable
-
-	// MTLSPermissive if authentication policy enable mTLS in permissive mode.
-	MTLSPermissive
-
-	// MTLSStrict if authentication policy enable mTLS in strict mode.
-	MTLSStrict
-)
 
 // GetMutualTLSMode returns the mTLS mode for given. If the policy is nil, or doesn't define mTLS, it returns MTLSDisable.
-func GetMutualTLSMode(policy *authn.Policy) MutualTLSMode {
+func GetMutualTLSMode(policy *authn.Policy) authn_model.MutualTLSMode {
 	if mTLSSetting := GetMutualTLS(policy); mTLSSetting != nil {
 		if mTLSSetting.GetMode() == authn.MutualTls_STRICT {
-			return MTLSStrict
+			return authn_model.MTLSStrict
 		}
-		return MTLSPermissive
+		return authn_model.MTLSPermissive
 	}
-	return MTLSDisable
-}
-
-// String converts MutualTLSMode to human readable string for debugging.
-func (mode MutualTLSMode) String() string {
-	// declare an array of strings
-	names := [...]string{
-		"UNKNOWN",
-		"DISABLE",
-		"PERMISSIVE",
-		"STRICT"}
-
-	return names[mode]
+	return authn_model.MTLSDisable
 }

--- a/pilot/pkg/security/authn/v1alpha1/model_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/model_test.go
@@ -18,23 +18,24 @@ import (
 	"testing"
 
 	authn "istio.io/api/authentication/v1alpha1"
+	authn_model "istio.io/istio/pilot/pkg/security/model"
 )
 
 func TestGetMutualTLSMode(t *testing.T) {
 	cases := []struct {
 		name     string
 		in       *authn.Policy
-		expected MutualTLSMode
+		expected authn_model.MutualTLSMode
 	}{
 		{
 			name:     "Null policy",
 			in:       nil,
-			expected: MTLSDisable,
+			expected: authn_model.MTLSDisable,
 		},
 		{
 			name:     "Empty policy",
 			in:       &authn.Policy{},
-			expected: MTLSDisable,
+			expected: authn_model.MTLSDisable,
 		},
 		{
 			name: "Policy with default mTLS mode",
@@ -43,7 +44,7 @@ func TestGetMutualTLSMode(t *testing.T) {
 					Params: &authn.PeerAuthenticationMethod_Mtls{},
 				}},
 			},
-			expected: MTLSStrict,
+			expected: authn_model.MTLSStrict,
 		},
 		{
 			name: "Policy with strict mTLS mode",
@@ -56,7 +57,7 @@ func TestGetMutualTLSMode(t *testing.T) {
 					},
 				}},
 			},
-			expected: MTLSStrict,
+			expected: authn_model.MTLSStrict,
 		},
 		{
 			name: "Policy with permissive mTLS mode",
@@ -69,7 +70,7 @@ func TestGetMutualTLSMode(t *testing.T) {
 					},
 				}},
 			},
-			expected: MTLSPermissive,
+			expected: authn_model.MTLSPermissive,
 		},
 		{
 			name: "Policy with multi peer methods",
@@ -85,7 +86,7 @@ func TestGetMutualTLSMode(t *testing.T) {
 					},
 				},
 			},
-			expected: MTLSStrict,
+			expected: authn_model.MTLSStrict,
 		},
 		{
 			name: "Policy with non-mtls peer method",
@@ -96,7 +97,7 @@ func TestGetMutualTLSMode(t *testing.T) {
 					},
 				},
 			},
-			expected: MTLSDisable,
+			expected: authn_model.MTLSDisable,
 		},
 	}
 	for _, c := range cases {

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -46,20 +46,6 @@ import (
 )
 
 const (
-	// IstioJwtFilterName is the name for the Istio Jwt filter. This should be the same
-	// as the name defined in
-	// https://github.com/istio/proxy/blob/master/src/envoy/http/jwt_auth/http_filter_factory.cc#L50
-	IstioJwtFilterName = "jwt-auth"
-
-	// EnvoyJwtFilterName is the name of the Envoy JWT filter. This should be the same as the name defined
-	// in https://github.com/envoyproxy/envoy/blob/v1.9.1/source/extensions/filters/http/well_known_names.h#L48
-	EnvoyJwtFilterName = "envoy.filters.http.jwt_authn"
-
-	// AuthnFilterName is the name for the Istio AuthN filter. This should be the same
-	// as the name defined in
-	// https://github.com/istio/proxy/blob/master/src/envoy/http/authn/http_filter_factory.cc#L30
-	AuthnFilterName = "istio_authn"
-
 	// The default header name for an exchanged token.
 	exchangedTokenHeaderName = "ingress-authorization"
 
@@ -230,11 +216,11 @@ func convertPolicyToJwtConfig(policy *authn_v1alpha1.Policy) (string, proto.Mess
 	}
 
 	if features.UseIstioJWTFilter.Get() {
-		return IstioJwtFilterName, convertToIstioJwtConfig(policyJwts)
+		return authn_model.IstioJwtFilterName, convertToIstioJwtConfig(policyJwts)
 	}
 
 	log.Debugf("Envoy JWT filter is used for JWT verification")
-	return EnvoyJwtFilterName, convertToEnvoyJwtConfig(policyJwts)
+	return authn_model.EnvoyJwtFilterName, convertToEnvoyJwtConfig(policyJwts)
 }
 
 // convertPolicyToAuthNFilterConfig returns an authn filter config corresponding for the input policy.
@@ -320,7 +306,7 @@ func (a v1alpha1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarsha
 		return nil
 	}
 	out := &http_conn.HttpFilter{
-		Name: AuthnFilterName,
+		Name: authn_model.AuthnFilterName,
 	}
 	if isXDSMarshalingToAnyEnabled {
 		out.ConfigType = &http_conn.HttpFilter_TypedConfig{TypedConfig: util.MessageToAny(filterConfigProto)}

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -723,8 +723,8 @@ func TestBuildAuthNFilter(t *testing.T) {
 			if c.expectedFilterConfig == nil {
 				t.Errorf("buildAuthNFilter(%#v), got: \n%#v\n, wanted none", c.in, got)
 			} else {
-				if got.GetName() != AuthnFilterName {
-					t.Errorf("buildAuthNFilter(%#v), filter name is %s, wanted %s", c.in, got.GetName(), AuthnFilterName)
+				if got.GetName() != authn_model.AuthnFilterName {
+					t.Errorf("buildAuthNFilter(%#v), filter name is %s, wanted %s", c.in, got.GetName(), authn_model.AuthnFilterName)
 				}
 				filterConfig := authn_filter.FilterConfig{}
 				if err := proto.Unmarshal(got.GetTypedConfig().GetValue(), &filterConfig); err != nil {

--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -23,9 +23,8 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoy_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
 	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
-
-	authn_v1alpha1 "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
 	"istio.io/istio/pilot/pkg/security/authz/model/matcher"
+	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/spiffe"
 )
 
@@ -221,7 +220,7 @@ func principalForKeyValue(key, value string, forTCPFilter bool) *envoy_rbac.Prin
 		// with format: cluster.local/ns/{NAMESPACE}/sa/{SERVICE-ACCOUNT}.
 		value = strings.Replace(value, "*", ".*", -1)
 		m := matcher.StringMatcherRegex(fmt.Sprintf(".*/ns/%s/.*", value))
-		metadata := matcher.MetadataStringMatcher(authn_v1alpha1.AuthnFilterName, attrSrcPrincipal, m)
+		metadata := matcher.MetadataStringMatcher(authn_model.AuthnFilterName, attrSrcPrincipal, m)
 		return principalMetadata(metadata)
 	case attrSrcPrincipal == key:
 		if value == allUsers || value == "*" {
@@ -238,10 +237,10 @@ func principalForKeyValue(key, value string, forTCPFilter bool) *envoy_rbac.Prin
 			m := matcher.StringMatcherWithPrefix(value, spiffe.URIPrefix)
 			return principalAuthenticated(m)
 		}
-		metadata := matcher.MetadataStringMatcher(authn_v1alpha1.AuthnFilterName, key, matcher.StringMatcher(value))
+		metadata := matcher.MetadataStringMatcher(authn_model.AuthnFilterName, key, matcher.StringMatcher(value))
 		return principalMetadata(metadata)
 	case found(key, []string{attrRequestPrincipal, attrRequestAudiences, attrRequestPresenter, attrSrcUser}):
-		m := matcher.MetadataStringMatcher(authn_v1alpha1.AuthnFilterName, key, matcher.StringMatcher(value))
+		m := matcher.MetadataStringMatcher(authn_model.AuthnFilterName, key, matcher.StringMatcher(value))
 		return principalMetadata(m)
 	case strings.HasPrefix(key, attrRequestHeader):
 		header, err := extractNameInBrackets(strings.TrimPrefix(key, attrRequestHeader))
@@ -258,7 +257,7 @@ func principalForKeyValue(key, value string, forTCPFilter bool) *envoy_rbac.Prin
 		}
 		// Generate a metadata list matcher for the given path keys and value.
 		// On proxy side, the value should be of list type.
-		m := matcher.MetadataListMatcher(authn_v1alpha1.AuthnFilterName, []string{attrRequestClaims, claim}, value)
+		m := matcher.MetadataListMatcher(authn_model.AuthnFilterName, []string{attrRequestClaims, claim}, value)
 		return principalMetadata(m)
 	default:
 		rbacLog.Debugf("generated dynamic metadata matcher for custom property: %s", key)

--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -23,6 +23,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoy_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
 	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
+
 	"istio.io/istio/pilot/pkg/security/authz/model/matcher"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/spiffe"

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -52,7 +52,50 @@ const (
 
 	// IngressGatewaySdsCaSuffix is the suffix of the sds resource name for root CA.
 	IngressGatewaySdsCaSuffix = "-cacert"
+
+	// IstioJwtFilterName is the name for the Istio Jwt filter. This should be the same
+	// as the name defined in
+	// https://github.com/istio/proxy/blob/master/src/envoy/http/jwt_auth/http_filter_factory.cc#L50
+	IstioJwtFilterName = "jwt-auth"
+
+	// EnvoyJwtFilterName is the name of the Envoy JWT filter. This should be the same as the name defined
+	// in https://github.com/envoyproxy/envoy/blob/v1.9.1/source/extensions/filters/http/well_known_names.h#L48
+	EnvoyJwtFilterName = "envoy.filters.http.jwt_authn"
+
+	// AuthnFilterName is the name for the Istio AuthN filter. This should be the same
+	// as the name defined in
+	// https://github.com/istio/proxy/blob/master/src/envoy/http/authn/http_filter_factory.cc#L30
+	AuthnFilterName = "istio_authn"
 )
+
+// MutualTLSMode is the mutule TLS mode specified by authentication policy.
+type MutualTLSMode int
+
+const (
+	// MTLSUnknown is used to indicate the variable hasn't been initialized correctly (with the authentication policy).
+	MTLSUnknown MutualTLSMode = iota
+
+	// MTLSDisable if authentication policy disable mTLS.
+	MTLSDisable
+
+	// MTLSPermissive if authentication policy enable mTLS in permissive mode.
+	MTLSPermissive
+
+	// MTLSStrict if authentication policy enable mTLS in strict mode.
+	MTLSStrict
+)
+
+// String converts MutualTLSMode to human readable string for debugging.
+func (mode MutualTLSMode) String() string {
+	// declare an array of strings
+	names := [...]string{
+		"UNKNOWN",
+		"DISABLE",
+		"PERMISSIVE",
+		"STRICT"}
+
+	return names[mode]
+}
 
 // ConstructSdsSecretConfigForGatewayListener constructs SDS secret configuration for ingress gateway.
 func ConstructSdsSecretConfigForGatewayListener(name, sdsUdsPath string) *auth.SdsSecretConfig {


### PR DESCRIPTION
Please provide a description for what this PR is for.

This is to share the common data structures and constants between future implementations of authN policy versions.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
