### PR TITLE
Virtualservice gateway analyzer allows 'mesh' as a gateway value

### DIFF
--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_gateways.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_gateways.yaml
@@ -27,3 +27,13 @@ spec:
   - "*"
   gateways:
   - httpbin-gateway-bogus # Expected: validation error since this gateway does not exist
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: httpbin-mesh
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - mesh # Expected: no validation error, "mesh" is a special-case value

--- a/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
@@ -29,6 +29,8 @@ type GatewayAnalyzer struct{}
 
 var _ analysis.Analyzer = &GatewayAnalyzer{}
 
+const meshGateway = "mesh"
+
 // Metadata implements Analyzer
 func (s *GatewayAnalyzer) Metadata() analysis.Metadata {
 	return analysis.Metadata{
@@ -53,8 +55,8 @@ func (s *GatewayAnalyzer) analyzeVirtualService(r *resource.Entry, c analysis.Co
 
 	ns, _ := r.Metadata.Name.InterpretAsNamespaceAndName()
 	for _, gwName := range vs.Gateways {
-		// "mesh" is a special-case accepted value
-		if gwName == "mesh" {
+		// This is a special-case accepted value
+		if gwName == meshGateway {
 			continue
 		}
 

--- a/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
@@ -53,6 +53,11 @@ func (s *GatewayAnalyzer) analyzeVirtualService(r *resource.Entry, c analysis.Co
 
 	ns, _ := r.Metadata.Name.InterpretAsNamespaceAndName()
 	for _, gwName := range vs.Gateways {
+		// "mesh" is a special-case accepted value
+		if gwName == "mesh" {
+			continue
+		}
+
 		if !c.Exists(metadata.IstioNetworkingV1Alpha3Gateways, resource.NewName(ns, gwName)) {
 			c.Report(metadata.IstioNetworkingV1Alpha3Virtualservices, msg.NewReferencedResourceNotFound(r, "gateway", gwName))
 		}


### PR DESCRIPTION
Fixes the first part of https://github.com/istio/istio/issues/17442

As per https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#VirtualService, a value of "mesh" should be accepted as a special case. 

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
