### PR TITLE
Fix Kubernetes 1.16 E2E tests

### DIFF
--- a/prow/config/metrics/metrics-server-deployment.yaml
+++ b/prow/config/metrics/metrics-server-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -95,14 +95,6 @@ function clone_cni() {
   fi
 }
 
-function check_kind() {
-  echo "Checking KinD is installed..."
-  if ! command -v curl > /dev/null; then
-    echo "Looks like KinD is not installed."
-    exit 1
-  fi
-}
-
 function cleanup_kind_cluster() {
   echo "Test exited with exit code $?."
   kind export logs --name istio-testing "${ARTIFACTS}/kind"
@@ -114,9 +106,6 @@ function cleanup_kind_cluster() {
 
 function setup_kind_cluster() {
   IMAGE="${1}"
-  # Installing KinD
-  check_kind
-
   # Delete any previous e2e KinD cluster
   echo "Deleting previous KinD cluster with name=istio-testing"
   if ! (kind delete cluster --name=istio-testing) > /dev/null; then


### PR DESCRIPTION
The deployment extensions API is deprecated. Also reverts an
accidentally commited changw to look for "curl" instead of "kind".
Really we don't need to check if its installed, we install it as part of
a previous step if its not installed and it is always in the build
container.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
