### PR TITLE
Fix analyzer test flake (istio/17617)

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -31,8 +31,6 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/meta/metadata"
 	"istio.io/istio/galley/pkg/config/meta/schema/collection"
-	"istio.io/istio/galley/pkg/config/scope"
-	"istio.io/pkg/log"
 )
 
 type message struct {
@@ -190,19 +188,6 @@ var testGrid = []testCase{
 // TestAnalyzers allows for table-based testing of Analyzers.
 func TestAnalyzers(t *testing.T) {
 	requestedInputsByAnalyzer := make(map[string]map[collection.Name]struct{})
-
-	// Temporarily make logging more verbose to debug https://github.com/istio/istio/issues/17617
-	oldSourceLevel := scope.Source.GetOutputLevel()
-	oldProcessingLevel := scope.Processing.GetOutputLevel()
-	oldAnalysisLevel := scope.Analysis.GetOutputLevel()
-	defer func() {
-		scope.Source.SetOutputLevel(oldSourceLevel)
-		scope.Processing.SetOutputLevel(oldProcessingLevel)
-		scope.Analysis.SetOutputLevel(oldAnalysisLevel)
-	}()
-	scope.Source.SetOutputLevel(log.DebugLevel)
-	scope.Processing.SetOutputLevel(log.DebugLevel)
-	scope.Analysis.SetOutputLevel(log.DebugLevel)
 
 	// For each test case, verify we get the expected messages as output
 	for _, testCase := range testGrid {

--- a/galley/pkg/config/processing/snapshotter/statusupdater_test.go
+++ b/galley/pkg/config/processing/snapshotter/statusupdater_test.go
@@ -38,6 +38,20 @@ func TestInMemoryStatusUpdaterWriteThenWait(t *testing.T) {
 	g.Expect(su.Get()).To(Equal(msgs))
 }
 
+func TestInMemoryStatusUpdaterWriteNothingThenWait(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	su := &InMemoryStatusUpdater{}
+
+	var msgs diag.Messages
+
+	cancelCh := make(chan struct{})
+
+	su.Update(msgs)
+	g.Expect(su.WaitForReport(cancelCh)).To(BeTrue())
+	g.Expect(su.Get()).To(Equal(msgs))
+}
+
 func TestInMemoryStatusUpdaterWaitThenWrite(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/17617

The "wait forever" was triggered when analysis finished before the call to wait for analysis to finish, AND the set of validation messages reported was empty. We had a short-circuit to avoid waiting forever in that case, but since [in Go empty slices  == nil](https://play.golang.org/p/Sd2yiNxrVXu), we couldn't cleanly distinguish "I haven't gotten a result" from "I got a result but it was empty."

Also removed the no-longer-needed verbose logging for the affected test. 

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
