### PR TITLE
Separate DNS certificate from other certificates

### DIFF
--- a/galley/cmd/galley/cmd/server.go
+++ b/galley/cmd/galley/cmd/server.go
@@ -181,13 +181,10 @@ func serverCmd() *cobra.Command {
 	// Hidden, file only flags for validation specific TLS
 	svr.PersistentFlags().StringVar(&serverArgs.ValidationArgs.CertFile, "validation.tls.clientCertificate", "",
 		"File containing the x509 Certificate for HTTPS validation.")
-	_ = svr.PersistentFlags().MarkHidden("validation.tls.clientCertificate")
 	svr.PersistentFlags().StringVar(&serverArgs.ValidationArgs.KeyFile, "validation.tls.privateKey", "",
 		"File containing the x509 private key matching --validation.tls.clientCertificate.")
-	_ = svr.PersistentFlags().MarkHidden("validation.tls.privateKey")
 	svr.PersistentFlags().StringVar(&serverArgs.ValidationArgs.CACertFile, "validation.tls.caCertificates", "",
 		"File containing the caBundle that signed the cert/key specified by --validation.tls.clientCertificate and --validation.tls.privateKey.")
-	_ = svr.PersistentFlags().MarkHidden("validation.tls.caCertificates")
 
 	serverArgs.IntrospectionOptions.AttachCobraFlags(svr)
 	loggingOptions.AttachCobraFlags(svr)

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
 {{- if not $.Values.global.configValidation }}
           - --enable-validation=false
 {{- end }}
-{{- if .Values.global.operator }}
+{{- if .Values.global.operatorManageWebhooks }}
           - --enable-reconcileWebhookConfiguration=false
 {{- else }}
           - --enable-reconcileWebhookConfiguration=true
@@ -85,10 +85,20 @@ spec:
 {{- if .Values.enableAnalysis }}
           - --enableAnalysis=true
 {{- end }}
+{{- if .Values.global.certificates }}
+          - --validation.tls.clientCertificate=/etc/dnscerts/cert-chain.pem
+          - --validation.tls.privateKey=/etc/dnscerts/key.pem
+          - --validation.tls.caCertificates=/etc/dnscerts/root-cert.pem
+{{- end }}
           volumeMounts:
           - name: certs
             mountPath: /etc/certs
             readOnly: true
+{{- if .Values.global.certificates }}
+          - name: dnscerts
+            mountPath: /etc/dnscerts
+            readOnly: true
+{{- end }}
           - name: config
             mountPath: /etc/config
             readOnly: true
@@ -122,10 +132,11 @@ spec:
       volumes:
       - name: certs
         secret:
-{{- if .Values.global.certificates }}
-          secretName: dns.istio-galley-service-account
-{{- else }}
           secretName: istio.istio-galley-service-account
+{{- if .Values.global.certificates }}
+      - name: dnscerts
+        secret:
+          secretName: dns.istio-galley-service-account
 {{- end }}
       - name: config
         configMap:

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
-{{- if .Values.global.operator }}
+{{- if .Values.global.operatorManageWebhooks }}
             - --reconcileWebhookConfig=false
 {{- else }}
             - --reconcileWebhookConfig=true

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -591,6 +591,9 @@ global:
   #     dnsNames: [istio-sidecar-injector.istio-system.svc, istio-sidecar-injector.istio-system]
   certificates: []
 
-  # Configures whether Operator manages webhook configurations. The current behavior
+  # Configure whether Operator manages webhook configurations. The current behavior
   # of Galley and Sidecar Injector is that they manage their own webhook configurations.
-  operator: false
+  # When this option is set as true, Istio Operator, instead of webhooks, manages the
+  # webhook configurations. When this option is set as false, webhooks manage their
+  # own webhook configurations.
+  operatorManageWebhooks: false

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -276,10 +276,9 @@ func NewServer(args PilotArgs) (*Server, error) {
 	if err := s.initMeshNetworks(&args); err != nil {
 		return nil, fmt.Errorf("mesh networks: %v", err)
 	}
-	// Certificate controller must be created before MCP
-	// controller to avoid deadlocks caused by the circular dependency, i.e.,
-	// MCP server pod waits to mount a certificate while
-	// Pilot waits for MCP server.
+	// Certificate controller is created before MCP
+	// controller in case MCP server pod waits to mount a certificate
+	// to be provisioned by the certificate controller.
 	if err := s.initCertController(&args); err != nil {
 		return nil, fmt.Errorf("certificate controller: %v", err)
 	}

--- a/tools/packaging/deb/Dockerfile
+++ b/tools/packaging/deb/Dockerfile
@@ -9,6 +9,9 @@ FROM docker.io/istio/base:${BASE_VERSION}
 # hadolint ignore=DL3006
 FROM istionightly/base_debug
 
+# Directory to store DNS certificate and key
+RUN mkdir -p /etc/dnscerts
+
 # Micro pilot+mock mixer+echo, local kube
 COPY hyperistio kube-apiserver etcd kubectl /usr/local/bin/
 COPY *.yaml /var/lib/istio/config/


### PR DESCRIPTION
- Separate DNS certificate from other certificates (e.g., SPIFFE, SDS, etc) so each certificate can be used for a specific purpose.
- Certificate controller is created before MCP controller in case MCP server pod waits to mount a certificate to be provisioned by the certificate controller.

Please provide a description for what this PR is for: https://github.com/istio/istio/issues/17061

Design documents:
[1]https://docs.google.com/document/d/1VHyBre8943USOx_YEVtA18KfEoGTmLT1iBHESO5bzcA/edit#heading=h.qex63c29z2to
[2] https://docs.google.com/document/d/1v8BxI07u-mby5f5rCruwF7odSXgb9G8-C9W5hQtSIAg/edit#heading=h.xw1gqgyqs5b

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
