### PR TITLE
New subcommand "istioctl x describe service"

### DIFF
--- a/istioctl/cmd/describe_test.go
+++ b/istioctl/cmd/describe_test.go
@@ -244,6 +244,12 @@ var (
 				},
 				Status: coreV1.PodStatus{
 					Phase: coreV1.PodRunning,
+					ContainerStatuses: []coreV1.ContainerStatus{
+						{
+							Name:  "istio-proxy",
+							Ready: true,
+						},
+					},
 				},
 			},
 			{
@@ -508,6 +514,25 @@ Service: ratings
    Port:  9080/UnsupportedProtocol
    Warning: Pod ratings-v1-f745cf57b-vfwcv port 9080 not exposed by Container
    9080 is unnamed which does not follow Istio conventions
+Pilot reports that pod is PERMISSIVE (enforces HTTP/mTLS) and clients speak mTLS
+RBAC policies: ratings-reader
+`,
+		},
+		{ // case 8 unknown service
+			args:           strings.Split("experimental describe service not-a-service", " "),
+			expectedString: "services \"not-a-service\" not found",
+			wantException:  true, // "istioctl experimental describe service not-a-service" should fail
+		},
+		{ // case 9 for a service
+			execClientConfig: cannedConfig,
+			configs:          cannedIstioConfig,
+			k8sConfigs:       cannedK8sEnv,
+			args:             strings.Split("x describe svc ratings.bookinfo", " "),
+			expectedOutput: `Service: ratings.bookinfo
+   Port: http 9080/HTTP
+DestinationRule: ratings.bookinfo for "ratings"
+   Matching subsets: v1
+   Traffic Policy TLS Mode: ISTIO_MUTUAL
 Pilot reports that pod is PERMISSIVE (enforces HTTP/mTLS) and clients speak mTLS
 RBAC policies: ratings-reader
 `,


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/17049 by introducing a new sub-command `istioctl x describe service`.  This command produces output extremely similar to `istioctl x describe pod`.  The difference is that if the service is not mesh it outputs a suggestion for adding it to the mesh.

If the service is already in the mesh it runs the analysis of `istioctl describe pod` on one of the service pods.

Alias: "describe svc"

(This PR is marked `size/L` but most of that is moving code into a method that can be reused by both subcommands.)