### PR TITLE
Fix envoy WASM headers

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -154,7 +154,7 @@ var (
 	// We need to propagate these as part of access log service stream
 	// Logging them by default on the console may be an issue as the base64 encoded string is bound to be a big one.
 	// But end users can certainly configure it on their own via the meshConfig
-	envoyWasmHeadersToLog = []string{"envoy.wasm.metadata_exchange.upstream", "envoy.wasm.metadata_exchange.downstream"}
+	envoyWasmHeadersToLog = []string{"x-envoy-peer-metadata", "x-envoy-peer-metadata-id"}
 
 	// EnvoyJSONLogFormat12 map of values for envoy json based access logs for Istio 1.2
 	EnvoyJSONLogFormat12 = &structpb.Struct{


### PR DESCRIPTION
The WASM headers that were being configured to log were not headers actually. They were
the keys inside the headers with dot separated fields. This PR fixes the code to use
the correct set of headers based on the istio proxy code.


Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure