### PR TITLE
mixer: enable consistent hash

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -1054,6 +1054,9 @@ spec:
       http:
         http2MaxRequests: 10000
         maxRequestsPerConnection: 10000
+    loadBalancer:
+      consistentHash:
+        httpHeaderName: :authority
 {{- end }}
 ---
 {{- if .Values.telemetry.enabled }}
@@ -1087,6 +1090,9 @@ spec:
       http:
         http2MaxRequests: 10000
         maxRequestsPerConnection: 10000
+    loadBalancer:
+      consistentHash:
+        httpHeaderName: :authority
 {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Enable https://github.com/istio/proxy/pull/2456
Istio does not support Maglev, so best we can do is ring hash cluster setting.
This should make Pilot use ring hash load balancer for mixer telemetry/policy clusters.
