### PR TITLE
Redirect IPv6 inbound traffic to specified port

### DIFF
--- a/tests/scripts/testdata/mode_tproxy_and_ipv6_golden.txt
+++ b/tests/scripts/testdata/mode_tproxy_and_ipv6_golden.txt
@@ -97,6 +97,7 @@ ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 7777 -j RETURN
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 8888 -j RETURN
+ip6tables -t nat -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -241,6 +241,8 @@ func handleInboundIpv6Rules(ext dep.Dependencies, config *config.Config, ipv6Ran
 						ext.RunOrFail(dep.IP6TABLES, "-t", table, "-A", constants.ISTIOINBOUND, "-p", constants.TCP, "--dport", port, "-j", constants.RETURN)
 					}
 				}
+				// Redirect left inbound traffic
+				ext.RunOrFail(dep.IP6TABLES, "-t", table, "-A", constants.ISTIOINBOUND, "-p", constants.TCP, "-j", constants.ISTIOINREDIRECT)
 			} else {
 				// User has specified a non-empty list of ports to be redirected to Envoy.
 				for _, port := range split(config.InboundPortsInclude) {

--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -544,6 +544,8 @@ if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
             ip6tables -t ${table} -A ISTIO_INBOUND -p tcp --dport "${port}" -j RETURN
         done
         fi
+        # Redirect other inbound traffic
+        ip6tables -t ${table} -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
     else
         # User has specified a non-empty list of ports to be redirected to Envoy.
         for port in ${INBOUND_PORTS_INCLUDE}; do


### PR DESCRIPTION
Please provide a description for what this PR is for.

Redirect ipv6 inbound traffic to target ISTIO_IN_REDIRECT

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ x ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
