### PR TITLE
Donot gen outbound listener to the instance itself for tcp headless service

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -429,6 +429,8 @@ func TestOutboundListenerForHeadlessServices(t *testing.T) {
 		{
 			name: "gen a listener per instance",
 			instances: []*model.ServiceInstance{
+				// This instance is the proxy itself, will not gen a outbound listener for it.
+				buildServiceInstance(services[0], "1.1.1.1"),
 				buildServiceInstance(services[0], "10.10.10.10"),
 				buildServiceInstance(services[0], "11.11.11.11"),
 				buildServiceInstance(services[0], "12.11.11.11"),


### PR DESCRIPTION

fixe: #17748

Previously for tcp headless service，we will gen many outbound listeners, each with the ip address of the service instances.  But for a proxy, if it is one of the headless service's instances, then it will duplicate with the inbound listener.  We skip build in this case, it is safe as the outbound listener to itself is never used at all.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
