### PR TITLE
Make istioctl metrics testing a sub-test so it follows regular metric…

### DIFF
--- a/tests/integration/mixer/telemetry/metrics/istioctl_metrics_test.go
+++ b/tests/integration/mixer/telemetry/metrics/istioctl_metrics_test.go
@@ -20,22 +20,8 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 )
-
-func TestIstioctlMetrics(t *testing.T) {
-	framework.
-		NewTest(t).
-		RequiresEnvironment(environment.Kube).
-		Run(func(ctx framework.TestContext) {
-			label := "destination_service"
-			labelValue := "productpage.{{.TestNamespace}}.svc.cluster.local"
-			testMetric(t, ctx, label, labelValue)
-			workload := "productpage-v1"
-			testIstioctl(t, ctx, workload)
-		})
-}
 
 func testIstioctl(t *testing.T, ctx framework.TestContext, workload string) { // nolint:interfacer
 	istioCtl := istioctl.NewOrFail(t, ctx, istioctl.Config{})

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -63,9 +63,18 @@ func TestIngessToPrometheus_IngressMetric(t *testing.T) {
 		NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			label := "destination_service"
-			labelValue := "productpage.{{.TestNamespace}}.svc.cluster.local"
-			testMetric(t, ctx, label, labelValue)
+			ctx.NewSubTest("SetupAndPrometheus").
+				Run(func(ctx framework.TestContext) {
+					label := "destination_service"
+					labelValue := "productpage.{{.TestNamespace}}.svc.cluster.local"
+					testMetric(t, ctx, label, labelValue)
+				})
+
+			ctx.NewSubTest("IstioctlPrometheusConnection").
+				Run(func(ctx framework.TestContext) {
+					workload := "productpage-v1"
+					testIstioctl(t, ctx, workload)
+				})
 		})
 }
 


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/17618 by combining the `istioctl x metrics` test and the non-flakey TestIngessToPrometheus_IngressMetric.  The TestIstioctlMetrics will always run after the TestIngessToPrometheus_IngressMetric, and will now only verify the istioctl part, not re-run the data collection.

This should also improve test performance.

cc @gargnupur 