### PR TITLE
retry webhook updates on failure

### DIFF
--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
@@ -99,24 +100,28 @@ func (whc *WebhookConfigController) monitorWebhookChanges(stopC <-chan struct{})
 	return webhookChangedCh
 }
 
-func (whc *WebhookConfigController) createOrUpdateWebhookConfig() {
+func (whc *WebhookConfigController) createOrUpdateWebhookConfig() (retry bool) {
 	if whc.webhookConfiguration == nil {
 		scope.Error("validatingwebhookconfiguration update failed: no configuration loaded")
 		reportValidationConfigUpdateError(errors.New("no configuration loaded"))
-		return
+		return false
 	}
 
 	client := whc.webhookParameters.Clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
 	updated, err := createOrUpdateWebhookConfigHelper(client, whc.webhookConfiguration)
 	if err != nil {
 		scope.Errorf("%v validatingwebhookconfiguration update failed: %v", whc.webhookConfiguration.Name, err)
-		reportValidationConfigUpdateError(err)
-	} else if updated {
+		reportValidationConfigUpdateError(fmt.Errorf("createOrUpdate failed: %v", kerrors.ReasonForError(err)))
+		return true
+	}
+
+	if updated {
 		scope.Infof("%v validatingwebhookconfiguration updated", whc.webhookConfiguration.Name)
 		reportValidationConfigUpdate()
 	} else {
 		scope.Infof("%v validatingwebhookconfiguration unchanged, no update needed", whc.webhookConfiguration.Name)
 	}
+	return false
 }
 
 // Create the specified validatingwebhookconfiguration resource or, if the resource
@@ -150,15 +155,17 @@ func createOrUpdateWebhookConfigHelper(
 }
 
 // Delete validatingwebhookconfiguration if the validation is disabled
-func (whc *WebhookConfigController) deleteWebhookConfig() {
+func (whc *WebhookConfigController) deleteWebhookConfig() (retry bool) {
 	client := whc.webhookParameters.Clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
 
 	deleted, err := deleteWebhookConfigHelper(client, whc.webhookParameters.WebhookName)
 	if err != nil {
 		scope.Errorf("%v validatingwebhookconfiguration delete failed: %v", whc.webhookParameters.WebhookName, err)
-		reportValidationConfigDeleteError(err)
+		reportValidationConfigDeleteError(fmt.Errorf("delete failed: %v", kerrors.ReasonForError(err)))
+		return true
 	}
 	scope.Infof("Delete %v validatingwebhookconfiguration is %v", whc.webhookParameters.WebhookName, deleted)
+	return false
 }
 
 // Delete validatingwebhookconfiguration if exists. otherwise, do nothing
@@ -370,8 +377,9 @@ func (whc *WebhookConfigController) reconcile(stopCh <-chan struct{}) {
 	// already exist). Setup a persistent monitor to reconcile the
 	// configuration if the observed configuration doesn't match
 	// the desired configuration.
+	var retryAfterSetup bool
 	if err := whc.rebuildWebhookConfig(); err == nil {
-		whc.createOrUpdateWebhookConfig()
+		retryAfterSetup = whc.createOrUpdateWebhookConfig()
 	}
 	webhookChangedCh := whc.monitorWebhookChanges(stopCh)
 
@@ -379,6 +387,11 @@ func (whc *WebhookConfigController) reconcile(stopCh <-chan struct{}) {
 	var keyCertTimerC <-chan time.Time
 	var configTimerC <-chan time.Time
 
+	if retryAfterSetup {
+		configTimerC = time.After(retryUpdateAfterFailureTimeout)
+	}
+
+	var retrying bool
 	for {
 		select {
 		case <-keyCertTimerC:
@@ -390,14 +403,32 @@ func (whc *WebhookConfigController) reconcile(stopCh <-chan struct{}) {
 			// rebuild the desired configuration and reconcile with the
 			// existing configuration.
 			if err := whc.rebuildWebhookConfig(); err == nil {
-				whc.createOrUpdateWebhookConfig()
+				if retry := whc.createOrUpdateWebhookConfig(); retry {
+					configTimerC = time.After(retryUpdateAfterFailureTimeout)
+					if !retrying {
+						retrying = true
+						log.Info("webhook create/update failed - retrying")
+					}
+				} else if retrying {
+					log.Infof("Retried create/update succeeded")
+					retrying = false
+				}
 			}
 		case <-webhookChangedCh:
+			var retry bool
 			if whc.webhookParameters.EnableValidation {
 				// reconcile the desired configuration
-				whc.createOrUpdateWebhookConfig()
+				if retry = whc.createOrUpdateWebhookConfig(); retry && !retrying {
+					log.Info("webhook create/update failed - retrying")
+				}
 			} else {
-				whc.deleteWebhookConfig()
+				if retry = whc.deleteWebhookConfig(); retry && !retrying {
+					log.Info("webhook delete failed - retrying")
+				}
+			}
+			retrying = retry
+			if retry {
+				time.AfterFunc(retryUpdateAfterFailureTimeout, func() { webhookChangedCh <- struct{}{} })
 			}
 		case event, more := <-whc.keyCertWatcher.Event:
 			if more && (event.IsModify() || event.IsCreate()) && keyCertTimerC == nil {

--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -407,7 +407,7 @@ func (whc *WebhookConfigController) reconcile(stopCh <-chan struct{}) {
 					configTimerC = time.After(retryUpdateAfterFailureTimeout)
 					if !retrying {
 						retrying = true
-						log.Info("webhook create/update failed - retrying")
+						log.Infof("webhook create/update failed - retrying every %v until success", retryUpdateAfterFailureTimeout)
 					}
 				} else if retrying {
 					log.Infof("Retried create/update succeeded")
@@ -419,11 +419,11 @@ func (whc *WebhookConfigController) reconcile(stopCh <-chan struct{}) {
 			if whc.webhookParameters.EnableValidation {
 				// reconcile the desired configuration
 				if retry = whc.createOrUpdateWebhookConfig(); retry && !retrying {
-					log.Info("webhook create/update failed - retrying")
+					log.Infof("webhook create/update failed - retrying every %v until success", retryUpdateAfterFailureTimeout)
 				}
 			} else {
 				if retry = whc.deleteWebhookConfig(); retry && !retrying {
-					log.Info("webhook delete failed - retrying")
+					log.Infof("webhook delete failed - retrying every %v until success", retryUpdateAfterFailureTimeout)
 				}
 			}
 			retrying = retry

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -62,7 +62,8 @@ func init() {
 }
 
 const (
-	watchDebounceDelay = 100 * time.Millisecond
+	watchDebounceDelay             = 100 * time.Millisecond
+	retryUpdateAfterFailureTimeout = time.Second
 
 	httpsHandlerReadyPath = "/ready"
 )

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -44,7 +44,7 @@ func New(a *settings.Args) *Server {
 	readiness := components.NewProbe(&a.Readiness)
 	s.host.Add(readiness)
 
-	if a.ValidationArgs != nil && a.ValidationArgs.EnableValidation {
+	if a.ValidationArgs != nil && (a.ValidationArgs.EnableValidation || a.ValidationArgs.EnableReconcileWebhookConfiguration) {
 		validation := components.NewValidation(a.KubeConfig, a.ValidationArgs, liveness.Controller(), readiness.Controller())
 		s.host.Add(validation)
 	}

--- a/sidecar-injector/cmd/sidecar-injector/main.go
+++ b/sidecar-injector/cmd/sidecar-injector/main.go
@@ -215,7 +215,7 @@ func patchCertLoop(stopCh <-chan struct{}) error {
 					if retry := doPatch(client, caCertPem); retry {
 						if delayedRetryC == nil {
 							delayedRetryC = time.After(delayedRetryTime)
-							log.Infof("Patch failed - retrying in", delayedRetryTime)
+							log.Infof("Patch failed - retrying every %v until success", delayedRetryTime)
 						}
 					} else {
 						delayedRetryC = nil

--- a/sidecar-injector/cmd/sidecar-injector/main.go
+++ b/sidecar-injector/cmd/sidecar-injector/main.go
@@ -187,7 +187,7 @@ func patchCertLoop(stopCh <-chan struct{}) error {
 	go func() {
 		var delayedRetryC <-chan time.Time
 		if retry {
-			delayedRetryC = time.After(0)
+			delayedRetryC = time.After(delayedRetryTime)
 		}
 
 		for {


### PR DESCRIPTION
The self-managed webhook reconciliation does not retry when patch/update fails. This mostly likely happens if the kube-apiserver is temporarily unavailable, e.g. during upgrade, transient network failure. Mitigate this problem by retrying failed patch/updates every second until success.

(not tested yet)