### PR TITLE
Fix dns warn log: pod name missing if it is not static pod

### DIFF
--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -533,8 +533,9 @@ func InjectionData(sidecarTemplate, valuesConfig, version string, typeMetadata *
 
 	// If DNSPolicy is not ClusterFirst, the Envoy sidecar may not able to connect to Istio Pilot.
 	if spec.DNSPolicy != "" && spec.DNSPolicy != corev1.DNSClusterFirst {
+		podName := potentialPodName(metadata)
 		log.Warnf("%q's DNSPolicy is not %q. The Envoy sidecar may not able to connect to Istio Pilot",
-			metadata.Namespace+"/"+metadata.Name, corev1.DNSClusterFirst)
+			metadata.Namespace+"/"+podName, corev1.DNSClusterFirst)
 	}
 
 	if err := validateAnnotations(metadata.GetAnnotations()); err != nil {


### PR DESCRIPTION
metadata.Name is "" if pod is not static pod, the result like `2019-10-12T02:06:26.599936Z	warn	"perf/"'s DNSPolicy is not "ClusterFirst". The Envoy sidecar may not able to connect to Istio Pilot`.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
