### PR TITLE
Fix build version exposed by proxy

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -49,6 +49,11 @@ const (
 	// required stats are used by readiness checks.
 	requiredEnvoyStatsMatcherInclusionPrefixes = "cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grpc"
 	requiredEnvoyStatsMatcherInclusionSuffix   = "ssl_context_update_by_sds"
+
+	// Prefixes of V2 metrics.
+	// "reporter" prefix is for istio standard metrics.
+	// "component" prefix is for istio_build metric.
+	v2Prefixes = "reporter=,component,"
 )
 
 var (

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -405,9 +405,9 @@ func checkStatsMatcher(t *testing.T, got, want *v2.Bootstrap, stats stats) {
 	gsm := got.GetStatsConfig().GetStatsMatcher()
 
 	if stats.prefixes == "" {
-		stats.prefixes = "reporter=," + requiredEnvoyStatsMatcherInclusionPrefixes
+		stats.prefixes = v2Prefixes + requiredEnvoyStatsMatcherInclusionPrefixes
 	} else {
-		stats.prefixes = "reporter=," + stats.prefixes + "," + requiredEnvoyStatsMatcherInclusionPrefixes
+		stats.prefixes = v2Prefixes + stats.prefixes + "," + requiredEnvoyStatsMatcherInclusionPrefixes
 	}
 
 	if stats.suffixes == "" {

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -119,6 +119,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -120,6 +120,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -122,6 +122,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -119,6 +119,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -141,6 +141,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -143,6 +143,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -119,6 +119,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -119,6 +119,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -119,6 +119,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -119,6 +119,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -119,6 +119,14 @@
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?)\\.)",
+        "tag_name": "tag"
       }
     ],
     "stats_matcher": {

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -129,6 +129,14 @@
       {
           "regex": "(cache\\.(.+?)\\.)",
           "tag_name": "cache"
+      },
+      {
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
+      },
+      {
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       }
     ],
     "stats_matcher": {
@@ -136,6 +144,9 @@
         "patterns": [
           {
           "prefix": "reporter="
+          },
+          {
+          "prefix": "component"
           },
           {{- range $a, $s := .inclusionPrefix }}
           {


### PR DESCRIPTION
Proxy exposes build_version gauge like all other components.
1. Updates bootstrap to allow that metric
2. Updates golden files.

emits metrics like this `istio_build{component="proxy",tag="1.4-dev"}`