### PR TITLE
sidecar: match services by port when egress listener has port

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -486,22 +486,6 @@ func (ilw *IstioEgressListenerWrapper) selectServices(services []*Service, confi
 								break
 							}
 						}
-						// If service does not have a matching port, check to see if there is a virtual service with matching port.
-						if !portMatched {
-							for _, vs := range ilw.virtualServices {
-								spec := vs.Spec.(*networking.VirtualService)
-								for _, http := range spec.Http {
-									for _, route := range http.Route {
-										if host.Name(route.Destination.Host).Matches(s.Hostname) &&
-											route.Destination.Port != nil &&
-											route.Destination.Port.Number == ilw.IstioListener.Port.GetNumber() {
-											portMatched = true
-											break
-										}
-									}
-								}
-							}
-						}
 					} else {
 						portMatched = true
 					}

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -493,6 +493,7 @@ func (ilw *IstioEgressListenerWrapper) selectServices(services []*Service, confi
 								for _, http := range spec.Http {
 									for _, route := range http.Route {
 										if host.Name(route.Destination.Host).Matches(s.Hostname) &&
+											route.Destination.Port != nil &&
 											route.Destination.Port.Number == ilw.IstioListener.Port.GetNumber() {
 											portMatched = true
 											break

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -88,6 +88,25 @@ var (
 		},
 	}
 
+	configs4 = &Config{
+		ConfigMeta: ConfigMeta{
+			Name:      "foo",
+			Namespace: "not-default",
+		},
+		Spec: &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Port: &networking.Port{
+						Number:   8000,
+						Protocol: "HTTP",
+						Name:     "uds",
+					},
+					Hosts: []string{"foo/*"},
+				},
+			},
+		},
+	}
+
 	services1 = []*Service{
 		{Hostname: "bar"},
 	}
@@ -111,6 +130,24 @@ var (
 	services4 = []*Service{
 		{Hostname: "bar"},
 		{Hostname: "barprime"},
+	}
+
+	services5 = []*Service{
+		{
+			Hostname: "bar",
+			Ports:    port8000,
+			Attributes: ServiceAttributes{
+				Name:      "bar",
+				Namespace: "foo",
+			},
+		},
+		{
+			Hostname: "barprime",
+			Attributes: ServiceAttributes{
+				Name:      "barprime",
+				Namespace: "foo",
+			},
+		},
 	}
 )
 
@@ -188,6 +225,12 @@ func TestCreateSidecarScope(t *testing.T) {
 			configs3,
 			services4,
 			[]string{"bar", "barprime"},
+		},
+		{
+			"sidecar-with-egress-port-match-with-services-with-and-without-port",
+			configs4,
+			services5,
+			[]string{"bar"},
 		},
 	}
 
@@ -427,7 +470,7 @@ func TestContainsEgressNamespace(t *testing.T) {
 
 			got := sidecarScope.DependsOnNamespace(tt.namespace)
 			if got != tt.contains {
-				t.Fatalf("Expected contains %v, got %v", got, tt.contains)
+				t.Fatalf("Expected contains %v, got %v", tt.contains, got)
 			}
 		})
 	}

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -26,7 +26,6 @@ import (
 
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/mesh"
-	"istio.io/istio/pkg/config/schemas"
 )
 
 var (
@@ -150,51 +149,6 @@ var (
 			},
 		},
 	}
-
-	services6 = []*Service{
-		{
-			Hostname: "bar",
-			Attributes: ServiceAttributes{
-				Name:      "bar",
-				Namespace: "foo",
-			},
-		},
-		{
-			Hostname: "barprime",
-			Attributes: ServiceAttributes{
-				Name:      "barprime",
-				Namespace: "foo",
-			},
-		},
-	}
-
-	virtualServices = []Config{
-		{
-			ConfigMeta: ConfigMeta{
-				Type:      schemas.VirtualService.Type,
-				Version:   schemas.VirtualService.Version,
-				Name:      "barprime",
-				Namespace: "foo",
-			},
-			Spec: &networking.VirtualService{
-				Hosts: []string{"barprime"},
-				Http: []*networking.HTTPRoute{
-					{
-						Route: []*networking.HTTPRouteDestination{
-							{
-								Destination: &networking.Destination{
-									Host: "barprime",
-									Port: &networking.PortSelector{
-										Number: 8000,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 )
 
 func TestCreateSidecarScope(t *testing.T) {
@@ -203,8 +157,6 @@ func TestCreateSidecarScope(t *testing.T) {
 		sidecarConfig *Config
 		// list of available service for a given proxy
 		services []*Service
-		// virtual service definitions
-		virtualServices []Config
 		// list of services expected to be in the listener
 		excpectedServices []string
 	}{
@@ -213,13 +165,11 @@ func TestCreateSidecarScope(t *testing.T) {
 			nil,
 			nil,
 			nil,
-			nil,
 		},
 		{
 			"no-sidecar-config-with-service",
 			nil,
 			services1,
-			nil,
 			[]string{"bar"},
 		},
 		{
@@ -227,33 +177,28 @@ func TestCreateSidecarScope(t *testing.T) {
 			configs1,
 			nil,
 			nil,
-			nil,
 		},
 		{
 			"sidecar-with-multiple-egress-with-service",
 			configs1,
 			services1,
-			nil,
 			[]string{"bar"},
 		},
 		{
 			"sidecar-with-multiple-egress-with-service-on-same-port",
 			configs1,
 			services3,
-			nil,
 			[]string{"bar", "barprime"},
 		},
 		{
 			"sidecar-with-multiple-egress-with-multiple-service",
 			configs1,
 			services4,
-			nil,
 			[]string{"bar", "barprime"},
 		},
 		{
 			"sidecar-with-zero-egress",
 			configs2,
-			nil,
 			nil,
 			nil,
 		},
@@ -262,12 +207,10 @@ func TestCreateSidecarScope(t *testing.T) {
 			configs2,
 			services4,
 			nil,
-			nil,
 		},
 		{
 			"sidecar-with-multiple-egress-noport",
 			configs3,
-			nil,
 			nil,
 			nil,
 		},
@@ -275,29 +218,19 @@ func TestCreateSidecarScope(t *testing.T) {
 			"sidecar-with-multiple-egress-noport-with-specific-service",
 			configs3,
 			services2,
-			nil,
 			[]string{"bar", "barprime"},
 		},
 		{
 			"sidecar-with-multiple-egress-noport-with-services",
 			configs3,
 			services4,
-			nil,
 			[]string{"bar", "barprime"},
 		},
 		{
 			"sidecar-with-egress-port-match-with-services-with-and-without-port",
 			configs4,
 			services5,
-			nil,
 			[]string{"bar"},
-		},
-		{
-			"sidecar-with-egress-port-match-with-virtual-service",
-			configs4,
-			services6,
-			virtualServices,
-			[]string{"barprime"},
 		},
 	}
 
@@ -311,9 +244,6 @@ func TestCreateSidecarScope(t *testing.T) {
 			}
 			if tt.services != nil {
 				ps.publicServices = append(ps.publicServices, tt.services...)
-			}
-			if tt.virtualServices != nil {
-				ps.publicVirtualServices = append(ps.publicVirtualServices, tt.virtualServices...)
 			}
 
 			sidecarConfig := tt.sidecarConfig

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -373,8 +373,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 	// With the config above, RDS should return a valid route for the following route names
 	// port 9000 - [bookinfo.com:9999, *.bookinfo.com:9990], [bookinfo.com:70, *.bookinfo.com:70] but no bookinfo.com
 	// unix://foo/bar/baz - [bookinfo.com:9999, *.bookinfo.com:9999], [bookinfo.com:70, *.bookinfo.com:70] but no bookinfo.com
-	// port 8080 - [bookinfo.com:9999, *.bookinfo.com:9999], [bookinfo.com:70, *.bookinfo.com:70],
-	//             [test.com:8080, 8.8.8.8:8080], but no bookinfo.com or test.com
+	// port 8080 - [test.com:8080, 8.8.8.8:8080], but no bookinfo.com or test.com
 	// port 9999 - [bookinfo.com, bookinfo.com:9999, *.bookinfo.com, *.bookinfo.com:9999]
 	// port 80 - [test-private.com, test-private.com:80, 9.9.9.9:80, 9.9.9.9]
 	// port 70 - [test-private.com, test-private.com:70, 9.9.9.9, 9.9.9.9:70], [bookinfo.com, bookinfo.com:70]
@@ -420,9 +419,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
-				"test.com:8080":     {"test.com:8080": true, "8.8.8.8:8080": true},
+				"test.com:8080": {"test.com:8080": true, "8.8.8.8:8080": true},
 			},
 		},
 		{


### PR DESCRIPTION
When a sidecar config is defined with egress listener specifying a port to match on, the listeners are generated correctly with the specified ports. But it generates outbound clusters for the all the services that does not match the port. The example described here https://github.com/istio/api/blob/master/networking/v1alpha3/sidecar.proto#L94 is not fully functional. Only listeners are generated for those ports. This PR implements port matching logic and only adds services that have associated ports.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
