### PR TITLE
It isn't an error to have no ingressgateway on a cluster

### DIFF
--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -1142,7 +1142,8 @@ func printIngressInfo(writer io.Writer, matchingServices []v1.Service, podLabels
 		return multierror.Prefix(err, "Could not find ingress gateway pods")
 	}
 	if len(pods.Items) == 0 {
-		return fmt.Errorf("no ingress gateway pods")
+		fmt.Fprintf(writer, "Skipping Gateway information (no ingress gateway pods)\n")
+		return nil
 	}
 	pod := pods.Items[0]
 


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/17832 by not giving up with an error if a cluster has no ingressgateway pods.  The tool mentions that and continues.