### PR TITLE
Place Istio validation logging under 'validation' scope

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -61,6 +61,7 @@ func defaultLogOptions() *log.Options {
 	o := log.DefaultOptions()
 
 	// These scopes are, by default, too chatty for command line use
+	o.SetOutputLevel("validation", log.ErrorLevel)
 	o.SetOutputLevel("processing", log.ErrorLevel)
 	o.SetOutputLevel("source", log.ErrorLevel)
 

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -95,6 +95,8 @@ var supportedMethods = map[string]bool{
 	http.MethodTrace:   true,
 }
 
+var scope = log.RegisterScope("validation", "CRD validation debugging", 0)
+
 // ValidateFunc defines a validation func for an API proto.
 type ValidateFunc func(name, namespace string, config proto.Message) error
 
@@ -455,20 +457,20 @@ func validateExportTo(exportTo []string) (errs error) {
 func ValidateEnvoyFilter(_, _ string, msg proto.Message) (errs error) {
 	rule, ok := msg.(*networking.EnvoyFilter)
 	if !ok {
-		return fmt.Errorf("cannot cast to envoy filter")
+		return fmt.Errorf("cannot cast to Envoy filter")
 	}
 
 	if len(rule.Filters) > 0 {
-		log.Warn("envoy filter: Filters is deprecated. use configPatches instead")
+		scope.Warn("Envoy filter: Filters is deprecated. use configPatches instead") // nolint: golint,stylecheck
 	}
 
 	if rule.WorkloadLabels != nil {
-		log.Warn("envoy filter: workloadLabels is deprecated. use workloadSelector instead")
+		scope.Warn("Envoy filter: workloadLabels is deprecated. use workloadSelector instead") // nolint: golint,stylecheck
 	}
 
 	if rule.WorkloadSelector != nil {
 		if rule.WorkloadSelector.GetLabels() == nil {
-			errs = appendErrors(errs, fmt.Errorf("envoy filter: workloadSelector cannot have empty labels"))
+			errs = appendErrors(errs, fmt.Errorf("Envoy filter: workloadSelector cannot have empty labels")) // nolint: golint,stylecheck
 		}
 	}
 
@@ -477,44 +479,44 @@ func ValidateEnvoyFilter(_, _ string, msg proto.Message) (errs error) {
 			if f.InsertPosition.Index == networking.EnvoyFilter_InsertPosition_BEFORE ||
 				f.InsertPosition.Index == networking.EnvoyFilter_InsertPosition_AFTER {
 				if f.InsertPosition.RelativeTo == "" {
-					errs = appendErrors(errs, fmt.Errorf("envoy filter: missing relativeTo filter with BEFORE/AFTER index"))
+					errs = appendErrors(errs, fmt.Errorf("Envoy filter: missing relativeTo filter with BEFORE/AFTER index")) // nolint: golint,stylecheck
 				}
 			}
 		}
 		if f.FilterType == networking.EnvoyFilter_Filter_INVALID {
-			errs = appendErrors(errs, fmt.Errorf("envoy filter: missing filter type"))
+			errs = appendErrors(errs, fmt.Errorf("Envoy filter: missing filter type")) // nolint: golint,stylecheck
 		}
 		if len(f.FilterName) == 0 {
-			errs = appendErrors(errs, fmt.Errorf("envoy filter: missing filter name"))
+			errs = appendErrors(errs, fmt.Errorf("Envoy filter: missing filter name")) // nolint: golint,stylecheck
 		}
 
 		if f.FilterConfig == nil {
-			errs = appendErrors(errs, fmt.Errorf("envoy filter: missing filter config"))
+			errs = appendErrors(errs, fmt.Errorf("Envoy filter: missing filter config")) // nolint: golint,stylecheck
 		}
 	}
 
 	for _, cp := range rule.ConfigPatches {
 		if cp.ApplyTo == networking.EnvoyFilter_INVALID {
-			errs = appendErrors(errs, fmt.Errorf("envoy filter: missing applyTo"))
+			errs = appendErrors(errs, fmt.Errorf("Envoy filter: missing applyTo")) // nolint: golint,stylecheck
 			continue
 		}
 		if cp.Patch == nil {
-			errs = appendErrors(errs, fmt.Errorf("envoy filter: missing patch"))
+			errs = appendErrors(errs, fmt.Errorf("Envoy filter: missing patch")) // nolint: golint,stylecheck
 			continue
 		}
 		if cp.Patch.Operation == networking.EnvoyFilter_Patch_INVALID {
-			errs = appendErrors(errs, fmt.Errorf("envoy filter: missing patch operation"))
+			errs = appendErrors(errs, fmt.Errorf("Envoy filter: missing patch operation")) // nolint: golint,stylecheck
 			continue
 		}
 		if cp.Patch.Operation != networking.EnvoyFilter_Patch_REMOVE && cp.Patch.Value == nil {
-			errs = appendErrors(errs, fmt.Errorf("envoy filter: missing patch value for non-remove operation"))
+			errs = appendErrors(errs, fmt.Errorf("Envoy filter: missing patch value for non-remove operation")) // nolint: golint,stylecheck
 			continue
 		}
 
 		// ensure that the supplied regex for proxy version compiles
 		if cp.Match != nil && cp.Match.Proxy != nil && cp.Match.Proxy.ProxyVersion != "" {
 			if _, err := regexp.Compile(cp.Match.Proxy.ProxyVersion); err != nil {
-				errs = appendErrors(errs, fmt.Errorf("envoy filter: invalid regex for proxy version, [%v]", err))
+				errs = appendErrors(errs, fmt.Errorf("Envoy filter: invalid regex for proxy version, [%v]", err)) // nolint: golint,stylecheck
 				continue
 			}
 		}
@@ -526,7 +528,7 @@ func ValidateEnvoyFilter(_, _ string, msg proto.Message) (errs error) {
 			networking.EnvoyFilter_HTTP_FILTER:
 			if cp.Match != nil && cp.Match.ObjectTypes != nil {
 				if cp.Match.GetListener() == nil {
-					errs = appendErrors(errs, fmt.Errorf("envoy filter: applyTo for listener class objects cannot have non listener match"))
+					errs = appendErrors(errs, fmt.Errorf("Envoy filter: applyTo for listener class objects cannot have non listener match")) // nolint: golint,stylecheck
 					continue
 				}
 				listenerMatch := cp.Match.GetListener()
@@ -534,22 +536,22 @@ func ValidateEnvoyFilter(_, _ string, msg proto.Message) (errs error) {
 					if listenerMatch.FilterChain.Filter != nil {
 						// filter names are required if network filter matches are being made
 						if listenerMatch.FilterChain.Filter.Name == "" {
-							errs = appendErrors(errs, fmt.Errorf("envoy filter: filter match has no name to match on"))
+							errs = appendErrors(errs, fmt.Errorf("Envoy filter: filter match has no name to match on")) // nolint: golint,stylecheck
 							continue
 						} else if listenerMatch.FilterChain.Filter.SubFilter != nil {
 							// sub filter match is supported only for applyTo HTTP_FILTER
 							if cp.ApplyTo != networking.EnvoyFilter_HTTP_FILTER {
-								errs = appendErrors(errs, fmt.Errorf("envoy filter: subfilter match can be used with applyTo HTTP_FILTER only"))
+								errs = appendErrors(errs, fmt.Errorf("Envoy filter: subfilter match can be used with applyTo HTTP_FILTER only")) // nolint: golint,stylecheck
 								continue
 							}
 							// sub filter match requires the network filter to match to envoy http connection manager
 							if listenerMatch.FilterChain.Filter.Name != xdsUtil.HTTPConnectionManager {
-								errs = appendErrors(errs, fmt.Errorf("envoy filter: subfilter match requires filter match with %s",
+								errs = appendErrors(errs, fmt.Errorf("Envoy filter: subfilter match requires filter match with %s", // nolint: golint,stylecheck
 									xdsUtil.HTTPConnectionManager))
 								continue
 							}
 							if listenerMatch.FilterChain.Filter.SubFilter.Name == "" {
-								errs = appendErrors(errs, fmt.Errorf("envoy filter: subfilter match has no name to match on"))
+								errs = appendErrors(errs, fmt.Errorf("Envoy filter: subfilter match has no name to match on")) // nolint: golint,stylecheck
 								continue
 							}
 						}
@@ -559,14 +561,15 @@ func ValidateEnvoyFilter(_, _ string, msg proto.Message) (errs error) {
 		case networking.EnvoyFilter_ROUTE_CONFIGURATION, networking.EnvoyFilter_VIRTUAL_HOST, networking.EnvoyFilter_HTTP_ROUTE:
 			if cp.Match != nil && cp.Match.ObjectTypes != nil {
 				if cp.Match.GetRouteConfiguration() == nil {
-					errs = appendErrors(errs, fmt.Errorf("envoy filter: applyTo for http route class objects cannot have non route configuration match"))
+					errs = appendErrors(errs,
+						fmt.Errorf("Envoy filter: applyTo for http route class objects cannot have non route configuration match")) // nolint: golint,stylecheck
 				}
 			}
 
 		case networking.EnvoyFilter_CLUSTER:
 			if cp.Match != nil && cp.Match.ObjectTypes != nil {
 				if cp.Match.GetCluster() == nil {
-					errs = appendErrors(errs, fmt.Errorf("envoy filter: applyTo for cluster class objects cannot have non cluster match"))
+					errs = appendErrors(errs, fmt.Errorf("Envoy filter: applyTo for cluster class objects cannot have non cluster match")) // nolint: golint,stylecheck
 				}
 			}
 		}
@@ -1177,7 +1180,7 @@ func ValidateProxyConfig(config *meshconfig.ProxyConfig) (errs error) {
 		if err := ValidateProxyAddress(config.EnvoyMetricsServiceAddress); err != nil {
 			errs = multierror.Append(errs, multierror.Prefix(err, fmt.Sprintf("invalid envoy metrics service address %q:", config.EnvoyMetricsServiceAddress)))
 		} else {
-			log.Warnf("EnvoyMetricsServiceAddress is deprecated, use EnvoyMetricsService instead.")
+			scope.Warnf("EnvoyMetricsServiceAddress is deprecated, use EnvoyMetricsService instead.") // nolint: golint,stylecheck
 		}
 	}
 
@@ -1703,7 +1706,7 @@ func ValidateClusterRbacConfig(name, _ string, msg proto.Message) error {
 
 // ValidateRbacConfig checks that RbacConfig is well-formed.
 func ValidateRbacConfig(name, _ string, msg proto.Message) error {
-	log.Warnf("RbacConfig is deprecated, use ClusterRbacConfig instead.")
+	scope.Warnf("RbacConfig is deprecated, use ClusterRbacConfig instead.")
 	return checkRbacConfig(name, "RbacConfig", msg)
 }
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3001,7 +3001,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					ApplyTo: 0,
 				},
 			},
-		}, error: "envoy filter: missing applyTo"},
+		}, error: "Envoy filter: missing applyTo"},
 		{name: "nil patch", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3009,7 +3009,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					Patch:   nil,
 				},
 			},
-		}, error: "envoy filter: missing patch"},
+		}, error: "Envoy filter: missing patch"},
 		{name: "invalid patch operation", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3017,7 +3017,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					Patch:   &networking.EnvoyFilter_Patch{},
 				},
 			},
-		}, error: "envoy filter: missing patch operation"},
+		}, error: "Envoy filter: missing patch operation"},
 		{name: "nil patch value", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3027,7 +3027,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "envoy filter: missing patch value for non-remove operation"},
+		}, error: "Envoy filter: missing patch value for non-remove operation"},
 		{name: "match with invalid regex", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3042,7 +3042,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "envoy filter: invalid regex for proxy version, [error parsing regexp: invalid nested repetition operator: `++`]"},
+		}, error: "Envoy filter: invalid regex for proxy version, [error parsing regexp: invalid nested repetition operator: `++`]"},
 		{name: "match with valid regex", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3072,7 +3072,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "envoy filter: applyTo for listener class objects cannot have non listener match"},
+		}, error: "Envoy filter: applyTo for listener class objects cannot have non listener match"},
 		{name: "listener with invalid filter match", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3092,7 +3092,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "envoy filter: filter match has no name to match on"},
+		}, error: "Envoy filter: filter match has no name to match on"},
 		{name: "listener with sub filter match and invalid applyTo", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3114,7 +3114,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "envoy filter: subfilter match can be used with applyTo HTTP_FILTER only"},
+		}, error: "Envoy filter: subfilter match can be used with applyTo HTTP_FILTER only"},
 		{name: "listener with sub filter match and invalid filter name", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3136,7 +3136,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "envoy filter: subfilter match requires filter match with envoy.http_connection_manager"},
+		}, error: "Envoy filter: subfilter match requires filter match with envoy.http_connection_manager"},
 		{name: "listener with sub filter match and no sub filter name", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3158,7 +3158,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "envoy filter: subfilter match has no name to match on"},
+		}, error: "Envoy filter: subfilter match has no name to match on"},
 		{name: "route configuration with invalid match", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3173,7 +3173,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "envoy filter: applyTo for http route class objects cannot have non route configuration match"},
+		}, error: "Envoy filter: applyTo for http route class objects cannot have non route configuration match"},
 		{name: "cluster with invalid match", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3188,7 +3188,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "envoy filter: applyTo for cluster class objects cannot have non cluster match"},
+		}, error: "Envoy filter: applyTo for cluster class objects cannot have non cluster match"},
 		{name: "invalid patch value", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
@@ -3210,7 +3210,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: `envoy filter: unknown field "foo" in envoy_api_v2.Cluster`},
+		}, error: `Envoy filter: unknown field "foo" in envoy_api_v2.Cluster`},
 		{name: "happy config", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{

--- a/pkg/config/xds/xds.go
+++ b/pkg/config/xds/xds.go
@@ -56,11 +56,11 @@ func BuildXDSObjectFromStruct(applyTo networking.EnvoyFilter_ApplyTo, value *typ
 	case networking.EnvoyFilter_HTTP_ROUTE:
 		obj = &route.Route{}
 	default:
-		return nil, fmt.Errorf("envoy filter: unknown object type for applyTo %s", applyTo.String())
+		return nil, fmt.Errorf("Envoy filter: unknown object type for applyTo %s", applyTo.String()) // nolint: golint,stylecheck
 	}
 
 	if err := GogoStructToMessage(value, obj); err != nil {
-		return nil, fmt.Errorf("envoy filter: %v", err)
+		return nil, fmt.Errorf("Envoy filter: %v", err) // nolint: golint,stylecheck
 	}
 	return obj, nil
 }


### PR DESCRIPTION
Resolve https://github.com/istio/istio/issues/17842 by placing Istio CRD validation logging under the 'validation' log scope and making that scope default to ERROR only.

Capitalize Envoy in log messages and Error returns to comply with https://istio.io/about/contribute/style-guide/ for any string that might surface to a user.