### PR TITLE
Add operator support to e2e tests

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/url"
 	"os"


### PR DESCRIPTION
This adds a --use_operator flag to the e2e tests. The e2e tests
expect a different component to store a manifest for deployment
in the $ISTIO/install/kubernetes directory.

One aspect of this test case is incorrect. Deletion of the operator
appears not to work within the test framework. The namespace locks
up with the namespace in the terminating state.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
