### PR TITLE
Analysis limits result messages to the specified namespace

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -193,7 +193,10 @@ func TestAnalyzers(t *testing.T) {
 
 			sa := local.NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("testCombined", testCase.analyzer), "", cr, true)
 
-			sa.AddFileKubeSource(testCase.inputFiles)
+			err := sa.AddFileKubeSource(testCase.inputFiles)
+			if err != nil {
+				t.Fatalf("Error setting up file kube source on testcase %s: %v", testCase.name, err)
+			}
 			cancel := make(chan struct{})
 
 			msgs, err := sa.Analyze(cancel)

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -191,9 +191,9 @@ func TestAnalyzers(t *testing.T) {
 				requestedInputsByAnalyzer[analyzerName][col] = struct{}{}
 			}
 
-			sa := local.NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("testCombined", testCase.analyzer), cr, true)
+			sa := local.NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("testCombined", testCase.analyzer), "", cr, true)
 
-			sa.AddFileKubeSource(testCase.inputFiles, "")
+			sa.AddFileKubeSource(testCase.inputFiles)
 			cancel := make(chan struct{})
 
 			msgs, err := sa.Analyze(cancel)

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -26,6 +26,10 @@ func (o testOrigin) FriendlyName() string {
 	return string(o)
 }
 
+func (o testOrigin) Namespace() string {
+	return ""
+}
+
 func TestMessage_String(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -62,7 +62,9 @@ type SourceAnalyzer struct {
 
 // NewSourceAnalyzer creates a new SourceAnalyzer with no sources. Use the Add*Source methods to add sources in ascending precedence order,
 // then execute Analyze to perform the analysis
-func NewSourceAnalyzer(m *schema.Metadata, analyzer *analysis.CombinedAnalyzer, namespace string, cr snapshotter.CollectionReporterFn, serviceDiscovery bool) *SourceAnalyzer {
+func NewSourceAnalyzer(m *schema.Metadata, analyzer *analysis.CombinedAnalyzer, namespace string,
+	cr snapshotter.CollectionReporterFn, serviceDiscovery bool) *SourceAnalyzer {
+
 	// collectionReporter hook function defaults to no-op
 	if cr == nil {
 		cr = func(collection.Name) {}

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -94,6 +94,11 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (diag.Messages, error) {
 	}
 	src := newPrecedenceSource(sa.sources)
 
+	var namespaces []string
+	if sa.namespace != "" {
+		namespaces = []string{sa.namespace}
+	}
+
 	updater := &snapshotter.InMemoryStatusUpdater{}
 	distributorSettings := snapshotter.AnalyzingDistributorSettings{
 		StatusUpdater:      updater,
@@ -102,7 +107,7 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (diag.Messages, error) {
 		AnalysisSnapshots:  []string{metadata.LocalAnalysis, metadata.SyntheticServiceEntry},
 		TriggerSnapshot:    metadata.LocalAnalysis,
 		CollectionReporter: sa.collectionReporter,
-		AnalysisNamespaces: []string{sa.namespace},
+		AnalysisNamespaces: namespaces,
 	}
 	distributor := snapshotter.NewAnalyzingDistributor(distributorSettings)
 

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -62,7 +62,7 @@ func TestAbortWithNoSources(t *testing.T) {
 
 	cancel := make(chan struct{})
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, nil, false)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
 	_, err := sa.Analyze(cancel)
 	g.Expect(err).To(Not(BeNil()))
 }
@@ -72,7 +72,7 @@ func TestAnalyzersRun(t *testing.T) {
 
 	cancel := make(chan struct{})
 
-	r := createTestResource("resource", "v1")
+	r := createTestResource("ns", "resource", "v1")
 	msg := msg.NewInternalError(r, "msg")
 	a := &testAnalyzer{
 		fn: func(ctx analysis.Context) {
@@ -86,8 +86,8 @@ func TestAnalyzersRun(t *testing.T) {
 		collectionAccessed = col
 	}
 
-	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), cr, false)
-	err := sa.AddFileKubeSource([]string{}, "")
+	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), "", cr, false)
+	err := sa.AddFileKubeSource([]string{})
 	g.Expect(err).To(BeNil())
 
 	msgs, err := sa.Analyze(cancel)
@@ -96,12 +96,37 @@ func TestAnalyzersRun(t *testing.T) {
 	g.Expect(collectionAccessed).To(Equal(data.Collection1))
 }
 
+func TestFilterOutputByNamespace(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cancel := make(chan struct{})
+
+	r1 := createTestResource("ns1", "resource", "v1")
+	r2 := createTestResource("ns2", "resource", "v1")
+	msg1 := msg.NewInternalError(r1, "msg")
+	msg2 := msg.NewInternalError(r2, "msg")
+	a := &testAnalyzer{
+		fn: func(ctx analysis.Context) {
+			ctx.Report(data.Collection1, msg1)
+			ctx.Report(data.Collection1, msg2)
+		},
+	}
+
+	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), "ns1", nil, false)
+	err := sa.AddFileKubeSource([]string{})
+	g.Expect(err).To(BeNil())
+
+	msgs, err := sa.Analyze(cancel)
+	g.Expect(err).To(BeNil())
+	g.Expect(msgs).To(ConsistOf(msg1))
+}
+
 func TestAddRunningKubeSource(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	mk := mock.NewKube()
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, nil, false)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
 
 	sa.AddRunningKubeSource(mk)
 	g.Expect(sa.sources).To(HaveLen(1))
@@ -110,7 +135,7 @@ func TestAddRunningKubeSource(t *testing.T) {
 func TestAddFileKubeSource(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, nil, false)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
 
 	tmpfile, err := ioutil.TempFile("", "")
 	if err != nil {
@@ -125,7 +150,7 @@ func TestAddFileKubeSource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = sa.AddFileKubeSource([]string{tmpfile.Name()}, "")
+	err = sa.AddFileKubeSource([]string{tmpfile.Name()})
 	g.Expect(err).To(BeNil())
 	g.Expect(sa.sources).To(HaveLen(1))
 }
@@ -149,7 +174,7 @@ func TestResourceFiltering(t *testing.T) {
 	}
 	mk := mock.NewKube()
 
-	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), nil, true)
+	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), "", nil, true)
 	sa.AddRunningKubeSource(mk)
 
 	// All but the used collection should be disabled

--- a/galley/pkg/config/analysis/local/helpers_test.go
+++ b/galley/pkg/config/analysis/local/helpers_test.go
@@ -20,6 +20,7 @@ import (
 
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/source/kube/rt"
 	"istio.io/istio/galley/pkg/config/testing/data"
 )
 
@@ -31,12 +32,16 @@ func createTestEvent(k event.Kind, r *resource.Entry) event.Event {
 	}
 }
 
-func createTestResource(name, version string) *resource.Entry {
+func createTestResource(ns, name, version string) *resource.Entry {
+	rname := resource.NewName(ns, name)
 	return &resource.Entry{
 		Metadata: resource.Metadata{
-			Name:    resource.NewName("ns", name),
+			Name:    rname,
 			Version: resource.Version(version),
 		},
 		Item: &types.Empty{},
+		Origin: &rt.Origin{
+			Name: rname,
+		},
 	}
 }

--- a/galley/pkg/config/analysis/local/source_test.go
+++ b/galley/pkg/config/analysis/local/source_test.go
@@ -35,7 +35,7 @@ func TestBasicSingleSource(t *testing.T) {
 	ps.Start()
 	defer ps.Stop()
 
-	e1 := createTestEvent(event.Added, createTestResource("resource1", "v1"))
+	e1 := createTestEvent(event.Added, createTestResource("ns", "resource1", "v1"))
 	e2 := createTestEvent(event.FullSync, nil)
 
 	s1.Handle(e1)
@@ -81,8 +81,8 @@ func TestPrecedence(t *testing.T) {
 	ps.Start()
 	defer ps.Stop()
 
-	e1 := createTestEvent(event.Added, createTestResource("resource1", "v1"))
-	e2 := createTestEvent(event.Added, createTestResource("resource1", "v2"))
+	e1 := createTestEvent(event.Added, createTestResource("ns", "resource1", "v1"))
+	e2 := createTestEvent(event.Added, createTestResource("ns", "resource1", "v2"))
 
 	s2.Handle(e1)
 	g.Expect(h.Events()).To(Equal([]event.Event{e1}))

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -141,10 +141,15 @@ func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name
 	scope.Analysis.Debugf("Finished analyzing the current snapshot, found messages: %v", ctx.messages)
 
 	// Only keep messages for resources in namespaces we want to analyze
+	// If no such limit is specified, keep them all.
 	var msgs diag.Messages
-	for _, m := range ctx.messages {
-		if _, ok := namespaces[m.Origin.Namespace()]; ok {
-			msgs = append(msgs, m)
+	if len(namespaces) == 0 {
+		msgs = ctx.messages
+	} else {
+		for _, m := range ctx.messages {
+			if _, ok := namespaces[m.Origin.Namespace()]; ok {
+				msgs = append(msgs, m)
+			}
 		}
 	}
 

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -63,6 +63,9 @@ type AnalyzingDistributorSettings struct {
 
 	// An optional hook that will be called whenever a collection is accessed. Useful for testing.
 	CollectionReporter CollectionReporterFn
+
+	// Namespaces that should be analyzed
+	AnalysisNamespaces []string
 }
 
 // NewAnalyzingDistributor returns a new instance of AnalyzingDistributor.
@@ -104,10 +107,15 @@ func (d *AnalyzingDistributor) Distribute(name string, s *Snapshot) {
 		d.cancelAnalysis = nil
 	}
 
+	namespaces := make(map[string]struct{})
+	for _, ns := range d.s.AnalysisNamespaces {
+		namespaces[ns] = struct{}{}
+	}
+
 	// start a new analysis session
 	cancelAnalysis := make(chan struct{})
 	d.cancelAnalysis = cancelAnalysis
-	go d.analyzeAndDistribute(cancelAnalysis, name, s)
+	go d.analyzeAndDistribute(cancelAnalysis, name, s, namespaces)
 }
 
 func (d *AnalyzingDistributor) isAnalysisSnapshot(s string) bool {
@@ -120,7 +128,7 @@ func (d *AnalyzingDistributor) isAnalysisSnapshot(s string) bool {
 	return false
 }
 
-func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name string, s *Snapshot) {
+func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name string, s *Snapshot, namespaces map[string]struct{}) {
 	// For analysis, we use a combined snapshot
 	ctx := &context{
 		sn:                 d.getCombinedSnapshot(),
@@ -132,8 +140,16 @@ func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name
 	d.s.Analyzer.Analyze(ctx)
 	scope.Analysis.Debugf("Finished analyzing the current snapshot, found messages: %v", ctx.messages)
 
+	// Only keep messages for resources in namespaces we want to analyze
+	var msgs diag.Messages
+	for _, m := range ctx.messages {
+		if _, ok := namespaces[m.Origin.Namespace()]; ok {
+			msgs = append(msgs, m)
+		}
+	}
+
 	if !ctx.Canceled() {
-		d.s.StatusUpdater.Update(ctx.messages)
+		d.s.StatusUpdater.Update(msgs)
 	}
 
 	// Execution only reaches this point for trigger snapshot group

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -21,22 +21,29 @@ import (
 
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/diag"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
 	coll "istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/meta/metadata"
 	"istio.io/istio/galley/pkg/config/meta/schema/collection"
 	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/source/kube/rt"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/pkg/mcp/snapshot"
 )
 
-type updaterMock struct{}
+type updaterMock struct {
+	messages diag.Messages
+}
 
 // Update implements StatusUpdater
-func (u *updaterMock) Update(messages diag.Messages) {}
+func (u *updaterMock) Update(messages diag.Messages) {
+	u.messages = messages
+}
 
 type analyzerMock struct {
 	analyzeCalls       []*Snapshot
 	collectionToAccess collection.Name
+	entriesToReport    []*resource.Entry
 }
 
 // Analyze implements Analyzer
@@ -45,7 +52,11 @@ func (a *analyzerMock) Analyze(c analysis.Context) {
 
 	a.analyzeCalls = append(a.analyzeCalls, ctx.sn)
 
-	ctx.Exists(a.collectionToAccess, resource.NewName("", ""))
+	c.Exists(a.collectionToAccess, resource.NewName("", ""))
+
+	for _, r := range a.entriesToReport {
+		c.Report(a.collectionToAccess, msg.NewInternalError(r, ""))
+	}
 }
 
 // Name implements Analyzer
@@ -62,6 +73,20 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 	u := &updaterMock{}
 	a := &analyzerMock{
 		collectionToAccess: data.Collection1,
+		entriesToReport: []*resource.Entry{
+			{
+				Origin: &rt.Origin{
+					Collection: data.Collection1,
+					Name:       resource.NewName("includedNamespace", "r1"),
+				},
+			},
+			{
+				Origin: &rt.Origin{
+					Collection: data.Collection1,
+					Name:       resource.NewName("excludedNamespace", "r2"),
+				},
+			},
+		},
 	}
 	d := NewInMemoryDistributor()
 
@@ -77,6 +102,7 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 		AnalysisSnapshots:  []string{metadata.Default, metadata.SyntheticServiceEntry},
 		TriggerSnapshot:    metadata.Default,
 		CollectionReporter: cr,
+		AnalysisNamespaces: []string{"includedNamespace"},
 	}
 	ad := NewAnalyzingDistributor(settings)
 
@@ -99,6 +125,12 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 
 	// Verify the collection reporter hook was called
 	g.Expect(collectionAccessed).To(Equal(a.collectionToAccess))
+
+	// Verify we only reported messages in the AnalysisNamespaces
+	g.Expect(u.messages).To(HaveLen(1))
+	for _, m := range u.messages {
+		g.Expect(m.Origin.Namespace()).To(Equal("includedNamespace"))
+	}
 }
 
 func getTestSnapshot(names ...string) *Snapshot {

--- a/galley/pkg/config/resource/origin.go
+++ b/galley/pkg/config/resource/origin.go
@@ -17,4 +17,6 @@ package resource
 // Origin of a resource. This is source-implementation dependent.
 type Origin interface {
 	FriendlyName() string
+
+	Namespace() string
 }

--- a/galley/pkg/config/source/kube/rt/origin.go
+++ b/galley/pkg/config/source/kube/rt/origin.go
@@ -17,6 +17,7 @@ package rt
 import (
 	"fmt"
 
+	"istio.io/istio/galley/pkg/config/meta/metadata"
 	"istio.io/istio/galley/pkg/config/meta/schema/collection"
 	"istio.io/istio/galley/pkg/config/resource"
 )
@@ -34,4 +35,15 @@ var _ resource.Origin = &Origin{}
 // FriendlyName implements resource.Origin
 func (o *Origin) FriendlyName() string {
 	return fmt.Sprintf("%s/%s", o.Kind, o.Name.String())
+}
+
+// Namespace implements resource.Origin
+func (o *Origin) Namespace() string {
+	// Special case: the namespace of a namespace resource is its own name
+	if o.Collection == metadata.K8SCoreV1Namespaces {
+		return o.Name.String()
+	}
+
+	ns, _ := o.Name.InterpretAsNamespaceAndName()
+	return ns
 }

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -76,7 +76,7 @@ istioctl experimental analyze -k -d false
 			// so it properly handles the --context option.
 			selectedNamespace := namespace
 
-			var k cfgKube.Interfaces = nil
+			var k cfgKube.Interfaces
 			if useKube {
 				// Set up the kube client
 				config := kube.BuildClientCmd(kubeconfig, configContext)


### PR DESCRIPTION
For https://github.com/istio/istio/issues/17595

1. Analysis framework takes a list of namespaces as input, and only outputs messages for resources in the specified namespaces.
2. `istioctl x analyze` always passes exactly one namespace to the analysis framework. This will be (in order) whatever the user specifies via --namespace, or whatever is specified in kube config (if using kube), or the default value specified by istioctl (which happens to be "default"). 

Note that the snapshots still include everything in the cluster, and if there are cross-namespace dependencies analyzers should be able to handle them. But we'll only output messages for resource in the specified namespace. 

Also note that Galley running with enableAnalysis will still be looking at everything Galley is paying attention to and generating status messages accordingly. Fixing that is future work, coupled with adding the ability to namespace-scope a Galley instance.

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
