### PR TITLE
Use watching instead of polling to get update from Consul catalog

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1065,7 +1065,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 func (s *Server) initConsulRegistry(serviceControllers *aggregate.Controller, args *PilotArgs) error {
 	log.Infof("Consul url: %v", args.Service.Consul.ServerURL)
 	conctl, conerr := consul.NewController(
-		args.Service.Consul.ServerURL, args.Service.Consul.Interval)
+		args.Service.Consul.ServerURL)
 	if conerr != nil {
 		return fmt.Errorf("failed to create Consul controller: %v", conerr)
 	}

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -16,9 +16,9 @@ package consul
 
 import (
 	"fmt"
-	"github.com/hashicorp/consul/api"
 	"sync"
 
+	"github.com/hashicorp/consul/api"
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -16,10 +16,8 @@ package consul
 
 import (
 	"fmt"
-	"sync"
-	"time"
-
 	"github.com/hashicorp/consul/api"
+	"sync"
 
 	"istio.io/pkg/log"
 
@@ -41,12 +39,12 @@ type Controller struct {
 }
 
 // NewController creates a new Consul controller
-func NewController(addr string, interval time.Duration) (*Controller, error) {
+func NewController(addr string) (*Controller, error) {
 	conf := api.DefaultConfig()
 	conf.Address = addr
 
 	client, err := api.NewClient(conf)
-	monitor := NewConsulMonitor(client, interval)
+	monitor := NewConsulMonitor(client)
 	controller := Controller{
 		monitor: monitor,
 		client:  client,

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/consul/api"
+
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/serviceregistry/consul/controller_test.go
+++ b/pilot/pkg/serviceregistry/consul/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"sort"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -31,135 +32,130 @@ import (
 	"istio.io/istio/pkg/config/labels"
 )
 
-var (
-	services = map[string][]string{
-		"productpage": {"version|v1"},
-		"reviews":     {"version|v1", "version|v2", "version|v3"},
-		"rating":      {"version|v1"},
-	}
-	productpage = []*api.CatalogService{
-		{
-			Node:           "istio-node",
-			Address:        "172.19.0.5",
-			ID:             "istio-node-id",
-			ServiceID:      "productpage",
-			ServiceName:    "productpage",
-			ServiceTags:    []string{"version|v1"},
-			ServiceAddress: "172.19.0.11",
-			ServicePort:    9080,
-		},
-	}
-	reviews = []*api.CatalogService{
-		{
-			Node:           "istio-node",
-			Address:        "172.19.0.5",
-			ID:             "istio-node-id",
-			ServiceID:      "reviews-id",
-			ServiceName:    "reviews",
-			ServiceTags:    []string{"version|v1"},
-			ServiceAddress: "172.19.0.6",
-			ServicePort:    9081,
-		},
-		{
-			Node:           "istio-node",
-			Address:        "172.19.0.5",
-			ID:             "istio-node-id",
-			ServiceID:      "reviews-id",
-			ServiceName:    "reviews",
-			ServiceTags:    []string{"version|v2"},
-			ServiceAddress: "172.19.0.7",
-			ServicePort:    9081,
-		},
-		{
-			Node:           "istio-node",
-			Address:        "172.19.0.5",
-			ID:             "istio-node-id",
-			ServiceID:      "reviews-id",
-			ServiceName:    "reviews",
-			ServiceTags:    []string{"version|v3"},
-			ServiceAddress: "172.19.0.8",
-			ServicePort:    9080,
-			ServiceMeta:    map[string]string{protocolTagName: "tcp"},
-		},
-	}
-	rating = []*api.CatalogService{
-		{
-			Node:           "istio-node",
-			Address:        "172.19.0.6",
-			ID:             "istio-node-id",
-			ServiceID:      "rating-id",
-			ServiceName:    "rating",
-			ServiceTags:    []string{"version|v1"},
-			ServiceAddress: "172.19.0.12",
-			ServicePort:    9080,
-		},
-	}
-)
-
 type mockServer struct {
-	Server      *httptest.Server
-	Services    map[string][]string
-	Productpage []*api.CatalogService
-	Reviews     []*api.CatalogService
-	Rating      []*api.CatalogService
-	Lock        sync.Mutex
+	server      *httptest.Server
+	services    map[string][]string
+	productpage []*api.CatalogService
+	reviews     []*api.CatalogService
+	rating      []*api.CatalogService
+	lock        sync.Mutex
+	consulIndex int
 }
 
 func newServer() *mockServer {
 	m := mockServer{
-		Productpage: make([]*api.CatalogService, len(productpage)),
-		Reviews:     make([]*api.CatalogService, len(reviews)),
-		Rating:      make([]*api.CatalogService, len(rating)),
-		Services:    make(map[string][]string),
-	}
-
-	copy(m.Reviews, reviews)
-	copy(m.Productpage, productpage)
-	copy(m.Rating, rating)
-	for k, v := range services {
-		m.Services[k] = v
+		productpage: []*api.CatalogService{
+			{
+				Node:           "istio-node",
+				Address:        "172.19.0.5",
+				ID:             "istio-node-id",
+				ServiceID:      "productpage",
+				ServiceName:    "productpage",
+				ServiceTags:    []string{"version|v1"},
+				ServiceAddress: "172.19.0.11",
+				ServicePort:    9080,
+			},
+		},
+		reviews: []*api.CatalogService{
+			{
+				Node:           "istio-node",
+				Address:        "172.19.0.5",
+				ID:             "istio-node-id",
+				ServiceID:      "reviews-id",
+				ServiceName:    "reviews",
+				ServiceTags:    []string{"version|v1"},
+				ServiceAddress: "172.19.0.6",
+				ServicePort:    9081,
+			},
+			{
+				Node:           "istio-node",
+				Address:        "172.19.0.5",
+				ID:             "istio-node-id",
+				ServiceID:      "reviews-id",
+				ServiceName:    "reviews",
+				ServiceTags:    []string{"version|v2"},
+				ServiceAddress: "172.19.0.7",
+				ServicePort:    9081,
+			},
+			{
+				Node:           "istio-node",
+				Address:        "172.19.0.5",
+				ID:             "istio-node-id",
+				ServiceID:      "reviews-id",
+				ServiceName:    "reviews",
+				ServiceTags:    []string{"version|v3"},
+				ServiceAddress: "172.19.0.8",
+				ServicePort:    9080,
+				ServiceMeta:    map[string]string{protocolTagName: "tcp"},
+			},
+		},
+		rating: []*api.CatalogService{
+			{
+				Node:           "istio-node",
+				Address:        "172.19.0.6",
+				ID:             "istio-node-id",
+				ServiceID:      "rating-id",
+				ServiceName:    "rating",
+				ServiceTags:    []string{"version|v1"},
+				ServiceAddress: "172.19.0.12",
+				ServicePort:    9080,
+			},
+		},
+		services: map[string][]string{
+			"productpage": {"version|v1"},
+			"reviews":     {"version|v1", "version|v2", "version|v3"},
+			"rating":      {"version|v1"},
+		},
+		consulIndex: 1,
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/catalog/services" {
-			m.Lock.Lock()
-			data, _ := json.Marshal(&m.Services)
-			m.Lock.Unlock()
+			m.lock.Lock()
+			data, _ := json.Marshal(&m.services)
+			w.Header().Set("X-Consul-Index", strconv.Itoa(m.consulIndex))
+			m.lock.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintln(w, string(data))
 		} else if r.URL.Path == "/v1/catalog/service/reviews" {
-			m.Lock.Lock()
-			data, _ := json.Marshal(&m.Reviews)
-			m.Lock.Unlock()
+			m.lock.Lock()
+			data, _ := json.Marshal(&m.reviews)
+			w.Header().Set("X-Consul-Index", strconv.Itoa(m.consulIndex))
+			m.lock.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintln(w, string(data))
 		} else if r.URL.Path == "/v1/catalog/service/productpage" {
-			m.Lock.Lock()
-			data, _ := json.Marshal(&m.Productpage)
-			m.Lock.Unlock()
+			m.lock.Lock()
+			data, _ := json.Marshal(&m.productpage)
+			w.Header().Set("X-Consul-Index", strconv.Itoa(m.consulIndex))
+			m.lock.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintln(w, string(data))
 		} else if r.URL.Path == "/v1/catalog/service/rating" {
-			m.Lock.Lock()
-			data, _ := json.Marshal(&m.Rating)
-			m.Lock.Unlock()
+			m.lock.Lock()
+			data, _ := json.Marshal(&m.rating)
+			w.Header().Set("X-Consul-Index", strconv.Itoa(m.consulIndex))
+			m.lock.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintln(w, string(data))
 		} else {
+			m.lock.Lock()
 			data, _ := json.Marshal(&[]*api.CatalogService{})
+			w.Header().Set("X-Consul-Index", strconv.Itoa(m.consulIndex))
+			m.lock.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintln(w, string(data))
 		}
 	}))
 
-	m.Server = server
+	m.server = server
 	return &m
 }
 
 func TestInstances(t *testing.T) {
 	ts := newServer()
-	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	defer ts.server.Close()
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -228,8 +224,8 @@ func TestInstances(t *testing.T) {
 
 func TestInstancesBadHostname(t *testing.T) {
 	ts := newServer()
-	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	defer ts.server.Close()
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -251,9 +247,9 @@ func TestInstancesBadHostname(t *testing.T) {
 
 func TestInstancesError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
-		ts.Server.Close()
+		ts.server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
 	hostname := serviceHostname("reviews")
@@ -264,7 +260,7 @@ func TestInstancesError(t *testing.T) {
 			Namespace: model.IstioDefaultConfigNamespace,
 		},
 	}
-	ts.Server.Close()
+	ts.server.Close()
 	instances, err := controller.InstancesByPort(svc, 0, labels.Collection{})
 	if err == nil {
 		t.Error("Instances() should return error when client experiences connection problem")
@@ -276,8 +272,8 @@ func TestInstancesError(t *testing.T) {
 
 func TestGetService(t *testing.T) {
 	ts := newServer()
-	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	defer ts.server.Close()
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -298,13 +294,13 @@ func TestGetService(t *testing.T) {
 
 func TestGetServiceError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
-		ts.Server.Close()
+		ts.server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
 
-	ts.Server.Close()
+	ts.server.Close()
 	service, err := controller.GetService("productpage.service.consul")
 	if err == nil {
 		t.Error("GetService() should return error when client experiences connection problem")
@@ -316,8 +312,8 @@ func TestGetServiceError(t *testing.T) {
 
 func TestGetServiceBadHostname(t *testing.T) {
 	ts := newServer()
-	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	defer ts.server.Close()
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -333,8 +329,8 @@ func TestGetServiceBadHostname(t *testing.T) {
 
 func TestGetServiceNoInstances(t *testing.T) {
 	ts := newServer()
-	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	defer ts.server.Close()
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -350,57 +346,57 @@ func TestGetServiceNoInstances(t *testing.T) {
 
 func TestServices(t *testing.T) {
 	ts := newServer()
-	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	defer ts.server.Close()
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
 
 	services, err := controller.Services()
 	if err != nil {
-		t.Errorf("client encountered error during Services(): %v", err)
+		t.Errorf("client encountered error during services(): %v", err)
 	}
 	serviceMap := make(map[string]*model.Service)
 	for _, svc := range services {
 		name, err := parseHostname(svc.Hostname)
 		if err != nil {
-			t.Errorf("Services() error parsing hostname: %v", err)
+			t.Errorf("services() error parsing hostname: %v", err)
 		}
 		serviceMap[name] = svc
 	}
 
 	for _, name := range []string{"productpage", "reviews", "rating"} {
 		if _, exists := serviceMap[name]; !exists {
-			t.Errorf("Services() missing: %q", name)
+			t.Errorf("services() missing: %q", name)
 		}
 	}
 	if len(services) != 3 {
-		t.Errorf("Services() returned wrong # of services: %q, want 3", len(services))
+		t.Errorf("services() returned wrong # of services: %q, want 3", len(services))
 	}
 }
 
 func TestServicesError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
-		ts.Server.Close()
+		ts.server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
 
-	ts.Server.Close()
+	ts.server.Close()
 	services, err := controller.Services()
 	if err == nil {
-		t.Error("Services() should return error when client experiences connection problem")
+		t.Error("services() should return error when client experiences connection problem")
 	}
 	if len(services) != 0 {
-		t.Errorf("Services() returned wrong # of services: %q, want 0", len(services))
+		t.Errorf("services() returned wrong # of services: %q, want 0", len(services))
 	}
 }
 
 func TestGetProxyServiceInstances(t *testing.T) {
 	ts := newServer()
-	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	defer ts.server.Close()
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -421,13 +417,13 @@ func TestGetProxyServiceInstances(t *testing.T) {
 
 func TestGetProxyServiceInstancesError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
-		ts.Server.Close()
+		ts.server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
 
-	ts.Server.Close()
+	ts.server.Close()
 	instances, err := controller.GetProxyServiceInstances(&model.Proxy{IPAddresses: []string{"172.19.0.11"}})
 	if err == nil {
 		t.Error("GetProxyServiceInstances() should return error when client experiences connection problem")
@@ -439,8 +435,8 @@ func TestGetProxyServiceInstancesError(t *testing.T) {
 
 func TestGetProxyServiceInstancesWithMultiIPs(t *testing.T) {
 	ts := newServer()
-	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	defer ts.server.Close()
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -461,8 +457,8 @@ func TestGetProxyServiceInstancesWithMultiIPs(t *testing.T) {
 
 func TestGetProxyWorkloadLabels(t *testing.T) {
 	ts := newServer()
-	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	defer ts.server.Close()
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -473,7 +469,7 @@ func TestGetProxyWorkloadLabels(t *testing.T) {
 		expected labels.Collection
 	}{
 		{
-			name:     "Rating",
+			name:     "rating",
 			ips:      []string{"10.78.11.18", "172.19.0.12"},
 			expected: labels.Collection{{"version": "v1"}},
 		},
@@ -521,12 +517,12 @@ func TestGetProxyWorkloadLabels(t *testing.T) {
 
 func TestGetServiceByCache(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.Server.URL, 3*time.Second)
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
 	_, _ = controller.GetService("productpage.service.consul")
-	ts.Server.Close()
+	ts.server.Close()
 	service, err := controller.GetService("productpage.service.consul")
 	if err != nil {
 		t.Errorf("client encountered error during GetService(): %v", err)
@@ -543,8 +539,8 @@ func TestGetServiceByCache(t *testing.T) {
 
 func TestGetInstanceByCacheAfterChanged(t *testing.T) {
 	ts := newServer()
-	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, 1*time.Second)
+	defer ts.server.Close()
+	controller, err := NewController(ts.server.URL)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -572,8 +568,8 @@ func TestGetInstanceByCacheAfterChanged(t *testing.T) {
 		}
 	}
 
-	ts.Lock.Lock()
-	ts.Reviews = []*api.CatalogService{
+	ts.lock.Lock()
+	ts.reviews = []*api.CatalogService{
 		{
 			Node:           "istio-node",
 			Address:        "172.19.0.5",
@@ -585,9 +581,10 @@ func TestGetInstanceByCacheAfterChanged(t *testing.T) {
 			ServicePort:    9081,
 		},
 	}
-	ts.Lock.Unlock()
+	ts.consulIndex++
+	ts.lock.Unlock()
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(notifyThreshold)
 	instances, err = controller.InstancesByPort(svc, 0, labels.Collection{})
 	if err != nil {
 		t.Errorf("client encountered error during Instances(): %v", err)

--- a/pilot/pkg/serviceregistry/consul/monitor.go
+++ b/pilot/pkg/serviceregistry/consul/monitor.go
@@ -64,7 +64,7 @@ func (m *consulMonitor) Start(stop <-chan struct{}) {
 }
 
 func (m *consulMonitor) watchConsul(change chan struct{}, stop <-chan struct{}) {
-	var consulWaitIndex uint64 = 0
+	var consulWaitIndex uint64
 
 	for {
 		select {
@@ -99,7 +99,7 @@ func (m *consulMonitor) updateRecord(change <-chan struct{}, stop <-chan struct{
 		case <-ticker.C:
 			currentTime := time.Now().Unix()
 			if lastChange > 0 && currentTime-lastChange > int64(refreshIdleTime.Seconds()) {
-				log.Infof("########################### Consul service changed ##############################")
+				log.Infof("Consul service changed")
 				m.updateServiceRecord()
 				m.updateInstanceRecord()
 				lastChange = int64(0)

--- a/pilot/pkg/serviceregistry/consul/monitor.go
+++ b/pilot/pkg/serviceregistry/consul/monitor.go
@@ -15,8 +15,6 @@
 package consul
 
 import (
-	"reflect"
-	"sort"
 	"time"
 
 	"github.com/hashicorp/consul/api"
@@ -24,9 +22,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/pkg/log"
 )
-
-type consulServices map[string][]string
-type consulServiceInstances []*api.CatalogService
 
 // Monitor handles service and instance changes
 type Monitor interface {
@@ -42,111 +37,111 @@ type InstanceHandler func(instance *api.CatalogService, event model.Event) error
 type ServiceHandler func(instances []*api.CatalogService, event model.Event) error
 
 type consulMonitor struct {
-	discovery            *api.Client
-	instanceCachedRecord consulServiceInstances
-	serviceCachedRecord  consulServices
-	instanceHandlers     []InstanceHandler
-	serviceHandlers      []ServiceHandler
-	period               time.Duration
+	discovery        *api.Client
+	instanceHandlers []InstanceHandler
+	serviceHandlers  []ServiceHandler
 }
 
-// NewConsulMonitor polls for changes in Consul Services and CatalogServices
-func NewConsulMonitor(client *api.Client, period time.Duration) Monitor {
+const (
+	refreshIdleTime    time.Duration = 5 * time.Second
+	periodicCheckTime  time.Duration = 2 * time.Second
+	blockQueryWaitTime time.Duration = 10 * time.Minute
+)
+
+// NewConsulMonitor watches for changes in Consul services and CatalogServices
+func NewConsulMonitor(client *api.Client) Monitor {
 	return &consulMonitor{
-		discovery:            client,
-		period:               period,
-		instanceCachedRecord: make(consulServiceInstances, 0),
-		serviceCachedRecord:  make(consulServices),
-		instanceHandlers:     make([]InstanceHandler, 0),
-		serviceHandlers:      make([]ServiceHandler, 0),
+		discovery:        client,
+		instanceHandlers: make([]InstanceHandler, 0),
+		serviceHandlers:  make([]ServiceHandler, 0),
 	}
 }
 
 func (m *consulMonitor) Start(stop <-chan struct{}) {
-	m.run(stop)
+	change := make(chan struct{})
+	go m.watchConsul(change, stop)
+	go m.updateRecord(change, stop)
 }
 
-func (m *consulMonitor) run(stop <-chan struct{}) {
-	ticker := time.NewTicker(m.period)
+func (m *consulMonitor) watchConsul(change chan struct{}, stop <-chan struct{}) {
+	var consulWaitIndex uint64 = 0
+
 	for {
 		select {
 		case <-stop:
+			return
+		default:
+			queryOptions := api.QueryOptions{
+				WaitIndex: consulWaitIndex,
+				WaitTime:  blockQueryWaitTime,
+			}
+			// This Consul REST API will block until service changes or timeout
+			_, queryMeta, err := m.discovery.Catalog().Services(&queryOptions)
+			if err != nil {
+				log.Warnf("Could not fetch services: %v", err)
+			} else if consulWaitIndex != queryMeta.LastIndex {
+				consulWaitIndex = queryMeta.LastIndex
+				change <- struct{}{}
+			}
+			time.Sleep(periodicCheckTime)
+		}
+	}
+}
+
+func (m *consulMonitor) updateRecord(change <-chan struct{}, stop <-chan struct{}) {
+	lastChange := int64(0)
+	ticker := time.NewTicker(periodicCheckTime)
+
+	for {
+		select {
+		case <-change:
+			lastChange = time.Now().Unix()
+		case <-ticker.C:
+			currentTime := time.Now().Unix()
+			if lastChange > 0 && currentTime-lastChange > int64(refreshIdleTime.Seconds()) {
+				log.Infof("########################### Consul service changed ##############################")
+				m.updateServiceRecord()
+				m.updateInstanceRecord()
+				lastChange = int64(0)
+			}
+		case <-stop:
 			ticker.Stop()
 			return
-		case <-ticker.C:
-			m.updateServiceRecord()
-			m.updateInstanceRecord()
 		}
 	}
 }
 
 func (m *consulMonitor) updateServiceRecord() {
-	svcs, _, err := m.discovery.Catalog().Services(nil)
-	if err != nil {
-		log.Warnf("Could not fetch services: %v", err)
-		return
-	}
-
-	// The order of service tags may change even there is no service change
-	// Sort the service tags to avoid unnecessary pushes to envoy
-	for _, tags := range svcs {
-		sort.Strings(tags)
-	}
-	newRecord := consulServices(svcs)
-	if !reflect.DeepEqual(newRecord, m.serviceCachedRecord) {
-		// This is only a work-around solution currently
-		// Since Handler functions generally act as a refresher
-		// regardless of the input, thus passing in meaningless
-		// input should make functionalities work
-		//TODO
-		var obj []*api.CatalogService
-		var event model.Event
-		for _, f := range m.serviceHandlers {
-			go func(handler ServiceHandler) {
-				if err := handler(obj, event); err != nil {
-					log.Warnf("Error executing service handler function: %v", err)
-				}
-			}(f)
-		}
-		m.serviceCachedRecord = newRecord
+	// This is only a work-around solution currently
+	// Since Handler functions generally act as a refresher
+	// regardless of the input, thus passing in meaningless
+	// input should make functionalities work
+	//TODO
+	var obj []*api.CatalogService
+	var event model.Event
+	for _, f := range m.serviceHandlers {
+		go func(handler ServiceHandler) {
+			if err := handler(obj, event); err != nil {
+				log.Warnf("Error executing service handler function: %v", err)
+			}
+		}(f)
 	}
 }
 
 func (m *consulMonitor) updateInstanceRecord() {
-	svcs, _, err := m.discovery.Catalog().Services(nil)
-	if err != nil {
-		log.Warnf("Could not fetch instances: %v", err)
-		return
-	}
-
-	instances := make([]*api.CatalogService, 0)
-	for name := range svcs {
-		endpoints, _, err := m.discovery.Catalog().Service(name, "", nil)
-		if err != nil {
-			log.Warnf("Could not retrieve service catalog from consul: %v", err)
-			continue
-		}
-		instances = append(instances, endpoints...)
-	}
-
-	newRecord := consulServiceInstances(instances)
-	sort.Sort(newRecord)
-	if !reflect.DeepEqual(newRecord, m.instanceCachedRecord) {
-		// This is only a work-around solution currently
-		// Since Handler functions generally act as a refresher
-		// regardless of the input, thus passing in meaningless
-		// input should make functionalities work
-		// TODO
-		obj := &api.CatalogService{}
-		var event model.Event
-		for _, f := range m.instanceHandlers {
-			go func(handler InstanceHandler) {
-				if err := handler(obj, event); err != nil {
-					log.Warnf("Error executing instance handler function: %v", err)
-				}
-			}(f)
-		}
-		m.instanceCachedRecord = newRecord
+	// This is only a work-around solution currently
+	// Since Handler functions generally act as a refresher
+	// regardless of the input, thus passing in meaningless
+	// input should make functionalities work
+	// TODO
+	obj := &api.CatalogService{}
+	var event model.Event
+	for _, f := range m.instanceHandlers {
+		go func(handler InstanceHandler) {
+			if err := handler(obj, event); err != nil {
+				log.Warnf("Error executing instance handler function: %v", err)
+			}
+		}(f)
 	}
 }
 
@@ -156,21 +151,4 @@ func (m *consulMonitor) AppendServiceHandler(h ServiceHandler) {
 
 func (m *consulMonitor) AppendInstanceHandler(h InstanceHandler) {
 	m.instanceHandlers = append(m.instanceHandlers, h)
-}
-
-// Len of the array
-func (a consulServiceInstances) Len() int {
-	return len(a)
-}
-
-// Swap i and j
-func (a consulServiceInstances) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}
-
-// Less i and j
-func (a consulServiceInstances) Less(i, j int) bool {
-	// ID is the node ID
-	// ServiceID is a unique service instance identifier
-	return a[i].ID+a[i].ServiceID < a[j].ID+a[j].ServiceID
 }


### PR DESCRIPTION
Using watching can significantly reduce the CPU resource usage and the number of TIME_WAIT socket introduced by polling
Change-Id: I966690ecfaa79364997e94e81559acaab46d6a9d
Signed-off-by: Huabing Zhao <zhaohuabing@gmail.com>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
