### PR TITLE
Fix kind load time and flakes

### DIFF
--- a/prow/e2e-kind-suite.sh
+++ b/prow/e2e-kind-suite.sh
@@ -39,20 +39,25 @@ set -x
 source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
 
+function load_kind_images() {
+	# Archived local images and load it into KinD's docker daemon
+	# Kubernetes in KinD can only access local images from its docker daemon.
+	docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 kind --loglevel debug --name istio-testing load docker-image
+
+	# If a variant is specified, load those images as well.
+	# We should load non-variant images as well for things like `app` which do not use variants
+	if [[ "${VARIANT:-}" != "" ]]; then
+	  docker images "${HUB}/*:${TAG}-${VARIANT}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 kind --loglevel debug --name istio-testing load docker-image
+  fi
+}
+
 function build_kind_images() {
   # Build just the images needed for the tests
   for image in pilot proxyv2 app test_policybackend mixer citadel galley sidecar_injector kubectl node-agent-k8s; do
     DOCKER_BUILD_VARIANTS="${VARIANT:-default}" make docker.${image}
   done
-	# Archived local images and load it into KinD's docker daemon
-	# Kubernetes in KinD can only access local images from its docker daemon.
-	docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 -P16 kind --loglevel debug --name istio-testing load docker-image
 
-	# If a variant is specified, load those images as well.
-	# We should load non-variant images as well for things like `app` which do not use variants
-	if [[ "${VARIANT:-}" != "" ]]; then
-	  docker images "${HUB}/*:${TAG}-${VARIANT}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 -P16 kind --loglevel debug --name istio-testing load docker-image
-  fi
+  time load_kind_images
 }
 
 # getopts only handles single character flags

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -36,7 +36,7 @@ setup_and_export_git_sha
 function load_kind_images() {
 	# Archived local images and load it into KinD's docker daemon
 	# Kubernetes in KinD can only access local images from its docker daemon.
-	docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 kind --loglevel debug --name istio-testing load docker-image
+	docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 -P10 kind --loglevel debug --name istio-testing load docker-image
 }
 
 function build_kind_images() {

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -36,7 +36,7 @@ setup_and_export_git_sha
 function load_kind_images() {
 	# Archived local images and load it into KinD's docker daemon
 	# Kubernetes in KinD can only access local images from its docker daemon.
-	docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 -P10 kind --loglevel debug --name istio-testing load docker-image
+	docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 kind --loglevel debug --name istio-testing load docker-image
 }
 
 function build_kind_images() {


### PR DESCRIPTION
This was timing the entire docker build and load, not just the load.


Also, drop `-P16` as it may be contributing to flakes, and with the help of this PR I identified it does not increase speed of load. See https://github.com/kubernetes-sigs/kind/issues/921

[x] Test and Release
