### PR TITLE
When analyzing sidecar version, ignore explicit annotations on pods

### DIFF
--- a/galley/pkg/config/analysis/analyzers/injection/injection-version.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection-version.go
@@ -79,6 +79,12 @@ func (a *VersionAnalyzer) Analyze(c analysis.Context) {
 			return true
 		}
 
+		// If the pod has been annotated with a custom sidecar, then ignore as
+		// it always overrides the injector logic.
+		if r.Metadata.Annotations["sidecar.istio.io/proxyImage"] != "" {
+			return true
+		}
+
 		for _, container := range pod.Spec.Containers {
 			if container.Name != istioProxyName {
 				continue

--- a/galley/pkg/config/analysis/analyzers/testdata/injection-with-mismatched-sidecar.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/injection-with-mismatched-sidecar.yaml
@@ -49,6 +49,24 @@ spec:
   - image: docker.io/istio/proxyv2:1.3.1
     name: istio-proxy
 ---
+# details-v1-pod-overwritten-sidecar has a custom sidecar version injected and
+# therefore should not match the injector version.
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: details
+  annotations:
+    sidecar.istio.io/proxyImage: docker.io/istio/proxyv2:1.3.0-prerelease
+  name: details-v1-pod-overwritten-sidecar
+  namespace: enabled-namespace
+spec:
+  containers:
+  - image: docker.io/istio/examples-bookinfo-details-v2:1.15.0
+    name: details
+  - image: docker.io/istio/proxyv2:1.3.0-prerelease
+    name: istio-proxy
+---
 # Namespace 'default' does not have an explicit label, so no version checking should happen.
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
Fixes #17805

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
