### PR TITLE
Fix a nil dereference bug in analysis namespace filtering

### DIFF
--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -141,6 +141,7 @@ func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name
 	scope.Analysis.Debugf("Finished analyzing the current snapshot, found messages: %v", ctx.messages)
 
 	// Only keep messages for resources in namespaces we want to analyze
+	// If the message doesn't have an origin (meaning we can't determine the namespace) fail open and keep it
 	// If no such limit is specified, keep them all.
 	var msgs diag.Messages
 	if len(namespaces) == 0 {

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -147,9 +147,12 @@ func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name
 		msgs = ctx.messages
 	} else {
 		for _, m := range ctx.messages {
-			if _, ok := namespaces[m.Origin.Namespace()]; ok {
-				msgs = append(msgs, m)
+			if m.Origin != nil {
+				if _, ok := namespaces[m.Origin.Namespace()]; !ok {
+					continue
+				}
 			}
+			msgs = append(msgs, m)
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug introduced in #17869 where validation messages with no origin (meaning no namespace) cause a panic when we try to filter them.

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
