### PR TITLE
re-enable v2 integration test with updated proxy

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "3781be0e624470a4ee613c4ffc9816976f5dd701"
+    "lastStableSHA": "cd63c8174bcebb5552264939f952fefe0df107bf"
   },
   {
     "_comment": "",

--- a/tests/integration/telemetry/stats/prometheus/stats_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/stats_filter_test.go
@@ -115,8 +115,6 @@ func TestStatsFilter(t *testing.T) {
 	framework.NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			// TODO(bianpengyuan) https://github.com/istio/istio/issues/17811
-			ctx.Skip()
 			ingress := getIngressInstance()
 			addr := ingress.HTTPAddress()
 			url := fmt.Sprintf("http://%s/productpage", addr.String())

--- a/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
+++ b/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
@@ -6,7 +6,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_OUTBOUND
         listener:
           filterChain:
             filter:
@@ -19,6 +19,57 @@ spec:
           name: envoy.filters.http.wasm
           config:
             config:
+              root_id: stats_outbound
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio",
+                }
+              vm_config:
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.stats
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stats_inbound
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio",
+                }
+              vm_config:
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.stats
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stats_outbound
               configuration: |
                 {
                   "debug": "false",


### PR DESCRIPTION
Update proxy and attempt to re-enable e2e test for stats v2