### PR TITLE
Fix synthetic-service-entry push context init

### DIFF
--- a/pilot/pkg/config/coredatamodel/syntheticserviceentrycontroller.go
+++ b/pilot/pkg/config/coredatamodel/syntheticserviceentrycontroller.go
@@ -247,12 +247,14 @@ func (c *SyntheticServiceEntryController) configStoreUpdate(resources []*sink.Ob
 			}
 		}
 
-		// this is done before updating internal cache
-		oldEpVersion := c.endpointVersion(conf.Namespace, conf.Name)
-		newEpVersion := version(conf.Annotations, endpointKey)
-		if newEpVersion != "" && oldEpVersion != newEpVersion {
-			if err := c.edsUpdate(conf); err != nil {
-				log.Warnf("edsUpdate: %v", err)
+		if !svcChanged {
+			// this is done before updating internal cache
+			oldEpVersion := c.endpointVersion(conf.Namespace, conf.Name)
+			newEpVersion := version(conf.Annotations, endpointKey)
+			if newEpVersion != "" && oldEpVersion != newEpVersion {
+				if err := c.edsUpdate(conf); err != nil {
+					log.Warnf("edsUpdate: %v", err)
+				}
 			}
 		}
 	}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -778,7 +778,7 @@ func (ps *PushContext) updateContext(
 
 	for k := range pushReq.ConfigTypesUpdated {
 		switch k {
-		case schemas.ServiceEntry.Type:
+		case schemas.ServiceEntry.Type, schemas.SyntheticServiceEntry.Type:
 			servicesChanged = true
 		case schemas.DestinationRule.Type:
 			destinationRulesChanged = true


### PR DESCRIPTION
Please provide a description for what this PR is for.

This is to fix incremental SyntheticSE update. Without this, the push context is not right.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
