### PR TITLE
Sort messages before finishing analysis

### DIFF
--- a/galley/pkg/config/analysis/diag/helper_test.go
+++ b/galley/pkg/config/analysis/diag/helper_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diag
+
+type testOrigin string
+
+func (o testOrigin) FriendlyName() string {
+	return string(o)
+}
+
+func (o testOrigin) Namespace() string {
+	return ""
+}

--- a/galley/pkg/config/analysis/diag/level.go
+++ b/galley/pkg/config/analysis/diag/level.go
@@ -15,15 +15,22 @@
 package diag
 
 // Level is the severity level of a message.
-type Level string
+type Level struct {
+	severity int
+	name     string
+}
 
-const (
+func (l Level) String() string {
+	return l.name
+}
+
+var (
 	// Info level is for informational messages
-	Info Level = "Info"
+	Info Level = Level{2, "Info"}
 
 	// Warning level is for warning messages
-	Warning Level = "Warn"
+	Warning Level = Level{1, "Warn"}
 
 	// Error level is for error messages
-	Error Level = "Error"
+	Error Level = Level{0, "Error"}
 )

--- a/galley/pkg/config/analysis/diag/level.go
+++ b/galley/pkg/config/analysis/diag/level.go
@@ -16,8 +16,8 @@ package diag
 
 // Level is the severity level of a message.
 type Level struct {
-	severity int
-	name     string
+	sortOrder int
+	name      string
 }
 
 func (l Level) String() string {

--- a/galley/pkg/config/analysis/diag/level.go
+++ b/galley/pkg/config/analysis/diag/level.go
@@ -26,11 +26,11 @@ func (l Level) String() string {
 
 var (
 	// Info level is for informational messages
-	Info Level = Level{2, "Info"}
+	Info = Level{2, "Info"}
 
 	// Warning level is for warning messages
-	Warning Level = Level{1, "Warn"}
+	Warning = Level{1, "Warn"}
 
 	// Error level is for error messages
-	Error Level = Level{0, "Error"}
+	Error = Level{0, "Error"}
 )

--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -57,7 +57,7 @@ func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	result["code"] = m.Type.Code()
-	result["level"] = string(m.Type.Level())
+	result["level"] = fmt.Sprintf("%s", m.Type.Level())
 	if includeOrigin && m.Origin != nil {
 		result["origin"] = m.Origin.FriendlyName()
 	}

--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -57,7 +57,7 @@ func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	result["code"] = m.Type.Code()
-	result["level"] = fmt.Sprintf("%s", m.Type.Level())
+	result["level"] = m.Type.Level().String()
 	if includeOrigin && m.Origin != nil {
 		result["origin"] = m.Origin.FriendlyName()
 	}

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -20,16 +20,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type testOrigin string
-
-func (o testOrigin) FriendlyName() string {
-	return string(o)
-}
-
-func (o testOrigin) Namespace() string {
-	return ""
-}
-
 func TestMessage_String(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")

--- a/galley/pkg/config/analysis/diag/messages.go
+++ b/galley/pkg/config/analysis/diag/messages.go
@@ -27,25 +27,23 @@ func (ms *Messages) Add(m Message) {
 // Sort the message lexicographically by level, code, origin, then string.
 func (ms Messages) Sort() {
 	sort.Slice(ms, func(i, j int) bool {
+		a, b := ms[i], ms[j]
 		switch {
-		case ms[i].Type.Level() != ms[j].Type.Level():
-			return ms[i].Type.Level() < ms[j].Type.Level()
-		case ms[i].Type.Code() != ms[j].Type.Code():
-			return ms[i].Type.Code() < ms[j].Type.Code()
-		case ms[i].Origin.FriendlyName() != ms[j].Origin.FriendlyName():
-			return ms[i].Origin.FriendlyName() < ms[j].Origin.FriendlyName()
+		case a.Type.Level() != b.Type.Level():
+			return a.Type.Level().severity < b.Type.Level().severity
+		case a.Type.Code() != b.Type.Code():
+			return a.Type.Code() < b.Type.Code()
+		case a.Origin.FriendlyName() != b.Origin.FriendlyName():
+			return a.Origin.FriendlyName() < b.Origin.FriendlyName()
 		default:
-			return ms[i].String() < ms[j].String()
+			return a.String() < b.String()
 		}
 	})
 }
 
 // Return a different sorted Messages struct
 func (ms Messages) Sorted() Messages {
-	var newMs Messages
-	for _, val := range ms {
-		newMs.Add(val)
-	}
+	newMs := append(ms[:0:0], ms...)
 	newMs.Sort()
 	return newMs
 }

--- a/galley/pkg/config/analysis/diag/messages.go
+++ b/galley/pkg/config/analysis/diag/messages.go
@@ -30,7 +30,7 @@ func (ms *Messages) Sort() {
 		a, b := (*ms)[i], (*ms)[j]
 		switch {
 		case a.Type.Level() != b.Type.Level():
-			return a.Type.Level().severity < b.Type.Level().severity
+			return a.Type.Level().sortOrder < b.Type.Level().sortOrder
 		case a.Type.Code() != b.Type.Code():
 			return a.Type.Code() < b.Type.Code()
 		case a.Origin.FriendlyName() != b.Origin.FriendlyName():

--- a/galley/pkg/config/analysis/diag/messages.go
+++ b/galley/pkg/config/analysis/diag/messages.go
@@ -14,10 +14,38 @@
 
 package diag
 
+import "sort"
+
 // Messages is a slice of Message items.
 type Messages []Message
 
 // Add a new message to the messages
 func (ms *Messages) Add(m Message) {
 	*ms = append(*ms, m)
+}
+
+// Sort the message lexicographically by level, code, origin, then string.
+func (ms Messages) Sort() {
+	sort.Slice(ms, func(i, j int) bool {
+		switch {
+		case ms[i].Type.Level() != ms[j].Type.Level():
+			return ms[i].Type.Level() < ms[j].Type.Level()
+		case ms[i].Type.Code() != ms[j].Type.Code():
+			return ms[i].Type.Code() < ms[j].Type.Code()
+		case ms[i].Origin.FriendlyName() != ms[j].Origin.FriendlyName():
+			return ms[i].Origin.FriendlyName() < ms[j].Origin.FriendlyName()
+		default:
+			return ms[i].String() < ms[j].String()
+		}
+	})
+}
+
+// Return a different sorted Messages struct
+func (ms Messages) Sorted() Messages {
+	var newMs Messages
+	for _, val := range ms {
+		newMs.Add(val)
+	}
+	newMs.Sort()
+	return newMs
 }

--- a/galley/pkg/config/analysis/diag/messages.go
+++ b/galley/pkg/config/analysis/diag/messages.go
@@ -25,9 +25,9 @@ func (ms *Messages) Add(m Message) {
 }
 
 // Sort the message lexicographically by level, code, origin, then string.
-func (ms Messages) Sort() {
-	sort.Slice(ms, func(i, j int) bool {
-		a, b := ms[i], ms[j]
+func (ms *Messages) Sort() {
+	sort.Slice(*ms, func(i, j int) bool {
+		a, b := (*ms)[i], (*ms)[j]
 		switch {
 		case a.Type.Level() != b.Type.Level():
 			return a.Type.Level().severity < b.Type.Level().severity
@@ -42,8 +42,8 @@ func (ms Messages) Sort() {
 }
 
 // Return a different sorted Messages struct
-func (ms Messages) Sorted() Messages {
-	newMs := append(ms[:0:0], ms...)
+func (ms *Messages) SortedCopy() Messages {
+	newMs := append((*ms)[:0:0], *ms...)
 	newMs.Sort()
 	return newMs
 }

--- a/galley/pkg/config/analysis/diag/messages_test.go
+++ b/galley/pkg/config/analysis/diag/messages_test.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diag
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestMessages_Sort(t *testing.T) {
+	g := NewGomegaWithT(t)
+	var msgs Messages
+	firstMsg := NewMessage(
+		NewMessageType(Error, "B1", "Template: %q"),
+		testOrigin("B"),
+		"B",
+	)
+	secondMsg := NewMessage(
+		NewMessageType(Warning, "A1", "Template: %q"),
+		testOrigin("B"),
+		"B",
+	)
+	thirdMsg := NewMessage(
+		NewMessageType(Warning, "B1", "Template: %q"),
+		testOrigin("A"),
+		"B",
+	)
+	fourthMsg := NewMessage(
+		NewMessageType(Warning, "B1", "Template: %q"),
+		testOrigin("B"),
+		"A",
+	)
+	fifthMsg := NewMessage(
+		NewMessageType(Warning, "B1", "Template: %q"),
+		testOrigin("B"),
+		"B",
+	)
+	msgs.Add(fifthMsg)
+	msgs.Add(fourthMsg)
+	msgs.Add(thirdMsg)
+	msgs.Add(secondMsg)
+	msgs.Add(firstMsg)
+
+	g.Expect(msgs[0]).To(Equal(fifthMsg))
+
+	msgs.Sort()
+
+	g.Expect(msgs[0]).To(Equal(firstMsg))
+	g.Expect(msgs[1]).To(Equal(secondMsg))
+	g.Expect(msgs[2]).To(Equal(thirdMsg))
+	g.Expect(msgs[3]).To(Equal(fourthMsg))
+	g.Expect(msgs[4]).To(Equal(fifthMsg))
+}
+
+func TestMessages_Sorted(t *testing.T) {
+	g := NewGomegaWithT(t)
+	var msgs Messages
+	firstMsg := NewMessage(
+		NewMessageType(Error, "B1", "Template: %q"),
+		testOrigin("B"),
+		"B",
+	)
+	secondMsg := NewMessage(
+		NewMessageType(Warning, "A1", "Template: %q"),
+		testOrigin("B"),
+		"B",
+	)
+	msgs.Add(secondMsg)
+	msgs.Add(firstMsg)
+
+	newMsgs := msgs.Sorted()
+
+	g.Expect(msgs[0]).To(Equal(secondMsg))
+	g.Expect(msgs[1]).To(Equal(firstMsg))
+
+	g.Expect(newMsgs[0]).To(Equal(firstMsg))
+	g.Expect(newMsgs[1]).To(Equal(secondMsg))
+}

--- a/galley/pkg/config/analysis/diag/messages_test.go
+++ b/galley/pkg/config/analysis/diag/messages_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestMessages_Sort(t *testing.T) {
 	g := NewGomegaWithT(t)
-	var msgs Messages
+
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
 		testOrigin("B"),
@@ -48,26 +48,18 @@ func TestMessages_Sort(t *testing.T) {
 		testOrigin("B"),
 		"B",
 	)
-	msgs.Add(fifthMsg)
-	msgs.Add(fourthMsg)
-	msgs.Add(thirdMsg)
-	msgs.Add(secondMsg)
-	msgs.Add(firstMsg)
 
-	g.Expect(msgs[0]).To(Equal(fifthMsg))
+	msgs := Messages{fifthMsg, fourthMsg, thirdMsg, secondMsg, firstMsg}
+	expectedMsgs := Messages{firstMsg, secondMsg, thirdMsg, fourthMsg, fifthMsg}
 
 	msgs.Sort()
 
-	g.Expect(msgs[0]).To(Equal(firstMsg))
-	g.Expect(msgs[1]).To(Equal(secondMsg))
-	g.Expect(msgs[2]).To(Equal(thirdMsg))
-	g.Expect(msgs[3]).To(Equal(fourthMsg))
-	g.Expect(msgs[4]).To(Equal(fifthMsg))
+	g.Expect(msgs).To(Equal(expectedMsgs))
 }
 
 func TestMessages_Sorted(t *testing.T) {
 	g := NewGomegaWithT(t)
-	var msgs Messages
+
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
 		testOrigin("B"),
@@ -78,14 +70,13 @@ func TestMessages_Sorted(t *testing.T) {
 		testOrigin("B"),
 		"B",
 	)
-	msgs.Add(secondMsg)
-	msgs.Add(firstMsg)
+
+	msgs := Messages{secondMsg, firstMsg}
+	sameMsgs := Messages{secondMsg, firstMsg}
+	expectedMsgs := Messages{firstMsg, secondMsg}
 
 	newMsgs := msgs.Sorted()
 
-	g.Expect(msgs[0]).To(Equal(secondMsg))
-	g.Expect(msgs[1]).To(Equal(firstMsg))
-
-	g.Expect(newMsgs[0]).To(Equal(firstMsg))
-	g.Expect(newMsgs[1]).To(Equal(secondMsg))
+	g.Expect(msgs).To(Equal(sameMsgs))
+	g.Expect(newMsgs).To(Equal(expectedMsgs))
 }

--- a/galley/pkg/config/analysis/diag/messages_test.go
+++ b/galley/pkg/config/analysis/diag/messages_test.go
@@ -57,7 +57,7 @@ func TestMessages_Sort(t *testing.T) {
 	g.Expect(msgs).To(Equal(expectedMsgs))
 }
 
-func TestMessages_Sorted(t *testing.T) {
+func TestMessages_SortedCopy(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	firstMsg := NewMessage(
@@ -75,7 +75,7 @@ func TestMessages_Sorted(t *testing.T) {
 	sameMsgs := Messages{secondMsg, firstMsg}
 	expectedMsgs := Messages{firstMsg, secondMsg}
 
-	newMsgs := msgs.Sorted()
+	newMsgs := msgs.SortedCopy()
 
 	g.Expect(msgs).To(Equal(sameMsgs))
 	g.Expect(newMsgs).To(Equal(expectedMsgs))

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -156,6 +156,7 @@ func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name
 			msgs = append(msgs, m)
 		}
 	}
+	msgs = msgs.Sorted()
 
 	if !ctx.Canceled() {
 		d.s.StatusUpdater.Update(msgs)

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -156,10 +156,9 @@ func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name
 			msgs = append(msgs, m)
 		}
 	}
-	msgs = msgs.Sorted()
 
 	if !ctx.Canceled() {
-		d.s.StatusUpdater.Update(msgs)
+		d.s.StatusUpdater.Update(msgs.Sorted())
 	}
 
 	// Execution only reaches this point for trigger snapshot group

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -158,7 +158,7 @@ func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name
 	}
 
 	if !ctx.Canceled() {
-		d.s.StatusUpdater.Update(msgs.Sorted())
+		d.s.StatusUpdater.Update(msgs.SortedCopy())
 	}
 
 	// Execution only reaches this point for trigger snapshot group

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -163,6 +163,48 @@ func TestAnalyzeNamespaceMessageHasNoOrigin(t *testing.T) {
 	g.Expect(u.messages).To(HaveLen(1))
 }
 
+func TestAnalyzeSortsMessages(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	u := &updaterMock{}
+	o1 := &rt.Origin{
+		Collection: data.Collection1,
+		Name:       resource.NewName("includedNamespace", "r2"),
+	}
+	o2 := &rt.Origin{
+		Collection: data.Collection1,
+		Name:       resource.NewName("includedNamespace", "r1"),
+	}
+	a := &analyzerMock{
+		collectionToAccess: data.Collection1,
+		entriesToReport: []*resource.Entry{
+			{Origin: o1},
+			{Origin: o2},
+		},
+	}
+	d := NewInMemoryDistributor()
+
+	settings := AnalyzingDistributorSettings{
+		StatusUpdater:      u,
+		Analyzer:           analysis.Combine("testCombined", a),
+		Distributor:        d,
+		AnalysisSnapshots:  []string{metadata.Default},
+		TriggerSnapshot:    metadata.Default,
+		CollectionReporter: nil,
+		AnalysisNamespaces: []string{"includedNamespace"},
+	}
+	ad := NewAnalyzingDistributor(settings)
+
+	sDefault := getTestSnapshot()
+
+	ad.Distribute(metadata.Default, sDefault)
+
+	g.Eventually(func() []*Snapshot { return a.analyzeCalls }).Should(ConsistOf(sDefault))
+	g.Expect(u.messages).To(HaveLen(2))
+	g.Expect(u.messages[0].Origin).To(Equal(o2))
+	g.Expect(u.messages[1].Origin).To(Equal(o1))
+}
+
 func getTestSnapshot(names ...string) *Snapshot {
 	c := make([]*coll.Instance, 0)
 	for _, name := range names {


### PR DESCRIPTION
Right now the output when running istioctl x analyze depends on what
order the analyzers run in, which isn't ideal. This adds a Sort function
to the Messages struct which will sort by the fields that happen to
occur on the log line right now, then calls it in the
analyzingdistributor. Fixes #17809.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
