### PR TITLE
Do not remove pod labels immediately on deletion timestamp being set, fixes #17913

### DIFF
--- a/pilot/pkg/serviceregistry/kube/pod.go
+++ b/pilot/pkg/serviceregistry/kube/pod.go
@@ -87,19 +87,9 @@ func (pc *PodCache) event(obj interface{}, ev model.Event) error {
 			}
 		case model.EventUpdate:
 			if pod.DeletionTimestamp != nil {
-				// we need to wait at least until the grace period before we start removing labels and, by proxy,
-				// listeners from the pod.
-				var gracePeriodSecs int64
-				switch {
-				case pod.DeletionGracePeriodSeconds != nil:
-					gracePeriodSecs = *pod.DeletionGracePeriodSeconds
-				case pod.Spec.TerminationGracePeriodSeconds != nil:
-					gracePeriodSecs = *pod.Spec.TerminationGracePeriodSeconds
-				default:
-					gracePeriodSecs = 30
-				}
-				expiry := pod.DeletionTimestamp.Add(time.Duration(gracePeriodSecs) * time.Second)
-				if time.Now().After(expiry) {
+				// we need to wait at least until the current time is later than the deletion timestamp
+				// to truly consider the pod deleted.
+				if time.Now().After(pod.DeletionTimestamp.Time) {
 					// delete only if this pod was in the cache
 					if pc.keys[ip] == key {
 						delete(pc.keys, ip)


### PR DESCRIPTION
This change does not remove pod labels immediately when the pod is deleted.
Doing so causes the pod's inbound listeners to be removed and the pod unable
to accept incoming traffic during its shutdown sequence.

Instead, we only remove pod labels once the pod is deleted AND its deletion
grace period has expired.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
