### PR TITLE
Send partial update on scale to zero endpoints

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -465,11 +465,11 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 			if svcShards == 0 {
 				delete(s.EndpointShardsByService[serviceName], namespace)
 			}
-			adsLog.Infof("Full push, service %s has no endpoints", serviceName)
+			adsLog.Infof("Incremental push, service %s has no endpoints", serviceName)
 			s.ConfigUpdate(&model.PushRequest{
-				Full:               true,
-				NamespacesUpdated:  map[string]struct{}{namespace: {}},
-				ConfigTypesUpdated: map[string]struct{}{schemas.ServiceEntry.Type: {}},
+				Full:              false,
+				NamespacesUpdated: map[string]struct{}{namespace: {}},
+				EdsUpdates:        map[string]struct{}{serviceName: {}},
 			})
 		}
 		return

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -417,7 +417,9 @@ func edsUpdateInc(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 	// Wipe out all endpoints - expect full
 	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc, "", []*model.IstioEndpoint{})
 
-	edsFullUpdateCheck(adsc, t)
+	if upd, err := adsc.Wait(15*time.Second, "eds"); err != nil {
+		t.Fatal("Expecting EDS update as part of a partial push", err, upd)
+	}
 
 	lbe := adsc.GetEndpoints()["outbound|8080||eds.test.svc.cluster.local"]
 	if len(lbe.Endpoints) != 0 {


### PR DESCRIPTION
https://github.com/istio/istio/pull/16967 introduced a change to do a
full push on scale to zero, but actually I think we can do a partial
push, so we just send an empty EDS set.

I am concerned about a case where a pod is flapping between ready/not
ready and sending tons of full push events. Now this will only send EDS
push.

[x] Networking
