### PR TITLE
Do not remove pod immediately on deletion timestamp being set

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -90,11 +91,24 @@ func (pc *PodCache) event(obj interface{}, ev model.Event) error {
 			}
 		case model.EventUpdate:
 			if pod.DeletionTimestamp != nil {
-				// delete only if this pod was in the cache
-				if pc.podsByIP[ip] == key {
-					delete(pc.podsByIP, ip)
+				// we need to wait at least until the grace period before we remove the pod.
+				var gracePeriodSecs int64
+				switch {
+				case pod.DeletionGracePeriodSeconds != nil:
+					gracePeriodSecs = *pod.DeletionGracePeriodSeconds
+				case pod.Spec.TerminationGracePeriodSeconds != nil:
+					gracePeriodSecs = *pod.Spec.TerminationGracePeriodSeconds
+				default:
+					gracePeriodSecs = 30
 				}
-				return nil
+				expiry := pod.DeletionTimestamp.Add(time.Duration(gracePeriodSecs) * time.Second)
+				if time.Now().After(expiry) {
+					// delete only if this pod was in the cache
+					if pc.podsByIP[ip] == key {
+						delete(pc.podsByIP, ip)
+					}
+					return nil
+				}
 			}
 			switch pod.Status.Phase {
 			case v1.PodPending, v1.PodRunning:


### PR DESCRIPTION
This is the same fix as #17955 but on master. The code on the 1.2 branch and master are
different and the same commit cannot be cherry-picked for backport.

This change does not remove the pod immediately after it is deleted.
Doing so causes the pod's inbound listeners to be removed and the pod unable
to accept incoming traffic during its shutdown sequence.

Instead, we only remove once the pod is deleted AND its deletion
grace period has expired.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
