### PR TITLE
do not create global destination rule when automtls enabled

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
@@ -16,6 +16,7 @@ metadata:
 spec:
   peers:
   - mtls: {}
+{{- if not .Values.global.mtls.auto }}
 ---
 # Corresponding destination rule to configure client side to use mutual TLS when talking to
 # any service (host) in the mesh.
@@ -60,4 +61,5 @@ spec:
   trafficPolicy:
     tls:
       mode: DISABLE
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Please provide a description for what this PR is for.
global DestinationRule is not required when automTLS is enabled

related PR: https://github.com/istio/istio/pull/17621

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure