### PR TITLE
Check wildcards when trying to match VS to ServiceEntries, fixes #17976

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -171,6 +171,7 @@ var testGrid = []testCase{
 		analyzer:   &virtualservice.DestinationHostAnalyzer{},
 		expected: []message{
 			{msg.ReferencedResourceNotFound, "VirtualService reviews-bogushost.default"},
+			{msg.ReferencedResourceNotFound, "VirtualService reviews-bookinfo-other.default"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/auth/serviceroleservices.go
+++ b/galley/pkg/config/analysis/analyzers/auth/serviceroleservices.go
@@ -74,7 +74,7 @@ func (s *ServiceRoleServicesAnalyzer) buildNamespaceServiceMap(ctx analysis.Cont
 
 	ctx.ForEach(metadata.K8SCoreV1Services, func(r *resource.Entry) bool {
 		rns, rs := r.Metadata.Name.InterpretAsNamespaceAndName()
-		nsm[rns] = append(nsm[rns], util.GetScopedFqdnHostname(rns, rns, rs))
+		nsm[rns] = append(nsm[rns], util.NewScopedFqdn(rns, rns, rs))
 		return true
 	})
 

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
@@ -14,6 +14,15 @@ spec:
   - external-reviews.org
 ---
 apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: service-entry-bookinfo
+  namespace: default
+spec:
+  hosts:
+  - "*.eu.bookinfo.com"
+---
+apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: reviews
@@ -60,3 +69,25 @@ spec:
     - destination:
         host: external-reviews.org  # Referring to a ServiceEntry host is valid and should not generate an error
                                     # Since this is an "external" service, subset is omitted
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-bookinfo-eu
+  namespace: default
+spec:
+  http:
+  - route:
+    - destination:
+        host: reviews.eu.bookinfo.com # Should match *.eu.bookinfo.com
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-bookinfo-eu-wildcard
+  namespace: default
+spec:
+  http:
+  - route:
+    - destination:
+        host: "*.eu.bookinfo.com" # Should match *.eu.bookinfo.com

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
@@ -23,6 +23,17 @@ spec:
   - "*.eu.bookinfo.com"
 ---
 apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: service-entry-bookinfo
+  namespace: default-ignore
+spec:
+  exportTo:
+    - "."
+  hosts:
+  - "*" # This ServiceEntry should not match any instance as it isn't exported to other namespaces
+---
+apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: reviews

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
@@ -25,13 +25,24 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: service-entry-bookinfo
+  name: service-entry-ignore
   namespace: default-ignore
 spec:
   exportTo:
     - "."
   hosts:
   - "*" # This ServiceEntry should not match any instance as it isn't exported to other namespaces
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: service-entry-other
+  namespace: other
+spec:
+  exportTo:
+    - "."
+  hosts:
+  - "other.bookinfo.com" # This ServiceEntry should not match any instance as it isn't exported to other namespaces
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -102,3 +113,14 @@ spec:
   - route:
     - destination:
         host: "*.eu.bookinfo.com" # Should match *.eu.bookinfo.com
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-bookinfo-other
+  namespace: default
+spec:
+  http:
+  - route:
+    - destination:
+        host: other.bookinfo.com # Should generate validation error, the SE is in another namespace

--- a/galley/pkg/config/analysis/analyzers/util/hosts.go
+++ b/galley/pkg/config/analysis/analyzers/util/hosts.go
@@ -28,6 +28,12 @@ func (s ScopedFqdn) GetScopedNamespaceAndName() (string, string) {
 	return parts[0], parts[1]
 }
 
+// NewScopedFqdn converts the passed host to FQDN if needed and applies the passed scope.
+func NewScopedFqdn(scope, namespace, host string) ScopedFqdn {
+	name := convertHostToFQDN(namespace, host)
+	return ScopedFqdn(scope + "/" + name)
+}
+
 // GetResourceNameFromHost figures out the resource.Name to look up from the provided host string
 // We need to handle two possible formats: short name and FQDN
 // https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#Destination
@@ -50,18 +56,6 @@ func getNamespaceAndNameFromFQDN(fqdn string) (string, string) {
 		return "", ""
 	}
 	return result[0][2], result[0][1]
-}
-
-// GetScopedFqdnHostname converts the passed host to FQDN if needed and applies the passed scope.
-func GetScopedFqdnHostname(scope, namespace, host string) ScopedFqdn {
-	name := convertHostToFQDN(namespace, host)
-	return ScopedFqdn(scope + "/" + name)
-}
-
-// GetScopedNamespaceAndName splits ScopedFqdn back to scope namespace and host
-func (s ScopedFqdn) GetScopedNamespaceAndName() (string, string) {
-	parts := strings.Split(string(s), "/")
-	return parts[0], parts[1]
 }
 
 func convertHostToFQDN(namespace, host string) string {

--- a/galley/pkg/config/analysis/analyzers/util/hosts.go
+++ b/galley/pkg/config/analysis/analyzers/util/hosts.go
@@ -58,6 +58,12 @@ func GetScopedFqdnHostname(scope, namespace, host string) ScopedFqdn {
 	return ScopedFqdn(scope + "/" + name)
 }
 
+// GetScopedNamespaceAndName splits ScopedFqdn back to scope namespace and host
+func (s ScopedFqdn) GetScopedNamespaceAndName() (string, string) {
+	parts := strings.Split(string(s), "/")
+	return parts[0], parts[1]
+}
+
 func convertHostToFQDN(namespace, host string) string {
 	fqdn := host
 	// Convert to FQDN only if host is not a wildcard or a FQDN

--- a/galley/pkg/config/analysis/analyzers/util/hosts_test.go
+++ b/galley/pkg/config/analysis/analyzers/util/hosts_test.go
@@ -39,32 +39,32 @@ func TestGetScopedFqdnHostname(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	// FQDN, same namespace, local scope
-	g.Expect(GetScopedFqdnHostname("default", "default", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("default", "default", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
 	// FQDN, cross namespace, local scope
-	g.Expect(GetScopedFqdnHostname("default", "other", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("default", "other", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
 	// FQDN, same namespace, all namespaces scope
-	g.Expect(GetScopedFqdnHostname("*", "default", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("*", "default", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
 	// FQDN, cross namespace, all namespaces scope
-	g.Expect(GetScopedFqdnHostname("*", "other", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("*", "other", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
 
 	// short name, same namespace, local scope
-	g.Expect(GetScopedFqdnHostname("default", "default", "foo")).To(Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("default", "default", "foo")).To(Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
 	// short name, same namespace, all namespaces scope
-	g.Expect(GetScopedFqdnHostname("*", "default", "foo")).To(Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("*", "default", "foo")).To(Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
 
 	// wildcard, local scope
-	g.Expect(GetScopedFqdnHostname("foo", "foo", "*")).To(Equal(ScopedFqdn("foo/*")))
+	g.Expect(NewScopedFqdn("foo", "foo", "*")).To(Equal(ScopedFqdn("foo/*")))
 	// wildcard sub domain, local scope
-	g.Expect(GetScopedFqdnHostname("foo", "foo", "*.xyz.abc")).To(Equal(ScopedFqdn("foo/*.xyz.abc")))
+	g.Expect(NewScopedFqdn("foo", "foo", "*.xyz.abc")).To(Equal(ScopedFqdn("foo/*.xyz.abc")))
 	// wildcard, all namespaces scope
-	g.Expect(GetScopedFqdnHostname("*", "foo", "*")).To(Equal(ScopedFqdn("*/*")))
+	g.Expect(NewScopedFqdn("*", "foo", "*")).To(Equal(ScopedFqdn("*/*")))
 	// wildcard sub domain, all namespaces scope
-	g.Expect(GetScopedFqdnHostname("*", "foo", "*.xyz.abc")).To(Equal(ScopedFqdn("*/*.xyz.abc")))
+	g.Expect(NewScopedFqdn("*", "foo", "*.xyz.abc")).To(Equal(ScopedFqdn("*/*.xyz.abc")))
 
 	// external host, local scope
-	g.Expect(GetScopedFqdnHostname("foo", "foo", "xyz.abc")).To(Equal(ScopedFqdn("foo/xyz.abc")))
+	g.Expect(NewScopedFqdn("foo", "foo", "xyz.abc")).To(Equal(ScopedFqdn("foo/xyz.abc")))
 	// external host, all namespaces scope
-	g.Expect(GetScopedFqdnHostname("*", "foo", "xyz.abc")).To(Equal(ScopedFqdn("*/xyz.abc")))
+	g.Expect(NewScopedFqdn("*", "foo", "xyz.abc")).To(Equal(ScopedFqdn("*/xyz.abc")))
 }
 
 func TestScopedFqdn_GetScopedNamespaceAndName(t *testing.T) {

--- a/galley/pkg/config/analysis/analyzers/virtualservice/conflictingmeshgatewayhosts.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/conflictingmeshgatewayhosts.go
@@ -92,7 +92,7 @@ func initMeshGatewayHosts(ctx analysis.Context) map[util.ScopedFqdn][]*resource.
 			}
 
 			for _, h := range vs.Hosts {
-				scopedFqdn := util.GetScopedFqdnHostname(hostsNamespaceScope, vsNamespace, h)
+				scopedFqdn := util.NewScopedFqdn(hostsNamespaceScope, vsNamespace, h)
 				vsNames := hostsVirtualServices[scopedFqdn]
 				if len(vsNames) == 0 {
 					hostsVirtualServices[scopedFqdn] = []*resource.Entry{r}

--- a/galley/pkg/config/analysis/analyzers/virtualservice/destinationhosts.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/destinationhosts.go
@@ -83,13 +83,13 @@ func (d *DestinationHostAnalyzer) checkDestinationHost(vsNamespace string, desti
 	// Check explicitly defined ServiceEntries as well as services discovered from the platform
 
 	// ServiceEntries can be either namespace scoped or exposed to all namespaces
-	nsScopedFqdn := util.GetScopedFqdnHostname(vsNamespace, vsNamespace, host)
+	nsScopedFqdn := util.NewScopedFqdn(vsNamespace, vsNamespace, host)
 	if _, ok := serviceEntryHosts[nsScopedFqdn]; ok {
 		return true
 	}
 
 	// Check ServiceEntries which are exposed to all namespaces
-	allNsScopedFqdn := util.GetScopedFqdnHostname(util.ExportToAllNamespaces, vsNamespace, host)
+	allNsScopedFqdn := util.NewScopedFqdn(util.ExportToAllNamespaces, vsNamespace, host)
 	if _, ok := serviceEntryHosts[allNsScopedFqdn]; ok {
 		return true
 	}
@@ -129,7 +129,7 @@ func initServiceEntryHostNames(ctx analysis.Context) (map[util.ScopedFqdn]bool, 
 			hostsNamespaceScope = util.ExportToAllNamespaces
 		}
 		for _, h := range s.GetHosts() {
-			scopedHost := util.GetScopedFqdnHostname(hostsNamespaceScope, ns, h)
+			scopedHost := util.NewScopedFqdn(hostsNamespaceScope, ns, h)
 			if strings.HasPrefix(h, "*") {
 				wildcardHosts = append(wildcardHosts, scopedHost)
 			}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fixing issue #17976, wildcard ServiceEnties can still match exact hosts in VirtualServices.

[x ] User Experience
