### PR TITLE
Fix validation test on Kubernetes 1.16

### DIFF
--- a/tests/integration/galley/validation_test.go
+++ b/tests/integration/galley/validation_test.go
@@ -83,7 +83,8 @@ func TestValidation(t *testing.T) {
 				// k8s typed errors.
 				return strings.Contains(err.Error(), "denied the request") ||
 					strings.Contains(err.Error(), "error validating data") ||
-					strings.Contains(err.Error(), "Invalid value")
+					strings.Contains(err.Error(), "Invalid value") ||
+					strings.Contains(err.Error(), "is invalid")
 			}
 
 			for _, d := range dataset {


### PR DESCRIPTION
I guess they must have changed the validation error message for k8s
1.16, so this was failing.

See https://testgrid.k8s.io/istio_istio_postsubmit#integ-k8s-116_istio_postsubmit&width=20&exclude-non-failed-tests=

