### PR TITLE
fix galley validation key/cert rotation

### DIFF
--- a/galley/pkg/crd/validation/validation.go
+++ b/galley/pkg/crd/validation/validation.go
@@ -29,7 +29,6 @@ import (
 	"istio.io/pkg/probe"
 
 	mixervalidate "istio.io/istio/mixer/pkg/validate"
-	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/kube"
 )
@@ -73,7 +72,7 @@ func webhookHTTPSHandlerReady(client httpClient, vc *WebhookParameters) error {
 }
 
 //RunValidation start running Galley validation mode
-func RunValidation(ready, stopCh chan struct{}, vc *WebhookParameters, kubeConfig string,
+func RunValidation(ready chan<- struct{}, stopCh chan struct{}, vc *WebhookParameters, kubeConfig string,
 	livenessProbeController, readinessProbeController probe.Controller) {
 	log.Infof("Galley validation started with\n%s", vc)
 	mixerValidator := mixervalidate.NewDefaultValidator(false)
@@ -137,8 +136,6 @@ func RunValidation(ready, stopCh chan struct{}, vc *WebhookParameters, kubeConfi
 
 	go wh.Run(ready, stopCh)
 	defer wh.Stop()
-
-	cmd.WaitSignal(stopCh)
 }
 
 // isDNS1123Label tests for a string that conforms to the definition of a label in

--- a/galley/pkg/crd/validation/validation.go
+++ b/galley/pkg/crd/validation/validation.go
@@ -113,13 +113,13 @@ func RunValidation(ready chan<- struct{}, stopCh chan struct{}, vc *WebhookParam
 			for {
 				if err := webhookHTTPSHandlerReady(client, vc); err != nil {
 					validationReadinessProbe.SetAvailable(errors.New("not ready"))
-					scope.Infof("https handler for validation webhook is not ready: %v", err)
+					scope.Infof("https handler for validation webhook is not ready: %v\n", err)
 					ready = false
 				} else {
 					validationReadinessProbe.SetAvailable(nil)
 
 					if !ready {
-						scope.Info("https handler for validation webhook is ready")
+						scope.Info("https handler for validation webhook is ready\n")
 						ready = true
 					}
 				}
@@ -135,7 +135,6 @@ func RunValidation(ready chan<- struct{}, stopCh chan struct{}, vc *WebhookParam
 	}
 
 	go wh.Run(ready, stopCh)
-	defer wh.Stop()
 }
 
 // isDNS1123Label tests for a string that conforms to the definition of a label in

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -223,6 +223,11 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 		return nil, err
 	}
 
+	// This is not strictly necessary, but is a workaround for having the dashboard pass. The migration
+	// to OpenCensus metrics means that zero value metrics are not exported, and the dashboard tests
+	// expect data for metrics.
+	reportValidationCertKeyUpdate()
+
 	// Configuration must be updated whenever the caBundle changes. Watch the parent directory of
 	// the target files so we can catch symlink updates of k8s secrets.
 	keyCertWatcher, err := fsnotify.NewWatcher()

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -17,6 +17,7 @@ package validation
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -213,7 +214,21 @@ func (wh *Webhook) reloadKeyCert() {
 	wh.mu.Unlock()
 
 	reportValidationCertKeyUpdate()
+
 	scope.Info("Cert and Key reloaded")
+	var i int
+	for _, cert := range pair.Certificate {
+		if x509Cert, err := x509.ParseCertificates(cert); err != nil {
+			scope.Infof("x509 cert [%] - ParseCertificates() error: %v\n", i, err)
+			i++
+		} else {
+			for _, c := range x509Cert {
+				scope.Infof("x509 cert [%] - SN: %q, NotBefore: %q, NotAfter: %q\n",
+					c.SerialNumber, c.NotBefore, c.NotAfter)
+				i++
+			}
+		}
+	}
 }
 
 // NewWebhook creates a new instance of the admission webhook controller.

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/howeyc/fsnotify"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -173,6 +175,8 @@ func DefaultArgs() *WebhookParameters {
 
 // Webhook implements the validating admission webhook for validating Istio configuration.
 type Webhook struct {
+	keyCertWatcher *fsnotify.Watcher
+
 	mu   sync.RWMutex
 	cert *tls.Certificate
 
@@ -189,9 +193,27 @@ type Webhook struct {
 	deploymentName                string
 	serviceName                   string
 	webhookName                   string
+	keyFile                       string
+	certFile                      string
 
 	// test hook for informers
 	createInformerEndpointSource createInformerEndpointSource
+}
+
+// Reload the server's cert/key for TLS from file.
+func (wh *Webhook) reloadKeyCert() {
+	pair, err := tls.LoadX509KeyPair(wh.certFile, wh.keyFile)
+	if err != nil {
+		reportValidationCertKeyUpdateError(err)
+		scope.Errorf("Cert/Key reload error: %v", err)
+		return
+	}
+	wh.mu.Lock()
+	wh.cert = &pair
+	wh.mu.Unlock()
+
+	reportValidationCertKeyUpdate()
+	scope.Info("Cert and Key reloaded")
 }
 
 // NewWebhook creates a new instance of the admission webhook controller.
@@ -201,10 +223,26 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 		return nil, err
 	}
 
+	// Configuration must be updated whenever the caBundle changes. Watch the parent directory of
+	// the target files so we can catch symlink updates of k8s secrets.
+	keyCertWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range []string{p.CertFile, p.KeyFile} {
+		watchDir, _ := filepath.Split(file)
+		if err := keyCertWatcher.Watch(watchDir); err != nil {
+			return nil, fmt.Errorf("could not watch %v: %v", file, err)
+		}
+	}
+
 	wh := &Webhook{
 		server: &http.Server{
 			Addr: fmt.Sprintf(":%v", p.Port),
 		},
+		keyFile:                       p.KeyFile,
+		certFile:                      p.CertFile,
+		keyCertWatcher:                keyCertWatcher,
 		cert:                          &pair,
 		descriptor:                    p.PilotDescriptor,
 		validator:                     p.MixerValidator,
@@ -233,7 +271,7 @@ func (wh *Webhook) Stop() {
 }
 
 // Run implements the webhook server
-func (wh *Webhook) Run(ready chan struct{}, stopCh <-chan struct{}) {
+func (wh *Webhook) Run(ready chan<- struct{}, stopCh <-chan struct{}) {
 	go func() {
 		if err := wh.server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 			scope.Fatalf("admission webhook ListenAndServeTLS failed: %v", err)
@@ -254,6 +292,24 @@ func (wh *Webhook) Run(ready chan struct{}, stopCh <-chan struct{}) {
 
 	ready <- struct{}{}
 
+	// use a timer to debounce key/cert updates
+	var keyCertTimerC <-chan time.Time
+
+	for {
+		select {
+		case <-keyCertTimerC:
+			keyCertTimerC = nil
+			wh.reloadKeyCert()
+		case event, more := <-wh.keyCertWatcher.Event:
+			if more && (event.IsModify() || event.IsCreate()) && keyCertTimerC == nil {
+				keyCertTimerC = time.After(watchDebounceDelay)
+			}
+		case err := <-wh.keyCertWatcher.Error:
+			scope.Errorf("configWatcher error: %v", err)
+		case <-stopCh:
+			return
+		}
+	}
 }
 
 func (wh *Webhook) getCert(*tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -277,6 +277,9 @@ func (wh *Webhook) Run(ready chan<- struct{}, stopCh <-chan struct{}) {
 			scope.Fatalf("admission webhook ListenAndServeTLS failed: %v", err)
 		}
 	}()
+	defer func() {
+		wh.Stop()
+	}()
 
 	// During initial Istio installation its possible for custom
 	// resources to be created concurrently with galley startup. This

--- a/galley/pkg/server/components/validation.go
+++ b/galley/pkg/server/components/validation.go
@@ -19,6 +19,7 @@ import (
 
 	"istio.io/istio/galley/pkg/crd/validation"
 	"istio.io/istio/galley/pkg/server/process"
+	"istio.io/istio/pkg/cmd"
 )
 
 // NewValidation returns a new validation component.
@@ -34,6 +35,9 @@ func NewValidation(kubeConfig string, params *validation.WebhookParameters, live
 			}
 			if params.EnableReconcileWebhookConfiguration {
 				go validation.ReconcileWebhookConfiguration(webhookServerReady, stopCh, params, kubeConfig)
+			}
+			if params.EnableValidation || params.EnableReconcileWebhookConfiguration {
+				go cmd.WaitSignal(stopCh)
 			}
 			return nil
 		},

--- a/tests/integration/galley/webhook/webhook_test.go
+++ b/tests/integration/galley/webhook/webhook_test.go
@@ -212,12 +212,12 @@ func startGalleyPortForwarderOrDie(t *testing.T, env *kube.Environment, ns strin
 		t.Fatalf("failed creating port forwarding to galley: %v", err)
 	}
 	if err := forwarder.Start(); err != nil {
-		t.Fatal("failed to start port forwarding: %v", err)
+		t.Fatalf("failed to start port forwarding: %v", err)
 	}
 
 	done = func() {
 		if err := forwarder.Close(); err != nil {
-			t.Errorf("an error occured when the port forwarder was closed: %v", err)
+			t.Errorf("An error occurred when the port forwarder was closed: %v", err)
 		}
 	}
 	return forwarder.Address(), done


### PR DESCRIPTION
Galley watched and reloaded key/certs prior to istio 1.3. https://github.com/istio/istio/pull/12571 refactored galley's validation into two parts: (1) config controller and (2) webhook server.

The watch/reload logic was retained in (1). It wasn't added at all to (2). This PR adds the missing watch/reload code to (2).

fix https://github.com/istio/istio/issues/17718