### PR TITLE
Add granular filtering support (Issue #17098)

### DIFF
--- a/tools/dump_kubernetes.sh
+++ b/tools/dump_kubernetes.sh
@@ -328,9 +328,8 @@ dump_resources() {
 dump_istio_status() {
   istioctl version > "${OUT_DIR}/istioctl-version.txt"
   istioctl proxy-status > "${OUT_DIR}/istioctl-proxy-status.txt"
-  kubectl get configmap -n istio-system > "${OUT_DIR}/istio-system-configmap.txt"
-  kubectl get configmap -n istio-system > "${OUT_DIR}/istio-system-configmap.txt"
-  kubectl get configmap istio -n istio-system && kubectl get configmap istio-sidecar-injector -n istio-system > "${OUT_DIR}/istio-system-configmaps.txt"
+  kubectl get configmap -n istio-system -oyaml > "${OUT_DIR}/mesh-config.txt"
+  kubectl get configmap istio-sidecar-injector -n istio-system -oyaml > "${OUT_DIR}/sidecar-injection-template.txt"
 }
 
 dump_control_plane() {

--- a/tools/dump_kubernetes.sh
+++ b/tools/dump_kubernetes.sh
@@ -438,7 +438,7 @@ main() {
     dump_time
     dump_cluster
     exit_code=$?
-  elif [ ! -z "${proxy_label}" ] ; then
+  elif [ -n "${proxy_label}" ] ; then
     dump_time
     dump_proxy
     exit_code=$?


### PR DESCRIPTION
c.f. #17098 :

- 3 modes as suggested by @howardjohn
  - -c/--control-plane e.g. ./tools/dump_kubernetes.sh -c
     would dump everything control plane.

  - -u/--cluster
     dump all services/nodes/pods

  - -p/--proxy
    fetch /config_dump, /clusters, /stats, /certs, /memory + proxy logs

- Added for @mandarjog a -p/--pod
  dump logs only for pod matching these values e.g.
  "-n istio-system -p istio-policy-7857db5f54-wj59d -p istio-pilot-5cb9d848b5-xx25q"

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[X] Developer Infrastructure
