### PR TITLE
istioctl subcommands to manage multi-cluster meshes (#17870) 

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -155,8 +155,9 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(profileCmd)
 
 	experimentalCmd.AddCommand(mesh.UpgradeCmd())
-
-	experimentalCmd.AddCommand(multicluster.NewCreateRemoteSecretCommand(&kubeconfig, &configContext, &istioNamespace))
+	experimentalCmd.AddCommand(multicluster.NewCreateRemoteSecretCommand())
+	experimentalCmd.AddCommand(multicluster.NewCreateTrustAnchorCommand())
+	experimentalCmd.AddCommand(multicluster.NewMulticlusterCommand())
 
 	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
 		Title:   "Istio Control",

--- a/istioctl/pkg/multicluster/cluster.go
+++ b/istioctl/pkg/multicluster/cluster.go
@@ -1,0 +1,177 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"crypto/x509"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"istio.io/istio/pkg/kube/secretcontroller"
+	pkiutil "istio.io/istio/security/pkg/pki/util"
+)
+
+// Cluster represents the current state  of a cluster in the mesh.
+type Cluster struct {
+	ClusterDesc
+
+	// Current context referenced by the MeshDesc. This context corresponds to the `context` in
+	// the current kubeconfig file. It is essentially the human friendly display
+	// name. It can be changed by the user with`kubectl config rename-context`.
+	context string
+	// uuid of kube-system Namespace. Fixed for the lifetime of cluster.
+	uid       types.UID
+	installed bool
+	client    kubernetes.Interface
+}
+
+const (
+	defaultIstioNamespace       = "istio-system"
+	defaultServiceAccountReader = "istio-multi"
+)
+
+// Use UUID of kube-system Namespace as unique identifier for cluster.
+// (see https://docs.google.com/document/d/1F__vEKeI41P7PPUCMM9PVPYY34pyrvQI5rbTJVnS5c4)
+func clusterUID(client kubernetes.Interface) (types.UID, error) {
+	kubeSystem, err := client.CoreV1().Namespaces().Get("kube-system", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return kubeSystem.UID, nil
+}
+
+func NewCluster(context string, desc ClusterDesc, env Environment) (*Cluster, error) {
+	if desc.Namespace == "" {
+		desc.Namespace = defaultIstioNamespace
+	}
+	if desc.ServiceAccountReader == "" {
+		desc.ServiceAccountReader = defaultServiceAccountReader
+	}
+
+	client, err := env.CreateClientSet(context)
+	if err != nil {
+		return nil, err
+	}
+
+	uid, err := clusterUID(client)
+	if err != nil {
+		return nil, err
+	}
+
+	// use the existence of pilot as assurance the control plane is present in the specified namespace.
+	var installed bool
+	if _, err := client.AppsV1().Deployments(desc.Namespace).Get("istio-pilot", metav1.GetOptions{}); err == nil {
+		installed = true
+	}
+
+	return &Cluster{
+		ClusterDesc: desc,
+		context:     context,
+		uid:         uid,
+		client:      client,
+		installed:   installed,
+	}, nil
+}
+
+func (c *Cluster) String() string {
+	return fmt.Sprintf("%v (%v)", c.uid, c.context)
+}
+
+type CACerts struct {
+	// TODO select precedence if both secrets are present
+	externalCACert     *x509.Certificate
+	externalRootCert   *x509.Certificate
+	selfSignedCACert   *x509.Certificate
+	selfSignedRootCert *x509.Certificate
+}
+
+func extractCert(filename string, secret *v1.Secret) (*x509.Certificate, error) {
+	encoded, ok := secret.Data[filename]
+	if !ok {
+		return nil, fmt.Errorf("%q not found in secret %v", filename, secret.Name)
+	}
+	cert, err := pkiutil.ParsePemEncodedCertificate(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %q from secret %v: %v", filename, secret.Name, err)
+	}
+	return cert, nil
+}
+
+type remoteSecrets map[types.UID]*v1.Secret
+
+func (c *Cluster) readRemoteSecrets(env Environment) remoteSecrets {
+	secretMap := make(remoteSecrets)
+	listOptions := metav1.ListOptions{
+		LabelSelector: fields.SelectorFromSet(fields.Set{secretcontroller.MultiClusterSecretLabel: "true"}).String(),
+	}
+	secrets, err := c.client.CoreV1().Secrets(c.Namespace).List(listOptions)
+	if err != nil {
+		env.Errorf("error: could not list secrets in cluster %v: %v\n", c, err)
+		return secretMap
+	}
+	for i := range secrets.Items {
+		secret := &secrets.Items[i]
+		secretMap[uidFromRemoteSecretName(secret.Name)] = secret
+	}
+	return secretMap
+}
+
+func (c *Cluster) readCACerts(env Environment) *CACerts {
+	cs := &CACerts{}
+	externalCASecret, err := c.client.CoreV1().Secrets(c.Namespace).Get("cacerts", metav1.GetOptions{})
+	if err == nil {
+		if cs.externalCACert, err = extractCert("ca-cert.pem", externalCASecret); err != nil {
+			env.Errorf("error: %v\n", err)
+		}
+		if cs.externalRootCert, err = extractCert("root-cert.pem", externalCASecret); err != nil {
+			env.Errorf("error: %v\n", err)
+		}
+	}
+	selfSignedCASecret, err := c.client.CoreV1().Secrets(c.Namespace).Get("istio-ca-secrets", metav1.GetOptions{})
+	if err == nil {
+		if cs.selfSignedCACert, err = extractCert("ca-cert.pem", selfSignedCASecret); err != nil {
+			env.Errorf("error: %v\n", err)
+		}
+		if cs.selfSignedRootCert, err = extractCert("root-cert.pem", selfSignedCASecret); err != nil {
+			env.Errorf("error: %v\n", err)
+		}
+	}
+	return cs
+}
+
+func (c *Cluster) readIngressGatewayAddresses(env Environment) []string {
+	var addresses []string
+
+	ingress, err := c.client.CoreV1().Services(c.Namespace).Get("istio-ingressgateway", metav1.GetOptions{})
+	if err != nil {
+		env.Errorf("error: istio-ingressgateway not found: %v\n", err)
+		return addresses
+	}
+
+	for _, ip := range ingress.Status.LoadBalancer.Ingress {
+		if ip.IP != "" {
+			addresses = append(addresses, ip.IP)
+		}
+		if ip.Hostname != "" {
+			addresses = append(addresses, ip.Hostname)
+		}
+	}
+	return addresses
+}

--- a/istioctl/pkg/multicluster/cluster_test.go
+++ b/istioctl/pkg/multicluster/cluster_test.go
@@ -1,0 +1,314 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"istio.io/istio/pkg/kube/secretcontroller"
+)
+
+const (
+	testNetwork = "test-network"
+)
+
+var (
+	kubeSystemNamespaceUID = types.UID("54643f96-eca0-11e9-bb97-42010a80000a")
+	kubeSystemNamespace    = &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-system",
+			UID:  kubeSystemNamespaceUID,
+		},
+	}
+
+	pilotDeployment = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istio-pilot",
+			Namespace: testNamespace,
+		},
+	}
+
+	pilotDeploymentDefaultIstioSystem = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istio-pilot",
+			Namespace: defaultIstioNamespace,
+		},
+	}
+)
+
+func TestClusterUID(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	if _, err := clusterUID(client); err == nil {
+		t.Errorf("clusterUID should fail when kube-system namespace is missing")
+	}
+
+	want := kubeSystemNamespaceUID
+	client = fake.NewSimpleClientset(kubeSystemNamespace)
+	got, err := clusterUID(client)
+	if err != nil {
+		t.Fatalf("clusterUID failed: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+var (
+	goodClusterDesc = ClusterDesc{
+		Network:              testNetwork,
+		Namespace:            testNamespace,
+		ServiceAccountReader: testServiceAccountName,
+	}
+
+	clusterDescFieldsNotSet = ClusterDesc{
+		Network: testNetwork,
+	}
+	clusterDescWithDefaults = ClusterDesc{
+		Network:              testNetwork,
+		ServiceAccountReader: defaultServiceAccountReader,
+		Namespace:            defaultIstioNamespace,
+	}
+)
+
+func TestNewCluster(t *testing.T) {
+	cases := []struct {
+		name                    string
+		objs                    []runtime.Object
+		context                 string
+		desc                    ClusterDesc
+		injectClientCreateError error
+		want                    *Cluster
+		wantErrStr              string
+	}{
+		{
+			name: "missing defaults",
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+				pilotDeploymentDefaultIstioSystem,
+			},
+			context: testContext,
+			desc:    clusterDescFieldsNotSet,
+			want: &Cluster{
+				ClusterDesc: clusterDescWithDefaults,
+				context:     testContext,
+				uid:         kubeSystemNamespaceUID,
+				installed:   true,
+			},
+		},
+		{
+			name: "create client failure",
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+				pilotDeployment,
+			},
+			injectClientCreateError: errors.New("failed to create client"),
+			context:                 testContext,
+			desc:                    goodClusterDesc,
+			wantErrStr:              "failed to create client",
+		},
+		{
+			name: "uid lookup failed",
+			objs: []runtime.Object{
+				pilotDeployment,
+			},
+			context:    testContext,
+			desc:       goodClusterDesc,
+			wantErrStr: `namespaces "kube-system" not found`,
+		},
+		{
+			name: "istio not installed",
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+			},
+			context: testContext,
+			desc:    goodClusterDesc,
+			want: &Cluster{
+				ClusterDesc: goodClusterDesc,
+				context:     testContext,
+				uid:         kubeSystemNamespaceUID,
+				installed:   false,
+			},
+		},
+		{
+			name: "success",
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+				pilotDeployment,
+			},
+			context: testContext,
+			desc:    goodClusterDesc,
+			want: &Cluster{
+				ClusterDesc: goodClusterDesc,
+				context:     testContext,
+				uid:         kubeSystemNamespaceUID,
+				installed:   true,
+			},
+		},
+	}
+
+	for i := range cases {
+		c := &cases[i]
+		t.Run(fmt.Sprintf("[%v] %v", i, c.name), func(tt *testing.T) {
+			env := newFakeEnvironmentOrDie(t, api.NewConfig(), c.objs...)
+			env.injectClientCreateError = c.injectClientCreateError
+
+			got, err := NewCluster(c.context, c.desc, env)
+			if c.wantErrStr != "" {
+				if err == nil {
+					tt.Fatalf("wanted error including %q but got none", c.wantErrStr)
+				} else if !strings.Contains(err.Error(), c.wantErrStr) {
+					tt.Fatalf("wanted error including %q but got %v", c.wantErrStr, err)
+				}
+			} else if c.wantErrStr == "" && err != nil {
+				tt.Fatalf("wanted non-error but got %q", err)
+			} else {
+				c.want.client = env.client
+				if !reflect.DeepEqual(got, c.want) {
+					tt.Fatalf("\n got %#v\nwant %#v", *got, *c.want)
+				}
+			}
+		})
+	}
+}
+
+func createTestClusterAndEnvOrDie(t *testing.T,
+	context string,
+	config *api.Config,
+	desc ClusterDesc,
+	objs ...runtime.Object,
+) (*fakeEnvironment, *Cluster) {
+	t.Helper()
+
+	env := newFakeEnvironmentOrDie(t, config, objs...)
+	c, err := NewCluster(context, desc, env)
+	if err != nil {
+		t.Fatalf("could not create test cluster: %v", err)
+	}
+	return env, c
+}
+
+var (
+	testSecretLabeled0 = &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testSecretLabeled0",
+			Namespace: testNamespace,
+			Labels:    map[string]string{secretcontroller.MultiClusterSecretLabel: "true"},
+		},
+	}
+	testSecretLabeled1 = &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testSecretLabeled1",
+			Namespace: testNamespace,
+			Labels:    map[string]string{secretcontroller.MultiClusterSecretLabel: "true"},
+		},
+	}
+	testSecretNotLabeled0 = &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testSecretNotLabeld0",
+			Namespace: testNamespace,
+		},
+	}
+)
+
+func TestReadRemoteSecrets(t *testing.T) {
+	cases := []struct {
+		name              string
+		objs              []runtime.Object
+		context           string
+		desc              ClusterDesc
+		injectListFailure error
+		want              remoteSecrets
+	}{
+		{
+			name: "list failed",
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+				pilotDeployment,
+				testSecretLabeled0,
+				testSecretLabeled1,
+				testSecretNotLabeled0,
+			},
+			injectListFailure: errors.New("list failed"),
+			context:           testContext,
+			desc:              goodClusterDesc,
+			want:              remoteSecrets{},
+		},
+		{
+			name: "no labeled secrets",
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+				pilotDeployment,
+				testSecretNotLabeled0,
+			},
+			context: testContext,
+			desc:    goodClusterDesc,
+			want:    remoteSecrets{},
+		},
+		{
+			name: "success",
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+				pilotDeployment,
+				testSecretLabeled0,
+				testSecretLabeled1,
+				testSecretNotLabeled0,
+			},
+			context: testContext,
+			desc:    goodClusterDesc,
+			want: remoteSecrets{
+				types.UID(testSecretLabeled0.Name): testSecretLabeled0,
+				types.UID(testSecretLabeled1.Name): testSecretLabeled1,
+			},
+		},
+	}
+
+	for i := range cases {
+		c := &cases[i]
+		t.Run(fmt.Sprintf("[%v] %v", i, c.name), func(tt *testing.T) {
+			env, cluster := createTestClusterAndEnvOrDie(t, c.context, nil, c.desc, c.objs...)
+			if c.injectListFailure != nil {
+				reaction := func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, c.injectListFailure
+				}
+				env.client.PrependReactor("list", "secrets", reaction)
+			}
+			got := cluster.readRemoteSecrets(env)
+			if !reflect.DeepEqual(got, c.want) {
+				tt.Fatalf("\n got %#v\nwant %#v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestReadCACerts(t *testing.T) {
+
+}
+
+func TestReadIngressGatewayAddresses(t *testing.T) {
+
+}

--- a/istioctl/pkg/multicluster/describe.go
+++ b/istioctl/pkg/multicluster/describe.go
@@ -1,0 +1,238 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/clientcmd/api/latest"
+)
+
+var (
+	clusterDisplaySeparator = strings.Repeat("-", 60)
+)
+
+type remoteSecretStatus string
+
+const (
+	rsStatusNotFound           remoteSecretStatus = "notFound"
+	rsStatusConfigMissing      remoteSecretStatus = "configMissing"
+	rsStatusConfigDecodeError  remoteSecretStatus = "configDecodeError"
+	rsStatusConfigInvalid      remoteSecretStatus = "configInvalid"
+	rsStatusServerNotFound     remoteSecretStatus = "serverNotFound"
+	seStatusServerAddrMismatch remoteSecretStatus = "serverAddrMismatch"
+	rsStatusOk                 remoteSecretStatus = "ok"
+)
+
+func secretStateAndServer(env Environment, srs remoteSecrets, c *Cluster) (remoteSecretStatus, string) {
+	remoteSecret, ok := srs[c.uid]
+	if !ok {
+		return rsStatusNotFound, ""
+	}
+	key := string(c.uid)
+	kubeconfig, ok := remoteSecret.Data[key]
+	if !ok {
+		return rsStatusConfigMissing, ""
+	}
+	out, _, err := latest.Codec.Decode(kubeconfig, nil, nil)
+	if err != nil {
+		return rsStatusConfigDecodeError, ""
+	}
+	config, ok := out.(*api.Config)
+	if !ok {
+		return rsStatusConfigInvalid, ""
+	}
+	cluster, ok := config.Clusters[config.CurrentContext]
+	if !ok {
+		return rsStatusServerNotFound, ""
+	}
+
+	server := cluster.Server
+	if configCluster, ok := env.GetConfig().Clusters[c.context]; ok {
+		if server != configCluster.Server {
+			return seStatusServerAddrMismatch, fmt.Sprintf("%v (%v from local kubeconfig)", server, configCluster.Server)
+		}
+	}
+
+	return rsStatusOk, cluster.Server
+}
+
+func describeCACerts(env Environment, c *Cluster, indent string) {
+	secrets := c.readCACerts(env)
+
+	tw := tabwriter.NewWriter(env.Stdout(), 0, 8, 2, '\t', 0)
+	fmt.Fprintf(tw, "%vNAME\tISSUER\tSUBJECT\tNOTAFTER\n", indent)
+
+	for _, info := range []struct {
+		cert *x509.Certificate
+		name string
+	}{
+		{secrets.externalRootCert, "ExternalRootCert"},
+		{secrets.externalCACert, "ExternalCACert"},
+		{secrets.selfSignedRootCert, "SelfSignedRootCert"},
+		{secrets.selfSignedCACert, "SelfSignedCACert"},
+	} {
+		if c := info.cert; c != nil {
+			fmt.Fprintf(tw, "%v%v\t%q\t%q\t%v\n",
+				indent,
+				info.name,
+				c.Issuer,
+				c.Subject,
+				c.NotAfter.Format(time.RFC3339))
+		}
+	}
+
+	tw.Flush()
+}
+
+func describeRemoteSecrets(env Environment, mesh *Mesh, c *Cluster, indent string) {
+	serviceRegistrySecrets := c.readRemoteSecrets(env)
+
+	tw := tabwriter.NewWriter(env.Stdout(), 0, 8, 2, '\t', 0)
+	fmt.Fprintf(tw, "%vCONTEXT\tUID\tREGISTERED\tMASTER\t\n", indent)
+	for _, other := range mesh.sortedClusters {
+		if other.uid == c.uid {
+			continue
+		}
+
+		secretState, server := secretStateAndServer(env, serviceRegistrySecrets, other)
+
+		fmt.Fprintf(tw, "%v%v\t%v\t%v\t%v\n",
+			indent,
+			other.context,
+			other.uid,
+			secretState,
+			server,
+		)
+	}
+	tw.Flush()
+}
+
+func describeIngressGateways(env Environment, c *Cluster, indent string) {
+	gatewayAddresses := c.readIngressGatewayAddresses(env)
+
+	env.Printf("%vgateways: ", indent)
+	if len(gatewayAddresses) == 0 {
+		env.Printf("<none>")
+	} else {
+		for i, addr := range gatewayAddresses {
+			env.Printf("%v", addr)
+			if i < len(gatewayAddresses)-1 {
+				env.Printf(", ")
+			}
+		}
+	}
+	env.Printf("\n")
+}
+
+func describeCluster(env Environment, mesh *Mesh, c *Cluster) error {
+	env.Printf("%v context=%v uid=%v network=%v istio=%v %v\n",
+		strings.Repeat("-", 10),
+		c.context,
+		c.uid,
+		c.Network,
+		c.installed,
+		strings.Repeat("-", 10))
+
+	indent := strings.Repeat(" ", 4)
+
+	env.Printf("\n")
+	describeCACerts(env, c, indent)
+
+	env.Printf("\n")
+	describeRemoteSecrets(env, mesh, c, indent)
+
+	env.Printf("\n")
+	describeIngressGateways(env, c, indent)
+
+	// TODO verify all clustersByContext have common trust
+
+	return nil
+}
+
+func Describe(opt describeOptions, env Environment) error {
+	mesh, err := meshFromFileDesc(opt.filename, opt.Kubeconfig, env)
+	if err != nil {
+		return err
+	}
+
+	if opt.all {
+		for _, cluster := range mesh.sortedClusters {
+			if err := describeCluster(env, mesh, cluster); err != nil {
+				env.Errorf("could not describe cluster %v: %v\n", cluster, err)
+			}
+			env.Printf("%v\n", clusterDisplaySeparator)
+		}
+	} else {
+		context := opt.Context
+		if context == "" {
+			context = env.GetConfig().CurrentContext
+		}
+		cluster, ok := mesh.clustersByContext[context]
+		if !ok {
+			return fmt.Errorf("cluster %v not found", context)
+		}
+		return describeCluster(env, mesh, cluster)
+	}
+
+	return nil
+}
+
+type describeOptions struct {
+	KubeOptions
+	filenameOption
+	all bool
+}
+
+func (o *describeOptions) prepare(flags *pflag.FlagSet) error {
+	o.KubeOptions.prepare(flags)
+	return o.filenameOption.prepare()
+}
+
+func (o *describeOptions) addFlags(flags *pflag.FlagSet) {
+	o.filenameOption.addFlags(flags)
+
+	flags.BoolVar(&o.all, "all", o.all,
+		"describe the status of all clustersByContext in the mesh")
+}
+
+func NewDescribeCommand() *cobra.Command {
+	opt := describeOptions{
+		all: false,
+	}
+	c := &cobra.Command{
+		Use:   "describe -f <mesh.yaml> [--all]",
+		Short: `Describe status of the multi-cluster mesh's control plane' `,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := opt.prepare(c.Flags()); err != nil {
+				return err
+			}
+			env, err := NewEnvironmentFromCobra(opt.Kubeconfig, opt.Context, c)
+			if err != nil {
+				return err
+			}
+			return Describe(opt, env)
+		},
+	}
+	opt.addFlags(c.PersistentFlags())
+	return c
+}

--- a/istioctl/pkg/multicluster/describe_test.go
+++ b/istioctl/pkg/multicluster/describe_test.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster

--- a/istioctl/pkg/multicluster/env.go
+++ b/istioctl/pkg/multicluster/env.go
@@ -1,0 +1,80 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"istio.io/istio/pkg/kube"
+)
+
+type Environment interface {
+	GetConfig() *api.Config
+	CreateClientSet(context string) (kubernetes.Interface, error)
+	Stdout() io.Writer
+	Stderr() io.Writer
+	ReadFile(filename string) ([]byte, error)
+	Printf(format string, a ...interface{})
+	Errorf(format string, a ...interface{})
+}
+
+type KubeEnvironment struct {
+	config     *api.Config
+	stdout     io.Writer
+	stderr     io.Writer
+	kubeconfig string
+}
+
+func (e *KubeEnvironment) CreateClientSet(context string) (kubernetes.Interface, error) {
+	return kube.CreateClientset(e.kubeconfig, context)
+}
+
+func (e *KubeEnvironment) Printf(format string, a ...interface{}) {
+	_, _ = fmt.Fprintf(e.stdout, format, a...)
+}
+func (e *KubeEnvironment) Errorf(format string, a ...interface{}) {
+	_, _ = fmt.Fprintf(e.stderr, format, a...)
+}
+
+func (e *KubeEnvironment) GetConfig() *api.Config                   { return e.config }
+func (e *KubeEnvironment) Stdout() io.Writer                        { return e.stdout }
+func (e *KubeEnvironment) Stderr() io.Writer                        { return e.stderr }
+func (e *KubeEnvironment) ReadFile(filename string) ([]byte, error) { return ioutil.ReadFile(filename) }
+
+var _ Environment = (*KubeEnvironment)(nil)
+
+func NewEnvironment(kubeconfig, context string, stdout, stderr io.Writer) (*KubeEnvironment, error) {
+	config, err := kube.BuildClientCmd(kubeconfig, context).ConfigAccess().GetStartingConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return &KubeEnvironment{
+		config:     config,
+		stdout:     stdout,
+		stderr:     stderr,
+		kubeconfig: kubeconfig,
+	}, nil
+}
+
+func NewEnvironmentFromCobra(kubeconfig, context string, cmd *cobra.Command) (Environment, error) {
+	return NewEnvironment(kubeconfig, context, cmd.OutOrStdout(), cmd.OutOrStderr())
+}

--- a/istioctl/pkg/multicluster/env_test.go
+++ b/istioctl/pkg/multicluster/env_test.go
@@ -1,0 +1,170 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"bytes"
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/clientcmd/api/latest"
+)
+
+var fakeKubeconfigData = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: UEhPTlkK
+    server: https://192.168.1.1
+  name: prod0
+contexts:
+- context:
+    cluster: prod0
+    user: prod0
+  name: prod0
+current-context: prod0
+users:
+- name: prod0
+  user:
+    auth-provider:
+      name: gcp` // nolint:lll
+
+func createFakeKubeconfigFileOrDie(t *testing.T) (string, *api.Config) {
+	t.Helper()
+
+	f, err := ioutil.TempFile("", "fakeKubeconfigForEnvironment")
+	if err != nil {
+		t.Fatalf("could not create fake kubeconfig file: %v", err)
+	}
+	kubeconfigPath := f.Name()
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("couldn't close temp file %v: %v", kubeconfigPath, err)
+		}
+	}()
+
+	if _, err = f.WriteString(fakeKubeconfigData); err != nil {
+		t.Fatalf("could not write fake kubeconfig data to %v: %v", kubeconfigPath, err)
+	}
+
+	out, _, err := latest.Codec.Decode([]byte(fakeKubeconfigData), nil, nil)
+	if err != nil {
+		t.Fatalf("could not decode fake kubeconfig: %v", err)
+	}
+	config, ok := out.(*api.Config)
+	if !ok {
+		t.Fatalf("decoded kubeconfig is not a valid api.Config (%v)", reflect.TypeOf(out))
+	}
+
+	// fill in missing defaults
+	config.Contexts[config.CurrentContext].LocationOfOrigin = kubeconfigPath
+	config.Clusters[config.CurrentContext].LocationOfOrigin = kubeconfigPath
+	config.AuthInfos[config.CurrentContext].LocationOfOrigin = kubeconfigPath
+	config.Extensions = make(map[string]runtime.Object)
+	config.Preferences.Extensions = make(map[string]runtime.Object)
+
+	return kubeconfigPath, config
+}
+
+type fakeEnvironment struct {
+	KubeEnvironment
+
+	client                  *fake.Clientset
+	injectClientCreateError error
+	kubeconfig              string
+	wOut                    bytes.Buffer
+	wErr                    bytes.Buffer
+}
+
+func newFakeEnvironmentOrDie(t *testing.T, config *api.Config, objs ...runtime.Object) *fakeEnvironment {
+	t.Helper()
+
+	var wOut, wErr bytes.Buffer
+
+	f := &fakeEnvironment{
+		KubeEnvironment: KubeEnvironment{
+			config:     config,
+			stdout:     &wOut,
+			stderr:     &wErr,
+			kubeconfig: "unused",
+		},
+		client:     fake.NewSimpleClientset(objs...),
+		kubeconfig: "unused",
+		wOut:       wOut,
+		wErr:       wErr,
+	}
+
+	return f
+}
+
+func (f *fakeEnvironment) CreateClientSet(context string) (kubernetes.Interface, error) {
+	if f.injectClientCreateError != nil {
+		return nil, f.injectClientCreateError
+	}
+	return f.client, nil
+}
+
+func TestNewEnvironment(t *testing.T) {
+	context := "" // empty, use current-context
+	kubeconfig, wantConfig := createFakeKubeconfigFileOrDie(t)
+
+	var wOut, wErr bytes.Buffer
+
+	wantEnv := &KubeEnvironment{
+		config:     wantConfig,
+		stdout:     &wOut,
+		stderr:     &wErr,
+		kubeconfig: kubeconfig,
+	}
+
+	gotEnv, err := NewEnvironment(kubeconfig, context, &wOut, &wErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(*wantEnv.GetConfig(), *gotEnv.GetConfig()); diff != "" {
+		t.Errorf("bad config: \n got %v \nwant %v\ndiff %v", gotEnv, wantEnv, diff)
+	}
+
+	wantEnv.config = nil
+	gotEnv.config = nil
+	if !reflect.DeepEqual(wantEnv, gotEnv) {
+		t.Errorf("bad environment: \n got %v \nwant %v", *gotEnv, *wantEnv)
+	}
+
+	// verify interface
+	if gotEnv.Stderr() != &wErr {
+		t.Errorf("Stderr() returned wrong io.writer")
+	}
+	if gotEnv.Stdout() != &wOut {
+		t.Errorf("Stdout() returned wrong io.writer")
+	}
+	gotEnv.Printf("stdout %v", "test")
+	wantOut := "stdout test"
+	if gotOut := wOut.String(); gotOut != wantOut {
+		t.Errorf("Printf() printed wrong string: got %v want %v", gotOut, wantOut)
+	}
+	gotEnv.Errorf("stderr %v", "test")
+	wantErr := "stderr test"
+	if gotErr := wErr.String(); gotErr != wantErr {
+		t.Errorf("Errorf() printed wrong string: got %v want %v", gotErr, wantErr)
+	}
+}

--- a/istioctl/pkg/multicluster/generate.go
+++ b/istioctl/pkg/multicluster/generate.go
@@ -1,0 +1,213 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"istio.io/api/mesh/v1alpha1"
+
+	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/util/protomarshal"
+)
+
+// TODO replace with common strongly typed values.yaml when available
+type valueType struct {
+	Global struct { // nolint:maligned
+		MeshNetworks                map[string]interface{} `json:"meshNetworks,omitempty"`
+		MeshID                      string                 `json:"meshID,omitempty"`
+		Network                     string                 `json:"network,omitempty"`
+		ControlPlaneSecurityEnabled bool                   `json:"controlPlaneSecurityEnabled,omitempty"`
+		MultiCluster                struct {
+			ClusterName string `json:"clusterName,omitempty"`
+		} `json:"multiCluster,omitempty"`
+		MTLS struct {
+			Enabled bool `json:"enabled,omitempty"`
+		} `json:"mtls,omitempty"`
+	} `json:"global,omitempty"`
+
+	Gateways struct {
+		IstioIngressGateway struct {
+			Env map[string]string `json:"env,omitempty"`
+		} `json:"istio-ingressgateway,omitempty"`
+	} `json:"gateways,omitempty"`
+}
+
+func generateValuesYAML(mesh *Mesh, current *Cluster, meshNetworks *v1alpha1.MeshNetworks) (string, error) { // nolint:interfacer
+	meshNetworksJSON, err := protomarshal.ToJSONMap(meshNetworks)
+	if err != nil {
+		return "", err
+	}
+
+	var values valueType
+	values.Global.MeshNetworks = meshNetworksJSON
+	values.Global.MeshID = mesh.meshID
+	values.Global.Network = current.Network
+	values.Global.ControlPlaneSecurityEnabled = true
+	values.Global.MTLS.Enabled = true // required?
+	values.Global.MultiCluster.ClusterName = string(current.uid)
+	// rRquired for istio <= 1.3 . Newer chart versions use `global.network` to assign the gateway's network.
+	values.Gateways.IstioIngressGateway.Env = map[string]string{"ISTIO_MESH_NETWORK": current.Network}
+
+	valuesStr, err := yaml.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+
+	header := fmt.Sprintf("# auto-generated values.yaml for cluster %q\n", current)
+	var buf bytes.Buffer
+	if _, err := buf.WriteString(header); err != nil {
+		return "", err
+	}
+	if _, err := buf.Write(valuesStr); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func generateValues(opt generateOptions, env Environment) error {
+	mesh, err := meshFromFileDesc(opt.filename, opt.Kubeconfig, env)
+	if err != nil {
+		return err
+	}
+
+	context := opt.Context
+	if context == "" {
+		context = env.GetConfig().CurrentContext
+	}
+
+	cluster, ok := mesh.clustersByContext[context]
+	if !ok {
+		return fmt.Errorf("context %v not found", context)
+	}
+
+	meshNetwork, err := meshNetworkForCluster(env, mesh, cluster)
+	if err != nil {
+		return err
+	}
+
+	out, err := generateValuesYAML(mesh, cluster, meshNetwork)
+	if err != nil {
+		return err
+	}
+
+	env.Printf("%v\n", out)
+
+	return nil
+}
+
+func meshNetworkForCluster(env Environment, mesh *Mesh, c *Cluster) (*v1alpha1.MeshNetworks, error) {
+	mn := &v1alpha1.MeshNetworks{
+		Networks: map[string]*v1alpha1.Network{},
+	}
+
+	for context, cluster := range mesh.clustersByContext {
+		if _, ok := env.GetConfig().Contexts[context]; !ok {
+			return nil, fmt.Errorf("context %v not found", context)
+		}
+
+		// Don't include this cluster in the mesh's network yet.
+		if cluster.DisableServiceDiscovery {
+			continue
+		}
+
+		network := cluster.Network
+		if _, ok := mn.Networks[network]; !ok {
+			mn.Networks[network] = &v1alpha1.Network{}
+		}
+
+		for _, address := range cluster.readIngressGatewayAddresses(env) {
+			// TODO debug why RegistryServiceName doesn't work
+			mn.Networks[network].Gateways = append(mn.Networks[network].Gateways,
+				&v1alpha1.Network_IstioNetworkGateway{
+					Gw: &v1alpha1.Network_IstioNetworkGateway_Address{
+						address,
+					},
+					Port: 443,
+				},
+			)
+		}
+
+		// Use the cluster uid for the registry name so we have consistency across the mesh. Pilot
+		// uses a special name for the local cluster against which it is running.
+		registry := string(c.uid)
+		if context == c.context {
+			registry = string(serviceregistry.KubernetesRegistry)
+		}
+
+		mn.Networks[network].Endpoints = append(mn.Networks[network].Endpoints,
+			&v1alpha1.Network_NetworkEndpoints{
+				Ne: &v1alpha1.Network_NetworkEndpoints_FromRegistry{
+					FromRegistry: registry,
+				},
+			},
+		)
+	}
+
+	return mn, nil
+}
+
+type generateOptions struct {
+	KubeOptions
+	filenameOption
+}
+
+func (o *generateOptions) addFlags(flagset *pflag.FlagSet) {
+	o.filenameOption.addFlags(flagset)
+}
+
+func (o *generateOptions) prepare(flags *pflag.FlagSet) error {
+	o.KubeOptions.prepare(flags)
+	return o.filenameOption.prepare()
+}
+
+func NewGenerateCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "generate",
+		Short: `generate configuration for setting up a multi-cluster mesh`,
+	}
+
+	c.AddCommand(
+		NewGenerateValuesCommand(),
+		// NewGenerateTrustAnchorCommand(),
+		// NewGenerateRemoteSecrete()
+	)
+	return c
+}
+
+func NewGenerateValuesCommand() *cobra.Command {
+	opt := generateOptions{}
+	c := &cobra.Command{
+		Use:   "values -f <mesh.yaml>",
+		Short: `generate a cluster-specific values.yaml file based on the mesh description and runtime state `,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := opt.prepare(c.Flags()); err != nil {
+				return err
+			}
+			env, err := NewEnvironmentFromCobra(opt.Kubeconfig, opt.Context, c)
+			if err != nil {
+				return err
+			}
+			return generateValues(opt, env)
+		},
+	}
+	opt.addFlags(c.PersistentFlags())
+	return c
+}

--- a/istioctl/pkg/multicluster/generate_test.go
+++ b/istioctl/pkg/multicluster/generate_test.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster

--- a/istioctl/pkg/multicluster/join.go
+++ b/istioctl/pkg/multicluster/join.go
@@ -1,0 +1,196 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"istio.io/istio/pkg/kube/secretcontroller"
+)
+
+func Join(opt joinOptions, env Environment) error {
+	mesh, err := meshFromFileDesc(opt.filename, opt.Kubeconfig, env)
+	if err != nil {
+		return err
+	}
+
+	if opt.serviceDiscovery {
+		if err := joinServiceRegistries(mesh, env); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteSecret(cluster *Cluster, s *v1.Secret) error {
+	return cluster.client.CoreV1().Secrets(cluster.Namespace).Delete(s.Name, &metav1.DeleteOptions{})
+}
+
+func applySecret(cluster *Cluster, curr *v1.Secret) error {
+	err := wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {
+		prev, err := cluster.client.CoreV1().Secrets(cluster.Namespace).Get(curr.Name, metav1.GetOptions{})
+		if err == nil {
+
+			prev.StringData = curr.StringData
+			prev.Annotations[clusterContextAnnotationKey] = cluster.context
+			prev.Labels[secretcontroller.MultiClusterSecretLabel] = "true"
+			if _, err := cluster.client.CoreV1().Secrets(cluster.Namespace).Update(prev); err != nil {
+				return false, err
+			}
+		} else if _, err := cluster.client.CoreV1().Secrets(cluster.Namespace).Create(curr); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	return err
+}
+
+func joinServiceRegistries(mesh *Mesh, env Environment) error {
+	preparedSecrets := make(map[types.UID]*v1.Secret)
+	existingSecretsByCluster := make(map[string]map[types.UID]*v1.Secret)
+
+	for _, cluster := range mesh.sortedClusters {
+		fmt.Printf("creating secret for first %v\n", cluster)
+		// skip clustersByContext without Istio installed
+		if !cluster.installed {
+			continue
+		}
+
+		opt := RemoteSecretOptions{
+			KubeOptions: KubeOptions{
+				Context:   cluster.context,
+				Namespace: cluster.Namespace,
+			},
+			ServiceAccountName: cluster.ServiceAccountReader,
+			AuthType:           RemoteSecretAuthTypeBearerToken,
+			// TODO add auth provider option (e.g. gcp)
+		}
+		secret, err := createRemoteSecret(opt, env)
+		if err != nil {
+			return fmt.Errorf("%v: %v", cluster.context, err)
+		}
+
+		preparedSecrets[cluster.uid] = secret
+
+		// build the list of preparedSecrets to potentially prune
+		existingSecretsByCluster[cluster.context] = cluster.readRemoteSecrets(env)
+	}
+
+	joined := make(map[string]bool)
+
+	for _, first := range mesh.sortedClusters {
+		for _, second := range mesh.sortedClusters {
+			if first.uid == second.uid {
+				continue
+			}
+
+			id0, id1 := string(first.uid), string(second.uid)
+			if strings.Compare(id0, id1) > 0 {
+				id1, id0 = id0, id1
+			}
+			hash := id0 + "/" + id1
+			if _, ok := joined[hash]; ok {
+				continue
+			}
+			joined[hash] = true
+
+			env.Printf("(re)joining %v and %v\n", first, second)
+
+			// pairwise Join
+			for _, s := range []struct {
+				local  *Cluster
+				remote *Cluster
+			}{
+				{first, second},
+				{second, first},
+			} {
+				remoteSecret, ok := preparedSecrets[s.remote.uid]
+				if !ok {
+					continue
+				}
+
+				if err := applySecret(s.local, remoteSecret); err != nil {
+					env.Errorf("%v failed: %v\n", s.local, err)
+				}
+				delete(existingSecretsByCluster[s.local.context], uidFromRemoteSecretName(remoteSecret.Name))
+			}
+		}
+	}
+
+	// existingSecretsByCluster any leftover preparedSecrets
+	for context, secrets := range existingSecretsByCluster {
+		for _, secret := range secrets {
+			cluster := mesh.clustersByContext[context]
+			fmt.Printf("pruning %v from %v\n", secret.Name, cluster)
+			if err := deleteSecret(cluster, secret); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+type joinOptions struct {
+	KubeOptions
+	filenameOption
+
+	serviceDiscovery bool
+	all              bool
+}
+
+func (o *joinOptions) prepare(flags *pflag.FlagSet) error {
+	o.KubeOptions.prepare(flags)
+	return o.filenameOption.prepare()
+}
+
+func (o *joinOptions) addFlags(flags *pflag.FlagSet) {
+	o.filenameOption.addFlags(flags)
+
+	flags.BoolVar(&o.serviceDiscovery, "discovery", true,
+		"link Istio service discovery with the clustersByContext service registriesS")
+	flags.BoolVar(&o.all, "all", o.all,
+		"join all clustersByContext together in the mesh")
+}
+
+func NewJoinCommand() *cobra.Command {
+	opt := joinOptions{}
+	c := &cobra.Command{
+		Use:   "join  -f <mesh.yaml> [--discovery]",
+		Short: `Join multiple clustersByContext into a single multi-cluster mesh`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := opt.prepare(c.Flags()); err != nil {
+				return err
+			}
+			env, err := NewEnvironmentFromCobra(opt.Kubeconfig, opt.Context, c)
+			if err != nil {
+				return err
+			}
+			return Join(opt, env)
+		},
+	}
+	opt.addFlags(c.PersistentFlags())
+	return c
+}

--- a/istioctl/pkg/multicluster/join_test.go
+++ b/istioctl/pkg/multicluster/join_test.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster

--- a/istioctl/pkg/multicluster/mesh.go
+++ b/istioctl/pkg/multicluster/mesh.go
@@ -1,0 +1,121 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+)
+
+// MeshDesc describes the topology of a multi-cluster mesh. The clustersByContext in the mesh reference the active
+// Kubeconfig file as described by https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig.
+type MeshDesc struct {
+	// Mesh Identifier.
+	MeshID string `json:"mesh_id,omitempty"`
+
+	// Collection of clustersByContext in the multi-cluster mesh. Clusters are indexed by Context name and
+	// reference clustersByContext defined in the Kubeconfig following kubectl precedence rules.
+	Clusters map[string]ClusterDesc `json:"clusters,omitempty"`
+}
+
+// ClusterDesc describes attributes of a cluster and the desired state of joining the mesh.
+type ClusterDesc struct {
+	// Name of the cluster's network
+	Network string `json:"network,omitempty"`
+
+	// Optional Namespace override of the Istio control plane. `istio-system` if not set.
+	Namespace string `json:"Namespace,omitempty"`
+
+	// Optional service account to use for cross-cluster authentication. `istio-multi` if not set.
+	ServiceAccountReader string `json:"serviceAccountReader"`
+
+	// When true, disables linking the service registry of this cluster with other clustersByContext in the mesh.
+	DisableServiceDiscovery bool `json:"joinServiceDiscovery,omitempty"`
+}
+
+type Mesh struct {
+	meshID            string
+	clustersByContext map[string]*Cluster // by context
+	sortedClusters    []*Cluster
+}
+
+func LoadMeshDesc(filename string, env Environment) (*MeshDesc, error) {
+	out, err := env.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %v: %v", filename, err)
+	}
+	md := &MeshDesc{}
+	if err := yaml.Unmarshal(out, md); err != nil {
+		return nil, err
+	}
+	return md, nil
+}
+
+func NewMesh(kubeconfig string, md *MeshDesc, env Environment) (*Mesh, error) {
+	clusters := make(map[string]*Cluster)
+	for context, clusterDesc := range md.Clusters {
+		cluster, err := NewCluster(context, clusterDesc, env)
+		if err != nil {
+			return nil, fmt.Errorf("error discovering %v: %v", context, err)
+		}
+		clusters[context] = cluster
+	}
+
+	sortedClusters := make([]*Cluster, 0, len(clusters))
+	for _, other := range clusters {
+		sortedClusters = append(sortedClusters, other)
+	}
+	sort.Slice(sortedClusters, func(i, j int) bool {
+		return strings.Compare(string(sortedClusters[i].uid), string(sortedClusters[j].uid)) < 0
+	})
+
+	return &Mesh{
+		meshID:            md.MeshID,
+		clustersByContext: clusters,
+		sortedClusters:    sortedClusters,
+	}, nil
+}
+
+func meshFromFileDesc(filename, kubeconfig string, env Environment) (*Mesh, error) {
+	md, err := LoadMeshDesc(filename, env)
+	if err != nil {
+		return nil, err
+	}
+	mesh, err := NewMesh(kubeconfig, md, env)
+	if err != nil {
+		return nil, err
+	}
+	return mesh, err
+}
+
+func NewMulticlusterCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "multicluster",
+		Short:   `Commands to assist in managing a multi-cluster mesh`,
+		Aliases: []string{"mc"},
+	}
+
+	c.AddCommand(
+		NewGenerateCommand(),
+		NewJoinCommand(),
+		NewDescribeCommand(),
+	)
+
+	return c
+}

--- a/istioctl/pkg/multicluster/mesh_test.go
+++ b/istioctl/pkg/multicluster/mesh_test.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster

--- a/istioctl/pkg/multicluster/options.go
+++ b/istioctl/pkg/multicluster/options.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"errors"
+
+	"github.com/spf13/pflag"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// TODO(ayj) - add to istio.io/api/annotations
+const clusterContextAnnotationKey = "istio.io/clusterContext"
+
+// KubeOptions contains kubernetes options common to all commands.
+type KubeOptions struct {
+	Kubeconfig string
+	Context    string
+	Namespace  string
+}
+
+// Inherit the common kubernetes flags defined in the root package. This is a bit of a hack,
+// but it allows us to directly get the final values for each of these flags without needing
+// to pass pointers-to-flags through all of the (sub)commands.
+func (o *KubeOptions) prepare(flags *pflag.FlagSet) {
+	if f := flags.Lookup("kubeconfig"); f != nil {
+		o.Kubeconfig = f.Value.String()
+	}
+	if f := flags.Lookup("context"); f != nil {
+		o.Context = f.Value.String()
+	}
+	if f := flags.Lookup("namespace"); f != nil {
+		o.Namespace = f.Value.String()
+	}
+
+	if o.Namespace == "" {
+		o.Namespace = v1.NamespaceDefault
+
+		configAccess := clientcmd.NewDefaultPathOptions()
+		configAccess.GlobalFile = o.Kubeconfig
+		if config, err := configAccess.GetStartingConfig(); err == nil {
+			if context, ok := config.Contexts[config.CurrentContext]; ok && context.Namespace != "" {
+				o.Namespace = context.Namespace
+			}
+		}
+	}
+}
+
+type filenameOption struct {
+	filename string
+}
+
+func (f *filenameOption) addFlags(flagset *pflag.FlagSet) {
+	if flagset.Lookup("filename") == nil {
+		flagset.StringVarP(&f.filename, "filename", "f", "",
+			"filename of the multicluster mesh description")
+	}
+}
+
+func (f *filenameOption) prepare() error {
+	if len(f.filename) == 0 {
+		return errors.New("must specify -f")
+	}
+	return nil
+}

--- a/istioctl/pkg/multicluster/options_test.go
+++ b/istioctl/pkg/multicluster/options_test.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster

--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -19,34 +19,37 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // to avoid 'No Auth Provider found for name "gcp"'
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
 
-	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/secretcontroller"
 )
 
 var (
-	Codec  runtime.Codec
-	Scheme *runtime.Scheme
+	codec  runtime.Codec
+	scheme *runtime.Scheme
 )
 
 func init() {
-	Scheme = runtime.NewScheme()
-	utilruntime.Must(v1.AddToScheme(Scheme))
-	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, Scheme, Scheme)
-	Codec = versioning.NewDefaultingCodecForScheme(
-		Scheme,
+	scheme = runtime.NewScheme()
+	utilruntime.Must(v1.AddToScheme(scheme))
+	opt := json.SerializerOptions{true, false, false}
+	yamlSerializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, opt)
+	codec = versioning.NewDefaultingCodecForScheme(
+		scheme,
 		yamlSerializer,
 		yamlSerializer,
 		v1.SchemeGroupVersion,
@@ -54,84 +57,88 @@ func init() {
 	)
 }
 
-type commandFlags struct {
-	serviceAccountName string
-}
+const (
+	// default service account to use for remote cluster access.
+	DefaultServiceAccountName = "istio-multi"
 
-var (
-	defaultSecretPrefix       = "istio-remote-secret-"
-	DefaultServiceAccountName = "istio-pilot-service-account"
+	remoteSecretPrefix = "istio-remote-secret-"
 )
 
-// NewCreateRemoteSecretCommand creates a new command for joining two clusters togeather in a multi-cluster mesh.
-func NewCreateRemoteSecretCommand(kubeconfig, context, namespace *string) *cobra.Command {
-	f := commandFlags{
-		serviceAccountName: DefaultServiceAccountName,
-	}
+func remoteSecretNameFromUID(uid types.UID) string {
+	return remoteSecretPrefix + string(uid)
+}
 
+func uidFromRemoteSecretName(name string) types.UID {
+	return types.UID(strings.TrimPrefix(name, remoteSecretPrefix))
+}
+
+// NewCreateRemoteSecretCommand creates a new command for joining two contexts
+// together in a multi-cluster mesh.
+func NewCreateRemoteSecretCommand() *cobra.Command {
+	opts := RemoteSecretOptions{
+		ServiceAccountName: DefaultServiceAccountName,
+		AuthType:           RemoteSecretAuthTypeBearerToken,
+		AuthPluginConfig:   make(map[string]string),
+	}
 	c := &cobra.Command{
 		Use:   "create-remote-secret <cluster-name>",
 		Short: "Create a secret with credentials to allow Istio to access remote Kubernetes apiservers",
 		Example: `
 # Create a secret to access cluster c0's apiserver and install it in cluster c1.
-istioctl --kubeconfig=c0.yaml x create-remote-secret c0 \
-    | kubectl -n istio-system --kubeconfig=c1.yaml apply -f -
+istioctl --Kubeconfig=c0.yaml x create-remote-secret \
+    | kubectl -n istio-system --Kubeconfig=c1.yaml apply -f -
 
 # Delete a secret that was previously installed in c1
-istioctl --kubeconfig=c0.yaml x create-remote-secret c1 \
-    | kubectl -n istio-system --kubeconfig=c1.yaml delete -f -
+istioctl --Kubeconfig=c0.yaml x create-remote-secret \
+    | kubectl -n istio-system --Kubeconfig=c1.yaml delete -f -
 
+# Create a secret  access a remote cluster with an auth plugin
+istioctl --Kubeconfig=c0.yaml x create-remote-secret --auth-type=plugin --auth-plugin-name=gcp \
+    | kubectl -n istio-system --Kubeconfig=c1.yaml apply -f -
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, args []string) error {
-			out, err := CreateRemoteSecret(*kubeconfig, *context, *namespace, f.serviceAccountName, args[0])
+			opts.prepare(c.Flags())
+			env, err := NewEnvironmentFromCobra(opts.Kubeconfig, opts.Context, c)
 			if err != nil {
-				fmt.Fprintf(c.OutOrStderr(), "%v", err)
+				return err
+			}
+			out, err := CreateRemoteSecret(opts, env)
+			if err != nil {
+				fmt.Fprintf(c.OutOrStderr(), "error: %v\n", err)
 				os.Exit(1)
 			}
 			fmt.Fprint(c.OutOrStdout(), out)
 			return nil
 		},
 	}
-
-	flags := c.PersistentFlags()
-	flags.StringVar(&f.serviceAccountName, "service-account", f.serviceAccountName,
-		"create a secret with this service account's credentials.")
-
+	opts.addFlags(c.PersistentFlags())
 	return c
 }
 
-// hooks for testing
-var (
-	newStartingConfig = func(kubeconfig, context string) (*api.Config, error) {
-		return kube.BuildClientCmd(kubeconfig, context).ConfigAccess().GetStartingConfig()
-	}
-
-	newKubernetesInterface = func(kubeconfig, context string) (kubernetes.Interface, error) {
-		return kube.CreateClientset(kubeconfig, context)
-	}
-)
-
-func createRemoteServiceAccountSecret(kubeconfig *api.Config, name string) (*v1.Secret, error) { // nolint:interfacer
+func createRemoteServiceAccountSecret(kubeconfig *api.Config, uid types.UID, context string) (*v1.Secret, error) { // nolint:interfacer
 	var data bytes.Buffer
 	if err := latest.Codec.Encode(kubeconfig, &data); err != nil {
 		return nil, err
 	}
 	out := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%v%v", defaultSecretPrefix, name),
+			Name: remoteSecretNameFromUID(uid),
+			Annotations: map[string]string{
+				clusterContextAnnotationKey: context,
+			},
 			Labels: map[string]string{
 				secretcontroller.MultiClusterSecretLabel: "true",
 			},
 		},
 		StringData: map[string]string{
-			name: data.String(),
+			string(uid): data.String(),
 		},
 	}
 	return out, nil
 }
 
-func createKubeconfig(caData, token []byte, context, server string) *api.Config {
+func createBaseKubeconfig(caData []byte, context, server string) *api.Config {
 	return &api.Config{
 		Clusters: map[string]*api.Cluster{
 			context: {
@@ -139,11 +146,7 @@ func createKubeconfig(caData, token []byte, context, server string) *api.Config 
 				Server:                   server,
 			},
 		},
-		AuthInfos: map[string]*api.AuthInfo{
-			context: {
-				Token: string(token),
-			},
-		},
+		AuthInfos: map[string]*api.AuthInfo{},
 		Contexts: map[string]*api.Context{
 			context: {
 				Cluster:  context,
@@ -154,12 +157,46 @@ func createKubeconfig(caData, token []byte, context, server string) *api.Config 
 	}
 }
 
+func createBearerTokenKubeconfig(caData, token []byte, context, server string) *api.Config {
+	c := createBaseKubeconfig(caData, context, server)
+	c.AuthInfos[context] = &api.AuthInfo{
+		Token: string(token),
+	}
+	return c
+}
+
+func createPluginKubeconfig(caData []byte, context, server string, authProviderConfig *api.AuthProviderConfig) *api.Config {
+	c := createBaseKubeconfig(caData, context, server)
+	c.AuthInfos[context] = &api.AuthInfo{
+		AuthProvider: authProviderConfig,
+	}
+	return c
+}
+
+func createRemoteSecretFromPlugin(
+	tokenSecret *v1.Secret,
+	context, server string,
+	uid types.UID,
+	authProviderConfig *api.AuthProviderConfig,
+) (*v1.Secret, error) {
+	caData, ok := tokenSecret.Data[v1.ServiceAccountRootCAKey]
+	if !ok {
+		return nil, errMissingRootCAKey
+	}
+
+	// Create a Kubeconfig to access the remote cluster using the auth provider plugin.
+	kubeconfig := createPluginKubeconfig(caData, context, server, authProviderConfig)
+
+	// Encode the Kubeconfig in a secret that can be loaded by Istio to dynamically discover and access the remote cluster.
+	return createRemoteServiceAccountSecret(kubeconfig, uid, context)
+}
+
 var (
 	errMissingRootCAKey = fmt.Errorf("no %q data found", v1.ServiceAccountRootCAKey)
 	errMissingTokenKey  = fmt.Errorf("no %q data found", v1.ServiceAccountTokenKey)
 )
 
-func createRemoteSecretFromTokenAndServer(tokenSecret *v1.Secret, name, server string) (*v1.Secret, error) {
+func createRemoteSecretFromTokenAndServer(tokenSecret *v1.Secret, uid types.UID, context, server string) (*v1.Secret, error) {
 	caData, ok := tokenSecret.Data[v1.ServiceAccountRootCAKey]
 	if !ok {
 		return nil, errMissingRootCAKey
@@ -170,16 +207,16 @@ func createRemoteSecretFromTokenAndServer(tokenSecret *v1.Secret, name, server s
 	}
 
 	// Create a Kubeconfig to access the remote cluster using the remote service account credentials.
-	kubeconfig := createKubeconfig(caData, token, name, server)
+	kubeconfig := createBearerTokenKubeconfig(caData, token, context, server)
 
 	// Encode the Kubeconfig in a secret that can be loaded by Istio to dynamically discover and access the remote cluster.
-	return createRemoteServiceAccountSecret(kubeconfig, name)
+	return createRemoteServiceAccountSecret(kubeconfig, uid, context)
 }
 
 func getServiceAccountSecretToken(kube kubernetes.Interface, saName, saNamespace string) (*v1.Secret, error) {
 	serviceAccount, err := kube.CoreV1().ServiceAccounts(saNamespace).Get(saName, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not find %v in namespace %v: %v", saName, saNamespace, err)
 	}
 	if len(serviceAccount.Secrets) != 1 {
 		return nil, fmt.Errorf("wrong number of secrets (%v) in serviceaccount %s/%s",
@@ -193,25 +230,20 @@ func getServiceAccountSecretToken(kube kubernetes.Interface, saName, saNamespace
 	return kube.CoreV1().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
 }
 
-func getClusterServerFromKubeconfig(kubeconfig, context string) (string, error) {
-	config, err := newStartingConfig(kubeconfig, context)
-	if err != nil {
-		return "", err
-	}
-
+func getCurrentContextAndClusterServerFromKubeconfig(context string, config *api.Config) (string, string, error) {
 	if context == "" {
 		context = config.CurrentContext
 	}
 
 	configContext, ok := config.Contexts[context]
 	if !ok {
-		return "", fmt.Errorf("could not find cluster for context %q", context)
+		return "", "", fmt.Errorf("could not find cluster for Context %q", context)
 	}
 	cluster, ok := config.Clusters[configContext.Cluster]
 	if !ok {
-		return "", fmt.Errorf("could not find server for context %q", context)
+		return "", "", fmt.Errorf("could not find server for Context %q", context)
 	}
-	return cluster.Server, nil
+	return context, cluster.Server, nil
 }
 
 const (
@@ -219,11 +251,11 @@ const (
 	outputTrailer = "---\n"
 )
 
-func writeEncodedSecret(out io.Writer, secret *v1.Secret) error {
+func writeEncodedObject(out io.Writer, in runtime.Object) error {
 	if _, err := fmt.Fprint(out, outputHeader); err != nil {
 		return err
 	}
-	if err := Codec.Encode(secret, out); err != nil {
+	if err := codec.Encode(in, out); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprint(out, outputTrailer); err != nil {
@@ -243,33 +275,108 @@ func makeOutputWriter() writer {
 
 var makeOutputWriterTestHook = makeOutputWriter
 
+// RemoteSecretAuthType is a strongly typed authentication type suitable for use with pflags.Var().
+type RemoteSecretAuthType string
+
+var _ pflag.Value = (*RemoteSecretAuthType)(nil)
+
+func (at *RemoteSecretAuthType) String() string { return string(*at) }
+func (at *RemoteSecretAuthType) Type() string   { return "RemoteSecretAuthType" }
+func (at *RemoteSecretAuthType) Set(in string) error {
+	*at = RemoteSecretAuthType(in)
+	return nil
+}
+
+const (
+	// Use a bearer token for authentication to the remote kubernetes cluster.
+	RemoteSecretAuthTypeBearerToken RemoteSecretAuthType = "bearer-token"
+
+	// User a custom custom authentication plugin for the remote kubernetes cluster.
+	RemoteSecretAuthTypePlugin RemoteSecretAuthType = "plugin"
+)
+
+// RemoteSecretOptions contains the options for creating a remote secret.
+type RemoteSecretOptions struct {
+	KubeOptions
+
+	// Create a secret with this service account's credentials.
+	ServiceAccountName string
+
+	// Authentication method for the remote Kubernetes cluster.
+	AuthType RemoteSecretAuthType
+
+	// Authenticator plugin configuration
+	AuthPluginName   string
+	AuthPluginConfig map[string]string
+}
+
+func (o *RemoteSecretOptions) addFlags(flagset *pflag.FlagSet) {
+	flagset.StringVar(&o.ServiceAccountName, "service-account", o.ServiceAccountName,
+		"create a secret with this service account's credentials.")
+	var supportedAuthType []string
+	for _, at := range []RemoteSecretAuthType{RemoteSecretAuthTypeBearerToken, RemoteSecretAuthTypePlugin} {
+		supportedAuthType = append(supportedAuthType, string(at))
+	}
+	flagset.Var(&o.AuthType, "auth-type",
+		fmt.Sprintf("type of authentication to use. supported values = %v", supportedAuthType))
+	flagset.StringVar(&o.AuthPluginName, "auth-plugin-name", o.AuthPluginName,
+		fmt.Sprintf("authenticator plug-in name. --auth-type=%v must be set with this option",
+			RemoteSecretAuthTypePlugin))
+	flagset.StringToString("auth-plugin-config", o.AuthPluginConfig,
+		fmt.Sprintf("authenticator plug-in configuration. --auth-type=%v must be set with this option",
+			RemoteSecretAuthTypePlugin))
+}
+
+func createRemoteSecret(opt RemoteSecretOptions, env Environment) (*v1.Secret, error) {
+	client, err := env.CreateClientSet(opt.Context)
+	if err != nil {
+		return nil, err
+	}
+
+	uid, err := clusterUID(client)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenSecret, err := getServiceAccountSecretToken(client, opt.ServiceAccountName, opt.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	currentContext, server, err := getCurrentContextAndClusterServerFromKubeconfig(opt.Context, env.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	var remoteSecret *v1.Secret
+	switch opt.AuthType {
+	case RemoteSecretAuthTypeBearerToken:
+		remoteSecret, err = createRemoteSecretFromTokenAndServer(tokenSecret, uid, currentContext, server)
+	case RemoteSecretAuthTypePlugin:
+		authProviderConfig := &api.AuthProviderConfig{
+			Name:   opt.AuthPluginName,
+			Config: opt.AuthPluginConfig,
+		}
+		remoteSecret, err = createRemoteSecretFromPlugin(tokenSecret, currentContext, server, uid, authProviderConfig)
+	default:
+		err = fmt.Errorf("unsupported authentication type: %v", opt.AuthType)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return remoteSecret, nil
+}
+
 // CreateRemoteSecret creates a remote secret with credentials of the specified service account.
 // This is useful for providing a cluster access to a remote apiserver.
-//
-// TODO extend to use other forms of k8s auth (see https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authentication-strategies)
-func CreateRemoteSecret(kubeconfig, context, namespace, serviceAccountName, name string) (string, error) {
-	kube, err := newKubernetesInterface(kubeconfig, context)
-	if err != nil {
-		return "", err
-	}
-
-	tokenSecret, err := getServiceAccountSecretToken(kube, serviceAccountName, namespace)
-	if err != nil {
-		return "", err
-	}
-
-	server, err := getClusterServerFromKubeconfig(kubeconfig, context)
-	if err != nil {
-		return "", err
-	}
-
-	remoteSecret, err := createRemoteSecretFromTokenAndServer(tokenSecret, name, server)
+func CreateRemoteSecret(opt RemoteSecretOptions, env Environment) (string, error) {
+	remoteSecret, err := createRemoteSecret(opt, env)
 	if err != nil {
 		return "", err
 	}
 
 	w := makeOutputWriterTestHook()
-	if err := writeEncodedSecret(w, remoteSecret); err != nil {
+	if err := writeEncodedObject(w, remoteSecret); err != nil {
 		return "", err
 	}
 	return w.String(), nil

--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -25,22 +25,24 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"istio.io/istio/pkg/kube/secretcontroller"
 )
 
-var (
+const (
 	testNamespace          = "istio-system-test"
 	testServiceAccountName = "test-service-account"
+	testKubeconfig         = "test-Kubeconfig"
+	testContext            = "test-context"
 )
 
-func makeServiceAccount(name string, secrets ...string) *v1.ServiceAccount {
+func makeServiceAccount(secrets ...string) *v1.ServiceAccount {
 	sa := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      testServiceAccountName,
 			Namespace: testNamespace,
 		},
 	}
@@ -88,16 +90,10 @@ func (w *fakeOutputWriter) Write(p []byte) (n int, err error) {
 func (w *fakeOutputWriter) String() string { return w.b.String() }
 
 func TestCreateRemoteSecrets(t *testing.T) {
-	prevStartingConfig := newStartingConfig
-	defer func() { newStartingConfig = prevStartingConfig }()
-
-	prevKubernetesInteface := newKubernetesInterface
-	defer func() { newKubernetesInterface = prevKubernetesInteface }()
-
 	prevOutputWriterStub := makeOutputWriterTestHook
 	defer func() { makeOutputWriterTestHook = prevOutputWriterStub }()
 
-	sa := makeServiceAccount(testServiceAccountName, "saSecret")
+	sa := makeServiceAccount("saSecret")
 	saSecret := makeSecret("saSecret", "caData", "token")
 	saSecretMissingToken := makeSecret("saSecret", "caData", "")
 
@@ -105,36 +101,35 @@ func TestCreateRemoteSecrets(t *testing.T) {
 apiVersion: v1
 kind: Secret
 metadata:
+  annotations:
+    istio.io/clusterContext: test-context
   creationTimestamp: null
   labels:
     istio/multiCluster: "true"
-  name: istio-remote-secret-cluster-foo
+  name: istio-remote-secret-54643f96-eca0-11e9-bb97-42010a80000a
 stringData:
-  cluster-foo: |
+  54643f96-eca0-11e9-bb97-42010a80000a: |
     apiVersion: v1
     clusters:
     - cluster:
         certificate-authority-data: Y2FEYXRh
         server: server
-      name: cluster-foo
+      name: test-context
     contexts:
     - context:
-        cluster: cluster-foo
-        user: cluster-foo
-      name: cluster-foo
-    current-context: cluster-foo
+        cluster: test-context
+        user: test-context
+      name: test-context
+    current-context: test-context
     kind: Config
     preferences: {}
     users:
-    - name: cluster-foo
+    - name: test-context
       user:
         token: token
 ---
 `
-
-	badStartingConfigErrStr := "bad starting config"
-	testKubeconfig := "test-kubeconfig"
-	testContext := "test-context"
+	badStartingConfigErrStr := "could not find cluster for Context"
 
 	cases := []struct {
 		testName string
@@ -153,27 +148,28 @@ stringData:
 	}{
 		{
 			testName:   "fail to get service account secret token",
-			objs:       []runtime.Object{sa},
+			objs:       []runtime.Object{kubeSystemNamespace, sa},
 			wantErrStr: fmt.Sprintf("secrets %q not found", saSecret.Name),
 		},
 		{
 			testName:          "fail to create starting config",
-			objs:              []runtime.Object{sa, saSecret},
+			objs:              []runtime.Object{kubeSystemNamespace, sa, saSecret},
+			config:            api.NewConfig(),
 			badStartingConfig: true,
 			wantErrStr:        badStartingConfigErrStr,
 		},
 		{
-			testName: "fail to find cluster in local kubeconfig",
-			objs:     []runtime.Object{sa, saSecret},
+			testName: "fail to find cluster in local Kubeconfig",
+			objs:     []runtime.Object{kubeSystemNamespace, sa, saSecret},
 			config: &api.Config{
 				CurrentContext: testContext,
 				Clusters:       map[string]*api.Cluster{ /* missing cluster */ },
 			},
-			wantErrStr: fmt.Sprintf(`could not find cluster for context %q`, testContext),
+			wantErrStr: fmt.Sprintf(`could not find cluster for Context %q`, testContext),
 		},
 		{
 			testName: "fail to create remote secret token",
-			objs:     []runtime.Object{sa, saSecretMissingToken},
+			objs:     []runtime.Object{kubeSystemNamespace, sa, saSecretMissingToken},
 			config: &api.Config{
 				CurrentContext: testContext,
 				Contexts: map[string]*api.Context{
@@ -187,7 +183,7 @@ stringData:
 		},
 		{
 			testName: "fail to encode secret",
-			objs:     []runtime.Object{sa, saSecret},
+			objs:     []runtime.Object{kubeSystemNamespace, sa, saSecret},
 			config: &api.Config{
 				CurrentContext: testContext,
 				Contexts: map[string]*api.Context{
@@ -202,7 +198,7 @@ stringData:
 		},
 		{
 			testName: "success",
-			objs:     []runtime.Object{sa, saSecret},
+			objs:     []runtime.Object{kubeSystemNamespace, sa, saSecret},
 			config: &api.Config{
 				CurrentContext: testContext,
 				Contexts: map[string]*api.Context{
@@ -220,37 +216,23 @@ stringData:
 	for i := range cases {
 		c := &cases[i]
 		t.Run(fmt.Sprintf("[%v] %v", i, c.testName), func(tt *testing.T) {
-			newStartingConfig = func(kubeconfig, context string) (*api.Config, error) {
-				if kubeconfig != testKubeconfig {
-					t.Fatalf("newStartingConfig invoked with wrong kubeconfig: got %v want %v",
-						kubeconfig, testKubeconfig)
-				}
-				if context != testContext {
-					t.Fatalf("newStartingConfig invoked with wrong context: got %v want %v",
-						context, testContext)
-				}
-				if c.badStartingConfig {
-					return nil, errors.New(badStartingConfigErrStr)
-				}
-				return c.config, nil
-			}
-
-			newKubernetesInterface = func(kubeconfig, context string) (kubernetes.Interface, error) {
-				if kubeconfig != testKubeconfig {
-					t.Fatalf("newKubernetesInterface invoked with wrong kubeconfig: got %v want %v",
-						kubeconfig, testKubeconfig)
-				}
-				if context != testContext {
-					t.Fatalf("newKubernetesInterface invoked invoked with wrong context: got %v want %v",
-						context, testContext)
-				}
-				return fake.NewSimpleClientset(c.objs...), nil
-			}
 			makeOutputWriterTestHook = func() writer {
 				return &fakeOutputWriter{injectError: c.outputWriterError}
 			}
 
-			got, err := CreateRemoteSecret(testKubeconfig, testContext, testNamespace, testServiceAccountName, c.name)
+			opts := RemoteSecretOptions{
+				ServiceAccountName: testServiceAccountName,
+				AuthType:           RemoteSecretAuthTypeBearerToken,
+				KubeOptions: KubeOptions{
+					Namespace:  testNamespace,
+					Context:    testContext,
+					Kubeconfig: testKubeconfig,
+				},
+			}
+
+			env := newFakeEnvironmentOrDie(t, c.config, c.objs...)
+
+			got, err := CreateRemoteSecret(opts, env) // TODO
 			if c.wantErrStr != "" {
 				if err == nil {
 					tt.Fatalf("wanted error including %q but got none", c.wantErrStr)
@@ -290,7 +272,7 @@ func TestGetServiceAccountSecretToken(t *testing.T) {
 			saName:      testServiceAccountName,
 			saNamespace: testNamespace,
 			objs: []runtime.Object{
-				makeServiceAccount(testServiceAccountName, "secret", "extra-secret"),
+				makeServiceAccount("secret", "extra-secret"),
 			},
 			wantErrStr: "wrong number of secrets",
 		},
@@ -299,7 +281,7 @@ func TestGetServiceAccountSecretToken(t *testing.T) {
 			saName:      testServiceAccountName,
 			saNamespace: testNamespace,
 			objs: []runtime.Object{
-				makeServiceAccount(testServiceAccountName, "wrong-secret"),
+				makeServiceAccount("wrong-secret"),
 				secret,
 			},
 			wantErrStr: `secrets "wrong-secret" not found`,
@@ -309,7 +291,7 @@ func TestGetServiceAccountSecretToken(t *testing.T) {
 			saName:      testServiceAccountName,
 			saNamespace: testNamespace,
 			objs: []runtime.Object{
-				makeServiceAccount(testServiceAccountName, "secret"),
+				makeServiceAccount("secret"),
 				secret,
 			},
 			want: secret,
@@ -338,31 +320,22 @@ func TestGetServiceAccountSecretToken(t *testing.T) {
 }
 
 func TestGetClusterServerFromKubeconfig(t *testing.T) {
-	prev := newStartingConfig
-	defer func() { newStartingConfig = prev }()
-
 	wantServer := "server0"
+	wantContext := "context0"
 	context := "context0"
 	cluster := "cluster0"
 
 	cases := []struct {
-		name              string
-		badStartingConfig bool
-		config            *api.Config
-		context           string
-		wantErrStr        string
+		name       string
+		config     *api.Config
+		context    string
+		wantErrStr string
 	}{
 		{
-			name:              "bad starting config",
-			context:           context,
-			badStartingConfig: true,
-			config: &api.Config{
-				CurrentContext: context,
-				Clusters: map[string]*api.Cluster{
-					context: {Server: wantServer},
-				},
-			},
-			wantErrStr: "bad starting config",
+			name:       "bad starting config",
+			context:    context,
+			config:     api.NewConfig(),
+			wantErrStr: "could not find cluster for Context",
 		},
 		{
 			name:    "missing cluster",
@@ -372,7 +345,7 @@ func TestGetClusterServerFromKubeconfig(t *testing.T) {
 				Contexts:       map[string]*api.Context{},
 				Clusters:       map[string]*api.Cluster{},
 			},
-			wantErrStr: "could not find cluster for context",
+			wantErrStr: "could not find cluster for Context",
 		},
 		{
 			name:    "missing server",
@@ -384,7 +357,7 @@ func TestGetClusterServerFromKubeconfig(t *testing.T) {
 				},
 				Clusters: map[string]*api.Cluster{},
 			},
-			wantErrStr: "could not find server for context",
+			wantErrStr: "could not find server for Context",
 		},
 		{
 			name:    "success",
@@ -400,10 +373,10 @@ func TestGetClusterServerFromKubeconfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "use explicit context different from current-context",
+			name:    "use explicit Context different from current-Context",
 			context: context,
 			config: &api.Config{
-				CurrentContext: "ignored-context", // verify context override is used
+				CurrentContext: "ignored-Context", // verify Context override is used
 				Contexts: map[string]*api.Context{
 					context: {Cluster: cluster},
 				},
@@ -417,15 +390,7 @@ func TestGetClusterServerFromKubeconfig(t *testing.T) {
 	for i := range cases {
 		c := &cases[i]
 		t.Run(fmt.Sprintf("[%v] %v", i, c.name), func(tt *testing.T) {
-			newStartingConfig = func(_, _ string) (*api.Config, error) {
-				if c.badStartingConfig {
-					return nil, errors.New("bad starting config")
-				}
-				return c.config, nil
-			}
-
-			gotServer, err := getClusterServerFromKubeconfig("foo", c.context)
-
+			gotContext, gotServer, err := getCurrentContextAndClusterServerFromKubeconfig(c.context, c.config)
 			if c.wantErrStr != "" {
 				if err == nil {
 					tt.Fatalf("wanted error including %q but got none", c.wantErrStr)
@@ -434,8 +399,13 @@ func TestGetClusterServerFromKubeconfig(t *testing.T) {
 				}
 			} else if c.wantErrStr == "" && err != nil {
 				tt.Fatalf("wanted non-error but got %q", err)
-			} else if gotServer != "server0" {
-				t.Fatalf("got server %v want %v", gotServer, wantServer)
+			} else {
+				if gotServer != wantServer {
+					t.Errorf("got server %v want %v", gotServer, wantServer)
+				}
+				if gotContext != wantContext {
+					t.Errorf("got Context %v want %v", gotContext, wantContext)
+				}
 			}
 		})
 	}
@@ -462,8 +432,10 @@ users:
     token: token
 `
 
+	fakeUID := types.UID("fake-uid-0")
 	cases := []struct {
 		name       string
+		uid        types.UID
 		context    string
 		server     string
 		in         *v1.Secret
@@ -474,27 +446,33 @@ users:
 			name:       "missing caData",
 			in:         makeSecret("", "", "token"),
 			context:    "c0",
+			uid:        fakeUID,
 			wantErrStr: errMissingRootCAKey.Error(),
 		},
 		{
 			name:       "missing token",
 			in:         makeSecret("", "caData", ""),
 			context:    "c0",
+			uid:        fakeUID,
 			wantErrStr: errMissingTokenKey.Error(),
 		},
 		{
 			name:    "success",
 			in:      makeSecret("", "caData", "token"),
 			context: "c0",
+			uid:     fakeUID,
 			want: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "istio-remote-secret-c0",
+					Name: remoteSecretNameFromUID(fakeUID),
+					Annotations: map[string]string{
+						"istio.io/clusterContext": "c0",
+					},
 					Labels: map[string]string{
 						secretcontroller.MultiClusterSecretLabel: "true",
 					},
 				},
 				StringData: map[string]string{
-					"c0": kubeconfig,
+					string(fakeUID): kubeconfig,
 				},
 			},
 		},
@@ -503,7 +481,7 @@ users:
 	for i := range cases {
 		c := &cases[i]
 		t.Run(fmt.Sprintf("[%v] %v", i, c.name), func(tt *testing.T) {
-			got, err := createRemoteSecretFromTokenAndServer(c.in, c.context, c.server)
+			got, err := createRemoteSecretFromTokenAndServer(c.in, c.uid, c.context, c.server)
 			if c.wantErrStr != "" {
 				if err == nil {
 					tt.Fatalf("wanted error including %q but none", c.wantErrStr)
@@ -527,22 +505,22 @@ func TestWriteEncodedSecret(t *testing.T) {
 	}
 
 	w := &fakeOutputWriter{failAfter: 0, injectError: errors.New("error")}
-	if err := writeEncodedSecret(w, s); err == nil {
-		t.Error("want error on first write failure")
+	if err := writeEncodedObject(w, s); err == nil {
+		t.Error("want error on local write failure")
 	}
 
 	w = &fakeOutputWriter{failAfter: 1, injectError: errors.New("error")}
-	if err := writeEncodedSecret(w, s); err == nil {
-		t.Error("want error on second write failure")
+	if err := writeEncodedObject(w, s); err == nil {
+		t.Error("want error on remote write failure")
 	}
 
 	w = &fakeOutputWriter{failAfter: 2, injectError: errors.New("error")}
-	if err := writeEncodedSecret(w, s); err == nil {
+	if err := writeEncodedObject(w, s); err == nil {
 		t.Error("want error on third write failure")
 	}
 
 	w = &fakeOutputWriter{}
-	if err := writeEncodedSecret(w, s); err != nil {
+	if err := writeEncodedObject(w, s); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
@@ -558,4 +536,119 @@ metadata:
 		t.Errorf("got\n%q\nwant\n%q", w.String(), want)
 	}
 
+}
+
+func TestCreateRemoteSecretFromPlugin(t *testing.T) {
+	kubeconfig := `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Y2FEYXRh
+    server: ""
+  name: c0
+contexts:
+- context:
+    cluster: c0
+    user: c0
+  name: c0
+current-context: c0
+kind: Config
+preferences: {}
+users:
+- name: c0
+  user:
+    auth-provider:
+      config:
+        k1: v1
+      name: foobar
+`
+	fakeUID := types.UID("fake-uid-0")
+
+	cases := []struct {
+		name               string
+		in                 *v1.Secret
+		context            string
+		uid                types.UID
+		server             string
+		authProviderConfig *api.AuthProviderConfig
+		want               *v1.Secret
+		wantErrStr         string
+	}{
+		{
+			name:       "error on missing caData",
+			in:         makeSecret("", "", "token"),
+			context:    "c0",
+			uid:        fakeUID,
+			wantErrStr: errMissingRootCAKey.Error(),
+		},
+		{
+			name:    "success on missing token",
+			in:      makeSecret("", "caData", ""),
+			context: "c0",
+			uid:     fakeUID,
+			authProviderConfig: &api.AuthProviderConfig{
+				Name: "foobar",
+				Config: map[string]string{
+					"k1": "v1",
+				},
+			},
+			want: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: remoteSecretNameFromUID(fakeUID),
+					Annotations: map[string]string{
+						"istio.io/clusterContext": "c0",
+					},
+					Labels: map[string]string{
+						secretcontroller.MultiClusterSecretLabel: "true",
+					},
+				},
+				StringData: map[string]string{
+					string(fakeUID): kubeconfig,
+				},
+			},
+		},
+		{
+			name:    "success",
+			in:      makeSecret("", "caData", "token"),
+			context: "c0",
+			uid:     types.UID("fake-uid-0"),
+			authProviderConfig: &api.AuthProviderConfig{
+				Name: "foobar",
+				Config: map[string]string{
+					"k1": "v1",
+				},
+			},
+			want: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: remoteSecretNameFromUID(fakeUID),
+					Annotations: map[string]string{
+						"istio.io/clusterContext": "c0",
+					},
+					Labels: map[string]string{
+						secretcontroller.MultiClusterSecretLabel: "true",
+					},
+				},
+				StringData: map[string]string{
+					string(fakeUID): kubeconfig,
+				},
+			},
+		},
+	}
+
+	for i := range cases {
+		c := &cases[i]
+		t.Run(fmt.Sprintf("[%v] %v", i, c.name), func(tt *testing.T) {
+			got, err := createRemoteSecretFromPlugin(c.in, c.context, c.server, c.uid, c.authProviderConfig)
+			if c.wantErrStr != "" {
+				if err == nil {
+					tt.Fatalf("wanted error including %q but none", c.wantErrStr)
+				} else if !strings.Contains(err.Error(), c.wantErrStr) {
+					tt.Fatalf("wanted error including %q but %v", c.wantErrStr, err)
+				}
+			} else if c.wantErrStr == "" && err != nil {
+				tt.Fatalf("wanted non-error but got %q", err)
+			} else if diff := cmp.Diff(got, c.want); diff != "" {
+				tt.Fatalf(" got %v\nwant %v\ndiff %v", got, c.want, diff)
+			}
+		})
+	}
 }

--- a/istioctl/pkg/multicluster/trust_anchor.go
+++ b/istioctl/pkg/multicluster/trust_anchor.go
@@ -1,0 +1,156 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"istio.io/istio/pkg/kube"
+	secConfigMap "istio.io/istio/security/pkg/k8s/configmap"
+)
+
+// TrustAnchorOptions contains the options for creating a trust anchor.
+type TrustAnchorOptions struct {
+	KubeOptions
+}
+
+// NewCreateTrustAnchorCommand creates a new command for establishing trust between two clustersByContext in a multi-cluster mesh.
+func NewCreateTrustAnchorCommand() *cobra.Command {
+	opts := TrustAnchorOptions{}
+	c := &cobra.Command{
+		Use:   "create-trust-anchor [<cluster-name>]",
+		Short: "Create a configmap with an additional trusted root CA cert",
+		Long: `Establish trust between two or more clustersByContext by appending each 
+cluster's public root CA cert to other cluster's list of trusted roots. This is 
+useful when form a multi-cluster mesh from existing clustersByContext with their own unique 
+CAs.
+
+
+`,
+		Example: `
+# Create a trust anchor configmap with c0's root CA cert and install it in cluster c1.
+istioctl --Kubeconfig=c0.yaml x create-trust-anchor c0 \
+    | kubectl -n istio-system --Kubeconfig=c1.yaml apply -f -
+
+# Delete a trust anchor configmap that was previously installed in c1
+istioctl --Kubeconfig=c0.yaml x create-trust-anchor c1 \
+    | kubectl -n istio-system --Kubeconfig=c1.yaml delete -f -
+
+`,
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts.prepare(c.Flags())
+			out, err := CreateTrustAnchor(opts)
+			if err != nil {
+				fmt.Fprintf(c.OutOrStderr(), "%v", err)
+				os.Exit(1)
+			}
+			fmt.Fprint(c.OutOrStdout(), out)
+			return nil
+		},
+	}
+	return c
+}
+
+type ClusterID struct {
+	KubeSystemUID types.UID
+	Context       string
+}
+
+func (c *ClusterID) String() string {
+	return string(c.KubeSystemUID) + "-" + c.Context
+}
+
+func NewClusterID(uid types.UID, context string) *ClusterID {
+	return &ClusterID{
+		KubeSystemUID: uid,
+		Context:       context,
+	}
+}
+
+const (
+	extraTrustAnchorPrefix = "istio-extra-trust-anchor-"
+)
+
+func trustAnchorNameFromUID(uid types.UID) string {
+	return extraTrustAnchorPrefix + string(uid)
+}
+
+// CreateTrustAnchor creates a configmap with the public root CA of the current cluster's Istio control plane.
+// This can be used to establish trust between two or more clustersByContext.
+func CreateTrustAnchor(opt TrustAnchorOptions) (string, error) {
+	client, err := kube.CreateClientset(opt.Kubeconfig, opt.Context)
+	if err != nil {
+		return "", err
+	}
+	config, err := kube.BuildClientCmd(opt.Kubeconfig, opt.Context).ConfigAccess().GetStartingConfig()
+	if err != nil {
+		return "", err
+	}
+
+	trustAnchor, err := createTrustAnchor(client, config, opt)
+	if err != nil {
+		return "", err
+	}
+
+	w := makeOutputWriterTestHook()
+	if err := writeEncodedObject(w, trustAnchor); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}
+
+func createTrustAnchor(client kubernetes.Interface, config *api.Config, opts TrustAnchorOptions) (*v1.ConfigMap, error) {
+	if opts.Context == "" {
+		opts.Context = config.CurrentContext
+	}
+
+	uid, err := clusterUID(client)
+	if err != nil {
+		return nil, err
+	}
+
+	caConfigMap, err := client.CoreV1().ConfigMaps(opts.Namespace).Get(secConfigMap.IstioSecurityConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	caRootCert, ok := caConfigMap.Data[secConfigMap.CATLSRootCertName]
+	if !ok {
+		return nil, fmt.Errorf("%q not found in configmap %v", secConfigMap.CATLSRootCertName, secConfigMap.IstioSecurityConfigMapName)
+	}
+
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: trustAnchorNameFromUID(uid),
+			Annotations: map[string]string{
+				"istio.io/clusterContext": opts.Context,
+			},
+			Labels: map[string]string{
+				"security.istio.io/extra-trust-anchors": "true", // TODO replace with type when trust anchor PR is merged.
+			},
+		},
+		Data: map[string]string{
+			string(uid): caRootCert,
+		},
+	}, nil
+}

--- a/istioctl/pkg/multicluster/trust_anchor_test.go
+++ b/istioctl/pkg/multicluster/trust_anchor_test.go
@@ -1,0 +1,188 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"istio.io/istio/security/pkg/k8s/configmap"
+)
+
+const (
+	fakeRootCA          = "fake root CA"
+	testOverrideContext = "test-override-Context"
+)
+
+var (
+	fakeCAConfigMapGood = &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      configmap.IstioSecurityConfigMapName,
+		},
+		Data: map[string]string{
+			configmap.CATLSRootCertName: fakeRootCA,
+		},
+	}
+
+	fakeCAConfigMapMissingRoot = &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      configmap.IstioSecurityConfigMapName,
+		},
+		Data: map[string]string{},
+	}
+)
+
+func TestCreateTrustAnchorInternal(t *testing.T) {
+	cases := []struct {
+		name       string
+		opts       TrustAnchorOptions
+		config     *api.Config
+		objs       []runtime.Object
+		want       *v1.ConfigMap
+		wantErrStr string
+	}{
+		{
+			name: "missing CA configmap",
+			opts: TrustAnchorOptions{KubeOptions{Namespace: testNamespace}},
+			config: &api.Config{
+				CurrentContext: testContext,
+				Contexts: map[string]*api.Context{
+					testContext: {Cluster: "cluster"},
+				},
+				Clusters: map[string]*api.Cluster{
+					"cluster": {Server: "server"},
+				},
+			},
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+			},
+			wantErrStr: `configmaps "istio-security" not found`,
+		},
+		{
+			name: "missing CA root in configmap",
+			opts: TrustAnchorOptions{KubeOptions{Namespace: testNamespace}},
+			config: &api.Config{
+				CurrentContext: testContext,
+				Contexts: map[string]*api.Context{
+					testContext: {Cluster: "cluster"},
+				},
+				Clusters: map[string]*api.Cluster{
+					"cluster": {Server: "server"},
+				},
+			},
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+				fakeCAConfigMapMissingRoot,
+			},
+			wantErrStr: `"caTLSRootCert" not found in configmap istio-security`,
+		},
+		{
+			name: "success with default Context",
+			opts: TrustAnchorOptions{KubeOptions{Namespace: testNamespace}},
+			config: &api.Config{
+				CurrentContext: testContext,
+				Contexts: map[string]*api.Context{
+					testContext: {Cluster: "cluster"},
+				},
+				Clusters: map[string]*api.Cluster{
+					"cluster": {Server: "server"},
+				},
+			},
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+				fakeCAConfigMapGood,
+			},
+			want: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: trustAnchorNameFromUID(kubeSystemNamespace.UID),
+					Annotations: map[string]string{
+						"istio.io/clusterContext": testContext,
+					},
+					Labels: map[string]string{
+						"security.istio.io/extra-trust-anchors": "true", // TODO replace with type when trust anchor PR is merged.
+					},
+				},
+				Data: map[string]string{
+					string(kubeSystemNamespace.UID): fakeRootCA,
+				},
+			},
+		},
+		{
+			name: "success with Context override",
+			opts: TrustAnchorOptions{
+				KubeOptions{
+					Context:   testOverrideContext,
+					Namespace: testNamespace,
+				},
+			},
+			config: &api.Config{
+				CurrentContext: testOverrideContext,
+				Contexts: map[string]*api.Context{
+					testOverrideContext: {Cluster: "cluster"},
+				},
+				Clusters: map[string]*api.Cluster{
+					"cluster": {Server: "server"},
+				},
+			},
+			objs: []runtime.Object{
+				kubeSystemNamespace,
+				fakeCAConfigMapGood,
+			},
+			want: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: trustAnchorNameFromUID(kubeSystemNamespace.UID),
+					Annotations: map[string]string{
+						"istio.io/clusterContext": testOverrideContext,
+					},
+					Labels: map[string]string{
+						"security.istio.io/extra-trust-anchors": "true", // TODO replace with type when trust anchor PR is merged.
+					},
+				},
+				Data: map[string]string{
+					string(kubeSystemNamespace.UID): fakeRootCA,
+				},
+			},
+		},
+	}
+
+	for i := range cases {
+		c := &cases[i]
+		t.Run(fmt.Sprintf("[%v] %v", i, c.name), func(tt *testing.T) {
+			client := fake.NewSimpleClientset(c.objs...)
+			got, err := createTrustAnchor(client, c.config, c.opts)
+			if c.wantErrStr != "" {
+				if err == nil {
+					tt.Fatalf("wanted error including %q but got none", c.wantErrStr)
+				} else if !strings.Contains(err.Error(), c.wantErrStr) {
+					tt.Fatalf("wanted error including %q but got %v", c.wantErrStr, err)
+				}
+			} else if c.wantErrStr == "" && err != nil {
+				tt.Fatalf("wanted non-error but got %q", err)
+			} else if diff := cmp.Diff(got, c.want); diff != "" {
+				tt.Errorf("got\n%v\nwant\n%vdiff %v", got, c.want, diff)
+			}
+		})
+	}
+}

--- a/security/pkg/k8s/configmap/configmap.go
+++ b/security/pkg/k8s/configmap/configmap.go
@@ -30,8 +30,8 @@ import (
 var configMapLog = log.RegisterScope("configMapController", "ConfigMap controller log", 0)
 
 const (
-	istioSecurityConfigMapName = "istio-security"
-	caTLSRootCertName          = "caTLSRootCert"
+	IstioSecurityConfigMapName = "istio-security"
+	CATLSRootCertName          = "caTLSRootCert"
 )
 
 // Controller manages the CA TLS root cert in ConfigMap.
@@ -50,14 +50,14 @@ func NewController(namespace string, core corev1.CoreV1Interface) *Controller {
 
 // InsertCATLSRootCert updates the CA TLS root certificate in the configmap.
 func (c *Controller) InsertCATLSRootCert(value string) error {
-	configmap, err := c.core.ConfigMaps(c.namespace).Get(istioSecurityConfigMapName, metav1.GetOptions{})
+	configmap, err := c.core.ConfigMaps(c.namespace).Get(IstioSecurityConfigMapName, metav1.GetOptions{})
 	exists := true
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Create a new ConfigMap.
 			configmap = &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      istioSecurityConfigMapName,
+					Name:      IstioSecurityConfigMapName,
 					Namespace: c.namespace,
 				},
 				Data: map[string]string{},
@@ -67,7 +67,7 @@ func (c *Controller) InsertCATLSRootCert(value string) error {
 			return fmt.Errorf("failed to insert CA TLS root cert: %v", err)
 		}
 	}
-	configmap.Data[caTLSRootCertName] = value
+	configmap.Data[CATLSRootCertName] = value
 	if exists {
 		if _, err = c.core.ConfigMaps(c.namespace).Update(configmap); err != nil {
 			return fmt.Errorf("failed to insert CA TLS root cert: %v", err)
@@ -107,14 +107,14 @@ func (c *Controller) InsertCATLSRootCertWithRetry(value string, retryInterval,
 
 // GetCATLSRootCert gets the CA TLS root certificate from the configmap.
 func (c *Controller) GetCATLSRootCert() (string, error) {
-	configmap, err := c.core.ConfigMaps(c.namespace).Get(istioSecurityConfigMapName, metav1.GetOptions{})
+	configmap, err := c.core.ConfigMaps(c.namespace).Get(IstioSecurityConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get CA TLS root cert: %v", err)
 	}
-	rootCert := configmap.Data[caTLSRootCertName]
+	rootCert := configmap.Data[CATLSRootCertName]
 	if rootCert == "" {
 		return "", fmt.Errorf("failed to get CA TLS root cert from configmap %s:%s",
-			istioSecurityConfigMapName, caTLSRootCertName)
+			IstioSecurityConfigMapName, CATLSRootCertName)
 	}
 
 	return rootCert, nil

--- a/security/pkg/k8s/configmap/configmap_test.go
+++ b/security/pkg/k8s/configmap/configmap_test.go
@@ -43,18 +43,18 @@ func TestInsertCATLSRootCert(t *testing.T) {
 			existingConfigMap: nil,
 			certToAdd:         "ABCD",
 			expectedActionsA: []ktesting.Action{
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 				ktesting.NewCreateAction(gvr, "test-ns", createConfigMap("test-ns", map[string]string{
-					"key1": "data1", caTLSRootCertName: "ABCD"})),
+					"key1": "data1", CATLSRootCertName: "ABCD"})),
 			},
 			expectedActionsB: []ktesting.Action{
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 				ktesting.NewCreateAction(gvr, "test-ns", createConfigMap("test-ns", map[string]string{
-					"key1": "data1", caTLSRootCertName: "ABCD"})),
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+					"key1": "data1", CATLSRootCertName: "ABCD"})),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 				ktesting.NewUpdateAction(gvr, "test-ns", &v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      istioSecurityConfigMapName,
+						Name:      IstioSecurityConfigMapName,
 						Namespace: "test-ns",
 					},
 					Data: map[string]string{},
@@ -67,17 +67,17 @@ func TestInsertCATLSRootCert(t *testing.T) {
 			existingConfigMap: createConfigMap("test-ns", map[string]string{"key1": "data1"}),
 			certToAdd:         "ABCD",
 			expectedActionsA: []ktesting.Action{
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 				ktesting.NewUpdateAction(gvr, "test-ns", createConfigMap("test-ns", map[string]string{
-					"key1": "data1", caTLSRootCertName: "ABCD"})),
+					"key1": "data1", CATLSRootCertName: "ABCD"})),
 			},
 			expectedActionsB: []ktesting.Action{
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 				ktesting.NewUpdateAction(gvr, "test-ns", createConfigMap("test-ns", map[string]string{
-					"key1": "data1", caTLSRootCertName: "ABCD"})),
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+					"key1": "data1", CATLSRootCertName: "ABCD"})),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 				ktesting.NewUpdateAction(gvr, "test-ns", createConfigMap("test-ns", map[string]string{
-					"key1": "data1", caTLSRootCertName: "ABCD"})),
+					"key1": "data1", CATLSRootCertName: "ABCD"})),
 			},
 			expectedErr: "",
 		},
@@ -86,17 +86,17 @@ func TestInsertCATLSRootCert(t *testing.T) {
 			existingConfigMap: createConfigMap("", map[string]string{"key1": "data1"}),
 			certToAdd:         "ABCD",
 			expectedActionsA: []ktesting.Action{
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 				ktesting.NewUpdateAction(gvr, "test-ns", createConfigMap("", map[string]string{
-					"key1": "data1", caTLSRootCertName: "ABCD"})),
+					"key1": "data1", CATLSRootCertName: "ABCD"})),
 			},
 			expectedActionsB: []ktesting.Action{
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 				ktesting.NewUpdateAction(gvr, "test-ns", createConfigMap("", map[string]string{
-					"key1": "data1", caTLSRootCertName: "ABCD"})),
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+					"key1": "data1", CATLSRootCertName: "ABCD"})),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 				ktesting.NewUpdateAction(gvr, "test-ns", createConfigMap("", map[string]string{
-					"key1": "data1", caTLSRootCertName: "ABCD"})),
+					"key1": "data1", CATLSRootCertName: "ABCD"})),
 			},
 			expectedErr: "",
 		},
@@ -157,7 +157,7 @@ func TestGetCATLSRootCert(t *testing.T) {
 		"ConfigMap not exists": {
 			existingConfigMap: nil,
 			expectedActions: []ktesting.Action{
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 			},
 			expectedErr: "failed to get CA TLS root cert: configmaps \"istio-security\" not found",
 		},
@@ -165,25 +165,25 @@ func TestGetCATLSRootCert(t *testing.T) {
 			namespace:         "test-ns",
 			existingConfigMap: createConfigMap("", map[string]string{"key1": "data1"}),
 			expectedActions: []ktesting.Action{
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 			},
 			expectedErr: "failed to get CA TLS root cert from configmap istio-security:caTLSRootCert",
 		},
 		"Cert exists": {
 			namespace: "test-ns",
 			existingConfigMap: createConfigMap("test-ns", map[string]string{
-				"key1": "data1", caTLSRootCertName: "TEST_CERT"}),
+				"key1": "data1", CATLSRootCertName: "TEST_CERT"}),
 			expectedActions: []ktesting.Action{
-				ktesting.NewGetAction(gvr, "test-ns", istioSecurityConfigMapName),
+				ktesting.NewGetAction(gvr, "test-ns", IstioSecurityConfigMapName),
 			},
 			expectedCert: "TEST_CERT",
 			expectedErr:  "",
 		},
 		"Cert exists, empty namespace": {
 			namespace:         "",
-			existingConfigMap: createConfigMap("", map[string]string{"key1": "data1", caTLSRootCertName: "TEST_CERT"}),
+			existingConfigMap: createConfigMap("", map[string]string{"key1": "data1", CATLSRootCertName: "TEST_CERT"}),
 			expectedActions: []ktesting.Action{
-				ktesting.NewGetAction(gvr, "", istioSecurityConfigMapName),
+				ktesting.NewGetAction(gvr, "", IstioSecurityConfigMapName),
 			},
 			expectedCert: "TEST_CERT",
 			expectedErr:  "",
@@ -225,7 +225,7 @@ func TestGetCATLSRootCert(t *testing.T) {
 func createConfigMap(namespace string, data map[string]string) *v1.ConfigMap {
 	return &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      istioSecurityConfigMapName,
+			Name:      IstioSecurityConfigMapName,
 			Namespace: namespace,
 		},
 		Data: data,

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -924,7 +924,21 @@ func CreateMultiClusterSecret(namespace string, remoteKubeConfig string, localKu
 
 	currentContext = strings.Trim(currentContext, "\n")
 
-	config, err := multicluster.CreateRemoteSecret(remoteKubeConfig, currentContext, namespace, "istio-multi", currentContext)
+	env, err := multicluster.NewEnvironment(remoteKubeConfig, currentContext, os.Stdout, os.Stderr)
+	if err != nil {
+		return err
+	}
+
+	opts := multicluster.RemoteSecretOptions{
+		ServiceAccountName: multicluster.DefaultServiceAccountName,
+		AuthType:           multicluster.RemoteSecretAuthTypeBearerToken,
+		KubeOptions: multicluster.KubeOptions{
+			Namespace:  namespace,
+			Context:    currentContext,
+			Kubeconfig: remoteKubeConfig,
+		},
+	}
+	config, err := multicluster.CreateRemoteSecret(opts, env)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
(cherry picked from commit 331320b174503525a64e3551de83e8ba66947416)

Provide convenience commands for managing a multicluster Istio control plane.

* **generate** - generate configuration that can be applied by the user, e.g. cluster specific values.yaml with correct meshNetworks settings and clusterName.

* **join** - join one or more clusters into a mesh. This includes managing cross-cluster service discovery. Can be run multiple times to reconcile the runtime configuration with the users desired intent.

* **describe** - describe the status of a multicluster mesh. This includes a per-cluster summary of root/intermediate CAs and service discovery registration status.

All three commands use two input files:

* **mesh description** - a concise description of a mesh. This includes a list of clusters with their
 associated network names. Each cluster is identified by a `context` which references an existing Kubernetes cluster context (see kubeconfig below).

* **kubeconfig** - the standard method for [organizing cluster access across clusters](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig).

The user is responsible for creating and persisting these files, e.g. via SCM. Neither file is persisted to the kube-apiserver.

note: `trust-anchor` support is pending https://github.com/istio/istio/pull/17198

Example mesh description:
```bash
$ cat mesh.yaml
mesh_id: MyMesh
clusters:
  uswest1-vpc0-prod0:
    network: vpc0
  uswest1-vpc0-prod1:
    network: vpc0
  useast1-vpc1-prod0:
    network: vpc1
  useast1-vpc1-prod1:
    network: vpc1
  uscentral1-vpc0-prod0:
    network: vpc0
```

example of generated values.yaml:
```bash
$ istioctl x mc generate values -f mesh.yaml
gateways:
  istio-ingressgateway:
    env:
      ISTIO_MESH_NETWORK: vpc0
global:
  controlPlaneSecurityEnabled: true
  meshID: mesh-foo
  meshNetworks:
    networks:
      vpc0:
        endpoints:
        - fromRegistry: Kubernetes
        - fromRegistry: 54715e58-eca0-11e9-bb97-42010a80000a
        gateways:
        - address: 192.169.2.1
          port: 443
        - address: 192.169.3.1
          port: 443
      vpc1:
        endpoints:
        - fromRegistry: 54715e58-eca0-11e9-bb97-42010a80000a
        gateways:
        - address: 192.169.4.1
          port: 443
  mtls:
    enabled: true
  multiCluster:
    clusterName: 54715e58-eca0-11e9-bb97-42010a80000a
  network: vpc0
```

Example script using above commands to install a multi-cluster capable control per-cluster and join the clusters into a mesh:
```bash
$ cat example.sh

for context in $(kubectl context get-contexts -o name); do
    kc() { kubectl --context ${context} $@; }
    ic() { istioctl --context ${context} $@; }

    ic x mc generate  -f mesh.yaml > extra.yaml
    helm template install/kubernetes/helm/istio-init --name istio-init --namespace istio-system \
        -f extra.yaml | kc apply -f -
    helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
         -f extra.yaml  kc apply -f -

        # ingress-gateway IPs are allocated after we install the control plane. We
        # need to update the control plane network configuration once the IPs are
        # ready. This is a temporary workaround until pilot can proper auto-discovery
        # the IPs for more than one cluster.
     ic x mc generate  -f mesh.yaml > extra.yaml
    helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
       -f extra.yaml | kc apply -f -
done

for context in $(kubectl context get-contexts -o name); do
    kc() { kubectl --context ${context} $@; }
    ic() { istioctl --context ${context} $@; }

    ic x mc join  -f mesh.yaml
done
```