### PR TITLE
Handle nils in Origin field when sorting analysis

### DIFF
--- a/galley/pkg/config/analysis/diag/messages.go
+++ b/galley/pkg/config/analysis/diag/messages.go
@@ -33,7 +33,11 @@ func (ms *Messages) Sort() {
 			return a.Type.Level().sortOrder < b.Type.Level().sortOrder
 		case a.Type.Code() != b.Type.Code():
 			return a.Type.Code() < b.Type.Code()
-		case a.Origin.FriendlyName() != b.Origin.FriendlyName():
+		case a.Origin == nil && b.Origin != nil:
+			return true
+		case a.Origin != nil && b.Origin == nil:
+			return false
+		case a.Origin != nil && b.Origin != nil && a.Origin.FriendlyName() != b.Origin.FriendlyName():
 			return a.Origin.FriendlyName() < b.Origin.FriendlyName()
 		default:
 			return a.String() < b.String()

--- a/galley/pkg/config/analysis/diag/messages_test.go
+++ b/galley/pkg/config/analysis/diag/messages_test.go
@@ -57,6 +57,33 @@ func TestMessages_Sort(t *testing.T) {
 	g.Expect(msgs).To(Equal(expectedMsgs))
 }
 
+func TestMessages_SortWithNilOrigin(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	firstMsg := NewMessage(
+		NewMessageType(Error, "B1", "Template: %q"),
+		nil,
+		"B",
+	)
+	secondMsg := NewMessage(
+		NewMessageType(Error, "B1", "Template: %q"),
+		nil,
+		"C",
+	)
+	thirdMsg := NewMessage(
+		NewMessageType(Error, "B1", "Template: %q"),
+		testOrigin("B"),
+		"B",
+	)
+
+	msgs := Messages{thirdMsg, secondMsg, firstMsg}
+	expectedMsgs := Messages{firstMsg, secondMsg, thirdMsg}
+
+	msgs.Sort()
+
+	g.Expect(msgs).To(Equal(expectedMsgs))
+}
+
 func TestMessages_SortedCopy(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
Fix bug introduced when sorting analysis fields. Fixes #18023. Also
orders nil correctly when sorting.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
