### PR TITLE
fix galley validation key/cert rotation (#17995)

### DIFF
--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -15,7 +15,6 @@
 package validation
 
 import (
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -25,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sync"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -60,9 +58,6 @@ var (
 
 // WebhookConfigController implements the validating admission webhook for validating Istio configuration.
 type WebhookConfigController struct {
-	mu                   sync.RWMutex
-	cert                 *tls.Certificate
-	keyCertWatcher       *fsnotify.Watcher
 	configWatcher        *fsnotify.Watcher
 	webhookParameters    *WebhookParameters
 	ownerRefs            []v1.OwnerReference
@@ -288,65 +283,25 @@ func rebuildWebhookConfigHelper(
 	return &webhookConfig, nil
 }
 
-// Reload the server's cert/key for TLS from file.
-func (whc *WebhookConfigController) reloadKeyCert() {
-	pair, err := tls.LoadX509KeyPair(whc.webhookParameters.CertFile, whc.webhookParameters.KeyFile)
-	if err != nil {
-		reportValidationCertKeyUpdateError(err)
-		scope.Errorf("Cert/Key reload error: %v", err)
-		return
-	}
-	whc.mu.Lock()
-	whc.cert = &pair
-	whc.mu.Unlock()
-
-	reportValidationCertKeyUpdate()
-	scope.Info("Cert and Key reloaded")
-}
-
 // NewWebhookConfigController manages validating webhook configuration.
 func NewWebhookConfigController(p WebhookParameters) (*WebhookConfigController, error) {
-	pair, err := tls.LoadX509KeyPair(p.CertFile, p.KeyFile)
-	if err != nil {
-		return nil, err
-	}
-	// This is not strictly necessary, but is a workaround for having the dashboard pass. The migration
-	// to OpenCensus metrics means that zero value metrics are not exported, and the dashboard tests
-	// expect data for metrics.
-	reportValidationCertKeyUpdate()
-	certKeyWatcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-	// watch the parent directory of the target files so we can catch
-	// symlink updates of k8s secrets
-	for _, file := range []string{p.CertFile, p.KeyFile, p.CACertFile, p.WebhookConfigFile} {
-		watchDir, _ := filepath.Split(file)
-		if err := certKeyWatcher.Watch(watchDir); err != nil {
-			return nil, fmt.Errorf("could not watch %v: %v", file, err)
-		}
-	}
 
-	// configuration must be updated whenever the caBundle changes.
-	// NOTE: Use a separate watcher to differentiate config/ca from cert/key updates. This is
-	// useful to avoid unnecessary updates and, more importantly, makes its easier to more
-	// accurately capture logs/metrics when files change.
-	configWatcher, err := fsnotify.NewWatcher()
+	// Configuration must be updated whenever the caBundle changes. watch the parent directory of
+	// the target files so we can catch symlink updates of k8s secrets.
+	fileWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
 	}
 	for _, file := range []string{p.CACertFile, p.WebhookConfigFile} {
 		watchDir, _ := filepath.Split(file)
-		if err := configWatcher.Watch(watchDir); err != nil {
+		if err := fileWatcher.Watch(watchDir); err != nil {
 			return nil, fmt.Errorf("could not watch %v: %v", file, err)
 		}
 	}
 
 	whc := &WebhookConfigController{
-		keyCertWatcher:              certKeyWatcher,
-		configWatcher:               configWatcher,
+		configWatcher:               fileWatcher,
 		webhookParameters:           &p,
-		cert:                        &pair,
 		createInformerWebhookSource: defaultCreateInformerWebhookSource,
 	}
 
@@ -370,8 +325,7 @@ func NewWebhookConfigController(p WebhookParameters) (*WebhookConfigController, 
 
 //reconcile monitors the keycert and webhook configuration changes, rebuild and reconcile the configuration
 func (whc *WebhookConfigController) reconcile(stopCh <-chan struct{}) {
-	defer whc.keyCertWatcher.Close() // nolint: errcheck
-	defer whc.configWatcher.Close()  // nolint: errcheck
+	defer whc.configWatcher.Close() // nolint: errcheck
 
 	// Try to create the initial webhook configuration (if it doesn't
 	// already exist). Setup a persistent monitor to reconcile the
@@ -384,7 +338,6 @@ func (whc *WebhookConfigController) reconcile(stopCh <-chan struct{}) {
 	webhookChangedCh := whc.monitorWebhookChanges(stopCh)
 
 	// use a timer to debounce file updates
-	var keyCertTimerC <-chan time.Time
 	var configTimerC <-chan time.Time
 
 	if retryAfterSetup {
@@ -394,9 +347,6 @@ func (whc *WebhookConfigController) reconcile(stopCh <-chan struct{}) {
 	var retrying bool
 	for {
 		select {
-		case <-keyCertTimerC:
-			keyCertTimerC = nil
-			whc.reloadKeyCert()
 		case <-configTimerC:
 			configTimerC = nil
 
@@ -430,16 +380,10 @@ func (whc *WebhookConfigController) reconcile(stopCh <-chan struct{}) {
 			if retry {
 				time.AfterFunc(retryUpdateAfterFailureTimeout, func() { webhookChangedCh <- struct{}{} })
 			}
-		case event, more := <-whc.keyCertWatcher.Event:
-			if more && (event.IsModify() || event.IsCreate()) && keyCertTimerC == nil {
-				keyCertTimerC = time.After(watchDebounceDelay)
-			}
 		case event, more := <-whc.configWatcher.Event:
 			if more && (event.IsModify() || event.IsCreate()) && configTimerC == nil {
 				configTimerC = time.After(watchDebounceDelay)
 			}
-		case err := <-whc.keyCertWatcher.Error:
-			scope.Errorf("keyCertWatcher error: %v", err)
 		case err := <-whc.configWatcher.Error:
 			scope.Errorf("configWatcher error: %v", err)
 		case <-stopCh:

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -17,14 +17,17 @@ package validation
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/howeyc/fsnotify"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -173,6 +176,8 @@ func DefaultArgs() *WebhookParameters {
 
 // Webhook implements the validating admission webhook for validating Istio configuration.
 type Webhook struct {
+	keyCertWatcher *fsnotify.Watcher
+
 	mu   sync.RWMutex
 	cert *tls.Certificate
 
@@ -189,23 +194,82 @@ type Webhook struct {
 	deploymentName                string
 	serviceName                   string
 	webhookName                   string
+	keyFile                       string
+	certFile                      string
 
 	// test hook for informers
 	createInformerEndpointSource createInformerEndpointSource
 }
 
+// Reload the server's cert/key for TLS from file and save it for later use by the https server.
+func (wh *Webhook) reloadKeyCert() {
+	pair, err := reloadKeyCert(wh.certFile, wh.keyFile)
+	if err != nil {
+		return
+	}
+
+	wh.mu.Lock()
+	wh.cert = pair
+	wh.mu.Unlock()
+}
+
+// Reload the server's cert/key for TLS from file.
+func reloadKeyCert(certFile, keyFile string) (*tls.Certificate, error) {
+	pair, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		reportValidationCertKeyUpdateError(err)
+		scope.Warnf("Cert/Key reload error: %v", err)
+		return nil, err
+	}
+
+	reportValidationCertKeyUpdate()
+	scope.Info("Cert and Key reloaded")
+
+	var row int
+	for _, cert := range pair.Certificate {
+		if x509Cert, err := x509.ParseCertificates(cert); err != nil {
+			scope.Infof("x509 cert [%v] - ParseCertificates() error: %v\n", row, err)
+			row++
+		} else {
+			for _, c := range x509Cert {
+				scope.Infof("x509 cert [%v] - Issuer: %q, Subject: %q, SN: %x, NotBefore: %q, NotAfter: %q\n",
+					row, c.Issuer, c.Subject, c.SerialNumber,
+					c.NotBefore.Format(time.RFC3339), c.NotAfter.Format(time.RFC3339))
+				row++
+			}
+		}
+	}
+	return &pair, nil
+}
+
 // NewWebhook creates a new instance of the admission webhook controller.
 func NewWebhook(p WebhookParameters) (*Webhook, error) {
-	pair, err := tls.LoadX509KeyPair(p.CertFile, p.KeyFile)
+	pair, err := reloadKeyCert(p.CertFile, p.KeyFile)
 	if err != nil {
 		return nil, err
+	}
+
+	// Configuration must be updated whenever the caBundle changes. Watch the parent directory of
+	// the target files so we can catch symlink updates of k8s secrets.
+	keyCertWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range []string{p.CertFile, p.KeyFile} {
+		watchDir, _ := filepath.Split(file)
+		if err := keyCertWatcher.Watch(watchDir); err != nil {
+			return nil, fmt.Errorf("could not watch %v: %v", file, err)
+		}
 	}
 
 	wh := &Webhook{
 		server: &http.Server{
 			Addr: fmt.Sprintf(":%v", p.Port),
 		},
-		cert:                          &pair,
+		keyFile:                       p.KeyFile,
+		certFile:                      p.CertFile,
+		keyCertWatcher:                keyCertWatcher,
+		cert:                          pair,
 		descriptor:                    p.PilotDescriptor,
 		validator:                     p.MixerValidator,
 		clientset:                     p.Clientset,
@@ -233,11 +297,14 @@ func (wh *Webhook) Stop() {
 }
 
 // Run implements the webhook server
-func (wh *Webhook) Run(ready chan struct{}, stopCh <-chan struct{}) {
+func (wh *Webhook) Run(ready chan<- struct{}, stopCh <-chan struct{}) {
 	go func() {
 		if err := wh.server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 			scope.Fatalf("admission webhook ListenAndServeTLS failed: %v", err)
 		}
+	}()
+	defer func() {
+		wh.Stop()
 	}()
 
 	// During initial Istio installation its possible for custom
@@ -254,6 +321,24 @@ func (wh *Webhook) Run(ready chan struct{}, stopCh <-chan struct{}) {
 
 	ready <- struct{}{}
 
+	// use a timer to debounce key/cert updates
+	var keyCertTimerC <-chan time.Time
+
+	for {
+		select {
+		case <-keyCertTimerC:
+			keyCertTimerC = nil
+			wh.reloadKeyCert()
+		case event, more := <-wh.keyCertWatcher.Event:
+			if more && (event.IsModify() || event.IsCreate()) && keyCertTimerC == nil {
+				keyCertTimerC = time.After(watchDebounceDelay)
+			}
+		case err := <-wh.keyCertWatcher.Error:
+			scope.Errorf("configWatcher error: %v", err)
+		case <-stopCh:
+			return
+		}
+	}
 }
 
 func (wh *Webhook) getCert(*tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/galley/pkg/crd/validation/webhook_test.go
+++ b/galley/pkg/crd/validation/webhook_test.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,6 +30,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/onsi/gomega"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -555,9 +557,9 @@ func TestServe(t *testing.T) {
 	ready := make(chan struct{})
 	defer func() {
 		close(stop)
-		close(ready)
 	}()
 	go wh.Run(ready, stop)
+	<-ready
 
 	validReview := makeTestReview(t, true)
 	invalidReview := makeTestReview(t, false)
@@ -642,4 +644,44 @@ func TestServe(t *testing.T) {
 			}
 		})
 	}
+}
+
+func checkCert(t *testing.T, whc *Webhook, cert, key []byte) bool {
+	t.Helper()
+	actual := whc.cert
+	expected, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		t.Fatalf("fail to load test certs.")
+	}
+	return bytes.Equal(actual.Certificate[0], expected.Certificate[0])
+}
+
+func TestReloadCert(t *testing.T) {
+	wh, cleanup := createTestWebhook(t,
+		fake.NewSimpleClientset(),
+		createFakeEndpointsSource(),
+		dummyConfig)
+	defer cleanup()
+	stop := make(chan struct{})
+	ready := make(chan struct{})
+	defer func() {
+		close(stop)
+	}()
+	go wh.Run(ready, stop)
+	<-ready
+
+	checkCert(t, wh, testcerts.ServerCert, testcerts.ServerKey)
+	// Update cert/key files.
+	if err := ioutil.WriteFile(wh.certFile, testcerts.RotatedCert, 0644); err != nil { // nolint: vetshadow
+		cleanup()
+		t.Fatalf("WriteFile(%v) failed: %v", wh.certFile, err)
+	}
+	if err := ioutil.WriteFile(wh.keyFile, testcerts.RotatedKey, 0644); err != nil { // nolint: vetshadow
+		cleanup()
+		t.Fatalf("WriteFile(%v) failed: %v", wh.keyFile, err)
+	}
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		return checkCert(t, wh, testcerts.RotatedCert, testcerts.RotatedKey)
+	}, "10s", "100ms").Should(gomega.BeTrue())
 }

--- a/galley/pkg/server/components/validation.go
+++ b/galley/pkg/server/components/validation.go
@@ -19,6 +19,7 @@ import (
 
 	"istio.io/istio/galley/pkg/crd/validation"
 	"istio.io/istio/galley/pkg/server/process"
+	"istio.io/istio/pkg/cmd"
 )
 
 // NewValidation returns a new validation component.
@@ -34,6 +35,9 @@ func NewValidation(kubeConfig string, params *validation.WebhookParameters, live
 			}
 			if params.EnableReconcileWebhookConfiguration {
 				go validation.ReconcileWebhookConfiguration(webhookServerReady, stopCh, params, kubeConfig)
+			}
+			if params.EnableValidation || params.EnableReconcileWebhookConfiguration {
+				go cmd.WaitSignal(stopCh)
 			}
 			return nil
 		},

--- a/tests/integration/galley/webhook/webhook_test.go
+++ b/tests/integration/galley/webhook/webhook_test.go
@@ -175,7 +175,7 @@ func startGalleyPortForwarderOrFail(t *testing.T, env *kube.Environment, ns stri
 	return forwarder.Address(), done
 }
 
-func fetchWebhookCertSerialNumbersOrFail(t *testing.T, client *http.Client, addr string) []string {
+func fetchWebhookCertSerialNumbersOrFail(t *testing.T, client *http.Client, addr string) []string { // nolint: interfacer
 	t.Helper()
 
 	url := fmt.Sprintf("https://%v/admitpilot", addr)

--- a/tests/integration/galley/webhook/webhook_test.go
+++ b/tests/integration/galley/webhook/webhook_test.go
@@ -15,14 +15,25 @@
 package galley
 
 import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sort"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/pkg/log"
 )
 
 var (
@@ -67,8 +78,41 @@ func TestWebhook(t *testing.T) {
 					}
 				})
 
-			// Verify that removing the galley deployment results in the webhook configuration being removed
-			ctx.NewSubTest("galleyUninstall").
+			// Verify that the webhook's key and cert are reloaded, e.g. on rotation
+			ctx.NewSubTest("key/cert reload").
+				Run(func(ctx framework.TestContext) {
+					addr, done := startGalleyPortForwarderOrFail(t, env, istioNs)
+					defer done()
+
+					client := &http.Client{
+						Transport: &http.Transport{
+							TLSClientConfig: &tls.Config{
+								InsecureSkipVerify: true,
+							},
+							DialContext: (&net.Dialer{
+								Timeout: 30 * time.Second,
+							}).DialContext,
+						},
+					}
+					defer client.CloseIdleConnections()
+
+					startingSN := fetchWebhookCertSerialNumbersOrFail(t, client, addr)
+
+					log.Infof("Initial cert serial numbers: %v", startingSN)
+
+					env.DeleteSecret(istioNs, "istio.istio-galley-service-account")
+
+					retry.UntilSuccessOrFail(t, func() error {
+						updated := fetchWebhookCertSerialNumbersOrFail(t, client, addr)
+						if diff := cmp.Diff(startingSN, updated); diff != "" {
+							log.Infof("Updated cert serial numbers: %v", updated)
+							return nil
+						}
+						return errors.New("no change to cert serial numbers")
+					}, retry.Timeout(5*time.Minute))
+				})
+
+			ctx.NewSubTest("webhookUninstall").
 				Run(func(ctx framework.TestContext) {
 					// Remove galley deployment
 					env.DeleteDeployment(istioNs, deployName)
@@ -95,6 +139,66 @@ func getVwcGeneration(vwcName string, t *testing.T, env *kube.Environment) int64
 		t.Fatalf("Could not get validating webhook webhook config %s: %v", vwcName, err)
 	}
 	return vwc.GetGeneration()
+}
+
+func startGalleyPortForwarderOrFail(t *testing.T, env *kube.Environment, ns string) (addr string, done func()) {
+	t.Helper()
+
+	fetchFunc := env.Accessor.NewSinglePodFetch(ns, "app=galley")
+	var galleyPod *v1.Pod
+	retry.UntilSuccessOrFail(t, func() error {
+		pods, err := env.Accessor.WaitUntilPodsAreReady(fetchFunc)
+		if err != nil {
+			return err
+		}
+		if len(pods) != 1 {
+			return fmt.Errorf("%v pods found, waiting for only one", len(pods))
+		}
+		galleyPod = &pods[0]
+		return nil
+	}, retry.Timeout(5*time.Minute))
+
+	forwarder, err := env.Accessor.NewPortForwarder(*galleyPod, 0, 9443)
+	if err != nil {
+		t.Fatalf("failed creating port forwarding to galley: %v", err)
+	}
+	if err := forwarder.Start(); err != nil {
+		t.Fatalf("failed to start port forwarding: %v", err)
+	}
+
+	done = func() {
+		if err := forwarder.Close(); err != nil {
+			t.Errorf("An error occurred when the port forwarder was closed: %v", err)
+		}
+	}
+	return forwarder.Address(), done
+}
+
+func fetchWebhookCertSerialNumbersOrFail(t *testing.T, client *http.Client, addr string) []string {
+	t.Helper()
+
+	url := fmt.Sprintf("https://%v/admitpilot", addr)
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		t.Fatalf("iunvalid request: %v", err)
+	}
+
+	req.Host = "istio-galley.istio-system.svc"
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("webhook request failed: %v", err)
+	}
+
+	if resp.TLS == nil {
+		t.Fatal("server did not provide certificates")
+	}
+
+	var sn []string
+	for _, cert := range resp.TLS.PeerCertificates {
+		sn = append(sn, cert.SerialNumber.Text(16))
+	}
+	sort.Strings(sn)
+	return sn
 }
 
 func TestMain(m *testing.M) {

--- a/tests/integration/galley/webhook/webhook_test.go
+++ b/tests/integration/galley/webhook/webhook_test.go
@@ -82,8 +82,8 @@ func TestWebhook(t *testing.T) {
 			// Verify that the webhook's key and cert are reloaded, e.g. on rotation
 			ctx.NewSubTest("key/cert reload").
 				Run(func(ctx framework.TestContext) {
-					addr, done := startGalleyPortForwarderOrFail(t, env, istioNs)
-					defer done()
+					scaleDeployment(istioNs, deployName, 0, t, env)
+					scaleDeployment(istioNs, deployName, 1, t, env)
 
 					client := &http.Client{
 						Transport: &http.Transport{
@@ -96,6 +96,9 @@ func TestWebhook(t *testing.T) {
 						},
 					}
 					defer client.CloseIdleConnections()
+
+					addr, done := startGalleyPortForwarderOrFail(t, env, istioNs)
+					defer done()
 
 					startingSN := fetchWebhookCertSerialNumbersOrFail(t, client, addr)
 

--- a/tests/integration/galley/webhook/webhook_test.go
+++ b/tests/integration/galley/webhook/webhook_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	tkube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/pkg/log"
 )
@@ -147,7 +148,7 @@ func startGalleyPortForwarderOrFail(t *testing.T, env *kube.Environment, ns stri
 	fetchFunc := env.Accessor.NewSinglePodFetch(ns, "app=galley")
 	var galleyPod *v1.Pod
 	retry.UntilSuccessOrFail(t, func() error {
-		pods, err := env.Accessor.WaitUntilPodsAreReady(fetchFunc)
+		pods, err := fetchFunc()
 		if err != nil {
 			return err
 		}
@@ -155,7 +156,7 @@ func startGalleyPortForwarderOrFail(t *testing.T, env *kube.Environment, ns stri
 			return fmt.Errorf("%v pods found, waiting for only one", len(pods))
 		}
 		galleyPod = &pods[0]
-		return nil
+		return tkube.CheckPodReady(galleyPod)
 	}, retry.Timeout(5*time.Minute))
 
 	forwarder, err := env.Accessor.NewPortForwarder(*galleyPod, 0, 9443)


### PR DESCRIPTION
* make validation watch and reload key/certs (again)

Galley watched and reloaded key/certs prior to istio
1.3. https://github.com/istio/istio/pull/12571 refactored galley's
validation into two parts: (1) config controller and (2) the webhook
server.

watch/reload logic was retained in (1) and not added at all to
(2). This PR adds the missing watch/reload code to (2).

fix https://github.com/istio/istio/issues/17718

(cherry picked from commit 39635d7507005cb8e2812d8731e84f17f244daa5)

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
