### PR TITLE
istio-iptables.sh: Specify default filter table where table is omitted

### DIFF
--- a/tests/scripts/testdata/empty_parameter_golden.txt
+++ b/tests/scripts/testdata/empty_parameter_golden.txt
@@ -39,9 +39,9 @@ iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
-ip6tables -F INPUT
-ip6tables -A INPUT -m state --state ESTABLISHED -j ACCEPT
-ip6tables -A INPUT -i lo -d ::1 -j ACCEPT
-ip6tables -A INPUT -j REJECT
+ip6tables -t filter -F INPUT
+ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
+ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
+ip6tables -t filter -A INPUT -j REJECT
 iptables-save 
 ip6tables-save 

--- a/tests/scripts/testdata/mode_redirect_golden.txt
+++ b/tests/scripts/testdata/mode_redirect_golden.txt
@@ -48,9 +48,9 @@ iptables -t nat -I PREROUTING 1 -i eth1 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth2 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -j RETURN
-ip6tables -F INPUT
-ip6tables -A INPUT -m state --state ESTABLISHED -j ACCEPT
-ip6tables -A INPUT -i lo -d ::1 -j ACCEPT
-ip6tables -A INPUT -j REJECT
+ip6tables -t filter -F INPUT
+ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
+ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
+ip6tables -t filter -A INPUT -j REJECT
 iptables-save 
 ip6tables-save 

--- a/tests/scripts/testdata/mode_tproxy_and_wildcard_port_golden.txt
+++ b/tests/scripts/testdata/mode_tproxy_and_wildcard_port_golden.txt
@@ -58,9 +58,9 @@ iptables -t nat -I PREROUTING 1 -i eth1 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth2 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -j RETURN
-ip6tables -F INPUT
-ip6tables -A INPUT -m state --state ESTABLISHED -j ACCEPT
-ip6tables -A INPUT -i lo -d ::1 -j ACCEPT
-ip6tables -A INPUT -j REJECT
+ip6tables -t filter -F INPUT
+ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
+ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
+ip6tables -t filter -A INPUT -j REJECT
 iptables-save 
 ip6tables-save 

--- a/tests/scripts/testdata/mode_tproxy_golden.txt
+++ b/tests/scripts/testdata/mode_tproxy_golden.txt
@@ -59,9 +59,9 @@ iptables -t nat -I PREROUTING 1 -i eth1 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth2 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -j RETURN
-ip6tables -F INPUT
-ip6tables -A INPUT -m state --state ESTABLISHED -j ACCEPT
-ip6tables -A INPUT -i lo -d ::1 -j ACCEPT
-ip6tables -A INPUT -j REJECT
+ip6tables -t filter -F INPUT
+ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
+ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
+ip6tables -t filter -A INPUT -j REJECT
 iptables-save 
 ip6tables-save 

--- a/tests/scripts/testdata/outbound_port_exclude_golden.txt
+++ b/tests/scripts/testdata/outbound_port_exclude_golden.txt
@@ -50,9 +50,9 @@ iptables -t nat -I PREROUTING 1 -i eth1 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth2 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -j RETURN
-ip6tables -F INPUT
-ip6tables -A INPUT -m state --state ESTABLISHED -j ACCEPT
-ip6tables -A INPUT -i lo -d ::1 -j ACCEPT
-ip6tables -A INPUT -j REJECT
+ip6tables -t filter -F INPUT
+ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
+ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
+ip6tables -t filter -A INPUT -j REJECT
 iptables-save 
 ip6tables-save 

--- a/tests/scripts/testdata/wildcard_include_ip_range_golden.txt
+++ b/tests/scripts/testdata/wildcard_include_ip_range_golden.txt
@@ -47,9 +47,9 @@ iptables -t nat -I PREROUTING 1 -i eth2 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth1 -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth2 -j ISTIO_REDIRECT
-ip6tables -F INPUT
-ip6tables -A INPUT -m state --state ESTABLISHED -j ACCEPT
-ip6tables -A INPUT -i lo -d ::1 -j ACCEPT
-ip6tables -A INPUT -j REJECT
+ip6tables -t filter -F INPUT
+ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
+ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
+ip6tables -t filter -A INPUT -j REJECT
 iptables-save 
 ip6tables-save 

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -263,10 +263,10 @@ func handleInboundIpv6Rules(ext dep.Dependencies, config *config.Config, ipv6Ran
 		}
 	} else {
 		// Drop all inbound traffic except established connections.
-		ext.RunQuietlyAndIgnore(dep.IP6TABLES, "-F", constants.INPUT)
-		ext.RunQuietlyAndIgnore(dep.IP6TABLES, "-A", constants.INPUT, "-m", "state", "--state", "ESTABLISHED", "-j", constants.ACCEPT)
-		ext.RunQuietlyAndIgnore(dep.IP6TABLES, "-A", constants.INPUT, "-i", "lo", "-d", "::1", "-j", constants.ACCEPT)
-		ext.RunQuietlyAndIgnore(dep.IP6TABLES, "-A", constants.INPUT, "-j", constants.REJECT)
+		ext.RunQuietlyAndIgnore(dep.IP6TABLES, "-t", constants.FILTER, "-F", constants.INPUT)
+		ext.RunQuietlyAndIgnore(dep.IP6TABLES, "-t", constants.FILTER, "-A", constants.INPUT, "-m", "state", "--state", "ESTABLISHED", "-j", constants.ACCEPT)
+		ext.RunQuietlyAndIgnore(dep.IP6TABLES, "-t", constants.FILTER, "-A", constants.INPUT, "-i", "lo", "-d", "::1", "-j", constants.ACCEPT)
+		ext.RunQuietlyAndIgnore(dep.IP6TABLES, "-t", constants.FILTER, "-A", constants.INPUT, "-j", constants.REJECT)
 	}
 }
 

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -18,6 +18,7 @@ package constants
 const (
 	MANGLE = "mangle"
 	NAT    = "nat"
+	FILTER = "filter"
 )
 
 // Constants used for generating iptables commands

--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -567,8 +567,8 @@ if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
   fi
 else
   # Drop all inbound traffic except established connections.
-  ip6tables -F INPUT || true
-  ip6tables -A INPUT -m state --state ESTABLISHED -j ACCEPT || true
-  ip6tables -A INPUT -i lo -d ::1 -j ACCEPT || true
-  ip6tables -A INPUT -j REJECT || true
+  ip6tables -t filter -F INPUT || true
+  ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT || true
+  ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT || true
+  ip6tables -t filter -A INPUT -j REJECT || true
 fi


### PR DESCRIPTION
By default, if -t <tablename> is not specified; then the default table is filter.
Explicitly specify this table in bash script; becomes easier for golang implementation

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
