### PR TITLE
Remove experimental from manifest subcommand

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -152,7 +152,7 @@ debug and diagnose their Istio mesh.
 
 	profileCmd := mesh.ProfileCmd()
 	hideInheritedFlags(profileCmd, "namespace", "istioNamespace")
-	experimentalCmd.AddCommand(profileCmd)
+	rootCmd.AddCommand(profileCmd)
 
 	experimentalCmd.AddCommand(mesh.UpgradeCmd())
 

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -148,7 +148,7 @@ debug and diagnose their Istio mesh.
 
 	manifestCmd := mesh.ManifestCmd()
 	hideInheritedFlags(manifestCmd, "namespace", "istioNamespace")
-	experimentalCmd.AddCommand(manifestCmd)
+	rootCmd.AddCommand(manifestCmd)
 
 	profileCmd := mesh.ProfileCmd()
 	hideInheritedFlags(profileCmd, "namespace", "istioNamespace")


### PR DESCRIPTION
manifest apply subcommand is no longer experimental in 1.4. 