### PR TITLE
Change istioctl x webhook tests output statements

### DIFF
--- a/istioctl/cmd/webhook.go
+++ b/istioctl/cmd/webhook.go
@@ -18,6 +18,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"strings"
 	"time"
@@ -189,7 +190,7 @@ istioctl experimental post-install webhook enable --validation --webhook-secret 
 			if err != nil {
 				return fmt.Errorf("err when creating Kubernetes client interface: %v", err)
 			}
-			err = enableWebhookConfig(client, opts)
+			err = enableWebhookConfig(client, opts, cmd.OutOrStdout())
 			if err != nil {
 				return fmt.Errorf("err when enabling webhook configurations: %v", err)
 			}
@@ -315,7 +316,7 @@ istioctl experimental post-install webhook status --validation --validation-conf
 			if err != nil {
 				return fmt.Errorf("err when creating Kubernetes client interface: %v", err)
 			}
-			validationErr, injectionErr := displayWebhookConfig(client, opts)
+			validationErr, injectionErr := displayWebhookConfig(client, opts, cmd.OutOrStdout())
 			// Not found is not treated as an error
 			if errors.IsNotFound(validationErr) && errors.IsNotFound(injectionErr) {
 				cmd.Printf("validation webhook (%v) and injection webhook (%v) are not found\n",
@@ -356,17 +357,17 @@ istioctl experimental post-install webhook status --validation --validation-conf
 
 // Create the validatingwebhookconfiguration
 func createValidatingWebhookConfig(k8sClient kubernetes.Interface,
-	config *v1beta1.ValidatingWebhookConfiguration) (*v1beta1.ValidatingWebhookConfiguration, error) {
+	config *v1beta1.ValidatingWebhookConfiguration, writer io.Writer) (*v1beta1.ValidatingWebhookConfiguration, error) {
 	var whConfig, curConfig *v1beta1.ValidatingWebhookConfiguration
 	var err error
 	client := k8sClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
 	curConfig, err = client.Get(config.Name, metav1.GetOptions{})
 	if err == nil {
-		fmt.Printf("update webhook configuration %v\n", config.Name)
+		fmt.Fprintf(writer, "update webhook configuration %v\n", config.Name)
 		config.ObjectMeta.ResourceVersion = curConfig.ObjectMeta.ResourceVersion
 		whConfig, err = client.Update(config)
 	} else {
-		fmt.Printf("create webhook configuration %v\n", config.Name)
+		fmt.Fprintf(writer, "create webhook configuration %v\n", config.Name)
 		whConfig, err = client.Create(config)
 	}
 	return whConfig, err
@@ -374,43 +375,43 @@ func createValidatingWebhookConfig(k8sClient kubernetes.Interface,
 
 // Create the mutatingwebhookconfiguration
 func createMutatingWebhookConfig(k8sClient kubernetes.Interface,
-	config *v1beta1.MutatingWebhookConfiguration) (*v1beta1.MutatingWebhookConfiguration, error) {
+	config *v1beta1.MutatingWebhookConfiguration, writer io.Writer) (*v1beta1.MutatingWebhookConfiguration, error) {
 	var curConfig, whConfig *v1beta1.MutatingWebhookConfiguration
 	var err error
 	client := k8sClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 	curConfig, err = client.Get(config.Name, metav1.GetOptions{})
 	if err == nil {
-		fmt.Printf("update webhook configuration %v\n", config.Name)
+		fmt.Fprintf(writer, "update webhook configuration %v\n", config.Name)
 		config.ObjectMeta.ResourceVersion = curConfig.ObjectMeta.ResourceVersion
 		whConfig, err = client.Update(config)
 	} else {
-		fmt.Printf("create webhook configuration %v\n", config.Name)
+		fmt.Fprintf(writer, "create webhook configuration %v\n", config.Name)
 		whConfig, err = client.Create(config)
 	}
 	return whConfig, err
 }
 
 // Enable webhook configurations
-func enableWebhookConfig(client kubernetes.Interface, opt *enableCliOptions) error {
+func enableWebhookConfig(client kubernetes.Interface, opt *enableCliOptions, writer io.Writer) error {
 	var errRet error
 
 	// Read Kubernetes CA certificate that will be used as the CA bundle of the webhook configurations
 	caCert, err := readCACert(client, opt.caCertPath, opt.webhookSecretName, opt.webhookSecretNameSpace,
-		opt.maxTimeForReadingWebhookCert)
+		opt.maxTimeForReadingWebhookCert, writer)
 	if err != nil {
 		errRet = multierror.Append(errRet, fmt.Errorf("err when reading CA certificate: %v", err))
 		return errRet
 	}
-	fmt.Printf("Webhook CA certificate:\n%v\n", string(caCert))
+	fmt.Fprintf(writer, "Webhook CA certificate:\n%v\n", string(caCert))
 
 	if opt.enableValidationWebhook {
-		err := enableValidationWebhookConfig(client, caCert, opt)
+		err := enableValidationWebhookConfig(client, caCert, opt, writer)
 		if err != nil {
 			errRet = multierror.Append(errRet, err)
 		}
 	}
 	if opt.enableMutationWebhook {
-		err := enableMutationWebhookConfig(client, caCert, opt)
+		err := enableMutationWebhookConfig(client, caCert, opt, writer)
 		if err != nil {
 			errRet = multierror.Append(errRet, err)
 		}
@@ -419,10 +420,10 @@ func enableWebhookConfig(client kubernetes.Interface, opt *enableCliOptions) err
 }
 
 // Enable validation webhook configuration
-func enableValidationWebhookConfig(client kubernetes.Interface, caCert []byte, opt *enableCliOptions) error {
+func enableValidationWebhookConfig(client kubernetes.Interface, caCert []byte, opt *enableCliOptions, writer io.Writer) error {
 	// Apply the webhook configuration when the Galley webhook server is running.
 	err := waitForServerRunning(client, namespace, opt.validatingWebhookServiceName,
-		opt.maxTimeForCheckingWebhookServer)
+		opt.maxTimeForCheckingWebhookServer, writer)
 	if err != nil {
 		return fmt.Errorf("err when checking validation webhook server: %v", err)
 	}
@@ -430,7 +431,7 @@ func enableValidationWebhookConfig(client kubernetes.Interface, caCert []byte, o
 	if err != nil {
 		return fmt.Errorf("err when build validatingwebhookconfiguration: %v", err)
 	}
-	_, err = createValidatingWebhookConfig(client, webhookConfig)
+	_, err = createValidatingWebhookConfig(client, webhookConfig, writer)
 	if err != nil {
 		return fmt.Errorf("error when creating validatingwebhookconfiguration: %v", err)
 	}
@@ -438,10 +439,10 @@ func enableValidationWebhookConfig(client kubernetes.Interface, caCert []byte, o
 }
 
 // Enable mutation webhook configuration
-func enableMutationWebhookConfig(client kubernetes.Interface, caCert []byte, opt *enableCliOptions) error {
+func enableMutationWebhookConfig(client kubernetes.Interface, caCert []byte, opt *enableCliOptions, writer io.Writer) error {
 	// Apply the webhook configuration when the Sidecar Injector webhook server is running.
 	err := waitForServerRunning(client, namespace, opt.mutatingWebhookServiceName,
-		opt.maxTimeForCheckingWebhookServer)
+		opt.maxTimeForCheckingWebhookServer, writer)
 	if err != nil {
 		return fmt.Errorf("err when checking injection webhook server: %v", err)
 	}
@@ -449,7 +450,7 @@ func enableMutationWebhookConfig(client kubernetes.Interface, caCert []byte, opt
 	if err != nil {
 		return fmt.Errorf("err when build mutatingwebhookconfiguration: %v", err)
 	}
-	_, err = createMutatingWebhookConfig(client, webhookConfig)
+	_, err = createMutatingWebhookConfig(client, webhookConfig, writer)
 	if err != nil {
 		return fmt.Errorf("error when creating mutatingwebhookconfiguration: %v", err)
 	}
@@ -470,20 +471,20 @@ func disableWebhookConfig(k8sClient kubernetes.Interface, opt *disableCliOptions
 }
 
 // Display webhook configurations
-func displayWebhookConfig(client kubernetes.Interface, opt *statusCliOptions) (error, error) {
+func displayWebhookConfig(client kubernetes.Interface, opt *statusCliOptions, writer io.Writer) (error, error) {
 	var validationErr error
 	var injectionErr error
 	if opt.validationWebhook {
-		validationErr = displayValidationWebhookConfig(client, opt)
+		validationErr = displayValidationWebhookConfig(client, opt, writer)
 	}
 	if opt.injectionWebhook {
-		injectionErr = displayMutationWebhookConfig(client, opt)
+		injectionErr = displayMutationWebhookConfig(client, opt, writer)
 	}
 	return validationErr, injectionErr
 }
 
 // Display validation webhook configuration
-func displayValidationWebhookConfig(client kubernetes.Interface, opt *statusCliOptions) error {
+func displayValidationWebhookConfig(client kubernetes.Interface, opt *statusCliOptions, writer io.Writer) error {
 	config, err := client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(
 		opt.validatingWebhookConfigName, metav1.GetOptions{})
 	if err != nil {
@@ -494,12 +495,12 @@ func displayValidationWebhookConfig(client kubernetes.Interface, opt *statusCliO
 		return fmt.Errorf("error when marshaling ValidatingWebhookConfiguration %v to yaml: %v",
 			opt.validatingWebhookConfigName, err)
 	}
-	fmt.Printf("ValidatingWebhookConfiguration %v is:\n%v\n", opt.validatingWebhookConfigName, string(b))
+	fmt.Fprintf(writer, "ValidatingWebhookConfiguration %v is:\n%v\n", opt.validatingWebhookConfigName, string(b))
 	return nil
 }
 
 // Display mutation webhook configuration
-func displayMutationWebhookConfig(client kubernetes.Interface, opt *statusCliOptions) error {
+func displayMutationWebhookConfig(client kubernetes.Interface, opt *statusCliOptions, writer io.Writer) error {
 	config, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(
 		opt.mutatingWebhookConfigName, metav1.GetOptions{})
 	if err != nil {
@@ -510,14 +511,15 @@ func displayMutationWebhookConfig(client kubernetes.Interface, opt *statusCliOpt
 		return fmt.Errorf("error when marshaling MutatingWebhookConfiguration %v to yaml: %v",
 			opt.mutatingWebhookConfigName, err)
 	}
-	fmt.Printf("MutatingWebhookConfiguration %v is:\n%v\n", opt.mutatingWebhookConfigName, string(b))
+	fmt.Fprintf(writer, "MutatingWebhookConfiguration %v is:\n%v\n", opt.mutatingWebhookConfigName, string(b))
 	return nil
 }
 
 // Read CA certificate and check whether it is a valid certificate.
 // First try read CA cert from a local file. If no local file, read from CA cert from default service account.
 // Next verify that the webhook certificate is issued by CA cert.
-func readCACert(client kubernetes.Interface, certPath, secretName, secretNamespace string, maxWaitTime time.Duration) ([]byte, error) {
+func readCACert(client kubernetes.Interface, certPath, secretName, secretNamespace string,
+	maxWaitTime time.Duration, writer io.Writer) ([]byte, error) {
 	var caCert []byte
 	var err error
 	if len(certPath) > 0 { // read the CA certificate from a local file
@@ -544,10 +546,10 @@ func readCACert(client kubernetes.Interface, certPath, secretName, secretNamespa
 	for {
 		cert, err = readCertFromSecret(client, secretName, secretNamespace)
 		if err == nil {
-			fmt.Printf("finished reading cert %v/%v\n", secretNamespace, secretName)
+			fmt.Fprintf(writer, "finished reading cert %v/%v\n", secretNamespace, secretName)
 			break
 		}
-		fmt.Printf("could not read secret %v/%v: %v\n", secretNamespace, secretName, err)
+		fmt.Fprintf(writer, "could not read secret %v/%v: %v\n", secretNamespace, secretName, err)
 		select {
 		case <-timerCh:
 			return nil, fmt.Errorf("the secret %v/%v is not readable within %v", secretNamespace, secretName, maxWaitTime)
@@ -566,7 +568,7 @@ func readCACert(client kubernetes.Interface, certPath, secretName, secretNamespa
 	return caCert, nil
 }
 
-func waitForServerRunning(client kubernetes.Interface, namespace, svc string, maxWaitTime time.Duration) error {
+func waitForServerRunning(client kubernetes.Interface, namespace, svc string, maxWaitTime time.Duration, writer io.Writer) error {
 	startTime := time.Now()
 	timerCh := time.After(maxWaitTime - time.Since(startTime))
 	// TODO (lei-tang): the retry here may be implemented through another retry mechanism.
@@ -575,10 +577,10 @@ func waitForServerRunning(client kubernetes.Interface, namespace, svc string, ma
 		// its https server.
 		err := isEndpointReady(client, svc, namespace)
 		if err == nil {
-			fmt.Printf("the server at %v/%v is running\n", namespace, svc)
+			fmt.Fprintf(writer, "the server at %v/%v is running\n", namespace, svc)
 			break
 		}
-		fmt.Printf("the server at %v/%v is not running: %v\n", namespace, svc, err)
+		fmt.Fprintf(writer, "the server at %v/%v is not running: %v\n", namespace, svc, err)
 		select {
 		case <-timerCh:
 			return fmt.Errorf("the server at %v/%v is not running within %v", namespace, svc, maxWaitTime)

--- a/istioctl/cmd/webhook_test.go
+++ b/istioctl/cmd/webhook_test.go
@@ -344,6 +344,7 @@ func TestStatusCliOptionsValidation(t *testing.T) {
 }
 
 func TestDisableWebhookConfig(t *testing.T) {
+	var buf bytes.Buffer
 	testCases := map[string]struct {
 		opt                           disableCliOptions
 		createValidatingWebhookConfig bool
@@ -408,7 +409,7 @@ func TestDisableWebhookConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%v: err when build validatingwebhookconfiguration: %v", tcName, err)
 			}
-			_, err = createValidatingWebhookConfig(client, webhookConfig)
+			_, err = createValidatingWebhookConfig(client, webhookConfig, &buf)
 			if err != nil {
 				t.Fatalf("%v: err when creating validatingwebhookconfiguration: %v", tcName, err)
 			}
@@ -420,7 +421,7 @@ func TestDisableWebhookConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%v: err when build mutatingwebhookconfiguration: %v", tcName, err)
 			}
-			_, err = createMutatingWebhookConfig(client, webhookConfig)
+			_, err = createMutatingWebhookConfig(client, webhookConfig, &buf)
 			if err != nil {
 				t.Fatalf("%v: error when creating mutatingwebhookconfiguration: %v", tcName, err)
 			}
@@ -479,6 +480,7 @@ func TestBuildMutatingWebhookConfig(t *testing.T) {
 }
 
 func TestCreateValidatingWebhookConfig(t *testing.T) {
+	var buf bytes.Buffer
 	testCases := map[string]struct {
 		createWebhookConfig bool
 		updateWebhookConfig bool
@@ -507,7 +509,7 @@ func TestCreateValidatingWebhookConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%v: err when build ValidatingWebhookConfiguration: %v", tcName, err)
 			}
-			_, err = createValidatingWebhookConfig(client, webhookConfig)
+			_, err = createValidatingWebhookConfig(client, webhookConfig, &buf)
 			if err != nil {
 				t.Fatalf("%v: error when creating ValidatingWebhookConfiguration: %v", tcName, err)
 			}
@@ -517,7 +519,7 @@ func TestCreateValidatingWebhookConfig(t *testing.T) {
 		}
 		if tc.updateWebhookConfig {
 			webhookConfig.Webhooks[0].ClientConfig.CABundle = []byte("new-ca-bundle")
-			updated, err := createValidatingWebhookConfig(client, webhookConfig)
+			updated, err := createValidatingWebhookConfig(client, webhookConfig, &buf)
 			if err != nil {
 				t.Fatalf("%v: error when updating ValidatingWebhookConfiguration: %v", tcName, err)
 			}
@@ -532,6 +534,7 @@ func TestCreateValidatingWebhookConfig(t *testing.T) {
 }
 
 func TestCreateMutatingWebhookConfig(t *testing.T) {
+	var buf bytes.Buffer
 	testCases := map[string]struct {
 		createWebhookConfig bool
 		updateWebhookConfig bool
@@ -560,7 +563,7 @@ func TestCreateMutatingWebhookConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%v: err when build MutatingWebhookConfiguration: %v", tcName, err)
 			}
-			_, err = createMutatingWebhookConfig(client, webhookConfig)
+			_, err = createMutatingWebhookConfig(client, webhookConfig, &buf)
 			if err != nil {
 				t.Fatalf("%v: error when creating MutatingWebhookConfiguration: %v", tcName, err)
 			}
@@ -570,7 +573,7 @@ func TestCreateMutatingWebhookConfig(t *testing.T) {
 		}
 		if tc.updateWebhookConfig {
 			webhookConfig.Webhooks[0].ClientConfig.CABundle = []byte("new-ca-bundle")
-			updated, err := createMutatingWebhookConfig(client, webhookConfig)
+			updated, err := createMutatingWebhookConfig(client, webhookConfig, &buf)
 			if err != nil {
 				t.Fatalf("%v: error when updating MutatingWebhookConfiguration: %v", tcName, err)
 			}
@@ -585,6 +588,7 @@ func TestCreateMutatingWebhookConfig(t *testing.T) {
 }
 
 func TestDisplayValidationWebhookConfig(t *testing.T) {
+	var buf bytes.Buffer
 	testCases := map[string]struct {
 		opt                           statusCliOptions
 		createValidatingWebhookConfig bool
@@ -617,13 +621,13 @@ func TestDisplayValidationWebhookConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%v: err when build validatingwebhookconfiguration: %v", tcName, err)
 			}
-			_, err = createValidatingWebhookConfig(client, webhookConfig)
+			_, err = createValidatingWebhookConfig(client, webhookConfig, &buf)
 			if err != nil {
 				t.Fatalf("%v: error when creating validatingwebhookconfiguration: %v", tcName, err)
 			}
 		}
 
-		validationErr := displayValidationWebhookConfig(client, &tc.opt)
+		validationErr := displayValidationWebhookConfig(client, &tc.opt, &buf)
 		if tc.shouldFail {
 			if validationErr == nil {
 				t.Errorf("%v: should have failed", tcName)
@@ -637,6 +641,7 @@ func TestDisplayValidationWebhookConfig(t *testing.T) {
 }
 
 func TestDisplayMutationWebhookConfig(t *testing.T) {
+	var buf bytes.Buffer
 	testCases := map[string]struct {
 		opt                         statusCliOptions
 		createMutatingWebhookConfig bool
@@ -670,13 +675,13 @@ func TestDisplayMutationWebhookConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%v: err when build mutatingwebhookconfiguration: %v", tcName, err)
 			}
-			_, err = createMutatingWebhookConfig(client, webhookConfig)
+			_, err = createMutatingWebhookConfig(client, webhookConfig, &buf)
 			if err != nil {
 				t.Fatalf("%v: error when creating mutatingwebhookconfiguration: %v", tcName, err)
 			}
 		}
 
-		injectionErr := displayMutationWebhookConfig(client, &tc.opt)
+		injectionErr := displayMutationWebhookConfig(client, &tc.opt, &buf)
 		if tc.shouldFail {
 			if injectionErr == nil {
 				t.Errorf("%v: should have failed", tcName)
@@ -690,6 +695,7 @@ func TestDisplayMutationWebhookConfig(t *testing.T) {
 }
 
 func TestDisplayWebhookConfig(t *testing.T) {
+	var buf bytes.Buffer
 	testCases := map[string]struct {
 		opt                           statusCliOptions
 		createValidatingWebhookConfig bool
@@ -754,7 +760,7 @@ func TestDisplayWebhookConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%v: err when build validatingwebhookconfiguration: %v", tcName, err)
 			}
-			_, err = createValidatingWebhookConfig(client, webhookConfig)
+			_, err = createValidatingWebhookConfig(client, webhookConfig, &buf)
 			if err != nil {
 				t.Fatalf("%v: error when creating validatingwebhookconfiguration: %v", tcName, err)
 			}
@@ -766,13 +772,13 @@ func TestDisplayWebhookConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%v: err when build mutatingwebhookconfiguration: %v", tcName, err)
 			}
-			_, err = createMutatingWebhookConfig(client, webhookConfig)
+			_, err = createMutatingWebhookConfig(client, webhookConfig, &buf)
 			if err != nil {
 				t.Fatalf("%v: error when creating mutatingwebhookconfiguration: %v", tcName, err)
 			}
 		}
 
-		validationErr, injectionErr := displayWebhookConfig(client, &tc.opt)
+		validationErr, injectionErr := displayWebhookConfig(client, &tc.opt, &buf)
 		if tc.shouldFail {
 			if validationErr == nil && injectionErr == nil {
 				t.Errorf("%v: should have failed", tcName)


### PR DESCRIPTION
Per https://github.com/istio/istio/issues/18025:
remove all fmt.Printf from webhook.go. Replace with fmt.Fprintf(writer, ... like the other istioctl commands.
The goal is that doing go test in the istioctl/cmd should not produce any output from webhook.go or webhook_test.go.

Please provide a description for what this PR is for: https://github.com/istio/istio/issues/18025

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
