### PR TITLE
Disable collections not needed by snapshots in Galley

### DIFF
--- a/galley/pkg/config/meta/schema/schema.go
+++ b/galley/pkg/config/meta/schema/schema.go
@@ -81,11 +81,15 @@ func (m *Metadata) DirectTransformSettings() *DirectTransformSettings {
 	panic("Metadata.DirectTransformSettings: DirectTransformSettings not found")
 }
 
-// AllCollectionsInSnapshots returns an aggregate list of names of collections that will appear in snapshots.
-func (m *Metadata) AllCollectionsInSnapshots() []string {
+// AllCollectionsInSnapshots returns an aggregate list of names of collections that will appear in the specified snapshots.
+func (m *Metadata) AllCollectionsInSnapshots(snapshotNames []string) []string {
 	names := make(map[collection.Name]struct{})
 
-	for _, s := range m.snapshots {
+	for _, n := range snapshotNames {
+		s, ok := m.snapshots[n]
+		if !ok {
+			panic(fmt.Sprintf("Invalid snapshot name provided: %q", n))
+		}
 		for _, c := range s.Collections {
 			names[c] = struct{}{}
 		}

--- a/galley/pkg/config/meta/schema/schema_test.go
+++ b/galley/pkg/config/meta/schema/schema_test.go
@@ -249,6 +249,8 @@ func TestSchemaBasic(t *testing.T) {
 		"istio.io/api/networking/v1alpha3",
 		"istio.networking.v1alpha3.VirtualService"))
 	g.Expect(s.AllCollections()).To(Equal(b.Build()))
+	g.Expect(s.AllCollectionsInSnapshots([]string{"default"})).To(ConsistOf("istio/networking.istio.io/v1alpha3/virtualservices"))
+	g.Expect(func() { s.AllCollectionsInSnapshots([]string{"bogus"}) }).To(Panic())
 
 	g.Expect(s.TransformSettings()).To(HaveLen(1))
 	g.Expect(s.TransformSettings()[0]).To(Equal(

--- a/galley/pkg/config/processing/transformer/provider.go
+++ b/galley/pkg/config/processing/transformer/provider.go
@@ -69,6 +69,33 @@ func (t Providers) Create(o processing.ProcessorOptions) []event.Transformer {
 	return xforms
 }
 
+// RequiredInputsFor back-maps a list of collections used as transformer outputs, returning the set of
+// upstream input collections required to generate those outputs.
+func (t Providers) RequiredInputsFor(outputs collection.Names) map[collection.Name]struct{} {
+	// For each transform, map output to inputs
+	outToIn := make(map[collection.Name]map[collection.Name]struct{})
+	for _, xfp := range t {
+		for _, out := range xfp.Outputs() {
+			if _, ok := outToIn[out]; !ok {
+				outToIn[out] = make(map[collection.Name]struct{})
+			}
+			for _, in := range xfp.Inputs() {
+				outToIn[out][in] = struct{}{}
+			}
+		}
+	}
+
+	// 2. For each input collection, get its inputs using the above mapping and include them in the output set
+	inputs := make(map[collection.Name]struct{})
+	for _, c := range outputs {
+		for in := range outToIn[c] {
+			inputs[in] = struct{}{}
+		}
+	}
+
+	return inputs
+}
+
 // NewSimpleTransformerProvider creates a basic transformer provider for a basic transformer
 func NewSimpleTransformerProvider(input, output collection.Name, handleFn func(e event.Event, h event.Handler)) Provider {
 	inputs := collection.Names{input}

--- a/galley/pkg/config/util/kuberesource/resources.go
+++ b/galley/pkg/config/util/kuberesource/resources.go
@@ -27,15 +27,15 @@ import (
 // - Builtin types are excluded by default.
 // - If ServiceDiscovery is enabled, any built-in type should be readded.
 // In addition, any resources not needed as inputs by the specified collections are disabled
-func DisableExcludedKubeResources(krs schema.KubeResources, xformProviders transformer.Providers,
+func DisableExcludedKubeResources(resources schema.KubeResources, providers transformer.Providers,
 	requiredCols collection.Names, excludedResourceKinds []string, enableServiceDiscovery bool) schema.KubeResources {
 
 	// Get upstream collections in terms of transformer configuration
 	// Required collections are specified in terms of transformer outputs, but we care here about the corresponding inputs
-	upstreamCols := xformProviders.RequiredInputsFor(requiredCols)
+	upstreamCols := providers.RequiredInputsFor(requiredCols)
 
 	var result schema.KubeResources
-	for _, r := range krs {
+	for _, r := range resources {
 		if isKindExcluded(excludedResourceKinds, r.Kind) {
 			// Found a matching exclude directive for this KubeResource. Disable the resource.
 			r.Disabled = true

--- a/galley/pkg/server/components/processing2.go
+++ b/galley/pkg/server/components/processing2.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/meta/metadata"
 	"istio.io/istio/galley/pkg/config/meta/schema"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
 	"istio.io/istio/galley/pkg/config/processing"
 	"istio.io/istio/galley/pkg/config/processing/snapshotter"
 	"istio.io/istio/galley/pkg/config/processor"
@@ -57,6 +58,11 @@ import (
 )
 
 const versionMetadataKey = "config.source.version"
+
+var (
+	snapshots       = []string{metadata.Default, metadata.SyntheticServiceEntry}
+	triggerSnapshot = metadata.Default
+)
 
 // Processing2 component is the main config processing component that will listen to a config source and publish
 // resources through an MCP server, or a dialout connection.
@@ -103,13 +109,19 @@ func (p *Processing2) Start() (err error) {
 
 	m := metadata.MustGet()
 
-	kubeResources := kuberesource.DisableExcludedKubeResources(m.KubeSource().Resources(), p.args.ExcludedResourceKinds, p.args.EnableServiceDiscovery)
+	transformProviders := transforms.Providers(m)
+
+	// Disable any unnecessary resources, including resources not in configured snapshots
+	var colsInSnapshots collection.Names
+	for _, c := range m.AllCollectionsInSnapshots(snapshots) {
+		colsInSnapshots = append(colsInSnapshots, collection.NewName(c))
+	}
+	kubeResources := kuberesource.DisableExcludedKubeResources(m.KubeSource().Resources(), transformProviders,
+		colsInSnapshots, p.args.ExcludedResourceKinds, p.args.EnableServiceDiscovery)
 
 	if src, updater, err = p.createSourceAndStatusUpdater(kubeResources); err != nil {
 		return
 	}
-
-	transformProviders := transforms.Providers(m)
 
 	var distributor snapshotter.Distributor = snapshotter.NewMCPDistributor(p.mcpCache)
 	if p.args.EnableConfigAnalysis {
@@ -117,8 +129,8 @@ func (p *Processing2) Start() (err error) {
 			StatusUpdater:     updater,
 			Analyzer:          analyzers.AllCombined().WithDisabled(kubeResources.DisabledCollections(), transformProviders),
 			Distributor:       distributor,
-			AnalysisSnapshots: []string{metadata.Default, metadata.SyntheticServiceEntry},
-			TriggerSnapshot:   metadata.Default,
+			AnalysisSnapshots: snapshots,
+			TriggerSnapshot:   triggerSnapshot,
 		}
 		distributor = snapshotter.NewAnalyzingDistributor(settings)
 	}
@@ -129,7 +141,7 @@ func (p *Processing2) Start() (err error) {
 		Source:             event.CombineSources(mesh, src),
 		TransformProviders: transformProviders,
 		Distributor:        distributor,
-		EnabledSnapshots:   []string{metadata.Default, metadata.SyntheticServiceEntry},
+		EnabledSnapshots:   snapshots,
 	}
 	if p.runtime, err = processorInitialize(processorSettings); err != nil {
 		return
@@ -160,7 +172,7 @@ func (p *Processing2) Start() (err error) {
 	options := &source.Options{
 		Watcher:            p.mcpCache,
 		Reporter:           p.reporter,
-		CollectionsOptions: source.CollectionOptionsFromSlice(m.AllCollectionsInSnapshots()),
+		CollectionsOptions: source.CollectionOptionsFromSlice(m.AllCollectionsInSnapshots(metadata.SnapshotNames())),
 		ConnRateLimiter:    mcprate.NewRateLimiter(time.Second, 100), // TODO(Nino-K): https://github.com/istio/istio/issues/12074
 	}
 

--- a/galley/pkg/server/settings/args.go
+++ b/galley/pkg/server/settings/args.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"istio.io/istio/galley/pkg/config/meta/metadata"
 	"istio.io/istio/galley/pkg/config/util/kuberesource"
 	"istio.io/istio/galley/pkg/crd/validation"
 	"istio.io/istio/pkg/keepalive"
@@ -134,6 +135,9 @@ type Args struct { // nolint:maligned
 	PprofPort       uint
 
 	UseOldProcessor bool
+
+	Snapshots       []string
+	TriggerSnapshot string
 }
 
 // DefaultArgs allocates an Args struct initialized with Galley's default configuration.
@@ -173,6 +177,8 @@ func DefaultArgs() *Args {
 			Path:           defaultReadinessProbeFilePath,
 			UpdateInterval: defaultProbeCheckInterval,
 		},
+		Snapshots:       []string{metadata.Default, metadata.SyntheticServiceEntry},
+		TriggerSnapshot: metadata.Default,
 	}
 }
 

--- a/galley/tools/mcpc/main.go
+++ b/galley/tools/mcpc/main.go
@@ -333,7 +333,7 @@ func main() {
 		}
 	}
 
-	for _, collection := range metadata.MustGet().AllCollectionsInSnapshots() {
+	for _, collection := range metadata.MustGet().AllCollectionsInSnapshots(metadata.SnapshotNames()) {
 
 		switch {
 		// pilot sortedCollections

--- a/pkg/istiod/galley.go
+++ b/pkg/istiod/galley.go
@@ -143,7 +143,7 @@ func (p *GalleyServer) Start() (err error) {
 	options := &source.Options{
 		Watcher:            p.mcpCache,
 		Reporter:           p.reporter,
-		CollectionsOptions: source.CollectionOptionsFromSlice(p.meta.AllCollectionsInSnapshots()),
+		CollectionsOptions: source.CollectionOptionsFromSlice(p.meta.AllCollectionsInSnapshots(metadata.SnapshotNames())),
 		ConnRateLimiter:    mcprate.NewRateLimiter(time.Second, 100), // TODO(Nino-K): https://github.com/istio/istio/issues/12074
 	}
 

--- a/tests/integration/conformance/sanity_test.go
+++ b/tests/integration/conformance/sanity_test.go
@@ -70,7 +70,7 @@ func TestMissingMCPTests(t *testing.T) {
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
 			collections := make(map[string]struct{})
-			for _, col := range metadata.MustGet().AllCollectionsInSnapshots() {
+			for _, col := range metadata.MustGet().AllCollectionsInSnapshots(metadata.SnapshotNames()) {
 				collections[col] = struct{}{}
 			}
 


### PR DESCRIPTION
Solves https://github.com/istio/istio/issues/18002

Disable any input resources not needed by the collection snapshot Galley will publish. This prevents Galley from creating unnecessary watchers, and also ensures that adding resources to the metadata for other snapshots doesn't automatically bleed into impacting Galley. 

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
