### PR TITLE
mixer: remove explicit flush in Opencensus tracing adapter

### DIFF
--- a/mixer/pkg/adapter/opencensus/trace.go
+++ b/mixer/pkg/adapter/opencensus/trace.go
@@ -71,7 +71,6 @@ func (h *Handler) HandleTraceSpan(_ context.Context, values []*tracespan.Instanc
 		return nil
 	}
 
-	numExported := 0
 	for _, val := range values {
 		parentContext, ok := ExtractParentContext(val.TraceId, val.ParentSpanId)
 		if !ok {
@@ -97,11 +96,6 @@ func (h *Handler) HandleTraceSpan(_ context.Context, values []*tracespan.Instanc
 
 		span := buildSpanData(val, parentContext, spanContext)
 		h.exporter(val).ExportSpan(span)
-		numExported++
-	}
-
-	if numExported > 0 {
-		h.tryFlush()
 	}
 
 	return
@@ -237,17 +231,4 @@ func (h *Handler) Close() error {
 		return h.CloseFunc()
 	}
 	return nil
-}
-
-func (h *Handler) tryFlush() {
-	h.exporters.Range(func(_, value interface{}) bool {
-		if flusher, ok := value.(flusher); ok {
-			flusher.Flush()
-		}
-		return true
-	})
-}
-
-type flusher interface {
-	Flush()
 }

--- a/mixer/pkg/adapter/opencensus/trace_test.go
+++ b/mixer/pkg/adapter/opencensus/trace_test.go
@@ -35,7 +35,6 @@ func TestHandleTraceSpan(t *testing.T) {
 		vals                   []*tracespan.Instance
 		wantSpans              []*trace.SpanData
 		sampler                trace.Sampler
-		wantFlushes            int
 		wantName, wantEndpoint string
 	}{
 		{
@@ -89,7 +88,6 @@ func TestHandleTraceSpan(t *testing.T) {
 				},
 			},
 			sampler:     trace.ProbabilitySampler(1.0),
-			wantFlushes: 1,
 		},
 		{
 			name: "error",
@@ -143,7 +141,6 @@ func TestHandleTraceSpan(t *testing.T) {
 				},
 			},
 			sampler:     trace.ProbabilitySampler(1.0),
-			wantFlushes: 1,
 		},
 		{
 			name: "no tracing",
@@ -165,7 +162,6 @@ func TestHandleTraceSpan(t *testing.T) {
 			},
 			wantSpans:   []*trace.SpanData(nil),
 			sampler:     trace.ProbabilitySampler(1.0),
-			wantFlushes: 0,
 		},
 		{
 			name: "tracing disabled",
@@ -187,7 +183,6 @@ func TestHandleTraceSpan(t *testing.T) {
 			},
 			wantSpans:   nil,
 			sampler:     nil,
-			wantFlushes: 0,
 		},
 		{
 			name: "no parent - server span",
@@ -254,7 +249,6 @@ func TestHandleTraceSpan(t *testing.T) {
 				},
 			},
 			sampler:     trace.AlwaysSample(),
-			wantFlushes: 1,
 		},
 		{
 			name: "client span",
@@ -321,7 +315,6 @@ func TestHandleTraceSpan(t *testing.T) {
 				},
 			},
 			sampler:     trace.AlwaysSample(),
-			wantFlushes: 1,
 		},
 		{
 			name: "error span",
@@ -387,7 +380,6 @@ func TestHandleTraceSpan(t *testing.T) {
 				},
 			},
 			sampler:     trace.AlwaysSample(),
-			wantFlushes: 1,
 		},
 		{
 			name: "client span rewrite id",
@@ -436,7 +428,6 @@ func TestHandleTraceSpan(t *testing.T) {
 				},
 			},
 			sampler:     trace.ProbabilitySampler(1.0),
-			wantFlushes: 1,
 		},
 		{
 			name: "server span rewrite id",
@@ -485,7 +476,6 @@ func TestHandleTraceSpan(t *testing.T) {
 				},
 			},
 			sampler:     trace.ProbabilitySampler(1.0),
-			wantFlushes: 1,
 		},
 	}
 
@@ -510,9 +500,6 @@ func TestHandleTraceSpan(t *testing.T) {
 			}
 			if diff := cmp.Diff(exporter.exported, tt.wantSpans); diff != "" {
 				t.Errorf("Exported spans differ, -got +want: %s\n", diff)
-			}
-			if got, want := exporter.flushes, tt.wantFlushes; got != want {
-				t.Errorf("exporter.flushes = %d; want %d", got, want)
 			}
 		})
 	}

--- a/mixer/pkg/adapter/opencensus/trace_test.go
+++ b/mixer/pkg/adapter/opencensus/trace_test.go
@@ -87,7 +87,7 @@ func TestHandleTraceSpan(t *testing.T) {
 					HasRemoteParent: true,
 				},
 			},
-			sampler:     trace.ProbabilitySampler(1.0),
+			sampler: trace.ProbabilitySampler(1.0),
 		},
 		{
 			name: "error",
@@ -140,7 +140,7 @@ func TestHandleTraceSpan(t *testing.T) {
 					HasRemoteParent: true,
 				},
 			},
-			sampler:     trace.ProbabilitySampler(1.0),
+			sampler: trace.ProbabilitySampler(1.0),
 		},
 		{
 			name: "no tracing",
@@ -160,8 +160,8 @@ func TestHandleTraceSpan(t *testing.T) {
 					HttpStatusCode: 200,
 				},
 			},
-			wantSpans:   []*trace.SpanData(nil),
-			sampler:     trace.ProbabilitySampler(1.0),
+			wantSpans: []*trace.SpanData(nil),
+			sampler:   trace.ProbabilitySampler(1.0),
 		},
 		{
 			name: "tracing disabled",
@@ -181,8 +181,8 @@ func TestHandleTraceSpan(t *testing.T) {
 					HttpStatusCode: 200,
 				},
 			},
-			wantSpans:   nil,
-			sampler:     nil,
+			wantSpans: nil,
+			sampler:   nil,
 		},
 		{
 			name: "no parent - server span",
@@ -248,7 +248,7 @@ func TestHandleTraceSpan(t *testing.T) {
 					HasRemoteParent: true,
 				},
 			},
-			sampler:     trace.AlwaysSample(),
+			sampler: trace.AlwaysSample(),
 		},
 		{
 			name: "client span",
@@ -314,7 +314,7 @@ func TestHandleTraceSpan(t *testing.T) {
 					HasRemoteParent: false,
 				},
 			},
-			sampler:     trace.AlwaysSample(),
+			sampler: trace.AlwaysSample(),
 		},
 		{
 			name: "error span",
@@ -379,7 +379,7 @@ func TestHandleTraceSpan(t *testing.T) {
 					HasRemoteParent: false,
 				},
 			},
-			sampler:     trace.AlwaysSample(),
+			sampler: trace.AlwaysSample(),
 		},
 		{
 			name: "client span rewrite id",
@@ -427,7 +427,7 @@ func TestHandleTraceSpan(t *testing.T) {
 					HasRemoteParent: false,
 				},
 			},
-			sampler:     trace.ProbabilitySampler(1.0),
+			sampler: trace.ProbabilitySampler(1.0),
 		},
 		{
 			name: "server span rewrite id",
@@ -475,7 +475,7 @@ func TestHandleTraceSpan(t *testing.T) {
 					HasRemoteParent: true,
 				},
 			},
-			sampler:     trace.ProbabilitySampler(1.0),
+			sampler: trace.ProbabilitySampler(1.0),
 		},
 	}
 


### PR DESCRIPTION
Currently, the Opencensus tracing adapter manually calls flush with each
batch of tracespan instances that are passed to it. The implementation
of the flush method is such that it calls (*Bundler).Flush, which blocks
until all batches of spans in the bundler are written to the tracing
backend.

Given the flush method is blocking (i.e. only one goroutine can be
flushing at any point in time), this makes the
(*Handler).HandleTraceSpan method blocking, which in turn prevents
concurrent calls to mixer's Report endpoint.

The blocking in the tracing adapter ultimately results in increased
overall latency to the Report endpoint, which can trip the rate limiting
functionality, resulting in unnecessary throttling, even on requests
that do not contain tracing information.

Remove the explicit flushing in the Opencensus tracing adapter, instead
relying on the flushing functionality provided in the underlying tracing
library, which defaults to flushing once every two seconds.

Fixes #18042.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
