### PR TITLE
Update snippet generation for istio.io tests

### DIFF
--- a/pkg/test/istioio/snippet.go
+++ b/pkg/test/istioio/snippet.go
@@ -20,12 +20,10 @@ import (
 )
 
 const (
-	startSnippetLineFormat   = "# $snippet %s\n"
-	endSnippetLine           = "# $endsnippet\n"
-	startTextBlockLineFormat = "{{< text %s >}}\n"
-	endTextBlockLine         = "{{< /text >}}\n"
-	syntaxFormat             = "syntax=\"%s\""
-	outputisFormat           = "outputis=\"%s\""
+	startSnippetLineFormat = "$snippet %s%s\n"
+	endSnippetLine         = "$endsnippet\n"
+	syntaxFormat           = " syntax=\"%s\""
+	outputisFormat         = " outputis=\"%s\""
 )
 
 var _ Step = Snippet{}
@@ -62,24 +60,20 @@ func (s Snippet) run(ctx Context) {
 		ctx.Fatalf("failed writing snippet %s: %v", snippetName, err)
 	}
 
-	// Start the snippet with the named snippet annotation.
-	snippetContent := fmt.Sprintf(startSnippetLineFormat, snippetName)
-
-	// Start the text block.
-	textAttrs := ""
+	// Create the text metadata for the snippet, if provided.
+	snippetMetadata := ""
 	if s.Syntax != "" {
-		textAttrs += fmt.Sprintf(syntaxFormat, s.Syntax)
+		snippetMetadata += fmt.Sprintf(syntaxFormat, s.Syntax)
 	}
 	if s.OutputIs != "" {
-		textAttrs += " " + fmt.Sprintf(outputisFormat, s.OutputIs)
+		snippetMetadata += fmt.Sprintf(outputisFormat, s.OutputIs)
 	}
-	snippetContent += fmt.Sprintf(startTextBlockLineFormat, textAttrs)
+
+	// Start the snippet with the named snippet annotation.
+	snippetContent := fmt.Sprintf(startSnippetLineFormat, snippetName, snippetMetadata)
 
 	// Add the content
 	snippetContent += content + "\n"
-
-	// End the text block
-	snippetContent += endTextBlockLine
 
 	// End the snippet
 	snippetContent += endSnippetLine + "\n"

--- a/tests/integration/istioio/README.md
+++ b/tests/integration/istioio/README.md
@@ -10,28 +10,33 @@ around the [Istio test framework](https://github.com/istio/istio/wiki/Istio-Test
 
 ## Output
 
-When you run an istioio test, it generates a file called `snippets.txt` in the working
-directory of the test.
-
-This file contains all the snippets for a particular `istio.io`
-page. Snippets are generated in the [istio.io syntax](https://istio.io/about/contribute/creating-and-editing-pages)
-and are ready for import to `istio.io`.
-
-For example, a test might generate following `snippets.txt`:
+When you run an `istio.io` test, it outputs snippets according to the
+[istio.io syntax](https://istio.io/about/contribute/creating-and-editing-pages) and are ready for
+import to `istio.io`. For example:
 
 ```text
-# $snippet enabling_istio_authorization.sh
-{{< text syntax="bash" >}}
+$snippet enabling_istio_authorization.sh syntax="bash"
 $ kubectl apply -f @samples/bookinfo/platform/kube/rbac/rbac-config-ON.yaml@
-{{< /text >}}
-# $endsnippet
+$endsnippet
 
-# $snippet enforcing_namespace_level_access_control_apply.sh
-{{< text syntax="bash" >}}
+$snippet enforcing_namespace_level_access_control_apply.sh syntax="bash"
 $ kubectl apply -f @samples/bookinfo/platform/kube/rbac/namespace-policy.yaml@
-{{< /text >}}
-# $endsnippet
+$endsnippet
 ```
+
+Snippets are written to a file in the working directory of the test with the extension
+`.snippets.txt`. The name of the file (minus the extension) is specified when creating
+the `Builder`.
+
+For example, `istioio.NewBuilder("path__to__my_istioio_content")` would
+generate the file `path__to__my_istioio_content.snippets.txt`.
+
+By convention, the file name should generally indicate the path to the content on `istio.io`.
+This helps to simplify collection and processing of these files later on.
+
+For example, the snippets for the page
+`Tasks->Secuity->Mutual TLS Migration` might be stored in
+`tasks__security__mutual_tls_migration.snippets.txt`.
 
 ## Test Authoring Overview
 
@@ -67,7 +72,7 @@ be run as part of the resulting test function:
 func TestCombinedMethods(t *testing.T) {
     framework.
         NewTest(t).
-        Run(istioio.NewBuilder().
+        Run(istioio.NewBuilder("tasks__security__my_task").
             // Run a script and create a snippet.
             Add(istioio.Command{
                 Input:         istioio.Path("myscript.sh"),

--- a/tests/integration/istioio/security/authz_http_test.go
+++ b/tests/integration/istioio/security/authz_http_test.go
@@ -31,7 +31,7 @@ func TestAuthorizationForHTTPServices(t *testing.T) {
 
 	framework.
 		NewTest(t).
-		Run(istioio.NewBuilder().
+		Run(istioio.NewBuilder("tasks__security__authorization_for_http_services").
 			// Setup the initial environment.
 			Add(istioio.Command{
 				Input: istioio.Inline{

--- a/tests/integration/istioio/security/mtls_migration_test.go
+++ b/tests/integration/istioio/security/mtls_migration_test.go
@@ -29,7 +29,7 @@ func TestMutualTLSMigration(t *testing.T) {
 
 	framework.
 		NewTest(t).
-		Run(istioio.NewBuilder().
+		Run(istioio.NewBuilder("tasks__security__mututal_tls_migration").
 			Add(istioio.Command{
 				Input: istioio.Inline{
 					FileName: "create_ns_foo_bar_legacy.sh",

--- a/tests/integration/istioio/trafficmanagement/ingress/secure_ingress_sds_test.go
+++ b/tests/integration/istioio/trafficmanagement/ingress/secure_ingress_sds_test.go
@@ -25,7 +25,7 @@ import (
 func TestSecureIngressSDS(t *testing.T) {
 	framework.
 		NewTest(t).
-		Run(istioio.NewBuilder().
+		Run(istioio.NewBuilder("traffic_management__ingress__secure_gateways_sds").
 			// Configure a TLS ingress gateway for a single host.
 			// https://preliminary.istio.io/docs/tasks/traffic-management/ingress/secure-ingress-sds/#configure-a-tls-ingress-gateway-for-a-single-host
 			Add(istioio.Command{


### PR DESCRIPTION
- Specify file name explicitly in the test. Automatically append .snippets.txt suffix.

- Remove the text tags when generating snippets. This is
invalid snippet syntax.

- Add metadata to snippet annotation to help with autogeneration of content.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
