### PR TITLE
Fix istiod logging

### DIFF
--- a/pkg/istiod/pilotstart.go
+++ b/pkg/istiod/pilotstart.go
@@ -315,7 +315,7 @@ func (s *Server) WaitStop(stop <-chan struct{}) {
 	}
 }
 
-func (s *Server) Serve(stop <-chan struct{}) error {
+func (s *Server) Serve(stop <-chan struct{}) {
 
 	go func() {
 		if err := s.httpServer.Serve(s.httpListener); err != nil {
@@ -338,7 +338,6 @@ func (s *Server) Serve(stop <-chan struct{}) error {
 			log.Warna(err)
 		}
 	}
-	return nil
 }
 
 // startFunc defines a function that will be used to start one or more components of the Pilot discovery service.


### PR DESCRIPTION
Logging should use istio logging for consistency, and not use Fatalf
without % formatters, which causes `go test` to fail.

Fixes https://github.com/istio/istio/issues/18098

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
