### PR TITLE
mixer: Allow configuration of trace flush interval

### DIFF
--- a/mixer/adapter/stackdriver/trace/exporter_test.go
+++ b/mixer/adapter/stackdriver/trace/exporter_test.go
@@ -16,28 +16,74 @@ package trace
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"istio.io/istio/mixer/adapter/stackdriver/config"
 	testenv "istio.io/istio/mixer/pkg/adapter/test"
 )
 
+const (
+	projectId          = "example-project"
+	serviceAccountPath = "testdata/serviceaccount.json"
+	sampleProbability  = 1
+)
+
 func TestGetStackdriverExporter(t *testing.T) {
 	ctx := context.Background()
-	var params config.Params
-	params.Trace = &config.Params_Trace{SampleProbability: 1}
-	params.ProjectId = "example-project"
-	params.Creds = &config.Params_ServiceAccountPath{
-		ServiceAccountPath: "testdata/serviceaccount.json",
-	}
-	_, err := getStackdriverExporter(ctx, testenv.NewEnv(t), &params)
+	params := newTestParams()
+	_, err := getStackdriverExporter(ctx, testenv.NewEnv(t), params)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to call getStackdriverExporter again with the same project ID: this should work.
-	_, err = getStackdriverExporter(ctx, testenv.NewEnv(t), &params)
+	_, err = getStackdriverExporter(ctx, testenv.NewEnv(t), params)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestGetOptions_flushInterval(t *testing.T) {
+	type duration struct {
+		flushInterval time.Duration
+	}
+
+	tests := []struct {
+		name         string
+		duration     *duration
+		wantInterval time.Duration
+	}{
+		{"unspecified", nil, 0 * time.Second},                      // default
+		{"negative", &duration{-1 * time.Second}, 0 * time.Second}, // default
+		{"positive", &duration{2 * time.Second}, 2 * time.Second},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			params := newTestParams()
+			if tt.duration != nil {
+				params.PushInterval = tt.duration.flushInterval
+			}
+
+			opts := getOptions(testenv.NewEnv(t), params)
+			delayInterval := opts.BundleDelayThreshold
+			if delayInterval != tt.wantInterval {
+				t.Fatalf("wanted delayInterval %s; got %s", tt.wantInterval, delayInterval)
+			}
+		})
+	}
+}
+
+// newTestParams returns a pointer to a new default instance of config.Params
+// that can be used for testing.
+func newTestParams() *config.Params {
+	return &config.Params{
+		ProjectId: projectId,
+		Creds: &config.Params_ServiceAccountPath{
+			ServiceAccountPath: serviceAccountPath,
+		},
+		Trace: &config.Params_Trace{SampleProbability: sampleProbability},
 	}
 }

--- a/mixer/adapter/stackdriver/trace/exporter_test.go
+++ b/mixer/adapter/stackdriver/trace/exporter_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	projectId          = "example-project"
+	projectID          = "example-project"
 	serviceAccountPath = "testdata/serviceaccount.json"
 	sampleProbability  = 1
 )
@@ -80,7 +80,7 @@ func TestGetOptions_flushInterval(t *testing.T) {
 // that can be used for testing.
 func newTestParams() *config.Params {
 	return &config.Params{
-		ProjectId: projectId,
+		ProjectId: projectID,
 		Creds: &config.Params_ServiceAccountPath{
 			ServiceAccountPath: serviceAccountPath,
 		},


### PR DESCRIPTION
Currently, the `flushInterval` parameter in the Stackdriver adapter only
applies to the metrics exporter. The change introduced in #18074 removed
the flush-on-each-batch behavior in favor of deferring the flush
interval to the underlying flush interval of the library (currently 2
seconds).

Allow the `flushInterval` parameter to be reused to configure the trace
exporter flush interval, allowing it to differ from the default.

Fixes #18077.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
