### PR TITLE
[1.2] kill k8s latest boskos resource

### DIFF
--- a/prow/e2e-simpleTests-cni.sh
+++ b/prow/e2e-simpleTests-cni.sh
@@ -32,8 +32,6 @@ echo 'Running e2e_simple test with rbac, auth Tests and CNI enabled'
 
 export ENABLE_ISTIO_CNI=true
 
-# only gke-e2e-test-latest is enabled for Networkpolicy and Calico
-export RESOURCE_TYPE="gke-e2e-test-latest"
 # TODO - When the inline kube inject code defaults to using the configmap this setting can be removed.
 export E2E_ARGS+=" --kube_inject_configmap=istio-sidecar-injector"
 ./prow/e2e-suite.sh --auth_enable --single_test e2e_simple "$@"

--- a/prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
+++ b/prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
@@ -27,8 +27,6 @@ set -u
 # Print commands
 set -x
 
-export RESOURCE_TYPE="gke-e2e-test-latest"
-
 # Run tests with auth disabled
 #echo 'Running pilot e2e tests (v1alpha3, noauth)'
 ./prow/e2e-suite.sh --single_test e2e_pilotv2_v1alpha3


### PR DESCRIPTION
We used to have dedicated boskos resources for the "Latest" GKE version. At the time this was 1.11, and other tests ran on 1.10.

Today, we cannot even create a 1.10 GKE cluster, since they bumped the minimum version, so we can just consolidate these to save on the number clusters we have.

This will fail until https://github.com/istio/test-infra/pull/1953/files is merged