### PR TITLE
Do not inject a sidecar into post-install jobs

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
@@ -75,6 +75,8 @@ spec:
         chart: {{ template "grafana.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istio-grafana-post-install-account
       containers:

--- a/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
@@ -79,6 +79,8 @@ spec:
         chart: {{ template "security.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istio-security-post-install-account
       containers:


### PR DESCRIPTION
All Istio control plane components except the post-install jobs have
opted out of injection with the `sidecar.istio.io/inject: false`
injection. This omission can cause problems when Istio is installed in
namespaces labeled for auto-injection.

fixes https://github.com/istio/istio/issues/15089
