### PR TITLE
Use different exit code on istioctl parse error

### DIFF
--- a/istioctl/cmd/istioctl_test.go
+++ b/istioctl/cmd/istioctl_test.go
@@ -300,6 +300,17 @@ func TestBadParse(t *testing.T) {
 	default:
 		t.Errorf("Expected a CommandParseError, but got %q.", fErr)
 	}
+
+	// all of the subcommands
+	rootCmd = GetRootCmd([]string{"authn", "tls-check", "--unknown-flag"})
+	fErr = rootCmd.Execute()
+
+	switch fErr.(type) {
+	case CommandParseError:
+		// do nothing
+	default:
+		t.Errorf("Expected a CommandParseError, but got %q.", fErr)
+	}
 }
 
 // mockClientFactoryGenerator creates a factory for model.ConfigStore preloaded with data

--- a/istioctl/cmd/istioctl_test.go
+++ b/istioctl/cmd/istioctl_test.go
@@ -278,6 +278,30 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestBadParse(t *testing.T) {
+	// unknown flags should be a command parse
+	rootCmd := GetRootCmd([]string{"--unknown-flag"})
+	fErr := rootCmd.Execute()
+
+	switch fErr.(type) {
+	case CommandParseError:
+		// do nothing
+	default:
+		t.Errorf("Expected a CommandParseError, but got %q.", fErr)
+	}
+
+	// we should propagate to subcommands
+	rootCmd = GetRootCmd([]string{"x", "analyze", "--unknown-flag"})
+	fErr = rootCmd.Execute()
+
+	switch fErr.(type) {
+	case CommandParseError:
+		// do nothing
+	default:
+		t.Errorf("Expected a CommandParseError, but got %q.", fErr)
+	}
+}
+
 // mockClientFactoryGenerator creates a factory for model.ConfigStore preloaded with data
 func mockClientFactoryGenerator(configs []model.Config) func() (model.ConfigStore, error) {
 	outFactory := func() (model.ConfigStore, error) {

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -35,6 +35,14 @@ import (
 	"istio.io/pkg/log"
 )
 
+type CommandParseError struct {
+	e error
+}
+
+func (c CommandParseError) Error() string {
+	return c.e.Error()
+}
+
 var (
 	kubeconfig       string
 	configContext    string
@@ -174,6 +182,16 @@ debug and diagnose their Istio mesh.
 	rootCmd.AddCommand(contextCmd)
 
 	rootCmd.AddCommand(validate.NewValidateCommand(&istioNamespace))
+
+	rootCmd.SetFlagErrorFunc(func(_ *cobra.Command, e error) error {
+		return CommandParseError{e}
+	})
+
+	for _, cmd := range rootCmd.Commands() {
+		cmd.SetFlagErrorFunc(func(_ *cobra.Command, e error) error {
+			return CommandParseError{e}
+		})
+	}
 
 	return rootCmd
 }

--- a/istioctl/cmd/sysexits.go
+++ b/istioctl/cmd/sysexits.go
@@ -20,8 +20,8 @@ import "strings"
 // See e.g. https://man.openbsd.org/sysexits.3
 // or `less /usr/includes/sysexits.h` if you're on Linux
 const (
-	EXIT_UNKNOWN_ERROR   = 1 // for compatibility with existing exit code
-	EXIT_INCORRECT_USAGE = 64
+	ExitUnknownError   = 1 // for compatibility with existing exit code
+	ExitIncorrectUsage = 64
 )
 
 func GetExitCode(e error) int {
@@ -31,8 +31,8 @@ func GetExitCode(e error) int {
 
 	switch e.(type) {
 	case CommandParseError:
-		return EXIT_INCORRECT_USAGE
+		return ExitIncorrectUsage
 	default:
-		return EXIT_UNKNOWN_ERROR
+		return ExitUnknownError
 	}
 }

--- a/istioctl/cmd/sysexits.go
+++ b/istioctl/cmd/sysexits.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Istio Authors
+// Copyright 2019 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
-import (
-	"os"
+import "strings"
 
-	// import all known client auth plugins
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
-	"istio.io/istio/istioctl/cmd"
+// Values should use sendmail-style values as in <sysexits.h>
+// See e.g. https://man.openbsd.org/sysexits.3
+// or `less /usr/includes/sysexits.h` if you're on Linux
+const (
+	EXIT_UNKNOWN_ERROR   = 1 // for compatibility with existing exit code
+	EXIT_INCORRECT_USAGE = 64
 )
 
-func main() {
-	rootCmd := cmd.GetRootCmd(os.Args[1:])
+func GetExitCode(e error) int {
+	if strings.Contains(e.Error(), "unknown command") {
+		e = CommandParseError{e}
+	}
 
-	if err := rootCmd.Execute(); err != nil {
-		exitCode := cmd.GetExitCode(err)
-		os.Exit(exitCode)
+	switch e.(type) {
+	case CommandParseError:
+		return EXIT_INCORRECT_USAGE
+	default:
+		return EXIT_UNKNOWN_ERROR
 	}
 }

--- a/istioctl/cmd/sysexits_test.go
+++ b/istioctl/cmd/sysexits_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Istio Authors
+// Copyright 2019 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
-	"os"
-
-	// import all known client auth plugins
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
-	"istio.io/istio/istioctl/cmd"
+	"errors"
+	"testing"
 )
 
-func main() {
-	rootCmd := cmd.GetRootCmd(os.Args[1:])
+var KnownSubstrings = []string{"unknown command"}
 
-	if err := rootCmd.Execute(); err != nil {
-		exitCode := cmd.GetExitCode(err)
-		os.Exit(exitCode)
+func TestKnownExitStrings(t *testing.T) {
+	for _, s := range KnownSubstrings {
+		if GetExitCode(errors.New(s)) == 1 {
+			t.Errorf("Expected %q to have a non-1 exit code.", s)
+		}
 	}
 }

--- a/istioctl/cmd/sysexits_test.go
+++ b/istioctl/cmd/sysexits_test.go
@@ -23,8 +23,8 @@ var KnownSubstrings = []string{"unknown command"}
 
 func TestKnownExitStrings(t *testing.T) {
 	for _, s := range KnownSubstrings {
-		if GetExitCode(errors.New(s)) == 1 {
-			t.Errorf("Expected %q to have a non-1 exit code.", s)
+		if GetExitCode(errors.New(s)) == ExitUnknownError {
+			t.Errorf("Expected %q to have a known exit code.", s)
 		}
 	}
 }


### PR DESCRIPTION
Right now all of the error codes for all CLI errors are hardcoded as 1.
In an effort to make these more useful, this diff changes incorrect CLI
usage to exit code 64. This is a necessary step for #17862.

It also has a bit of an idea on how adding new exit codes would
work--the intention is to add mappings of error type -> integer via a
switch statement in sysexit.go. The name of the file is also a nod
towards the inspiration for the values: sendmail/glibc/BSD sysexits.h

I don't like checking for substrings but cobra doesn't give much
flexibility outside of flag parsing so this is the best I could come up
with.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure
