### PR TITLE
Output empty JSON array to body when proxyID is not found for debug/authz

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -358,10 +358,8 @@ func (s *DiscoveryServer) Authenticationz(w http.ResponseWriter, req *http.Reque
 		connections, ok := adsSidecarIDConnectionsMap[proxyID]
 		if !ok {
 			w.WriteHeader(http.StatusNotFound)
-			_, _ = fmt.Fprintf(w, "ADS for %q does not exist. Only have:\n", proxyID)
-			for key := range adsSidecarIDConnectionsMap {
-				_, _ = fmt.Fprintf(w, "  %q,\n", key)
-			}
+			// Need to dump an empty JSON array so istioctl can peacefully ignore.
+			_, _ = fmt.Fprintf(w, "\n[\n]")
 			return
 		}
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

`istioctl auth tls-check` always tries to parse the body of this /debug/authenticationz response, hence cause error if the body is not valid JSON. As a result, it will stop checking other pilot instance, and display parsing error.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
