### PR TITLE
fix redis key expire setting, set the right key

### DIFF
--- a/mixer/adapter/redisquota/rolling_window.go
+++ b/mixer/adapter/redisquota/rolling_window.go
@@ -103,7 +103,7 @@ end
 -- update the expiration time for automatic cleanup
 --------------------------------------------------------------------------------
 redis.call("PEXPIRE", key_meta, windowLength / 1000000)
-redis.call("PEXPIRE", key_meta, windowLength / 1000000)
+redis.call("PEXPIRE", key_data, windowLength / 1000000)
 
 -- calculate available token
 --------------------------------------------------------------------------------


### PR DESCRIPTION
In the stage `update the expiration time for automatic cleanup` , both key should be added: `key_meta` and `key_data`, however the `key_data` has been lost in here, this pr added it back.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[x] Developer Infrastructure
