### PR TITLE
Workaround for Helm 2.15 regression

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/_affinity.tpl
@@ -15,7 +15,7 @@
           operator: In
           values:
         {{- range $key, $val := .root.Values.global.arch }}
-          {{- if gt ($val | int) 0 }}
+          {{- if gt ($val | toString | int) 0 }}
           - {{ $key | quote }}
           {{- end }}
         {{- end }}
@@ -30,8 +30,8 @@
 
 {{- define "gatewayNodeAffinityPreferredDuringScheduling" }}
   {{- range $key, $val := .root.Values.global.arch }}
-    {{- if gt ($val | int) 0 }}
-    - weight: {{ $val | int }}
+    {{- if gt ($val | toString | int) 0 }}
+    - weight: {{ $val | toString | int }}
       preference:
         matchExpressions:
         - key: beta.kubernetes.io/arch

--- a/install/kubernetes/helm/istio/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/templates/_affinity.tpl
@@ -15,7 +15,7 @@
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
-          {{- if gt ($val | int) 0 }}
+          {{- if gt ($val | toString | int) 0 }}
           - {{ $key | quote }}
           {{- end }}
         {{- end }}
@@ -30,8 +30,8 @@
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
   {{- range $key, $val := .Values.global.arch }}
-    {{- if gt ($val | int) 0 }}
-    - weight: {{ $val | int }}
+    {{- if gt ($val | toString | int) 0 }}
+    - weight: {{ $val | toString | int }}
       preference:
         matchExpressions:
         - key: beta.kubernetes.io/arch


### PR DESCRIPTION
`int` is broken on Helm 2.15. See
https://github.com/helm/helm/issues/6708

I don't see how anyone can use Helm 2.15 given the breakage, but might
as well support those users that do and fix this...

I did a diff of helm 2.14 and helm 2.15 and there were no changes after
this patch.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
