### PR TITLE
[release 1.4] Update operator version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.4
 	istio.io/api v0.0.0-20191015210738-bfa91e88abf1
 	istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a
-	istio.io/operator v0.0.0-20191017202355-6d9826b3f6e6
+	istio.io/operator v0.0.0-20191022111219-3cd84fa74f86
 	istio.io/pkg v0.0.0-20191015053120-592d80277a1b
 	k8s.io/api v0.0.0
 	k8s.io/apiextensions-apiserver v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -950,8 +950,8 @@ istio.io/api v0.0.0-20191015210738-bfa91e88abf1 h1:pkQv7+x97NKR70CODSOZBt4XKvb2H
 istio.io/api v0.0.0-20191015210738-bfa91e88abf1/go.mod h1:UP3a6saAz6eoOaXQqzy49/ygIjzUcEGZ0QTFpcfmSEA=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a h1:w7zILua2dnYo9CxImhpNW4NE/8ZxEoc/wfBfHrhUhrE=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
-istio.io/operator v0.0.0-20191017202355-6d9826b3f6e6 h1:BKrqcmfgxtDfoaWbrM/sm3oDDbLg2Ecrkb3E4lo/Q0Y=
-istio.io/operator v0.0.0-20191017202355-6d9826b3f6e6/go.mod h1:3zAM53nNPyv9Z59m/61pCbZyTg9S5p+4dQCy9O8Ldi0=
+istio.io/operator v0.0.0-20191022111219-3cd84fa74f86 h1:VVO86R2pGxN5/qJ9+Kgf09HAvFrgAoTqsxiPSRPhAtI=
+istio.io/operator v0.0.0-20191022111219-3cd84fa74f86/go.mod h1:3zAM53nNPyv9Z59m/61pCbZyTg9S5p+4dQCy9O8Ldi0=
 istio.io/pkg v0.0.0-20190515193414-9332430ad747/go.mod h1:0EkPwmR0tESYjN4Ilq1D52nTBurXaQvny3r2VY4j4tw=
 istio.io/pkg v0.0.0-20191015053120-592d80277a1b h1:R0eb+7Rq04CL7T07heD9wphxbKdVFfRa1LFLHuPQv2g=
 istio.io/pkg v0.0.0-20191015053120-592d80277a1b/go.mod h1:QT1C27oNOnDmw3D0qNztxETMjV08jE347wrbxm4zIvI=


### PR DESCRIPTION
Sync the go.mod version to latest istio.io/operator@release-1.4
https://github.com/istio/istio/issues/18173