### PR TITLE
Set exit code 79 if istioctl analyze finds issues

### DIFF
--- a/galley/pkg/config/analysis/diag/level.go
+++ b/galley/pkg/config/analysis/diag/level.go
@@ -24,8 +24,8 @@ func (l Level) String() string {
 	return l.name
 }
 
-func (l Level) IsWorseThan(target Level) bool {
-	return l.sortOrder < target.sortOrder
+func (l Level) IsWorseThanOrEqualTo(target Level) bool {
+	return l.sortOrder <= target.sortOrder
 }
 
 var (

--- a/galley/pkg/config/analysis/diag/level.go
+++ b/galley/pkg/config/analysis/diag/level.go
@@ -24,6 +24,10 @@ func (l Level) String() string {
 	return l.name
 }
 
+func (l Level) IsWorseThan(target Level) bool {
+	return l.sortOrder < target.sortOrder
+}
+
 var (
 	// Info level is for informational messages
 	Info = Level{2, "Info"}

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -30,12 +30,10 @@ import (
 	"istio.io/istio/pkg/kube"
 )
 
-type FoundAnalyzeIssuesError struct {
-	int
-}
+type FoundAnalyzeIssuesError struct{}
 
 func (f FoundAnalyzeIssuesError) Error() string {
-	return fmt.Sprintf("Found %v issues.", f.int)
+	return "Found analyzer issues."
 }
 
 var (
@@ -195,17 +193,17 @@ func serviceDiscovery() (bool, error) {
 	}
 }
 
-func handleAnalyzeMessages(f io.Writer, messages []diag.Message) error {
-	foundIssues := 0
+func outputAndSetError(f io.Writer, messages []diag.Message) error {
+	foundIssues := false
 	for _, m := range messages {
 		if m.Type.Level().IsWorseThan(messageLevelThreshold) {
-			foundIssues++
+			foundIssues = true
 		}
 		fmt.Fprintf(f, "%v\n", m.String())
 	}
 
-	if foundIssues > 0 {
-		return FoundAnalyzeIssuesError{foundIssues}
+	if foundIssues {
+		return FoundAnalyzeIssuesError{}
 	}
 
 	return nil

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -32,8 +32,13 @@ import (
 
 type AnalyzerFoundIssuesError struct{}
 
+const (
+	FoundIssueString = "Analyzer found issues."
+	NoIssuesString   = "No analyzer issues found."
+)
+
 func (f AnalyzerFoundIssuesError) Error() string {
-	return "Analyzer found issues."
+	return FoundIssueString
 }
 
 var (
@@ -212,6 +217,10 @@ func errorIfMessagesExceedThreshold(messages []diag.Message) error {
 }
 
 func outputMessages(f io.Writer, messages []diag.Message) {
+	if len(messages) == 0 {
+		fmt.Fprint(f, NoIssuesString)
+		return
+	}
 	for _, m := range messages {
 		fmt.Fprintf(f, "%v\n", m.String())
 	}

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -199,7 +199,7 @@ func handleAnalyzeMessages(f io.Writer, messages []diag.Message) error {
 	foundIssues := 0
 	for _, m := range messages {
 		if m.Type.Level().IsWorseThan(messageLevelThreshold) {
-			foundIssues += 1
+			foundIssues++
 		}
 		fmt.Fprintf(f, "%v\n", m.String())
 	}

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -34,7 +33,6 @@ type AnalyzerFoundIssuesError struct{}
 
 const (
 	FoundIssueString = "Analyzer found issues."
-	NoIssuesString   = "No analyzer issues found."
 )
 
 func (f AnalyzerFoundIssuesError) Error() string {
@@ -160,10 +158,8 @@ istioctl experimental analyze -k -d false
 					fmt.Fprintln(cmd.OutOrStdout(), m.String())
 				}
 			}
-			return nil
-			outputMessages(cmd.OutOrStdout(), messages)
 
-			return errorIfMessagesExceedThreshold(messages)
+			return errorIfMessagesExceedThreshold(result.Messages)
 		},
 	}
 
@@ -214,14 +210,4 @@ func errorIfMessagesExceedThreshold(messages []diag.Message) error {
 	}
 
 	return nil
-}
-
-func outputMessages(f io.Writer, messages []diag.Message) {
-	if len(messages) == 0 {
-		fmt.Fprint(f, NoIssuesString)
-		return
-	}
-	for _, m := range messages {
-		fmt.Fprintf(f, "%v\n", m.String())
-	}
 }

--- a/istioctl/cmd/analyze_test.go
+++ b/istioctl/cmd/analyze_test.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"istio.io/istio/galley/pkg/config/analysis/diag"
@@ -39,12 +38,12 @@ func TestErrorOnIssuesFound(t *testing.T) {
 		),
 	}
 
-	err := outputAndSetError(ioutil.Discard, msgs)
+	err := errorIfMessagesExceedThreshold(msgs)
 
-	g.Expect(err).To(BeIdenticalTo(FoundAnalyzeIssuesError{}))
+	g.Expect(err).To(BeIdenticalTo(AnalyzerFoundIssuesError{}))
 }
 
-func TestNoErrorOnNoIssuesFound(t *testing.T) {
+func TestNoErrorIfMessageLevelsBelowThreshold(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	msgs := []diag.Message{
@@ -60,7 +59,7 @@ func TestNoErrorOnNoIssuesFound(t *testing.T) {
 		),
 	}
 
-	err := outputAndSetError(ioutil.Discard, msgs)
+	err := errorIfMessagesExceedThreshold(msgs)
 
 	g.Expect(err).To(BeNil())
 }

--- a/istioctl/cmd/analyze_test.go
+++ b/istioctl/cmd/analyze_test.go
@@ -37,10 +37,10 @@ func TestErrorOnIssuesFound(t *testing.T) {
 
 	err := handleAnalyzeMessages(ioutil.Discard, msgs)
 
-	switch err.(type) {
+	switch err := err.(type) {
 	case FoundAnalyzeIssuesError:
-		if len(msgs) != err.(FoundAnalyzeIssuesError).int {
-			t.Errorf("Expected %v errors, but got %v.", len(msgs), err.(FoundAnalyzeIssuesError).int)
+		if len(msgs) != err.int {
+			t.Errorf("Expected %v errors, but got %v.", len(msgs), err.int)
 		}
 	default:
 		t.Errorf("Expected a CommandParseError, but got %q.", err)

--- a/istioctl/cmd/analyze_test.go
+++ b/istioctl/cmd/analyze_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"istio.io/istio/galley/pkg/config/analysis/diag"
+)
+
+func TestErrorOnIssuesFound(t *testing.T) {
+	msgs := []diag.Message{
+		diag.NewMessage(
+			diag.NewMessageType(diag.Error, "B1", "Template: %q"),
+			nil,
+			"",
+		),
+		diag.NewMessage(
+			diag.NewMessageType(diag.Warning, "A1", "Template: %q"),
+			nil,
+			"",
+		),
+	}
+
+	err := handleAnalyzeMessages(ioutil.Discard, msgs)
+
+	switch err.(type) {
+	case FoundAnalyzeIssuesError:
+		if len(msgs) != err.(FoundAnalyzeIssuesError).int {
+			t.Errorf("Expected %v errors, but got %v.", len(msgs), err.(FoundAnalyzeIssuesError).int)
+		}
+	default:
+		t.Errorf("Expected a CommandParseError, but got %q.", err)
+		return
+	}
+}
+
+func TestNoErrorOnNoIssuesFound(t *testing.T) {
+	msgs := []diag.Message{
+		diag.NewMessage(
+			diag.NewMessageType(diag.Info, "B1", "Template: %q"),
+			nil,
+			"",
+		),
+		diag.NewMessage(
+			diag.NewMessageType(diag.Info, "A1", "Template: %q"),
+			nil,
+			"",
+		),
+	}
+
+	err := handleAnalyzeMessages(ioutil.Discard, msgs)
+
+	if err != nil {
+		t.Errorf("Expected nil, but got %q.", err)
+	}
+}

--- a/istioctl/cmd/analyze_test.go
+++ b/istioctl/cmd/analyze_test.go
@@ -19,9 +19,13 @@ import (
 	"testing"
 
 	"istio.io/istio/galley/pkg/config/analysis/diag"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestErrorOnIssuesFound(t *testing.T) {
+	g := NewGomegaWithT(t)
+
 	msgs := []diag.Message{
 		diag.NewMessage(
 			diag.NewMessageType(diag.Error, "B1", "Template: %q"),
@@ -35,20 +39,14 @@ func TestErrorOnIssuesFound(t *testing.T) {
 		),
 	}
 
-	err := handleAnalyzeMessages(ioutil.Discard, msgs)
+	err := outputAndSetError(ioutil.Discard, msgs)
 
-	switch err := err.(type) {
-	case FoundAnalyzeIssuesError:
-		if len(msgs) != err.int {
-			t.Errorf("Expected %v errors, but got %v.", len(msgs), err.int)
-		}
-	default:
-		t.Errorf("Expected a CommandParseError, but got %q.", err)
-		return
-	}
+	g.Expect(err).To(BeIdenticalTo(FoundAnalyzeIssuesError{}))
 }
 
 func TestNoErrorOnNoIssuesFound(t *testing.T) {
+	g := NewGomegaWithT(t)
+
 	msgs := []diag.Message{
 		diag.NewMessage(
 			diag.NewMessageType(diag.Info, "B1", "Template: %q"),
@@ -62,9 +60,7 @@ func TestNoErrorOnNoIssuesFound(t *testing.T) {
 		),
 	}
 
-	err := handleAnalyzeMessages(ioutil.Discard, msgs)
+	err := outputAndSetError(ioutil.Discard, msgs)
 
-	if err != nil {
-		t.Errorf("Expected nil, but got %q.", err)
-	}
+	g.Expect(err).To(BeNil())
 }

--- a/istioctl/cmd/sysexits.go
+++ b/istioctl/cmd/sysexits.go
@@ -16,12 +16,14 @@ package cmd
 
 import "strings"
 
-// Values should use sendmail-style values as in <sysexits.h>
+// Values should try to use sendmail-style values as in <sysexits.h>
 // See e.g. https://man.openbsd.org/sysexits.3
 // or `less /usr/includes/sysexits.h` if you're on Linux
 const (
 	ExitUnknownError   = 1 // for compatibility with existing exit code
 	ExitIncorrectUsage = 64
+	// below here are non-zero exit codes that don't indicate an error with istioctl itself
+	ExitAnalyzeFoundIssues = 79 // istioctl analyze found issues, for CI/CD
 )
 
 func GetExitCode(e error) int {
@@ -32,6 +34,8 @@ func GetExitCode(e error) int {
 	switch e.(type) {
 	case CommandParseError:
 		return ExitIncorrectUsage
+	case FoundAnalyzeIssuesError:
+		return ExitAnalyzeFoundIssues
 	default:
 		return ExitUnknownError
 	}

--- a/istioctl/cmd/sysexits.go
+++ b/istioctl/cmd/sysexits.go
@@ -19,9 +19,18 @@ import "strings"
 // Values should try to use sendmail-style values as in <sysexits.h>
 // See e.g. https://man.openbsd.org/sysexits.3
 // or `less /usr/includes/sysexits.h` if you're on Linux
+//
+// Picking the right range is tricky--there are a lot of reserved ones (see
+// https://www.tldp.org/LDP/abs/html/exitcodes.html#EXITCODESREF) and then some
+// used by convention (see sysexits).
+//
+// My intention here is to use 64-78 in a way that matches the attempt in
+// sysexits to signify some error running istioctl, and use 79-125 as custom
+// error codes for other info that we'd like to use to pass info on.
 const (
 	ExitUnknownError   = 1 // for compatibility with existing exit code
 	ExitIncorrectUsage = 64
+
 	// below here are non-zero exit codes that don't indicate an error with istioctl itself
 	ExitAnalyzeFoundIssues = 79 // istioctl analyze found issues, for CI/CD
 )

--- a/istioctl/cmd/sysexits.go
+++ b/istioctl/cmd/sysexits.go
@@ -24,7 +24,7 @@ import "strings"
 // https://www.tldp.org/LDP/abs/html/exitcodes.html#EXITCODESREF) and then some
 // used by convention (see sysexits).
 //
-// My intention here is to use 64-78 in a way that matches the attempt in
+// The intention here is to use 64-78 in a way that matches the attempt in
 // sysexits to signify some error running istioctl, and use 79-125 as custom
 // error codes for other info that we'd like to use to pass info on.
 const (
@@ -32,7 +32,7 @@ const (
 	ExitIncorrectUsage = 64
 
 	// below here are non-zero exit codes that don't indicate an error with istioctl itself
-	ExitAnalyzeFoundIssues = 79 // istioctl analyze found issues, for CI/CD
+	ExitAnalyzerFoundIssues = 79 // istioctl analyze found issues, for CI/CD
 )
 
 func GetExitCode(e error) int {
@@ -43,8 +43,8 @@ func GetExitCode(e error) int {
 	switch e.(type) {
 	case CommandParseError:
 		return ExitIncorrectUsage
-	case FoundAnalyzeIssuesError:
-		return ExitAnalyzeFoundIssues
+	case AnalyzerFoundIssuesError:
+		return ExitAnalyzerFoundIssues
 	default:
 		return ExitUnknownError
 	}

--- a/tests/integration/istioctl/analyze_test.go
+++ b/tests/integration/istioctl/analyze_test.go
@@ -52,6 +52,7 @@ func TestEmptyCluster(t *testing.T) {
 			// For a clean istio install with injection enabled, expect no validation errors
 			output := istioctlOrFail(t, istioCtl, ns.Name(), "--use-kube")
 			expectNoMessages(t, g, output)
+			g.Expect(output[0]).To(ContainSubstring(cmd.NoIssuesString))
 		})
 }
 

--- a/tests/integration/istioctl/analyze_test.go
+++ b/tests/integration/istioctl/analyze_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/istioctl/cmd"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
@@ -31,6 +32,8 @@ const (
 	serviceRoleBindingFile = "testdata/servicerolebinding.yaml"
 	serviceRoleFile        = "testdata/servicerole.yaml"
 )
+
+var foundAnalyzeError = cmd.FoundAnalyzeIssuesError{}
 
 func TestEmptyCluster(t *testing.T) {
 	framework.
@@ -66,9 +69,11 @@ func TestFileOnly(t *testing.T) {
 			istioCtl := istioctl.NewOrFail(t, ctx, istioctl.Config{})
 
 			// Validation error if we have a service role binding without a service role
-			output := istioctlOrFail(t, istioCtl, ns.Name(), serviceRoleBindingFile)
-			g.Expect(output).To(HaveLen(1))
+			output, err := istioctlSafe(t, istioCtl, ns.Name(), serviceRoleBindingFile)
+			g.Expect(output).To(HaveLen(2))
 			g.Expect(output[0]).To(ContainSubstring(msg.ReferencedResourceNotFound.Code()))
+			g.Expect(output[1]).To(ContainSubstring(foundAnalyzeError.Error()))
+			g.Expect(err).To(BeIdenticalTo(foundAnalyzeError))
 
 			// Error goes away if we include both the binding and its role
 			output = istioctlOrFail(t, istioCtl, ns.Name(), serviceRoleBindingFile, serviceRoleFile)
@@ -93,9 +98,11 @@ func TestKubeOnly(t *testing.T) {
 			istioCtl := istioctl.NewOrFail(t, ctx, istioctl.Config{})
 
 			// Validation error if we have a service role binding without a service role
-			output := istioctlOrFail(t, istioCtl, ns.Name(), "--use-kube")
-			g.Expect(output).To(HaveLen(1))
+			output, err := istioctlSafe(t, istioCtl, ns.Name(), "--use-kube")
+			g.Expect(output).To(HaveLen(2))
 			g.Expect(output[0]).To(ContainSubstring(msg.ReferencedResourceNotFound.Code()))
+			g.Expect(output[1]).To(ContainSubstring(foundAnalyzeError.Error()))
+			g.Expect(err).To(BeIdenticalTo(foundAnalyzeError))
 
 			// Error goes away if we include both the binding and its role
 			applyFileOrFail(t, ns.Name(), serviceRoleFile)
@@ -131,6 +138,16 @@ func expectNoMessages(t *testing.T, g *GomegaWithT, output []string) {
 	t.Helper()
 	g.Expect(output).To(HaveLen(1))
 	g.Expect(output[0]).To(ContainSubstring("No validation issues found"))
+}
+
+func istioctlSafe(t *testing.T, i istioctl.Instance, ns string, extraArgs ...string) ([]string, error) {
+	t.Helper()
+	args := []string{"experimental", "analyze", "--namespace", ns}
+	output, err := i.Invoke(append(args, extraArgs...))
+	if output == "" {
+		return []string{}, err
+	}
+	return strings.Split(strings.TrimSpace(output), "\n"), err
 }
 
 func istioctlOrFail(t *testing.T, i istioctl.Instance, ns string, extraArgs ...string) []string {

--- a/tests/integration/istioctl/analyze_test.go
+++ b/tests/integration/istioctl/analyze_test.go
@@ -33,7 +33,7 @@ const (
 	serviceRoleFile        = "testdata/servicerole.yaml"
 )
 
-var foundAnalyzeError = cmd.FoundAnalyzeIssuesError{}
+var analyzerFoundIssuesError = cmd.AnalyzerFoundIssuesError{}
 
 func TestEmptyCluster(t *testing.T) {
 	framework.
@@ -72,8 +72,8 @@ func TestFileOnly(t *testing.T) {
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), serviceRoleBindingFile)
 			g.Expect(output).To(HaveLen(2))
 			g.Expect(output[0]).To(ContainSubstring(msg.ReferencedResourceNotFound.Code()))
-			g.Expect(output[1]).To(ContainSubstring(foundAnalyzeError.Error()))
-			g.Expect(err).To(BeIdenticalTo(foundAnalyzeError))
+			g.Expect(output[1]).To(ContainSubstring(analyzerFoundIssuesError.Error()))
+			g.Expect(err).To(BeIdenticalTo(analyzerFoundIssuesError))
 
 			// Error goes away if we include both the binding and its role
 			output = istioctlOrFail(t, istioCtl, ns.Name(), serviceRoleBindingFile, serviceRoleFile)
@@ -101,8 +101,8 @@ func TestKubeOnly(t *testing.T) {
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), "--use-kube")
 			g.Expect(output).To(HaveLen(2))
 			g.Expect(output[0]).To(ContainSubstring(msg.ReferencedResourceNotFound.Code()))
-			g.Expect(output[1]).To(ContainSubstring(foundAnalyzeError.Error()))
-			g.Expect(err).To(BeIdenticalTo(foundAnalyzeError))
+			g.Expect(output[1]).To(ContainSubstring(analyzerFoundIssuesError.Error()))
+			g.Expect(err).To(BeIdenticalTo(analyzerFoundIssuesError))
 
 			// Error goes away if we include both the binding and its role
 			applyFileOrFail(t, ns.Name(), serviceRoleFile)

--- a/tests/integration/istioctl/analyze_test.go
+++ b/tests/integration/istioctl/analyze_test.go
@@ -52,7 +52,6 @@ func TestEmptyCluster(t *testing.T) {
 			// For a clean istio install with injection enabled, expect no validation errors
 			output := istioctlOrFail(t, istioCtl, ns.Name(), "--use-kube")
 			expectNoMessages(t, g, output)
-			g.Expect(output[0]).To(ContainSubstring(cmd.NoIssuesString))
 		})
 }
 


### PR DESCRIPTION
See #17862 for more context. This sets an initial threshold of INFO
level issues and anything worse than that triggers a specific error from
analyze, which should trigger an exit code of 79 on the shell.


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

