### PR TITLE
istioctl analyze should print on broken files, but try to continue

### DIFF
--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 
 	"github.com/hashicorp/go-multierror"
+
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 	"istio.io/istio/galley/pkg/config/event"

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -27,8 +27,10 @@ import (
 	"istio.io/istio/galley/pkg/config/meta/schema/collection"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/k8smeta"
+	"istio.io/istio/galley/pkg/config/util/kubeyaml"
 	"istio.io/istio/galley/pkg/testing/mock"
 )
 
@@ -135,23 +137,39 @@ func TestAddRunningKubeSource(t *testing.T) {
 func TestAddFileKubeSource(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
+	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
 
-	tmpfile, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmpfile := tempFileFromString(t, data.YamlN1I1V1)
 	defer func() { _ = os.Remove(tmpfile.Name()) }()
-	_, err = tmpfile.WriteString(data.YamlN1I1V1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = tmpfile.Close(); err != nil {
-		t.Fatal(err)
-	}
 
-	err = sa.AddFileKubeSource([]string{tmpfile.Name()})
+	err := sa.AddFileKubeSource([]string{tmpfile.Name()})
 	g.Expect(err).To(BeNil())
+	g.Expect(sa.sources).To(HaveLen(1))
+}
+
+func TestAddFileKubeSourceSkipsBadEntries(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
+
+	tmpfile := tempFileFromString(t, kubeyaml.JoinString(data.YamlN1I1V1, "bogus resource entry\n"))
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
+
+	err := sa.AddFileKubeSource([]string{tmpfile.Name()})
+	g.Expect(err).To(Not(BeNil()))
+	g.Expect(sa.sources).To(HaveLen(1))
+}
+
+func TestAddFileKubeSourceSkipsBadFiles(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
+
+	tmpfile := tempFileFromString(t, data.YamlN1I1V1)
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
+
+	err := sa.AddFileKubeSource([]string{tmpfile.Name(), "nonexistent-file.yaml"})
+	g.Expect(err).To(Not(BeNil()))
 	g.Expect(sa.sources).To(HaveLen(1))
 }
 
@@ -185,4 +203,20 @@ func TestResourceFiltering(t *testing.T) {
 			g.Expect(r.Disabled).To(BeTrue(), fmt.Sprintf("%s should be disabled", r.Collection.Name))
 		}
 	}
+}
+
+func tempFileFromString(t *testing.T, content string) *os.File {
+	t.Helper()
+	tmpfile, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tmpfile.WriteString(content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return tmpfile
 }

--- a/galley/pkg/config/source/kube/inmemory/kubesource_test.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource_test.go
@@ -200,7 +200,7 @@ func TestKubeSource_UnparseableSegment(t *testing.T) {
 	defer s.Stop()
 
 	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, "	\n", data.YamlN2I2V1))
-	g.Expect(err).To(BeNil())
+	g.Expect(err).To(Not(BeNil()))
 
 	actual := removeEntryOrigins(s.Get(data.Collection1).AllSorted())
 	g.Expect(actual).To(HaveLen(2))
@@ -216,7 +216,7 @@ func TestKubeSource_Unrecognized(t *testing.T) {
 	defer s.Stop()
 
 	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, data.YamlUnrecognized))
-	g.Expect(err).To(BeNil())
+	g.Expect(err).To(Not(BeNil()))
 
 	actual := removeEntryOrigins(s.Get(data.Collection1).AllSorted())
 	g.Expect(actual).To(HaveLen(1))
@@ -231,7 +231,7 @@ func TestKubeSource_UnparseableResource(t *testing.T) {
 	defer s.Stop()
 
 	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, data.YamlUnparseableResource))
-	g.Expect(err).To(BeNil())
+	g.Expect(err).To(Not(BeNil()))
 
 	actual := removeEntryOrigins(s.Get(data.Collection1).AllSorted())
 	g.Expect(actual).To(HaveLen(1))
@@ -246,7 +246,7 @@ func TestKubeSource_NonStringKey(t *testing.T) {
 	defer s.Stop()
 
 	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, data.YamlNonStringKey))
-	g.Expect(err).To(BeNil())
+	g.Expect(err).To(Not(BeNil()))
 
 	actual := removeEntryOrigins(s.Get(data.Collection1).AllSorted())
 	g.Expect(actual).To(HaveLen(1))

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -111,7 +111,9 @@ istioctl experimental analyze -k -d false
 			// If files are provided, treat them (collectively) as a source.
 			if len(files) > 0 {
 				if err = sa.AddFileKubeSource(files); err != nil {
-					return err
+					// Partial success is possible, so don't return early, but do print.
+					// TODO(https://github.com/istio/istio/issues/17862): If we had any such errors, we should return a nonzero exit code
+					fmt.Fprintf(cmd.ErrOrStderr(), "Error(s) reading files: %v", err)
 				}
 			}
 


### PR DESCRIPTION
For unparseable resources or unreadable files, `istioctl analyze` should print a message but try to continue reading & analyzing what else it can. 

Mostly solves https://github.com/istio/istio/issues/18124. The exit code part will be solved soon also. 

