### PR TITLE
When Operator manages webhooks, Galley and Sidecar Injector are deprivileged (#18029)

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
@@ -26,9 +26,11 @@ rules:
   "security.istio.io"]
   resources: ["*/status"]
   verbs: ["update"]
+{{- if not .Values.global.operatorManageWebhooks }}
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["validatingwebhookconfigurations"]
   verbs: ["*"]
+{{- end }}
 - apiGroups: ["extensions","apps"]
   resources: ["deployments"]
   resourceNames: ["istio-galley"]

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/clusterrole.yaml
@@ -12,6 +12,8 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list", "watch"]
+{{- if not .Values.global.operatorManageWebhooks }}
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
   verbs: ["get", "list", "watch", "patch"]
+{{- end }}


### PR DESCRIPTION
(cherry-pick the commit: https://github.com/istio/istio/commit/156d828d379be772f8d04cac342210e2f04b97b2)

Please provide a description for what this PR is for: https://github.com/istio/istio/issues/17061

The matching PR on istio/installer: https://github.com/istio/installer/pull/441

Design documents:
