### PR TITLE
add passthrough filter chain support for v1beta1 authorization policy

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
+
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -463,7 +463,7 @@ func newInboundPassthroughFilterChains(configgen *ConfigGeneratorImpl,
 			},
 		}
 		for _, p := range configgen.Plugins {
-			if err := p.OnInboundPasssthrough(in, mutable); err != nil {
+			if err := p.OnInboundPassthrough(in, mutable); err != nil {
 				log.Errorf("Build inbound passthrough filter chains error: %v", err)
 			}
 		}
@@ -525,7 +525,7 @@ func newHTTPPassThroughFilterChain(configgen *ConfigGeneratorImpl, env *model.En
 			},
 		}
 		for _, p := range configgen.Plugins {
-			if err := p.OnInboundPasssthrough(in, mutable); err != nil {
+			if err := p.OnInboundPassthrough(in, mutable); err != nil {
 				log.Errorf("Build inbound passthrough filter chains error: %v", err)
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"istio.io/istio/pilot/pkg/features"
+	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
+	"istio.io/istio/pilot/pkg/security/authz/policy"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
@@ -163,6 +165,10 @@ func prepareListeners(t *testing.T) []*v2.Listener {
 	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 		t.Fatalf("init push context error: %s", err.Error())
 	}
+	env.PushContext.AuthzPolicies = policy.NewAuthzPolicies([]*model.Config{
+		policy.SimpleAuthzPolicy("authz", "not-default"),
+	}, t)
+
 	instances := make([]*model.ServiceInstance, len(services))
 	for i, s := range services {
 		instances[i] = &model.ServiceInstance{
@@ -246,11 +252,15 @@ func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
 			"plus the 2 fallthrough filter chains, found %d", len(listeners[0].FilterChains)+2, len(l.FilterChains))
 	}
 
+	sawRBACTCPFilter := false
 	sawIpv4PassthroughCluster := false
 	sawIpv6PassthroughCluster := false
 	for _, fc := range l.FilterChains {
-		if len(fc.Filters) == 1 && fc.Filters[0].Name == xdsutil.TCPProxy &&
+		if len(fc.Filters) == 2 && fc.Filters[1].Name == xdsutil.TCPProxy &&
 			fc.Metadata.FilterMetadata[PilotMetaKey].Fields["original_listener_name"].GetStringValue() == VirtualInboundListenerName {
+			if fc.Filters[0].Name == authz_model.RBACTCPFilterName {
+				sawRBACTCPFilter = true
+			}
 			if ipLen := len(fc.FilterChainMatch.PrefixRanges); ipLen != 1 {
 				t.Fatalf("expect passthrough filter chain has 1 ip address, found %d", ipLen)
 			}
@@ -274,11 +284,18 @@ func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
 			if !reflect.DeepEqual(fc.FilterChainMatch.ApplicationProtocols, applicationProtocols) {
 				t.Fatalf("expect %v application protocols, found %v", applicationProtocols, fc.FilterChainMatch.ApplicationProtocols)
 			}
+			if !strings.Contains(fc.Filters[0].GetTypedConfig().String(), authz_model.RBACHTTPFilterName) {
+				t.Errorf("failed to find the RBAC HTTP filter: %v", fc.Filters[0].GetTypedConfig().String())
+			}
 		}
 	}
 
 	if !sawIpv4PassthroughCluster {
 		t.Fatalf("fail to find the ipv4 passthrough filter chain in listener %v", l)
+	}
+
+	if !sawRBACTCPFilter {
+		t.Fatalf("fail to find the RBAC TCP filter in listener %v", l)
 	}
 
 	if len(l.ListenerFilters) != 2 {

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -24,6 +24,7 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	http_filter "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
@@ -46,7 +47,9 @@ import (
 )
 
 const (
-	wildcardIP = "0.0.0.0"
+	wildcardIP           = "0.0.0.0"
+	fakePluginHTTPFilter = "fake-plugin-http-filter"
+	fakePluginTCPFilter  = "fake-plugin-tcp-filter"
 )
 
 var (
@@ -1505,6 +1508,26 @@ func (p *fakePlugin) OnInboundRouteConfiguration(in *plugin.InputParams, routeCo
 
 func (p *fakePlugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.FilterChain {
 	return []plugin.FilterChain{{}, {}}
+}
+
+func (p *fakePlugin) OnInboundPasssthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	switch in.ListenerProtocol {
+	case plugin.ListenerProtocolTCP:
+		for cnum := range mutable.FilterChains {
+			filter := &listener.Filter{
+				Name: fakePluginTCPFilter,
+			}
+			mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, filter)
+		}
+	case plugin.ListenerProtocolHTTP:
+		for cnum := range mutable.FilterChains {
+			filter := &http_filter.HttpFilter{
+				Name: fakePluginHTTPFilter,
+			}
+			mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, filter)
+		}
+	}
+	return nil
 }
 
 func isHTTPListener(listener *xdsapi.Listener) bool {

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1510,7 +1510,7 @@ func (p *fakePlugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.Filt
 	return []plugin.FilterChain{{}, {}}
 }
 
-func (p *fakePlugin) OnInboundPasssthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+func (p *fakePlugin) OnInboundPassthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	switch in.ListenerProtocol {
 	case plugin.ListenerProtocolTCP:
 		for cnum := range mutable.FilterChains {

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -103,7 +103,7 @@ func (Plugin) OnInboundRouteConfiguration(in *plugin.InputParams, route *xdsapi.
 func (Plugin) OnOutboundCluster(in *plugin.InputParams, cluster *xdsapi.Cluster) {
 }
 
-// OnInboundPasssthrough is called whenever a new passthrough filter chain is added to the LDS output.
-func (Plugin) OnInboundPasssthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+// OnInboundPassthrough is called whenever a new passthrough filter chain is added to the LDS output.
+func (Plugin) OnInboundPassthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	return nil
 }

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -102,3 +102,8 @@ func (Plugin) OnInboundRouteConfiguration(in *plugin.InputParams, route *xdsapi.
 // OnOutboundCluster implements the Plugin interface method.
 func (Plugin) OnOutboundCluster(in *plugin.InputParams, cluster *xdsapi.Cluster) {
 }
+
+// OnInboundPasssthrough is called whenever a new passthrough filter chain is added to the LDS output.
+func (Plugin) OnInboundPasssthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	return nil
+}

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -166,8 +166,8 @@ func (Plugin) OnInboundRouteConfiguration(in *plugin.InputParams, route *xdsapi.
 func (Plugin) OnOutboundCluster(in *plugin.InputParams, cluster *xdsapi.Cluster) {
 }
 
-// OnInboundPasssthrough is called whenever a new passthrough filter chain is added to the LDS output.
-func (Plugin) OnInboundPasssthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+// OnInboundPassthrough is called whenever a new passthrough filter chain is added to the LDS output.
+func (Plugin) OnInboundPassthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	if in.Node.Type != model.SidecarProxy {
 		// Only care about sidecar.
 		return nil

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -77,11 +77,6 @@ func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableO
 }
 
 func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
-	if in.ServiceInstance == nil {
-		rbacLog.Errorf("nil service instance")
-		return
-	}
-
 	// TODO: Get trust domain from MeshConfig instead.
 	// https://github.com/istio/istio/issues/17873
 	trustDomainBundle := trustdomain.NewTrustDomainBundle(spiffe.GetTrustDomain(), in.Env.Mesh.TrustDomainAliases)

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -165,3 +165,14 @@ func (Plugin) OnInboundRouteConfiguration(in *plugin.InputParams, route *xdsapi.
 // OnOutboundCluster implements the Plugin interface method.
 func (Plugin) OnOutboundCluster(in *plugin.InputParams, cluster *xdsapi.Cluster) {
 }
+
+// OnInboundPasssthrough is called whenever a new passthrough filter chain is added to the LDS output.
+func (Plugin) OnInboundPasssthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	if in.Node.Type != model.SidecarProxy {
+		// Only care about sidecar.
+		return nil
+	}
+
+	buildFilter(in, mutable)
+	return nil
+}

--- a/pilot/pkg/networking/plugin/health/health.go
+++ b/pilot/pkg/networking/plugin/health/health.go
@@ -155,3 +155,8 @@ func (Plugin) OnOutboundCluster(in *plugin.InputParams, cluster *xdsapi.Cluster)
 func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.FilterChain {
 	return nil
 }
+
+// OnInboundPasssthrough is called whenever a new passthrough filter chain is added to the LDS output.
+func (Plugin) OnInboundPasssthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	return nil
+}

--- a/pilot/pkg/networking/plugin/health/health.go
+++ b/pilot/pkg/networking/plugin/health/health.go
@@ -156,7 +156,7 @@ func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.FilterChain
 	return nil
 }
 
-// OnInboundPasssthrough is called whenever a new passthrough filter chain is added to the LDS output.
-func (Plugin) OnInboundPasssthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+// OnInboundPassthrough is called whenever a new passthrough filter chain is added to the LDS output.
+func (Plugin) OnInboundPassthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	return nil
 }

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -328,6 +328,11 @@ func (mixerplugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.Filter
 	return nil
 }
 
+// OnInboundPasssthrough is called whenever a new passthrough filter chain is added to the LDS output.
+func (mixerplugin) OnInboundPasssthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	return nil
+}
+
 func buildUpstreamName(address string) string {
 	// effectively disable the upstream
 	if address == "" {

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -328,8 +328,8 @@ func (mixerplugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.Filter
 	return nil
 }
 
-// OnInboundPasssthrough is called whenever a new passthrough filter chain is added to the LDS output.
-func (mixerplugin) OnInboundPasssthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+// OnInboundPassthrough is called whenever a new passthrough filter chain is added to the LDS output.
+func (mixerplugin) OnInboundPassthrough(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	return nil
 }
 

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -192,7 +192,7 @@ type Plugin interface {
 	// configuration, like FilterChainMatch and TLSContext.
 	OnInboundFilterChains(in *InputParams) []FilterChain
 
-	// OnInboundPasssthrough is called whenever a new passthrough filter chain is added to the LDS output.
+	// OnInboundPassthrough is called whenever a new passthrough filter chain is added to the LDS output.
 	// Can be used to add additional filters.
-	OnInboundPasssthrough(in *InputParams, mutable *MutableObjects) error
+	OnInboundPassthrough(in *InputParams, mutable *MutableObjects) error
 }

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -191,4 +191,8 @@ type Plugin interface {
 	// OnInboundFilterChains is called whenever a plugin needs to setup the filter chains, including relevant filter chain
 	// configuration, like FilterChainMatch and TLSContext.
 	OnInboundFilterChains(in *InputParams) []FilterChain
+
+	// OnInboundPasssthrough is called whenever a new passthrough filter chain is added to the LDS output.
+	// Can be used to add additional filters.
+	OnInboundPasssthrough(in *InputParams, mutable *MutableObjects) error
 }

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -51,6 +51,9 @@ func NewBuilder(trustDomainBundle trustdomain.Bundle, serviceInstance *model.Ser
 		generator = v1beta1.NewGenerator(trustDomainBundle, p)
 		rbacLog.Debugf("v1beta1 authorization enabled for workload %v in %s", workloadLabels, configNamespace)
 	} else {
+		if serviceInstance == nil {
+			return nil
+		}
 		if serviceInstance.Service == nil {
 			rbacLog.Errorf("no service for serviceInstance: %v", serviceInstance)
 			return nil

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -106,6 +106,8 @@ spec:
 {{- end }}
           - "{{ $p.Port }}"
 {{- end }}
+          - --port
+          - "8081"
           - --version
           - "{{ .Version }}"
         ports:

--- a/tests/integration/security/rbac_v1beta1_pass_through_test.go
+++ b/tests/integration/security/rbac_v1beta1_pass_through_test.go
@@ -1,0 +1,174 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/echo/common/response"
+	epb "istio.io/istio/pkg/test/echo/proto"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/tmpl"
+)
+
+func getWorkload(instance echo.Instance, t *testing.T) echo.Workload {
+	workloads, err := instance.Workloads()
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("failed to get workloads: %v", err))
+	}
+	if len(workloads) < 1 {
+		t.Fatalf("want at least 1 workload but found 0")
+	}
+	return workloads[0]
+}
+
+// TestV1beta1_PassThroughFilterChain tests the v1beta1 authorization policy works on the passthrough filter chain.
+func TestV1beta1_PassThroughFilterChain(t *testing.T) {
+	framework.
+		NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "v1beta1-pass-through",
+				Inject: true,
+			})
+
+			// Apply the authorization policy to allow access to server-1 and deny access to server-2.
+			args := map[string]string{
+				"Namespace": ns.Name(),
+			}
+			policies := tmpl.EvaluateAllOrFail(t, args,
+				file.AsStringOrFail(t, "testdata/rbac/v1beta1-pass-through.yaml.tmpl"))
+			g.ApplyConfigOrFail(t, ns, policies...)
+			defer g.DeleteConfigOrFail(t, ns, policies...)
+
+			// client is created without sidecar to allow us to send traffic to server at
+			// ports not defined in the service.
+			// server-1 and server-2 are created without port 8081 (HTTP) in its service.
+			var client, server1, server2 echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&client, echo.Config{
+					Service:     "client",
+					Namespace:   ns,
+					Galley:      g,
+					Pilot:       p,
+					Annotations: echo.NewAnnotations().Set(echo.SidecarInject, "false"),
+				}).
+				With(&server1, echo.Config{
+					Service:   "server-1",
+					Namespace: ns,
+					Galley:    g,
+					Pilot:     p,
+					Ports: []echo.Port{
+						{
+							Name:     "grpc",
+							Protocol: protocol.GRPC,
+						},
+					},
+				}).
+				With(&server2, echo.Config{
+					Service:   "server-2",
+					Namespace: ns,
+					Galley:    g,
+					Pilot:     p,
+					Ports: []echo.Port{
+						{
+							Name:     "grpc",
+							Protocol: protocol.GRPC,
+						},
+					},
+				}).BuildOrFail(t)
+
+			clientWorkload := getWorkload(client, t)
+			server1Workload := getWorkload(server1, t)
+			server2Workload := getWorkload(server2, t)
+			cases := []struct {
+				name string
+				ip   string
+				want bool
+			}{
+				{
+					name: "server-1",
+					ip:   server1Workload.Address(),
+					want: true,
+				},
+				{
+					name: "server-2",
+					ip:   server2Workload.Address(),
+					want: false,
+				},
+			}
+
+			verify := func(ip string, want bool) error {
+				// Send the requests at port 8081 (HTTP) which is not defined in the service of
+				// server-1 and server-2. The request should be handled by the passthrough filter chain.
+				host := fmt.Sprintf("%s:8081", ip)
+				responses, err := clientWorkload.ForwardEcho(context.TODO(), &epb.ForwardEchoRequest{
+					Url:   fmt.Sprintf("http://%s/", host),
+					Count: 1,
+					Headers: []*epb.Header{
+						{
+							Key:   "Host",
+							Value: host,
+						},
+					},
+				})
+
+				if want {
+					if err != nil {
+						return fmt.Errorf("failed to make request to %s: %v", host, err)
+					}
+					if len(responses) < 1 {
+						return fmt.Errorf("received no responses from request to %s", host)
+					}
+					if response.StatusCodeOK != responses[0].Code {
+						return fmt.Errorf("want status %s but got %s", response.StatusCodeOK, responses[0].Code)
+					}
+				} else {
+					if err == nil {
+						return fmt.Errorf("want error but got nil")
+					}
+					if !strings.Contains(err.Error(), "EOF") {
+						return fmt.Errorf("want error EOF but got: %v", err)
+					}
+				}
+				return nil
+			}
+			for _, tc := range cases {
+				name := ""
+				if tc.want {
+					name = fmt.Sprintf("%s[allow]", tc.name)
+				} else {
+					name = fmt.Sprintf("%s[deny]", tc.name)
+				}
+				t.Run(name, func(t *testing.T) {
+					retry.UntilSuccessOrFail(t, func() error {
+						return verify(tc.ip, tc.want)
+					}, retry.Delay(250*time.Millisecond), retry.Timeout(30*time.Second))
+				})
+			}
+		})
+}

--- a/tests/integration/security/testdata/rbac/v1beta1-pass-through.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-pass-through.yaml.tmpl
@@ -1,0 +1,22 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: allow-server-1
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      app: server-1
+  rules:
+  - to:
+    - operation:
+        ports: ["8081"]
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: deny-all
+  namespace: "{{ .Namespace }}"
+spec:
+  {}
+---


### PR DESCRIPTION
For #12394

1. Added e2e tests with v1beta1 authorization policy for the passthrough filter chain.
1. Tested manually in the cluster that the RBAC filter is inserted for the passthrough filter chain.


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

