### PR TITLE
Add support for DryRun to kubernetes 1.12 config

### DIFF
--- a/prow/config/trustworthy-jwt-12.yaml
+++ b/prow/config/trustworthy-jwt-12.yaml
@@ -1,4 +1,5 @@
 # This configs KinD to spin up a k8s cluster with trustworthy jwt (Service Account Token Volume Projection) feature.
+# This also enables serverside dry run support
 # This must be used for 1.12 k8s versions
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
@@ -9,6 +10,7 @@ kubeadmConfigPatches:
     metadata:
       name: config
     apiServerExtraArgs:
+      "feature-gates": "DryRun=true"
       "service-account-issuer": "kubernetes.default.svc"
       "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
       "service-account-api-audiences": "kubernetes.default.svc"


### PR DESCRIPTION
The PR https://github.com/istio/istio/pull/18145 added this test which
breaks k8s 1.12.