### PR TITLE
Wait for kind cluster to startup

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -134,7 +134,7 @@ function setup_kind_cluster() {
   fi
 
   # Create KinD cluster
-  if ! (kind create cluster --name=istio-testing --config "${CONFIG}" --loglevel debug --retain --image "${IMAGE}"); then
+  if ! (kind create cluster --name=istio-testing --config "${CONFIG}" --loglevel debug --retain --image "${IMAGE}" --wait=60s); then
     echo "Could not setup KinD environment. Something wrong with KinD setup. Exporting logs."
     exit 1
   fi


### PR DESCRIPTION
There are some race conditions during startup, where if we apply config
before the cluster has started, it will never start. Best practice here
is to wait for the cluster to come up.