### PR TITLE
fix(stackdriver mesh id): pull mesh id from GCE metadata when available

### DIFF
--- a/mixer/adapter/stackdriver/contextgraph/contextgraph.go
+++ b/mixer/adapter/stackdriver/contextgraph/contextgraph.go
@@ -39,6 +39,7 @@ type (
 		projectID string
 		zone      string
 		cluster   string
+		meshID    string
 		mg        helper.MetadataGenerator
 		newClient newClientFn
 		cfg       *config.Params
@@ -73,13 +74,15 @@ func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, 
 	env.Logger().Debugf("Proj, zone, cluster, opts: %s,%s,%s,%s",
 		b.projectID, b.zone, b.cluster, opts)
 
-	// TODO: meshUID should come from an attribute when
-	// multi-cluster Istio is supported. Currently we assume each
-	// cluster is its own mesh.
+	meshUID := fmt.Sprintf("%s/%s/%s", b.projectID, b.zone, b.cluster)
+	if len(b.meshID) > 0 {
+		meshUID = b.meshID
+	}
+
 	h := &handler{
 		env:            env,
 		projectID:      b.projectID,
-		meshUID:        fmt.Sprintf("%s/%s/%s", b.projectID, b.zone, b.cluster),
+		meshUID:        meshUID,
 		zone:           b.zone,
 		cluster:        b.cluster,
 		entityCache:    newEntityCache(env.Logger()),
@@ -113,6 +116,7 @@ func (b *builder) SetAdapterConfig(cfg adapter.Config) {
 	}
 	b.zone = md.Location
 	b.cluster = md.ClusterName
+	b.meshID = md.MeshID
 }
 
 // adapter.HandlerBuilder#Validate

--- a/mixer/adapter/stackdriver/contextgraph/contextgraph_test.go
+++ b/mixer/adapter/stackdriver/contextgraph/contextgraph_test.go
@@ -140,6 +140,30 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+func TestBuildWithMeshID(t *testing.T) {
+	m := &mockNC{}
+	b := &builder{
+		newClient: m.NewClient,
+		projectID: "myid",
+		zone:      "myzone",
+		cluster:   "mycluster",
+		meshID:    "mesh-id",
+		cfg:       &config.Params{ProjectId: "myid"},
+	}
+
+	mEnv := env.NewEnv(t)
+
+	han, err := b.Build(context.TODO(), mEnv)
+	h := han.(*handler)
+	if err != nil {
+		t.Errorf("Build returned unexpected err: %v", err)
+	}
+
+	if h.meshUID != "mesh-id" {
+		t.Errorf("handler.meshUID: got %q, want %q", h.meshUID, "mesh-id")
+	}
+}
+
 func TestHandleEdge(t *testing.T) {
 	h := &handler{
 		traffics:  make(chan trafficAssertion, 1),

--- a/mixer/adapter/stackdriver/helper/common.go
+++ b/mixer/adapter/stackdriver/helper/common.go
@@ -31,6 +31,7 @@ type Metadata struct {
 	ProjectID   string
 	Location    string
 	ClusterName string
+	MeshID      string
 }
 
 // MetadataGenerator creates metadata based on the given metadata functions.
@@ -43,15 +44,17 @@ type metadataGeneratorImpl struct {
 	projectIDFn   metadataFn
 	locationFn    metadataFn
 	clusterNameFn metadataFn
+	meshIDFn      metadataFn
 }
 
 // NewMetadataGenerator creates a MetadataGenerator with the given functions.
-func NewMetadataGenerator(shouldFill shouldFillFn, projectIDFn, locationFn, clusterNameFn metadataFn) MetadataGenerator {
+func NewMetadataGenerator(shouldFill shouldFillFn, projectIDFn, locationFn, clusterNameFn, meshIDFn metadataFn) MetadataGenerator {
 	return &metadataGeneratorImpl{
 		shouldFill:    shouldFill,
 		projectIDFn:   projectIDFn,
 		locationFn:    locationFn,
 		clusterNameFn: clusterNameFn,
+		meshIDFn:      meshIDFn,
 	}
 }
 
@@ -70,6 +73,9 @@ func (mg *metadataGeneratorImpl) GenerateMetadata() Metadata {
 	if cn, err := mg.clusterNameFn(); err == nil {
 		md.ClusterName = cn
 	}
+	if mid, err := mg.meshIDFn(); err == nil {
+		md.MeshID = mid
+	}
 	return md
 }
 
@@ -87,6 +93,9 @@ func (md *Metadata) FillProjectMetadata(in map[string]string) {
 		}
 		if key == "cluster_name" {
 			in[key] = md.ClusterName
+		}
+		if key == "mesh_uid" {
+			in[key] = md.MeshID
 		}
 	}
 }

--- a/mixer/adapter/stackdriver/helper/common_test.go
+++ b/mixer/adapter/stackdriver/helper/common_test.go
@@ -92,6 +92,7 @@ func TestMetadata(t *testing.T) {
 		projectIDFn   metadataFn
 		locationFn    metadataFn
 		clusterNameFn metadataFn
+		meshIDFn      metadataFn
 		want          Metadata
 	}{
 		{
@@ -100,6 +101,7 @@ func TestMetadata(t *testing.T) {
 			func() (string, error) { return "pid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "mesh-id", nil },
 			Metadata{ProjectID: "", Location: "", ClusterName: ""},
 		},
 		{
@@ -108,7 +110,8 @@ func TestMetadata(t *testing.T) {
 			func() (string, error) { return "pid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
-			Metadata{ProjectID: "pid", Location: "location", ClusterName: "cluster"},
+			func() (string, error) { return "mesh-id", nil },
+			Metadata{ProjectID: "pid", Location: "location", ClusterName: "cluster", MeshID: "mesh-id"},
 		},
 		{
 			"project id error",
@@ -116,7 +119,8 @@ func TestMetadata(t *testing.T) {
 			func() (string, error) { return "", errors.New("error") },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
-			Metadata{ProjectID: "", Location: "location", ClusterName: "cluster"},
+			func() (string, error) { return "mesh-id", nil },
+			Metadata{ProjectID: "", Location: "location", ClusterName: "cluster", MeshID: "mesh-id"},
 		},
 		{
 			"location error",
@@ -124,7 +128,8 @@ func TestMetadata(t *testing.T) {
 			func() (string, error) { return "pid", nil },
 			func() (string, error) { return "location", errors.New("error") },
 			func() (string, error) { return "cluster", nil },
-			Metadata{ProjectID: "pid", Location: "", ClusterName: "cluster"},
+			func() (string, error) { return "mesh-id", nil },
+			Metadata{ProjectID: "pid", Location: "", ClusterName: "cluster", MeshID: "mesh-id"},
 		},
 		{
 			"cluster name error",
@@ -132,13 +137,23 @@ func TestMetadata(t *testing.T) {
 			func() (string, error) { return "pid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", errors.New("error") },
-			Metadata{ProjectID: "pid", Location: "location", ClusterName: ""},
+			func() (string, error) { return "mesh-id", nil },
+			Metadata{ProjectID: "pid", Location: "location", ClusterName: "", MeshID: "mesh-id"},
+		},
+		{
+			"mesh id error",
+			func() bool { return true },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "mesh-id", errors.New("error") },
+			Metadata{ProjectID: "pid", Location: "location", ClusterName: "cluster"},
 		},
 	}
 
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			mg := NewMetadataGenerator(tt.shouldFill, tt.projectIDFn, tt.locationFn, tt.clusterNameFn)
+			mg := NewMetadataGenerator(tt.shouldFill, tt.projectIDFn, tt.locationFn, tt.clusterNameFn, tt.meshIDFn)
 			got := mg.GenerateMetadata()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Unexpected generated metadata: want %v got %v", tt.want, got)

--- a/mixer/adapter/stackdriver/log/log_test.go
+++ b/mixer/adapter/stackdriver/log/log_test.go
@@ -41,7 +41,7 @@ import (
 
 var dummyShouldFill = func() bool { return true }
 var dummyMetadataFn = func() (string, error) { return "", nil }
-var dummyMetadataGenerator = helper.NewMetadataGenerator(dummyShouldFill, dummyMetadataFn, dummyMetadataFn, dummyMetadataFn)
+var dummyMetadataGenerator = helper.NewMetadataGenerator(dummyShouldFill, dummyMetadataFn, dummyMetadataFn, dummyMetadataFn, dummyMetadataFn)
 
 func TestBuild(t *testing.T) {
 	b := &builder{makeClient: func(context.Context, string, ...option.ClientOption) (*logging.Client, error) {
@@ -135,7 +135,7 @@ func TestEmptyProjectID(t *testing.T) {
 				makeSyncClient: func(context.Context, string, ...option.ClientOption) (*logadmin.Client, error) {
 					return &logadmin.Client{}, nil
 				},
-				mg: helper.NewMetadataGenerator(dummyShouldFill, tt.pidFn, dummyMetadataFn, dummyMetadataFn),
+				mg: helper.NewMetadataGenerator(dummyShouldFill, tt.pidFn, dummyMetadataFn, dummyMetadataFn, dummyMetadataFn),
 			}
 			b.SetAdapterConfig(tt.cfg)
 			if _, err := b.Build(context.Background(), test.NewEnv(t)); err != nil {

--- a/mixer/adapter/stackdriver/metric/metric.go
+++ b/mixer/adapter/stackdriver/metric/metric.go
@@ -242,6 +242,11 @@ func (h *handler) HandleMetric(_ context.Context, vals []*metric.Instance) error
 			},
 		}
 
+		// Populate the "mesh_uid" label from a canonical source if we know it
+		if len(h.md.MeshID) > 0 {
+			ts.Metric.Labels["mesh_uid"] = h.md.MeshID
+		}
+
 		// The logging SDK has logic built in that does this for us: if a resource is not provided it fills in the global
 		// resource as a default. Since we don't have equivalent behavior for monitoring, we do it ourselves.
 		if val.MonitoredResourceType != "" {

--- a/mixer/adapter/stackdriver/stackdriver.go
+++ b/mixer/adapter/stackdriver/stackdriver.go
@@ -84,7 +84,10 @@ func GetInfo() adapter.Info {
 		}
 		return md.Zone()
 	}
-	mg := helper.NewMetadataGenerator(md.OnGCE, md.ProjectID, clusterLocationFn, clusterNameFn)
+	meshIDFn := func() (string, error) {
+		return md.InstanceAttributeValue("mesh-id")
+	}
+	mg := helper.NewMetadataGenerator(md.OnGCE, md.ProjectID, clusterLocationFn, clusterNameFn, meshIDFn)
 	info := metadata.GetInfo("stackdriver")
 	info.NewBuilder = func() adapter.HandlerBuilder {
 		return &builder{

--- a/mixer/adapter/stackdriver/trace/trace_integration_test.go
+++ b/mixer/adapter/stackdriver/trace/trace_integration_test.go
@@ -257,7 +257,10 @@ func getInfo() adapter.Info {
 		}
 		return cn, nil
 	}
-	mg := helper.NewMetadataGenerator(md.OnGCE, md.ProjectID, md.Zone, clusterNameFn)
+	meshIDFn := func() (string, error) {
+		return md.InstanceAttributeValue("mesh-id")
+	}
+	mg := helper.NewMetadataGenerator(md.OnGCE, md.ProjectID, md.Zone, clusterNameFn, meshIDFn)
 	return adapter.Info{
 		Name:        "stackdriver",
 		Impl:        "istio.io/istio/mixer/adapte/stackdriver",

--- a/mixer/adapter/stackdriver/trace/trace_test.go
+++ b/mixer/adapter/stackdriver/trace/trace_test.go
@@ -90,7 +90,7 @@ func TestProjectID(t *testing.T) {
 
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			mg := helper.NewMetadataGenerator(dummyShouldFill, tt.pid, dummyMetadataFn, dummyMetadataFn)
+			mg := helper.NewMetadataGenerator(dummyShouldFill, tt.pid, dummyMetadataFn, dummyMetadataFn, dummyMetadataFn)
 			b := &builder{mg: mg}
 			b.SetAdapterConfig(tt.cfg)
 			_, err := b.Build(context.Background(), test.NewEnv(t))


### PR DESCRIPTION
The Stackdriver adapter for Mixer was previously not populating `mesh_uid` dimensions for metrics and reporting a hardcoded value of `<project>/<zone>/<cluster>` for contextgraph edges.

This PR updates that behavior to pull a value for `mesh_uid` from the GCE metadata (when available, otherwise reverting to existing behavior). This will allow correct reporting of `mesh_uid` values when the GCE Instances have been properly labeled to match the `MeshConfig` values.

This PR will likely need to be cherry-picked in to the 1.2, 1.3, and 1.4 branches.

/cc @quentinmit 