### PR TITLE
Added test and release as owners for the istio.io tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,7 +35,7 @@
 /tests/integration/pilot/                                        @istio/wg-networking-maintainers
 /tests/integration/qualification/                                @istio/wg-test-and-release-maintainers
 /tests/integration/security/                                     @istio/wg-security-maintainers
-/tests/integration/istioio/                                      @istio/wg-docs-maintainers
+/tests/integration/istioio/                                      @istio/wg-docs-maintainers @istio/wg-test-and-release-maintainers
 /tools/                                                          @istio/wg-test-and-release-maintainers
 /tools/istio-iptables/                                           @istio/wg-networking-maintainers
 /tools/istio-clean-iptables/                                     @istio/wg-networking-maintainers


### PR DESCRIPTION
This PR adds the Test and Release as a CODEOWNER for the istio.io tests.