### PR TITLE
Add more verbose output / options for istioctl analyze

### DIFF
--- a/galley/pkg/config/analysis/analyzer_test.go
+++ b/galley/pkg/config/analysis/analyzer_test.go
@@ -63,8 +63,10 @@ func TestCombinedAnalyzer(t *testing.T) {
 
 	xform := transformer.NewSimpleTransformerProvider(data.Collection3, data.Collection3, func(_ event.Event, _ event.Handler) {})
 
-	a := Combine("combined", a1, a2, a3).WithDisabled(collection.Names{data.Collection3}, transformer.Providers{xform})
+	a := Combine("combined", a1, a2, a3)
+	removed := a.RemoveDisabled(collection.Names{data.Collection3}, transformer.Providers{xform})
 
+	g.Expect(removed).To(ConsistOf(a3.Metadata().Name))
 	g.Expect(a.Metadata().Inputs).To(ConsistOf(data.Collection1, data.Collection2, data.Collection3))
 
 	a.Analyze(&context{})

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -226,12 +226,12 @@ func TestAnalyzers(t *testing.T) {
 			}
 			cancel := make(chan struct{})
 
-			msgs, err := sa.Analyze(cancel)
+			result, err := sa.Analyze(cancel)
 			if err != nil {
 				t.Fatalf("Error running analysis on testcase %s: %v", testCase.name, err)
 			}
 
-			actualMsgs := extractFields(msgs)
+			actualMsgs := extractFields(result.Messages)
 			g.Expect(actualMsgs).To(ConsistOf(testCase.expected))
 		})
 	}

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -60,6 +60,13 @@ type SourceAnalyzer struct {
 	collectionReporter snapshotter.CollectionReporterFn
 }
 
+// AnalysisResult represents the returnable results of an analysis execution
+type AnalysisResult struct {
+	Messages          diag.Messages
+	SkippedAnalyzers  []string
+	ExecutedAnalyzers []string
+}
+
 // NewSourceAnalyzer creates a new SourceAnalyzer with no sources. Use the Add*Source methods to add sources in ascending precedence order,
 // then execute Analyze to perform the analysis
 func NewSourceAnalyzer(m *schema.Metadata, analyzer *analysis.CombinedAnalyzer, namespace string,
@@ -92,12 +99,14 @@ func NewSourceAnalyzer(m *schema.Metadata, analyzer *analysis.CombinedAnalyzer, 
 }
 
 // Analyze loads the sources and executes the analysis
-func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (diag.Messages, error) {
+func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (AnalysisResult, error) {
+	var result AnalysisResult
+
 	meshsrc := meshcfg.NewInmemory()
 	meshsrc.Set(meshcfg.Default())
 
 	if len(sa.sources) == 0 {
-		return nil, fmt.Errorf("at least one file and/or kubernetes source must be provided")
+		return result, fmt.Errorf("at least one file and/or kubernetes source must be provided")
 	}
 	src := newPrecedenceSource(sa.sources)
 
@@ -106,10 +115,13 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (diag.Messages, error) {
 		namespaces = []string{sa.namespace}
 	}
 
+	result.SkippedAnalyzers = sa.analyzer.RemoveDisabled(sa.kubeResources.DisabledCollections(), sa.transformerProviders)
+	result.ExecutedAnalyzers = sa.analyzer.AnalyzerNames()
+
 	updater := &snapshotter.InMemoryStatusUpdater{}
 	distributorSettings := snapshotter.AnalyzingDistributorSettings{
 		StatusUpdater:      updater,
-		Analyzer:           sa.analyzer.WithDisabled(sa.kubeResources.DisabledCollections(), sa.transformerProviders),
+		Analyzer:           sa.analyzer,
 		Distributor:        snapshotter.NewInMemoryDistributor(),
 		AnalysisSnapshots:  []string{metadata.LocalAnalysis, metadata.SyntheticServiceEntry},
 		TriggerSnapshot:    metadata.LocalAnalysis,
@@ -128,17 +140,18 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (diag.Messages, error) {
 	}
 	rt, err := processor.Initialize(processorSettings)
 	if err != nil {
-		return nil, err
+		return result, err
 	}
 	rt.Start()
 	defer rt.Stop()
 
 	scope.Analysis.Debugf("Waiting for analysis messages to be available...")
 	if updater.WaitForReport(cancel) {
-		return updater.Get(), nil
+		result.Messages = updater.Get()
+		return result, nil
 	}
 
-	return nil, errors.New("cancelled")
+	return result, errors.New("cancelled")
 }
 
 // AddFileKubeSource adds a source based on the specified k8s yaml files to the current SourceAnalyzer

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -106,7 +106,7 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (AnalysisResult, error) 
 	meshsrc.Set(meshcfg.Default())
 
 	if len(sa.sources) == 0 {
-		return result, fmt.Errorf("at least one file and/or kubernetes source must be provided")
+		return result, fmt.Errorf("at least one file and/or Kubernetes source must be provided")
 	}
 	src := newPrecedenceSource(sa.sources)
 

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -90,10 +90,11 @@ func TestAnalyzersRun(t *testing.T) {
 	err := sa.AddFileKubeSource([]string{})
 	g.Expect(err).To(BeNil())
 
-	msgs, err := sa.Analyze(cancel)
+	result, err := sa.Analyze(cancel)
 	g.Expect(err).To(BeNil())
-	g.Expect(msgs).To(ConsistOf(msg))
+	g.Expect(result.Messages).To(ConsistOf(msg))
 	g.Expect(collectionAccessed).To(Equal(data.Collection1))
+	g.Expect(result.ExecutedAnalyzers).To(ConsistOf(a.Metadata().Name))
 }
 
 func TestFilterOutputByNamespace(t *testing.T) {
@@ -116,9 +117,9 @@ func TestFilterOutputByNamespace(t *testing.T) {
 	err := sa.AddFileKubeSource([]string{})
 	g.Expect(err).To(BeNil())
 
-	msgs, err := sa.Analyze(cancel)
+	result, err := sa.Analyze(cancel)
 	g.Expect(err).To(BeNil())
-	g.Expect(msgs).To(ConsistOf(msg1))
+	g.Expect(result.Messages).To(ConsistOf(msg1))
 }
 
 func TestAddRunningKubeSource(t *testing.T) {

--- a/galley/pkg/server/components/processing2.go
+++ b/galley/pkg/server/components/processing2.go
@@ -119,14 +119,19 @@ func (p *Processing2) Start() (err error) {
 	}
 
 	var distributor snapshotter.Distributor = snapshotter.NewMCPDistributor(p.mcpCache)
+
 	if p.args.EnableConfigAnalysis {
+		combinedAnalyzer := analyzers.AllCombined()
+		combinedAnalyzer.RemoveDisabled(kubeResources.DisabledCollections(), transformProviders)
+
 		settings := snapshotter.AnalyzingDistributorSettings{
 			StatusUpdater:     updater,
-			Analyzer:          analyzers.AllCombined().WithDisabled(kubeResources.DisabledCollections(), transformProviders),
+			Analyzer:          combinedAnalyzer,
 			Distributor:       distributor,
 			AnalysisSnapshots: p.args.Snapshots,
 			TriggerSnapshot:   p.args.TriggerSnapshot,
 		}
+
 		distributor = snapshotter.NewAnalyzingDistributor(settings)
 	}
 

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -138,7 +138,7 @@ istioctl experimental analyze -k -d false
 			}
 
 			if len(result.Messages) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "No validation issues found.")
+				fmt.Fprintln(cmd.OutOrStdout(), "\u2714 No validation issues found.")
 			} else {
 				for _, m := range result.Messages {
 					fmt.Fprintln(cmd.OutOrStdout(), m.String())

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -154,7 +154,7 @@ istioctl experimental analyze -k -d false
 		"'true' to enable service discovery, 'false' to disable it. "+
 			"Defaults to true if --use-kube is set, false otherwise. "+
 			"Analyzers requiring resources made available by enabling service discovery will be skipped.")
-	analysisCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enables verbose output")
+	analysisCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	return analysisCmd
 }
 

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -123,22 +123,22 @@ istioctl experimental analyze -k -d false
 			// Maybe output details about which analyzers ran
 			if verbose {
 				if len(result.SkippedAnalyzers) > 0 {
-					fmt.Fprintln(cmd.OutOrStdout(), "Skipped analyzers:")
+					fmt.Fprintln(cmd.ErrOrStderr(), "Skipped analyzers:")
 					for _, a := range result.SkippedAnalyzers {
-						fmt.Fprintln(cmd.OutOrStdout(), "\t", a)
+						fmt.Fprintln(cmd.ErrOrStderr(), "\t", a)
 					}
 				}
 				if len(result.ExecutedAnalyzers) > 0 {
-					fmt.Fprintln(cmd.OutOrStdout(), "Executed analyzers:")
+					fmt.Fprintln(cmd.ErrOrStderr(), "Executed analyzers:")
 					for _, a := range result.ExecutedAnalyzers {
-						fmt.Fprintln(cmd.OutOrStdout(), "\t", a)
+						fmt.Fprintln(cmd.ErrOrStderr(), "\t", a)
 					}
 				}
-				fmt.Fprintln(cmd.OutOrStdout())
+				fmt.Fprintln(cmd.ErrOrStderr())
 			}
 
 			if len(result.Messages) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "\u2714 No validation issues found.")
+				fmt.Fprintln(cmd.ErrOrStderr(), "\u2714 No validation issues found.")
 			} else {
 				for _, m := range result.Messages {
 					fmt.Fprintln(cmd.OutOrStdout(), m.String())

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -68,10 +68,11 @@ var (
 func defaultLogOptions() *log.Options {
 	o := log.DefaultOptions()
 
-	// These scopes are, by default, too chatty for command line use
+	// These scopes are, at the default "INFO" level, too chatty for command line use
 	o.SetOutputLevel("validation", log.ErrorLevel)
 	o.SetOutputLevel("processing", log.ErrorLevel)
 	o.SetOutputLevel("source", log.ErrorLevel)
+	o.SetOutputLevel("analysis", log.WarnLevel)
 
 	return o
 }

--- a/tests/integration/istioctl/analyze_test.go
+++ b/tests/integration/istioctl/analyze_test.go
@@ -128,6 +128,7 @@ func TestFileAndKubeCombined(t *testing.T) {
 }
 
 func expectNoMessages(t *testing.T, g *GomegaWithT, output []string) {
+	t.Helper()
 	g.Expect(output).To(HaveLen(1))
 	g.Expect(output[0]).To(ContainSubstring("No validation issues found"))
 }

--- a/tests/integration/istioctl/analyze_test.go
+++ b/tests/integration/istioctl/analyze_test.go
@@ -48,7 +48,7 @@ func TestEmptyCluster(t *testing.T) {
 
 			// For a clean istio install with injection enabled, expect no validation errors
 			output := istioctlOrFail(t, istioCtl, ns.Name(), "--use-kube")
-			g.Expect(output).To(BeEmpty())
+			expectNoMessages(t, g, output)
 		})
 }
 
@@ -72,7 +72,7 @@ func TestFileOnly(t *testing.T) {
 
 			// Error goes away if we include both the binding and its role
 			output = istioctlOrFail(t, istioCtl, ns.Name(), serviceRoleBindingFile, serviceRoleFile)
-			g.Expect(output).To(BeEmpty())
+			expectNoMessages(t, g, output)
 		})
 }
 
@@ -100,7 +100,7 @@ func TestKubeOnly(t *testing.T) {
 			// Error goes away if we include both the binding and its role
 			applyFileOrFail(t, ns.Name(), serviceRoleFile)
 			output = istioctlOrFail(t, istioCtl, ns.Name(), "--use-kube")
-			g.Expect(output).To(BeEmpty())
+			expectNoMessages(t, g, output)
 		})
 }
 
@@ -123,8 +123,13 @@ func TestFileAndKubeCombined(t *testing.T) {
 			// Simulating applying the service role to a cluster that already has the binding, we should
 			// fix the error and thus see no message
 			output := istioctlOrFail(t, istioCtl, ns.Name(), "--use-kube", serviceRoleFile)
-			g.Expect(output).To(BeEmpty())
+			expectNoMessages(t, g, output)
 		})
+}
+
+func expectNoMessages(t *testing.T, g *GomegaWithT, output []string) {
+	g.Expect(output).To(HaveLen(1))
+	g.Expect(output[0]).To(ContainSubstring("No validation issues found"))
 }
 
 func istioctlOrFail(t *testing.T, i istioctl.Instance, ns string, extraArgs ...string) []string {


### PR DESCRIPTION
1. Adds a --verbose option to `istioctl analyze` that prints which analyzers are run or skipped. 
2. Prints a line if no validation messages are found. (https://github.com/istio/istio/issues/17996)

(I expect this to collide a bit with https://github.com/istio/istio/pull/18196 and https://github.com/istio/istio/pull/18187, but that's what rebasing is for!)