### PR TITLE
Increase timeout on TestTcpMetric

### DIFF
--- a/tests/integration/mixer/util.go
+++ b/tests/integration/mixer/util.go
@@ -85,7 +85,7 @@ func ValidateMetric(t *testing.T, prometheus prometheus.Instance, query, metricN
 		var err error
 		got, err = getMetric(t, prometheus, query, metricName)
 		return err
-	})
+	}, retry.Delay(time.Second), retry.Timeout(time.Minute*3))
 
 	t.Logf("%s: %f", metricName, got)
 	if got < want {


### PR DESCRIPTION
This test has the exact same thing running stable in the e2e tests, but
fails almost 50% of the time here. The only difference I can see is the
amount of time we wait for prometheus config, so this is extended to
match that test.