### PR TITLE
different virtualHosts may share same routes pointer

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -156,6 +156,8 @@ func doHTTPRouteOperation(proxy *model.Proxy, patchContext networking.EnvoyFilte
 			virtualHostMatch(virtualHost, cp) &&
 			routeMatch(virtualHost.Routes[routeIndex], cp) {
 
+			// different virtualHosts may share same routes pointer
+			virtualHost.Routes = cloneVhostRoutes(virtualHost.Routes)
 			if cp.Operation == networking.EnvoyFilter_Patch_REMOVE {
 				virtualHost.Routes[routeIndex] = nil
 				*routesRemoved = true
@@ -276,4 +278,13 @@ func routeMatch(httpRoute *route.Route, cp *model.EnvoyFilterConfigPatchWrapper)
 		}
 	}
 	return true
+}
+
+func cloneVhostRoutes(routes []*route.Route) []*route.Route {
+	out := make([]*route.Route, len(routes))
+	for i := 0; i < len(routes); i++ {
+		clone := proto.Clone(routes[i]).(*route.Route)
+		out[i] = clone
+	}
+	return out
 }


### PR DESCRIPTION
Please provide a description for what this PR is for.

Normal route config can be got below when I run command:

 >- istioctl proxy-config routes istio-ingressgateway-5545df5445-vdtlx.istio-system --name http.80 -o json

```json
[
    {
        "name": "http.80",
        "virtualHosts": [
            {
                "name": "eu.bookinfo.com:80",
                "domains": [
                    "eu.bookinfo.com",
                    "eu.bookinfo.com:80"
                ],
                "routes": [
                    {
                        "match": {
                            "prefix": "/",
                            "caseSensitive": true,
                            "headers": [
                                {
                                    "name": "cookie",
                                    "exactMatch": "user=dev-123"
                                }
                            ]
                        },
                        "route": {
                            "cluster": "outbound|7777||reviews.qa.svc.cluster.local",
                            "timeout": "0s",
                            "retryPolicy": {
                                "retryOn": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
                                "numRetries": 2,
                                "retryHostPredicate": [
                                    {
                                        "name": "envoy.retry_host_predicates.previous_hosts"
                                    }
                                ],
                                "hostSelectionRetryMaxAttempts": "5",
                                "retriableStatusCodes": [
                                    503
                                ]
                            },
                            "maxGrpcTimeout": "0s"
                        },
                        "metadata": {
                            "filterMetadata": {
                                "istio": {
                                    "config": "/apis/networking.istio.io/v1alpha3/namespaces/prj-wcytest/virtual-service/bookinfo-rule"
                                }
                            }
                        },
                        "decorator": {
                            "operation": "reviews.qa.svc.cluster.local:7777/*"
                        },
                        "typedPerFilterConfig": {
                            "mixer": {
                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                "mixerAttributes": {},
                                "forwardAttributes": {}
                            }
                        }
                    },
                    {
                        "match": {
                            "prefix": "/reviews/",
                            "caseSensitive": true
                        },
                        "route": {
                            "weightedClusters": {
                                "clusters": [
                                    {
                                        "name": "outbound|9080||reviews.prod.svc.cluster.local",
                                        "weight": 80,
                                        "typedPerFilterConfig": {
                                            "mixer": {
                                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                                "mixerAttributes": {},
                                                "forwardAttributes": {}
                                            }
                                        }
                                    },
                                    {
                                        "name": "outbound|80||reviews.qa.svc.cluster.local",
                                        "weight": 20,
                                        "typedPerFilterConfig": {
                                            "mixer": {
                                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                                "mixerAttributes": {},
                                                "forwardAttributes": {}
                                            }
                                        }
                                    }
                                ]
                            },
                            "timeout": "0s",
                            "retryPolicy": {
                                "retryOn": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
                                "numRetries": 2,
                                "retryHostPredicate": [
                                    {
                                        "name": "envoy.retry_host_predicates.previous_hosts"
                                    }
                                ],
                                "hostSelectionRetryMaxAttempts": "5",
                                "retriableStatusCodes": [
                                    503
                                ]
                            },
                            "maxGrpcTimeout": "0s"
                        },
                        "metadata": {
                            "filterMetadata": {
                                "istio": {
                                    "config": "/apis/networking.istio.io/v1alpha3/namespaces/prj-wcytest/virtual-service/bookinfo-rule"
                                }
                            }
                        },
                        "decorator": {
                            "operation": "bookinfo-rule:80/reviews/*"
                        },
                        "typedPerFilterConfig": {
                            "mixer": {
                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig"
                            }
                        }
                    }
                ]
            },
            {
                "name": "uk.bookinfo.com:80",
                "domains": [
                    "uk.bookinfo.com",
                    "uk.bookinfo.com:80"
                ],
                "routes": [
                    {
                        "match": {
                            "prefix": "/",
                            "caseSensitive": true,
                            "headers": [
                                {
                                    "name": "cookie",
                                    "exactMatch": "user=dev-123"
                                }
                            ]
                        },
                        "route": {
                            "cluster": "outbound|7777||reviews.qa.svc.cluster.local",
                            "timeout": "0s",
                            "retryPolicy": {
                                "retryOn": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
                                "numRetries": 2,
                                "retryHostPredicate": [
                                    {
                                        "name": "envoy.retry_host_predicates.previous_hosts"
                                    }
                                ],
                                "hostSelectionRetryMaxAttempts": "5",
                                "retriableStatusCodes": [
                                    503
                                ]
                            },
                            "maxGrpcTimeout": "0s"
                        },
                        "metadata": {
                            "filterMetadata": {
                                "istio": {
                                    "config": "/apis/networking.istio.io/v1alpha3/namespaces/prj-wcytest/virtual-service/bookinfo-rule"
                                }
                            }
                        },
                        "decorator": {
                            "operation": "reviews.qa.svc.cluster.local:7777/*"
                        },
                        "typedPerFilterConfig": {
                            "mixer": {
                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                "mixerAttributes": {},
                                "forwardAttributes": {}
                            }
                        }
                    },
                    {
                        "match": {
                            "prefix": "/reviews/",
                            "caseSensitive": true
                        },
                        "route": {
                            "weightedClusters": {
                                "clusters": [
                                    {
                                        "name": "outbound|9080||reviews.prod.svc.cluster.local",
                                        "weight": 80,
                                        "typedPerFilterConfig": {
                                            "mixer": {
                                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                                "mixerAttributes": {},
                                                "forwardAttributes": {}
                                            }
                                        }
                                    },
                                    {
                                        "name": "outbound|80||reviews.qa.svc.cluster.local",
                                        "weight": 20,
                                        "typedPerFilterConfig": {
                                            "mixer": {
                                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                                "mixerAttributes": {},
                                                "forwardAttributes": {}
                                            }
                                        }
                                    }
                                ]
                            },
                            "timeout": "0s",
                            "retryPolicy": {
                                "retryOn": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
                                "numRetries": 2,
                                "retryHostPredicate": [
                                    {
                                        "name": "envoy.retry_host_predicates.previous_hosts"
                                    }
                                ],
                                "hostSelectionRetryMaxAttempts": "5",
                                "retriableStatusCodes": [
                                    503
                                ]
                            },
                            "maxGrpcTimeout": "0s"
                        },
                        "metadata": {
                            "filterMetadata": {
                                "istio": {
                                    "config": "/apis/networking.istio.io/v1alpha3/namespaces/prj-wcytest/virtual-service/bookinfo-rule"
                                }
                            }
                        },
                        "decorator": {
                            "operation": "bookinfo-rule:80/reviews/*"
                        },
                        "typedPerFilterConfig": {
                            "mixer": {
                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig"
                            }
                        }
                    }
                ]
            }
        ],
        "validateClusters": false
    }
]
```

But,  after a envoyFilter which routed to virtualhost "eu.bookinfo.com:80" created.

```json
apiVersion: networking.istio.io/v1alpha3
kind: EnvoyFilter
metadata:
  name: httproute
spec:
  configPatches:
  - applyTo: HTTP_ROUTE
    match:
      context: GATEWAY
      routeConfiguration:
        portNumber: 80
        vhost:
          name: eu.bookinfo.com:80
    patch:
      operation: MERGE
      value:
        route:
          rate_limits:
          - actions:
            - remote_address: {}
          - actions:
            - request_headers:
                descriptor_key: action
                header_name: x-ucloud-action
          - actions:
            - request_headers:
                descriptor_key: account
                header_name: x-ucloud-account
``` 

All virtualhost routes have been updated. Cause different virtualhosts share the same routes pointer in same route configuration.

```json
[
    {
        "name": "http.80",
        "virtualHosts": [
            {
                "name": "eu.bookinfo.com:80",
                "domains": [
                    "eu.bookinfo.com",
                    "eu.bookinfo.com:80"
                ],
                "routes": [
                    {
                        "match": {
                            "prefix": "/",
                            "caseSensitive": true,
                            "headers": [
                                {
                                    "name": "cookie",
                                    "exactMatch": "user=dev-123"
                                }
                            ]
                        },
                        "route": {
                            "cluster": "outbound|7777||reviews.qa.svc.cluster.local",
                            "timeout": "0s",
                            "retryPolicy": {
                                "retryOn": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
                                "numRetries": 2,
                                "retryHostPredicate": [
                                    {
                                        "name": "envoy.retry_host_predicates.previous_hosts"
                                    }
                                ],
                                "hostSelectionRetryMaxAttempts": "5",
                                "retriableStatusCodes": [
                                    503
                                ]
                            },
                            "rateLimits": [
                                {
                                    "actions": [
                                        {
                                            "remoteAddress": {}
                                        }
                                    ]
                                },
                                {
                                    "actions": [
                                        {
                                            "requestHeaders": {
                                                "headerName": "x-ucloud-action",
                                                "descriptorKey": "action"
                                            }
                                        }
                                    ]
                                },
                                {
                                    "actions": [
                                        {
                                            "requestHeaders": {
                                                "headerName": "x-ucloud-account",
                                                "descriptorKey": "account"
                                            }
                                        }
                                    ]
                                }
                            ],
                            "maxGrpcTimeout": "0s"
                        },
                        "metadata": {
                            "filterMetadata": {
                                "istio": {
                                    "config": "/apis/networking.istio.io/v1alpha3/namespaces/prj-wcytest/virtual-service/bookinfo-rule"
                                }
                            }
                        },
                        "decorator": {
                            "operation": "reviews.qa.svc.cluster.local:7777/*"
                        },
                        "typedPerFilterConfig": {
                            "mixer": {
                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                "mixerAttributes": {},
                                "forwardAttributes": {}
                            }
                        }
                    },
                    {
                        "match": {
                            "prefix": "/reviews/",
                            "caseSensitive": true
                        },
                        "route": {
                            "weightedClusters": {
                                "clusters": [
                                    {
                                        "name": "outbound|9080||reviews.prod.svc.cluster.local",
                                        "weight": 80,
                                        "typedPerFilterConfig": {
                                            "mixer": {
                                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                                "mixerAttributes": {},
                                                "forwardAttributes": {}
                                            }
                                        }
                                    },
                                    {
                                        "name": "outbound|80||reviews.qa.svc.cluster.local",
                                        "weight": 20,
                                        "typedPerFilterConfig": {
                                            "mixer": {
                                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                                "mixerAttributes": {},
                                                "forwardAttributes": {}
                                            }
                                        }
                                    }
                                ]
                            },
                            "timeout": "0s",
                            "retryPolicy": {
                                "retryOn": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
                                "numRetries": 2,
                                "retryHostPredicate": [
                                    {
                                        "name": "envoy.retry_host_predicates.previous_hosts"
                                    }
                                ],
                                "hostSelectionRetryMaxAttempts": "5",
                                "retriableStatusCodes": [
                                    503
                                ]
                            },
                            "rateLimits": [
                                {
                                    "actions": [
                                        {
                                            "remoteAddress": {}
                                        }
                                    ]
                                },
                                {
                                    "actions": [
                                        {
                                            "requestHeaders": {
                                                "headerName": "x-ucloud-action",
                                                "descriptorKey": "action"
                                            }
                                        }
                                    ]
                                },
                                {
                                    "actions": [
                                        {
                                            "requestHeaders": {
                                                "headerName": "x-ucloud-account",
                                                "descriptorKey": "account"
                                            }
                                        }
                                    ]
                                }
                            ],
                            "maxGrpcTimeout": "0s"
                        },
                        "metadata": {
                            "filterMetadata": {
                                "istio": {
                                    "config": "/apis/networking.istio.io/v1alpha3/namespaces/prj-wcytest/virtual-service/bookinfo-rule"
                                }
                            }
                        },
                        "decorator": {
                            "operation": "bookinfo-rule:80/reviews/*"
                        },
                        "typedPerFilterConfig": {
                            "mixer": {
                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig"
                            }
                        }
                    }
                ]
            },
            {
                "name": "uk.bookinfo.com:80",
                "domains": [
                    "uk.bookinfo.com",
                    "uk.bookinfo.com:80"
                ],
                "routes": [
                    {
                        "match": {
                            "prefix": "/",
                            "caseSensitive": true,
                            "headers": [
                                {
                                    "name": "cookie",
                                    "exactMatch": "user=dev-123"
                                }
                            ]
                        },
                        "route": {
                            "cluster": "outbound|7777||reviews.qa.svc.cluster.local",
                            "timeout": "0s",
                            "retryPolicy": {
                                "retryOn": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
                                "numRetries": 2,
                                "retryHostPredicate": [
                                    {
                                        "name": "envoy.retry_host_predicates.previous_hosts"
                                    }
                                ],
                                "hostSelectionRetryMaxAttempts": "5",
                                "retriableStatusCodes": [
                                    503
                                ]
                            },
                            "rateLimits": [
                                {
                                    "actions": [
                                        {
                                            "remoteAddress": {}
                                        }
                                    ]
                                },
                                {
                                    "actions": [
                                        {
                                            "requestHeaders": {
                                                "headerName": "x-ucloud-action",
                                                "descriptorKey": "action"
                                            }
                                        }
                                    ]
                                },
                                {
                                    "actions": [
                                        {
                                            "requestHeaders": {
                                                "headerName": "x-ucloud-account",
                                                "descriptorKey": "account"
                                            }
                                        }
                                    ]
                                }
                            ],
                            "maxGrpcTimeout": "0s"
                        },
                        "metadata": {
                            "filterMetadata": {
                                "istio": {
                                    "config": "/apis/networking.istio.io/v1alpha3/namespaces/prj-wcytest/virtual-service/bookinfo-rule"
                                }
                            }
                        },
                        "decorator": {
                            "operation": "reviews.qa.svc.cluster.local:7777/*"
                        },
                        "typedPerFilterConfig": {
                            "mixer": {
                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                "mixerAttributes": {},
                                "forwardAttributes": {}
                            }
                        }
                    },
                    {
                        "match": {
                            "prefix": "/reviews/",
                            "caseSensitive": true
                        },
                        "route": {
                            "weightedClusters": {
                                "clusters": [
                                    {
                                        "name": "outbound|9080||reviews.prod.svc.cluster.local",
                                        "weight": 80,
                                        "typedPerFilterConfig": {
                                            "mixer": {
                                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                                "mixerAttributes": {},
                                                "forwardAttributes": {}
                                            }
                                        }
                                    },
                                    {
                                        "name": "outbound|80||reviews.qa.svc.cluster.local",
                                        "weight": 20,
                                        "typedPerFilterConfig": {
                                            "mixer": {
                                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig",
                                                "mixerAttributes": {},
                                                "forwardAttributes": {}
                                            }
                                        }
                                    }
                                ]
                            },
                            "timeout": "0s",
                            "retryPolicy": {
                                "retryOn": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
                                "numRetries": 2,
                                "retryHostPredicate": [
                                    {
                                        "name": "envoy.retry_host_predicates.previous_hosts"
                                    }
                                ],
                                "hostSelectionRetryMaxAttempts": "5",
                                "retriableStatusCodes": [
                                    503
                                ]
                            },
                            "rateLimits": [
                                {
                                    "actions": [
                                        {
                                            "remoteAddress": {}
                                        }
                                    ]
                                },
                                {
                                    "actions": [
                                        {
                                            "requestHeaders": {
                                                "headerName": "x-ucloud-action",
                                                "descriptorKey": "action"
                                            }
                                        }
                                    ]
                                },
                                {
                                    "actions": [
                                        {
                                            "requestHeaders": {
                                                "headerName": "x-ucloud-account",
                                                "descriptorKey": "account"
                                            }
                                        }
                                    ]
                                }
                            ],
                            "maxGrpcTimeout": "0s"
                        },
                        "metadata": {
                            "filterMetadata": {
                                "istio": {
                                    "config": "/apis/networking.istio.io/v1alpha3/namespaces/prj-wcytest/virtual-service/bookinfo-rule"
                                }
                            }
                        },
                        "decorator": {
                            "operation": "bookinfo-rule:80/reviews/*"
                        },
                        "typedPerFilterConfig": {
                            "mixer": {
                                "@type": "type.googleapis.com/istio.mixer.v1.config.client.ServiceConfig"
                            }
                        }
                    }
                ]
            }
        ],
        "validateClusters": false
    }
]
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ x ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
