### PR TITLE
Added jaeger-collector-headless service

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
@@ -65,6 +65,26 @@ items:
 - apiVersion: v1
   kind: Service
   metadata:
+    name: jaeger-collector-headless
+    namespace: {{ .Release.Namespace }}
+    labels:
+      app: jaeger
+      jaeger-infra: collector-service
+      chart: {{ template "tracing.chart" . }}
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+  spec:
+    ports:
+    - name: jaeger-collector-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    selector:
+      app: jaeger
+    clusterIP: None
+- apiVersion: v1
+  kind: Service
+  metadata:
     name: jaeger-agent
     namespace: {{ .Release.Namespace }}
     labels:


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <jpkroehling@redhat.com>

This PR adds a new service called `jaeger-collector-headless`, to be used when the Jaeger client is using gRPC. This way, the gRPC client is able to do client side load balancing with DNS as the source. This is similar to what the Jaeger Operator does already.