### PR TITLE
Flatten validation messages from schema validation

### DIFF
--- a/galley/pkg/config/analysis/analyzers/schema/validation.go
+++ b/galley/pkg/config/analysis/analyzers/schema/validation.go
@@ -38,7 +38,7 @@ func AllValidationAnalyzers() []analysis.Analyzer {
 	result := make([]analysis.Analyzer, 0)
 	for _, s := range schemas.Istio {
 		// Skip synthetic service entries
-		// TODO(https://github.com/istio/istio/issues/17949)
+		// See https://github.com/istio/istio/issues/17949
 		if s.VariableName == schemas.SyntheticServiceEntry.VariableName {
 			continue
 		}

--- a/galley/pkg/config/analysis/analyzers/schema/validation.go
+++ b/galley/pkg/config/analysis/analyzers/schema/validation.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/meta/schema/collection"

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -46,8 +46,8 @@ var (
 	IstioProxyVersionMismatch = diag.NewMessageType(diag.Warning, "IST0105", "The version of the Istio proxy running on the pod does not match the version used by the istio injector (pod version: %s; injector version: %s). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pod.")
 
 	// SchemaValidationError defines a diag.MessageType for message "SchemaValidationError".
-	// Description: The resource has one or more schema validation errors.
-	SchemaValidationError = diag.NewMessageType(diag.Error, "IST0106", "The resource has one or more schema validation errors: %v")
+	// Description: The resource has a schema validation error.
+	SchemaValidationError = diag.NewMessageType(diag.Error, "IST0106", "Schema validation error: %v")
 
 	// MisplacedAnnotation defines a diag.MessageType for message "MisplacedAnnotation".
 	// Description: An Istio annotation is applied to the wrong kind of resource.
@@ -149,11 +149,11 @@ func NewIstioProxyVersionMismatch(entry *resource.Entry, proxyVersion string, in
 }
 
 // NewSchemaValidationError returns a new diag.Message based on SchemaValidationError.
-func NewSchemaValidationError(entry *resource.Entry, combinedErr error) diag.Message {
+func NewSchemaValidationError(entry *resource.Entry, err error) diag.Message {
 	return diag.NewMessage(
 		SchemaValidationError,
 		originOrNil(entry),
-		combinedErr,
+		err,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -95,10 +95,10 @@ messages:
   - name: "SchemaValidationError"
     code: IST0106
     level: Error
-    description: "The resource has one or more schema validation errors."
-    template: "The resource has one or more schema validation errors: %v"
+    description: "The resource has a schema validation error."
+    template: "Schema validation error: %v"
     args:
-      - name: combinedErr
+      - name: err
         type: error
 
   - name: "MisplacedAnnotation"


### PR DESCRIPTION
Fixes the unnecessarily (and confusingly) nested structure of validation messages from schema validation. 

Before:
```
Error 