### PR TITLE
authz: fix the presence match in v1beta1 policy

### DIFF
--- a/pilot/pkg/security/authz/builder/integration_test.go
+++ b/pilot/pkg/security/authz/builder/integration_test.go
@@ -89,6 +89,11 @@ func TestBuildHTTPFilter(t *testing.T) {
 			policies:          getPolicies("testdata/v1alpha1-simple-policy-td-aliases-in.yaml", t),
 			want:              getProto("testdata/v1alpha1-simple-policy-td-aliases-out.yaml", t),
 		},
+		{
+			name:     "v1alpha1 all fields",
+			policies: getPolicies("testdata/v1alpha1-all-fields-in.yaml", t),
+			want:     getProto("testdata/v1alpha1-all-fields-out.yaml", t),
+		},
 	}
 
 	httpbinLabels := map[string]string{

--- a/pilot/pkg/security/authz/builder/testdata/v1alpha1-all-fields-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1alpha1-all-fields-in.yaml
@@ -1,0 +1,57 @@
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ClusterRbacConfig
+metadata:
+  name: default
+spec:
+  mode: 'ON_WITH_INCLUSION'
+  inclusion:
+    namespaces: ["foo"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: httpbin-viewer
+  namespace: foo
+spec:
+  rules:
+    - services: ["httpbin.foo.svc.cluster.local"]
+      methods: ["method", "method-prefix-*", "*-suffix-method", "*"]
+      paths: ["/exact", "/prefix/*", "*/suffix", "*"]
+      constraints:
+      - key: "destination.ip"
+        values: ["10.10.10.10", "192.168.10.0/24"]
+      - key: "destination.port"
+        values: ["91", "92"]
+      - key: "destination.user"
+        values: ["destination-user", "destination-user-prefix-*", "*-suffix-destination-user", "*"]
+      - key: "experimental.envoy.filters.network.mysql_proxy[db.table]"
+        values: ["experimental", "experimental-prefix-*", "*-suffix-experimental", "*"]
+      - key: "request.headers[X-header]"
+        values: ["header", "header-prefix-*", "*-suffix-header", "*"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: bind-httpbin-viewer
+  namespace: foo
+spec:
+  subjects:
+    - user: "user"
+      properties:
+        source.ip: "1.2.3.4"
+        source.namespace: "source-ns"
+        source.principal: "source-principal"
+        request.auth.principal: "request-principal"
+        request.auth.audiences: "request-audiences"
+        request.auth.presenter: "request-presenter"
+        request.auth.claims[iss]: "request-claims"
+    - properties:
+        source.namespace: "*"
+        source.principal: "*"
+        request.auth.principal: "*"
+        request.auth.audiences: "*"
+        request.auth.presenter: "*"
+        request.auth.claims[iss]: "*"
+  roleRef:
+    kind: ServiceRole
+    name: httpbin-viewer

--- a/pilot/pkg/security/authz/builder/testdata/v1alpha1-all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1alpha1-all-fields-out.yaml
@@ -1,0 +1,192 @@
+rules:
+  policies:
+    httpbin-viewer:
+      permissions:
+        - andRules:
+            rules:
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: method
+                        name: :method
+                    - header:
+                        name: :method
+                        prefixMatch: method-prefix-
+                    - header:
+                        name: :method
+                        suffixMatch: -suffix-method
+                    - header:
+                        name: :method
+                        presentMatch: true
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: /exact
+                        name: :path
+                    - header:
+                        name: :path
+                        prefixMatch: /prefix/
+                    - header:
+                        name: :path
+                        suffixMatch: /suffix
+                    - header:
+                        name: :path
+                        presentMatch: true
+              - orRules:
+                  rules:
+                    - destinationIp:
+                        addressPrefix: 10.10.10.10
+                        prefixLen: 32
+                    - destinationIp:
+                        addressPrefix: 192.168.10.0
+                        prefixLen: 24
+              - orRules:
+                  rules:
+                    - destinationPort: 91
+                    - destinationPort: 92
+              - orRules:
+                  rules:
+                    - metadata:
+                        filter: envoy.filters.network.mysql_proxy
+                        path:
+                          - key: db.table
+                        value:
+                          stringMatch:
+                            exact: experimental
+                    - metadata:
+                        filter: envoy.filters.network.mysql_proxy
+                        path:
+                          - key: db.table
+                        value:
+                          stringMatch:
+                            prefix: experimental-prefix-
+                    - metadata:
+                        filter: envoy.filters.network.mysql_proxy
+                        path:
+                          - key: db.table
+                        value:
+                          stringMatch:
+                            suffix: -suffix-experimental
+                    - metadata:
+                        filter: envoy.filters.network.mysql_proxy
+                        path:
+                          - key: db.table
+                        value:
+                          stringMatch:
+                            regex: .*
+              - orRules:
+                  rules:
+                    - header:
+                        exactMatch: header
+                        name: X-header
+                    - header:
+                        name: X-header
+                        prefixMatch: header-prefix-
+                    - header:
+                        name: X-header
+                        suffixMatch: -suffix-header
+                    - header:
+                        name: X-header
+                        presentMatch: true
+      principals:
+        - andIds:
+            ids:
+              - orIds:
+                  ids:
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            exact: user
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: request.auth.audiences
+                  value:
+                    stringMatch:
+                      exact: request-audiences
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: request.auth.claims
+                    - key: iss
+                  value:
+                    listMatch:
+                      oneOf:
+                        stringMatch:
+                          exact: request-claims
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: request.auth.presenter
+                  value:
+                    stringMatch:
+                      exact: request-presenter
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      exact: request-principal
+              - sourceIp:
+                  addressPrefix: 1.2.3.4
+                  prefixLen: 32
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/source-ns/.*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: source.principal
+                  value:
+                    stringMatch:
+                      exact: source-principal
+        - andIds:
+            ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: request.auth.audiences
+                  value:
+                    stringMatch:
+                      regex: .*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: request.auth.claims
+                    - key: iss
+                  value:
+                    listMatch:
+                      oneOf:
+                        stringMatch:
+                          regex: .*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: request.auth.presenter
+                  value:
+                    stringMatch:
+                      regex: .*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      regex: .*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                    - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/.*/.*
+              - any: true
+

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1-all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1-all-fields-out.yaml
@@ -71,7 +71,7 @@ rules:
                     - requestedServerName:
                         prefix: prefix.
                     - requestedServerName:
-                        regex: .*
+                        regex: .+
               - orRules:
                   rules:
                     - metadata:
@@ -101,7 +101,7 @@ rules:
                           - key: c
                         value:
                           stringMatch:
-                            regex: .*
+                            regex: .+
       principals:
         - andIds:
             ids:
@@ -128,7 +128,13 @@ rules:
                         value:
                           stringMatch:
                             suffix: -suffix-principal
-                    - any: true
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .+
               - orIds:
                   ids:
                     - metadata:
@@ -158,7 +164,7 @@ rules:
                           - key: request.auth.principal
                         value:
                           stringMatch:
-                            regex: .*
+                            regex: .+
               - orIds:
                   ids:
                     - metadata:
@@ -272,7 +278,13 @@ rules:
                         value:
                           stringMatch:
                             suffix: -suffix-principal
-                    - any: true
+                    - metadata:
+                        filter: istio_authn
+                        path:
+                          - key: source.principal
+                        value:
+                          stringMatch:
+                            regex: .+
               - orIds:
                   ids:
                     - metadata:
@@ -302,7 +314,7 @@ rules:
                           - key: request.auth.principal
                         value:
                           stringMatch:
-                            regex: .*
+                            regex: .+
               - orIds:
                   ids:
                     - metadata:
@@ -332,7 +344,7 @@ rules:
                           - key: request.auth.audiences
                         value:
                           stringMatch:
-                            regex: .*
+                            regex: .+
               - orIds:
                   ids:
                     - metadata:
@@ -362,7 +374,7 @@ rules:
                           - key: request.auth.presenter
                         value:
                           stringMatch:
-                            regex: .*
+                            regex: .+
               - orIds:
                   ids:
                     - metadata:
@@ -404,4 +416,4 @@ rules:
                           listMatch:
                             oneOf:
                               stringMatch:
-                                regex: .*
+                                regex: .+

--- a/pilot/pkg/security/authz/model/matcher/metadata.go
+++ b/pilot/pkg/security/authz/model/matcher/metadata.go
@@ -37,12 +37,12 @@ func MetadataStringMatcher(filter, key string, m *envoy_matcher.StringMatcher) *
 }
 
 // MetadataListMatcher generates a metadata list matcher for the given path keys and value.
-func MetadataListMatcher(filter string, keys []string, value string) *envoy_matcher.MetadataMatcher {
+func MetadataListMatcher(filter string, keys []string, value string, v1beta1 bool) *envoy_matcher.MetadataMatcher {
 	listMatcher := &envoy_matcher.ListMatcher{
 		MatchPattern: &envoy_matcher.ListMatcher_OneOf{
 			OneOf: &envoy_matcher.ValueMatcher{
 				MatchPattern: &envoy_matcher.ValueMatcher_StringMatch{
-					StringMatch: StringMatcher(value),
+					StringMatch: StringMatcher(value, v1beta1),
 				},
 			},
 		},

--- a/pilot/pkg/security/authz/model/matcher/metadata.go
+++ b/pilot/pkg/security/authz/model/matcher/metadata.go
@@ -18,6 +18,8 @@ import (
 	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 )
 
+// MetadataStringMatcher creates a metadata string matcher for the given filter, key and the
+// string matcher.
 func MetadataStringMatcher(filter, key string, m *envoy_matcher.StringMatcher) *envoy_matcher.MetadataMatcher {
 	return &envoy_matcher.MetadataMatcher{
 		Filter: filter,
@@ -36,13 +38,14 @@ func MetadataStringMatcher(filter, key string, m *envoy_matcher.StringMatcher) *
 	}
 }
 
-// MetadataListMatcher generates a metadata list matcher for the given path keys and value.
-func MetadataListMatcher(filter string, keys []string, value string, v1beta1 bool) *envoy_matcher.MetadataMatcher {
+// MetadataListMatcher creates a metadata list matcher for the given path keys and value.
+// If treatWildcardAsRequired is true, the wildcard "*" will be generated as ".+" instead of ".*".
+func MetadataListMatcher(filter string, keys []string, value string, treatWildcardAsRequired bool) *envoy_matcher.MetadataMatcher {
 	listMatcher := &envoy_matcher.ListMatcher{
 		MatchPattern: &envoy_matcher.ListMatcher_OneOf{
 			OneOf: &envoy_matcher.ValueMatcher{
 				MatchPattern: &envoy_matcher.ValueMatcher_StringMatch{
-					StringMatch: StringMatcher(value, v1beta1),
+					StringMatch: StringMatcher(value, treatWildcardAsRequired),
 				},
 			},
 		},

--- a/pilot/pkg/security/authz/model/matcher/metadata_test.go
+++ b/pilot/pkg/security/authz/model/matcher/metadata_test.go
@@ -15,6 +15,7 @@
 package matcher
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -45,6 +46,69 @@ func TestMetadataStringMatcher(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(*actual, *expect) {
-		t.Errorf("expecting %v, but got %v", *expect, *actual)
+		t.Errorf("want %s, got %s", expect.String(), actual.String())
+	}
+}
+
+func TestMetadataListMatcher(t *testing.T) {
+	getWant := func(regex string) envoy_matcher.MetadataMatcher {
+		return envoy_matcher.MetadataMatcher{
+			Filter: "istio_authn",
+			Path: []*envoy_matcher.MetadataMatcher_PathSegment{
+				{
+					Segment: &envoy_matcher.MetadataMatcher_PathSegment_Key{
+						Key: "key1",
+					},
+				},
+				{
+					Segment: &envoy_matcher.MetadataMatcher_PathSegment_Key{
+						Key: "key2",
+					},
+				},
+			},
+			Value: &envoy_matcher.ValueMatcher{
+				MatchPattern: &envoy_matcher.ValueMatcher_ListMatch{
+					ListMatch: &envoy_matcher.ListMatcher{
+						MatchPattern: &envoy_matcher.ListMatcher_OneOf{
+							OneOf: &envoy_matcher.ValueMatcher{
+								MatchPattern: &envoy_matcher.ValueMatcher_StringMatch{
+									StringMatch: &envoy_matcher.StringMatcher{
+										MatchPattern: &envoy_matcher.StringMatcher_Regex{
+											Regex: regex,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	getActual := func(treatWildcardAsRequired bool) envoy_matcher.MetadataMatcher {
+		return *MetadataListMatcher("istio_authn", []string{"key1", "key2"}, "*", treatWildcardAsRequired)
+	}
+
+	testCases := []struct {
+		treatWildcardAsRequired bool
+		want                    string
+	}{
+		{
+			treatWildcardAsRequired: false,
+			want:                    ".*",
+		},
+		{
+			treatWildcardAsRequired: true,
+			want:                    ".+",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("treatWildcardAsRequired[%v]", tc.treatWildcardAsRequired), func(t *testing.T) {
+			want := getWant(tc.want)
+			actual := getActual(tc.treatWildcardAsRequired)
+			if !reflect.DeepEqual(want, actual) {
+				t.Errorf("want %s, but got %s", want.String(), actual.String())
+			}
+		})
 	}
 }

--- a/pilot/pkg/security/authz/model/matcher/string.go
+++ b/pilot/pkg/security/authz/model/matcher/string.go
@@ -20,19 +20,22 @@ import (
 	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 )
 
-func StringMatcher(v string) *envoy_matcher.StringMatcher {
-	return StringMatcherWithPrefix(v, "")
+func StringMatcher(v string, v1beta1 bool) *envoy_matcher.StringMatcher {
+	return StringMatcherWithPrefix(v, "", v1beta1)
 }
 
 func StringMatcherRegex(regex string) *envoy_matcher.StringMatcher {
 	return &envoy_matcher.StringMatcher{MatchPattern: &envoy_matcher.StringMatcher_Regex{Regex: regex}}
 }
 
-func StringMatcherWithPrefix(v, prefix string) *envoy_matcher.StringMatcher {
+func StringMatcherWithPrefix(v, prefix string, v1beta1 bool) *envoy_matcher.StringMatcher {
 	switch {
 	// Check if v is "*" first to make sure we won't generate an empty prefix/suffix StringMatcher,
 	// the Envoy StringMatcher doesn't allow empty prefix/suffix.
 	case v == "*":
+		if v1beta1 {
+			return StringMatcherRegex(".+")
+		}
 		return StringMatcherRegex(".*")
 	case strings.HasPrefix(v, "*"):
 		return &envoy_matcher.StringMatcher{

--- a/pilot/pkg/security/authz/model/matcher/string.go
+++ b/pilot/pkg/security/authz/model/matcher/string.go
@@ -20,20 +20,25 @@ import (
 	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 )
 
-func StringMatcher(v string, v1beta1 bool) *envoy_matcher.StringMatcher {
-	return StringMatcherWithPrefix(v, "", v1beta1)
+// StringMatcher creates a string matcher for v.
+func StringMatcher(v string, treatWildcardAsRequired bool) *envoy_matcher.StringMatcher {
+	return StringMatcherWithPrefix(v, "", treatWildcardAsRequired)
 }
 
+// StringMatcherRegex creates a regex string matcher for regex.
 func StringMatcherRegex(regex string) *envoy_matcher.StringMatcher {
 	return &envoy_matcher.StringMatcher{MatchPattern: &envoy_matcher.StringMatcher_Regex{Regex: regex}}
 }
 
-func StringMatcherWithPrefix(v, prefix string, v1beta1 bool) *envoy_matcher.StringMatcher {
+// StringMatcherWithPrefix creates a string matcher for v with the extra prefix inserted to the
+// created string matcher, note the prefix is ignored if v is wildcard ("*").
+// If treatWildcardAsRequired is true, the wildcard "*" will be generated as ".+" instead of ".*".
+func StringMatcherWithPrefix(v, prefix string, treatWildcardAsRequired bool) *envoy_matcher.StringMatcher {
 	switch {
 	// Check if v is "*" first to make sure we won't generate an empty prefix/suffix StringMatcher,
 	// the Envoy StringMatcher doesn't allow empty prefix/suffix.
 	case v == "*":
-		if v1beta1 {
+		if treatWildcardAsRequired {
 			return StringMatcherRegex(".+")
 		}
 		return StringMatcherRegex(".*")

--- a/pilot/pkg/security/authz/model/matcher/string_test.go
+++ b/pilot/pkg/security/authz/model/matcher/string_test.go
@@ -1,0 +1,80 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"reflect"
+	"testing"
+
+	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
+)
+
+func TestStringMatcherWithPrefix(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		v                       string
+		treatWildcardAsRequired bool
+		want                    *envoy_matcher.StringMatcher
+	}{
+		{
+			name:                    "wildcardAsRequired",
+			v:                       "*",
+			treatWildcardAsRequired: true,
+			want:                    StringMatcherRegex(".+"),
+		},
+		{
+			name:                    "wildcard",
+			v:                       "*",
+			treatWildcardAsRequired: false,
+			want:                    StringMatcherRegex(".*"),
+		},
+		{
+			name: "prefix",
+			v:    "-prefix-*",
+			want: &envoy_matcher.StringMatcher{
+				MatchPattern: &envoy_matcher.StringMatcher_Prefix{
+					Prefix: "abc-prefix-",
+				},
+			},
+		},
+		{
+			name: "suffix",
+			v:    "*-suffix",
+			want: &envoy_matcher.StringMatcher{
+				MatchPattern: &envoy_matcher.StringMatcher_Suffix{
+					Suffix: "abc-suffix",
+				},
+			},
+		},
+		{
+			name: "exact",
+			v:    "-exact",
+			want: &envoy_matcher.StringMatcher{
+				MatchPattern: &envoy_matcher.StringMatcher_Exact{
+					Exact: "abc-exact",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := StringMatcherWithPrefix(tc.v, "abc", tc.treatWildcardAsRequired)
+			if !reflect.DeepEqual(*actual, *tc.want) {
+				t.Errorf("want %s but got %s", tc.want.String(), actual.String())
+			}
+		})
+	}
+}

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -193,6 +193,7 @@ func NewModelV1beta1(trustDomainBundle trustdomain.Bundle, rule *security.Rule) 
 				Namespaces:        source.Namespaces,
 				RequestPrincipals: source.RequestPrincipals,
 				Properties:        conditionsForPrincipal,
+				v1beta1:           true,
 			}
 			m.Principals = append(m.Principals, principal)
 		}
@@ -201,10 +202,12 @@ func NewModelV1beta1(trustDomainBundle trustdomain.Bundle, rule *security.Rule) 
 		if len(conditionsForPrincipal) != 0 {
 			m.Principals = []Principal{{
 				Properties: conditionsForPrincipal,
+				v1beta1:    true,
 			}}
 		} else {
 			m.Principals = []Principal{{
 				AllowAll: true,
+				v1beta1:  true,
 			}}
 		}
 	}
@@ -217,6 +220,7 @@ func NewModelV1beta1(trustDomainBundle trustdomain.Bundle, rule *security.Rule) 
 				Ports:       operation.Ports,
 				Paths:       operation.Paths,
 				Constraints: conditionsForPermission,
+				v1beta1:     true,
 			}
 			m.Permissions = append(m.Permissions, permission)
 		}
@@ -225,10 +229,12 @@ func NewModelV1beta1(trustDomainBundle trustdomain.Bundle, rule *security.Rule) 
 		if len(conditionsForPermission) != 0 {
 			m.Permissions = []Permission{{
 				Constraints: conditionsForPermission,
+				v1beta1:     true,
 			}}
 		} else {
 			m.Permissions = []Permission{{
 				AllowAll: true,
+				v1beta1:  true,
 			}}
 		}
 	}

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -146,11 +146,13 @@ func TestNewModelV1beta1(t *testing.T) {
 					{
 						Names:      []string{"principal"},
 						Properties: []KeyValues{},
+						v1beta1:    true,
 					},
 				},
 				Permissions: []Permission{
 					{
 						AllowAll: true,
+						v1beta1:  true,
 					},
 				},
 			},
@@ -170,12 +172,14 @@ func TestNewModelV1beta1(t *testing.T) {
 				Principals: []Principal{
 					{
 						AllowAll: true,
+						v1beta1:  true,
 					},
 				},
 				Permissions: []Permission{
 					{
 						Hosts:       []string{"host"},
 						Constraints: []KeyValues{},
+						v1beta1:     true,
 					},
 				},
 			},
@@ -193,11 +197,13 @@ func TestNewModelV1beta1(t *testing.T) {
 						Constraints: []KeyValues{
 							{"destination.ip": []string{"value-destination.ip-1", "value-destination.ip-2"}},
 						},
+						v1beta1: true,
 					},
 				},
 				Principals: []Principal{
 					{
 						AllowAll: true,
+						v1beta1:  true,
 					},
 				},
 			},
@@ -213,6 +219,7 @@ func TestNewModelV1beta1(t *testing.T) {
 				Permissions: []Permission{
 					{
 						AllowAll: true,
+						v1beta1:  true,
 					},
 				},
 				Principals: []Principal{
@@ -220,6 +227,7 @@ func TestNewModelV1beta1(t *testing.T) {
 						Properties: []KeyValues{
 							{"request.headers": []string{"value-request.headers-1", "value-request.headers-2"}},
 						},
+						v1beta1: true,
 					},
 				},
 			},
@@ -289,6 +297,7 @@ func TestNewModelV1beta1(t *testing.T) {
 							{"destination.port": []string{"value-destination.port-1", "value-destination.port-2"}},
 							{"connection.sni": []string{"value-connection.sni-1", "value-connection.sni-2"}},
 						},
+						v1beta1: true,
 					},
 					{
 						Hosts: []string{"h3"},
@@ -297,6 +306,7 @@ func TestNewModelV1beta1(t *testing.T) {
 							{"destination.port": []string{"value-destination.port-1", "value-destination.port-2"}},
 							{"connection.sni": []string{"value-connection.sni-1", "value-connection.sni-2"}},
 						},
+						v1beta1: true,
 					},
 				},
 				Principals: []Principal{
@@ -317,6 +327,7 @@ func TestNewModelV1beta1(t *testing.T) {
 							{"request.auth.claims": []string{"value-request.auth.claims-1", "value-request.auth.claims-2"}},
 							{"request.auth.claims[groups]": []string{"value-request.auth.claims[groups]-1", "value-request.auth.claims[groups]-2"}},
 						},
+						v1beta1: true,
 					},
 					{
 						Names: []string{"p3"},
@@ -332,6 +343,7 @@ func TestNewModelV1beta1(t *testing.T) {
 							{"request.auth.claims": []string{"value-request.auth.claims-1", "value-request.auth.claims-2"}},
 							{"request.auth.claims[groups]": []string{"value-request.auth.claims[groups]-1", "value-request.auth.claims[groups]-2"}},
 						},
+						v1beta1: true,
 					},
 				},
 			},

--- a/tests/integration/security/testdata/rbac/v1beta1-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-jwt.yaml.tmpl
@@ -24,6 +24,7 @@ spec:
 # The following policy enables authorization on workload b:
 # - Allow request principal test-issuer-1@istio.io/sub-1 to access path /token1
 # - Allow request in group-2 to access path /token2
+# - Allow request with any token to access path /tokenAny
 
 apiVersion: "security.istio.io/v1beta1"
 kind: AuthorizationPolicy
@@ -49,4 +50,11 @@ spec:
     when:
     - key: request.auth.claims[groups]
       values: ["group-2"]
+  - to:
+    - operation:
+        paths: ["/tokenAny"]
+        methods: ["GET"]
+    from:
+    - source:
+        requestPrincipals: ["*"]
 ---


### PR DESCRIPTION
For #12394

In v1beta1 policy, "*" means presence match for non-empty values, change to use regex `.+` instead of `.*`. Also added e2e tests to cover this.