### PR TITLE
eds: add endpoint count stat

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -891,5 +891,5 @@ func updateEdsStats(locEps []*endpoint.LocalityLbEndpoints, cluster string) {
 	for _, locLbEps := range locEps {
 		epc += len(locLbEps.GetLbEndpoints())
 	}
-	edsEndpoints.With(clusterTag.Value(cluster)).Record(float64(epc))
+	edsAllLocalityEndpoints.With(clusterTag.Value(cluster)).Record(float64(epc))
 }

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -44,8 +44,8 @@ var (
 		monitoring.WithLabels(clusterTag),
 	)
 
-	edsEndpoints = monitoring.NewGauge(
-		"pilot_xds_eds_endpoints",
+	edsAllLocalityEndpoints = monitoring.NewGauge(
+		"pilot_xds_eds_all_locality_endpoints",
 		"Network endpoints for each cluster(across all localities), as of last push. Zero endpoints is an error.",
 		monitoring.WithLabels(clusterTag),
 	)

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -40,13 +40,13 @@ var (
 
 	edsInstances = monitoring.NewGauge(
 		"pilot_xds_eds_instances",
-		"Instances for each cluster, as of last push. Zero instances is an error.",
+		"Instances for each cluster(grouped by locality), as of last push. Zero instances is an error.",
 		monitoring.WithLabels(clusterTag),
 	)
 
 	edsEndpoints = monitoring.NewGauge(
 		"pilot_xds_eds_endpoints",
-		"Network endpoints for each cluster, as of last push. Zero endpoints is an error.",
+		"Network endpoints for each cluster(across all localities), as of last push. Zero endpoints is an error.",
 		monitoring.WithLabels(clusterTag),
 	)
 

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -44,6 +44,12 @@ var (
 		monitoring.WithLabels(clusterTag),
 	)
 
+	edsEndpoints = monitoring.NewGauge(
+		"pilot_xds_eds_endpoints",
+		"Network endpoints for each cluster, as of last push. Zero endpoints is an error.",
+		monitoring.WithLabels(clusterTag),
+	)
+
 	ldsReject = monitoring.NewGauge(
 		"pilot_xds_lds_reject",
 		"Pilot rejected LDS.",


### PR DESCRIPTION
Currently we have a stat called `pilot_xds_eds_instances` that lists instances grouped by locality. But it would be good to have the actual endpoint count across all localities. This PR adds that stat.