### PR TITLE
Add back applicationPorts function to the injector (fixes test)

### DIFF
--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -557,6 +557,7 @@ func InjectionData(sidecarTemplate, valuesConfig, version string, typeMetadata *
 		"excludeInboundPort":  excludeInboundPort,
 		"includeInboundPorts": includeInboundPorts,
 		"kubevirtInterfaces":  kubevirtInterfaces,
+		"applicationPorts":    applicationPorts,
 		"annotation":          getAnnotation,
 		"valueOrDefault":      valueOrDefault,
 		"toJSON":              toJSON,
@@ -870,6 +871,13 @@ func getContainerPorts(containers []corev1.Container, shouldIncludePorts func(co
 	}
 
 	return strings.Join(parts, ",")
+}
+
+// this function is no longer used by the template but kept around for backwards compatibility
+func applicationPorts(containers []corev1.Container) string {
+	return getContainerPorts(containers, func(c corev1.Container) bool {
+		return c.Name != ProxyContainerName
+	})
 }
 
 func includeInboundPorts(containers []corev1.Container) string {


### PR DESCRIPTION
This was removed in https://github.com/istio/istio/pull/17986. The
removal was not neccesarily wrong, but it means that the injector
deployment and injection template need to move in lock step, which has
some problems. Specifically, the operator did not have charts updated,
so it fails now, and anyone using :latest tags will also fail without
updating the template.

There is a near-zero cost of keeping the function around, so we might as
well add it back to make things a bit simpler.