### PR TITLE
Allow failures in kind cleanup and log

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -132,10 +132,10 @@ function clone_cni() {
 function cleanup_kind_cluster() {
   NAME="${1}"
   echo "Test exited with exit code $?."
-  kind export logs --name "${NAME}" "${ARTIFACTS}/kind"
+  kind export logs --name "${NAME}" "${ARTIFACTS}/kind" --loglevel debug || true
   if [[ -z "${SKIP_CLEANUP:-}" ]]; then
     echo "Cleaning up kind cluster"
-    kind delete cluster --name "${NAME}"
+    kind delete cluster --name "${NAME}" --loglevel debug || true
   fi
 }
 


### PR DESCRIPTION
There have been a couple failures where kind breaks at the end of the
test, with no indiciation of any issues. We should allow these to fail,
as they are not relevant to the test, but add some debug logging so we
can track down the issues.