### PR TITLE
Add analyzers for DestinationRules

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/auth"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deployment"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deprecation"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/destinationrule"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/schema"
@@ -37,6 +38,7 @@ func All() []analysis.Analyzer {
 		&auth.ServiceRoleServicesAnalyzer{},
 		&deployment.ServiceAssociationAnalyzer{},
 		&deprecation.FieldAnalyzer{},
+		&destinationrule.TargetAnalyzer{},
 		&gateway.IngressGatewayPortAnalyzer{},
 		&injection.Analyzer{},
 		&injection.VersionAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/auth"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deployment"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deprecation"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/destinationrule"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/sidecar"
@@ -183,6 +184,19 @@ var testGrid = []testCase{
 			{msg.Deprecated, "EnvoyFilter istio-multicluster-egressgateway.istio-system"},
 			{msg.Deprecated, "EnvoyFilter istio-multicluster-egressgateway.istio-system"}, // Duplicate, because resource has two problems
 			{msg.Deprecated, "ServiceRoleBinding bind-mongodb-viewer.default"},
+		},
+	},
+	{
+		name:       "destinationRulesLabels",
+		inputFiles: []string{"testdata/destinationrule_drhosts.yaml"},
+		analyzer:   &destinationrule.TargetAnalyzer{},
+		expected: []message{
+			{msg.ConflictingDestinationRulesHost, "DestinationRule reviews-buggy.default"},
+			{msg.ConflictingDestinationRulesHost, "DestinationRule reviews-unlucky.default"},
+			{msg.ConflictingDestinationRulesHost, "DestinationRule reviews-wildcard.default"},
+			{msg.ConflictingDestinationRulesHost, "DestinationRule reviews-wildcard-victim.default"},
+			{msg.ReferencedResourceNotFound, "DestinationRule reviews-buggy.default"},
+			{msg.ReferencedResourceNotFound, "DestinationRule reviews-forgot.default"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/destinationrule/targets.go
+++ b/galley/pkg/config/analysis/analyzers/destinationrule/targets.go
@@ -1,0 +1,207 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package destinationrule
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	k8s_labels "k8s.io/apimachinery/pkg/labels"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/galley/pkg/config/meta/metadata"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+)
+
+// TargetAnalyzer checks the destination rule hosts for duplicates and host + subsets for missing services / pods
+type TargetAnalyzer struct{}
+
+var _ analysis.Analyzer = &TargetAnalyzer{}
+
+type hostAndSubset struct {
+	host   resource.Name
+	subset string
+}
+
+// Metadata implements Analyzer
+func (d *TargetAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name: "destinationrule.TargetAnalyzer",
+		Inputs: collection.Names{
+			metadata.IstioNetworkingV1Alpha3Destinationrules,
+			metadata.IstioNetworkingV1Alpha3Serviceentries,
+			// Synthetic is not used by this analyzer, but the test requires it because of util package
+			metadata.IstioNetworkingV1Alpha3SyntheticServiceentries,
+			metadata.K8SCoreV1Services,
+			metadata.K8SCoreV1Pods,
+		},
+	}
+}
+
+// Analyze implements Analyzer
+func (d *TargetAnalyzer) Analyze(ctx analysis.Context) {
+	seHosts := util.ServiceEntriesToFqdnMap(ctx)
+	services := availableServices(ctx)
+	subsets := hostSubsetCombinations(ctx)
+
+	for hs, resources := range subsets {
+		hostResourceName := hs.host
+		drNamespace, drHost := hostResourceName.InterpretAsNamespaceAndName()
+
+		wildCardEntries := []*resource.Entry{}
+
+		// Look for wildcarded DRs also, they're duplicate to this one
+		if hs.subset != util.AllSubsets {
+			hsWildcardSearch := hs
+			hsWildcardSearch.subset = util.AllSubsets
+
+			if wildCardEntriesFound, found := subsets[hsWildcardSearch]; found {
+				wildCardEntries = wildCardEntriesFound
+			}
+		}
+
+		if len(resources) > 1 || len(wildCardEntries) > 0 {
+			// Create Report for duplicate host + subset combination
+			errorEntries := combineResourceEntryNames(append(resources, wildCardEntries...))
+			for _, r := range resources {
+				ctx.Report(metadata.IstioNetworkingV1Alpha3Destinationrules,
+					msg.NewConflictingDestinationRulesHost(r, errorEntries, drHost, hs.subset))
+			}
+			for _, r := range wildCardEntries {
+				// We need to create the duplicate report here of wildcard subsets since searching the other way isn't possible
+				ctx.Report(metadata.IstioNetworkingV1Alpha3Destinationrules,
+					msg.NewConflictingDestinationRulesHost(r, errorEntries, drHost, util.AllSubsets))
+			}
+		}
+
+		nsScopedFqdn := util.NewScopedFqdn(drNamespace, drNamespace, drHost)
+		allNsScopedFqdn := util.NewScopedFqdn(util.ExportToAllNamespaces, drNamespace, drHost)
+
+		_, nsFound := seHosts[nsScopedFqdn]
+		_, allFound := seHosts[allNsScopedFqdn]
+		targetService, serviceFound := services[nsScopedFqdn]
+
+		if !nsFound && !allFound && !serviceFound {
+			// DestinationRule host does not match any ServiceEntry or platform Service
+			for _, r := range resources {
+				ctx.Report(metadata.IstioNetworkingV1Alpha3Destinationrules,
+					msg.NewReferencedResourceNotFound(r, "host", drHost))
+			}
+		}
+
+		if serviceFound {
+			// Check subset labels
+			for _, r := range resources {
+				dr := r.Item.(*v1alpha3.DestinationRule)
+			NextSubset:
+				for _, ss := range dr.GetSubsets() {
+					if ss.Name != hs.subset {
+						continue
+					}
+					subsetSelector := k8s_labels.SelectorFromSet(k8s_labels.Set(ss.GetLabels()))
+					for _, targetPodLabels := range targetService {
+						if subsetSelector.Matches(targetPodLabels) {
+							continue NextSubset
+						}
+					}
+					// No target pods found
+					errDest := fmt.Sprintf("%s/subset:%s", drHost, ss.Name)
+					ctx.Report(metadata.IstioNetworkingV1Alpha3Destinationrules,
+						msg.NewReferencedResourceNotFound(r, "subset", errDest))
+				}
+			}
+		}
+	}
+}
+
+func hostSubsetCombinations(ctx analysis.Context) map[hostAndSubset][]*resource.Entry {
+	seenCombinations := map[hostAndSubset][]*resource.Entry{}
+
+	addMatch := func(hs hostAndSubset, r *resource.Entry) {
+		if subset, found := seenCombinations[hs]; found {
+			subset = append(subset, r)
+			seenCombinations[hs] = subset
+		} else if !found {
+			seenCombinations[hs] = []*resource.Entry{r}
+		}
+	}
+
+	ctx.ForEach(metadata.IstioNetworkingV1Alpha3Destinationrules, func(r *resource.Entry) bool {
+		dr := r.Item.(*v1alpha3.DestinationRule)
+		drNamespace, _ := r.Metadata.Name.InterpretAsNamespaceAndName()
+
+		// If there are no subsets, then we need to match ALL the subsets..
+		if len(dr.GetSubsets()) < 1 || (len(dr.GetSubsets()) == 1 && dr.GetSubsets()[0].Name == util.AllSubsets) {
+			hs := hostAndSubset{
+				host:   util.GetResourceNameFromHost(drNamespace, dr.GetHost()),
+				subset: util.AllSubsets,
+			}
+			addMatch(hs, r)
+		}
+		for _, ss := range dr.GetSubsets() {
+			hs := hostAndSubset{
+				host:   util.GetResourceNameFromHost(drNamespace, dr.GetHost()),
+				subset: ss.GetName(),
+			}
+			addMatch(hs, r)
+		}
+
+		return true
+	})
+
+	return seenCombinations
+}
+
+func availableServices(ctx analysis.Context) map[util.ScopedFqdn][]k8s_labels.Set {
+	podLabelSets := make([]k8s_labels.Set, 0)
+	ctx.ForEach(metadata.K8SCoreV1Pods, func(r *resource.Entry) bool {
+		pod := r.Item.(*v1.Pod)
+		podLabels := k8s_labels.Set(pod.ObjectMeta.Labels)
+		podLabelSets = append(podLabelSets, podLabels)
+		return true
+	})
+
+	services := make(map[util.ScopedFqdn][]k8s_labels.Set)
+	ctx.ForEach(metadata.K8SCoreV1Services, func(r *resource.Entry) bool {
+		service := r.Item.(*v1.ServiceSpec)
+		ns, serviceName := r.Metadata.Name.InterpretAsNamespaceAndName()
+		selector := k8s_labels.SelectorFromSet(k8s_labels.Set(service.Selector))
+
+		podLabels := make([]k8s_labels.Set, 0)
+		for _, labels := range podLabelSets {
+			if selector.Matches(labels) {
+				podLabels = append(podLabels, labels)
+			}
+		}
+
+		services[util.NewScopedFqdn(ns, ns, serviceName)] = podLabels
+
+		return true
+	})
+
+	return services
+}
+
+func combineResourceEntryNames(rList []*resource.Entry) []string {
+	names := []string{}
+	for _, r := range rList {
+		names = append(names, r.Metadata.Name.String())
+	}
+	return names
+}

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule_drhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule_drhosts.yaml
@@ -1,0 +1,128 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  namespace: default
+  labels:
+    app: reviews
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews-buggy
+  namespace: default
+  labels:
+    app: reviews
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews-wildcard
+  namespace: default
+  labels:
+    app: reviews
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-reviews
+  namespace: default
+spec:
+  hosts:
+  - external-reviews.org
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: reviews-app-v1
+  labels:
+    app: reviews
+    version: v1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: reviews-app-v2
+  labels:
+    app: reviews
+    version: v2
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews
+  namespace: default
+spec:
+  host: reviews
+  subsets:
+  - labels:
+      version: v1
+    name: v1
+  - labels:
+      version: v2
+    name: v2
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-buggy
+  namespace: default
+spec:
+  host: reviews-buggy 
+  subsets:
+  - labels:
+      version: v1 # Duplicate hostname+subset, should generate an error
+    name: v1
+  - labels:
+      version: v3 # Incorrect version label, no matching version v3 found from any pod
+    name: v3
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-unlucky
+  namespace: default
+spec:
+  host: reviews-buggy 
+  subsets:
+  - labels:
+      version: v1 # Duplicate hostname+subset, should generate an error
+    name: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-external
+  namespace: default
+spec:
+  host: external-reviews.org # This is matched by the ServiceEntry
+  subsets:
+    - name: en # Subset without labels should not cause a validation error
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-wildcard-victim
+  namespace: default
+spec:
+  host: reviews-wildcard
+  subsets:
+  - labels:
+      version: v1 # Should generate validation error, matches reviews-wildcard
+    name: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-wildcard
+  namespace: default
+spec:
+  host: reviews-wildcard # Should generate validation error, matches reviews-wildcard-victim since this is matching all subsets
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-forgot
+  namespace: default
+spec:
+  host: reviews-forgot # Should generate validation error, no such service found

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule_drhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule_drhosts.yaml
@@ -83,7 +83,7 @@ metadata:
   name: reviews-unlucky
   namespace: default
 spec:
-  host: reviews-buggy 
+  host: reviews-buggy.default.svc.cluster.local
   subsets:
   - labels:
       version: v1 # Duplicate hostname+subset, should generate an error

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule_drhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule_drhosts.yaml
@@ -68,7 +68,7 @@ metadata:
   name: reviews-buggy
   namespace: default
 spec:
-  host: reviews-buggy
+  host: reviews-buggy 
   subsets:
   - labels:
       version: v1 # Duplicate hostname+subset, should generate an error
@@ -83,7 +83,7 @@ metadata:
   name: reviews-unlucky
   namespace: default
 spec:
-  host: reviews-buggy.default.svc.cluster.local
+  host: reviews-buggy 
   subsets:
   - labels:
       version: v1 # Duplicate hostname+subset, should generate an error

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule_drhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule_drhosts.yaml
@@ -68,7 +68,7 @@ metadata:
   name: reviews-buggy
   namespace: default
 spec:
-  host: reviews-buggy 
+  host: reviews-buggy
   subsets:
   - labels:
       version: v1 # Duplicate hostname+subset, should generate an error
@@ -83,7 +83,7 @@ metadata:
   name: reviews-unlucky
   namespace: default
 spec:
-  host: reviews-buggy 
+  host: reviews-buggy.default.svc.cluster.local
   subsets:
   - labels:
       version: v1 # Duplicate hostname+subset, should generate an error

--- a/galley/pkg/config/analysis/analyzers/util/constants.go
+++ b/galley/pkg/config/analysis/analyzers/util/constants.go
@@ -24,6 +24,7 @@ const (
 	ExportToNamespaceLocal  = "."
 	ExportToAllNamespaces   = "*"
 	Wildcard                = "*"
+	AllSubsets              = "~"
 )
 
 var (

--- a/galley/pkg/config/analysis/analyzers/util/conversions.go
+++ b/galley/pkg/config/analysis/analyzers/util/conversions.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/meta/metadata"
+	"istio.io/istio/galley/pkg/config/resource"
+)
+
+// ServiceEntriesToFqdnMap transforms IstioNetworkingV1Alpha3Serviceentries hostnames
+// to a map with ScopedFqdn key
+func ServiceEntriesToFqdnMap(ctx analysis.Context) map[ScopedFqdn]*v1alpha3.ServiceEntry {
+	hosts := make(map[ScopedFqdn]*v1alpha3.ServiceEntry)
+
+	extractFn := func(r *resource.Entry) bool {
+		s := r.Item.(*v1alpha3.ServiceEntry)
+		ns, _ := r.Metadata.Name.InterpretAsNamespaceAndName()
+		hostsNamespaceScope := ns
+		if IsExportToAllNamespaces(s.ExportTo) {
+			hostsNamespaceScope = ExportToAllNamespaces
+		}
+
+		for _, h := range s.GetHosts() {
+			hosts[NewScopedFqdn(hostsNamespaceScope, ns, h)] = s
+		}
+		return true
+	}
+
+	ctx.ForEach(metadata.IstioNetworkingV1Alpha3Serviceentries, extractFn)
+	ctx.ForEach(metadata.IstioNetworkingV1Alpha3SyntheticServiceentries, extractFn)
+
+	return hosts
+}

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -84,6 +84,10 @@ var (
 	// DeploymentRequiresServiceAssociated defines a diag.MessageType for message "DeploymentRequiresServiceAssociated".
 	// Description: The resulting pods of a service mesh deployment must be associated with at least one service.
 	DeploymentRequiresServiceAssociated = diag.NewMessageType(diag.Warning, "IST0117", "No service associated with this deployment. Service mesh deployments must be associated with a service.")
+
+	// ConflictingDestinationRulesHost defines a diag.MessageType for message "ConflictingDestinationRulesHost".
+	// Description: Conflicting hosts on DestinationRules
+	ConflictingDestinationRulesHost = diag.NewMessageType(diag.Error, "IST0118", "The DestinationRules %s define the same host %s and subset %s combination, which can lead to undefined behavior. This can be fixed by merging the conflicting DestinationRules into a single resource.")
 )
 
 // NewInternalError returns a new diag.Message based on InternalError.
@@ -273,6 +277,17 @@ func NewDeploymentRequiresServiceAssociated(entry *resource.Entry, deployment st
 		DeploymentRequiresServiceAssociated,
 		originOrNil(entry),
 		deployment,
+	)
+}
+
+// NewConflictingDestinationRulesHost returns a new diag.Message based on ConflictingDestinationRulesHost.
+func NewConflictingDestinationRulesHost(entry *resource.Entry, destinationRules []string, host string, subset string) diag.Message {
+	return diag.NewMessage(
+		ConflictingDestinationRulesHost,
+		originOrNil(entry),
+		destinationRules,
+		host,
+		subset,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -209,3 +209,16 @@ messages:
     args:
       - name: deployment
         type: string
+
+  - name: "ConflictingDestinationRulesHost"
+    code: IST0118
+    level: Error
+    description: "Conflicting hosts on DestinationRules"
+    template: "The DestinationRules %s define the same host %s and subset %s combination, which can lead to undefined behavior. This can be fixed by merging the conflicting DestinationRules into a single resource."
+    args:
+      - name: destinationRules
+        type: "[]string"
+      - name: host
+        type: string
+      - name: subset
+        type: string


### PR DESCRIPTION
Adds analyzers for destination rules to catch duplicate host+subset combinations, missing services as well as missing pods for subsets labels. Closes issue #17507 

[x ] User Experience
