### PR TITLE
GatewayAnalyzer should parse namespace from the gw info in VS first

### DIFF
--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_gateways.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_gateways.yaml
@@ -9,6 +9,15 @@ spec:
     istio: ingressgateway
 ---
 apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: crossnamespace-gw
+  namespace: another
+spec:
+  selector:
+    istio: ingressgateway
+---
+apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: httpbin
@@ -37,3 +46,14 @@ spec:
   - "*"
   gateways:
   - mesh # Expected: no validation error, "mesh" is a special-case value
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: cross-test
+  namespace: default
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - another/crossnamespace-gw  # No validation error expected


### PR DESCRIPTION
If the gateway link in the VirtualService has namespace information, use that to the find the correct resource instead of always trying the same namespace.

Fixes #18366 

[x ] User Experience
