### PR TITLE
Make istioctl analyze integ test output clearer

### DIFF
--- a/pkg/test/framework/components/istioctl/kube.go
+++ b/pkg/test/framework/components/istioctl/kube.go
@@ -65,7 +65,9 @@ func (c *kubeComponent) Invoke(args []string) (string, error) {
 func (c *kubeComponent) InvokeOrFail(t *testing.T, args []string) string {
 	output, err := c.Invoke(args)
 	if err != nil {
-		t.Fatalf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), err)
+		t.Logf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), err)
+		t.Logf("Output:\n%v", output)
+		t.FailNow()
 	}
 	return output
 }

--- a/pkg/test/framework/components/istioctl/native.go
+++ b/pkg/test/framework/components/istioctl/native.go
@@ -59,7 +59,9 @@ func (c *nativeComponent) Invoke(args []string) (string, error) {
 func (c *nativeComponent) InvokeOrFail(t *testing.T, args []string) string {
 	output, err := c.Invoke(args)
 	if err != nil {
-		t.Fatalf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), err)
+		t.Logf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), err)
+		t.Logf("Output:\n%v", output)
+		t.FailNow()
 	}
 	return output
 }


### PR DESCRIPTION
Improve the clarity of `istioctl analyze` integ test failures. Previously, a test failure caused by an unexpected validation error wouldn't display any output that indicated what validation failed. Now it does.

1. test istioctl `InvokeOrFail` now also logs output when there's an unexpected nonzero return code.
2. tests specifically for `istioctl analyze` universally use `istioctlSafe` to explicitly check both output and return code. 