### PR TITLE
Strip out the prefix 'docker.io' when loading images in kind

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -72,10 +72,14 @@ function build_images() {
 
 function kind_load_images() {
   NAME="${1:-istio-testing}"
+
+  # If HUB starts with "docker.io/" removes that part so that filtering and loading below works
+  local hub=${HUB#"docker.io/"}
+
   for i in {1..3}; do
     # Archived local images and load it into KinD's docker daemon
     # Kubernetes in KinD can only access local images from its docker daemon.
-    docker images "${HUB}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 kind --loglevel debug --name "${NAME}" load docker-image && break
+    docker images "${hub}/*:${TAG}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 kind --loglevel debug --name "${NAME}" load docker-image && break
     echo "Attempt ${i} to load images failed, retrying in 5s..."
     sleep 5
 	done
@@ -84,7 +88,7 @@ function kind_load_images() {
   # We should still load non-variant images as well for things like `app` which do not use variants
   if [[ "${VARIANT:-}" != "" ]]; then
     for i in {1..3}; do
-      docker images "${HUB}/*:${TAG}-${VARIANT}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 kind --loglevel debug --name "${NAME}" load docker-image && break
+      docker images "${hub}/*:${TAG}-${VARIANT}" --format '{{.Repository}}:{{.Tag}}' | xargs -n1 kind --loglevel debug --name "${NAME}" load docker-image && break
       echo "Attempt ${i} to load images failed, retrying in 5s..."
       sleep 5
     done


### PR DESCRIPTION
If an image starts with `docker.io/`, docker strips it from the result of
`docker images`. Then those images were not being loaded into kind cluster.