### PR TITLE
Consider the gateway namespace, if supplied

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -177,6 +177,12 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name:       "virtualServiceCrossNamespaceGateways",
+		inputFiles: []string{"testdata/virtualservice_crossnamespace_gateways.yaml"},
+		analyzer:   &virtualservice.GatewayAnalyzer{},
+		expected:   []message{},
+	},
+	{
 		name: "misannoted",
 		inputFiles: []string{
 			"testdata/misannotated.yaml",

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_crossnamespace_gateways.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_crossnamespace_gateways.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: helloworld-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: helloworld
+  namespace: default
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - istio-system/helloworld-gateway
+  http:
+  - match:
+    - uri:
+        exact: /hello
+    route:
+    - destination:
+        host: helloworld
+        port:
+          number: 5000

--- a/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
@@ -59,7 +59,7 @@ func (s *GatewayAnalyzer) analyzeVirtualService(r *resource.Entry, c analysis.Co
 			continue
 		}
 
-		if !c.Exists(metadata.IstioNetworkingV1Alpha3Gateways, resource.NewName(ns, gwName)) {
+		if !c.Exists(metadata.IstioNetworkingV1Alpha3Gateways, resource.NewFullOrLocalName(ns, gwName)) {
 			c.Report(metadata.IstioNetworkingV1Alpha3Virtualservices, msg.NewReferencedResourceNotFound(r, "gateway", gwName))
 		}
 	}

--- a/galley/pkg/config/resource/name.go
+++ b/galley/pkg/config/resource/name.go
@@ -23,6 +23,11 @@ import (
 // Name of the resource. It is unique within a given set of resource of the same collection.
 type Name struct{ string }
 
+var (
+	// InvalidName represents a name that can never be matched
+	InvalidName = Name{string: "~~INVALID~~"}
+)
+
 // NewName returns a Name from namespace and name.
 func NewName(namespace, local string) Name {
 	if namespace == "" {
@@ -50,6 +55,18 @@ func NewFullName(name string) (Name, error) {
 		return Name{string: ""}, fmt.Errorf("invalid name %s: name must not be empty", name)
 	}
 	return Name{string: name}, nil
+}
+
+// NewFullOrLocalName returns a given name as a resource Name.  If name was a local name, the supplied namespace is used
+func NewFullOrLocalName(namespace, name string) Name {
+	if strings.ContainsRune(name, '/') {
+		if retval, err := NewFullName(name); err == nil {
+			return retval
+		}
+		return InvalidName
+	}
+
+	return NewName(namespace, name)
 }
 
 // String interface implementation.


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/18366 by considering the namespace, if supplied.

@sushicw Please review especially hard the new function/constructor added to `resource.Name`.  My first version of `resource.NewFullOrLocalName()` returned a `(Name, error)` like `NewFullName()` but I found it cumbersome to use.

I expect the Issue occurs more places in the framework than where @howardjohn found it.  Please create a follow-up if you detect any candidates.