### PR TITLE
Improve root cert rotation

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -464,7 +464,7 @@ func createCA(client corev1.CoreV1Interface) *ca.IstioCA {
 		} else {
 			checkInterval = -1
 		}
-		caOpts, err = ca.NewSelfSignedIstioCAOptions(ctx, opts.readSigningCertOnly,
+		caOpts, err = ca.NewSelfSignedIstioCAOptions(ctx,
 			opts.selfSignedRootCertGracePeriodPercentile, opts.selfSignedCACertTTL,
 			opts.selfSignedRootCertCheckInterval, opts.workloadCertTTL,
 			opts.maxWorkloadCertTTL, spiffe.GetTrustDomain(), opts.dualUse,

--- a/security/pkg/k8s/configmap/configmap.go
+++ b/security/pkg/k8s/configmap/configmap.go
@@ -88,6 +88,8 @@ func (c *Controller) InsertCATLSRootCertWithRetry(value string, retryInterval,
 		err := c.InsertCATLSRootCert(value)
 		if err == nil {
 			return nil
+		} else {
+			configMapLog.Errorf("Failed on updating root cert in config map: %s", err.Error())
 		}
 		if time.Since(start) > timeout {
 			configMapLog.Errorf("Timeout on updating root cert in config map.")

--- a/security/pkg/k8s/configmap/configmap.go
+++ b/security/pkg/k8s/configmap/configmap.go
@@ -88,9 +88,9 @@ func (c *Controller) InsertCATLSRootCertWithRetry(value string, retryInterval,
 		err := c.InsertCATLSRootCert(value)
 		if err == nil {
 			return nil
-		} else {
-			configMapLog.Errorf("Failed on updating root cert in config map: %s", err.Error())
 		}
+		configMapLog.Errorf("Failed on updating root cert in config map: %s", err.Error())
+
 		if time.Since(start) > timeout {
 			configMapLog.Errorf("Timeout on updating root cert in config map.")
 			return err

--- a/security/pkg/k8s/configmap/configmap.go
+++ b/security/pkg/k8s/configmap/configmap.go
@@ -15,7 +15,6 @@
 package configmap
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -84,25 +83,18 @@ func (c *Controller) InsertCATLSRootCert(value string) error {
 // retries until timeout.
 func (c *Controller) InsertCATLSRootCertWithRetry(value string, retryInterval,
 	timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	err := c.InsertCATLSRootCert(value)
-	ticker := time.NewTicker(retryInterval)
-	for err != nil {
-		configMapLog.Errorf("Failed to update root cert in config map: %s", err.Error())
-		select {
-		case <-ticker.C:
-			if err = c.InsertCATLSRootCert(value); err == nil {
-				break
-			}
-		case <-ctx.Done():
-			configMapLog.Error("Failed to update root cert in config map until timeout.")
-			ticker.Stop()
+	start := time.Now()
+	for {
+		err := c.InsertCATLSRootCert(value)
+		if err == nil {
+			return nil
+		}
+		if time.Since(start) > timeout {
+			configMapLog.Errorf("Timeout on updating root cert in config map.")
 			return err
 		}
+		time.Sleep(retryInterval)
 	}
-	return nil
 }
 
 // GetCATLSRootCert gets the CA TLS root certificate from the configmap.

--- a/security/pkg/k8s/controller/casecret.go
+++ b/security/pkg/k8s/controller/casecret.go
@@ -50,6 +50,9 @@ func (csc *CaSecretController) LoadCASecretWithRetry(secretName, namespace strin
 		caSecret, scrtErr = csc.client.Secrets(namespace).Get(secretName, metav1.GetOptions{})
 		if scrtErr == nil {
 			return caSecret, scrtErr
+		} else {
+			caSecretControllerLog.Errorf("Failed on loading CA secret %s:%s.",
+				namespace, secretName)
 		}
 		if time.Since(start) > timeout {
 			caSecretControllerLog.Errorf("Timeout on loading CA secret %s:%s.",
@@ -68,6 +71,9 @@ func (csc *CaSecretController) UpdateCASecretWithRetry(caSecret *v1.Secret,
 		_, scrtErr := csc.client.Secrets(caSecret.Namespace).Update(caSecret)
 		if scrtErr == nil {
 			return nil
+		} else {
+			caSecretControllerLog.Errorf("Failed on updating CA secret %s:%s.",
+				caSecret.Namespace, caSecret.Name)
 		}
 		if time.Since(start) > timeout {
 			caSecretControllerLog.Errorf("Timeout on updating CA secret %s:%s.",

--- a/security/pkg/k8s/controller/casecret.go
+++ b/security/pkg/k8s/controller/casecret.go
@@ -50,10 +50,10 @@ func (csc *CaSecretController) LoadCASecretWithRetry(secretName, namespace strin
 		caSecret, scrtErr = csc.client.Secrets(namespace).Get(secretName, metav1.GetOptions{})
 		if scrtErr == nil {
 			return caSecret, scrtErr
-		} else {
-			caSecretControllerLog.Errorf("Failed on loading CA secret %s:%s.",
-				namespace, secretName)
 		}
+		caSecretControllerLog.Errorf("Failed on loading CA secret %s:%s.",
+			namespace, secretName)
+
 		if time.Since(start) > timeout {
 			caSecretControllerLog.Errorf("Timeout on loading CA secret %s:%s.",
 				namespace, secretName)
@@ -71,10 +71,10 @@ func (csc *CaSecretController) UpdateCASecretWithRetry(caSecret *v1.Secret,
 		_, scrtErr := csc.client.Secrets(caSecret.Namespace).Update(caSecret)
 		if scrtErr == nil {
 			return nil
-		} else {
-			caSecretControllerLog.Errorf("Failed on updating CA secret %s:%s.",
-				caSecret.Namespace, caSecret.Name)
 		}
+		caSecretControllerLog.Errorf("Failed on updating CA secret %s:%s.",
+			caSecret.Namespace, caSecret.Name)
+
 		if time.Since(start) > timeout {
 			caSecretControllerLog.Errorf("Timeout on updating CA secret %s:%s.",
 				caSecret.Namespace, caSecret.Name)

--- a/security/pkg/k8s/controller/casecret.go
+++ b/security/pkg/k8s/controller/casecret.go
@@ -15,11 +15,9 @@
 package controller
 
 import (
-	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
@@ -45,54 +43,37 @@ func NewCaSecretController(core corev1.CoreV1Interface) *CaSecretController {
 // LoadCASecretWithRetry reads CA secret with retries until timeout.
 func (csc *CaSecretController) LoadCASecretWithRetry(secretName, namespace string,
 	retryInterval, timeout time.Duration) (*v1.Secret, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	caSecret, scrtErr := csc.client.Secrets(namespace).Get(secretName, metav1.GetOptions{})
-	if scrtErr != nil && !errors.IsNotFound(scrtErr) {
-		caSecretControllerLog.Errorf("Failed to read secret that holds CA certificate: %s. "+
-			"Wait until secret %s:%s can be loaded", scrtErr.Error(), namespace, secretName)
-		ticker := time.NewTicker(retryInterval)
-		for scrtErr != nil {
-			select {
-			case <-ticker.C:
-				if caSecret, scrtErr = csc.client.Secrets(namespace).Get(secretName, metav1.GetOptions{}); scrtErr == nil {
-					break
-				}
-			case <-ctx.Done():
-				caSecretControllerLog.Errorf("Timeout on loading CA secret %s:%s.", namespace, secretName)
-				ticker.Stop()
-				break
-			}
+	start := time.Now()
+	var caSecret *v1.Secret
+	var scrtErr error
+	for {
+		caSecret, scrtErr = csc.client.Secrets(namespace).Get(secretName, metav1.GetOptions{})
+		if scrtErr == nil {
+			return caSecret, scrtErr
 		}
+		if time.Since(start) > timeout {
+			caSecretControllerLog.Errorf("Timeout on loading CA secret %s:%s.",
+				namespace, secretName)
+			return caSecret, scrtErr
+		}
+		time.Sleep(retryInterval)
 	}
-	return caSecret, scrtErr
 }
 
 // UpdateCASecretWithRetry updates CA secret with retries until timeout.
 func (csc *CaSecretController) UpdateCASecretWithRetry(caSecret *v1.Secret,
 	retryInterval, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	_, scrtErr := csc.client.Secrets(caSecret.Namespace).Update(caSecret)
-	if scrtErr != nil {
-		caSecretControllerLog.Errorf("Failed to update CA secret: %s. Wait until "+
-			"secret %s:%s can be updated", scrtErr.Error(), caSecret.Namespace, caSecret.Name)
-		ticker := time.NewTicker(retryInterval)
-		for scrtErr != nil {
-			select {
-			case <-ticker.C:
-				if caSecret, scrtErr = csc.client.Secrets(caSecret.Namespace).Update(caSecret); scrtErr == nil {
-					break
-				}
-			case <-ctx.Done():
-				caSecretControllerLog.Errorf("Timeout on updating CA secret %s:%s.",
-					caSecret.Namespace, caSecret.Name)
-				ticker.Stop()
-				break
-			}
+	start := time.Now()
+	for {
+		_, scrtErr := csc.client.Secrets(caSecret.Namespace).Update(caSecret)
+		if scrtErr == nil {
+			return nil
 		}
+		if time.Since(start) > timeout {
+			caSecretControllerLog.Errorf("Timeout on updating CA secret %s:%s.",
+				caSecret.Namespace, caSecret.Name)
+			return scrtErr
+		}
+		time.Sleep(retryInterval)
 	}
-	return scrtErr
 }

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -568,12 +568,11 @@ func (sc *SecretController) tryToSyncKeyCertBundle(rootCertInMem, caCertInMem []
 			return rootCertInMem, fmt.Errorf("failed to reload root cert into KeyCertBundle (%v)", err)
 		}
 		k8sControllerLog.Info("Successfully reloaded root cert into KeyCertBundle.")
-		sc.lastKCBSyncTime = time.Now()
 	} else {
 		k8sControllerLog.Info("CA cert in KeyCertBundle matches CA cert in " +
 			"istio-ca-secret. Skip reloading root cert into KeyCertBundle")
 	}
-
+	sc.lastKCBSyncTime = time.Now()
 	return rootCertInMem, nil
 }
 

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -50,8 +50,9 @@ var (
 	certChain       = []byte("fake cert chain")
 	rootCert        = []byte("fake root cert")
 	signedCert      = []byte("fake signed cert")
-	istioTestSecret = k8ssecret.BuildSecret("test", "istio.test", "test-ns", certChain, caKey, rootCert, nil, nil, IstioSecretType)
-	cert1Pem        = `
+	istioTestSecret = k8ssecret.BuildSecret("test", "istio.test", "test-ns",
+		certChain, caKey, rootCert, nil, nil, IstioSecretType)
+	cert1Pem = `
 -----BEGIN CERTIFICATE-----
 MIIC3jCCAcagAwIBAgIJAMwyWk0iqlOoMA0GCSqGSIb3DQEBCwUAMBwxGjAYBgNV
 BAoMEWs4cy5jbHVzdGVyLmxvY2FsMB4XDTE4MDkyMTAyMjAzNFoXDTI4MDkxODAy

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -90,7 +90,7 @@ type IstioCAOptions struct {
 }
 
 // NewSelfSignedIstioCAOptions returns a new IstioCAOptions instance using self-signed certificate.
-func NewSelfSignedIstioCAOptions(ctx context.Context, readSigningCertOnly bool,
+func NewSelfSignedIstioCAOptions(ctx context.Context,
 	rootCertGracePeriodPercentile int, caCertTTL, rootCertCheckInverval, certTTL,
 	maxCertTTL time.Duration, org string, dualUse bool, namespace string,
 	readCertRetryInterval time.Duration, client corev1.CoreV1Interface,
@@ -120,17 +120,16 @@ func NewSelfSignedIstioCAOptions(ctx context.Context, readSigningCertOnly bool,
 		CertTTL:    certTTL,
 		MaxCertTTL: maxCertTTL,
 		RotatorConfig: &SelfSignedCARootCertRotatorConfig{
-			CheckInterval:       rootCertCheckInverval,
-			caCertTTL:           caCertTTL,
-			retryInterval:       cmd.ReadSigningCertRetryInterval,
-			certInspector:       certutil.NewCertUtil(rootCertGracePeriodPercentile),
-			caStorageNamespace:  namespace,
-			dualUse:             dualUse,
-			readSigningCertOnly: readSigningCertOnly,
-			org:                 org,
-			rootCertFile:        rootCertFile,
-			enableJitter:        enableJitter,
-			client:              client,
+			CheckInterval:      rootCertCheckInverval,
+			caCertTTL:          caCertTTL,
+			retryInterval:      cmd.ReadSigningCertRetryInterval,
+			certInspector:      certutil.NewCertUtil(rootCertGracePeriodPercentile),
+			caStorageNamespace: namespace,
+			dualUse:            dualUse,
+			org:                org,
+			rootCertFile:       rootCertFile,
+			enableJitter:       enableJitter,
+			client:             client,
 		},
 	}
 	if scrtErr != nil {

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -96,10 +96,9 @@ func TestCreateSelfSignedIstioCAWithoutSecret(t *testing.T) {
 	const caNamespace = "default"
 	client := fake.NewSimpleClientset()
 	rootCertFile := ""
-	readSigningCertOnly := false
 	rootCertCheckInverval := time.Hour
 
-	caopts, err := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly,
+	caopts, err := NewSelfSignedIstioCAOptions(context.Background(),
 		0, caCertTTL, rootCertCheckInverval, defaultCertTTL,
 		maxCertTTL, org, false, caNamespace, -1, client.CoreV1(),
 		rootCertFile, false)
@@ -188,10 +187,9 @@ func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 	org := "test.ca.Org"
 	caNamespace := "default"
 	const rootCertFile = ""
-	readSigningCertOnly := false
 	rootCertCheckInverval := time.Hour
 
-	caopts, err := NewSelfSignedIstioCAOptions(context.Background(), readSigningCertOnly,
+	caopts, err := NewSelfSignedIstioCAOptions(context.Background(),
 		0, caCertTTL, rootCertCheckInverval, certTTL, maxCertTTL,
 		org, false, caNamespace, -1, client.CoreV1(),
 		rootCertFile, false)
@@ -254,7 +252,6 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 	org := "test.ca.Org"
 	caNamespace := "default"
 	const rootCertFile = ""
-	readSigningCertOnly := true
 	rootCertCheckInverval := time.Hour
 
 	client := fake.NewSimpleClientset()
@@ -263,7 +260,7 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 	expectedErr := "secret waiting thread is terminated"
 	ctx0, cancel0 := context.WithTimeout(context.Background(), time.Millisecond*50)
 	defer cancel0()
-	_, err := NewSelfSignedIstioCAOptions(ctx0, readSigningCertOnly, 0,
+	_, err := NewSelfSignedIstioCAOptions(ctx0, 0,
 		caCertTTL, certTTL, rootCertCheckInverval, maxCertTTL, org, false,
 		caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile, false)
 	if err == nil {
@@ -282,7 +279,7 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	defer cancel1()
-	caopts, err := NewSelfSignedIstioCAOptions(ctx1, readSigningCertOnly, 0,
+	caopts, err := NewSelfSignedIstioCAOptions(ctx1, 0,
 		caCertTTL, certTTL, rootCertCheckInverval, maxCertTTL, org, false,
 		caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile, false)
 	if err != nil {

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
@@ -17,18 +17,19 @@ package ca
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	ktesting "k8s.io/client-go/testing"
 
 	"istio.io/istio/security/pkg/cmd"
 
-	k8ssecret "istio.io/istio/security/pkg/k8s/secret"
 	"istio.io/istio/security/pkg/pki/util"
 	certutil "istio.io/istio/security/pkg/util"
 )
@@ -68,93 +69,6 @@ func TestRootCertRotatorWithoutRootCertSecret(t *testing.T) {
 	caSecret, err := client0.Secrets(rotator0.config.caStorageNamespace).Get(CASecret, metav1.GetOptions{})
 	if !errors.IsNotFound(err) || caSecret != nil {
 		t.Errorf("CA secret should not exist, but get %v: %v", caSecret, err)
-	}
-
-	// Verifies that in read only mode, root cert rotator does not create CA secret.
-	readOnlyCaOptions := getDefaultSelfSignedIstioCAOptions(nil)
-	readOnlyCaOptions.RotatorConfig.readSigningCertOnly = true
-	rotator1 := getRootCertRotator(readOnlyCaOptions)
-	client1 := rotator1.config.client
-	client1.Secrets(rotator1.config.caStorageNamespace).Delete(CASecret, &metav1.DeleteOptions{})
-
-	rotator1.checkAndRotateRootCert()
-	caSecret, err = client1.Secrets(rotator1.config.caStorageNamespace).Get(CASecret, metav1.GetOptions{})
-	if !errors.IsNotFound(err) || caSecret != nil {
-		t.Errorf("CA secret should not exist, but get %v: %v", caSecret, err)
-	}
-}
-
-// TestRootCertRotatorForReadOnlyCitadel verifies that rotator updates local
-// key cert bundle if root cert secret is rotated.
-func TestRootCertRotatorForReadOnlyCitadel(t *testing.T) {
-	client := fake.NewSimpleClientset().CoreV1()
-	// Create CA secret
-	signingCertPem := []byte(cert1Pem)
-	signingKeyPem := []byte(key1Pem)
-	caSecret := k8ssecret.BuildSecret("", CASecret, caNamespace,
-		nil, nil, nil, signingCertPem, signingKeyPem, istioCASecretType)
-	_, err := client.Secrets(caNamespace).Create(caSecret)
-	if err != nil {
-		t.Fatalf("Failed to create CA secret: %v", err)
-	}
-
-	// Create root cert rotator with the same k8s client.
-	readOnlyCaOptions := getDefaultSelfSignedIstioCAOptions(client)
-	readOnlyCaOptions.RotatorConfig.readSigningCertOnly = true
-	rotator := getRootCertRotator(readOnlyCaOptions)
-
-	// Verifies that the read-only Citadel has loaded root cert into key cert bundle.
-	rootCertFromBundle := rotator.ca.keyCertBundle.GetRootCertPem()
-	if !bytes.Equal(rootCertFromBundle, caSecret.Data[caCertID]) {
-		t.Fatalf("Root cert in key cert bundle should match the root cert in CA secret. %v vs %v",
-			rootCertFromBundle, caSecret.Data[caCertID])
-	}
-
-	// Verifies if CA secret is not changed, rotates root cert is no-op
-	rotator.checkAndRotateRootCert()
-	rootCertFromBundle1 := rotator.ca.keyCertBundle.GetRootCertPem()
-	if !bytes.Equal(rootCertFromBundle1, rootCertFromBundle) {
-		t.Errorf("Root cert in the key cert bundle should remain the same.")
-	}
-
-	// Make a copy of root cert from config map.
-	rootCertInConfigMap, _ := rotator.configMapController.GetCATLSRootCert()
-
-	// Change the root cert and private key in CA secret to let rotator rotate root cert.
-	pemCert, pemKey, ckErr := util.GenCertKeyFromOptions(util.CertOptions{
-		TTL:          1 * time.Hour,
-		Org:          "org",
-		IsCA:         true,
-		IsSelfSigned: true,
-		RSAKeySize:   caKeySize,
-		IsDualUse:    false,
-	})
-	if ckErr != nil {
-		t.Fatalf("Unable to generate CA cert and key for self-signed CA (%v)", ckErr)
-	}
-	caSecret.Data[caCertID] = pemCert
-	caSecret.Data[caPrivateKeyID] = pemKey
-	newCaSecret, err := client.Secrets(rotator.config.caStorageNamespace).Update(caSecret)
-	if err != nil {
-		t.Fatalf("Failed to update CA secret: %v", err)
-	}
-	if bytes.Equal(rootCertFromBundle, newCaSecret.Data[caCertID]) {
-		t.Fatal("Root cert in key cert bundle should not match root cert in CA secret now")
-	}
-
-	// Verifies that after rotation, root cert in the key cert bundle has been updated.
-	rotator.checkAndRotateRootCert()
-	rootCertFromBundle = rotator.ca.keyCertBundle.GetRootCertPem()
-	if !bytes.Equal(rootCertFromBundle, newCaSecret.Data[caCertID]) {
-		t.Errorf("Root cert in the key cert bundle should have been updated")
-	}
-
-	// Because root cert rotator does not update the root cert in config map. That
-	// root cert from config map should remain the same.
-	rootCertInConfigMap2, _ := rotator.configMapController.GetCATLSRootCert()
-	if rootCertInConfigMap != rootCertInConfigMap2 {
-		t.Errorf("Unexpected root cert change in config map, %s vs %s",
-			rootCertInConfigMap, rootCertInConfigMap2)
 	}
 }
 
@@ -198,9 +112,7 @@ func loadCert(rotator *SelfSignedCARootCertRotator) rootCertItem {
 // TestRootCertRotatorForSigningCitadel verifies that rotator rotates root cert,
 // updates key cert bundle and config map.
 func TestRootCertRotatorForSigningCitadel(t *testing.T) {
-	readOnlyCaOptions := getDefaultSelfSignedIstioCAOptions(nil)
-	readOnlyCaOptions.RotatorConfig.readSigningCertOnly = false
-	rotator := getRootCertRotator(readOnlyCaOptions)
+	rotator := getRootCertRotator(getDefaultSelfSignedIstioCAOptions(nil))
 
 	// Make a copy of CA secret, a copy of root cert form key cert bundle, and
 	// a copy of root cert from config map for verification.
@@ -225,9 +137,7 @@ func TestRootCertRotatorForSigningCitadel(t *testing.T) {
 // rotator reloads root cert into KeyCertBundle if the root cert in key cert bundle is
 // different from istio-ca-secret.
 func TestKeyCertBundleReloadInRootCertRotatorForSigningCitadel(t *testing.T) {
-	readOnlyCaOptions := getDefaultSelfSignedIstioCAOptions(nil)
-	readOnlyCaOptions.RotatorConfig.readSigningCertOnly = false
-	rotator := getRootCertRotator(readOnlyCaOptions)
+	rotator := getRootCertRotator(getDefaultSelfSignedIstioCAOptions(nil))
 
 	// Mutate the root cert and private key as if they are rotated by other Citadel.
 	certItem0 := loadCert(rotator)
@@ -270,12 +180,48 @@ func TestKeyCertBundleReloadInRootCertRotatorForSigningCitadel(t *testing.T) {
 	}
 }
 
+// TestRollbackAtRootCertRotatorForSigningCitadel verifies that rotator rollbacks
+// new root cert if it fails to update new root cert into configmap.
+func TestRollbackAtRootCertRotatorForSigningCitadel(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	rotator := getRootCertRotator(getDefaultSelfSignedIstioCAOptions(fakeClient))
+
+	// Make a copy of CA secret, a copy of root cert form key cert bundle, and
+	// a copy of root cert from config map for verification.
+	certItem0 := loadCert(rotator)
+
+	// Change grace period percentage to 100, so that root cert is guarantee to rotate.
+	rotator.config.certInspector = certutil.NewCertUtil(100)
+	fakeClient.PrependReactor("update", "configmaps", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, &v1.ConfigMap{}, errors.NewUnauthorized("no permission to update configmap")
+	})
+	rotator.checkAndRotateRootCert()
+	certItem1 := loadCert(rotator)
+	// Verify that root cert does not change.
+	verifyRootCertAndPrivateKey(t, true, certItem0, certItem1)
+}
+
+func checkActions(actual, expected []ktesting.Action) error {
+	if len(actual) != len(expected) {
+		return fmt.Errorf("unexpected number of actions, want %d but got %d", len(expected), len(actual))
+	}
+
+	for i, action := range actual {
+		expectedAction := expected[i]
+		verb := expectedAction.GetVerb()
+		resource := expectedAction.GetResource().Resource
+		if !action.Matches(verb, resource) {
+			return fmt.Errorf("unexpected %dth action, want %q but got %q", i, expectedAction, action)
+		}
+	}
+
+	return nil
+}
+
 // TestRootCertRotatorGoroutineForSigningCitadel verifies that rotator
 // periodically rotates root cert, updates key cert bundle and config map.
 func TestRootCertRotatorGoroutineForSigningCitadel(t *testing.T) {
-	readOnlyCaOptions := getDefaultSelfSignedIstioCAOptions(nil)
-	readOnlyCaOptions.RotatorConfig.readSigningCertOnly = false
-	rotator := getRootCertRotator(readOnlyCaOptions)
+	rotator := getRootCertRotator(getDefaultSelfSignedIstioCAOptions(nil))
 
 	// Make a copy of CA secret, a copy of root cert form key cert bundle, and
 	// a copy of root cert from config map for verification.
@@ -299,20 +245,20 @@ func TestRootCertRotatorGoroutineForSigningCitadel(t *testing.T) {
 	verifyRootCertAndPrivateKey(t, false, certItem1, certItem2)
 }
 
-func getDefaultSelfSignedIstioCAOptions(client corev1.CoreV1Interface) *IstioCAOptions {
+func getDefaultSelfSignedIstioCAOptions(fclient *fake.Clientset) *IstioCAOptions {
 	caCertTTL := time.Hour
 	defaultCertTTL := 30 * time.Minute
 	maxCertTTL := time.Hour
 	org := "test.ca.Org"
-	if client == nil {
-		client = fake.NewSimpleClientset().CoreV1()
+	client := fake.NewSimpleClientset().CoreV1()
+	if fclient != nil {
+		client = fclient.CoreV1()
 	}
 	rootCertFile := ""
-	readSigningCertOnly := false
 	rootCertCheckInverval := time.Hour
 
 	caopts, _ := NewSelfSignedIstioCAOptions(context.Background(),
-		readSigningCertOnly, cmd.DefaultRootCertGracePeriodPercentile, caCertTTL,
+		cmd.DefaultRootCertGracePeriodPercentile, caCertTTL,
 		rootCertCheckInverval, defaultCertTTL, maxCertTTL, org, false,
 		caNamespace, -1, client, rootCertFile, false)
 	return caopts

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
@@ -201,23 +201,6 @@ func TestRollbackAtRootCertRotatorForSigningCitadel(t *testing.T) {
 	verifyRootCertAndPrivateKey(t, true, certItem0, certItem1)
 }
 
-func checkActions(actual, expected []ktesting.Action) error {
-	if len(actual) != len(expected) {
-		return fmt.Errorf("unexpected number of actions, want %d but got %d", len(expected), len(actual))
-	}
-
-	for i, action := range actual {
-		expectedAction := expected[i]
-		verb := expectedAction.GetVerb()
-		resource := expectedAction.GetResource().Resource
-		if !action.Matches(verb, resource) {
-			return fmt.Errorf("unexpected %dth action, want %q but got %q", i, expectedAction, action)
-		}
-	}
-
-	return nil
-}
-
 // TestRootCertRotatorGoroutineForSigningCitadel verifies that rotator
 // periodically rotates root cert, updates key cert bundle and config map.
 func TestRootCertRotatorGoroutineForSigningCitadel(t *testing.T) {

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
@@ -17,7 +17,6 @@ package ca
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"testing"
 	"time"
 


### PR DESCRIPTION
- Remove ```readSigningCertOnly``` from rotator config, and keep rotator behaves the same in read-only Citadel and self-signed Citadel.
- Add a rollback step when root cert rotation fails, to keep the root cert consistently in ```istio-ca-secret```, in memory keycertbundle, and configmap ```istio-security```.
- Fix the update of KCBSyncTime in workload secret controller
- Simplifies the retry logic in casecret.go and configmap.go

#17059