### PR TITLE
The format of template has been changed since 1.2

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -414,7 +414,7 @@ global:
   # NOTE: If using templates, follow the pattern in the commented example below.
   # podDNSSearchNamespaces:
   # - global
-  # - "[[ valueOrDefault .DeploymentMeta.Namespace \"default\" ]].global"
+  # - "{{ valueOrDefault .DeploymentMeta.Namespace \"default\" }}.global"
 
   # If set to true, the pilot and citadel mtls will be exposed on the
   # ingress gateway


### PR DESCRIPTION
The format of template has been changed since 1.2. Change the comment to the one we are currently using:
For example: https://raw.githubusercontent.com/istio/istio/release-1.2/install/kubernetes/helm/istio/example-values/values-istio-multicluster-gateways.yaml
```
  - "{{ valueOrDefault .DeploymentMeta.Namespace \"default\" }}.global"
```
, otherwise it will trigger error:
```
Internal error occurred: admission webhook "sidecar-injector.istio.io" denied the request: failed parsing generated injected YAML (check Istio sidecar injector configuration): error converting YAML to JSON: yaml: line 169: did not find expected '-' indicator
```