### PR TITLE
disable SNI-DNAT at ingress gateway by default

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -119,11 +119,12 @@ istio-ingressgateway:
     mountPath: /etc/istio/ingressgateway-ca-certs
   ### Advanced options ############
 
-  #env:
-    # A gateway with this mode ensures that pilot generates an additional
-    # set of clusters for internal services but without Istio mTLS, to
+  env:
+    # By default, a gateway is in "standard" mode. If the mode is set to "sni-dnat", 
+    # pilot generates an additional
+    # set of clusters for internal services without Istio mTLS, to
     # enable cross cluster routing. Enable when using multi-cluster routing.
-    # ISTIO_META_ROUTER_MODE: "sni-dnat"
+    ISTIO_META_ROUTER_MODE: "standard"
   nodeSelector: {}
   tolerations: []
 
@@ -189,7 +190,7 @@ istio-egressgateway:
     secretName: istio-egressgateway-ca-certs
     mountPath: /etc/istio/egressgateway-ca-certs
   #### Advanced options ########
-  #env:
+  env:
     # Set this to "external" if and only if you want the egress gateway to
     # act as a transparent SNI gateway that routes mTLS/TLS traffic to
     # external services defined using service entries, where the service
@@ -198,10 +199,12 @@ istio-egressgateway:
     # the egress gateway sees the same set of endpoints as the sidecars
     # preserving backward compatibility
     # ISTIO_META_REQUESTED_NETWORK_VIEW: ""
-    # A gateway with this mode ensures that pilot generates an additional
+
+    # By default, a gateway is in "standard" mode. If the mode is set to "sni-dnat", 
+    # pilot generates an additional 
     # set of clusters for internal services but without Istio mTLS, to
     # enable cross cluster routing.
-    # ISTIO_META_ROUTER_MODE: "sni-dnat"
+    ISTIO_META_ROUTER_MODE: "standard"
   nodeSelector: {}
   tolerations: []
   

--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -122,8 +122,8 @@ istio-ingressgateway:
   env:
     # A gateway with this mode ensures that pilot generates an additional
     # set of clusters for internal services but without Istio mTLS, to
-    # enable cross cluster routing.
-    ISTIO_META_ROUTER_MODE: "sni-dnat"
+    # enable cross cluster routing. Enable when using multi-cluster routing.
+    # ISTIO_META_ROUTER_MODE: "sni-dnat"
   nodeSelector: {}
   tolerations: []
 
@@ -201,7 +201,7 @@ istio-egressgateway:
     # A gateway with this mode ensures that pilot generates an additional
     # set of clusters for internal services but without Istio mTLS, to
     # enable cross cluster routing.
-    ISTIO_META_ROUTER_MODE: "sni-dnat"
+    # ISTIO_META_ROUTER_MODE: "sni-dnat"
   nodeSelector: {}
   tolerations: []
   

--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -119,7 +119,7 @@ istio-ingressgateway:
     mountPath: /etc/istio/ingressgateway-ca-certs
   ### Advanced options ############
 
-  env:
+  #env:
     # A gateway with this mode ensures that pilot generates an additional
     # set of clusters for internal services but without Istio mTLS, to
     # enable cross cluster routing. Enable when using multi-cluster routing.
@@ -189,7 +189,7 @@ istio-egressgateway:
     secretName: istio-egressgateway-ca-certs
     mountPath: /etc/istio/egressgateway-ca-certs
   #### Advanced options ########
-  env:
+  #env:
     # Set this to "external" if and only if you want the egress gateway to
     # act as a transparent SNI gateway that routes mTLS/TLS traffic to
     # external services defined using service entries, where the service


### PR DESCRIPTION
SNI-DNAT is only useful for multi-cluster routing where each cluster has separate control planes, and the ingress gateway in a cluster forwards traffic to the destination by parsing the SNI to identify the local service. Enabling this by default will double the number of clusters that the ingress gateway has, increasing memory and CPU. Since most users wont need this out of the box, let us disable this for now and let users enable this explicitly