### PR TITLE
remove unused validation message types

### DIFF
--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -13,17 +13,9 @@ var (
 	// Description: There was an internal error in the toolchain. This is almost always a bug in the implementation.
 	InternalError = diag.NewMessageType(diag.Error, "IST0001", "Internal error: %v")
 
-	// NotYetImplemented defines a diag.MessageType for message "NotYetImplemented".
-	// Description: A feature that the configuration is depending on is not implemented yet.
-	NotYetImplemented = diag.NewMessageType(diag.Error, "IST0002", "Not yet implemented: %s")
-
-	// ParseError defines a diag.MessageType for message "ParseError".
-	// Description: There was a parse error during the parsing of the configuration text
-	ParseError = diag.NewMessageType(diag.Warning, "IST0003", "Parse error: %s")
-
 	// Deprecated defines a diag.MessageType for message "Deprecated".
 	// Description: A feature that the configuration is depending on is now deprecated.
-	Deprecated = diag.NewMessageType(diag.Warning, "IST0004", "Deprecated: %s")
+	Deprecated = diag.NewMessageType(diag.Warning, "IST0002", "Deprecated: %s")
 
 	// ReferencedResourceNotFound defines a diag.MessageType for message "ReferencedResourceNotFound".
 	// Description: A resource being referenced does not exist.
@@ -66,24 +58,6 @@ var (
 func NewInternalError(entry *resource.Entry, detail string) diag.Message {
 	return diag.NewMessage(
 		InternalError,
-		originOrNil(entry),
-		detail,
-	)
-}
-
-// NewNotYetImplemented returns a new diag.Message based on NotYetImplemented.
-func NewNotYetImplemented(entry *resource.Entry, detail string) diag.Message {
-	return diag.NewMessage(
-		NotYetImplemented,
-		originOrNil(entry),
-		detail,
-	)
-}
-
-// NewParseError returns a new diag.Message based on ParseError.
-func NewParseError(entry *resource.Entry, detail string) diag.Message {
-	return diag.NewMessage(
-		ParseError,
 		originOrNil(entry),
 		detail,
 	)

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -10,26 +10,8 @@ messages:
       - name: detail
         type: string
 
-  - name: "NotYetImplemented"
-    code: IST0002
-    level: Error
-    description: "A feature that the configuration is depending on is not implemented yet."
-    template: "Not yet implemented: %s"
-    args:
-      - name: detail
-        type: string
-
-  - name: "ParseError"
-    code: IST0003
-    level: Warning
-    description: "There was a parse error during the parsing of the configuration text"
-    template: "Parse error: %s"
-    args:
-      - name: detail
-        type: string
-
   - name: "Deprecated"
-    code: IST0004
+    code: IST0002
     level: Warning
     description: "A feature that the configuration is depending on is now deprecated."
     template: "Deprecated: %s"


### PR DESCRIPTION
Remove validation message types that we aren't using (and so far seem unlikely to need). We can re-add them if they end up being useful, but in the meantime they'll just clutter up our auto-generated documentation. 