### PR TITLE
fix flaky TestProcessor_Publishing test

### DIFF
--- a/galley/pkg/runtime/publish/strategy.go
+++ b/galley/pkg/runtime/publish/strategy.go
@@ -142,7 +142,10 @@ func (s *Strategy) startTimer() {
 			case <-s.resetChan:
 				// Reset should be invoked only on stopped or expired timers with drained channels.
 				if !s.timer.Stop() {
-					<-s.timer.C
+					select {
+					case <-s.timer.C:
+					default:
+					}
 				}
 				s.timer.Reset(s.timerFrequency)
 			case <-ctx.Done():


### PR DESCRIPTION
This PR fixes a few issues:

* Non-deterministic code leading to flakey tests. TestProcessor_Publishing 
  generates two input events: FullSync and Add. If the time between events 
  is small the runtime processor publishes a single snapshot. If the time is 
  larger than the publish strategy's queise period the runtime processor
  publishes two snapshots.

* fixed a bug in the publish strateg's time reset code which could
  lead to deadlock.

* Remove duplicate tests. TestProcessor_EventAccumulation, and
  TestProcessor_EventAccumulation_WithFullSync were identical
  line-for-line. Both duplicated logic already covered by
  TestProcessor_Publishing. The only difference between the tests was
  the method of waiting for snapshots (time.Sleep vs. function hook).

fixes https://github.com/istio/istio/issues/18258
