### PR TITLE
do not call instance handlers for service entry

### DIFF
--- a/pilot/pkg/serviceregistry/external/controller_test.go
+++ b/pilot/pkg/serviceregistry/external/controller_test.go
@@ -86,7 +86,7 @@ func TestController(t *testing.T) {
 			Resolution: networking.ServiceEntry_STATIC,
 		},
 	}
-	expectedCount := int64(7) // 1 service + 6 instances
+	expectedCount := int64(1) // 1 service - We do not call instance handlers any more.
 
 	_, err = configController.Create(cfg)
 	if err != nil {

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -66,17 +66,14 @@ func NewServiceDiscovery(callbacks model.ConfigStoreCache, store model.IstioConf
 			c.updateNeeded = true
 			c.changeMutex.Unlock()
 
+			// TODO : Currently any update to ServiceEntry triggers a full push. We need to identify what has actually
+			// changed and call appropriate handlers - for example call only service handler for the changed services
+			// and call instance handlers only when instance update happens. This requires us to rework the handlers to
+			// have both old and new objects so that they can compare and be smart.
 			services := convertServices(config)
 			for _, handler := range c.serviceHandlers {
 				for _, service := range services {
 					go handler(service, event)
-				}
-			}
-
-			instances := convertInstances(config, services)
-			for _, handler := range c.instanceHandlers {
-				for _, instance := range instances {
-					go handler(instance, event)
 				}
 			}
 		})


### PR DESCRIPTION
Currently instance handlers for service entry are ineffective because we call service handler in all cases and it triggers a full push.