### PR TITLE
Include virtualservice mirror destinations in analysis

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -172,6 +172,7 @@ var testGrid = []testCase{
 		expected: []message{
 			{msg.ReferencedResourceNotFound, "VirtualService reviews-bogushost.default"},
 			{msg.ReferencedResourceNotFound, "VirtualService reviews-bookinfo-other.default"},
+			{msg.ReferencedResourceNotFound, "VirtualService reviews-mirror-bogushost.default"},
 		},
 	},
 	{
@@ -180,6 +181,7 @@ var testGrid = []testCase{
 		analyzer:   &virtualservice.DestinationRuleAnalyzer{},
 		expected: []message{
 			{msg.ReferencedResourceNotFound, "VirtualService reviews-bogussubset.default"},
+			{msg.ReferencedResourceNotFound, "VirtualService reviews-mirror-bogussubset.default"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
@@ -128,6 +128,21 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
+  name: reviews-mirror
+  namespace: default
+spec:
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+    mirror: # Includes mirroring, but should not generate any errors
+      host: reviews
+      subset: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
   name: reviews-mirror-bogushost
   namespace: default
 spec:

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
@@ -124,3 +124,18 @@ spec:
   - route:
     - destination:
         host: other.bookinfo.com # Should generate validation error, the SE is in another namespace
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-mirror-bogushost
+  namespace: default
+spec:
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+    mirror:
+      host: reviews-bogus # This host does not exist, should result in a validation error
+      subset: v1

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationrules.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationrules.yaml
@@ -45,3 +45,18 @@ spec:
     - destination:
         host: reviews.default.svc.cluster.local # FQDN representation is valid and should not generate an error
         subset: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-mirror-bogussubset
+  namespace: default
+spec:
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+    mirror:
+      host: reviews
+      subset: bogus # This subset does not exist, should result in a validation error

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationrules.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationrules.yaml
@@ -49,6 +49,21 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
+  name: reviews-mirror
+  namespace: default
+spec:
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+    mirror: # Includes mirroring, but should not generate any errors
+      host: reviews
+      subset: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
   name: reviews-mirror-bogussubset
   namespace: default
 spec:

--- a/galley/pkg/config/analysis/analyzers/virtualservice/util.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/util.go
@@ -34,6 +34,11 @@ func getRouteDestinations(vs *v1alpha3.VirtualService) []*v1alpha3.Destination {
 		for _, rd := range r.GetRoute() {
 			destinations = append(destinations, rd.GetDestination())
 		}
+		// If there is a mirror destination, check it too
+		m := r.GetMirror()
+		if m != nil {
+			destinations = append(destinations, m)
+		}
 	}
 
 	return destinations


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/17999

Mirror destinations should be checked for correctness just like route destinations.