### PR TITLE
Reenable mtls test

### DIFF
--- a/tests/integration/istioio/security/mtls_migration_test.go
+++ b/tests/integration/istioio/security/mtls_migration_test.go
@@ -25,7 +25,6 @@ import (
 //https://istio.io/docs/tasks/security/mtls-migration/
 //https://github.com/istio/istio.io/blob/release-1.2/content/docs/tasks/security/mtls-migration/index.md
 func TestMutualTLSMigration(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/17909")
 
 	framework.
 		NewTest(t).


### PR DESCRIPTION

I'm unable to reproduce the failure locally, so re-enabling the mTLS test and trying in prow. This may already be fixed as a side-effect of framework changes.