### PR TITLE
Fix CRD jobs to have DNS-compatible names

### DIFF
--- a/install/kubernetes/helm/istio-init/templates/job-crd-all.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-all.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: istio-init-crd-all-{{ .Values.global.tag | printf "%v" | trunc 32 }}
+  name: istio-init-crd-all-{{ .Values.global.tag | printf "%v" | trunc 32 | trimSuffix "-" }}
 spec:
   template:
     metadata:

--- a/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-10.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-10.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: istio-init-crd-certmanager-10-{{ .Values.global.tag | printf "%v" | trunc 32 }}
+  name: istio-init-crd-certmanager-10-{{ .Values.global.tag | printf "%v" | trunc 32 | trimSuffix "-" }}
 spec:
   template:
     metadata:

--- a/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-11.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-11.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: istio-init-crd-certmanager-11-{{ .Values.global.tag | printf "%v" | trunc 32 }}
+  name: istio-init-crd-certmanager-11-{{ .Values.global.tag | printf "%v" | trunc 32 | trimSuffix "-" }}
 spec:
   template:
     metadata:

--- a/install/kubernetes/helm/istio-init/templates/job-crd-mixer.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-mixer.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: istio-init-crd-mixer-{{ .Values.global.tag | printf "%v" | trunc 32 }}
+  name: istio-init-crd-mixer-{{ .Values.global.tag | printf "%v" | trunc 32 | trimSuffix "-" }}
 spec:
   template:
     metadata:

--- a/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
@@ -56,7 +56,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-grafana-post-install-{{ .Values.global.tag | printf "%v" | trunc 32 }}
+  name: istio-grafana-post-install-{{ .Values.global.tag | printf "%v" | trunc 32 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install

--- a/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
@@ -60,7 +60,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-security-post-install-{{ .Values.global.tag | printf "%v" | trunc 32  }}
+  name: istio-security-post-install-{{ .Values.global.tag | printf "%v" | trunc 32 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade


### PR DESCRIPTION
The name field of CRD jobs comes from a truncated .Value.global.tag.
This could end in a hyphen, which is not a legal k8s name.
Trim any hyphen from the end of the name.