### PR TITLE
remove export ISTIOCTL_BIN

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -59,8 +59,6 @@ function download_untar_istio_release() {
 
   wget  -q "${LINUX_DIST_URL}" -P "${dir}"
   tar -xzf "${dir}/istio-${tag}-linux.tar.gz" -C "${dir}"
-
-  export ISTIOCTL_BIN="${GOPATH}/src/istio.io/istio/istio-${TAG}/bin/istioctl"
 }
 
 function build_images() {


### PR DESCRIPTION
fix error for `istio-upgrade-helm-chart` job
```
+ LINUX_DIST_URL=https://github.com/istio/istio/releases/download/1.3.1/istio-1.3.1-linux.tar.gz
+ wget -q https://github.com/istio/istio/releases/download/1.3.1/istio-1.3.1-linux.tar.gz -P from_dir.75a7KI
+ tar -xzf from_dir.75a7KI/istio-1.3.1-linux.tar.gz -C from_dir.75a7KI
/home/prow/go/src/istio.io/istio/prow/lib.sh: line 63: TAG: unbound variable
```

We do not need the `ISTIOCTL_BIN` environment variable, since in test_crossgrade.sh, we have set the correct `istioclt` binary path.