### PR TITLE
Fix delete istio-operator namespace error

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -625,11 +625,6 @@ func (k *KubeInfo) Teardown() error {
 	log.Infof("Deleting namespace %v", k.Namespace)
 	for attempts := 1; attempts <= maxAttempts; attempts++ {
 		if *useOperator {
-			if _, err := util.Shell("kubectl delete ns istio-operator --kubeconfig=%s",
-				k.KubeConfig); err != nil {
-				log.Errorf("Failed to delete istio-operator namespace.")
-				return err
-			}
 			namespaceDeleted = true
 		} else {
 			namespaceDeleted, _ = util.NamespaceDeleted(k.Namespace, k.KubeConfig)

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -625,7 +625,7 @@ func (k *KubeInfo) Teardown() error {
 	log.Infof("Deleting namespace %v", k.Namespace)
 	for attempts := 1; attempts <= maxAttempts; attempts++ {
 		if *useOperator {
-			namespaceDeleted = true
+			namespaceDeleted, _ = util.NamespaceDeleted("istio-operator", k.KubeConfig)
 		} else {
 			namespaceDeleted, _ = util.NamespaceDeleted(k.Namespace, k.KubeConfig)
 		}


### PR DESCRIPTION
Fix error in operator e2e like:

```
Command output: 
Error from server (NotFound): namespaces "istio-operator" not found
2019-10-31T02:44:23.502124Z	info	Command error: exit status 1
2019-10-31T02:44:23.502143Z	error	Failed to delete istio-operator namespace.
2019-10-31T02:44:23.502158Z	error	Failed to cleanup. Error command failed: "Error from server (NotFound): namespaces \"istio-operator\" not found\n" exit status 1
```