### PR TITLE
create slice with capacity, when capacity is known

### DIFF
--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -76,14 +76,14 @@ func getProxyInfo() (*[]istioVersion.ProxyInfo, error) {
 		return nil, err
 	}
 
-	pi := []istioVersion.ProxyInfo{}
+	var pi []istioVersion.ProxyInfo
 	for _, syncz := range allSyncz {
 		var sss []*sidecarSyncStatus
 		err = json.Unmarshal(syncz, &sss)
 		if err != nil {
 			return nil, err
 		}
-
+		pi = make([]istioVersion.ProxyInfo, 0, len(sss))
 		for _, ss := range sss {
 			pi = append(pi, istioVersion.ProxyInfo{
 				ID:           ss.ProxyID,


### PR DESCRIPTION
This reduces the number of allocations made to the underlying array, while append() attempts to 'grow' the slice beyond its initial capacity