### PR TITLE
Revert "create slice with capacity, when capacity is known"

### DIFF
--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -76,14 +76,14 @@ func getProxyInfo() (*[]istioVersion.ProxyInfo, error) {
 		return nil, err
 	}
 
-	var pi []istioVersion.ProxyInfo
+	pi := []istioVersion.ProxyInfo{}
 	for _, syncz := range allSyncz {
 		var sss []*sidecarSyncStatus
 		err = json.Unmarshal(syncz, &sss)
 		if err != nil {
 			return nil, err
 		}
-		pi = make([]istioVersion.ProxyInfo, 0, len(sss))
+
 		for _, ss := range sss {
 			pi = append(pi, istioVersion.ProxyInfo{
 				ID:           ss.ProxyID,


### PR DESCRIPTION
Reverts istio/istio#18504
This PR introduces a regression, and throws away results from other Pilot instances when there are multiple