### PR TITLE
Drop dependency of controllers for DiscoveryService

### DIFF
--- a/pilot/pkg/config/coredatamodel/syntheticserviceentrycontroller.go
+++ b/pilot/pkg/config/coredatamodel/syntheticserviceentrycontroller.go
@@ -105,10 +105,6 @@ func (c *SyntheticServiceEntryController) Apply(change *sink.Change) error {
 	if change.Collection != schemas.SyntheticServiceEntry.Collection {
 		return fmt.Errorf("apply: type not supported %s", change.Collection)
 	}
-	// Apply is getting called with no changes!!
-	if len(change.Objects) == 0 {
-		return nil
-	}
 
 	defer atomic.AddUint32(&c.synced, 1)
 

--- a/pilot/pkg/config/coredatamodel/syntheticserviceentrycontroller.go
+++ b/pilot/pkg/config/coredatamodel/syntheticserviceentrycontroller.go
@@ -108,6 +108,10 @@ func (c *SyntheticServiceEntryController) Apply(change *sink.Change) error {
 
 	defer atomic.AddUint32(&c.synced, 1)
 
+	if len(change.Objects) == 0 {
+		return nil
+	}
+
 	if change.Incremental {
 		// removed first
 		c.removeConfig(change.Removed)

--- a/pilot/pkg/proxy/envoy/v2/bench_test.go
+++ b/pilot/pkg/proxy/envoy/v2/bench_test.go
@@ -66,8 +66,7 @@ func SetupDiscoveryServer(t testing.TB, cfgs ...model.Config) *DiscoveryServer {
 	if err := env.PushContext.InitContext(env, env.PushContext, nil); err != nil {
 		t.Fatal(err)
 	}
-	s := NewDiscoveryServer(env, v1alpha3.NewConfigGenerator([]plugin.Plugin{}),
-		serviceControllers, nil, configController)
+	s := NewDiscoveryServer(env, v1alpha3.NewConfigGenerator([]plugin.Plugin{}))
 	if err := s.updateServiceShards(s.globalPushContext()); err != nil {
 		t.Fatalf("Failed to update service shards: %v", err)
 	}

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -637,18 +637,6 @@ func writeAllADS(w io.Writer) {
 }
 
 func (s *DiscoveryServer) ready(w http.ResponseWriter, req *http.Request) {
-	if s.ConfigController != nil {
-		if !s.ConfigController.HasSynced() {
-			w.WriteHeader(503)
-			return
-		}
-	}
-	if s.KubeController != nil {
-		if !s.KubeController.HasSynced() {
-			w.WriteHeader(503)
-			return
-		}
-	}
 	w.WriteHeader(200)
 }
 

--- a/pkg/istiod/pilotstart.go
+++ b/pkg/istiod/pilotstart.go
@@ -650,7 +650,6 @@ func (s *Server) initGrpcServer(options *istiokeepalive.Options) {
 	s.EnvoyXdsServer.Register(s.GrpcServer)
 }
 
-
 // initEventHandlers sets up event handlers for config and service updates
 func (s *Server) initEventHandlers() error {
 	// Flush cached discovery responses whenever services configuration change.
@@ -699,7 +698,6 @@ func (s *Server) initEventHandlers() error {
 
 	return nil
 }
-
 
 func (s *Server) grpcServerOptions(options *istiokeepalive.Options) []grpc.ServerOption {
 	interceptors := []grpc.UnaryServerInterceptor{


### PR DESCRIPTION
Attempt to decouple things a bit. Rather than registering the handlers
in NewDiscovery, break this part out and register independantly.
Additionally, do the cache sync before we create the DiscoveryService
rather than as part of Ready(); instead, just don't start the service
until the cache has synced.
