### PR TITLE
Support principals in source.principal.

### DIFF
--- a/pilot/pkg/security/authz/builder/integration_test.go
+++ b/pilot/pkg/security/authz/builder/integration_test.go
@@ -106,6 +106,18 @@ func TestBuildHTTPFilter(t *testing.T) {
 			policies:          getPolicies("testdata/v1beta1/simple-policy-principal-with-*-in.yaml", t),
 			want:              getProto("testdata/v1beta1/simple-policy-principal-with-*-out.yaml", t),
 		},
+		{
+			name:              "v1alpha1 trust domain aliases with source.principal",
+			trustDomainBundle: trustdomain.NewTrustDomainBundle("new-td", []string{"old-td", "some-trustdomain"}),
+			policies:          getPolicies("testdata/v1alpha1/td-aliases-source-principal-in.yaml", t),
+			want:              getProto("testdata/v1alpha1/td-aliases-source-principal-out.yaml", t),
+		},
+		{
+			name:              "v1beta1 trust domain aliases with source.principal",
+			trustDomainBundle: trustdomain.NewTrustDomainBundle("new-td", []string{"old-td", "some-trustdomain"}),
+			policies:          getPolicies("testdata/v1beta1/td-aliases-source-principal-in.yaml", t),
+			want:              getProto("testdata/v1beta1/td-aliases-source-principal-out.yaml", t),
+		},
 	}
 
 	httpbinLabels := map[string]string{

--- a/pilot/pkg/security/authz/builder/testdata/v1alpha1/td-aliases-source-principal-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1alpha1/td-aliases-source-principal-in.yaml
@@ -1,0 +1,36 @@
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ClusterRbacConfig
+metadata:
+  name: default
+spec:
+  mode: 'ON_WITH_INCLUSION'
+  inclusion:
+    namespaces: ["foo"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: httpbin-viewer
+  namespace: foo
+spec:
+  rules:
+    - services: ["httpbin.foo.svc.cluster.local"]
+      methods: ["GET"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: bind-httpbin-viewer
+  namespace: foo
+spec:
+  subjects:
+    - group: "some-group"
+    - properties:
+        source.principal: "*"
+    - properties:
+        source.principal: "*/ns/foo/sa/all-td"
+    - properties:
+        source.principal: "*-td/ns/foo/sa/prefix-td"
+  roleRef:
+    kind: ServiceRole
+    name: httpbin-viewer

--- a/pilot/pkg/security/authz/builder/testdata/v1alpha1/td-aliases-source-principal-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1alpha1/td-aliases-source-principal-out.yaml
@@ -1,0 +1,54 @@
+rules:
+              policies:
+                httpbin-viewer:
+                  permissions:
+                  - andRules:
+                      rules:
+                      - orRules:
+                          rules:
+                          - header:
+                              exactMatch: GET
+                              name: :method
+                  principals:
+                  - andIds:
+                      ids:
+                      - metadata:
+                          filter: istio_authn
+                          path:
+                          - key: request.auth.claims
+                          - key: groups
+                          value:
+                            listMatch:
+                              oneOf:
+                                stringMatch:
+                                  exact: some-group
+                  - andIds:
+                      ids:
+                      - any: true
+                  - andIds:
+                      ids:
+                      - metadata:
+                          filter: istio_authn
+                          path:
+                          - key: source.principal
+                          value:
+                            stringMatch:
+                              suffix: /ns/foo/sa/all-td
+                  - andIds:
+                      ids:
+                      - orIds:
+                          ids:
+                          - metadata:
+                              filter: istio_authn
+                              path:
+                              - key: source.principal
+                              value:
+                                stringMatch:
+                                  suffix: -td/ns/foo/sa/prefix-td
+                          - metadata:
+                              filter: istio_authn
+                              path:
+                              - key: source.principal
+                              value:
+                                stringMatch:
+                                  exact: some-trustdomain/ns/foo/sa/prefix-td

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/td-aliases-source-principal-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/td-aliases-source-principal-in.yaml
@@ -1,0 +1,17 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+    - from:
+        - source:
+            namespaces: ["istio-system"]
+      when:
+        - key: "source.principal"
+          values: ["*", "*/ns/foo/sa/all-td", "*-td/ns/foo/sa/prefix-td"]

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/td-aliases-source-principal-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/td-aliases-source-principal-out.yaml
@@ -1,0 +1,49 @@
+rules:
+              policies:
+                ns[foo]-policy[httpbin]-rule[0]:
+                  permissions:
+                  - andRules:
+                      rules:
+                      - any: true
+                  principals:
+                  - andIds:
+                      ids:
+                      - orIds:
+                          ids:
+                          - metadata:
+                              filter: istio_authn
+                              path:
+                              - key: source.principal
+                              value:
+                                stringMatch:
+                                  regex: .*/ns/istio-system/.*
+                      - orIds:
+                          ids:
+                          - metadata:
+                              filter: istio_authn
+                              path:
+                              - key: source.principal
+                              value:
+                                stringMatch:
+                                  regex: .+
+                          - metadata:
+                              filter: istio_authn
+                              path:
+                              - key: source.principal
+                              value:
+                                stringMatch:
+                                  suffix: /ns/foo/sa/all-td
+                          - metadata:
+                              filter: istio_authn
+                              path:
+                              - key: source.principal
+                              value:
+                                stringMatch:
+                                  suffix: -td/ns/foo/sa/prefix-td
+                          - metadata:
+                              filter: istio_authn
+                              path:
+                              - key: source.principal
+                              value:
+                                stringMatch:
+                                  exact: some-trustdomain/ns/foo/sa/prefix-td

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -159,6 +159,8 @@ func NewModelV1alpha1(trustDomainBundle trustdomain.Bundle, role *istio_rbac.Ser
 			for k, v := range subject.Properties {
 				values := []string{v}
 				if k == attrSrcPrincipal {
+					// TODO(pitlv2109): Refactor this by creating a method for Principal
+					// that searches and replaces all trust domains in both v1alpha1 and v1beta1.
 					values = trustDomainBundle.ReplaceTrustDomainAliases([]string{v})
 				}
 				property[k] = values

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -157,7 +157,11 @@ func NewModelV1alpha1(trustDomainBundle trustdomain.Bundle, role *istio_rbac.Ser
 
 			property := KeyValues{}
 			for k, v := range subject.Properties {
-				property[k] = []string{v}
+				values := []string{v}
+				if k == attrSrcPrincipal {
+					values = trustDomainBundle.ReplaceTrustDomainAliases([]string{v})
+				}
+				property[k] = values
 			}
 			principal.Properties = []KeyValues{property}
 
@@ -176,7 +180,11 @@ func NewModelV1beta1(trustDomainBundle trustdomain.Bundle, rule *security.Rule) 
 	conditionsForPermission := make([]KeyValues, 0)
 	for _, when := range rule.When {
 		if isSupportedPrincipal(when.Key) {
-			conditionsForPrincipal = append(conditionsForPrincipal, KeyValues{when.Key: when.Values})
+			values := when.Values
+			if when.Key == attrSrcPrincipal {
+				values = trustDomainBundle.ReplaceTrustDomainAliases(when.Values)
+			}
+			conditionsForPrincipal = append(conditionsForPrincipal, KeyValues{when.Key: values})
 		} else if isSupportedPermission(when.Key) {
 			conditionsForPermission = append(conditionsForPermission, KeyValues{when.Key: when.Values})
 		} else {

--- a/pilot/pkg/security/trustdomain/bundle.go
+++ b/pilot/pkg/security/trustdomain/bundle.go
@@ -38,7 +38,6 @@ type Bundle struct {
 }
 
 func NewTrustDomainBundle(trustDomain string, trustDomainAliases []string) Bundle {
-
 	return Bundle{
 		// Put the new trust domain to the beginning of the list to avoid changing existing tests.
 		TrustDomains: append([]string{trustDomain}, trustDomainAliases...),

--- a/pilot/pkg/security/trustdomain/bundle.go
+++ b/pilot/pkg/security/trustdomain/bundle.go
@@ -90,10 +90,17 @@ func (t Bundle) replaceTrustDomains(principal, trustDomainFromPrincipal string) 
 		// If the trust domain has a prefix * (e.g. *local from *local/ns/foo/ns/bar), keep the principal
 		// as-is for the matched trust domain. For others, replace the trust domain with the new trust domain
 		// or alias.
+		var newPrincipal string
 		if suffixMatch(td, trustDomainFromPrincipal) {
-			principalsForAliases = append(principalsForAliases, principal)
+			newPrincipal = principal
 		} else {
-			principalsForAliases = append(principalsForAliases, replaceTrustDomainInPrincipal(td, principal))
+			newPrincipal = replaceTrustDomainInPrincipal(td, principal)
+		}
+		// Check to make sure we don't generate duplicated principals. This happens when trust domain
+		// has a * prefix. For example, "*-td" can match with "old-td" and "new-td", but we only want
+		// to keep the principal as-is in the generated config, .i.e. *-td.
+		if !isKeyInList(newPrincipal, principalsForAliases) {
+			principalsForAliases = append(principalsForAliases, newPrincipal)
 		}
 	}
 	return principalsForAliases

--- a/pilot/pkg/security/trustdomain/bundle_test.go
+++ b/pilot/pkg/security/trustdomain/bundle_test.go
@@ -100,6 +100,13 @@ func TestReplaceTrustDomainAliases(t *testing.T) {
 			principals:        []string{"/ns/some-ns/sa/some-sa"},
 			expect:            []string{"/ns/some-ns/sa/some-sa"},
 		},
+		{
+			name:              "No duplicated principals for prefix",
+			trustDomainBundle: NewTrustDomainBundle("new-td", []string{"old-td"}),
+			principals:        []string{"*-td/ns/some-ns/sa/some-sa"},
+			// Rather than output *-td/ns/some-ns/sa/some-sa once for each trust domain.
+			expect:            []string{"*-td/ns/some-ns/sa/some-sa"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pilot/pkg/security/trustdomain/util.go
+++ b/pilot/pkg/security/trustdomain/util.go
@@ -48,3 +48,12 @@ func suffixMatch(a string, pattern string) bool {
 	pattern = strings.TrimPrefix(pattern, "*")
 	return strings.HasSuffix(a, pattern)
 }
+
+func isKeyInList(key string, list []string) bool {
+	for _, l := range list {
+		if key == l {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This is for trust domain migration:
* Support principals in source.principal.
* Handle duplicated principals from * prefix.