### PR TITLE
remove default True value for UPGRADE_TEST_LOCAL

### DIFF
--- a/prow/upgrade-tests.sh
+++ b/prow/upgrade-tests.sh
@@ -41,7 +41,7 @@ export FROM_PATH=${FROM_PATH:-"$(mktemp -d from_dir.XXXXXX)"}
 export TO_PATH=${TO_PATH:-"$(mktemp -d to_dir.XXXXXX)"}
 
 # Set to any non-empty value to use kubectl configured cluster instead of mason provisioned cluster.
-UPGRADE_TEST_LOCAL="${UPGRADE_TEST_LOCAL:-"true"}"
+UPGRADE_TEST_LOCAL="${UPGRADE_TEST_LOCAL:-""}"
 
 echo "Testing upgrade and downgrade between ${SOURCE_HUB}/${SOURCE_TAG} and ${TARGET_HUB}/${TARGET_TAG}"
 

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -31,11 +31,11 @@ const (
 )
 
 var BuiltInChainsMap = map[string]struct{}{
-	INPUT:       struct{}{},
-	OUTPUT:      struct{}{},
-	FORWARD:     struct{}{},
-	PREROUTING:  struct{}{},
-	POSTROUTING: struct{}{},
+	INPUT:       {},
+	OUTPUT:      {},
+	FORWARD:     {},
+	PREROUTING:  {},
+	POSTROUTING: {},
 }
 
 // Constants used for generating iptables commands


### PR DESCRIPTION
fix `The connection to the server localhost:8080 was refused - did you specify the right host or port?` error