### PR TITLE
Fixes linter error

### DIFF
--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -31,11 +31,11 @@ const (
 )
 
 var BuiltInChainsMap = map[string]struct{}{
-	INPUT:       struct{}{},
-	OUTPUT:      struct{}{},
-	FORWARD:     struct{}{},
-	PREROUTING:  struct{}{},
-	POSTROUTING: struct{}{},
+	INPUT:       {},
+	OUTPUT:      {},
+	FORWARD:     {},
+	PREROUTING:  {},
+	POSTROUTING: {},
 }
 
 // Constants used for generating iptables commands


### PR DESCRIPTION
This code got merged without passing gofmt in the linter and is now failing (see https://github.com/istio/istio/pull/18528). This PR just runs gofmt.  