### PR TITLE
allows for customization of sds ingress secrets namespace from helm chart

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -75,11 +75,15 @@ spec:
             value: "false"
           - name: "ENABLE_INGRESS_GATEWAY_SDS"
             value: "true"
-          - name: "INGRESS_GATEWAY_NAMESPACE"
+          - name: "INGRESS_GATEWAY_SECRETS_NAMESPACE"
+{{- if $spec.sds.secretsNamespace }}
+            value: {{ $spec.sds.secretsNamespace }}
+{{- else }}
             valueFrom:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
+{{- end }}
           volumeMounts:
           - name: ingressgatewaysdsudspath
             mountPath: /var/run/ingress_gateway

--- a/install/kubernetes/helm/istio/charts/gateways/templates/role.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/role.yaml
@@ -6,7 +6,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $key }}-sds
+  {{- if $spec.sds.secretsNamespace }}
+  namespace: {{ $spec.sds.secretsNamespace }}
+  {{- else }}
   namespace: {{ $spec.namespace | default $.Release.Namespace }}
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources: ["secrets"]

--- a/install/kubernetes/helm/istio/charts/gateways/templates/rolebindings.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/rolebindings.yaml
@@ -6,7 +6,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $key }}-sds
+  {{- if $spec.sds.secretsNamespace }}
+  namespace: {{ $spec.sds.secretsNamespace }}
+  {{- else }}
   namespace: {{ $spec.namespace | default $.Release.Namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -18,6 +18,8 @@ istio-ingressgateway:
     # SDS server that watches kubernetes secrets and provisions credentials to ingress gateway.
     # This server runs in the same pod as ingress gateway.
     image: node-agent-k8s
+    # Namespace to watch for kubernetes secrets
+    secretsNamespace: ""
     resources:
       requests:
         cpu: 100m

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher.go
@@ -53,7 +53,7 @@ const (
 	tlsScrtKey = "tls.key"
 
 	// IngressSecretNamespace the namespace of kubernetes secrets to watch.
-	ingressSecretNamespace = "INGRESS_GATEWAY_NAMESPACE"
+	ingressSecretNamespace = "INGRESS_GATEWAY_SECRETS_NAMESPACE"
 
 	// IngressGatewaySdsCaSuffix is the suffix of the sds resource name for root CA. All resource
 	// names for ingress gateway root certs end with "-cacert".

--- a/tests/integration/security/sds_ingress/single_tls_gateway_custom_secrets_namespace/main_test.go
+++ b/tests/integration/security/sds_ingress/single_tls_gateway_custom_secrets_namespace/main_test.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package singletlsgateway
+package singletlsgatewaycustomsecretsnamespace
 
 import (
 	"testing"

--- a/tests/integration/security/sds_ingress/single_tls_gateway_custom_secrets_namespace/main_test.go
+++ b/tests/integration/security/sds_ingress/single_tls_gateway_custom_secrets_namespace/main_test.go
@@ -1,0 +1,65 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package singletlsgateway
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst istio.Instance
+	g    galley.Instance
+	p    pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	// Integration test for the ingress SDS Gateway (with custom secrets namespace) flow.
+	framework.
+		NewSuite("sds_ingress_single_tls_gateway_custom_secrets_namespace_test", m).
+		Label(label.CustomSetup).
+		Label(label.Flaky).
+	SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// Enable SDS key/certificate provisioning for ingress gateway.
+	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
+	// Use custom SDS secrets namespace
+	cfg.Values["gateways.istio-ingressgateway.sds.secretsNamespace"] = "foo"
+}

--- a/tests/integration/security/sds_ingress/single_tls_gateway_custom_secrets_namespace/single_tls_gateway_custom_secrets_namespace.go
+++ b/tests/integration/security/sds_ingress/single_tls_gateway_custom_secrets_namespace/single_tls_gateway_custom_secrets_namespace.go
@@ -1,0 +1,81 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package singletlsgateway
+
+import (
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/ingress"
+	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
+)
+
+var (
+	credName = []string{"bookinfo-credential-1"}
+	host     = "bookinfo1.example.com"
+)
+
+func TestSingleTlsGateway_CustomSecretNamespace(t *testing.T) {
+	framework.
+		NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			// Add kubernetes secret to provision key/cert for ingress gateway.
+			ingressutil.CreateIngressKubeSecret(t, ctx, credName, ingress.TLS, ingressutil.IngressCredentialA)
+			ingressutil.DeployBookinfo(t, ctx, g, ingressutil.SingleTLSGateway)
+
+			ingA := ingress.NewOrFail(t, ctx, ingress.Config{Istio: inst})
+			err := ingressutil.WaitUntilGatewaySdsStatsGE(t, ingA, 1, 10*time.Second)
+			if err != nil {
+				t.Errorf("sds update stats does not match: %v", err)
+			}
+			// Expect 2 active listeners, one listens on 443 and the other listens on 15090
+			err = ingressutil.WaitUntilGatewayActiveListenerStatsGE(t, ingA, 2, 60*time.Second)
+			if err != nil {
+				t.Errorf("total active listener stats does not match: %v", err)
+			}
+			tlsContext := ingressutil.TLSContext{CaCert: ingressutil.CaCertA}
+			err = ingressutil.VisitProductPage(ingA, host, ingress.TLS, tlsContext, 30*time.Second,
+				ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""}, t)
+			if err != nil {
+				t.Errorf("unable to retrieve 200 from product page at host %s: %v", host, err)
+			}
+
+			// key/cert rotation
+			ingressutil.RotateSecrets(t, ctx, credName, ingress.TLS, ingressutil.IngressCredentialB)
+			err = ingressutil.WaitUntilGatewaySdsStatsGE(t, ingA, 2, 10*time.Second)
+			if err != nil {
+				t.Errorf("sds update stats does not match: %v", err)
+			}
+
+			// Client use old server CA cert to set up SSL connection would fail.
+			err = ingressutil.VisitProductPage(ingA, host, ingress.TLS, tlsContext, 30*time.Second,
+				ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"}, t)
+			if err != nil {
+				t.Errorf("unable to retrieve 404 from product page at host %s: %v", host, err)
+			}
+
+			// Client use new server CA cert to set up SSL connection.
+			tlsContext = ingressutil.TLSContext{CaCert: ingressutil.CaCertB}
+			ingB := ingress.NewOrFail(t, ctx, ingress.Config{Istio: inst})
+			err = ingressutil.VisitProductPage(ingB, host, ingress.TLS, tlsContext, 30*time.Second,
+				ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""}, t)
+			if err != nil {
+				t.Errorf("unable to retrieve 200 from product page at host %s: %v", host, err)
+			}
+		})
+}

--- a/tests/integration/security/sds_ingress/single_tls_gateway_custom_secrets_namespace/single_tls_gateway_custom_secrets_namespace.go
+++ b/tests/integration/security/sds_ingress/single_tls_gateway_custom_secrets_namespace/single_tls_gateway_custom_secrets_namespace.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package singletlsgateway
+package singletlsgatewaycustomsecretsnamespace
 
 import (
 	"testing"


### PR DESCRIPTION
Signed-off-by: Marshall Ford <inbox@marshallford.me>

See title. Allows for ingress certificate secrets to be managed in a different namespace then where istio was installed. Piggybacks off of this closed PR: #13345. 


- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
