### PR TITLE
Optimizes SyntheticServiceEntries discovery to read from cache

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -270,7 +270,6 @@ type Server struct {
 	mux                   *http.ServeMux
 	kubeRegistry          *controller2.Controller
 	fileWatcher           filewatcher.FileWatcher
-	discoveryOptions      *coredatamodel.DiscoveryOptions
 	mcpDiscovery          *coredatamodel.MCPDiscovery
 	incrementalMcpOptions *coredatamodel.Options
 	mcpOptions            *coredatamodel.Options
@@ -774,10 +773,7 @@ func (s *Server) sseMCPController(args *PilotArgs,
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 	}
 	controller := coredatamodel.NewSyntheticServiceEntryController(s.incrementalMcpOptions)
-	s.discoveryOptions = &coredatamodel.DiscoveryOptions{
-		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
-	}
-	s.mcpDiscovery = coredatamodel.NewMCPDiscovery(controller, s.discoveryOptions)
+	s.mcpDiscovery = coredatamodel.NewMCPDiscovery(controller)
 	incrementalSinkOptions := &sink.Options{
 		CollectionOptions: []sink.CollectionOptions{
 			{
@@ -1019,8 +1015,6 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 		clusterID := args.Config.ControllerOptions.ClusterID
 		s.incrementalMcpOptions.XDSUpdater = s.EnvoyXdsServer
 		s.incrementalMcpOptions.ClusterID = clusterID
-		s.discoveryOptions.Env = environment
-		s.discoveryOptions.ClusterID = clusterID
 	}
 
 	// Implement EnvoyXdsServer grace shutdown

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -271,6 +271,7 @@ type Server struct {
 	kubeRegistry          *controller2.Controller
 	fileWatcher           filewatcher.FileWatcher
 	mcpDiscovery          *coredatamodel.MCPDiscovery
+	discoveryOptions      *coredatamodel.DiscoveryOptions
 	incrementalMcpOptions *coredatamodel.Options
 	mcpOptions            *coredatamodel.Options
 	certController        *chiron.WebhookController
@@ -773,7 +774,10 @@ func (s *Server) sseMCPController(args *PilotArgs,
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 	}
 	controller := coredatamodel.NewSyntheticServiceEntryController(s.incrementalMcpOptions)
-	s.mcpDiscovery = coredatamodel.NewMCPDiscovery(controller)
+	s.discoveryOptions = &coredatamodel.DiscoveryOptions{
+		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
+	}
+	s.mcpDiscovery = coredatamodel.NewMCPDiscovery(controller, s.discoveryOptions)
 	incrementalSinkOptions := &sink.Options{
 		CollectionOptions: []sink.CollectionOptions{
 			{
@@ -1015,6 +1019,8 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 		clusterID := args.Config.ControllerOptions.ClusterID
 		s.incrementalMcpOptions.XDSUpdater = s.EnvoyXdsServer
 		s.incrementalMcpOptions.ClusterID = clusterID
+		s.discoveryOptions.Env = environment
+		s.discoveryOptions.ClusterID = clusterID
 	}
 
 	// Implement EnvoyXdsServer grace shutdown

--- a/pilot/pkg/config/coredatamodel/controller_test.go
+++ b/pilot/pkg/config/coredatamodel/controller_test.go
@@ -162,7 +162,7 @@ var (
 	}
 
 	syntheticServiceEntry2 = &networking.ServiceEntry{
-		Hosts: []string{"example2.com"},
+		Hosts: []string{"example3.com"},
 		Ports: []*networking.Port{
 			{Number: 80, Name: "http-port2", Protocol: "http"},
 			{Number: 8080, Name: "http-alt-port2", Protocol: "http"},

--- a/pilot/pkg/config/coredatamodel/controller_test.go
+++ b/pilot/pkg/config/coredatamodel/controller_test.go
@@ -147,7 +147,7 @@ var (
 		Endpoints: []*networking.ServiceEntry_Endpoint{
 			{
 				Address: "2.2.2.2",
-				Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
+				Ports:   map[string]uint32{"http-port": 9080, "http-alt-port": 18081},
 			},
 			{
 				Address: "3.3.3.3",
@@ -157,6 +157,23 @@ var (
 				Address: "5.5.5.5",
 				Ports:   map[string]uint32{"http-port": 1081},
 				Labels:  map[string]string{"foo1": "bar1"},
+			},
+		},
+	}
+
+	syntheticServiceEntry2 = &networking.ServiceEntry{
+		Hosts: []string{"example2.com"},
+		Ports: []*networking.Port{
+			{Number: 80, Name: "http-port2", Protocol: "http"},
+			{Number: 8080, Name: "http-alt-port2", Protocol: "http"},
+		},
+		Location:   networking.ServiceEntry_MESH_EXTERNAL,
+		Resolution: networking.ServiceEntry_DNS,
+		Endpoints: []*networking.ServiceEntry_Endpoint{
+			{
+				Address: "2.2.2.2",
+				Ports:   map[string]uint32{"http-port2": 7082, "http-alt-port2": 18082},
+				Labels:  map[string]string{"foo3": "bar3"},
 			},
 		},
 	}

--- a/pilot/pkg/config/coredatamodel/discovery_test.go
+++ b/pilot/pkg/config/coredatamodel/discovery_test.go
@@ -54,9 +54,8 @@ var (
 )
 
 // Since service instance is representation of a service with a corresponding backend port
-// the following ServiceEntry plus a notReadyEndpoint 4.4.4.4:5555 should  yield into 10
+// the following ServiceEntry plus a notReadyEndpoint 4.4.4.4:5555 should  yield into 4
 // service instances once flattened. That is one endpoints IP + endpoint Port, per service Port, per service host.
-// However GetProxyServiceInstances should only return all the ones with 4.4.4.4 IP address since they match the
 // given proxy address
 // e.g:
 //	&networking.ServiceEntry{
@@ -85,47 +84,66 @@ var (
 // notReadyEndpoint 4.4.4.4:5555
 // should result in the following service instances:
 //
-// NetworkEndpoint(endpoint{Address:2.2.2.2, Port:18080, servicePort: &{http-port 80 http}} service:{Hostname: svc.example2.com})
-// NetworkEndpoint(endpoint{Address:2.2.2.2, Port:7080, servicePort: &{http-port 80 http}} service:{Hostname: svc.example2.com})
-// NetworkEndpoint(endpoint{Address:2.2.2.2, Port:18080, servicePort: &{http-alt-port 8080 http}} service:{Hostname: svc.example2.com})
-// NetworkEndpoint(endpoint{Address:2.2.2.2, Port:7080, servicePort: &{http-alt-port 8080 http}} service:{Hostname: svc.example2.com})
-// NetworkEndpoint(endpoint{Address:3.3.3.3, Port:1080, servicePort: &{http-alt-port 8080 http}} service:{Hostname: svc.example2.com})
-// NetworkEndpoint(endpoint{Address:3.3.3.3, Port:1080, servicePort: &{http-port 80 http}} service:{Hostname: svc.example2.com})
 // NetworkEndpoint(endpoint{Address:4.4.4.4, Port:5555, servicePort: &{http-port 80 http}} service:{Hostname: svc.example2.com})
-// NetworkEndpoint(endpoint{Address:4.4.4.4, Port:1080, servicePort: &{http-port 80 http}} service:{Hostname: svc.example2.com})
 // NetworkEndpoint(endpoint{Address:4.4.4.4, Port:5555, servicePort: &{http-alt-port 8080 http}} service:{Hostname: svc.example2.com})
-// NetworkEndpoint(endpoint{Address:4.4.4.4, Port:1080, servicePort: &{http-alt-port 8080 http}} service:{Hostname: svc.example2.com})
+// NetworkEndpoint(endpoint{Address:4.4.4.4, Port:1080, servicePort: &{http-port 80 http}} service:{Hostname: svc.example2.com})
+// NetworkEndpoint(endpoint{Address:4.4.4.4, Port:8080, servicePort: &{http-alt-port 8080 http}} service:{Hostname: svc.example2.com})
 
 func TestGetProxyServiceInstances(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	// add first config
 	testSetup(g)
 
-	svcInstances, err := d.GetProxyServiceInstances(buildProxy("4.4.4.4"))
+	// add second config
+	message := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry1)
+
+	namespace2 := "random-namespace2"
+	change := convertToChange([]proto.Message{message},
+		[]string{fmt.Sprintf("%s/%s", namespace2, name)},
+		setCollection(schemas.SyntheticServiceEntry.Collection),
+		setTypeURL(schemas.SyntheticServiceEntry.MessageName))
+
+	err := controller.Apply(change)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(svcInstances)).To(gomega.Equal(4))
 
 	steps := map[string]struct {
-		address     string
-		ports       []int
-		servicePort []*model.Port
-		hostname    host.Name
+		namespace       string
+		address         string
+		numSvcInstances int
+		ports           []int
+		servicePort     []*model.Port
+		hostname        []host.Name
 	}{
-		"4.4.4.4": {
-			address:     "4.4.4.4",
-			ports:       []int{1080, 5555, 8080},
-			servicePort: svcPort,
-			hostname:    host.Name("svc.example2.com"),
+		"single namespace": {
+			namespace:       namespace,
+			address:         "4.4.4.4",
+			numSvcInstances: 4,
+			ports:           []int{1080, 5555, 8080},
+			servicePort:     svcPort,
+			hostname:        []host.Name{host.Name("svc.example2.com")},
+		},
+		"all namespaces": {
+			namespace:       model.NamespaceAll,
+			address:         "2.2.2.2",
+			numSvcInstances: 4,
+			ports:           []int{7080, 18080, 9080, 18081},
+			servicePort:     svcPort,
+			hostname:        []host.Name{host.Name("example2.com"), host.Name("svc.example2.com")},
 		},
 	}
 
-	t.Run("verify service instances", func(_ *testing.T) {
-		for _, svcInstance := range svcInstances {
-			step := steps[svcInstance.Endpoint.Address]
-			g.Expect(step.address).To(gomega.Equal(svcInstance.Endpoint.Address))
-			g.Expect(step.hostname).To(gomega.Equal(svcInstance.Service.Hostname))
-			g.Expect(step.ports).To(gomega.ContainElement(svcInstance.Endpoint.Port))
-		}
-	})
+	for description, step := range steps {
+		t.Run(fmt.Sprintf("verify service instances from %s", description), func(_ *testing.T) {
+			svcInstances, err := d.GetProxyServiceInstances(buildProxy(step.address, step.namespace))
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(len(svcInstances)).To(gomega.Equal(step.numSvcInstances))
+			for _, svcInstance := range svcInstances {
+				g.Expect(step.address).To(gomega.Equal(svcInstance.Endpoint.Address))
+				g.Expect(step.hostname).To(gomega.ContainElement(svcInstance.Service.Hostname))
+				g.Expect(step.ports).To(gomega.ContainElement(svcInstance.Endpoint.Port))
+			}
+		})
+	}
 }
 
 func TestInstancesByPort(t *testing.T) {
@@ -212,10 +230,10 @@ func TestInstancesByPort(t *testing.T) {
 	})
 }
 
-func TestItShouldReadFromCache(t *testing.T) {
+func TestGetProxyServiceInstancesReadsFromCache(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	testSetup(g)
-	proxy := buildProxy("4.4.4.4")
+	proxy := buildProxy("4.4.4.4", namespace)
 
 	svcInstances, err := d.GetProxyServiceInstances(proxy)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -231,6 +249,7 @@ func TestItShouldReadFromCache(t *testing.T) {
 			Namespace:         namespace,
 			CreationTimestamp: fakeCreateTime,
 		},
+		Spec: syntheticServiceEntry0,
 	}
 	d.HandleCacheEvents(conf, model.EventDelete)
 
@@ -243,29 +262,16 @@ func TestItShouldReadFromCache(t *testing.T) {
 func TestHandleCacheEvents(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	initDiscovery()
-	fakeCreateTime, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
-	conf := model.Config{
-		ConfigMeta: model.ConfigMeta{
-			Type:              schemas.ServiceEntry.Type,
-			Group:             schemas.ServiceEntry.Group,
-			Version:           schemas.ServiceEntry.Version,
-			Name:              name,
-			Namespace:         "default",
-			Domain:            "example2.com",
-			ResourceVersion:   "1",
-			CreationTimestamp: fakeCreateTime,
-			Labels:            map[string]string{"lk1": "lv1"},
-			Annotations:       map[string]string{"ak1": "av1"},
-		},
-		Spec: syntheticServiceEntry0,
-	}
 
 	// add the first config
+	conf1Ns := "default"
+	conf := buildConfig(syntheticServiceEntry0, name, conf1Ns)
+
 	d.HandleCacheEvents(conf, model.EventAdd)
 
-	svcInstances, err := d.GetProxyServiceInstances(buildProxy("4.4.4.4"))
+	svcInstances, err := d.GetProxyServiceInstances(buildProxy("4.4.4.4", conf1Ns))
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(svcInstances)).ToNot(gomega.Equal(0))
+	g.Expect(len(svcInstances)).To(gomega.Equal(2))
 	for _, s := range svcInstances {
 		g.Expect(s.Labels).To(gomega.Equal(labels.Instance{"foo": "bar"}))
 	}
@@ -282,10 +288,12 @@ func TestHandleCacheEvents(t *testing.T) {
 			Labels:  map[string]string{"foo": "bar2"},
 		},
 	}
+	conf.Spec = syntheticServiceEntry0
+
 	d.HandleCacheEvents(conf, model.EventUpdate)
-	svcInstances, err = d.GetProxyServiceInstances(buildProxy("4.4.4.4"))
+	svcInstances, err = d.GetProxyServiceInstances(buildProxy("4.4.4.4", conf1Ns))
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(svcInstances)).ToNot(gomega.Equal(0))
+	g.Expect(len(svcInstances)).To(gomega.Equal(2))
 	for _, s := range svcInstances {
 		g.Expect(s.Labels).To(gomega.Equal(labels.Instance{"foo": "bar2"}))
 	}
@@ -302,55 +310,46 @@ func TestHandleCacheEvents(t *testing.T) {
 			Labels:  map[string]string{"foo1": "bar1"},
 		},
 	}
-	conf2 := conf
-	conf2.Spec = syntheticServiceEntry1
-	conf2.ConfigMeta.Name = "test-name"
-	conf2.ConfigMeta.Namespace = "test-namespace"
+	conf2Ns := "test-namespace"
+	conf2 := buildConfig(syntheticServiceEntry1, "test-name", conf2Ns)
+
 	d.HandleCacheEvents(conf2, model.EventAdd)
-	svcInstances, err = d.GetProxyServiceInstances(buildProxy("5.5.5.5"))
+	svcInstances, err = d.GetProxyServiceInstances(buildProxy("5.5.5.5", conf2Ns))
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(svcInstances)).ToNot(gomega.Equal(0))
+	g.Expect(len(svcInstances)).To(gomega.Equal(2))
 	for _, s := range svcInstances {
 		g.Expect(s.Labels).To(gomega.Equal(labels.Instance{"foo1": "bar1"}))
 	}
 
 	// add another config in the same namespace as the second one
-	syntheticServiceEntry2 := syntheticServiceEntry1
-	syntheticServiceEntry2.Endpoints = []*networking.ServiceEntry_Endpoint{
-		{
-			Address: "2.2.2.2",
-			Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
-			Labels:  map[string]string{"foo3": "bar3"},
-		},
-	}
+	conf3Ns := "test-namespace"
+	conf3 := buildConfig(syntheticServiceEntry2, "test-name", conf3Ns)
 
-	conf3 := conf
-	conf3.Spec = syntheticServiceEntry2
-	conf3.ConfigMeta.Name = "test-name2"
-	conf3.ConfigMeta.Namespace = "test-namespace"
 	d.HandleCacheEvents(conf3, model.EventAdd)
-	svcInstances, err = d.GetProxyServiceInstances(buildProxy("2.2.2.2"))
+	proxy := buildProxy("2.2.2.2", conf3Ns)
+	svcInstances, err = d.GetProxyServiceInstances(proxy)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(svcInstances)).ToNot(gomega.Equal(0))
+	g.Expect(len(svcInstances)).To(gomega.Equal(2))
 	for _, s := range svcInstances {
 		g.Expect(s.Labels).To(gomega.Equal(labels.Instance{"foo3": "bar3"}))
 	}
 
 	// delete the first config
 	d.HandleCacheEvents(conf, model.EventDelete)
-	svcInstances, err = d.GetProxyServiceInstances(buildProxy("4.4.4.4"))
+	svcInstances, err = d.GetProxyServiceInstances(buildProxy("4.4.4.4", conf1Ns))
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(len(svcInstances)).To(gomega.Equal(0))
 
 	// delete the second config
 	d.HandleCacheEvents(conf2, model.EventDelete)
-	svcInstances, err = d.GetProxyServiceInstances(buildProxy("5.5.5.5"))
+	proxy = buildProxy("5.5.5.5", conf2Ns)
+	svcInstances, err = d.GetProxyServiceInstances(proxy)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(len(svcInstances)).To(gomega.Equal(0))
 
 	// check to see if other config in the same namespace
 	// as second config is not deleted
-	svcInstances, err = d.GetProxyServiceInstances(buildProxy("2.2.2.2"))
+	svcInstances, err = d.GetProxyServiceInstances(buildProxy("2.2.2.2", conf3Ns))
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(len(svcInstances)).ToNot(gomega.Equal(0))
 	for _, s := range svcInstances {
@@ -359,14 +358,33 @@ func TestHandleCacheEvents(t *testing.T) {
 
 	// delete the last config
 	d.HandleCacheEvents(conf3, model.EventDelete)
-	svcInstances, err = d.GetProxyServiceInstances(buildProxy("2.2.2.2"))
+	svcInstances, err = d.GetProxyServiceInstances(buildProxy("2.2.2.2", conf3Ns))
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(len(svcInstances)).To(gomega.Equal(0))
 }
 
-func buildProxy(proxyIP string) *model.Proxy {
+func buildProxy(proxyIP, ns string) *model.Proxy {
 	return &model.Proxy{
-		IPAddresses: []string{proxyIP},
+		IPAddresses:     []string{proxyIP},
+		ConfigNamespace: ns,
+	}
+}
+
+func buildConfig(se *networking.ServiceEntry, name, ns string) model.Config {
+	return model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Type:              schemas.ServiceEntry.Type,
+			Group:             schemas.ServiceEntry.Group,
+			Version:           schemas.ServiceEntry.Version,
+			Name:              name,
+			Namespace:         ns,
+			Domain:            "example2.com",
+			ResourceVersion:   "1",
+			CreationTimestamp: fakeCreateTime,
+			Labels:            map[string]string{"lk1": "lv1"},
+			Annotations:       map[string]string{"ak1": "av1"},
+		},
+		Spec: se,
 	}
 }
 
@@ -386,7 +404,6 @@ func initDiscovery() {
 		},
 	}
 	d = coredatamodel.NewMCPDiscovery(controller, options)
-
 }
 
 func testSetup(g *gomega.GomegaWithT) {

--- a/pilot/pkg/config/coredatamodel/discovery_test.go
+++ b/pilot/pkg/config/coredatamodel/discovery_test.go
@@ -94,18 +94,6 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	// add first config
 	testSetup(g)
 
-	// add second config
-	message := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry1)
-
-	namespace2 := "random-namespace2"
-	change := convertToChange([]proto.Message{message},
-		[]string{fmt.Sprintf("%s/%s", namespace2, name)},
-		setCollection(schemas.SyntheticServiceEntry.Collection),
-		setTypeURL(schemas.SyntheticServiceEntry.MessageName))
-
-	err := controller.Apply(change)
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-
 	steps := map[string]struct {
 		namespace       string
 		address         string
@@ -122,19 +110,12 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			servicePort:     svcPort,
 			hostname:        []host.Name{host.Name("svc.example2.com")},
 		},
-		"all namespaces": {
-			namespace:       model.NamespaceAll,
-			address:         "2.2.2.2",
-			numSvcInstances: 4,
-			ports:           []int{7080, 18080, 9080, 18081},
-			servicePort:     svcPort,
-			hostname:        []host.Name{host.Name("example2.com"), host.Name("svc.example2.com")},
-		},
 	}
 
 	for description, step := range steps {
 		t.Run(fmt.Sprintf("verify service instances from %s", description), func(_ *testing.T) {
-			svcInstances, err := d.GetProxyServiceInstances(buildProxy(step.address, step.namespace))
+			proxy := buildProxy(step.address, step.namespace)
+			svcInstances, err := d.GetProxyServiceInstances(proxy)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(len(svcInstances)).To(gomega.Equal(step.numSvcInstances))
 			for _, svcInstance := range svcInstances {


### PR DESCRIPTION
Introduces caching mechanism in SyntheticServiceEntries discovery. The discovery keep track of two caches one by endpoint IP the other by service hostname. The caches are being synced via Controller's event handler. 
Related issue: https://github.com/istio/istio/issues/18480

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
