### PR TITLE
Fix sds info in control plane bootstrap

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -372,6 +372,8 @@ var (
 						option.PodIP(podIP),
 						option.ControlPlaneAuth(controlPlaneAuthEnabled),
 						option.DisableReportCalls(disableInternalTelemetry),
+						option.SDSTokenPath(sdsTokenPath),
+						option.SDSUDSPath(sdsUDSPath),
 					}
 
 					// Check if nodeIP carries IPv4 or IPv6 and set up proxy accordingly


### PR DESCRIPTION
This was a regression cause in (#17478). Previously, we set these two
fields outside of the `if controlPlaneBootstrap` section, but in that
change we removed it without adding it here.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
