### PR TITLE
Add validation for regex max length

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -214,6 +214,21 @@ func ValidateHTTPHeaderName(name string) error {
 	return nil
 }
 
+// ValidateStringMatch validates a StringMatch
+func ValidateStringMatch(m *networking.StringMatch) error {
+	if m == nil {
+		return nil
+	}
+	switch x := m.MatchType.(type) {
+	case *networking.StringMatch_Regex:
+		// Default max size for safe regex is 100
+		if len(x.Regex) > 100 {
+			return fmt.Errorf("regex match '%s' cannot be greater than 100 bytes", x.Regex)
+		}
+	}
+	return nil
+}
+
 // ValidatePercent checks that percent is in range
 func ValidatePercent(val int32) error {
 	if val < 0 || val > 100 {
@@ -1980,7 +1995,15 @@ func validateHTTPRoute(http *networking.HTTPRoute) (errs error) {
 					errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))
 				}
 				errs = appendErrors(errs, ValidateHTTPHeaderName(name))
+				errs = appendErrors(errs, ValidateStringMatch(header))
 			}
+			for _, m := range match.QueryParams {
+				errs = appendErrors(errs, ValidateStringMatch(m))
+			}
+			errs = appendErrors(errs, ValidateStringMatch(match.Authority))
+			errs = appendErrors(errs, ValidateStringMatch(match.Method))
+			errs = appendErrors(errs, ValidateStringMatch(match.Scheme))
+			errs = appendErrors(errs, ValidateStringMatch(match.Uri))
 
 			if match.Port != 0 {
 				errs = appendErrors(errs, ValidatePort(int(match.Port)))

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2238,6 +2238,26 @@ func TestValidateHTTPRoute(t *testing.T) {
 			}},
 			Match: []*networking.HTTPMatchRequest{nil},
 		}, valid: true},
+		{name: "valid regex", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Regex{Regex: "foo"},
+				},
+			}},
+		}, valid: true},
+		{name: "too large regex", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Regex{Regex: strings.Repeat("a", 101)},
+				},
+			}},
+		}, valid: false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
In 1.3 and below, the max length was 1024. In 1.4, with safe_regex, this
is only 100 by default. Either way, we need some validation here.

Fixes https://github.com/istio/istio/issues/17411