### PR TITLE
[1.3] Reject HTTP listeners on port 443 (#17515)

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -221,7 +221,14 @@ var (
 		false,
 		"If enabled, for a headless service/stateful set in Kubernetes, pilot will generate an "+
 			"outbound listener for each pod in a headless service. This feature should be disabled "+
-			"if headless services have a large number of pods. ",
+			"if headless services have a large number of pods.",
+	)
+
+	BlockHTTPonHTTPSPort = env.RegisterBoolVar(
+		"PILOT_BLOCK_HTTP_ON_443",
+		false,
+		"If enabled, any HTTP services will be blocked on HTTPS port (443). If this is disabled, any "+
+			"HTTP service on port 443 could block all external traffic",
 	)
 )
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -297,6 +297,13 @@ var (
 		"Number of conflicting wildcard tcp listeners with current wildcard http listener.",
 	)
 
+	// ProxyStatusConflictOutboundListenerHTTPoverHTTPS metric tracks number of
+	// HTTP listeners that conflicted with well known HTTPS ports
+	ProxyStatusConflictOutboundListenerHTTPoverHTTPS = monitoring.NewGauge(
+		"pilot_conflict_outbound_listener_http_over_https",
+		"Number of conflicting HTTP listeners with well known HTTPS ports",
+	)
+
 	// ProxyStatusConflictOutboundListenerTCPOverTCP metric tracks number of
 	// TCP listeners that conflicted with existing TCP listeners on same port
 	ProxyStatusConflictOutboundListenerTCPOverTCP = monitoring.NewGauge(
@@ -361,6 +368,7 @@ var (
 		ProxyStatusNoService,
 		ProxyStatusEndpointNotReady,
 		ProxyStatusConflictOutboundListenerTCPOverHTTP,
+		ProxyStatusConflictOutboundListenerHTTPoverHTTPS,
 		ProxyStatusConflictOutboundListenerTCPOverTCP,
 		ProxyStatusConflictOutboundListenerHTTPOverTCP,
 		ProxyStatusConflictInboundListener,

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -135,6 +135,10 @@ const (
 	// Used in xds config. Metavalue bind to this key is used by pilot as xds server but not by envoy.
 	// So the meta data can be erased when pushing to envoy.
 	PilotMetaKey = "pilot_meta"
+
+	// CanonicalHTTPSPort defines the standard port for HTTPS traffic. To avoid conflicts, http services
+	// are not allowed on this port.
+	CanonicalHTTPSPort = 443
 )
 
 var (
@@ -1199,7 +1203,14 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(node *model.Proxy, listenerOpts buildListenerOpts,
 	pluginParams *plugin.InputParams, listenerMap map[string]*outboundListenerEntry,
 	virtualServices []model.Config, actualWildcard string) {
-
+	if features.BlockHTTPonHTTPSPort.Get() {
+		if listenerOpts.port == CanonicalHTTPSPort && pluginParams.Port.Protocol == protocol.HTTP {
+			msg := fmt.Sprintf("listener conflict detected: service %v specifies an HTTP service on HTTPS only port %d.",
+				pluginParams.Service.Hostname, CanonicalHTTPSPort)
+			pluginParams.Push.Add(model.ProxyStatusConflictOutboundListenerHTTPoverHTTPS, string(pluginParams.Service.Hostname), node, msg)
+			return
+		}
+	}
 	var destinationCIDR string
 	var listenerMapKey string
 	var currentListenerEntry *outboundListenerEntry


### PR DESCRIPTION
Main changes here are turning this OFF by default, where it is ON in 1.4, since its backwards incompatible(ish)