### PR TITLE
[1.2] Backport changes to prevent proxy startup race condition

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -404,7 +404,7 @@ func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext
 	}
 	adsLog.Infof("Cluster init time %v %s", time.Since(t0), version)
 
-	s.startPush(version, push, false, edsUpdates)
+	s.startPush(version, push, false, edsUpdates, "")
 }
 
 // WorkloadUpdate is called when workload labels/annotations are updated.
@@ -447,6 +447,10 @@ func (s *DiscoveryServer) WorkloadUpdate(id string, labels map[string]string, _ 
 			}
 			s.proxyUpdates[id] = struct{}{}
 			s.proxyUpdatesMutex.Unlock()
+			if pilot.UpdatePartialPush.Get() {
+				adsLog.Infof("Workload update detected for %v, triggering a push now", id)
+				go s.startPush(versionInfo(), s.globalPushContext(), false, nil, id)
+			}
 		}
 		return
 	}

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -189,6 +189,13 @@ var (
 			"and will be removed in the near future.",
 	)
 
+	UpdatePartialPush = env.RegisterBoolVar(
+		"PILOT_UPDATE_PARTIAL_PUSH",
+		false,
+		"If enabled, a push will be sent to a proxy when an update is detected. This can be "+
+			"useful to avoid situations where a pod gets stuck during startup due to race conditions "+
+			"when retrieving pod information.")
+
 	InitialConnectionWindowSize = env.RegisterIntVar("PILOT_INITIAL_CONNECTION_WINDOW_SIZE", 0, "specifies the window size to use for http2 connections").Get()
 
 	InitialStreamWindowSize = env.RegisterIntVar("PILOT_INITIAL_Stream_WINDOW_SIZE", 0, "specifies the window size to use for http2 streams").Get()


### PR DESCRIPTION
There has been issues with proxies failing to start up for quite some
time. On 1.3 this has been fixed by reading from Pod metadata, but this
is not possible on 1.2 without major surgery to add all the required
metadata. Instead, we can trigger a push for any proxy when we get a
workload update. This is inspired by
https://github.com/Maistra/istio/commit/c7ec7d4dfbe97812802f21c7cdb843bf62bed1a2.

This is off by default to avoid breaking users as we are late in the 1.2
release cycle.