### PR TITLE
reorganize the tcp-echo sample

### DIFF
--- a/samples/tcp-echo/tcp-echo.yaml
+++ b/samples/tcp-echo/tcp-echo.yaml
@@ -12,15 +12,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-################################################################################
-# tcp-echo service
-################################################################################
 apiVersion: v1
 kind: Service
 metadata:
   name: tcp-echo
   labels:
-    app: tcp-echo
+    service: tcp-echo
 spec:
   ports:
   - name: tcp
@@ -31,7 +28,10 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tcp-echo
+  name: tcp-echo-v1
+  labels:
+    app: tcp-echo
+    version: v1
 spec:
   replicas: 1
   selector:
@@ -48,6 +48,33 @@ spec:
       - name: tcp-echo
         image: docker.io/istio/tcp-echo-server:1.1
         imagePullPolicy: IfNotPresent
-        args: [ "9000", "hello" ]
+        args: [ "9000", "one" ]
+        ports:
+        - containerPort: 9000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-echo-v2
+  labels:
+    app: tcp-echo
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcp-echo
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: tcp-echo
+        version: v2
+    spec:
+      containers:
+      - name: tcp-echo
+        image: docker.io/istio/tcp-echo-server:1.1
+        imagePullPolicy: IfNotPresent
+        args: [ "9000", "two" ]
         ports:
         - containerPort: 9000

--- a/samples/tcp-echo/tcp-hello-echo.yaml
+++ b/samples/tcp-echo/tcp-hello-echo.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 Istio Authors
+# Copyright 2019 Istio Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/samples/tcp-echo/tcp-hello-echo.yaml
+++ b/samples/tcp-echo/tcp-hello-echo.yaml
@@ -15,60 +15,39 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: tcp-echo
+  name: tcp-hello-echo
   labels:
-    app: tcp-echo
+    service: tcp-hello-echo
 spec:
   ports:
   - name: tcp
     port: 9000
   selector:
-    app: tcp-echo
+    app: tcp-hello-echo
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tcp-echo-v1
+  name: tcp-hello-echo
+  labels:
+    app: tcp-hello-echo
+    version: v1
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: tcp-echo
+      app: tcp-hello-echo
       version: v1
   template:
     metadata:
       labels:
-        app: tcp-echo
+        app: tcp-hello-echo
         version: v1
     spec:
       containers:
-      - name: tcp-echo
+      - name: tcp-hello-echo
         image: docker.io/istio/tcp-echo-server:1.1
         imagePullPolicy: IfNotPresent
-        args: [ "9000", "one" ]
-        ports:
-        - containerPort: 9000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: tcp-echo-v2
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: tcp-echo
-      version: v2
-  template:
-    metadata:
-      labels:
-        app: tcp-echo
-        version: v2
-    spec:
-      containers:
-      - name: tcp-echo
-        image: docker.io/istio/tcp-echo-server:1.1
-        imagePullPolicy: IfNotPresent
-        args: [ "9000", "two" ]
+        args: [ "9000", "hello" ]
         ports:
         - containerPort: 9000


### PR DESCRIPTION
    1. add labels to the configuration items, so different versions can be deployed separately, e.g.:
    kubectl apply -l service=tcp-echo -f tcp-echo.yaml
    kubectl apply -l app=tcp-echo,version=v1 -f tcp-echo.yaml

    This is useful for multi-cluster/multi-mesh examples when different versions are deployed in different clusters.

    2. Rename the file names, new file names:

    tcp-echo.yaml contains two tcp-echo services, v1 and v2
    tcp-hello-echo.yaml contains the tcp-hello-echo service

    This way two different TCP services can be deployed, one of the services with two versions, and each version can be deployed selectively.