### PR TITLE
Update release-builder

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -32,7 +32,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=b6ce79ae8b17bd46287401166aa0add43b3b2c53
+BUILDER_SHA=f518f97c49f6fc80082a78894fdea8397c869f66
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha


### PR DESCRIPTION
This is needed to pull in changes to correctly build the operator docker
image.