### PR TITLE
eds: reduce locks while updating eds clusters

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -353,16 +353,6 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 
 				s.updateEdsClusters(current.Difference(previous), previous.Difference(current), con)
 
-				// removed clusters
-				for cn := range previous.Difference(current) {
-					s.removeEdsCon(cn, con.ConID)
-				}
-
-				// new added clusters
-				for cn := range current.Difference(previous) {
-					s.getOrAddEdsCluster(cn, con)
-				}
-
 				con.Clusters = clusters
 				adsLog.Debugf("ADS:EDS: REQ %s %s clusters:%d", peerAddr, con.ConID, len(con.Clusters))
 				err := s.pushEds(s.globalPushContext(), con, versionInfo(), nil)

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -351,7 +351,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				previous := sets.NewSet(con.Clusters...)
 				current := sets.NewSet(clusters...)
 
-				s.updateEdsClusters(current.Difference(previous), previous.Difference(current), con)
+				s.updateEdsClients(current.Difference(previous), previous.Difference(current), con)
 
 				con.Clusters = clusters
 				adsLog.Debugf("ADS:EDS: REQ %s %s clusters:%d", peerAddr, con.ConID, len(con.Clusters))

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -351,6 +351,8 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				previous := sets.NewSet(con.Clusters...)
 				current := sets.NewSet(clusters...)
 
+				s.updateEdsClusters(current.Difference(previous), previous.Difference(current), con)
+
 				// removed clusters
 				for cn := range previous.Difference(current) {
 					s.removeEdsCon(cn, con.ConID)

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -795,7 +795,7 @@ func (s *DiscoveryServer) removeEdsCon(clusterName string, node string) {
 	}
 }
 
-func (s *DiscoveryServer) updateEdsClusters(added sets.Set, removed sets.Set, connection *XdsConnection) {
+func (s *DiscoveryServer) updateEdsClients(added sets.Set, removed sets.Set, connection *XdsConnection) {
 	edsClusterMutex.Lock()
 	defer edsClusterMutex.Unlock()
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -803,7 +803,7 @@ func (s *DiscoveryServer) updateEdsClients(added sets.Set, removed sets.Set, con
 		c := edsClusters[rc]
 		if c == nil {
 			adsLog.Warnf("EDS: Missing cluster: %s", rc)
-			return
+			continue
 		}
 		c.mutex.Lock()
 		delete(c.EdsClients, connection.ConID)

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -772,28 +772,6 @@ func (s *DiscoveryServer) getEdsCluster(clusterName string) *EdsCluster {
 	return edsClusters[clusterName]
 }
 
-// getOrAddEdsCluster will track the eds connection with clusters, for optimized event-based push and debug
-func (s *DiscoveryServer) getOrAddEdsCluster(clusterName string, connection *XdsConnection) *EdsCluster {
-	edsClusterMutex.Lock()
-	defer edsClusterMutex.Unlock()
-
-	c := edsClusters[clusterName]
-	if c == nil {
-		c = &EdsCluster{
-			EdsClients: map[string]*XdsConnection{},
-		}
-		edsClusters[clusterName] = c
-	}
-
-	// TODO: find a more efficient way to make edsClusters and EdsClients init atomic
-	// Currently use edsClusterMutex lock
-	c.mutex.Lock()
-	c.EdsClients[connection.ConID] = connection
-	c.mutex.Unlock()
-
-	return c
-}
-
 // removeEdsCon is called when a gRPC stream is closed, for each cluster that was watched by the
 // stream. As of 0.7 envoy watches a single cluster per gprc stream.
 func (s *DiscoveryServer) removeEdsCon(clusterName string, node string) {


### PR DESCRIPTION
add/remove eds cluster currently taking a lock for every add and remove. This PR tries to aggregate the adds/removes together so that we can take lock at once.,