### PR TITLE
add collector endpoint version for zipkin

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -397,7 +397,7 @@
       "name": "envoy.zipkin",
       "config": {
         "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans",
+        "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
         "trace_id_128bit":"true",
         "shared_span_context": "false"

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -398,6 +398,7 @@
       "config": {
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v1/spans",
+        "collector_endpoint_version": "HTTP_JSON",
         "trace_id_128bit":"true",
         "shared_span_context": "false"
       }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -365,6 +365,7 @@
       "config": {
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v1/spans",
+        "collector_endpoint_version": "HTTP_JSON",
         "trace_id_128bit":"true",
         "shared_span_context":"false"
       }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -364,7 +364,7 @@
       "name": "envoy.zipkin",
       "config": {
         "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans",
+        "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
         "trace_id_128bit":"true",
         "shared_span_context":"false"

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -426,6 +426,7 @@
       "config": {
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v1/spans",
+        "collector_endpoint_version": "HTTP_JSON",
         "trace_id_128bit":"true",
         "shared_span_context":"false"
       }

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -425,7 +425,7 @@
       "name": "envoy.zipkin",
       "config": {
         "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans",
+        "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
         "trace_id_128bit":"true",
         "shared_span_context":"false"

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -317,6 +317,7 @@
       "config": {
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v1/spans",
+        "collector_endpoint_version": "HTTP_JSON",
         "trace_id_128bit":"true",
         "shared_span_context": "false"
       }

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -316,7 +316,7 @@
       "name": "envoy.zipkin",
       "config": {
         "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans",
+        "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
         "trace_id_128bit":"true",
         "shared_span_context": "false"

--- a/pkg/test/framework/components/zipkin/kube.go
+++ b/pkg/test/framework/components/zipkin/kube.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	appName    = "zipkin"
-	tracesAPI  = "/api/v1/spans?limit=%d&spanName=%s&annotationQuery=%s"
+	tracesAPI  = "/api/v2/traces?limit=%d&spanName=%s&annotationQuery=%s"
 	zipkinPort = 9411
 )
 

--- a/pkg/test/framework/components/zipkin/kube.go
+++ b/pkg/test/framework/components/zipkin/kube.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	appName    = "zipkin"
-	tracesAPI  = "/api/v2/traces?limit=%d&spanName=%s&annotationQuery=%s"
+	tracesAPI  = "/api/v1/spans?limit=%d&spanName=%s&annotationQuery=%s"
 	zipkinPort = 9411
 )
 

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -536,6 +536,7 @@
       "config": {
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v1/spans",
+        "collector_endpoint_version": "HTTP_JSON",
         "trace_id_128bit": "true",
         "shared_span_context": "false"
       }

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -535,7 +535,7 @@
       "name": "envoy.zipkin",
       "config": {
         "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans",
+        "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
         "trace_id_128bit": "true",
         "shared_span_context": "false"


### PR DESCRIPTION
Envoy now expects the collector endpoint version to be set correctly (not use the default) https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/trace/v2/trace.proto#L76. This PR sets the collector endpoint version in the template