### PR TITLE
Remove reference to demo profile; add note about istioctl x analyze

### DIFF
--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -196,9 +196,6 @@ func NewVerifyCommand() *cobra.Command {
 		# Verify that Istio can be freshly installed
 		istioctl verify-install
 		
-		# Verify that the deployment matches the istio-demo profile
-		istioctl verify-install -f istio-demo.yaml
-		
 		# Verify the deployment matches a custom Istio deployment configuration
 		istioctl verify-install -f $HOME/istio.yaml
 `,

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -283,6 +283,9 @@ func NewValidateCommand(istioNamespace *string) *cobra.Command {
 
 		# Validate current services under 'default' namespace within the cluster
 		kubectl get services -o yaml |istioctl validate -f -
+
+		# Also see the related experimental command 'istioctl x analyze'
+		istioctl x analyze samples/bookinfo/networking/bookinfo-gateway.yaml
 `,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {


### PR DESCRIPTION
This PR is about the istioctl usage message that appears in istio.io

Resolves https://github.com/istio/istio/issues/18643

Adds a reference for users of `istioctl validate` who read the instructions that there is a new `istioctl x analyze`.  This change was agreed at the UX meeting.

