### PR TITLE
Fix protoc.sh to output retry logging on stderr

### DIFF
--- a/bin/protoc.sh
+++ b/bin/protoc.sh
@@ -28,6 +28,6 @@ for (( i=1; i <= RETRY_COUNT; i++ )); do
   protoc -I"${REPO_ROOT}"/common-protos -I"${api}" "$@" && break
 
   ret=$?
-  echo "Attempt ${i}/${RETRY_COUNT} to run protoc failed with exit code ${ret}"
+  echo "Attempt ${i}/${RETRY_COUNT} to run protoc failed with exit code ${ret}" >&2
   (( i == RETRY_COUNT )) && exit $ret
 done


### PR DESCRIPTION
`mixer_codegen.sh` treats any stdout as an error, so it ends up failing even if it succeeded on retry. (e.g. https://prow.istio.io/view/gcs/istio-prow/logs/gencheck_istio_postsubmit/404)

This output should be on stderr anyway.