### PR TITLE
Update authz convert to support converting policies applied in the current cluster

### DIFF
--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -21,16 +21,17 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/config/memory"
-	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
-	"istio.io/istio/pkg/config/schemas"
 
 	"istio.io/istio/istioctl/pkg/authz"
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/istioctl/pkg/util/configdump"
 	"istio.io/istio/istioctl/pkg/util/handlers"
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pilot/pkg/config/memory"
+	"istio.io/istio/pilot/pkg/model"
+	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/pilot/pkg/security/authz/converter"
+	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )

--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -259,9 +259,11 @@ func getV1alpha1Policies(v1PolicyFiles []string) (*model.AuthorizationPolicies, 
 		for _, result := range results {
 			authzDebug := v2.AuthorizationDebug{}
 			if err := json.Unmarshal(result, &authzDebug); err != nil {
-				return nil, err
+				log.Debugf("JSON unmarshal failed: %v", err)
+				continue
 			}
 			authzPolicies = authzDebug.AuthorizationPolicies
+			// Break once we found a successful response from Pilot.
 			break
 		}
 	}

--- a/istioctl/pkg/authz/util.go
+++ b/istioctl/pkg/authz/util.go
@@ -15,11 +15,8 @@
 package authz
 
 import (
-	"fmt"
-	"io/ioutil"
 	"strings"
 
-	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/model"
 
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
@@ -27,26 +24,6 @@ import (
 
 // PolicyTypeToConfigs maps policy type (e.g. service-role) to a list of its config.
 type PolicyTypeToConfigs map[string][]model.Config
-
-// getConfigsFromFiles returns a list of model.Configs from the given files.
-func getConfigsFromFiles(fileNames []string) (PolicyTypeToConfigs, error) {
-	policyTypeToConfigs := make(PolicyTypeToConfigs)
-	for _, fileName := range fileNames {
-		fileBuf, err := ioutil.ReadFile(fileName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read file %s", fileName)
-		}
-		configsFromFile, _, err := crd.ParseInputs(string(fileBuf))
-		if err != nil {
-			return nil, err
-		}
-		for _, config := range configsFromFile {
-			configType := config.Type
-			policyTypeToConfigs[configType] = append(policyTypeToConfigs[configType], config)
-		}
-	}
-	return policyTypeToConfigs, nil
-}
 
 func getCertificate(ctx *envoy_auth.CommonTlsContext) string {
 	cert := "none"
@@ -79,22 +56,4 @@ func getCertificate(ctx *envoy_auth.CommonTlsContext) string {
 		cert += "SDS: " + strings.Join(sdsConfigs, ",")
 	}
 	return cert
-}
-
-func getValidate(ctx *envoy_auth.CommonTlsContext) string {
-	var ret string
-	switch v := ctx.ValidationContextType.(type) {
-	case *envoy_auth.CommonTlsContext_ValidationContext:
-		ret = strings.Join(v.ValidationContext.VerifySubjectAltName, ",")
-	case *envoy_auth.CommonTlsContext_ValidationContextSdsSecretConfig:
-		ret = fmt.Sprintf("SDS: %s", v.ValidationContextSdsSecretConfig.Name)
-	case *envoy_auth.CommonTlsContext_CombinedValidationContext:
-		san := strings.Join(v.CombinedValidationContext.GetDefaultValidationContext().GetVerifySubjectAltName(), ",")
-		sds := fmt.Sprintf("SDS: %s", v.CombinedValidationContext.GetValidationContextSdsSecretConfig().GetName())
-		ret = fmt.Sprintf("[%s] + [%s]", san, sds)
-	}
-	if ret == "" {
-		return "none"
-	}
-	return ret
 }

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -49,6 +49,7 @@ type RolesAndBindings struct {
 }
 
 // AuthorizationPolicies organizes authorization policies by namespace.
+// TODO(yangminzhu): Rename to avoid confusion from the AuthorizationPolicy CRD.
 type AuthorizationPolicies struct {
 	// Maps from namespace to the v1alpha1 RBAC policies, deprecated by v1beta1 Authorization policy.
 	NamespaceToV1alpha1Policies map[string]*RolesAndBindings `json:"namespace_to_v1alpha1_policies"`

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -28,37 +28,48 @@ var (
 	rbacLog = istiolog.RegisterScope("rbac", "rbac debugging", 0)
 )
 
+type ServiceRoleConfig struct {
+	Name        string                 `json:"name"`
+	ServiceRole *rbacproto.ServiceRole `json:"service_role"`
+}
+
+type AuthorizationPolicyConfig struct {
+	Name                string                      `json:"name"`
+	Namespace           string                      `json:"namespace"`
+	AuthorizationPolicy *authpb.AuthorizationPolicy `json:"authorization_policy"`
+}
+
 // RolesAndBindings stores the the ServiceRole and ServiceRoleBinding in the same namespace.
 type RolesAndBindings struct {
 	// ServiceRoles in the same namespace.
-	Roles []Config
+	Roles []ServiceRoleConfig `json:"roles"`
 
 	// ServiceRoleBindings indexed by its associated ServiceRole's name.
-	Bindings map[string][]*rbacproto.ServiceRoleBinding
+	Bindings map[string][]*rbacproto.ServiceRoleBinding `json:"bindings"`
 }
 
 // AuthorizationPolicies organizes authorization policies by namespace.
 type AuthorizationPolicies struct {
 	// Maps from namespace to the v1alpha1 RBAC policies, deprecated by v1beta1 Authorization policy.
-	namespaceToV1alpha1Policies map[string]*RolesAndBindings
+	NamespaceToV1alpha1Policies map[string]*RolesAndBindings `json:"namespace_to_v1alpha1_policies"`
 
 	// The mesh global RbacConfig, deprecated by v1beta1 Authorization policy.
-	rbacConfig *rbacproto.RbacConfig
+	RbacConfig *rbacproto.RbacConfig `json:"rbac_config"`
 
 	// Maps from namespace to the v1beta1 Authorization policies.
-	namespaceToV1beta1Policies map[string][]Config
+	NamespaceToV1beta1Policies map[string][]AuthorizationPolicyConfig `json:"namespace_to_v1beta1_policies"`
 
 	// The name of the root namespace. Policy in the root namespace applies to workloads in all
 	// namespaces. Only used for v1beta1 Authorization policy.
-	rootNamespace string
+	RootNamespace string `json:"root_namespace"`
 }
 
 // GetAuthorizationPolicies gets the authorization policies in the mesh.
 func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) {
 	policy := &AuthorizationPolicies{
-		namespaceToV1alpha1Policies: map[string]*RolesAndBindings{},
-		namespaceToV1beta1Policies:  map[string][]Config{},
-		rootNamespace:               env.Mesh.GetRootNamespace(),
+		NamespaceToV1alpha1Policies: map[string]*RolesAndBindings{},
+		NamespaceToV1beta1Policies:  map[string][]AuthorizationPolicyConfig{},
+		RootNamespace:               env.Mesh.GetRootNamespace(),
 	}
 
 	rbacConfig := env.IstioConfigStore.ClusterRbacConfig()
@@ -66,7 +77,7 @@ func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) 
 		rbacConfig = env.IstioConfigStore.RbacConfig()
 	}
 	if rbacConfig != nil {
-		policy.rbacConfig = rbacConfig.Spec.(*rbacproto.RbacConfig)
+		policy.RbacConfig = rbacConfig.Spec.(*rbacproto.RbacConfig)
 	}
 
 	roles, err := env.List(schemas.ServiceRole.Type, NamespaceAll)
@@ -95,16 +106,16 @@ func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) 
 
 // GetClusterRbacConfig returns the global RBAC config.
 func (policy *AuthorizationPolicies) GetClusterRbacConfig() *rbacproto.RbacConfig {
-	return policy.rbacConfig
+	return policy.RbacConfig
 }
 
 // IsRBACEnabled returns true if RBAC is enabled for the service in the given namespace.
 func (policy *AuthorizationPolicies) IsRBACEnabled(service string, namespace string) bool {
-	if policy == nil || policy.rbacConfig == nil {
+	if policy == nil || policy.RbacConfig == nil {
 		return false
 	}
 
-	rbacConfig := policy.rbacConfig
+	rbacConfig := policy.RbacConfig
 	switch rbacConfig.Mode {
 	case rbacproto.RbacConfig_ON:
 		return true
@@ -119,29 +130,29 @@ func (policy *AuthorizationPolicies) IsRBACEnabled(service string, namespace str
 
 // IsGlobalPermissiveEnabled returns true if global permissive mode is enabled.
 func (policy *AuthorizationPolicies) IsGlobalPermissiveEnabled() bool {
-	return policy != nil && policy.rbacConfig != nil &&
-		policy.rbacConfig.EnforcementMode == rbacproto.EnforcementMode_PERMISSIVE
+	return policy != nil && policy.RbacConfig != nil &&
+		policy.RbacConfig.EnforcementMode == rbacproto.EnforcementMode_PERMISSIVE
 }
 
-// ListNamespacesOfToV1alpha1Policies returns all namespaces that have V1alpha1 policies.
-func (policy *AuthorizationPolicies) ListNamespacesOfToV1alpha1Policies() []string {
+// ListV1alpha1Namespaces returns all namespaces that have V1alpha1 policies.
+func (policy *AuthorizationPolicies) ListV1alpha1Namespaces() []string {
 	if policy == nil {
 		return nil
 	}
-	namespaces := make([]string, 0, len(policy.namespaceToV1alpha1Policies))
-	for ns := range policy.namespaceToV1alpha1Policies {
+	namespaces := make([]string, 0, len(policy.NamespaceToV1alpha1Policies))
+	for ns := range policy.NamespaceToV1alpha1Policies {
 		namespaces = append(namespaces, ns)
 	}
 	return namespaces
 }
 
 // ListServiceRoles returns ServiceRole in the given namespace.
-func (policy *AuthorizationPolicies) ListServiceRoles(ns string) []Config {
+func (policy *AuthorizationPolicies) ListServiceRoles(ns string) []ServiceRoleConfig {
 	if policy == nil {
 		return nil
 	}
 
-	rolesAndBindings := policy.namespaceToV1alpha1Policies[ns]
+	rolesAndBindings := policy.NamespaceToV1alpha1Policies[ns]
 	if rolesAndBindings == nil {
 		return nil
 	}
@@ -154,7 +165,7 @@ func (policy *AuthorizationPolicies) ListServiceRoleBindings(ns string) map[stri
 		return map[string][]*rbacproto.ServiceRoleBinding{}
 	}
 
-	rolesAndBindings := policy.namespaceToV1alpha1Policies[ns]
+	rolesAndBindings := policy.NamespaceToV1alpha1Policies[ns]
 	if rolesAndBindings == nil || rolesAndBindings.Bindings == nil {
 		return map[string][]*rbacproto.ServiceRoleBinding{}
 	}
@@ -164,24 +175,24 @@ func (policy *AuthorizationPolicies) ListServiceRoleBindings(ns string) map[stri
 
 // ListAuthorizationPolicies returns the AuthorizationPolicy for the workload in root namespace and the config namespace.
 func (policy *AuthorizationPolicies) ListAuthorizationPolicies(configNamespace string,
-	workloadLabels labels.Collection) []Config {
+	workloadLabels labels.Collection) []AuthorizationPolicyConfig {
 	if policy == nil {
 		return nil
 	}
 
 	var namespaces []string
-	if policy.rootNamespace != "" {
-		namespaces = append(namespaces, policy.rootNamespace)
+	if policy.RootNamespace != "" {
+		namespaces = append(namespaces, policy.RootNamespace)
 	}
 	// To prevent duplicate policies in case root namespace equals proxy's namespace.
-	if configNamespace != policy.rootNamespace {
+	if configNamespace != policy.RootNamespace {
 		namespaces = append(namespaces, configNamespace)
 	}
 
-	var ret []Config
+	var ret []AuthorizationPolicyConfig
 	for _, ns := range namespaces {
-		for _, config := range policy.namespaceToV1beta1Policies[ns] {
-			spec := config.Spec.(*authpb.AuthorizationPolicy)
+		for _, config := range policy.NamespaceToV1beta1Policies[ns] {
+			spec := config.AuthorizationPolicy
 			selector := labels.Instance(spec.GetSelector().GetMatchLabels())
 			if workloadLabels.IsSupersetOf(selector) {
 				ret = append(ret, config)
@@ -197,13 +208,17 @@ func (policy *AuthorizationPolicies) addServiceRoles(roles []Config) {
 		return
 	}
 	for _, role := range roles {
-		if policy.namespaceToV1alpha1Policies[role.Namespace] == nil {
-			policy.namespaceToV1alpha1Policies[role.Namespace] = &RolesAndBindings{
+		if policy.NamespaceToV1alpha1Policies[role.Namespace] == nil {
+			policy.NamespaceToV1alpha1Policies[role.Namespace] = &RolesAndBindings{
 				Bindings: map[string][]*rbacproto.ServiceRoleBinding{},
 			}
 		}
-		rolesAndBindings := policy.namespaceToV1alpha1Policies[role.Namespace]
-		rolesAndBindings.Roles = append(rolesAndBindings.Roles, role)
+		rolesAndBindings := policy.NamespaceToV1alpha1Policies[role.Namespace]
+		config := ServiceRoleConfig{
+			Name:        role.Name,
+			ServiceRole: role.Spec.(*rbacproto.ServiceRole),
+		}
+		rolesAndBindings.Roles = append(rolesAndBindings.Roles, config)
 	}
 }
 
@@ -221,12 +236,12 @@ func (policy *AuthorizationPolicies) addServiceRoleBindings(bindings []Config) {
 			return
 		}
 
-		if policy.namespaceToV1alpha1Policies[binding.Namespace] == nil {
-			policy.namespaceToV1alpha1Policies[binding.Namespace] = &RolesAndBindings{
+		if policy.NamespaceToV1alpha1Policies[binding.Namespace] == nil {
+			policy.NamespaceToV1alpha1Policies[binding.Namespace] = &RolesAndBindings{
 				Bindings: map[string][]*rbacproto.ServiceRoleBinding{},
 			}
 		}
-		rolesAndBindings := policy.namespaceToV1alpha1Policies[binding.Namespace]
+		rolesAndBindings := policy.NamespaceToV1alpha1Policies[binding.Namespace]
 		rolesAndBindings.Bindings[name] = append(
 			rolesAndBindings.Bindings[name], binding.Spec.(*rbacproto.ServiceRoleBinding))
 	}
@@ -238,8 +253,13 @@ func (policy *AuthorizationPolicies) addAuthorizationPolicies(configs []Config) 
 	}
 
 	for _, config := range configs {
-		policy.namespaceToV1beta1Policies[config.Namespace] =
-			append(policy.namespaceToV1beta1Policies[config.Namespace], config)
+		authzConfig := AuthorizationPolicyConfig{
+			Name:                config.Name,
+			Namespace:           config.Namespace,
+			AuthorizationPolicy: config.Spec.(*authpb.AuthorizationPolicy),
+		}
+		policy.NamespaceToV1beta1Policies[config.Namespace] =
+			append(policy.NamespaceToV1beta1Policies[config.Namespace], authzConfig)
 	}
 }
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -94,7 +94,7 @@ type PushContext struct {
 
 	// AuthzPolicies stores the existing authorization policies in the cluster. Could be nil if there
 	// are no authorization policies in the cluster.
-	AuthzPolicies *AuthorizationPolicies `json:"-"`
+	AuthzPolicies *AuthorizationPolicies `json:"authz_policies"`
 
 	// Env has a pointer to the shared environment used to create the snapshot.
 	Env *Environment `json:"-"`

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -84,6 +84,7 @@ func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controll
 	mux.HandleFunc("/debug/configz", s.configz)
 
 	mux.HandleFunc("/debug/authenticationz", s.Authenticationz)
+	mux.HandleFunc("/debug/authorizationz", s.Authorizationz)
 	mux.HandleFunc("/debug/config_dump", s.ConfigDump)
 	mux.HandleFunc("/debug/push_status", s.PushStatusHandler)
 }
@@ -409,6 +410,23 @@ func (s *DiscoveryServer) Authenticationz(w http.ResponseWriter, req *http.Reque
 
 	w.WriteHeader(http.StatusBadRequest)
 	_, _ = w.Write([]byte("You must provide a proxyID in the query string"))
+}
+
+// AuthorizationDebug holds debug information for authorization policy.
+type AuthorizationDebug struct {
+	AuthorizationPolicies *model.AuthorizationPolicies `json:"authorization_policies"`
+}
+
+// Authorizationz dumps the internal authorization policies.
+func (s *DiscoveryServer) Authorizationz(w http.ResponseWriter, req *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+
+	info := AuthorizationDebug{
+		AuthorizationPolicies: s.globalPushContext().AuthzPolicies,
+	}
+	if b, err := json.MarshalIndent(info, "  ", "  "); err == nil {
+		_, _ = w.Write(b)
+	}
 }
 
 // AnalyzeMTLSSettings returns mTLS compatibility status between client and server policies.

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -102,8 +102,8 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 		{
 			name: "v1beta1 only",
 			policies: []*model.Config{
-				policy.SimpleAuthzPolicy("authz-bar", "a"),
-				policy.SimpleAuthzPolicy("authz-foo", "a"),
+				policy.SimpleAuthorizationPolicy("authz-bar", "a"),
+				policy.SimpleAuthorizationPolicy("authz-foo", "a"),
 			},
 			wantPolicies: []string{"ns[a]-policy[authz-bar]-rule[0]", "ns[a]-policy[authz-foo]-rule[0]"},
 		},
@@ -113,7 +113,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 				policy.SimpleClusterRbacConfig(),
 				policy.SimpleRole("role-1", "a", "bar"),
 				policy.SimpleBinding("binding-1", "a", "role-1"),
-				policy.SimpleAuthzPolicy("authz-bar", "a"),
+				policy.SimpleAuthorizationPolicy("authz-bar", "a"),
 			},
 			wantPolicies: []string{"ns[a]-policy[authz-bar]-rule[0]"},
 		},

--- a/pilot/pkg/security/authz/converter/converter.go
+++ b/pilot/pkg/security/authz/converter/converter.go
@@ -224,12 +224,13 @@ func (c *Converter) convert(authzPolicies *model.AuthorizationPolicies) error {
 		return nil
 	}
 	// Build a model for each ServiceRole and associated list of ServiceRoleBinding
+	td := trustdomain.NewTrustDomainBundle("cluster.local", nil)
 	for _, ns := range namespaces {
 		bindingsKeyList := authzPolicies.ListServiceRoleBindings(ns)
 		for _, roleConfig := range authzPolicies.ListServiceRoles(ns) {
 			roleName := roleConfig.Name
 			if bindings, found := bindingsKeyList[roleName]; found {
-				m := authz_model.NewModelV1alpha1(trustdomain.NewTrustDomainBundle("", nil), roleConfig.ServiceRole, bindings)
+				m := authz_model.NewModelV1alpha1(td, roleConfig.ServiceRole, bindings)
 				err := c.v1alpha1ModelTov1beta1Policy(m, ns)
 				if err != nil {
 					return err

--- a/pilot/pkg/security/authz/converter/converter.go
+++ b/pilot/pkg/security/authz/converter/converter.go
@@ -36,7 +36,6 @@ import (
 	"istio.io/api/type/v1beta1"
 	"istio.io/istio/pilot/cmd"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
@@ -53,12 +52,10 @@ type WorkloadLabels map[string]string
 type ServiceToWorkloadLabels map[string]WorkloadLabels
 
 type Converter struct {
-	K8sClient *kubernetes.Clientset
-
 	v1alpha1Policies             *model.AuthorizationPolicies
 	RootNamespace                string
 	NamespaceToServiceToSelector map[string]ServiceToWorkloadLabels
-	AuthorizationPolicies        []model.Config
+	v1beta1Policies              []model.Config
 	ConvertedPolicies            strings.Builder
 }
 
@@ -95,64 +92,31 @@ const (
 	istioConfigMapKey = "mesh"
 )
 
-func New(k8sClient *kubernetes.Clientset, v1PolicyFiles, serviceFiles []string,
+func New(k8sClient *kubernetes.Clientset, v1alpha1Policies *model.AuthorizationPolicies, serviceFiles []string,
 	meshConfigFile, istioNamespace, meshConfigMapName string) (*Converter, error) {
-	v1alpha1Policies, err := getV1alpha1Policies(v1PolicyFiles)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read policies: %v", err)
+	var rootNamespace string
+	if v1alpha1Policies.RootNamespace != "" {
+		rootNamespace = v1alpha1Policies.RootNamespace
+	} else {
+		var err error
+		rootNamespace, err = getRootNamespace(k8sClient, meshConfigFile, meshConfigMapName, istioNamespace)
+		if err != nil {
+			log.Warnf("failed to get root namespace: %v", err)
+		}
 	}
 
-	rootNamespace, err := getRootNamespace(k8sClient, meshConfigFile, meshConfigMapName, istioNamespace)
-	if err != nil {
-		log.Warnf("failed to get root namespace: %v", err)
-	}
-
-	namespaceToServiceToSelector, err := getNamespaceToServiceToSelector(k8sClient, serviceFiles, v1alpha1Policies.ListNamespacesOfToV1alpha1Policies())
+	namespaceToServiceToSelector, err := getNamespaceToServiceToSelector(k8sClient, serviceFiles, v1alpha1Policies.ListV1alpha1Namespaces())
 	if err != nil {
 		log.Warnf("failed to get services: %v", err)
 	}
 
 	converter := Converter{
-		K8sClient:                    k8sClient,
 		v1alpha1Policies:             v1alpha1Policies,
 		RootNamespace:                rootNamespace,
 		NamespaceToServiceToSelector: namespaceToServiceToSelector,
-		AuthorizationPolicies:        []model.Config{},
+		v1beta1Policies:              []model.Config{},
 	}
 	return &converter, nil
-}
-
-func getV1alpha1Policies(v1PolicyFiles []string) (*model.AuthorizationPolicies, error) {
-	var configs []model.Config
-	if len(v1PolicyFiles) != 0 {
-		for _, fileName := range v1PolicyFiles {
-			rbacFileBuf, err := ioutil.ReadFile(fileName)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read file %s", fileName)
-			}
-			configFromFile, _, err := crd.ParseInputs(string(rbacFileBuf))
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse file: %v", err)
-			}
-			configs = append(configs, configFromFile...)
-		}
-	}
-	// TODO: get from K8s API server.
-
-	store := model.MakeIstioStore(memory.Make(schemas.Istio))
-	for _, config := range configs {
-		if _, err := store.Create(config); err != nil {
-			return nil, fmt.Errorf("failed to add config: %s", err)
-		}
-	}
-	env := &model.Environment{
-		IstioConfigStore: store,
-	}
-	authzPolicies, err := model.GetAuthorizationPolicies(env)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create authz policies: %s", err)
-	}
-	return authzPolicies, nil
 }
 
 // getRootNamespace returns the root namespace configured in the MeshConfig.
@@ -235,7 +199,7 @@ func (c *Converter) ConvertV1alpha1ToV1beta1() error {
 	if err := c.convert(c.v1alpha1Policies); err != nil {
 		return fmt.Errorf("failed to convert policies: %v", err)
 	}
-	for _, authzPolicy := range c.AuthorizationPolicies {
+	for _, authzPolicy := range c.v1beta1Policies {
 		err := c.parseConfigToString(authzPolicy)
 		if err != nil {
 			return fmt.Errorf("failed to parse config to string: %v", err)
@@ -253,7 +217,7 @@ func (c *Converter) convert(authzPolicies *model.AuthorizationPolicies) error {
 		// output a warning instead.
 		log.Warnf("failed to convert ClusterRbacConfig: %s", err)
 	}
-	namespaces := authzPolicies.ListNamespacesOfToV1alpha1Policies()
+	namespaces := authzPolicies.ListV1alpha1Namespaces()
 	if len(namespaces) == 0 {
 		// Similarly, a user might want to convert ClusterRbacConfig only.
 		log.Warn("no namespace found for ServiceRole and ServiceRoleBinding")
@@ -265,8 +229,7 @@ func (c *Converter) convert(authzPolicies *model.AuthorizationPolicies) error {
 		for _, roleConfig := range authzPolicies.ListServiceRoles(ns) {
 			roleName := roleConfig.Name
 			if bindings, found := bindingsKeyList[roleName]; found {
-				role := roleConfig.Spec.(*rbac_v1alpha1.ServiceRole)
-				m := authz_model.NewModelV1alpha1(trustdomain.NewTrustDomainBundle("", nil), role, bindings)
+				m := authz_model.NewModelV1alpha1(trustdomain.NewTrustDomainBundle("", nil), roleConfig.ServiceRole, bindings)
 				err := c.v1alpha1ModelTov1beta1Policy(m, ns)
 				if err != nil {
 					return err
@@ -394,7 +357,7 @@ func (c *Converter) v1alpha1ModelTov1beta1Policy(v1alpha1Model *authz_model.Mode
 
 		if len(accessRule.Services) == 0 {
 			authzConfig := createAuthzConfig("all-workloads", nil, operation)
-			c.AuthorizationPolicies = append(c.AuthorizationPolicies, authzConfig)
+			c.v1beta1Policies = append(c.v1beta1Policies, authzConfig)
 		}
 		for _, service := range accessRule.Services {
 			for j, selector := range c.getSelectors(service, namespace) {
@@ -402,7 +365,7 @@ func (c *Converter) v1alpha1ModelTov1beta1Policy(v1alpha1Model *authz_model.Mode
 				authzConfig := createAuthzConfig(name, &v1beta1.WorkloadSelector{
 					MatchLabels: selector,
 				}, operation)
-				c.AuthorizationPolicies = append(c.AuthorizationPolicies, authzConfig)
+				c.v1beta1Policies = append(c.v1beta1Policies, authzConfig)
 			}
 		}
 	}

--- a/pilot/pkg/security/authz/policy/helper.go
+++ b/pilot/pkg/security/authz/policy/helper.go
@@ -186,7 +186,7 @@ func AuthzPolicyTag(name string) string {
 	return fmt.Sprintf("UserFromPolicy[%s]", name)
 }
 
-func SimpleAuthzProto(name string) *authpb.AuthorizationPolicy {
+func SimpleAuthorizationProto(name string) *authpb.AuthorizationPolicy {
 	return &authpb.AuthorizationPolicy{
 		Rules: []*authpb.Rule{
 			{
@@ -209,14 +209,14 @@ func SimpleAuthzProto(name string) *authpb.AuthorizationPolicy {
 	}
 }
 
-func SimpleAuthzPolicy(name string, namespace string) *model.Config {
+func SimpleAuthorizationPolicy(name string, namespace string) *model.Config {
 	return &model.Config{
 		ConfigMeta: model.ConfigMeta{
 			Type:      schemas.AuthorizationPolicy.Type,
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: SimpleAuthzProto(name),
+		Spec: SimpleAuthorizationProto(name),
 	}
 }
 

--- a/pilot/pkg/security/authz/policy/helper.go
+++ b/pilot/pkg/security/authz/policy/helper.go
@@ -186,6 +186,29 @@ func AuthzPolicyTag(name string) string {
 	return fmt.Sprintf("UserFromPolicy[%s]", name)
 }
 
+func SimpleAuthzProto(name string) *authpb.AuthorizationPolicy {
+	return &authpb.AuthorizationPolicy{
+		Rules: []*authpb.Rule{
+			{
+				From: []*authpb.Rule_From{
+					{
+						Source: &authpb.Source{
+							Principals: []string{AuthzPolicyTag(name)},
+						},
+					},
+				},
+				To: []*authpb.Rule_To{
+					{
+						Operation: &authpb.Operation{
+							Methods: []string{"GET"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func SimpleAuthzPolicy(name string, namespace string) *model.Config {
 	return &model.Config{
 		ConfigMeta: model.ConfigMeta{
@@ -193,26 +216,7 @@ func SimpleAuthzPolicy(name string, namespace string) *model.Config {
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: &authpb.AuthorizationPolicy{
-			Rules: []*authpb.Rule{
-				{
-					From: []*authpb.Rule_From{
-						{
-							Source: &authpb.Source{
-								Principals: []string{AuthzPolicyTag(name)},
-							},
-						},
-					},
-					To: []*authpb.Rule_To{
-						{
-							Operation: &authpb.Operation{
-								Methods: []string{"GET"},
-							},
-						},
-					},
-				},
-			},
-		},
+		Spec: SimpleAuthzProto(name),
 	}
 }
 

--- a/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1.go
+++ b/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1.go
@@ -82,7 +82,7 @@ func (g *v1alpha1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 				enforcedBindings = append(enforcedBindings, binding)
 			}
 		}
-		role := roleConfig.Spec.(*istio_rbac.ServiceRole)
+		role := roleConfig.ServiceRole
 		if p := g.generatePolicy(g.trustDomainBundle, role, enforcedBindings, forTCPFilter); p != nil {
 			rbacLog.Debugf("generated policy for role: %s", roleName)
 			enforcedConfig.Policies[roleName] = p

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1.go
@@ -35,10 +35,10 @@ var (
 
 type v1beta1Generator struct {
 	trustDomainBundle trustdomain.Bundle
-	policies          []model.Config
+	policies          []model.AuthorizationPolicyConfig
 }
 
-func NewGenerator(trustDomainBundle trustdomain.Bundle, policies []model.Config) policy.Generator {
+func NewGenerator(trustDomainBundle trustdomain.Bundle, policies []model.AuthorizationPolicyConfig) policy.Generator {
 	return &v1beta1Generator{
 		trustDomainBundle: trustDomainBundle,
 		policies:          policies,
@@ -54,8 +54,7 @@ func (g *v1beta1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 	}
 
 	for _, config := range g.policies {
-		spec := config.Spec.(*istio_rbac.AuthorizationPolicy)
-		for i, rule := range spec.Rules {
+		for i, rule := range config.AuthorizationPolicy.Rules {
 			if p := g.generatePolicy(g.trustDomainBundle, rule, forTCPFilter); p != nil {
 				name := fmt.Sprintf("ns[%s]-policy[%s]-rule[%d]", config.Namespace, config.Name, i)
 				rbac.Policies[name] = p

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
@@ -41,7 +41,7 @@ func TestV1beta1Generator_Generate(t *testing.T) {
 				{
 					Name:                "default",
 					Namespace:           "foo",
-					AuthorizationPolicy: policy.SimpleAuthzProto("default"),
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default"),
 				},
 			},
 			wantRules: map[string][]string{
@@ -56,12 +56,12 @@ func TestV1beta1Generator_Generate(t *testing.T) {
 				{
 					Name:                "default",
 					Namespace:           "foo",
-					AuthorizationPolicy: policy.SimpleAuthzProto("default"),
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default"),
 				},
 				{
 					Name:                "default",
 					Namespace:           "istio-system",
-					AuthorizationPolicy: policy.SimpleAuthzProto("default"),
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default"),
 				},
 			},
 			wantRules: map[string][]string{

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
@@ -28,7 +28,7 @@ import (
 func TestV1beta1Generator_Generate(t *testing.T) {
 	testCases := []struct {
 		name         string
-		policies     []model.Config
+		policies     []model.AuthorizationPolicyConfig
 		wantRules    map[string][]string
 		forTCPFilter bool
 	}{
@@ -37,8 +37,12 @@ func TestV1beta1Generator_Generate(t *testing.T) {
 		},
 		{
 			name: "one policy",
-			policies: []model.Config{
-				*policy.SimpleAuthzPolicy("default", "foo"),
+			policies: []model.AuthorizationPolicyConfig{
+				{
+					Name:                "default",
+					Namespace:           "foo",
+					AuthorizationPolicy: policy.SimpleAuthzProto("default"),
+				},
 			},
 			wantRules: map[string][]string{
 				"ns[foo]-policy[default]-rule[0]": {
@@ -48,9 +52,17 @@ func TestV1beta1Generator_Generate(t *testing.T) {
 		},
 		{
 			name: "two policies",
-			policies: []model.Config{
-				*policy.SimpleAuthzPolicy("default", "foo"),
-				*policy.SimpleAuthzPolicy("default", "istio-system"),
+			policies: []model.AuthorizationPolicyConfig{
+				{
+					Name:                "default",
+					Namespace:           "foo",
+					AuthorizationPolicy: policy.SimpleAuthzProto("default"),
+				},
+				{
+					Name:                "default",
+					Namespace:           "istio-system",
+					AuthorizationPolicy: policy.SimpleAuthzProto("default"),
+				},
 			},
 			wantRules: map[string][]string{
 				"ns[foo]-policy[default]-rule[0]": {

--- a/pilot/pkg/security/trustdomain/bundle.go
+++ b/pilot/pkg/security/trustdomain/bundle.go
@@ -50,6 +50,10 @@ func NewTrustDomainBundle(trustDomain string, trustDomainAliases []string) Bundl
 // If the local trust domain is "td2" and its alias is "td1" (migrating from td1 to td2),
 // replaceTrustDomainAliases returns ["td2/ns/foo/sa/bar", "td1/ns/foo/sa/bar]].
 func (t Bundle) ReplaceTrustDomainAliases(principals []string) []string {
+	if len(t.TrustDomains) == 0 {
+		return principals
+	}
+
 	principalsIncludingAliases := []string{}
 	for _, principal := range principals {
 		isTrustDomainBeingEnforced := isTrustDomainBeingEnforced(principal)

--- a/pilot/pkg/security/trustdomain/bundle.go
+++ b/pilot/pkg/security/trustdomain/bundle.go
@@ -50,10 +50,6 @@ func NewTrustDomainBundle(trustDomain string, trustDomainAliases []string) Bundl
 // If the local trust domain is "td2" and its alias is "td1" (migrating from td1 to td2),
 // replaceTrustDomainAliases returns ["td2/ns/foo/sa/bar", "td1/ns/foo/sa/bar]].
 func (t Bundle) ReplaceTrustDomainAliases(principals []string) []string {
-	if len(t.TrustDomains) == 0 {
-		return principals
-	}
-
 	principalsIncludingAliases := []string{}
 	for _, principal := range principals {
 		isTrustDomainBeingEnforced := isTrustDomainBeingEnforced(principal)


### PR DESCRIPTION
For #12394

* Added a new debug endpoint `/debug/authorizationz` in pilot to expose the internal authzPolicies in Model
* Updated the `istioctl x auth convert` to use the authzPolicies directly from Pilot, so that user could run the command to directly convert the v1alpha1 policies in the cluster instead of passing the policy file through command line
* Fixed a bug that principal `cluster.local/ns/foo/sa/bar` is incorrectly converted to `/ns/foo/sa/bar` due to the trust domain is empty when calling from `istioctl x auth convert`