### PR TITLE
Unable to create readiness and liveness probe path

### DIFF
--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -7,8 +7,6 @@ ARG BASE_VERSION=latest
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
 
-USER 1337:1337
-
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless


### PR DESCRIPTION

if istio-galley run as istio-proxy,  error occured:

```
2019-11-06T07:57:32.111656Z	error	Failed to create the path /healthready: open /healthready: permission denied
```