### PR TITLE
Try to fix flaky TestTcpMetric test on newer k8s

### DIFF
--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -175,8 +175,6 @@ func TestStateMetrics(t *testing.T) {
 func TestTcpMetric(t *testing.T) {
 	framework.
 		NewTest(t).
-		// TODO(https://github.com/istio/istio/issues/18105)
-		Label(label.Flaky).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			_ = bookinfo.DeployOrFail(t, ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookinfoRatingsv2})

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -204,16 +204,16 @@ func TestTcpMetric(t *testing.T) {
 				t.Fatalf("unable to retrieve 200 from product page: %v", res.RetCodes)
 			}
 
-			query := fmt.Sprintf("sum(istio_tcp_sent_bytes_total{destination_app=\"%s\"})", "mongodb")
+			query := fmt.Sprintf("sum(istio_tcp_sent_bytes_total{destination_service_name=\"%s\"})", "mongodb")
 			util.ValidateMetric(t, prom, query, "istio_tcp_sent_bytes_total", 1)
 
-			query = fmt.Sprintf("sum(istio_tcp_received_bytes_total{destination_app=\"%s\"})", "mongodb")
+			query = fmt.Sprintf("sum(istio_tcp_received_bytes_total{destination_service_name=\"%s\"})", "mongodb")
 			util.ValidateMetric(t, prom, query, "istio_tcp_received_bytes_total", 1)
 
-			query = fmt.Sprintf("sum(istio_tcp_connections_opened_total{destination_app=\"%s\"})", "mongodb")
+			query = fmt.Sprintf("sum(istio_tcp_connections_opened_total{destination_service_name=\"%s\"})", "mongodb")
 			util.ValidateMetric(t, prom, query, "istio_tcp_connections_opened_total", 1)
 
-			query = fmt.Sprintf("sum(istio_tcp_connections_closed_total{destination_app=\"%s\"})", "mongodb")
+			query = fmt.Sprintf("sum(istio_tcp_connections_closed_total{destination_service_name=\"%s\"})", "mongodb")
 			util.ValidateMetric(t, prom, query, "istio_tcp_connections_closed_total", 1)
 		})
 }


### PR DESCRIPTION
Try to fix flaky TestTcpMetric test on newer k8s
Ref: https://github.com/istio/istio/issues/18105