### PR TITLE
Skip syncing root cert if not in self signed CA mode

### DIFF
--- a/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
+++ b/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
@@ -17,10 +17,6 @@
 package contextgraph
 
 import (
-	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
-)
-
-import (
 	"flag"
 	"fmt"
 	"io"
@@ -34,10 +30,14 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
+
+	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
+
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+
 	gstatus "google.golang.org/grpc/status"
 )
 

--- a/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
+++ b/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
@@ -17,6 +17,10 @@
 package contextgraph
 
 import (
+	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
+)
+
+import (
 	"flag"
 	"fmt"
 	"io"
@@ -30,14 +34,10 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
-
-	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
-
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-
 	gstatus "google.golang.org/grpc/status"
 )
 

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -351,7 +351,7 @@ func runCA() {
 		sc, err := controller.NewSecretController(ca, opts.enableNamespacesByDefault,
 			opts.workloadCertTTL, opts.workloadCertGracePeriodRatio, opts.workloadCertMinGracePeriod,
 			opts.dualUse, cs.CoreV1(), opts.signCACerts, opts.pkcs8Keys, listenedNamespaces, webhooks,
-			opts.istioCaStorageNamespace, opts.rootCertFile)
+			opts.istioCaStorageNamespace, opts.rootCertFile, opts.selfSignedCA)
 		if err != nil {
 			fatalf("Failed to create secret controller: %v", err)
 		}

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -163,13 +163,18 @@ type SecretController struct {
 	// The most recent time when root cert in keycertbundle is synced with root
 	// cert in istio-ca-secret.
 	lastKCBSyncTime time.Time
+
+	// If true, periodically sync with istio-ca-secret to load latest root certificate.
+	// Only used in self signed CA mode.
+	syncWithCaSecret bool
 }
 
 // NewSecretController returns a pointer to a newly constructed SecretController instance.
 func NewSecretController(ca certificateAuthority, enableNamespacesByDefault bool,
 	certTTL time.Duration, gracePeriodRatio float32, minGracePeriod time.Duration,
 	dualUse bool, core corev1.CoreV1Interface, forCA bool, pkcs8Key bool, namespaces []string,
-	dnsNames map[string]*DNSNameEntry, istioCaStorageNamespace, rootCertFile string) (*SecretController, error) {
+	dnsNames map[string]*DNSNameEntry, istioCaStorageNamespace, rootCertFile string,
+	selfSignedCa bool) (*SecretController, error) {
 
 	if gracePeriodRatio < 0 || gracePeriodRatio > 1 {
 		return nil, fmt.Errorf("grace period ratio %f should be within [0, 1]", gracePeriodRatio)
@@ -197,6 +202,7 @@ func NewSecretController(ca certificateAuthority, enableNamespacesByDefault bool
 		dnsNames:                  dnsNames,
 		monitoring:                newMonitoringMetrics(),
 		lastKCBSyncTime:           time.Time{},
+		syncWithCaSecret:          selfSignedCa,
 	}
 
 	for _, ns := range namespaces {
@@ -494,7 +500,7 @@ func (sc *SecretController) scrtUpdated(oldObj, newObj interface{}) {
 	_, waitErr := sc.certUtil.GetWaitTime(scrt.Data[CertChainID], time.Now(), sc.minGracePeriod)
 
 	caCert, _, _, rootCertificate := sc.ca.GetCAKeyCertBundle().GetAllPem()
-	if !bytes.Equal(rootCertificate, scrt.Data[RootCertID]) {
+	if sc.syncWithCaSecret && !bytes.Equal(rootCertificate, scrt.Data[RootCertID]) {
 		var err error
 		rootCertificate, err = sc.tryToSyncKeyCertBundle(rootCertificate, caCert)
 		if err != nil {

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -204,10 +204,7 @@ func TestSecretController(t *testing.T) {
 				Namespace:   "test-ns",
 			},
 		}
-		controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault,
-			defaultTTL, tc.gracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(),
-			false, false, []string{metav1.NamespaceAll}, webhooks,
-			"test-ns", "")
+		controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault, defaultTTL, tc.gracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, webhooks, "test-ns", "", false)
 		if tc.shouldFail {
 			if err == nil {
 				t.Errorf("should have failed to create secret controller")
@@ -243,10 +240,7 @@ func TestSecretContent(t *testing.T) {
 	saName := "test-serviceaccount"
 	saNamespace := "test-namespace"
 	client := fake.NewSimpleClientset()
-	controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault, defaultTTL,
-		defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false,
-		false, []string{metav1.NamespaceAll}, map[string]*DNSNameEntry{},
-		"test-namespace", "")
+	controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault, defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, map[string]*DNSNameEntry{}, "test-namespace", "", false)
 	if err != nil {
 		t.Errorf("Failed to create secret controller: %v", err)
 	}
@@ -268,10 +262,7 @@ func TestSecretContent(t *testing.T) {
 }
 func TestDeletedIstioSecret(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault,
-		defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false,
-		client.CoreV1(), false, false, []string{metav1.NamespaceAll}, nil,
-		"test-ns", "")
+	controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault, defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, nil, "test-ns", "", false)
 	if err != nil {
 		t.Errorf("failed to create secret controller: %v", err)
 	}
@@ -454,9 +445,7 @@ func TestUpdateSecret(t *testing.T) {
 	for k, tc := range testCases {
 		client := fake.NewSimpleClientset()
 		ca := createFakeCA()
-		controller, err := NewSecretController(ca, enableNamespacesByDefault, time.Hour,
-			tc.gracePeriodRatio, tc.minGracePeriod, false, client.CoreV1(), false,
-			false, []string{metav1.NamespaceAll}, nil, "", "")
+		controller, err := NewSecretController(ca, enableNamespacesByDefault, time.Hour, tc.gracePeriodRatio, tc.minGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, nil, "", "", false)
 		if err != nil {
 			t.Errorf("failed to create secret controller: %v", err)
 		}
@@ -552,10 +541,7 @@ func TestManagedNamespaceRules(t *testing.T) {
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
-			controller, err := NewSecretController(createFakeCA(), tc.enableNamespacesByDefault,
-				defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false,
-				client.CoreV1(), false, false, []string{metav1.NamespaceAll},
-				nil, tc.istioCaStorageNamespace, "")
+			controller, err := NewSecretController(createFakeCA(), tc.enableNamespacesByDefault, defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, nil, tc.istioCaStorageNamespace, "", false)
 			if err != nil {
 				t.Errorf("failed to create secret controller: %v", err)
 			}
@@ -627,10 +613,7 @@ func TestRetroactiveNamespaceActivation(t *testing.T) {
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
-			controller, err := NewSecretController(createFakeCA(), tc.enableNamespacesByDefault,
-				defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false,
-				client.CoreV1(), false, false, []string{metav1.NamespaceAll},
-				nil, tc.istioCaStorageNamespace, "")
+			controller, err := NewSecretController(createFakeCA(), tc.enableNamespacesByDefault, defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, nil, tc.istioCaStorageNamespace, "", false)
 			if err != nil {
 				t.Errorf("failed to create secret controller: %v", err)
 			}

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -204,7 +204,10 @@ func TestSecretController(t *testing.T) {
 				Namespace:   "test-ns",
 			},
 		}
-		controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault, defaultTTL, tc.gracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, webhooks, "test-ns", "", false)
+		controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault,
+			defaultTTL, tc.gracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(),
+			false, false, []string{metav1.NamespaceAll}, webhooks,
+			"test-ns", "", false)
 		if tc.shouldFail {
 			if err == nil {
 				t.Errorf("should have failed to create secret controller")
@@ -240,7 +243,10 @@ func TestSecretContent(t *testing.T) {
 	saName := "test-serviceaccount"
 	saNamespace := "test-namespace"
 	client := fake.NewSimpleClientset()
-	controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault, defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, map[string]*DNSNameEntry{}, "test-namespace", "", false)
+	controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault,
+		defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false,
+		client.CoreV1(), false, false, []string{metav1.NamespaceAll}, map[string]*DNSNameEntry{},
+		"test-namespace", "", false)
 	if err != nil {
 		t.Errorf("Failed to create secret controller: %v", err)
 	}
@@ -262,7 +268,10 @@ func TestSecretContent(t *testing.T) {
 }
 func TestDeletedIstioSecret(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault, defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, nil, "test-ns", "", false)
+	controller, err := NewSecretController(createFakeCA(), enableNamespacesByDefault,
+		defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false,
+		client.CoreV1(), false, false, []string{metav1.NamespaceAll}, nil,
+		"test-ns", "", false)
 	if err != nil {
 		t.Errorf("failed to create secret controller: %v", err)
 	}
@@ -445,7 +454,10 @@ func TestUpdateSecret(t *testing.T) {
 	for k, tc := range testCases {
 		client := fake.NewSimpleClientset()
 		ca := createFakeCA()
-		controller, err := NewSecretController(ca, enableNamespacesByDefault, time.Hour, tc.gracePeriodRatio, tc.minGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, nil, "", "", false)
+		controller, err := NewSecretController(ca, enableNamespacesByDefault, time.Hour,
+			tc.gracePeriodRatio, tc.minGracePeriod, false, client.CoreV1(), false,
+			false, []string{metav1.NamespaceAll}, nil, "", "",
+			false)
 		if err != nil {
 			t.Errorf("failed to create secret controller: %v", err)
 		}
@@ -541,7 +553,10 @@ func TestManagedNamespaceRules(t *testing.T) {
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
-			controller, err := NewSecretController(createFakeCA(), tc.enableNamespacesByDefault, defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, nil, tc.istioCaStorageNamespace, "", false)
+			controller, err := NewSecretController(createFakeCA(), tc.enableNamespacesByDefault,
+				defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false,
+				client.CoreV1(), false, false, []string{metav1.NamespaceAll},
+				nil, tc.istioCaStorageNamespace, "", false)
 			if err != nil {
 				t.Errorf("failed to create secret controller: %v", err)
 			}
@@ -613,7 +628,10 @@ func TestRetroactiveNamespaceActivation(t *testing.T) {
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
-			controller, err := NewSecretController(createFakeCA(), tc.enableNamespacesByDefault, defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false, []string{metav1.NamespaceAll}, nil, tc.istioCaStorageNamespace, "", false)
+			controller, err := NewSecretController(createFakeCA(), tc.enableNamespacesByDefault,
+				defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod, false,
+				client.CoreV1(), false, false, []string{metav1.NamespaceAll},
+				nil, tc.istioCaStorageNamespace, "", false)
 			if err != nil {
 				t.Errorf("failed to create secret controller: %v", err)
 			}

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -457,7 +457,7 @@ func TestUpdateSecret(t *testing.T) {
 		controller, err := NewSecretController(ca, enableNamespacesByDefault, time.Hour,
 			tc.gracePeriodRatio, tc.minGracePeriod, false, client.CoreV1(), false,
 			false, []string{metav1.NamespaceAll}, nil, "", "",
-			false)
+			true)
 		if err != nil {
 			t.Errorf("failed to create secret controller: %v", err)
 		}


### PR DESCRIPTION
When Citadel is running as plugin CA mode, Citadel reads root cert from file. Workload secret controller should not sync with _istio-ca-secret_ in this mode, otherwise, it use the root cert from _istio-ca-secret_ to sign workload certificates.

#17059