### PR TITLE
fix(galley dash): provide correct dimension to query for state type

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/dashboards/galley-dashboard.json
+++ b/install/kubernetes/helm/istio/charts/grafana/dashboards/galley-dashboard.json
@@ -903,10 +903,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (typeURL) (galley_runtime_state_type_instances_total)",
+          "expr": "sum by (collection) (galley_runtime_state_type_instances_total)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ typeURL }}",
+          "legendFormat": "{{ collection }}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
This PR addresses an issue with the galley dashboard. The existing dashboard does not match the actual metric definition in `galley/pkg/config/monitoring/monitoring.go` (`newView(stateTypeInstancesTotal, collectionKeys, view.LastValue())`).

Fixes https://github.com/istio/istio/issues/18720.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>