### PR TITLE
fix namespaced name parsing in validation analyzer

### DIFF
--- a/galley/pkg/config/analysis/analyzers/schema/validation.go
+++ b/galley/pkg/config/analysis/analyzers/schema/validation.go
@@ -61,7 +61,7 @@ func (a *ValidationAnalyzer) Analyze(ctx analysis.Context) {
 	c := collection.NewName(a.s.Collection)
 
 	ctx.ForEach(c, func(r *resource.Entry) bool {
-		name, ns := r.Metadata.Name.InterpretAsNamespaceAndName()
+		ns, name := r.Metadata.Name.InterpretAsNamespaceAndName()
 
 		err := a.s.Validate(name, ns, r.Item)
 		if err != nil {


### PR DESCRIPTION
Perhaps I'm missing something trivial but the order of variables here is wrong. This caused some false positives while I was running `istioctl x analyze`.