### PR TITLE
Extra checks to avoid breaking ingress - which is not yet fully switched

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -348,7 +348,7 @@ var (
 			sdsUDSPath := sdsUdsPathVar.Get()
 			sdsEnabled, sdsTokenPath := detectSds(controlPlaneBootstrap, sdsUDSPath, trustworthyJWTPath)
 
-			if !sdsEnabled { // Not using citadel agent - this is either Pilot or Istiod.
+			if !sdsEnabled && role.Type == model.SidecarProxy { // Not using citadel agent - this is either Pilot or Istiod.
 
 				// Istiod and new SDS-only mode doesn't use sdsUdsPathVar - sdsEnabled will be false.
 				sa := istio_agent.NewSDSAgent(discoveryAddress, controlPlaneAuthEnabled)
@@ -498,7 +498,7 @@ var (
 
 			agent := envoy.NewAgent(envoyProxy, features.TerminationDrainDuration())
 
-			if sdsEnabled {
+			if sdsEnabled && role.Type == model.SidecarProxy {
 				tlsCertsToWatch = []string{}
 			}
 

--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -168,7 +168,7 @@ type SDSAgent struct {
 func NewSDSAgent(discAddr string, tlsRequired bool) *SDSAgent {
 	ac := &SDSAgent{}
 
-	istiodHost, discPort, err := net.SplitHostPort(discAddr)
+	discHost, discPort, err := net.SplitHostPort(discAddr)
 	if err != nil {
 		log.Fatala("Invalid discovery address", discAddr, err)
 	}
@@ -198,10 +198,10 @@ func NewSDSAgent(discAddr string, tlsRequired bool) *SDSAgent {
 	if discPort == "15012" {
 		ac.RequireCerts = true
 		// For local debugging - the discoveryAddress is set to localhost, but the cert issued for normal SA.
-		if istiodHost == "localhost" {
-			istiodHost = "istiod.istio-system"
+		if discHost == "localhost" {
+			discHost = "istiod.istio-system"
 		}
-		ac.SAN = istiodHost
+		ac.SAN = discHost
 	}
 
 	return ac

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -53,6 +53,11 @@ const (
 	// Binary header name must has suffix "-bin", according to https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md.
 	// Same value defined in pilot pkg(k8sSAJwtTokenHeaderKey)
 	k8sSAJwtTokenHeaderKey = "istio_sds_credentials_header-bin"
+
+	// JWTPath is the path to the JWT token used for authentication.
+	// Note the use of "./", meaning on tests and VMs it is possible to use without root access.
+	// Pilot-agent runs with PWD=/
+	JWTPath = "./var/run/secrets/tokens/istio-token"
 )
 
 var (
@@ -265,7 +270,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			conIDresourceNamePrefix := sdsLogPrefix(conID, resourceName)
 			if s.localJWT {
 				// Running in-process, no need to pass the token from envoy to agent as in-context - use the file
-				tok, err := ioutil.ReadFile("./var/run/secrets/tokens/istio-token")
+				tok, err := ioutil.ReadFile(JWTPath)
 				if err != nil {
 					sdsServiceLog.Errorf("Failed to get credential token: %v", err)
 					return err
@@ -373,7 +378,7 @@ func (s *sdsservice) FetchSecrets(ctx context.Context, discReq *xdsapi.Discovery
 	token := ""
 	if s.localJWT {
 		// Running in-process, no need to pass the token from envoy to agent as in-context - use the file
-		tok, err := ioutil.ReadFile("./var/run/secrets/tokens/istio-token")
+		tok, err := ioutil.ReadFile(JWTPath)
 		if err != nil {
 			sdsServiceLog.Errorf("Failed to get credential token: %v", err)
 			return nil, err

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher.go
@@ -159,7 +159,7 @@ func (sf *SecretFetcher) InitWithKubeClient(core corev1.CoreV1Interface) { // no
 	sf.InitWithKubeClientAndNs(core, namespaceVar.Get())
 }
 
-// InitWithKubeClient initializes SecretFetcher to watch kubernetes secrets.
+// InitWithKubeClientAndNs initializes SecretFetcher to watch kubernetes secrets.
 func (sf *SecretFetcher) InitWithKubeClientAndNs(core corev1.CoreV1Interface, namespace string) { // nolint:interfacer
 	istioSecretSelector := fields.SelectorFromSet(nil).String()
 	scrtLW := &cache.ListWatch{


### PR DESCRIPTION
After the merge it appears the Ingress SDS test has become flaky, making sure we enable 
only for Sidecar until ingress is migrated. 

Ingress uses a node agent as another sidecar.