### PR TITLE
Make kind 1.16 the default

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -153,7 +153,7 @@ function cleanup_kind_cluster() {
 }
 
 function setup_kind_cluster() {
-  IMAGE="${1:-}"
+  IMAGE="${1:-kindest/node:v1.16.2}"
   NAME="${2:-istio-testing}"
   CONFIG="${3:-}"
   # Delete any previous e2e KinD cluster

--- a/tests/integration/qualification/loadbalancing_test.go
+++ b/tests/integration/qualification/loadbalancing_test.go
@@ -99,7 +99,7 @@ func TestIngressLoadBalancing(t *testing.T) {
 	rangeEnd := time.Now()
 
 	// Gather the CPU usage across all of the ingress gateways.
-	query := `sum(rate(container_cpu_usage_seconds_total{job='kubernetes-cadvisor', pod_name=~'istio-ingressgateway-.*'}[1m])) by (pod_name)`
+	query := `sum(rate(container_cpu_usage_seconds_total{job='kubernetes-cadvisor', pod=~'istio-ingressgateway-.*'}[1m])) by (pod_name)`
 	v, _, err := prom.API().QueryRange(context.Background(), query, v1.Range{
 		Start: rangeStart,
 		End:   rangeEnd,


### PR DESCRIPTION
This changes the default kind image to k8s 1.16. This means other than the postsubmit tests for different k8s versions, all test will run with k8s 1.16.

The minor change to a test is because the metric was removed in 1.16.

