### PR TITLE
allow pass through for eds updates

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -640,7 +640,8 @@ func (s *DiscoveryServer) loadAssignmentsForClusterIsolated(proxy *model.Proxy, 
 	// will update "XdsConnection.Clusters", we might accidentally send EDS updates for STRICT_DNS cluster. This check gaurds
 	// against such behavior and returns nil. When the updated cluster warms up in Envoy, it would update with new endpoints
 	// automatically.
-	if svc.Resolution != model.ClientSideLB {
+	// Gateways use EDS for Passthrough cluster. So we should allow Passthrough here.
+	if svc.Resolution == model.DNSLB {
 		adsLog.Infof("XdsConnection has %s in its eds clusters but its resolution now is updated to %v, skipping it.", clusterName, svc.Resolution)
 		return nil
 	}


### PR DESCRIPTION
Looks like gateways use EDS for Passthrough clusters. https://github.com/istio/istio/blob/master/pilot/pkg/networking/core/v1alpha3/cluster.go#L720. So we should allow Passthrough resolution for EDS endpoints. With out this, we are seeing log lines like "ads	XdsConnection has outbound|1111||acds-relay-stateful-lb.user-mmanthena.svc.cluster.local in its eds clusters but its resolution now is updated to Passthrough, skipping it" for gateways.