### PR TITLE
Log only the push status

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -444,13 +444,13 @@ func NewPushContext() *PushContext {
 }
 
 // JSON implements json.Marshaller, with a lock.
-func (ps *PushContext) JSON() ([]byte, error) {
+func (ps *PushContext) StatusJSON() ([]byte, error) {
 	if ps == nil {
 		return []byte{'{', '}'}, nil
 	}
 	ps.proxyStatusMutex.RLock()
 	defer ps.proxyStatusMutex.RUnlock()
-	return json.MarshalIndent(ps, "", "    ")
+	return json.MarshalIndent(ps.ProxyStatus, "", "    ")
 }
 
 // OnConfigChange is called when a config change is detected.

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -615,7 +615,7 @@ func (s *DiscoveryServer) PushStatusHandler(w http.ResponseWriter, req *http.Req
 	if model.LastPushStatus == nil {
 		return
 	}
-	out, err := model.LastPushStatus.JSON()
+	out, err := model.LastPushStatus.StatusJSON()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = fmt.Fprintf(w, "unable to marshal push information: %v", err)

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -171,7 +171,7 @@ func (s *DiscoveryServer) periodicRefreshMetrics(stopCh <-chan struct{}) {
 			if model.LastPushStatus != push {
 				model.LastPushStatus = push
 				push.UpdateMetrics()
-				out, _ := model.LastPushStatus.JSON()
+				out, _ := model.LastPushStatus.StatusJSON()
 				adsLog.Infof("Push Status: %s", string(out))
 			}
 			model.LastPushMutex.Unlock()

--- a/tests/e2e/tests/pilot/listener_conflict_test.go
+++ b/tests/e2e/tests/pilot/listener_conflict_test.go
@@ -132,7 +132,7 @@ func TestListenerConflicts(t *testing.T) {
 
 			for _, info := range infos {
 				pushStatus := info.pushStatus
-				conflict, ok := pushStatus.ProxyStatus[metricName]
+				conflict, ok := pushStatus[metricName]
 				if !ok {
 					err = multierror.Prefix(err, fmt.Sprintf("unable to find push status metric %s", metricName))
 					// See if another pod has the status we're looking for.
@@ -211,7 +211,7 @@ func (i pilotInfos) String() string {
 type pilotInfo struct {
 	pod            string
 	pushStatusJSON string
-	pushStatus     *model.PushContext
+	pushStatus     map[string]map[string]model.ProxyPushStatus
 }
 
 func (i *pilotInfo) String() string {
@@ -260,8 +260,8 @@ func getPilotInfo(podIP string, pod string) (*pilotInfo, error) {
 	pushStatusJSON := result[pushStatusStartIndex : pushStatusEndIndex+1]
 
 	// Parse the push status.
-	pushStatus := &model.PushContext{}
-	if err := json.Unmarshal([]byte(pushStatusJSON), pushStatus); err != nil {
+	var pushStatus map[string]map[string]model.ProxyPushStatus
+	if err := json.Unmarshal([]byte(pushStatusJSON), &pushStatus); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Right now we serialize the whole push context, but add json:- to every
field except the push status, which means extra fields get accidentally
added over time.