### PR TITLE
authz: a few minor fixes

### DIFF
--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -253,7 +253,7 @@ func getV1alpha1Policies(v1PolicyFiles []string) (*model.AuthorizationPolicies, 
 			return nil, err
 		}
 
-		if len(results) < 0 {
+		if len(results) == 0 {
 			return nil, fmt.Errorf("received empty response for authorization information")
 		}
 

--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -267,6 +267,10 @@ func getV1alpha1Policies(v1PolicyFiles []string) (*model.AuthorizationPolicies, 
 			// Break once we found a successful response from Pilot.
 			break
 		}
+
+		if authzPolicies == nil {
+			return nil, fmt.Errorf("no v1alpha1 RBAC policy")
+		}
 	}
 
 	return authzPolicies, nil

--- a/istioctl/cmd/testdata/authz/converter/multiple-access-rules-one-subject.golden.yaml
+++ b/istioctl/cmd/testdata/authz/converter/multiple-access-rules-one-subject.golden.yaml
@@ -1,7 +1,7 @@
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-wildcard-0
+  name: service-wildcard-rule0-target0
   namespace: default
 spec:
   rules:
@@ -19,7 +19,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-productpage-0
+  name: service-productpage-rule1-target0
   namespace: default
 spec:
   rules:
@@ -38,7 +38,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-reviews-0
+  name: service-reviews-rule1-target0
   namespace: default
 spec:
   rules:

--- a/istioctl/cmd/testdata/authz/converter/multiple-access-rules-two-subjects.golden.yaml
+++ b/istioctl/cmd/testdata/authz/converter/multiple-access-rules-two-subjects.golden.yaml
@@ -1,7 +1,7 @@
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-wildcard-0
+  name: service-wildcard-rule0-target0
   namespace: default
 spec:
   rules:
@@ -24,7 +24,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-productpage-0
+  name: service-productpage-rule1-target0
   namespace: default
 spec:
   rules:
@@ -48,7 +48,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-reviews-0
+  name: service-reviews-rule1-target0
   namespace: default
 spec:
   rules:

--- a/istioctl/cmd/testdata/authz/converter/one-rule-all-services-with-exclusion.golden.yaml
+++ b/istioctl/cmd/testdata/authz/converter/one-rule-all-services-with-exclusion.golden.yaml
@@ -27,7 +27,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-wildcard-0
+  name: service-wildcard-rule0-target0
   namespace: default
 spec:
   rules:

--- a/istioctl/cmd/testdata/authz/converter/one-rule-all-services-with-inclusion.golden.yaml
+++ b/istioctl/cmd/testdata/authz/converter/one-rule-all-services-with-inclusion.golden.yaml
@@ -17,7 +17,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-wildcard-0
+  name: service-wildcard-rule0-target0
   namespace: default
 spec:
   rules:

--- a/istioctl/cmd/testdata/authz/converter/one-rule-all-services.golden.yaml
+++ b/istioctl/cmd/testdata/authz/converter/one-rule-all-services.golden.yaml
@@ -9,7 +9,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-wildcard-0
+  name: service-wildcard-rule0-target0
   namespace: default
 spec:
   rules:

--- a/istioctl/cmd/testdata/authz/converter/one-rule-multiple-services.golden.yaml
+++ b/istioctl/cmd/testdata/authz/converter/one-rule-multiple-services.golden.yaml
@@ -9,7 +9,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-productpage-0
+  name: service-productpage-rule0-target0
   namespace: default
 spec:
   rules:
@@ -33,7 +33,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-reviews-0
+  name: service-reviews-rule0-target0
   namespace: default
 spec:
   rules:

--- a/istioctl/cmd/testdata/authz/converter/one-rule-one-service.golden.yaml
+++ b/istioctl/cmd/testdata/authz/converter/one-rule-one-service.golden.yaml
@@ -9,7 +9,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-productpage-0
+  name: service-productpage-rule0-target0
   namespace: default
 spec:
   rules:

--- a/istioctl/cmd/testdata/authz/converter/one-rule-two-services-prefix-suffix.golden.yaml
+++ b/istioctl/cmd/testdata/authz/converter/one-rule-two-services-prefix-suffix.golden.yaml
@@ -9,7 +9,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-svc-wildcard-0
+  name: service-svc-wildcard-rule0-target0
   namespace: default
 spec:
   rules:
@@ -29,7 +29,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-svc-wildcard-1
+  name: service-svc-wildcard-rule0-target1
   namespace: default
 spec:
   rules:
@@ -49,7 +49,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-svc-wildcard-2
+  name: service-svc-wildcard-rule0-target2
   namespace: default
 spec:
   rules:
@@ -69,7 +69,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-wildcard-xyz-0
+  name: service-wildcard-xyz-rule0-target0
   namespace: default
 spec:
   rules:
@@ -89,7 +89,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-wildcard-xyz-1
+  name: service-wildcard-xyz-rule0-target1
   namespace: default
 spec:
   rules:
@@ -109,7 +109,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: service-wildcard-xyz-2
+  name: service-wildcard-xyz-rule0-target2
   namespace: default
 spec:
   rules:

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -94,7 +94,7 @@ type PushContext struct {
 
 	// AuthzPolicies stores the existing authorization policies in the cluster. Could be nil if there
 	// are no authorization policies in the cluster.
-	AuthzPolicies *AuthorizationPolicies `json:"authz_policies"`
+	AuthzPolicies *AuthorizationPolicies `json:"-"`
 
 	// Env has a pointer to the shared environment used to create the snapshot.
 	Env *Environment `json:"-"`

--- a/pilot/pkg/security/authz/converter/converter.go
+++ b/pilot/pkg/security/authz/converter/converter.go
@@ -350,7 +350,7 @@ func (c *Converter) v1alpha1ModelTov1beta1Policy(v1alpha1Model *authz_model.Mode
 		}
 	}
 
-	for _, accessRule := range v1alpha1Model.Permissions {
+	for i, accessRule := range v1alpha1Model.Permissions {
 		operation, err := convertAccessRuleToOperation(&accessRule)
 		if err != nil {
 			return fmt.Errorf("cannot convert access rule to operation: %v", err)
@@ -362,7 +362,7 @@ func (c *Converter) v1alpha1ModelTov1beta1Policy(v1alpha1Model *authz_model.Mode
 		}
 		for _, service := range accessRule.Services {
 			for j, selector := range c.getSelectors(service, namespace) {
-				name := fmt.Sprintf("service-%s-%d", strings.ReplaceAll(service, "*", "wildcard"), j)
+				name := fmt.Sprintf("service-%s-rule%d-target%d", strings.ReplaceAll(service, "*", "wildcard"), i, j)
 				authzConfig := createAuthzConfig(name, &v1beta1.WorkloadSelector{
 					MatchLabels: selector,
 				}, operation)


### PR DESCRIPTION
For #18399 

- Remove the annotation in push_context as it's not needed. see #18870.
- Fix a bug when `authzPolicies` is nil, just return an error message for no v1alpha1 RBAC policies.
- Fix the naming in generated v1beta1 policies to avoid potential duplicate names.