### PR TITLE
test: cover headless in reachability test

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -220,7 +220,7 @@ var (
 
 	EnableHeadlessService = env.RegisterBoolVar(
 		"PILOT_ENABLE_HEADLESS_SERVICE_POD_LISTENERS",
-		true,
+		false,
 		"If enabled, for a headless service/stateful set in Kubernetes, pilot will generate an "+
 			"outbound listener for each pod in a headless service. This feature should be disabled "+
 			"if headless services have a large number of pods.",

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -73,7 +73,7 @@ func CreateContext(ctx framework.TestContext, g galley.Instance, p pilot.Instanc
 	echoboot.NewBuilderOrFail(ctx, ctx).
 		With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
 		With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
-		With(&headless, util.EchoConfig("headless", ns, false, nil, g, p)).
+		With(&headless, util.EchoConfig("headless", ns, true, nil, g, p)).
 		With(&naked, util.EchoConfig("naked", ns, false, echo.NewAnnotations().
 			SetBool(echo.SidecarInject, false), g, p)).
 		BuildOrFail(ctx)


### PR DESCRIPTION
I find our reach-ability test case doesn't cover headless service.
Fix it to cover more test cases.
Will create issue if the test fails.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>