### PR TITLE
authz: build service metadata only if rbac is enabled

### DIFF
--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -116,6 +116,11 @@ func (policy *AuthorizationPolicies) IsRBACEnabled(service string, namespace str
 		return false
 	}
 
+	// If service or namespace is empty just return false.
+	if len(service) == 0 || len(namespace) == 0 {
+		return false
+	}
+
 	rbacConfig := policy.RbacConfig
 	switch rbacConfig.Mode {
 	case rbacproto.RbacConfig_ON:

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -615,7 +615,9 @@ func TestAuthorizationPolicies_IsRBACEnabled(t *testing.T) {
 						Mode: rbacproto.RbacConfig_ON,
 					}),
 			},
-			want: true,
+			service:   "product.default.svc",
+			namespace: "default",
+			want:      true,
 		},
 		{
 			name: "enabled with permissive",
@@ -626,7 +628,9 @@ func TestAuthorizationPolicies_IsRBACEnabled(t *testing.T) {
 						EnforcementMode: rbacproto.EnforcementMode_PERMISSIVE,
 					}),
 			},
-			want: true,
+			service:   "product.default.svc",
+			namespace: "default",
+			want:      true,
 		},
 		{
 			name: "enabled by inclusion.service",
@@ -672,7 +676,9 @@ func TestAuthorizationPolicies_IsRBACEnabled(t *testing.T) {
 						Mode: rbacproto.RbacConfig_ON,
 					}),
 			},
-			want: true,
+			service:   "override.svc",
+			namespace: "ns",
+			want:      true,
 		},
 		{
 			name: "disabled by default",
@@ -685,6 +691,29 @@ func TestAuthorizationPolicies_IsRBACEnabled(t *testing.T) {
 						Mode: rbacproto.RbacConfig_OFF,
 					}),
 			},
+		},
+		{
+			name: "disabled-if-service-empty",
+			config: []Config{
+				newConfig("default", "",
+					&rbacproto.RbacConfig{
+						Mode: rbacproto.RbacConfig_ON,
+					}),
+			},
+			service:   "",
+			namespace: "default",
+			want:      false,
+		},
+		{
+			name: "disabled-if-ns-empty",
+			config: []Config{
+				newConfig("default", "",
+					&rbacproto.RbacConfig{
+						Mode: rbacproto.RbacConfig_ON,
+					}),
+			},
+			service: "product.default.svc",
+			want:    false,
 		},
 		{
 			name: "disabled by exclusion.service",

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -58,16 +58,15 @@ func NewBuilder(trustDomainBundle trustdomain.Bundle, serviceInstance *model.Ser
 			rbacLog.Errorf("no service for serviceInstance: %v", serviceInstance)
 			return nil
 		}
-		serviceName := serviceInstance.Service.Attributes.Name
 		serviceNamespace := serviceInstance.Service.Attributes.Namespace
-		serviceMetadata, err := authz_model.NewServiceMetadata(serviceName, serviceNamespace, serviceInstance)
-		if err != nil {
-			rbacLog.Errorf("failed to create ServiceMetadata for %s: %s", serviceName, err)
-			return nil
-		}
-
 		serviceHostname := string(serviceInstance.Service.Hostname)
 		if policies.IsRBACEnabled(serviceHostname, serviceNamespace) {
+			serviceName := serviceInstance.Service.Attributes.Name
+			serviceMetadata, err := authz_model.NewServiceMetadata(serviceName, serviceNamespace, serviceInstance)
+			if err != nil {
+				rbacLog.Errorf("failed to create ServiceMetadata for %s: %s", serviceName, err)
+				return nil
+			}
 			generator = v1alpha1.NewGenerator(trustDomainBundle, serviceMetadata, policies, policies.IsGlobalPermissiveEnabled())
 			rbacLog.Debugf("v1alpha1 RBAC enabled for service %s", serviceHostname)
 		}


### PR DESCRIPTION
Build service metadata only if RBAC is enabled. Otherwise this is called on every outbound listener.