### PR TITLE
Remove endpoints/ingresses/nodes from annotations analyzer

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -66,7 +66,6 @@ var testGrid = []testCase{
 			{msg.MisplacedAnnotation, "Pod grafana-test"},
 			{msg.MisplacedAnnotation, "Deployment fortio-deploy"},
 			{msg.MisplacedAnnotation, "Namespace staging"},
-			{msg.MisplacedAnnotation, "Endpoints test-endpoints"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/annotations/annotations.go
+++ b/galley/pkg/config/analysis/analyzers/annotations/annotations.go
@@ -38,12 +38,9 @@ func (*K8sAnalyzer) Metadata() analysis.Metadata {
 	return analysis.Metadata{
 		Name: "annotations.K8sAnalyzer",
 		Inputs: collection.Names{
-			metadata.K8SCoreV1Endpoints,
 			metadata.K8SCoreV1Namespaces,
 			metadata.K8SCoreV1Services,
 			metadata.K8SCoreV1Pods,
-			metadata.K8SExtensionsV1Beta1Ingresses,
-			metadata.K8SCoreV1Nodes,
 			metadata.K8SAppsV1Deployments,
 		},
 	}
@@ -51,28 +48,16 @@ func (*K8sAnalyzer) Metadata() analysis.Metadata {
 
 // Analyze implements analysis.Analyzer
 func (fa *K8sAnalyzer) Analyze(ctx analysis.Context) {
-	ctx.ForEach(metadata.K8SCoreV1Endpoints, func(r *resource.Entry) bool {
-		fa.allowAnnotations(r, ctx, "Endpoints", metadata.K8SCoreV1Endpoints)
-		return true
-	})
 	ctx.ForEach(metadata.K8SCoreV1Namespaces, func(r *resource.Entry) bool {
 		fa.allowAnnotations(r, ctx, "Namespace", metadata.K8SCoreV1Namespaces)
-		return true
-	})
-	ctx.ForEach(metadata.K8SCoreV1Nodes, func(r *resource.Entry) bool {
-		fa.allowAnnotations(r, ctx, "Node", metadata.K8SCoreV1Nodes)
-		return true
-	})
-	ctx.ForEach(metadata.K8SCoreV1Pods, func(r *resource.Entry) bool {
-		fa.allowAnnotations(r, ctx, "Pod", metadata.K8SCoreV1Pods)
 		return true
 	})
 	ctx.ForEach(metadata.K8SCoreV1Services, func(r *resource.Entry) bool {
 		fa.allowAnnotations(r, ctx, "Service", metadata.K8SCoreV1Services)
 		return true
 	})
-	ctx.ForEach(metadata.K8SExtensionsV1Beta1Ingresses, func(r *resource.Entry) bool {
-		fa.allowAnnotations(r, ctx, "Ingress", metadata.K8SExtensionsV1Beta1Ingresses)
+	ctx.ForEach(metadata.K8SCoreV1Pods, func(r *resource.Entry) bool {
+		fa.allowAnnotations(r, ctx, "Pod", metadata.K8SCoreV1Pods)
 		return true
 	})
 	ctx.ForEach(metadata.K8SAppsV1Deployments, func(r *resource.Entry) bool {

--- a/galley/pkg/config/analysis/analyzers/testdata/misannotated.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/misannotated.yaml
@@ -104,12 +104,3 @@ metadata:
     # Sidecar injector annotation does not belong to Namespace
     sidecar.istio.io/inject: "true"
 spec: {}
----
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: test-endpoints
-  annotations:
-    # Endpoints should not have any Istio annotations
-    sidecar.istio.io/statsInclusionPrefixes: cluster.outbound
-subsets: []

--- a/galley/pkg/config/meta/metadata/metadata.gen.go
+++ b/galley/pkg/config/meta/metadata/metadata.gen.go
@@ -624,7 +624,6 @@ snapshots:
       - "istio/networking/v1alpha3/sidecars"
       - "istio/networking/v1alpha3/virtualservices"
       - "istio/networking/v1alpha3/synthetic/serviceentries"
-      - "k8s/core/v1/endpoints"
       - "k8s/core/v1/namespaces"
       - "k8s/core/v1/services"
       - "k8s/core/v1/pods"
@@ -1036,7 +1035,6 @@ transforms:
       "k8s/core/v1/services": "k8s/core/v1/services"
       "k8s/core/v1/pods": "k8s/core/v1/pods"
       "k8s/apps/v1/deployments": "k8s/apps/v1/deployments"
-      "k8s/core/v1/endpoints": "k8s/core/v1/endpoints"
       "istio/mesh/v1alpha1/MeshConfig": "istio/mesh/v1alpha1/MeshConfig"
 
       # Legacy Mixer CRD mappings

--- a/galley/pkg/config/meta/metadata/metadata.yaml
+++ b/galley/pkg/config/meta/metadata/metadata.yaml
@@ -578,7 +578,6 @@ snapshots:
       - "istio/networking/v1alpha3/sidecars"
       - "istio/networking/v1alpha3/virtualservices"
       - "istio/networking/v1alpha3/synthetic/serviceentries"
-      - "k8s/core/v1/endpoints"
       - "k8s/core/v1/namespaces"
       - "k8s/core/v1/services"
       - "k8s/core/v1/pods"
@@ -990,7 +989,6 @@ transforms:
       "k8s/core/v1/services": "k8s/core/v1/services"
       "k8s/core/v1/pods": "k8s/core/v1/pods"
       "k8s/apps/v1/deployments": "k8s/apps/v1/deployments"
-      "k8s/core/v1/endpoints": "k8s/core/v1/endpoints"
       "istio/mesh/v1alpha1/MeshConfig": "istio/mesh/v1alpha1/MeshConfig"
 
       # Legacy Mixer CRD mappings


### PR DESCRIPTION
As discussed in some post-submit comments on https://github.com/istio/istio/pull/18829: 

* Removing ingresses and nodes from the annotations analyzer. They aren't in the set of resources pulled in for analyzers, so having them is currently a no-op. 
* This was also true for endpoints until the above PR, where we added them in metadata.yaml, but this reverses that change. 

This unblocks an implementation of https://github.com/istio/istio/issues/18874.

While we could add all of the above resources to metadata.yaml and have them pulled from the API server for analysis, this feels like overkill.

@esnible, I'm particularly interested in your thoughts on this.