### PR TITLE
[release-1.4] Fix incorrect ALS config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20190630181448-f1e96bc0f4c5 // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20190630181448-f1e96bc0f4c5 // indirect
 	github.com/emicklei/go-restful v2.9.6+incompatible
-	github.com/envoyproxy/go-control-plane v0.9.1-0.20191002184426-9d865299d2ff
+	github.com/envoyproxy/go-control-plane v0.9.1
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fluent/fluent-logger-golang v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/emicklei/go-restful v2.9.6+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191002184426-9d865299d2ff h1:c03aOTa9x9VOSKW5w0Mm9NeRPceC013YduuOudsHNlQ=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191002184426-9d865299d2ff/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.1 h1:+8frETDtT11P1dMCWySse/d0jMPOKYYF7OZjl7cZLvQ=
+github.com/envoyproxy/go-control-plane v0.9.1/go.mod h1:G1fbsNGAFpC1aaERrShZQVdUV2ZuZuv6FCl2v9JNSxQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -148,11 +148,12 @@ const (
 var (
 	applicationProtocols = []string{"http/1.0", "http/1.1"}
 
-	// Headers added by the metadata exchange filter
+	// State logged by the metadata exchange filter about the upstream and downstream service instances
 	// We need to propagate these as part of access log service stream
 	// Logging them by default on the console may be an issue as the base64 encoded string is bound to be a big one.
-	// But end users can certainly configure it on their own via the meshConfig
-	envoyWasmHeadersToLog = []string{"x-envoy-peer-metadata", "x-envoy-peer-metadata-id"}
+	// But end users can certainly configure it on their own via the meshConfig using the %FILTERSTATE% macro.
+	envoyWasmStateToLog = []string{"envoy.wasm.metadata_exchange.upstream", "envoy.wasm.metadata_exchange.upstream_id",
+		"envoy.wasm.metadata_exchange.downstream", "envoy.wasm.metadata_exchange.downstream_id"}
 
 	// EnvoyJSONLogFormat12 map of values for envoy json based access logs for Istio 1.2
 	EnvoyJSONLogFormat12 = &structpb.Struct{
@@ -1748,8 +1749,10 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 					},
 				},
 			},
-			AdditionalRequestHeadersToLog:  envoyWasmHeadersToLog,
-			AdditionalResponseHeadersToLog: envoyWasmHeadersToLog,
+		}
+
+		if util.IsIstioVersionGE14(node) {
+			fl.CommonConfig.FilterStateObjectsToLog = envoyWasmStateToLog
 		}
 
 		acc := &accesslog.AccessLog{


### PR DESCRIPTION
We were logging metadata headers incorrectly in the access log service. 
These would log the same arbitrary value on both sender and receiver
and create problems in all the analysis systems. Per https://github.com/istio/envoy/pull/121
and (preceding work on logging filter state), the correct way is to log
the filter state objects created by the metadata exchange filters.

If the filter state does not exist, the operation would be a no-op

Sending two separate PRs for each branch due to merge conflicts

Signed-off-by: Shriram Rajagopalan <rshriram@tetrate.io>