### PR TITLE
Skip calling updateEDS for headless service

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -901,7 +901,7 @@ func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.
 
 		log.Debugf("Handle event %s for endpoint %s in namespace %s", event, ep.Name, ep.Namespace)
 
-		// headless service cluster discovery type is ORIGINAL_DST, we do not need update EDD.
+		// headless service cluster discovery type is ORIGINAL_DST, we do not need update EDS.
 		if features.EnableHeadlessService.Get() {
 			if obj, _, _ := c.services.informer.GetIndexer().GetByKey(kube.KeyFunc(ep.Name, ep.Namespace)); obj != nil {
 				svc := obj.(*v1.Service)

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/yl2chen/cidranger"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/informers"


### PR DESCRIPTION


This is an improvement, skip endpoints conversion.

Fixes: #18943