### PR TITLE
Set dnsLookupFamily by node ip

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1275,6 +1275,9 @@ func buildDefaultCluster(push *model.PushContext, name string, discoveryType api
 
 	if discoveryType == apiv2.Cluster_STRICT_DNS {
 		cluster.DnsLookupFamily = apiv2.Cluster_V4_ONLY
+		if _, ipv6 := ipv4AndIpv6Support(proxy); ipv6 {
+			cluster.DnsLookupFamily = apiv2.Cluster_AUTO
+		}
 		dnsRate := gogo.DurationToProtoDuration(push.Mesh.DnsRefreshRate)
 		cluster.DnsRefreshRate = dnsRate
 		if util.IsIstioVersionGE13(proxy) && features.RespectDNSTTL.Get() {


### PR DESCRIPTION

The serviceentry with dns resolution created in ipv6 environment,  cluster with  DNS v4_only would generated by pilot.
```
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: foo
spec:
  hosts:
  - foo.bar.svc.cluster.local
  location: MESH_EXTERNAL
  ports:
  - name: http
    number: 80
    protocol: HTTP
  resolution: DNS
```