### PR TITLE
Use istio-iptables golang implementation instead of bash script

### DIFF
--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -7,7 +7,7 @@ FROM docker.io/istio/base:${BASE_VERSION} as default
 ARG proxy_version
 ARG istio_version
 
-COPY istio-iptables.sh /usr/local/bin/istio-iptables
+COPY istio-iptables /usr/local/bin/istio-iptables
 
 # Install Envoy.
 COPY envoy /usr/local/bin/envoy

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -33,7 +33,7 @@ COPY pilot-agent /usr/local/bin/pilot-agent
 COPY envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 COPY envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 COPY envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
-COPY istio-iptables.sh /usr/local/bin/istio-iptables
+COPY istio-iptables /usr/local/bin/istio-iptables
 
 # Copy Envoy bootstrap templates used by pilot-agent
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -13,7 +13,7 @@ COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 
 RUN chown -R istio-proxy /var/lib/istio
 
-COPY istio-iptables.sh /usr/local/bin/istio-iptables
+COPY istio-iptables /usr/local/bin/istio-iptables
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar
@@ -12,8 +12,8 @@ COPY pilot-agent                      /usr/local/bin/pilot-agent
 COPY node_agent                       /usr/local/bin/node_agent
 COPY istio-start.sh                   /usr/local/bin/istio-start.sh
 COPY istio-node-agent-start.sh        /usr/local/bin/istio-node-agent-start.sh
-COPY istio-iptables.sh                /usr/local/bin/istio-iptables
-COPY istio-clean-iptables.sh          /usr/local/bin/istio-clean-iptables
+COPY istio-iptables                   /usr/local/bin/istio-iptables
+COPY istio-clean-iptables             /usr/local/bin/istio-clean-iptables
 COPY postinst.sh                      /usr/local/bin/postinst.sh
 COPY envoy_bootstrap_v2.json          /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 

--- a/prow/e2e-kind-suite.sh
+++ b/prow/e2e-kind-suite.sh
@@ -82,7 +82,6 @@ E2E_ARGS+=("--use_local_cluster")
 # See https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster
 E2E_ARGS+=("--image_pull_policy" "IfNotPresent")
 
-
 export HUB=${HUB:-"istio-testing"}
 export TAG="${TAG:-"istio-testing"}"
 

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -60,11 +60,7 @@ $(ISTIO_DOCKER)/certs:
 
 # tell make which files are copied from the source tree and generate rules to copy them to the proper location:
 # TODO(sdake)                      $(NODE_AGENT_TEST_FILES) $(GRAFANA_FILES)
-DOCKER_FILES_FROM_SOURCE:=tools/packaging/common/istio-iptables.sh tools/packaging/common/istio-clean-iptables.sh \
-                          tests/testdata/certs/cert.crt tests/testdata/certs/cert.key tests/testdata/certs/cacert.pem
-# generates rules like the following:
-# $(ISTIO_DOCKER)/tools/packaging/common/istio-iptables.sh: $(ISTIO_OUT)/tools/packaging/common/istio-iptables.sh | $(ISTIO_DOCKER)
-# 	cp $FILE $$(@D))
+DOCKER_FILES_FROM_SOURCE:=tests/testdata/certs/cert.crt tests/testdata/certs/cert.key tests/testdata/certs/cacert.pem
 $(foreach FILE,$(DOCKER_FILES_FROM_SOURCE), \
         $(eval $(ISTIO_DOCKER)/$(notdir $(FILE)): $(FILE) | $(ISTIO_DOCKER); cp $(FILE) $$(@D)))
 
@@ -107,7 +103,6 @@ docker.proxyv2: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.proxyv2: pilot/docker/Dockerfile.proxyv2
 docker.proxyv2: pilot/docker/envoy_pilot.yaml.tmpl
 docker.proxyv2: pilot/docker/envoy_policy.yaml.tmpl
-docker.proxyv2: tools/packaging/common/istio-iptables.sh
 docker.proxyv2: pilot/docker/envoy_telemetry.yaml.tmpl
 docker.proxyv2: $(ISTIO_DOCKER)/istio-iptables
 	$(DOCKER_RULE)
@@ -121,8 +116,8 @@ docker.proxytproxy: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.proxytproxy: pilot/docker/Dockerfile.proxytproxy
 docker.proxytproxy: pilot/docker/envoy_pilot.yaml.tmpl
 docker.proxytproxy: pilot/docker/envoy_policy.yaml.tmpl
-docker.proxytproxy: tools/packaging/common/istio-iptables.sh
 docker.proxytproxy: pilot/docker/envoy_telemetry.yaml.tmpl
+docker.proxytproxy: $(ISTIO_DOCKER)/istio-iptables
 	$(DOCKER_RULE)
 
 docker.pilot: BUILD_PRE=chmod 755 pilot-discovery cacert.pem &&
@@ -150,8 +145,6 @@ docker.app: $(ISTIO_DOCKER)/certs
 # Test application bundled with the sidecar (for non-k8s).
 docker.app_sidecar: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.app_sidecar: tools/packaging/common/envoy_bootstrap_v2.json
-docker.app_sidecar: tools/packaging/common/istio-iptables.sh
-docker.app_sidecar: tools/packaging/common/istio-clean-iptables.sh
 docker.app_sidecar: tools/packaging/common/istio-start.sh
 docker.app_sidecar: tools/packaging/common/istio-node-agent-start.sh
 docker.app_sidecar: tools/packaging/deb/postinst.sh
@@ -166,6 +159,8 @@ docker.app_sidecar: pkg/test/echo/docker/Dockerfile.app_sidecar
 docker.app_sidecar: pilot/docker/envoy_pilot.yaml.tmpl
 docker.app_sidecar: pilot/docker/envoy_policy.yaml.tmpl
 docker.app_sidecar: pilot/docker/envoy_telemetry.yaml.tmpl
+docker.app_sidecar: $(ISTIO_DOCKER)/istio-iptables
+docker.app_sidecar: $(ISTIO_DOCKER)/istio-clean-iptables
 	$(DOCKER_RULE)
 
 # Test policy backend for mixer integration

--- a/tools/packaging/deb/istio.mk
+++ b/tools/packaging/deb/istio.mk
@@ -36,8 +36,8 @@ $(foreach DEP,$(SIDECAR_DEB_DEPS),\
 
 ISTIO_DEB_DEST:=${ISTIO_DEB_BIN}/istio-start.sh \
 		${ISTIO_DEB_BIN}/istio-node-agent-start.sh \
-		${ISTIO_DEB_BIN}/istio-iptables.sh \
-		${ISTIO_DEB_BIN}/istio-clean-iptables.sh \
+		${ISTIO_DEB_BIN}/istio-iptables \
+		${ISTIO_DEB_BIN}/istio-clean-iptables \
 		/lib/systemd/system/istio.service \
 		/lib/systemd/system/istio-auth-node-agent.service \
 		/var/lib/istio/envoy/sidecar.env


### PR DESCRIPTION
Testing all E2E tests that will use golang implementation for istio-iptables
Issue: https://github.com/istio/istio/issues/13967