### PR TITLE
[install/kubernetes] Add persistent volume to Prometheus chart

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/statefulset.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/statefulset.yaml
@@ -1,7 +1,6 @@
-# TODO: the original template has service account, roles, etc
-{{- if not .Values.persistentVolume.enabled }}
+{{- if .Values.persistentVolume.enabled }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: prometheus
   namespace: {{ .Release.Namespace }}
@@ -25,17 +24,23 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      # Storage Volume is owned by the root user
+      securityContext:
+        fsGroup: 0
+        runAsGroup: 0
+        runAsUser: 0
       serviceAccountName: prometheus
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
       containers:
         - name: prometheus
-          image: "{{ .Values.hub }}/{{ .Values.image }}:{{ .Values.tag }}"
+          image: "{{ .Values.hub }}/prometheus:{{ .Values.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
             - '--storage.tsdb.retention={{ .Values.retention }}'
             - '--config.file=/etc/prometheus/prometheus.yml'
+            - '--storage.tsdb.path={{ .Values.persistentVolume.mountPath }}'
           ports:
             - containerPort: 9090
               name: http
@@ -58,6 +63,8 @@ spec:
             mountPath: /etc/prometheus
           - mountPath: /etc/istio-certs
             name: istio-certs
+          - name: storage-volume
+            mountPath: {{ .Values.persistentVolume.mountPath }}
       volumes:
       - name: config-volume
         configMap:
@@ -78,5 +85,25 @@ spec:
       {{- else if .Values.global.defaultTolerations }}
       tolerations:
 {{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: storage-volume
+        {{- if .Values.persistentVolume.annotations }}
+        annotations:
+{{ toYaml .Values.persistentVolume.annotations | indent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+{{ toYaml .Values.persistentVolume.accessModes | indent 10 }}
+        resources:
+          requests:
+            storage: "{{ .Values.persistentVolume.size }}"
+      {{- if .Values.persistentVolume.storageClass }}
+      {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+      {{- end }}
       {{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -58,3 +58,20 @@ service:
 
 security:
   enabled: true
+
+persistentVolume:
+  # If true, Prometheus will create/use a Persistent Volume Claim
+  # If false, use emptyDir
+  enabled: false
+  # Prometheus server data Persistent Volume access modes
+  accessModes:
+    - ReadWriteOnce
+  annotations: {}
+  # Prometheus data Persistent Volume existing claim name
+  # Requires server.persistentVolume.enabled: true
+  # If defined, PVC must be created before volume will be bound
+  existingClaim: ""
+  # Prometheus data Persistent Volume mount root path
+  mountPath: /data
+  # Persistent Volume size
+  size: 2Gi


### PR DESCRIPTION
The current Prometheus chart does not allow creation of PVC, hence loses metrics when ever pods are restarted.  This PR adds the ability to enable persistent volume for Prometheus.

- `persistentVolume.enabled` toggles the use of PVC
- `persistentVolume.enabled` is false by default
- Uses statefulset resource if `persistentVolume.enabled` is set to `true`
  - This is required for creating one PVC per pod
- Uses deployment resource if `persistentVolume.enabled` is set to `false`