### PR TITLE
Allow environmental override of proxy GCS source

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -164,10 +164,12 @@ endif
 
 # Envoy binary variables Keep the default URLs up-to-date with the latest push from istio/proxy.
 
+export ISTIO_ENVOY_BASE_URL ?= https://storage.googleapis.com/istio-build/proxy
+
 # OS-neutral vars. These currently only work for linux.
 export ISTIO_ENVOY_VERSION ?= ${PROXY_REPO_SHA}
-export ISTIO_ENVOY_DEBUG_URL ?= https://storage.googleapis.com/istio-build/proxy/envoy-debug-$(ISTIO_ENVOY_VERSION).tar.gz
-export ISTIO_ENVOY_RELEASE_URL ?= https://storage.googleapis.com/istio-build/proxy/envoy-alpha-$(ISTIO_ENVOY_VERSION).tar.gz
+export ISTIO_ENVOY_DEBUG_URL ?= $(ISTIO_ENVOY_BASE_URL)/envoy-debug-$(ISTIO_ENVOY_VERSION).tar.gz
+export ISTIO_ENVOY_RELEASE_URL ?= $(ISTIO_ENVOY_BASE_URL)/envoy-alpha-$(ISTIO_ENVOY_VERSION).tar.gz
 
 # Envoy Linux vars.
 export ISTIO_ENVOY_LINUX_VERSION ?= ${ISTIO_ENVOY_VERSION}

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -117,11 +117,14 @@ if [[ -z "${PROXY_REPO_SHA:-}" ]] ; then
   export PROXY_REPO_SHA
 fi
 
+# Defines the base URL to download envoy from
+ISTIO_ENVOY_BASE_URL=${ISTIO_ENVOY_BASE_URL:-https://storage.googleapis.com/istio-build/proxy}
+
 # These variables are normally set by the Makefile.
 # OS-neutral vars. These currently only work for linux.
 ISTIO_ENVOY_VERSION=${ISTIO_ENVOY_VERSION:-${PROXY_REPO_SHA}}
-ISTIO_ENVOY_DEBUG_URL=${ISTIO_ENVOY_DEBUG_URL:-https://storage.googleapis.com/istio-build/proxy/envoy-debug-${ISTIO_ENVOY_LINUX_VERSION}.tar.gz}
-ISTIO_ENVOY_RELEASE_URL=${ISTIO_ENVOY_RELEASE_URL:-https://storage.googleapis.com/istio-build/proxy/envoy-alpha-${ISTIO_ENVOY_LINUX_VERSION}.tar.gz}
+ISTIO_ENVOY_DEBUG_URL=${ISTIO_ENVOY_DEBUG_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-debug-${ISTIO_ENVOY_LINUX_VERSION}.tar.gz}
+ISTIO_ENVOY_RELEASE_URL=${ISTIO_ENVOY_RELEASE_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-alpha-${ISTIO_ENVOY_LINUX_VERSION}.tar.gz}
 
 # Envoy Linux vars. Normally set by the Makefile.
 ISTIO_ENVOY_LINUX_VERSION=${ISTIO_ENVOY_LINUX_VERSION:-${ISTIO_ENVOY_VERSION}}

--- a/pkg/test/envoy/download.go
+++ b/pkg/test/envoy/download.go
@@ -17,6 +17,7 @@ package envoy
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"istio.io/istio/pkg/test/deps"
 	"istio.io/istio/pkg/test/util"
@@ -28,10 +29,14 @@ var (
 )
 
 func init() {
+	envoyBaseUrl := "https://storage.googleapis.com/istio-build/proxy"
+	if override, f := os.LookupEnv("ISTIO_ENVOY_BASE_URL"); f {
+		envoyBaseUrl = override
+	}
 	for _, dep := range deps.Istio {
 		if dep.Name == "PROXY_REPO_SHA" {
 			LatestStableSHA = dep.LastStableSHA
-			LinuxReleaseURL = fmt.Sprintf("https://storage.googleapis.com/istio-build/proxy/envoy-alpha-%s.tar.gz", LatestStableSHA)
+			LinuxReleaseURL = fmt.Sprintf("%s/envoy-alpha-%s.tar.gz", envoyBaseUrl, LatestStableSHA)
 			return
 		}
 	}


### PR DESCRIPTION
This is required for building from other sources