### PR TITLE
Inject alpn protocol for telemetry v2 to use metadata exchange filter

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -161,14 +161,14 @@ var (
 	plaintextHTTPALPNs = []string{"http/1.0", "http/1.1", "h2c"}
 	mtlsHTTPALPNs      = []string{"istio-http/1.0", "istio-http/1.1", "istio-h2"}
 
-	mtlsTCPALPNs = []string{"istio"}
+	mtlsTCPALPNs = []string{"istio", "istio-mixerless"}
 
 	// These ALPNs are injected in the client side by the ALPN filter.
 	// "istio" is added for each upstream protocol in order to make it
 	// backward compatible. e.g., 1.4 proxy -> 1.3 proxy.
-	mtlsHTTP10ALPN = []string{"istio-http/1.0", "istio"}
-	mtlsHTTP11ALPN = []string{"istio-http/1.1", "istio"}
-	mtlsHTTP2ALPN  = []string{"istio-h2", "istio"}
+	mtlsHTTP10ALPN = []string{"istio-http/1.0", "istio", "istio-mixerless"}
+	mtlsHTTP11ALPN = []string{"istio-http/1.1", "istio", "istio-mixerless"}
+	mtlsHTTP2ALPN  = []string{"istio-h2", "istio", "istio-mixerless"}
 
 	// Double the number of filter chains. Half of filter chains are used as http filter chain and half of them are used as tcp proxy
 	// id in [0, len(allChains)/2) are configured as http filter chain, [(len(allChains)/2, len(allChains)) are configured as tcp proxy

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -90,11 +90,11 @@ var ALPNH2Only = []string{"h2"}
 // ALPNInMeshH2 advertises that Proxy is going to use HTTP/2 when talking to the in-mesh cluster.
 // The custom "istio" value indicates in-mesh traffic and it's going to be used for routing decisions.
 // Once Envoy supports client-side ALPN negotiation, this should be {"istio", "h2", "http/1.1"}.
-var ALPNInMeshH2 = []string{"istio", "h2"}
+var ALPNInMeshH2 = []string{"istio-mixerless", "istio", "h2"}
 
 // ALPNInMesh advertises that Proxy is going to talk to the in-mesh cluster.
 // The custom "istio" value indicates in-mesh traffic and it's going to be used for routing decisions.
-var ALPNInMesh = []string{"istio"}
+var ALPNInMesh = []string{"istio-mixerless", "istio"}
 
 // ALPNHttp advertises that Proxy is going to talking either http2 or http 1.1.
 var ALPNHttp = []string{"h2", "http/1.1"}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -97,7 +97,7 @@ var ALPNInMeshH2 = []string{"istio-mixerless", "istio", "h2"}
 var ALPNInMesh = []string{"istio-mixerless", "istio"}
 
 // ALPNHttp advertises that Proxy is going to talking either http2 or http 1.1.
-var ALPNHttp = []string{"h2", "http/1.1"}
+var ALPNHttp = []string{"istio-mixerless", "h2", "http/1.1"}
 
 // FallThroughFilterChainBlackHoleService is the blackhole service used for fall though
 // filter chain

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -853,7 +853,7 @@ func TestOnInboundFilterChains(t *testing.T) {
 				{
 					TLSContext: tlsContext,
 					FilterChainMatch: &listener.FilterChainMatch{
-						ApplicationProtocols: []string{"istio", "istio-mixerless"},
+						ApplicationProtocols: []string{"istio-mixerless", "istio"},
 					},
 					ListenerFilters: []*listener.ListenerFilter{
 						{

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -853,7 +853,7 @@ func TestOnInboundFilterChains(t *testing.T) {
 				{
 					TLSContext: tlsContext,
 					FilterChainMatch: &listener.FilterChainMatch{
-						ApplicationProtocols: []string{"istio"},
+						ApplicationProtocols: []string{"istio", "istio-mixerless"},
 					},
 					ListenerFilters: []*listener.ListenerFilter{
 						{

--- a/pkg/bootstrap/option/instances_test.go
+++ b/pkg/bootstrap/option/instances_test.go
@@ -528,7 +528,7 @@ func TestOptions(t *testing.T) {
 			option: option.EnvoyMetricsServiceTLS(&networkingAPI.TLSSettings{
 				Mode: networkingAPI.TLSSettings_ISTIO_MUTUAL,
 			}, &model.NodeMetadata{}),
-			expected: "{\"common_tls_context\":{\"tls_certificates\":[{\"certificate_chain\":{\"filename\":\"/etc/certs/root-cert.pem\"},\"private_key\":{\"filename\":\"/etc/certs/key.pem\"}}],\"validation_context\":{\"trusted_ca\":{\"filename\":\"/etc/certs/cert-chain.pem\"}},\"alpn_protocols\":[\"istio\",\"h2\"]},\"sni\":\"envoy_metrics_service\"}", // nolint: lll
+			expected: "{\"common_tls_context\":{\"tls_certificates\":[{\"certificate_chain\":{\"filename\":\"/etc/certs/root-cert.pem\"},\"private_key\":{\"filename\":\"/etc/certs/key.pem\"}}],\"validation_context\":{\"trusted_ca\":{\"filename\":\"/etc/certs/cert-chain.pem\"}},\"alpn_protocols\":[\"istio-mixerless\",\"istio\",\"h2\"]},\"sni\":\"envoy_metrics_service\"}", // nolint: lll
 		},
 		{
 			testName: "envoy metrics keepalive nil",
@@ -598,7 +598,7 @@ func TestOptions(t *testing.T) {
 			option: option.EnvoyAccessLogServiceTLS(&networkingAPI.TLSSettings{
 				Mode: networkingAPI.TLSSettings_ISTIO_MUTUAL,
 			}, &model.NodeMetadata{}),
-			expected: "{\"common_tls_context\":{\"tls_certificates\":[{\"certificate_chain\":{\"filename\":\"/etc/certs/root-cert.pem\"},\"private_key\":{\"filename\":\"/etc/certs/key.pem\"}}],\"validation_context\":{\"trusted_ca\":{\"filename\":\"/etc/certs/cert-chain.pem\"}},\"alpn_protocols\":[\"istio\",\"h2\"]},\"sni\":\"envoy_accesslog_service\"}", // nolint: lll
+			expected: "{\"common_tls_context\":{\"tls_certificates\":[{\"certificate_chain\":{\"filename\":\"/etc/certs/root-cert.pem\"},\"private_key\":{\"filename\":\"/etc/certs/key.pem\"}}],\"validation_context\":{\"trusted_ca\":{\"filename\":\"/etc/certs/cert-chain.pem\"}},\"alpn_protocols\":[\"istio-mixerless\",\"istio\",\"h2\"]},\"sni\":\"envoy_accesslog_service\"}", // nolint: lll
 		},
 		{
 			testName: "envoy access log keepalive nil",

--- a/tests/integration/security/mtls_permissive_test.go
+++ b/tests/integration/security/mtls_permissive_test.go
@@ -62,8 +62,8 @@ func verifyListener(listener *xdsapi.Listener, t *testing.T) error {
 		return fmt.Errorf("expect exactly 2 filter chains, actually %d", l)
 	}
 	mtlsChain := listener.FilterChains[0]
-	if !reflect.DeepEqual(mtlsChain.FilterChainMatch.ApplicationProtocols, []string{"istio"}) {
-		return errors.New("alpn is not istio")
+	if !reflect.DeepEqual(mtlsChain.FilterChainMatch.ApplicationProtocols, []string{"istio", "istio-mixerless"}) {
+		return errors.New("alpn is not istio/istio-mixerless")
 	}
 	if mtlsChain.TlsContext == nil {
 		return errors.New("tls context is empty")


### PR DESCRIPTION
Inject alpn protocol for telemetry v2 to use metadata exchange filter when using mTLS

This PR injects Alpn protocol named "istio-mixerless", to select metadata exchange filter in envoy.