### PR TITLE
Optionally support passing header to envoy download

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -92,7 +92,7 @@ function download_envoy_if_necessary () {
 
     # Download and extract the binary to the output directory.
     echo "Downloading Envoy: ${DOWNLOAD_COMMAND} $1 to $2"
-    time ${DOWNLOAD_COMMAND} "$1" | tar xz
+    time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" | tar xz
 
     # Copy the extracted binary to the output location
     cp usr/local/bin/envoy "$2"


### PR DESCRIPTION
This works for (a) both `curl` and `wget` and (b) whether `AUTH_HEADER` is set or unset.

This is needed to authorized requests (and download envoy) from *private* GCS locations. The `AUTH_HEADER` can be set from a CI or other external environment.

**e.g.** `"https://storage.googleapis.com/<private-bucket>/<private-envoy>.tar.gz"`