### PR TITLE
Fix mixer source namespace attribute when dot in pod name

### DIFF
--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -732,7 +732,7 @@ func attrUID(node *model.Proxy) attribute {
 func attrNamespace(node *model.Proxy) attribute {
 	parts := strings.Split(node.ID, ".")
 	if len(parts) >= 2 {
-		return attrStringValue(parts[1])
+		return attrStringValue(parts[len(parts)-1])
 	}
 	return attrStringValue("")
 }

--- a/pilot/pkg/networking/plugin/mixer/mixer_test.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer_test.go
@@ -268,6 +268,26 @@ func TestOnOutboundListenerSkipMixer(t *testing.T) {
 	}
 }
 
+func Test_attrNamespace(t *testing.T) {
+	testcases := []struct {
+		name      string
+		nodeID    string
+		namespace string
+	}{
+		{"standard pod name", "foo.bar", "bar"},
+		{"pod name with dot", "foo.123.bar", "bar"},
+	}
+	for _, v := range testcases {
+		t.Run(v.name, func(t *testing.T) {
+			node := model.Proxy{ID: v.nodeID}
+			ns := attrNamespace(&node).GetStringValue()
+			if ns != v.namespace {
+				t.Errorf("%s: expecting %v but got %v", v.name, ns, v.namespace)
+			}
+		})
+	}
+}
+
 func TestOnInboundListenerSkipMixer(t *testing.T) {
 	mp := mixerplugin{}
 


### PR DESCRIPTION
Relates to https://github.com/istio/istio/issues/19015

Mixer `source.namespace` attribute missconfigured on the envoy sidecar when the pod name includes a dot. `.` .

For example, if the pod name is 'foo.bar-1234-5678' in the namespace 'demo', the `source.namespace` mixer attribute inside the sidecar proxy will be set to 'bar-1234-5678' instead of 'demo'.

Proxy.Id format is `<pod_name>.<namespace>` in kubernetes
https://github.com/istio/istio/blob/master/pilot/pkg/model/context.go#L82-L84