### PR TITLE
add k8s configurations for kiali

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
@@ -33,6 +33,21 @@ data:
         url: {{ .Values.dashboard.grafanaURL }}
       prometheus:
         url: {{ .Values.prometheusAddr }}
+{{- if .Values.kubernetesConfig }}
+    kubernetes_config:
+{{- if .Values.kubernetesConfig.burst }}
+      burst: {{ .Values.kubernetesConfig.burst }}
+{{- end }}
+{{- if .Values.kubernetesConfig.qps }}
+      qps: {{ .Values.kubernetesConfig.qps }}
+{{- end }}
+{{- if .Values.kubernetesConfig.cacheDuration }}
+      cache_duration: {{ .Values.kubernetesConfig.cacheDuration }}
+{{- end }}
+{{- if .Values.kubernetesConfig.cacheEnabled }}
+      cache_enabled: {{ .Values.kubernetesConfig.cacheEnabled }}
+{{- end }}
+{{- end }}
 {{- if .Values.security.enabled }}
     identity:
       cert_file: {{ .Values.security.cert_file }}

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -69,6 +69,12 @@ dashboard:
   jaegerURL:  # If you have Jaeger installed and it is accessible to client browsers, then set this property to its external URL. Kiali will redirect users to this URL when Jaeger tracing is to be shown.
 prometheusAddr: http://prometheus:9090
 
+kubernetesConfig:
+  burst: 200
+  qps: 175
+  cacheEnabled: false
+  cacheDuration: 300
+
 # When true, a secret will be created with a default username and password. Useful for demos.
 createDemoSecret: false
 


### PR DESCRIPTION
Allow Kiali installed with k8s configurations. The default values are the same as the ones in Kiali repo: 
https://github.com/kiali/kiali/blob/1e1b94b69e02cc582be46ad0fbacef7bf48d6053/config/config.go#L339