### PR TITLE
service entry: allow empty endpoints for static resolution

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2411,11 +2411,6 @@ func ValidateServiceEntry(_, _ string, config proto.Message) (errs error) {
 			errs = appendErrors(errs, fmt.Errorf("no endpoints should be provided for resolution type none"))
 		}
 	case networking.ServiceEntry_STATIC:
-		if len(serviceEntry.Endpoints) == 0 {
-			errs = appendErrors(errs,
-				fmt.Errorf("endpoints must be provided if service entry resolution mode is static"))
-		}
-
 		unixEndpoint := false
 		for _, endpoint := range serviceEntry.Endpoints {
 			addr := endpoint.GetAddress()

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3510,7 +3510,7 @@ func TestValidateServiceEntries(t *testing.T) {
 			},
 			Resolution: networking.ServiceEntry_STATIC,
 		},
-			valid: false},
+			valid: true},
 
 		{name: "discovery type static, bad endpoint port name", in: networking.ServiceEntry{
 			Hosts:     []string{"google.com"},


### PR DESCRIPTION
For Service Entries with STATIC resolution, we should allow empty endpoints. Since we internally convert it to EDS type of cluster in Envoy - it will work and it is valid for the external service represented by the Service Entry to have zero endpoints. When such an event happens today, Pilot rejects the ServiceEntry with error "error: endpoints must be provided if service entry resolution mode is static" and all Envoys will have stale data. Another alternative is to delete the service entry and recreate it with fresh endpoints when they are available.