### PR TITLE
Set stream_idle_timeout to 0s for xDS listener in pilot sidecar config

### DIFF
--- a/pilot/docker/envoy_pilot.yaml.tmpl
+++ b/pilot/docker/envoy_pilot.yaml.tmpl
@@ -297,6 +297,7 @@ static_resources:
                   cluster: in.15010
                   timeout: 0.000s
           stat_prefix: "15011"
+          stream_idle_timeout: 0s
         name: envoy.http_connection_manager
 {{- if .sds_uds_path }}
       tls_context:


### PR DESCRIPTION

Envoy's default value for `stream_idle_timeout` is [5 minutes](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout). Pilot expects to kill connections every 30 minutes to promote even connection balancing, but the lower default idle timeout can cause connections to be killed more rapidly than expected. This change disables the idle timeout entirely, giving control back to Pilot regarding when the connections are killed.