### PR TITLE
Use k8s.io/apimachinery yaml decoder in kubesource

### DIFF
--- a/galley/pkg/config/source/kube/inmemory/kubesource.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource.go
@@ -18,9 +18,13 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
 	"sync"
 
-	"github.com/ghodss/yaml"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
 	"github.com/hashicorp/go-multierror"
 	kubeJson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 
@@ -31,7 +35,6 @@ import (
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/source/inmemory"
 	"istio.io/istio/galley/pkg/config/source/kube/rt"
-	"istio.io/istio/galley/pkg/config/util/kubeyaml"
 )
 
 var inMemoryKubeNameDiscriminator int64
@@ -196,11 +199,29 @@ func (s *KubeSource) RemoveContent(name string) {
 func (s *KubeSource) parseContent(r schema.KubeResources, name, yamlText string) ([]kubeResource, error) {
 	var resources []kubeResource
 	var errs error
-	for i, chunk := range kubeyaml.Split([]byte(yamlText)) {
-		chunk = bytes.TrimSpace(chunk)
+
+	reader := strings.NewReader(yamlText)
+	readCloser := ioutil.NopCloser(reader)
+	decoder := yaml.NewDocumentDecoder(readCloser)
+
+	buf := make([]byte, 4096)
+	for {
+		doc, err := readDocument(decoder, buf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			e := fmt.Errorf("error reading documents in %s: %v", name, err)
+			scope.Source.Warnf("%v - skipping", e)
+			scope.Source.Debugf("Failed to parse yamlText chunk: %v", yamlText)
+			errs = multierror.Append(errs, e)
+			break
+		}
+
+		chunk := bytes.TrimSpace(doc)
 		r, err := s.parseChunk(r, chunk)
 		if err != nil {
-			e := fmt.Errorf("error processing %s[%d]: %v", name, i, err)
+			e := fmt.Errorf("error processing %s: %v", name, err)
 			scope.Source.Warnf("%v - skipping", e)
 			scope.Source.Debugf("Failed to parse yaml chunk: %v", string(chunk))
 			errs = multierror.Append(errs, e)
@@ -208,12 +229,35 @@ func (s *KubeSource) parseContent(r schema.KubeResources, name, yamlText string)
 		}
 		resources = append(resources, r)
 	}
+
 	return resources, errs
+}
+
+// readDocument is a helper for reading documents from yaml.NewDocumentDecoder.
+// yaml.NewDocumentDecoder returns a Reader instance such that every Read call
+// is an entire document; however like all Readers it requires a byte buffer to
+// write to.
+func readDocument(r io.Reader, buf []byte) ([]byte, error) {
+	var doc []byte
+
+	for {
+		num, err := r.Read(buf)
+		if err != nil && err != io.ErrShortBuffer {
+			return []byte{}, err
+		}
+		doc = append(doc, buf[:num]...)
+
+		if err == nil {
+			break
+		}
+	}
+
+	return doc, nil
 }
 
 func (s *KubeSource) parseChunk(r schema.KubeResources, yamlChunk []byte) (kubeResource, error) {
 	// Convert to JSON
-	jsonChunk, err := yaml.YAMLToJSON(yamlChunk)
+	jsonChunk, err := yaml.ToJSON(yamlChunk)
 	if err != nil {
 		return kubeResource{}, fmt.Errorf("failed converting YAML to JSON: %v", err)
 	}

--- a/galley/pkg/config/source/kube/inmemory/kubesource_test.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource_test.go
@@ -329,6 +329,20 @@ func TestKubeSource_DefaultNamespaceSkipClusterScoped(t *testing.T) {
 	g.Expect(actual[0].Metadata.Name).To(Equal(data.EntryI1V1NoNamespace.Metadata.Name))
 }
 
+func TestKubeSource_CanHandleDocumentSeparatorInComments(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s, _ := setupKubeSource()
+	s.Start()
+	defer s.Stop()
+
+	s.SetDefaultNamespace("default")
+
+	err := s.ApplyContent("foo", data.YamlI1V1WithCommentContainingDocumentSeparator)
+	g.Expect(err).To(BeNil())
+	g.Expect(s.ContentNames()).To(Equal(map[string]struct{}{"foo": {}}))
+}
+
 func setupKubeSource() (*KubeSource, *fixtures.Accumulator) {
 	s := NewKubeSource(basicmeta.MustGet().KubeSource().Resources())
 

--- a/galley/pkg/config/testing/data/yaml.go
+++ b/galley/pkg/config/testing/data/yaml.go
@@ -126,4 +126,17 @@ metadata:
 spec:
   n1_i1: v1
 `
+
+	// YamlI1V1WithCommentContainingDocumentSeparator is a testing resource in
+	// yaml form with a comment containing a document separator.
+	YamlI1V1WithCommentContainingDocumentSeparator = `
+# ---
+apiVersion: testdata.istio.io/v1alpha1
+kind: Kind1
+metadata:
+  namespace: n1
+  name: i1
+spec:
+  n1_i1: v1
+`
 )

--- a/galley/pkg/config/util/kubeyaml/kubeyaml.go
+++ b/galley/pkg/config/util/kubeyaml/kubeyaml.go
@@ -23,30 +23,6 @@ const (
 	yamlSeparator = "---\n"
 )
 
-// Split the given yaml doc if it's multipart document.
-func Split(yamlText []byte) [][]byte {
-	parts := bytes.Split(yamlText, []byte(yamlSeparator))
-	var result [][]byte
-	for _, p := range parts {
-		if len(p) != 0 {
-			result = append(result, p)
-		}
-	}
-	return result
-}
-
-// SplitString splits the given yaml doc if it's multipart document.
-func SplitString(yamlText string) []string {
-	parts := strings.Split(yamlText, yamlSeparator)
-	var result []string
-	for _, p := range parts {
-		if len(p) != 0 {
-			result = append(result, p)
-		}
-	}
-	return result
-}
-
 // Join the given yaml parts into a single multipart document.
 func Join(parts ...[]byte) []byte {
 	var b bytes.Buffer

--- a/galley/pkg/config/util/kubeyaml/kubeyaml_test.go
+++ b/galley/pkg/config/util/kubeyaml/kubeyaml_test.go
@@ -66,34 +66,6 @@ yaml: foo
 	},
 }
 
-func TestSplit(t *testing.T) {
-	for i, c := range splitCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			g := NewGomegaWithT(t)
-
-			actual := Split([]byte(c.merged))
-
-			var exp [][]byte
-			for _, e := range c.split {
-				exp = append(exp, []byte(e))
-			}
-			g.Expect(actual).To(Equal(exp))
-		})
-	}
-}
-
-func TestSplitString(t *testing.T) {
-	for i, c := range splitCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			g := NewGomegaWithT(t)
-
-			actual := SplitString(c.merged)
-
-			g.Expect(actual).To(Equal(c.split))
-		})
-	}
-}
-
 var joinCases = []struct {
 	merged string
 	split  []string


### PR DESCRIPTION
Previously we used our own library for splitting multipart documents, but it had a bug (#18998). To avoid this in the future we now use the same decoder used by the k8s project.