### PR TITLE
Do not download non released (ie, alpha, beta, rc) versions of istioctl

### DIFF
--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -35,7 +35,7 @@ fi
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
   ISTIO_VERSION=$(curl -L -s https://api.github.com/repos/istio/istio/releases | \
                   grep tag_name | sed "s/ *\"tag_name\": *\"\\(.*\\)\",*/\\1/" | \
-                  sort -t"." -k 1,1 -k 2,2 -k 3,3 -k 4,4 | tail -n 1)
+                  grep -v -E "(alpha|beta|rc)\.[0-9]$" | sort -t"." -k 1,1 -k 2,2 -k 3,3 -k 4,4 | tail -n 1)
 fi
 
 if [ "x${ISTIO_VERSION}" = "x" ] ; then


### PR DESCRIPTION
downloadIstioCtl does not remove the beta, rc, and alpha versions when determining the latest version to download. 