### PR TITLE
Revert "Use k8s.io/apimachinery yaml decoder in kubesource"

### DIFF
--- a/galley/pkg/config/source/kube/inmemory/kubesource_test.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource_test.go
@@ -329,20 +329,6 @@ func TestKubeSource_DefaultNamespaceSkipClusterScoped(t *testing.T) {
 	g.Expect(actual[0].Metadata.Name).To(Equal(data.EntryI1V1NoNamespace.Metadata.Name))
 }
 
-func TestKubeSource_CanHandleDocumentSeparatorInComments(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	s, _ := setupKubeSource()
-	s.Start()
-	defer s.Stop()
-
-	s.SetDefaultNamespace("default")
-
-	err := s.ApplyContent("foo", data.YamlI1V1WithCommentContainingDocumentSeparator)
-	g.Expect(err).To(BeNil())
-	g.Expect(s.ContentNames()).To(Equal(map[string]struct{}{"foo": {}}))
-}
-
 func setupKubeSource() (*KubeSource, *fixtures.Accumulator) {
 	s := NewKubeSource(basicmeta.MustGet().KubeSource().Resources())
 

--- a/galley/pkg/config/testing/data/yaml.go
+++ b/galley/pkg/config/testing/data/yaml.go
@@ -126,17 +126,4 @@ metadata:
 spec:
   n1_i1: v1
 `
-
-	// YamlI1V1WithCommentContainingDocumentSeparator is a testing resource in
-	// yaml form with a comment containing a document separator.
-	YamlI1V1WithCommentContainingDocumentSeparator = `
-# ---
-apiVersion: testdata.istio.io/v1alpha1
-kind: Kind1
-metadata:
-  namespace: n1
-  name: i1
-spec:
-  n1_i1: v1
-`
 )

--- a/galley/pkg/config/util/kubeyaml/kubeyaml.go
+++ b/galley/pkg/config/util/kubeyaml/kubeyaml.go
@@ -23,6 +23,30 @@ const (
 	yamlSeparator = "---\n"
 )
 
+// Split the given yaml doc if it's multipart document.
+func Split(yamlText []byte) [][]byte {
+	parts := bytes.Split(yamlText, []byte(yamlSeparator))
+	var result [][]byte
+	for _, p := range parts {
+		if len(p) != 0 {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// SplitString splits the given yaml doc if it's multipart document.
+func SplitString(yamlText string) []string {
+	parts := strings.Split(yamlText, yamlSeparator)
+	var result []string
+	for _, p := range parts {
+		if len(p) != 0 {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
 // Join the given yaml parts into a single multipart document.
 func Join(parts ...[]byte) []byte {
 	var b bytes.Buffer

--- a/galley/pkg/config/util/kubeyaml/kubeyaml_test.go
+++ b/galley/pkg/config/util/kubeyaml/kubeyaml_test.go
@@ -66,6 +66,34 @@ yaml: foo
 	},
 }
 
+func TestSplit(t *testing.T) {
+	for i, c := range splitCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			actual := Split([]byte(c.merged))
+
+			var exp [][]byte
+			for _, e := range c.split {
+				exp = append(exp, []byte(e))
+			}
+			g.Expect(actual).To(Equal(exp))
+		})
+	}
+}
+
+func TestSplitString(t *testing.T) {
+	for i, c := range splitCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			actual := SplitString(c.merged)
+
+			g.Expect(actual).To(Equal(c.split))
+		})
+	}
+}
+
 var joinCases = []struct {
 	merged string
 	split  []string


### PR DESCRIPTION
Reverts istio/istio#19045

The yaml decoder from k8s.io/apimachinery has a max token size (the default from bufio.Scanner). Mixer adapters can easily run over this token size in practice. 