### PR TITLE
Fix concurrent map write and read in galley

### DIFF
--- a/galley/pkg/config/source/kube/apiserver/source.go
+++ b/galley/pkg/config/source/kube/apiserver/source.go
@@ -107,7 +107,6 @@ func (s *Source) Start() {
 		return
 	}
 	s.started = true
-	s.mu.Unlock()
 
 	// Create a set of pending resources. These will be matched up with incoming CRD events for creating watchers for
 	// each resource that we expect.
@@ -118,6 +117,7 @@ func (s *Source) Start() {
 		key := asKey(r.Group, r.Kind)
 		s.expectedResources[key] = r
 	}
+	s.mu.Unlock()
 
 	// Start the CRD listener. When the listener is fully-synced, the listening of actual resources will start.
 	scope.Source.Infof("Beginning CRD Discovery, to figure out resources that are available...")

--- a/galley/pkg/config/source/kube/apiserver/source.go
+++ b/galley/pkg/config/source/kube/apiserver/source.go
@@ -117,6 +117,7 @@ func (s *Source) Start() {
 		key := asKey(r.Group, r.Kind)
 		s.expectedResources[key] = r
 	}
+	// Releasing the lock here to avoid deadlock on crdWatcher between the existing one and a newly started one.
 	s.mu.Unlock()
 
 	// Start the CRD listener. When the listener is fully-synced, the listening of actual resources will start.


### PR DESCRIPTION
fixes https://github.com/istio/istio/issues/18879

The map used in kube source for Galley is not properly handled for concurrency, thus triggering `fatal error: concurrent map iteration and map write` and crashing galley. 

ref: https://storage.googleapis.com/istio-prow/logs/pilot-e2e-envoyv2-v1alpha3_istio_postsubmit/705/artifacts/kind/istio-testing-control-plane/containers/istio-galley-6c54ff4bd9-7hrlv_istio-system_galley-df475b891f129b0c8fae8ce1e94b27f8054051f979ceda1584108d144f6ea09f.log