### PR TITLE
validation: respect unsafe regex config in regex validation

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -225,16 +225,14 @@ func ValidateStringMatch(m *networking.StringMatch) error {
 	case *networking.StringMatch_Regex:
 		// Pilot allows unsafe regex based on env var. We should respect that.
 		// TODO: See if there is a better way to get this flag here.
-		var unsaferegex bool
+		saferegex := true
 		if result, ok := os.LookupEnv("PILOT_ENABLE_UNSAFE_REGEX"); ok {
 			if value, err := strconv.ParseBool(result); err == nil {
-				unsaferegex = value
-			} else {
-				unsaferegex = false // Assume safe regex if it unparsable.
+				saferegex = !value
 			}
 		}
 		// Default max size for safe regex is 100
-		if !unsaferegex && len(x.Regex) > 100 {
+		if saferegex && len(x.Regex) > 100 {
 			return fmt.Errorf("regex match '%s' cannot be greater than 100 bytes", x.Regex)
 		}
 	}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"path"
 	"regexp"
 	"strconv"
@@ -222,8 +223,18 @@ func ValidateStringMatch(m *networking.StringMatch) error {
 	}
 	switch x := m.MatchType.(type) {
 	case *networking.StringMatch_Regex:
+		// Pilot allows unsafe regex based on env var. We should respect that.
+		// TODO: See if there is a better way to get this flag here.
+		var unsaferegex bool
+		if result, ok := os.LookupEnv("PILOT_ENABLE_UNSAFE_REGEX"); ok {
+			if value, err := strconv.ParseBool(result); err == nil {
+				unsaferegex = value
+			} else {
+				unsaferegex = false // Assume safe regex if it unparsable.
+			}
+		}
 		// Default max size for safe regex is 100
-		if len(x.Regex) > 100 {
+		if !unsaferegex && len(x.Regex) > 100 {
 			return fmt.Errorf("regex match '%s' cannot be greater than 100 bytes", x.Regex)
 		}
 	}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -2035,9 +2036,10 @@ func TestValidateDestination(t *testing.T) {
 
 func TestValidateHTTPRoute(t *testing.T) {
 	testCases := []struct {
-		name  string
-		route *networking.HTTPRoute
-		valid bool
+		name        string
+		route       *networking.HTTPRoute
+		unsaferegex bool
+		valid       bool
 	}{
 		{name: "empty", route: &networking.HTTPRoute{ // nothing
 		}, valid:                                     false},
@@ -2258,9 +2260,24 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 		}, valid: false},
+		{name: "too large regex with unsafe enabled", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Regex{Regex: strings.Repeat("a", 101)},
+				},
+			}},
+		}, unsaferegex: true, valid: true},
 	}
 
 	for _, tc := range testCases {
+		if tc.unsaferegex {
+			_ = os.Setenv("PILOT_ENABLE_UNSAFE_REGEX", "true")
+
+			defer func() { _ = os.Unsetenv("PILOT_ENABLE_UNSAFE_REGEX") }()
+		}
 		t.Run(tc.name, func(t *testing.T) {
 			if err := validateHTTPRoute(tc.route); (err == nil) != tc.valid {
 				t.Fatalf("got valid=%v but wanted valid=%v: %v", err == nil, tc.valid, err)


### PR DESCRIPTION
This PR https://github.com/istio/istio/pull/18539 added validation for regex > 100 chars. But Pilot has env var support that can be used to turn off safe regex. For non galley use cases, this flag should be considered during validation.