### PR TITLE
Make use of the new GA topology labels

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -53,9 +53,9 @@ const (
 	// NodeZoneLabel is the well-known label for kubernetes node zone in beta
 	NodeZoneLabel = "failure-domain.beta.kubernetes.io/zone"
 	// NodeRegionLabelGA is the well-known label for kubernetes node region in ga
-	NodeRegionLabelGA = "failure-domain.kubernetes.io/region"
+	NodeRegionLabelGA = "topology.kubernetes.io/region"
 	// NodeZoneLabelGA is the well-known label for kubernetes node zone in ga
-	NodeZoneLabelGA = "failure-domain.kubernetes.io/zone"
+	NodeZoneLabelGA = "topology.kubernetes.io/zone"
 	// IstioNamespace used by default for Istio cluster-wide installation
 	IstioNamespace = "istio-system"
 	// IstioConfigMap is used by default


### PR DESCRIPTION

In https://github.com/istio/istio/pull/17755 we added support for the "informal" topology GA labels. The Kubernetes PR: https://github.com/kubernetes/kubernetes/pull/81431 adds now official topology GA labels (which will be introduced in Kubernetes 1.17 and support for the old beta labels will be dropped in 1.21.