### PR TITLE
Let fluentd adapter encode timestamp with millsecond

### DIFF
--- a/mixer/adapter/fluentd/fluentd.go
+++ b/mixer/adapter/fluentd/fluentd.go
@@ -126,7 +126,7 @@ func (b *builder) build(_ context.Context, env adapter.Env, newFluentd func(flue
 		pushInterval:  interval,
 		pushTimeout:   timeout,
 	}
-	han.logger, err = newFluentd(fluent.Config{FluentPort: p, FluentHost: h, BufferLimit: int(batchBytes), WriteTimeout: timeout})
+	han.logger, err = newFluentd(fluent.Config{FluentPort: p, FluentHost: h, BufferLimit: int(batchBytes), WriteTimeout: timeout, SubSecondPrecision: true})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Current fluentd adapter using [fluent-logger-golang](https://github.com/fluent/fluent-logger-golang/) doesn't encoded timestamp with milliseconds information as my issue #19070 shown. A tiny changed is doned and now it can encode timestamp with milliseconds.