### PR TITLE
Analysis output includes doc links

### DIFF
--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -65,7 +65,7 @@ func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 		result["origin"] = m.Origin.FriendlyName()
 	}
 	result["message"] = fmt.Sprintf(m.Type.Template(), m.Parameters...)
-	result["doc"] = fmt.Sprintf("%s/%s", DocPrefix, m.Type.Code())
+	result["documentation_url"] = fmt.Sprintf("%s/%s", DocPrefix, m.Type.Code())
 
 	return result
 }

--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -21,6 +21,8 @@ import (
 	"istio.io/istio/galley/pkg/config/resource"
 )
 
+const DocPrefix = "https://istio.io/docs/reference/config/analysis"
+
 // MessageType is a type of diagnostic message
 type MessageType struct {
 	// The level of the message.
@@ -63,6 +65,7 @@ func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 		result["origin"] = m.Origin.FriendlyName()
 	}
 	result["message"] = fmt.Sprintf(m.Type.Template(), m.Parameters...)
+	result["doc"] = fmt.Sprintf("%s/%s", DocPrefix, m.Type.Code())
 
 	return result
 }

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -59,5 +59,6 @@ func TestMessage_JSON(t *testing.T) {
 	m := NewMessage(mt, o, "Feta")
 
 	j, _ := json.Marshal(&m)
-	g.Expect(string(j)).To(Equal(`{"code":"IST-0042","level":"Error","message":"Cheese type not found: \"Feta\"","origin":"toppings/cheese"}`))
+	g.Expect(string(j)).To(Equal(`{"code":"IST-0042","doc":"https://istio.io/docs/reference/config/analysis/IST-0042"` +
+		`,"level":"Error","message":"Cheese type not found: \"Feta\"","origin":"toppings/cheese"}`))
 }

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -59,5 +59,6 @@ func TestMessage_JSON(t *testing.T) {
 	m := NewMessage(mt, o, "Feta")
 
 	j, _ := json.Marshal(&m)
-	g.Expect(string(j)).To(Equal(`{"code":"IST-0042","documentation_url":"https://istio.io/docs/reference/config/analysis/IST-0042","level":"Error","message":"Cheese type not found: \"Feta\"","origin":"toppings/cheese"}`))
+	g.Expect(string(j)).To(Equal(`{"code":"IST-0042","documentation_url":"https://istio.io/docs/reference/config/analysis/IST-0042"` +
+		`,"level":"Error","message":"Cheese type not found: \"Feta\"","origin":"toppings/cheese"}`))
 }

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -59,6 +59,5 @@ func TestMessage_JSON(t *testing.T) {
 	m := NewMessage(mt, o, "Feta")
 
 	j, _ := json.Marshal(&m)
-	g.Expect(string(j)).To(Equal(`{"code":"IST-0042","doc":"https://istio.io/docs/reference/config/analysis/IST-0042"` +
-		`,"level":"Error","message":"Cheese type not found: \"Feta\"","origin":"toppings/cheese"}`))
+	g.Expect(string(j)).To(Equal(`{"code":"IST-0042","documentation_url":"https://istio.io/docs/reference/config/analysis/IST-0042","level":"Error","message":"Cheese type not found: \"Feta\"","origin":"toppings/cheese"}`))
 }

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -38,7 +38,7 @@ type AnalyzerFoundIssuesError struct{}
 type FileParseError struct{}
 
 const (
-	FoundIssueString = "Analyzer found issues."
+	FoundIssueString = "Analyzers found issues."
 	FileParseString  = "Some files couldn't be parsed."
 	LogOutput        = "log"
 	JSONOutput       = "json"
@@ -46,7 +46,7 @@ const (
 )
 
 func (f AnalyzerFoundIssuesError) Error() string {
-	return FoundIssueString
+	return fmt.Sprintf("%s\nSee %s for more information about causes and resolutions.", FoundIssueString, diag.DocPrefix)
 }
 
 func (f FileParseError) Error() string {

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -38,6 +38,7 @@ type AnalyzerFoundIssuesError struct{}
 type FileParseError struct{}
 
 const (
+	NoIssuesString   = "\u2714 No validation issues found."
 	FoundIssueString = "Analyzers found issues."
 	FileParseString  = "Some files couldn't be parsed."
 	LogOutput        = "log"
@@ -214,7 +215,7 @@ istioctl experimental analyze -k -d false
 				// Print validation message output, or a line indicating that none were found
 				if len(outputMessages) == 0 {
 					if parseErrors == 0 {
-						fmt.Fprintln(cmd.ErrOrStderr(), "\u2714 No validation issues found.")
+						fmt.Fprintln(cmd.ErrOrStderr(), NoIssuesString)
 					} else {
 						fileOrFiles := "files"
 						if parseErrors == 1 {

--- a/pkg/mcp/monitoring/monitoring.go
+++ b/pkg/mcp/monitoring/monitoring.go
@@ -25,12 +25,11 @@ import (
 )
 
 const (
-	collection   = "collection"
-	errorCode    = "code"
-	errorStr     = "error"
-	connectionID = "connectionID"
-	code         = "code"
-	component    = "component"
+	collection = "collection"
+	errorCode  = "code"
+	errorStr   = "error"
+	code       = "code"
+	component  = "component"
 )
 
 var (

--- a/tests/integration/istioctl/versionanalyze/analyze_test.go
+++ b/tests/integration/istioctl/versionanalyze/analyze_test.go
@@ -170,18 +170,19 @@ func TestServiceDiscovery(t *testing.T) {
 }
 
 // Verify the output contains messages of the expected type, in order, followed by boilerplate lines
-func expectMessages(t *testing.T, g *GomegaWithT, output []string, messageTypes ...*diag.MessageType) {
+func expectMessages(t *testing.T, g *GomegaWithT, outputLines []string, expected ...*diag.MessageType) {
 	t.Helper()
 
-	foundIssuesParts := strings.Split(analyzerFoundIssuesError.Error(), "\n")
+	// The boilerplate lines that appear if any issues are found
+	boilerplateLines := strings.Split(analyzerFoundIssuesError.Error(), "\n")
 
-	g.Expect(output).To(HaveLen(len(messageTypes) + len(foundIssuesParts)))
+	g.Expect(outputLines).To(HaveLen(len(expected) + len(boilerplateLines)))
 
-	for i, line := range output {
-		if i < len(messageTypes) {
-			g.Expect(line).To(ContainSubstring(messageTypes[i].Code()))
+	for i, line := range outputLines {
+		if i < len(expected) {
+			g.Expect(line).To(ContainSubstring(expected[i].Code()))
 		} else {
-			g.Expect(line).To(ContainSubstring(foundIssuesParts[i-len(messageTypes)]))
+			g.Expect(line).To(ContainSubstring(boilerplateLines[i-len(expected)]))
 		}
 	}
 }


### PR DESCRIPTION
Solves https://github.com/istio/istio/issues/18451



Example output in the status field:
```yaml
status:
  validationMessages:
  - code: IST0101
    doc: https://istio.io/docs/reference/config/analysis/IST0101
    level: Error
    message: 'Referenced gateway not found: "bogus-reviews-gateway-2"'
  - code: IST0101
    doc: https://istio.io/docs/reference/config/analysis/IST0101
    level: Error
    message: 'Referenced host+subset in destinationrule not found: "reviews+v1-bogus"'
  - code: IST0101
    doc: https://istio.io/docs/reference/config/analysis/IST0101
    level: Error
    message: 'Referenced host+subset in destinationrule not found: "reviews-bogus2+v1"'
```

Example outputs via CLI:

`istioctl experimental analyze ~/tmp2/test_config/test.yaml`:
```
Error [IST0101] (VirtualService httpbin.default) Referenced gateway not found: "httpbin-gateway-bogus"
Error [IST0109] (VirtualService foo1.default) The VirtualServices default/foo1,default/foo2 associated with mesh gateway define the same host */barhost.default.svc.cluster.local which can lead to undefined behavior. This can be fixed by merging the conflicting VirtualServices into a single resource.
Error [IST0109] (VirtualService foo2.default) The VirtualServices default/foo1,default/foo2 associated with mesh gateway define the same host */barhost.default.svc.cluster.local which can lead to undefined behavior. This can be fixed by merging the conflicting VirtualServices into a single resource.
Error: Analyzers found issues.
See https://istio.io/docs/reference/config/analysis for more information about causes and resolutions.
```

`istioctl experimental analyze ~/tmp2/test_config/test.yaml -o yaml`
```
- code: IST0101
  doc: https://istio.io/docs/reference/config/analysis/IST0101
  level: Error
  message: 'Referenced gateway not found: "httpbin-gateway-bogus"'
  origin: VirtualService httpbin.default
- code: IST0109
  doc: https://istio.io/docs/reference/config/analysis/IST0109
  level: Error
  message: The VirtualServices default/foo1,default/foo2 associated with mesh gateway
    define the same host */barhost.default.svc.cluster.local which can lead to undefined
    behavior. This can be fixed by merging the conflicting VirtualServices into a
    single resource.
  origin: VirtualService foo1.default
- code: IST0109
  doc: https://istio.io/docs/reference/config/analysis/IST0109
  level: Error
  message: The VirtualServices default/foo1,default/foo2 associated with mesh gateway
    define the same host */barhost.default.svc.cluster.local which can lead to undefined
    behavior. This can be fixed by merging the conflicting VirtualServices into a
    single resource.
  origin: VirtualService foo2.default

Error: Analyzers found issues.
See https://istio.io/docs/reference/config/analysis for more information about causes and resolutions.
```