### PR TITLE
Service registry cleanup

### DIFF
--- a/istioctl/pkg/multicluster/generate.go
+++ b/istioctl/pkg/multicluster/generate.go
@@ -272,7 +272,7 @@ func meshNetworkForCluster(env Environment, mesh *Mesh, current *Cluster) (*v1al
 		// uses a special name for the local cluster against which it is running.
 		registry := string(cluster.uid)
 		if context == current.Context {
-			registry = string(serviceregistry.KubernetesRegistry)
+			registry = string(serviceregistry.Kubernetes)
 		}
 
 		mn.Networks[network].Endpoints = append(mn.Networks[network].Endpoints,

--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -49,7 +49,7 @@ func TestPilotSanIfAuthenticationMutualDomainEmptyKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{}
 	role.DNSDomain = ""
-	registry = serviceregistry.KubernetesRegistry
+	registryID = serviceregistry.Kubernetes
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain("", role.DNSDomain)
@@ -63,7 +63,7 @@ func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 	role = &model.Proxy{}
 	role.DNSDomain = "my.domain"
 	trustDomain = ""
-	registry = serviceregistry.KubernetesRegistry
+	registryID = serviceregistry.Kubernetes
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain("", role.DNSDomain)
@@ -77,7 +77,7 @@ func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 func TestPilotSanIfAuthenticationMutualDomainEmptyConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role.DNSDomain = ""
-	registry = serviceregistry.ConsulRegistry
+	registryID = serviceregistry.Consul
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain("", role.DNSDomain)
@@ -94,7 +94,7 @@ func TestPilotSanIfAuthenticationMutualTrustDomain(t *testing.T) {
 	defer func() {
 		trustDomain = ""
 	}()
-	registry = serviceregistry.KubernetesRegistry
+	registryID = serviceregistry.Kubernetes
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain("", role.DNSDomain)
@@ -111,7 +111,7 @@ func TestPilotSanIfAuthenticationMutualTrustDomainAndDomain(t *testing.T) {
 	defer func() {
 		trustDomain = ""
 	}()
-	registry = serviceregistry.KubernetesRegistry
+	registryID = serviceregistry.Kubernetes
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain("", role.DNSDomain)
@@ -124,7 +124,7 @@ func TestPilotDefaultDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{}
 	role.DNSDomain = ""
-	registry = serviceregistry.KubernetesRegistry
+	registryID = serviceregistry.Kubernetes
 
 	domain := getDNSDomain("default", role.DNSDomain)
 
@@ -219,7 +219,7 @@ func TestPilotDefaultDomainConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role := &model.Proxy{}
 	role.DNSDomain = ""
-	registry = serviceregistry.ConsulRegistry
+	registryID = serviceregistry.Consul
 
 	domain := getDNSDomain("", role.DNSDomain)
 
@@ -230,7 +230,7 @@ func TestPilotDefaultDomainOthers(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{}
 	role.DNSDomain = ""
-	registry = serviceregistry.MockRegistry
+	registryID = serviceregistry.Mock
 
 	domain := getDNSDomain("", role.DNSDomain)
 
@@ -240,7 +240,7 @@ func TestPilotDefaultDomainOthers(t *testing.T) {
 func TestPilotDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role.DNSDomain = "my.domain"
-	registry = serviceregistry.MockRegistry
+	registryID = serviceregistry.Mock
 
 	domain := getDNSDomain("", role.DNSDomain)
 
@@ -251,7 +251,7 @@ func TestPilotSanIfAuthenticationMutualStdDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	role = &model.Proxy{}
 	role.DNSDomain = ".svc.cluster.local"
-	registry = serviceregistry.KubernetesRegistry
+	registryID = serviceregistry.Kubernetes
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain("", role.DNSDomain)
@@ -267,7 +267,7 @@ func TestPilotSanIfAuthenticationMutualStdDomainConsul(t *testing.T) {
 	role = &model.Proxy{}
 	role.DNSDomain = "service.consul"
 	trustDomain = ""
-	registry = serviceregistry.ConsulRegistry
+	registryID = serviceregistry.Consul
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain("", role.DNSDomain)
@@ -281,7 +281,7 @@ func TestCustomPilotSanIfAuthenticationMutualDomainKubernetesNoTrustDomain(t *te
 	role = &model.Proxy{}
 	role.DNSDomain = ""
 	pilotIdentity = "pilot-identity"
-	registry = serviceregistry.KubernetesRegistry
+	registryID = serviceregistry.Kubernetes
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain("", role.DNSDomain)
@@ -296,7 +296,7 @@ func TestCustomPilotSanIfAuthenticationMutualDomainKubernetes(t *testing.T) {
 	role.DNSDomain = ""
 	trustDomain = "mesh.com"
 	pilotIdentity = "pilot-identity"
-	registry = serviceregistry.KubernetesRegistry
+	registryID = serviceregistry.Kubernetes
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain("", role.DNSDomain)
@@ -311,7 +311,7 @@ func TestCustomMixerSanIfAuthenticationMutualDomainKubernetes(t *testing.T) {
 	role.DNSDomain = ""
 	trustDomain = "mesh.com"
 	mixerIdentity = "mixer-identity"
-	registry = serviceregistry.KubernetesRegistry
+	registryID = serviceregistry.Kubernetes
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
 	setSpiffeTrustDomain("", role.DNSDomain)

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -97,7 +97,7 @@ var (
 // when we run on k8s, the default trust domain is 'cluster.local', otherwise it is the empty string
 func hasKubeRegistry() bool {
 	for _, r := range serverArgs.Service.Registries {
-		if serviceregistry.ServiceRegistry(r) == serviceregistry.KubernetesRegistry {
+		if serviceregistry.ProviderID(r) == serviceregistry.Kubernetes {
 			return true
 		}
 	}
@@ -106,9 +106,9 @@ func hasKubeRegistry() bool {
 
 func init() {
 	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.Service.Registries, "registries",
-		[]string{string(serviceregistry.KubernetesRegistry)},
+		[]string{string(serviceregistry.Kubernetes)},
 		fmt.Sprintf("Comma separated list of platform service registries to read from (choose one or more from {%s, %s, %s, %s})",
-			serviceregistry.KubernetesRegistry, serviceregistry.ConsulRegistry, serviceregistry.MCPRegistry, serviceregistry.MockRegistry))
+			serviceregistry.Kubernetes, serviceregistry.Consul, serviceregistry.MCP, serviceregistry.Mock))
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ClusterRegistriesNamespace, "clusterRegistriesNamespace", metav1.NamespaceAll,
 		"Namespace for ConfigMap which stores clusters configs")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.KubeConfig, "kubeconfig", "",

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -167,7 +167,7 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 		if resourceContains(configSource.SubscribedResources, meshconfig.Resource_SERVICE_REGISTRY) {
 
 			//TODO(Nino-K): https://github.com/istio/istio/issues/16976
-			args.Service.Registries = []string{string(serviceregistry.MCPRegistry)}
+			args.Service.Registries = []string{string(serviceregistry.MCP)}
 			conn, err := grpcDial(ctx, cancel, configSource, args)
 			if err != nil {
 				log.Errorf("Unable to dial MCP Server %q: %v", configSource.Address, err)

--- a/pilot/pkg/bootstrap/util.go
+++ b/pilot/pkg/bootstrap/util.go
@@ -22,7 +22,7 @@ import (
 
 func hasKubeRegistry(registries []string) bool {
 	for _, r := range registries {
-		if serviceregistry.ServiceRegistry(r) == serviceregistry.KubernetesRegistry {
+		if serviceregistry.ProviderID(r) == serviceregistry.Kubernetes {
 			return true
 		}
 	}

--- a/pilot/pkg/config/clusterregistry/multicluster.go
+++ b/pilot/pkg/config/clusterregistry/multicluster.go
@@ -21,13 +21,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/log"
+
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/kube/secretcontroller"
-	"istio.io/pkg/log"
 )
 
 type kubeController struct {
@@ -96,13 +96,7 @@ func (m *Multicluster) AddMemberCluster(clientset kubernetes.Interface, clusterI
 	kubectl.InitNetworkLookup(m.meshNetworks)
 
 	remoteKubeController.rc = kubectl
-	m.serviceController.AddRegistry(
-		aggregate.Registry{
-			Name:             serviceregistry.KubernetesRegistry,
-			ClusterID:        clusterID,
-			ServiceDiscovery: kubectl,
-			Controller:       kubectl,
-		})
+	m.serviceController.AddRegistry(kubectl)
 
 	m.remoteKubeControllers[clusterID] = &remoteKubeController
 	m.m.Unlock()

--- a/pilot/pkg/config/coredatamodel/discovery.go
+++ b/pilot/pkg/config/coredatamodel/discovery.go
@@ -34,8 +34,7 @@ import (
 )
 
 var (
-	_ model.Controller       = &MCPDiscovery{}
-	_ model.ServiceDiscovery = &MCPDiscovery{}
+	_ serviceregistry.Instance = &MCPDiscovery{}
 )
 
 // DiscoveryOptions stores the configurable attributes of a Control
@@ -110,6 +109,14 @@ func (d *MCPDiscovery) Run(stop <-chan struct{}) {
 	if err := d.initializeCache(); err != nil {
 		log.Warnf("Run: %s", err)
 	}
+}
+
+func (d *MCPDiscovery) Provider() serviceregistry.ProviderID {
+	return serviceregistry.MCP
+}
+
+func (d *MCPDiscovery) Cluster() string {
+	return d.ClusterID
 }
 
 // Services list declarations of all SyntheticServiceEntries in the system
@@ -354,7 +361,7 @@ func convertServices(cfg model.Config) map[string]*model.Service {
 						Ports:        svcPorts,
 						Resolution:   resolution,
 						Attributes: model.ServiceAttributes{
-							ServiceRegistry: string(serviceregistry.MCPRegistry),
+							ServiceRegistry: string(serviceregistry.MCP),
 							Name:            hostname,
 							Namespace:       cfg.Namespace,
 							ExportTo:        exportTo,
@@ -369,7 +376,7 @@ func convertServices(cfg model.Config) map[string]*model.Service {
 						Ports:        svcPorts,
 						Resolution:   resolution,
 						Attributes: model.ServiceAttributes{
-							ServiceRegistry: string(serviceregistry.MCPRegistry),
+							ServiceRegistry: string(serviceregistry.MCP),
 							Name:            hostname,
 							Namespace:       cfg.Namespace,
 							ExportTo:        exportTo,
@@ -386,7 +393,7 @@ func convertServices(cfg model.Config) map[string]*model.Service {
 				Ports:        svcPorts,
 				Resolution:   resolution,
 				Attributes: model.ServiceAttributes{
-					ServiceRegistry: string(serviceregistry.MCPRegistry),
+					ServiceRegistry: string(serviceregistry.MCP),
 					Name:            hostname,
 					Namespace:       cfg.Namespace,
 					ExportTo:        exportTo,

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1358,7 +1358,7 @@ func altStatName(statPattern string, host string, subset string, port *model.Por
 
 // shotHostName removes the domain from kubernetes hosts. For other hosts like VMs, this method does not do any thing.
 func shortHostName(host string, attributes model.ServiceAttributes) string {
-	if attributes.ServiceRegistry == string(serviceregistry.KubernetesRegistry) {
+	if attributes.ServiceRegistry == string(serviceregistry.Kubernetes) {
 		return fmt.Sprintf("%s.%s", attributes.Name, attributes.Namespace)
 	}
 	return host

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1591,7 +1591,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},
@@ -1604,7 +1604,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "namespace1",
 			},
@@ -1617,7 +1617,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "namespace1",
 			},
@@ -1630,7 +1630,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.ConsulRegistry),
+				ServiceRegistry: string(serviceregistry.Consul),
 				Name:            "foo",
 				Namespace:       "bar",
 			},
@@ -1643,7 +1643,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},
@@ -1656,7 +1656,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},
@@ -1669,7 +1669,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},
@@ -1682,7 +1682,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},
@@ -1695,7 +1695,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},
@@ -1708,7 +1708,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},
@@ -1721,7 +1721,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},
@@ -1734,7 +1734,7 @@ func TestAltStatName(t *testing.T) {
 			"",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},
@@ -1747,7 +1747,7 @@ func TestAltStatName(t *testing.T) {
 			"v1",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},
@@ -1760,7 +1760,7 @@ func TestAltStatName(t *testing.T) {
 			"v1",
 			&model.Port{Name: "grpc-svc", Port: 7443, Protocol: "GRPC"},
 			model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "reviews",
 				Namespace:       "default",
 			},

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -377,7 +377,7 @@ func generateVirtualHostDomains(service *model.Service, port int, node *model.Pr
 	domains = append(domains, generateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)...)
 
 	if service.Resolution == model.Passthrough &&
-		service.Attributes.ServiceRegistry == string(serviceregistry.KubernetesRegistry) {
+		service.Attributes.ServiceRegistry == string(serviceregistry.Kubernetes) {
 		for _, domain := range domains {
 			domains = append(domains, wildcardDomainPrefix+domain)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -706,7 +706,7 @@ func buildHTTPService(hostname string, v visibility.Instance, ip, namespace stri
 		ClusterVIPs:  make(map[string]string),
 		Resolution:   model.DNSLB,
 		Attributes: model.ServiceAttributes{
-			ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+			ServiceRegistry: string(serviceregistry.Kubernetes),
 			Namespace:       namespace,
 			ExportTo:        map[visibility.Instance]bool{v: true},
 		},

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -998,7 +998,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 					// for each instance. HTTP services can happily reside on 0.0.0.0:PORT and use the
 					// wildcard route match to get to the appropriate pod through original dst clusters.
 					if features.EnableHeadlessService.Get() && bind == "" && service.Resolution == model.Passthrough &&
-						service.Attributes.ServiceRegistry == string(serviceregistry.KubernetesRegistry) && servicePort.Protocol.IsTCP() {
+						service.Attributes.ServiceRegistry == string(serviceregistry.Kubernetes) && servicePort.Protocol.IsTCP() {
 						if instances, err := env.InstancesByPort(service, servicePort.Port, nil); err == nil {
 							for _, instance := range instances {
 								// Skip build outbound listener to the node itself,

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -475,7 +475,7 @@ func TestOutboundListenerForHeadlessServices(t *testing.T) {
 	defer func() { _ = os.Unsetenv("PILOT_ENABLE_FALLTHROUGH_ROUTE") }()
 
 	svc := buildServiceWithPort("test.com", 9999, protocol.TCP, tnow)
-	svc.Attributes.ServiceRegistry = string(serviceregistry.KubernetesRegistry)
+	svc.Attributes.ServiceRegistry = string(serviceregistry.Kubernetes)
 	svc.Resolution = model.Passthrough
 	services := []*model.Service{svc}
 

--- a/pilot/pkg/proxy/envoy/v2/bench_test.go
+++ b/pilot/pkg/proxy/envoy/v2/bench_test.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/external"
 	"istio.io/istio/pkg/config/mesh"
@@ -42,8 +43,8 @@ func SetupDiscoveryServer(t testing.TB, cfgs ...model.Config) *DiscoveryServer {
 	serviceControllers := aggregate.NewController()
 	serviceEntryStore := external.NewServiceDiscovery(configController, istioConfigStore)
 	go configController.Run(make(chan struct{}))
-	serviceEntryRegistry := aggregate.Registry{
-		Name:             "ServiceEntries",
+	serviceEntryRegistry := serviceregistry.Simple{
+		ProviderID:       "ServiceEntries",
 		Controller:       serviceEntryStore,
 		ServiceDiscovery: serviceEntryStore,
 	}

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -98,9 +98,9 @@ func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controll
 	s.MemRegistry.EDSUpdater = s
 	s.MemRegistry.ClusterID = "v2-debug"
 
-	sctl.AddRegistry(aggregate.Registry{
+	sctl.AddRegistry(serviceregistry.Simple{
 		ClusterID:        "v2-debug",
-		Name:             serviceregistry.ServiceRegistry("memAdapter"),
+		ProviderID:       serviceregistry.ProviderID("memAdapter"),
 		ServiceDiscovery: s.MemRegistry,
 		Controller:       s.MemRegistry.controller,
 	})

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -248,20 +248,20 @@ func (s *DiscoveryServer) updateServiceShards(push *model.PushContext) error {
 
 	// TODO: if ServiceDiscovery is aggregate, and all members support direct, use
 	// the direct interface.
-	var registries []aggregate.Registry
-	var nonK8sRegistries []aggregate.Registry
+	var registries []serviceregistry.Instance
+	var nonK8sRegistries []serviceregistry.Instance
 	if agg, ok := s.Env.ServiceDiscovery.(*aggregate.Controller); ok {
 		registries = agg.GetRegistries()
 	} else {
-		registries = []aggregate.Registry{
-			{
+		registries = []serviceregistry.Instance{
+			serviceregistry.Simple{
 				ServiceDiscovery: s.Env.ServiceDiscovery,
 			},
 		}
 	}
 
 	for _, registry := range registries {
-		if registry.Name != serviceregistry.KubernetesRegistry {
+		if registry.Provider() != serviceregistry.Kubernetes {
 			nonK8sRegistries = append(nonK8sRegistries, registry)
 		}
 	}
@@ -305,7 +305,7 @@ func (s *DiscoveryServer) updateServiceShards(push *model.PushContext) error {
 				}
 			}
 
-			s.edsUpdate(registry.ClusterID, string(svc.Hostname), svc.Attributes.Namespace, entries, true)
+			s.edsUpdate(registry.Cluster(), string(svc.Hostname), svc.Attributes.Namespace, entries, true)
 		}
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -30,7 +30,7 @@ import (
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
-	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/env"
@@ -229,9 +229,9 @@ func initRegistry(server *bootstrap.Server, clusterNum int, gatewaysIP []string,
 	id := fmt.Sprintf("network%d", clusterNum)
 	memRegistry := v2.NewMemServiceDiscovery(
 		map[host.Name]*model.Service{}, 2)
-	server.ServiceController.AddRegistry(aggregate.Registry{
+	server.ServiceController.AddRegistry(serviceregistry.Simple{
 		ClusterID:        id,
-		Name:             "memAdapter",
+		ProviderID:       "memAdapter",
 		ServiceDiscovery: memRegistry,
 		Controller:       &v2.MemServiceController{},
 	})

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdsapi_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
@@ -586,7 +587,7 @@ func memServiceDiscovery(server *bootstrap.Server, t *testing.T) *v2.MemServiceD
 	if !found {
 		t.Fatal("Could not find Mock ServiceRegistry")
 	}
-	registry, ok := server.ServiceController.GetRegistries()[index].ServiceDiscovery.(*v2.MemServiceDiscovery)
+	registry, ok := server.ServiceController.GetRegistries()[index].(serviceregistry.Simple).ServiceDiscovery.(*v2.MemServiceDiscovery)
 	if !ok {
 		t.Fatal("Unexpected type of Mock ServiceRegistry")
 	}

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -27,39 +27,30 @@ import (
 	"istio.io/istio/pkg/config/labels"
 )
 
-// Registry specifies the collection of service registry related interfaces
-type Registry struct {
-	// Name is the type of the registry - Kubernetes, Consul, etc.
-	Name serviceregistry.ServiceRegistry
-	// ClusterID is used when multiple registries of the same type are used,
-	// for example in the case of K8S multicluster.
-	ClusterID string
-	model.Controller
-	model.ServiceDiscovery
-}
-
-// TODO: rename Name to Type and ClusterID to Name ?
-
 var (
 	clusterAddressesMutex sync.Mutex
 )
 
+// The aggregate controller does not implement serviceregistry.Instance since it may be comprised of various
+// providers and clusters.
+var _ model.ServiceDiscovery = &Controller{}
+var _ model.Controller = &Controller{}
+
 // Controller aggregates data across different registries and monitors for changes
 type Controller struct {
-	registries []Registry
+	registries []serviceregistry.Instance
 	storeLock  sync.RWMutex
 }
 
 // NewController creates a new Aggregate controller
 func NewController() *Controller {
-
 	return &Controller{
-		registries: []Registry{},
+		registries: make([]serviceregistry.Instance, 0),
 	}
 }
 
 // AddRegistry adds registries into the aggregated controller
-func (c *Controller) AddRegistry(registry Registry) {
+func (c *Controller) AddRegistry(registry serviceregistry.Instance) {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
 
@@ -89,7 +80,7 @@ func (c *Controller) DeleteRegistry(clusterID string) {
 }
 
 // GetRegistries returns a copy of all registries
-func (c *Controller) GetRegistries() []Registry {
+func (c *Controller) GetRegistries() []serviceregistry.Instance {
 	c.storeLock.RLock()
 	defer c.storeLock.RUnlock()
 
@@ -99,7 +90,7 @@ func (c *Controller) GetRegistries() []Registry {
 // GetRegistryIndex returns the index of a registry
 func (c *Controller) GetRegistryIndex(clusterID string) (int, bool) {
 	for i, r := range c.registries {
-		if r.ClusterID == clusterID {
+		if r.Cluster() == clusterID {
 			return i, true
 		}
 	}
@@ -124,7 +115,7 @@ func (c *Controller) Services() ([]*model.Service, error) {
 		// Race condition: multiple threads may call Services, and multiple services
 		// may modify one of the service's cluster ID
 		clusterAddressesMutex.Lock()
-		if r.ClusterID == "" { // Should we instead check for registry name to be on safe side?
+		if r.Cluster() == "" { // Should we instead check for registry name to be on safe side?
 			// If the service is does not have a cluster ID (consul, ServiceEntries, CloudFoundry, etc.)
 			// Do not bother checking for the cluster ID.
 			// DO NOT ASSIGN CLUSTER ID to non-k8s registries. This will prevent service entries with multiple
@@ -150,13 +141,13 @@ func (c *Controller) Services() ([]*model.Service, error) {
 				if sp.ClusterVIPs == nil {
 					sp.ClusterVIPs = make(map[string]string)
 				}
-				sp.ClusterVIPs[r.ClusterID] = s.Address
+				sp.ClusterVIPs[r.Cluster()] = s.Address
 
-				if s.Attributes.ClusterExternalAddresses != nil && len(s.Attributes.ClusterExternalAddresses[r.ClusterID]) > 0 {
+				if s.Attributes.ClusterExternalAddresses != nil && len(s.Attributes.ClusterExternalAddresses[r.Cluster()]) > 0 {
 					if sp.Attributes.ClusterExternalAddresses == nil {
 						sp.Attributes.ClusterExternalAddresses = make(map[string][]string)
 					}
-					sp.Attributes.ClusterExternalAddresses[r.ClusterID] = s.Attributes.ClusterExternalAddresses[r.ClusterID]
+					sp.Attributes.ClusterExternalAddresses[r.Cluster()] = s.Attributes.ClusterExternalAddresses[r.Cluster()]
 				}
 				sp.Mutex.Unlock()
 			}
@@ -242,7 +233,7 @@ func (c *Controller) GetProxyServiceInstances(node *model.Proxy) ([]*model.Servi
 			errs = multierror.Append(errs, err)
 		} else if len(instances) > 0 {
 			out = append(out, instances...)
-			node.ClusterID = r.ClusterID
+			node.ClusterID = r.Cluster()
 			break
 		}
 	}
@@ -297,7 +288,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) error {
 	for _, r := range c.GetRegistries() {
 		if err := r.AppendServiceHandler(f); err != nil {
-			log.Infof("Fail to append service handler to adapter %s", r.Name)
+			log.Infof("Fail to append service handler to adapter %s", r.Provider())
 			return err
 		}
 	}
@@ -308,7 +299,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.Event)) error {
 	for _, r := range c.GetRegistries() {
 		if err := r.AppendInstanceHandler(f); err != nil {
-			log.Infof("Fail to append instance handler to adapter %s", r.Name)
+			log.Infof("Fail to append instance handler to adapter %s", r.Provider())
 			return err
 		}
 	}

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -44,14 +44,14 @@ func buildMockController() *Controller {
 			memory.ExtHTTPSService.Hostname: memory.ExtHTTPSService,
 		}, 2)
 
-	registry1 := Registry{
-		Name:             serviceregistry.ServiceRegistry("mockAdapter1"),
+	registry1 := serviceregistry.Simple{
+		ProviderID:       serviceregistry.ProviderID("mockAdapter1"),
 		ServiceDiscovery: discovery1,
 		Controller:       &memory.MockController{},
 	}
 
-	registry2 := Registry{
-		Name:             serviceregistry.ServiceRegistry("mockAdapter2"),
+	registry2 := serviceregistry.Simple{
+		ProviderID:       serviceregistry.ProviderID("mockAdapter2"),
 		ServiceDiscovery: discovery2,
 		Controller:       &memory.MockController{},
 	}
@@ -75,15 +75,15 @@ func buildMockControllerForMultiCluster() *Controller {
 			memory.WorldService.Hostname: memory.WorldService,
 		}, 2)
 
-	registry1 := Registry{
-		Name:             serviceregistry.ServiceRegistry("mockAdapter1"),
+	registry1 := serviceregistry.Simple{
+		ProviderID:       serviceregistry.ProviderID("mockAdapter1"),
 		ClusterID:        "cluster-1",
 		ServiceDiscovery: discovery1,
 		Controller:       &memory.MockController{},
 	}
 
-	registry2 := Registry{
-		Name:             serviceregistry.ServiceRegistry("mockAdapter2"),
+	registry2 := serviceregistry.Simple{
+		ProviderID:       serviceregistry.ProviderID("mockAdapter2"),
 		ClusterID:        "cluster-2",
 		ServiceDiscovery: discovery2,
 		Controller:       &memory.MockController{},
@@ -469,14 +469,14 @@ func TestManagementPorts(t *testing.T) {
 
 func TestAddRegistry(t *testing.T) {
 
-	registries := []Registry{
+	registries := []serviceregistry.Simple{
 		{
-			Name:      "registry1",
-			ClusterID: "cluster1",
+			ProviderID: "registry1",
+			ClusterID:  "cluster1",
 		},
 		{
-			Name:      "registry2",
-			ClusterID: "cluster2",
+			ProviderID: "registry2",
+			ClusterID:  "cluster2",
 		},
 	}
 	ctrl := NewController()
@@ -489,14 +489,14 @@ func TestAddRegistry(t *testing.T) {
 }
 
 func TestDeleteRegistry(t *testing.T) {
-	registries := []Registry{
+	registries := []serviceregistry.Simple{
 		{
-			Name:      "registry1",
-			ClusterID: "cluster1",
+			ProviderID: "registry1",
+			ClusterID:  "cluster1",
 		},
 		{
-			Name:      "registry2",
-			ClusterID: "cluster2",
+			ProviderID: "registry2",
+			ClusterID:  "cluster2",
 		},
 	}
 	ctrl := NewController()
@@ -510,14 +510,14 @@ func TestDeleteRegistry(t *testing.T) {
 }
 
 func TestGetRegistries(t *testing.T) {
-	registries := []Registry{
+	registries := []serviceregistry.Simple{
 		{
-			Name:      "registry1",
-			ClusterID: "cluster1",
+			ProviderID: "registry1",
+			ClusterID:  "cluster1",
 		},
 		{
-			Name:      "registry2",
-			ClusterID: "cluster2",
+			ProviderID: "registry2",
+			ClusterID:  "cluster2",
 		},
 	}
 	ctrl := NewController()

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -23,10 +23,13 @@ import (
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/spiffe"
 )
+
+var _ serviceregistry.Instance = &Controller{}
 
 // Controller communicates with Consul and monitors for changes
 type Controller struct {
@@ -37,24 +40,34 @@ type Controller struct {
 	serviceInstances map[string][]*model.ServiceInstance //key hostname value serviceInstance array
 	cacheMutex       sync.Mutex
 	initDone         bool
+	clusterID        string
 }
 
 // NewController creates a new Consul controller
-func NewController(addr string) (*Controller, error) {
+func NewController(addr string, clusterID string) (*Controller, error) {
 	conf := api.DefaultConfig()
 	conf.Address = addr
 
 	client, err := api.NewClient(conf)
 	monitor := NewConsulMonitor(client)
 	controller := Controller{
-		monitor: monitor,
-		client:  client,
+		monitor:   monitor,
+		client:    client,
+		clusterID: clusterID,
 	}
 
 	//Watch the change events to refresh local caches
 	monitor.AppendServiceHandler(controller.ServiceChanged)
 	monitor.AppendInstanceHandler(controller.InstanceChanged)
 	return &controller, err
+}
+
+func (c *Controller) Provider() serviceregistry.ProviderID {
+	return serviceregistry.Consul
+}
+
+func (c *Controller) Cluster() string {
+	return c.clusterID
 }
 
 // Services list declarations of all services in the system

--- a/pilot/pkg/serviceregistry/consul/controller_test.go
+++ b/pilot/pkg/serviceregistry/consul/controller_test.go
@@ -32,6 +32,10 @@ import (
 	"istio.io/istio/pkg/config/labels"
 )
 
+const (
+	clusterID = ""
+)
+
 type mockServer struct {
 	server      *httptest.Server
 	services    map[string][]string
@@ -155,7 +159,7 @@ func newServer() *mockServer {
 func TestInstances(t *testing.T) {
 	ts := newServer()
 	defer ts.server.Close()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -225,7 +229,7 @@ func TestInstances(t *testing.T) {
 func TestInstancesBadHostname(t *testing.T) {
 	ts := newServer()
 	defer ts.server.Close()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -247,7 +251,7 @@ func TestInstancesBadHostname(t *testing.T) {
 
 func TestInstancesError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		ts.server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
@@ -273,7 +277,7 @@ func TestInstancesError(t *testing.T) {
 func TestGetService(t *testing.T) {
 	ts := newServer()
 	defer ts.server.Close()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -294,7 +298,7 @@ func TestGetService(t *testing.T) {
 
 func TestGetServiceError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		ts.server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
@@ -313,7 +317,7 @@ func TestGetServiceError(t *testing.T) {
 func TestGetServiceBadHostname(t *testing.T) {
 	ts := newServer()
 	defer ts.server.Close()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -330,7 +334,7 @@ func TestGetServiceBadHostname(t *testing.T) {
 func TestGetServiceNoInstances(t *testing.T) {
 	ts := newServer()
 	defer ts.server.Close()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -347,7 +351,7 @@ func TestGetServiceNoInstances(t *testing.T) {
 func TestServices(t *testing.T) {
 	ts := newServer()
 	defer ts.server.Close()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -377,7 +381,7 @@ func TestServices(t *testing.T) {
 
 func TestServicesError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		ts.server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
@@ -396,7 +400,7 @@ func TestServicesError(t *testing.T) {
 func TestGetProxyServiceInstances(t *testing.T) {
 	ts := newServer()
 	defer ts.server.Close()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -417,7 +421,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 
 func TestGetProxyServiceInstancesError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		ts.server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
@@ -436,7 +440,7 @@ func TestGetProxyServiceInstancesError(t *testing.T) {
 func TestGetProxyServiceInstancesWithMultiIPs(t *testing.T) {
 	ts := newServer()
 	defer ts.server.Close()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -458,7 +462,7 @@ func TestGetProxyServiceInstancesWithMultiIPs(t *testing.T) {
 func TestGetProxyWorkloadLabels(t *testing.T) {
 	ts := newServer()
 	defer ts.server.Close()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -517,7 +521,7 @@ func TestGetProxyWorkloadLabels(t *testing.T) {
 
 func TestGetServiceByCache(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -540,7 +544,7 @@ func TestGetServiceByCache(t *testing.T) {
 func TestGetInstanceByCacheAfterChanged(t *testing.T) {
 	ts := newServer()
 	defer ts.server.Close()
-	controller, err := NewController(ts.server.URL)
+	controller, err := NewController(ts.server.URL, clusterID)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}

--- a/pilot/pkg/serviceregistry/consul/conversion.go
+++ b/pilot/pkg/serviceregistry/consul/conversion.go
@@ -100,7 +100,7 @@ func convertService(endpoints []*api.CatalogService) *model.Service {
 		MeshExternal: meshExternal,
 		Resolution:   resolution,
 		Attributes: model.ServiceAttributes{
-			ServiceRegistry: string(serviceregistry.ConsulRegistry),
+			ServiceRegistry: string(serviceregistry.Consul),
 			Name:            string(hostname),
 			Namespace:       model.IstioDefaultConfigNamespace,
 		},

--- a/pilot/pkg/serviceregistry/external/conversion.go
+++ b/pilot/pkg/serviceregistry/external/conversion.go
@@ -83,7 +83,7 @@ func convertServices(cfg model.Config) []*model.Service {
 						Ports:        svcPorts,
 						Resolution:   resolution,
 						Attributes: model.ServiceAttributes{
-							ServiceRegistry: string(serviceregistry.MCPRegistry),
+							ServiceRegistry: string(serviceregistry.MCP),
 							Name:            hostname,
 							Namespace:       cfg.Namespace,
 							ExportTo:        exportTo,
@@ -98,7 +98,7 @@ func convertServices(cfg model.Config) []*model.Service {
 						Ports:        svcPorts,
 						Resolution:   resolution,
 						Attributes: model.ServiceAttributes{
-							ServiceRegistry: string(serviceregistry.MCPRegistry),
+							ServiceRegistry: string(serviceregistry.MCP),
 							Name:            hostname,
 							Namespace:       cfg.Namespace,
 							ExportTo:        exportTo,
@@ -115,7 +115,7 @@ func convertServices(cfg model.Config) []*model.Service {
 				Ports:        svcPorts,
 				Resolution:   resolution,
 				Attributes: model.ServiceAttributes{
-					ServiceRegistry: string(serviceregistry.MCPRegistry),
+					ServiceRegistry: string(serviceregistry.MCP),
 					Name:            hostname,
 					Namespace:       cfg.Namespace,
 					ExportTo:        exportTo,

--- a/pilot/pkg/serviceregistry/external/conversion_test.go
+++ b/pilot/pkg/serviceregistry/external/conversion_test.go
@@ -311,7 +311,7 @@ func makeService(hostname host.Name, configNamespace, address string, ports map[
 		MeshExternal: external,
 		Resolution:   resolution,
 		Attributes: model.ServiceAttributes{
-			ServiceRegistry: string(serviceregistry.MCPRegistry),
+			ServiceRegistry: string(serviceregistry.MCP),
 			Name:            string(hostname),
 			Namespace:       configNamespace,
 		},

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schemas"
@@ -27,6 +28,8 @@ import (
 // TODO: move this out of 'external' package. Either 'serviceentry' package or
 // merge with aggregate (caching, events), and possibly merge both into the
 // config directory, for a single top-level cache and event system.
+
+var _ serviceregistry.Instance = &ServiceEntryStore{}
 
 type serviceHandler func(*model.Service, model.Event)
 type instanceHandler func(*model.ServiceInstance, model.Event)
@@ -80,6 +83,14 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 	}
 
 	return c
+}
+
+func (d *ServiceEntryStore) Provider() serviceregistry.ProviderID {
+	return serviceregistry.External
+}
+
+func (d *ServiceEntryStore) Cluster() string {
+	return ""
 }
 
 // AppendServiceHandler adds service resource event handler

--- a/pilot/pkg/serviceregistry/instance.go
+++ b/pilot/pkg/serviceregistry/instance.go
@@ -1,0 +1,51 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceregistry
+
+import (
+	"istio.io/istio/pilot/pkg/model"
+)
+
+// Instance of a service registry. A single service registry combines the capabilities of service discovery
+// and the controller for managing asynchronous events.
+type Instance interface {
+	model.Controller
+	model.ServiceDiscovery
+
+	// Provider backing this service registry (i.e. Kubernetes, Consul, etc.)
+	Provider() ProviderID
+
+	// Cluster for which the service registry applies. Only needed for multicluster systems.
+	Cluster() string
+}
+
+var _ Instance = &Simple{}
+
+// Simple Instance implementation, where fields are set individually.
+type Simple struct {
+	ProviderID ProviderID
+	ClusterID  string
+
+	model.Controller
+	model.ServiceDiscovery
+}
+
+func (r Simple) Provider() ProviderID {
+	return r.ProviderID
+}
+
+func (r Simple) Cluster() string {
+	return r.ClusterID
+}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -40,6 +40,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config/host"
 	configKube "istio.io/istio/pkg/config/kube"
@@ -113,6 +114,8 @@ type Options struct {
 	TrustDomain string
 }
 
+var _ serviceregistry.Instance = &Controller{}
+
 // Controller is a collection of synchronized resource watchers
 // Caches are thread-safe
 type Controller struct {
@@ -130,8 +133,8 @@ type Controller struct {
 	// use env data and push status. It may be null in tests.
 	Env *model.Environment
 
-	// ClusterID identifies the remote cluster in a multicluster env.
-	ClusterID string
+	// clusterID identifies the remote cluster in a multicluster env.
+	clusterID string
 
 	// XDSUpdater will push EDS changes to the ADS model.
 	XDSUpdater model.XDSUpdater
@@ -167,7 +170,7 @@ func NewController(client kubernetes.Interface, options Options) *Controller {
 		domainSuffix:               options.DomainSuffix,
 		client:                     client,
 		queue:                      kube.NewQueue(1 * time.Second),
-		ClusterID:                  options.ClusterID,
+		clusterID:                  options.ClusterID,
 		XDSUpdater:                 options.XDSUpdater,
 		servicesMap:                make(map[host.Name]*model.Service),
 		externalNameSvcInstanceMap: make(map[host.Name][]*model.ServiceInstance),
@@ -188,6 +191,14 @@ func NewController(client kubernetes.Interface, options Options) *Controller {
 	out.pods = newPodCache(out.createCacheHandler(podInformer, "Pod"), out)
 
 	return out
+}
+
+func (c *Controller) Provider() serviceregistry.ProviderID {
+	return serviceregistry.Kubernetes
+}
+
+func (c *Controller) Cluster() string {
+	return c.clusterID
 }
 
 // notify is the first handler in the handler chain.
@@ -611,8 +622,8 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 		return nil, fmt.Errorf("no workload labels found")
 	}
 
-	if proxy.Metadata.ClusterID != c.ClusterID {
-		return nil, fmt.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.ClusterID)
+	if proxy.Metadata.ClusterID != c.clusterID {
+		return nil, fmt.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.clusterID)
 	}
 
 	// Create a pod with just the information needed to find the associated Services
@@ -856,7 +867,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 
 		log.Debugf("Handle event %s for service %s in namespace %s", event, svc.Name, svc.Namespace)
 
-		svcConv := kube.ConvertService(*svc, c.domainSuffix, c.ClusterID)
+		svcConv := kube.ConvertService(*svc, c.domainSuffix, c.clusterID)
 		switch event {
 		case model.EventDelete:
 			c.Lock()
@@ -864,7 +875,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 			delete(c.externalNameSvcInstanceMap, svcConv.Hostname)
 			c.Unlock()
 			// EDS needs to just know when service is deleted.
-			c.XDSUpdater.SvcUpdate(c.ClusterID, svc.Name, svc.Namespace, event)
+			c.XDSUpdater.SvcUpdate(c.clusterID, svc.Name, svc.Namespace, event)
 		default:
 			// instance conversion is only required when service is added/updated.
 			instances := kube.ExternalNameServiceInstances(*svc, svcConv)
@@ -876,7 +887,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 				c.externalNameSvcInstanceMap[svcConv.Hostname] = instances
 			}
 			c.Unlock()
-			c.XDSUpdater.SvcUpdate(c.ClusterID, svc.Name, svc.Namespace, event)
+			c.XDSUpdater.SvcUpdate(c.clusterID, svc.Name, svc.Namespace, event)
 		}
 
 		f(svcConv, event)
@@ -1000,7 +1011,7 @@ func (c *Controller) updateEDS(ep *v1.Endpoints, event model.Event) {
 		log.Infof("Handle EDS endpoint %s in namespace %s -> %v", ep.Name, ep.Namespace, addresses)
 	}
 
-	_ = c.XDSUpdater.EDSUpdate(c.ClusterID, string(hostname), ep.Namespace, endpoints)
+	_ = c.XDSUpdater.EDSUpdate(c.clusterID, string(hostname), ep.Namespace, endpoints)
 }
 
 // namedRangerEntry for holding network's CIDR and name
@@ -1037,7 +1048,7 @@ func (c *Controller) InitNetworkLookup(meshNetworks *meshconfig.MeshNetworks) {
 				}
 				_ = c.ranger.Insert(rangerEntry)
 			}
-			if ep.GetFromRegistry() != "" && ep.GetFromRegistry() == c.ClusterID {
+			if ep.GetFromRegistry() != "" && ep.GetFromRegistry() == c.clusterID {
 				c.networkForRegistry = n
 			}
 		}

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -539,7 +539,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			Ports:           []*model.Port{{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP}},
 			ServiceAccounts: []string{"acctvm2@gserviceaccount2.com", "spiffe://cluster.local/ns/nsa/sa/acct4"},
 			Attributes: model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "svc1",
 				Namespace:       "nsa",
 				UID:             "istio://nsa/services/svc1"},
@@ -592,7 +592,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			Ports:           []*model.Port{{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP}},
 			ServiceAccounts: []string{"acctvm2@gserviceaccount2.com", "spiffe://cluster.local/ns/nsa/sa/acct4"},
 			Attributes: model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "svc1",
 				Namespace:       "nsa",
 				UID:             "istio://nsa/services/svc1"},
@@ -641,7 +641,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			Ports:           []*model.Port{{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP}},
 			ServiceAccounts: []string{"acctvm2@gserviceaccount2.com", "spiffe://cluster.local/ns/nsa/sa/acct4"},
 			Attributes: model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+				ServiceRegistry: string(serviceregistry.Kubernetes),
 				Name:            "svc1",
 				Namespace:       "nsa",
 				UID:             "istio://nsa/services/svc1"},

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -123,7 +123,7 @@ func (pc *PodCache) event(obj interface{}, ev model.Event) error {
 
 func (pc *PodCache) proxyUpdates(ip string) {
 	if pc.c != nil && pc.c.XDSUpdater != nil {
-		pc.c.XDSUpdater.ProxyUpdate(pc.c.ClusterID, ip)
+		pc.c.XDSUpdater.ProxyUpdate(pc.c.clusterID, ip)
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -107,7 +107,7 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 		Resolution:      resolution,
 		CreationTime:    svc.CreationTimestamp.Time,
 		Attributes: model.ServiceAttributes{
-			ServiceRegistry: string(serviceregistry.KubernetesRegistry),
+			ServiceRegistry: string(serviceregistry.Kubernetes),
 			Name:            svc.Name,
 			Namespace:       svc.Namespace,
 			UID:             fmt.Sprintf("istio://%s/services/%s", svc.Namespace, svc.Name),

--- a/pilot/pkg/serviceregistry/providers.go
+++ b/pilot/pkg/serviceregistry/providers.go
@@ -14,16 +14,18 @@
 
 package serviceregistry
 
-// ServiceRegistry defines underlying platform supporting service registry
-type ServiceRegistry string
+// ProviderID defines underlying platform supporting service registry
+type ProviderID string
 
 const (
-	// MockRegistry is a service registry that contains 2 hard-coded test services
-	MockRegistry ServiceRegistry = "Mock"
-	// KubernetesRegistry is a service registry backed by k8s API server
-	KubernetesRegistry ServiceRegistry = "Kubernetes"
-	// ConsulRegistry is a service registry backed by Consul
-	ConsulRegistry ServiceRegistry = "Consul"
-	// MCPRegistry is a service registry backed by MCP ServiceEntries
-	MCPRegistry ServiceRegistry = "MCP"
+	// Mock is a service registry that contains 2 hard-coded test services
+	Mock ProviderID = "Mock"
+	// Kubernetes is a service registry backed by k8s API server
+	Kubernetes ProviderID = "Kubernetes"
+	// Consul is a service registry backed by Consul
+	Consul ProviderID = "Consul"
+	// MCP is a service registry backed by MCP ServiceEntries
+	MCP ProviderID = "MCP"
+	// External is a service registry for externally provided ServiceEntries
+	External = "External"
 )

--- a/pkg/istiod/k8s/k8sstart.go
+++ b/pkg/istiod/k8s/k8sstart.go
@@ -170,18 +170,12 @@ func (s *Controllers) initConfigController(args *istiod.PilotArgs) error {
 
 // createK8sServiceControllers creates all the k8s service controllers under this pilot
 func (s *Controllers) createK8sServiceControllers(serviceControllers *aggregate.Controller) {
-	clusterID := string(serviceregistry.KubernetesRegistry)
+	clusterID := string(serviceregistry.Kubernetes)
 	log.Infof("Primary Cluster name: %s", clusterID)
 	s.ControllerOptions.ClusterID = clusterID
 	kubectl := controller2.NewController(s.kubeClient, s.ControllerOptions)
 	s.kubeRegistry = kubectl
-	serviceControllers.AddRegistry(
-		aggregate.Registry{
-			Name:             serviceregistry.KubernetesRegistry,
-			ClusterID:        clusterID,
-			ServiceDiscovery: kubectl,
-			Controller:       kubectl,
-		})
+	serviceControllers.AddRegistry(kubectl)
 }
 
 func (s *Controllers) makeKubeConfigController(args *istiod.PilotArgs) (model.ConfigStoreCache, error) {

--- a/pkg/istiod/pilotstart.go
+++ b/pkg/istiod/pilotstart.go
@@ -37,6 +37,11 @@ import (
 
 	mcpapi "istio.io/api/mcp/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/ctrlz"
+	"istio.io/pkg/env"
+	"istio.io/pkg/log"
+	"istio.io/pkg/version"
+
 	"istio.io/istio/pilot/cmd"
 	configaggregate "istio.io/istio/pilot/pkg/config/aggregate"
 	"istio.io/istio/pilot/pkg/config/coredatamodel"
@@ -53,10 +58,6 @@ import (
 	istiokeepalive "istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/mcp/monitoring"
 	"istio.io/istio/pkg/mcp/sink"
-	"istio.io/pkg/ctrlz"
-	"istio.io/pkg/env"
-	"istio.io/pkg/log"
-	"istio.io/pkg/version"
 )
 
 const (
@@ -549,14 +550,7 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 // ServiceEntries from config store to discovery.
 func (s *Server) addConfig2ServiceEntry() {
 	serviceEntryStore := external.NewServiceDiscovery(s.ConfigController, s.IstioConfigStore)
-
-	// add service entry registry to aggregator by default
-	serviceEntryRegistry := aggregate.Registry{
-		Name:             "ServiceEntries",
-		Controller:       serviceEntryStore,
-		ServiceDiscovery: serviceEntryStore,
-	}
-	s.ServiceController.AddRegistry(serviceEntryRegistry)
+	s.ServiceController.AddRegistry(serviceEntryStore)
 }
 
 func (s *Server) initDiscoveryService(args *PilotArgs, onXDSStart func(model.XDSUpdater)) error {

--- a/pkg/mcp/monitoring/monitoring.go
+++ b/pkg/mcp/monitoring/monitoring.go
@@ -25,12 +25,11 @@ import (
 )
 
 const (
-	collection   = "collection"
-	errorCode    = "code"
-	errorStr     = "error"
-	connectionID = "connectionID"
-	code         = "code"
-	component    = "component"
+	collection = "collection"
+	errorCode  = "code"
+	errorStr   = "error"
+	code       = "code"
+	component  = "component"
 )
 
 var (

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -96,7 +96,7 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, Tea
 		Service: bootstrap.ServiceArgs{
 			// Using the Mock service registry, which provides the hello and world services.
 			Registries: []string{
-				string(serviceregistry.MockRegistry)},
+				string(serviceregistry.Mock)},
 		},
 		MeshConfig:        &meshConfig,
 		MCPMaxMessageSize: 1024 * 1024 * 4,

--- a/tools/hyperistio/hyperistio.go
+++ b/tools/hyperistio/hyperistio.go
@@ -174,7 +174,7 @@ func startPilot() error {
 		Service: bootstrap.ServiceArgs{
 			// Using the Mock service registry, which provides the hello and world services.
 			Registries: []string{
-				string(serviceregistry.MockRegistry)},
+				string(serviceregistry.Mock)},
 		},
 		MeshConfig:       &mcfg,
 		KeepaliveOptions: keepalive.DefaultOption(),


### PR DESCRIPTION
This addresses a few things:

- Renaming serviceregistry.ServiceRegistry to serviceregistry.ProviderID. This avoids name stutter and also clarifies the intent of the value.

- Introduce new interface serviceregistry.Instance, which includes all of the fields needed by the aggregate.Registry (clusterID, providerID, model.ServiceDiscovery, model.Controller).

- Made several controllers implement the new serviceregistry.Instance interface. This is important because kubernetes has its own clusterID that must be set. Allowing the controller to implement the interface means that clusterID only has to be set once.

- Moved aggregate.Registry to serviceregistry.Simple. This seemed to be a more natural place for it since we now have the interface. It's odd to need the aggregate package in order to manually construct a simple serviceregistry.Instance.