### PR TITLE
Remove setting redundant registry as MCP is default

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -37,7 +37,6 @@ import (
 	"istio.io/istio/pilot/pkg/config/memory"
 	configmonitor "istio.io/istio/pilot/pkg/config/monitor"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schemas"
 	configz "istio.io/istio/pkg/mcp/configz/client"
@@ -165,9 +164,6 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 
 		// create MCP SyntheticServiceEntryController
 		if resourceContains(configSource.SubscribedResources, meshconfig.Resource_SERVICE_REGISTRY) {
-
-			//TODO(Nino-K): https://github.com/istio/istio/issues/16976
-			args.Service.Registries = []string{string(serviceregistry.MCP)}
 			conn, err := grpcDial(ctx, cancel, configSource, args)
 			if err != nil {
 				log.Errorf("Unable to dial MCP Server %q: %v", configSource.Address, err)

--- a/pkg/test/framework/components/pilot/native.go
+++ b/pkg/test/framework/components/pilot/native.go
@@ -90,6 +90,13 @@ func newNative(ctx resource.Context, cfg Config) (Instance, error) {
 		m = cfg.MeshConfig
 	}
 
+	if cfg.ServiceArgs.Registries == nil {
+		cfg.ServiceArgs = bootstrap.ServiceArgs{
+			// A ServiceEntry registry is added by default, which is what we want. Don't include any other registries.
+			Registries: []string{},
+		}
+	}
+
 	bootstrapArgs := bootstrap.PilotArgs{
 		Namespace:        e.SystemNamespace,
 		DiscoveryOptions: options,
@@ -100,10 +107,7 @@ func newNative(ctx resource.Context, cfg Config) (Instance, error) {
 		},
 		MeshConfig: m,
 		// Use the config store for service entries as well.
-		Service: bootstrap.ServiceArgs{
-			// A ServiceEntry registry is added by default, which is what we want. Don't include any other registries.
-			Registries: []string{},
-		},
+		Service: cfg.ServiceArgs,
 		// Include all of the default plugins for integration with Mixer, etc.
 		Plugins:   bootstrap.DefaultPlugins,
 		ForceStop: true,

--- a/pkg/test/framework/components/pilot/pilot.go
+++ b/pkg/test/framework/components/pilot/pilot.go
@@ -22,6 +22,7 @@ import (
 	xdscore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	meshConfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/galley"
@@ -61,6 +62,8 @@ type Config struct {
 	// The MeshConfig to be used for Pilot in native environment. In Kube environment this can be
 	// configured with Helm.
 	MeshConfig *meshConfig.MeshConfig
+
+	ServiceArgs bootstrap.ServiceArgs
 }
 
 // New returns a new instance of echo.

--- a/tests/integration/pilot/mcp/main_test.go
+++ b/tests/integration/pilot/mcp/main_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 				Galley:     g,
 				MeshConfig: &meshCfg,
 				ServiceArgs: bootstrap.ServiceArgs{
-					Registries: []string{string(serviceregistry.MCPRegistry)},
+					Registries: []string{string(serviceregistry.MCP)},
 				},
 			}); err != nil {
 				return err

--- a/tests/integration/pilot/mcp/main_test.go
+++ b/tests/integration/pilot/mcp/main_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/bootstrap"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
@@ -57,6 +59,9 @@ func TestMain(m *testing.M) {
 			if p, err = pilot.New(ctx, pilot.Config{
 				Galley:     g,
 				MeshConfig: &meshCfg,
+				ServiceArgs: bootstrap.ServiceArgs{
+					Registries: []string{string(serviceregistry.MCPRegistry)},
+				},
 			}); err != nil {
 				return err
 			}


### PR DESCRIPTION
Removes assigning redundant MCP registry.