### PR TITLE
remove the useless todo

### DIFF
--- a/mixer/adapter/memquota/dedup.go
+++ b/mixer/adapter/memquota/dedup.go
@@ -107,7 +107,7 @@ func (du *dedupUtil) reapDedup() {
 	if len(t) > 0 {
 		du.logger.Debugf("Running repear to reclaim %d old deduplication entries", len(t))
 	}
-	
+
 	for k := range t {
 		delete(t, k)
 	}

--- a/mixer/adapter/memquota/dedup.go
+++ b/mixer/adapter/memquota/dedup.go
@@ -107,8 +107,7 @@ func (du *dedupUtil) reapDedup() {
 	if len(t) > 0 {
 		du.logger.Debugf("Running repear to reclaim %d old deduplication entries", len(t))
 	}
-
-	// TODO: why isn't there a O(1) way to clear a map to the empty state?!
+	
 	for k := range t {
 		delete(t, k)
 	}


### PR DESCRIPTION



According to `github.com/golang/go/blob/master/doc/go1.11.html `, Starting from Go 1.11, map clearing operations of this form are optimized by the compiler. And there's no built-in function to do this. So the todo list is useless now. Remove it.