### PR TITLE
push context: handle panic if there is an error in resource initialization

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -24,7 +24,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/features"
-	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/util/goutils"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -732,7 +732,7 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 func (ps *PushContext) createNewContext(env *Environment) error {
 
 	// If any of the custom CRD initialization causes panic, we should recover.
-	defer util.HandleCrash(func() {
+	defer goutils.HandleCrash(func() {
 		log.Errorf("initializing push context caused panic")
 	})
 
@@ -778,7 +778,7 @@ func (ps *PushContext) updateContext(
 	pushReq *PushRequest) error {
 
 	// If any of the custom CRD initialization causes panic, we should recover.
-	defer util.HandleCrash(func() {
+	defer goutils.HandleCrash(func() {
 		log.Errorf("updating push context caused panic")
 	})
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -24,6 +24,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -729,6 +730,12 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 }
 
 func (ps *PushContext) createNewContext(env *Environment) error {
+
+	// If any of the custom CRD initialization causes panic, we should recover.
+	defer util.HandleCrash(func() {
+		log.Errorf("initializing push context caused panic")
+	})
+
 	if err := ps.initServiceRegistry(env); err != nil {
 		return err
 	}
@@ -769,6 +776,11 @@ func (ps *PushContext) updateContext(
 	env *Environment,
 	oldPushContext *PushContext,
 	pushReq *PushRequest) error {
+
+	// If any of the custom CRD initialization causes panic, we should recover.
+	defer util.HandleCrash(func() {
+		log.Errorf("updating push context caused panic")
+	})
 
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
 		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged bool

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -22,7 +22,7 @@ import (
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/util/goutils"
 	"istio.io/istio/pkg/config/host"
 )
 
@@ -32,7 +32,7 @@ func ApplyClusterPatches(
 	proxy *model.Proxy,
 	push *model.PushContext,
 	clusters []*xdsapi.Cluster) (out []*xdsapi.Cluster) {
-	defer util.HandleCrash(func() {
+	defer goutils.HandleCrash(func() {
 		log.Errorf("clusters patch caused panic, so the patches did not take effect")
 	})
 	// In case the patches cause panic, use the clusters generated before to reduce the influence.

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -29,6 +29,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/util/goutils"
 )
 
 // ApplyListenerPatches applies patches to LDS output
@@ -38,7 +39,7 @@ func ApplyListenerPatches(
 	push *model.PushContext,
 	listeners []*xdsapi.Listener,
 	skipAdds bool) (out []*xdsapi.Listener) {
-	defer util.HandleCrash(func() {
+	defer goutils.HandleCrash(func() {
 		log.Errorf("listeners patch caused panic, so the patches did not take effect")
 	})
 	// In case the patches cause panic, use the listeners generated before to reduce the influence.

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -24,7 +24,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/util/goutils"
 	"istio.io/pkg/log"
 )
 
@@ -33,7 +33,7 @@ func ApplyRouteConfigurationPatches(
 	proxy *model.Proxy,
 	push *model.PushContext,
 	routeConfiguration *xdsapi.RouteConfiguration) (out *xdsapi.RouteConfiguration) {
-	defer util.HandleCrash(func() {
+	defer goutils.HandleCrash(func() {
 		log.Errorf("listeners patch caused panic, so the patches did not take effect")
 	})
 	// In case the patches cause panic, use the route generated before to reduce the influence.

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -17,7 +17,6 @@ package util
 import (
 	"fmt"
 	"net"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -525,26 +524,6 @@ func MergeAnyWithAny(dst *any.Any, src *any.Any) (*any.Any, error) {
 	}
 
 	return retVal, nil
-}
-
-// logPanic logs the caller tree when a panic occurs.
-func logPanic(r interface{}) {
-	// Same as stdlib http server code. Manually allocate stack trace buffer size
-	// to prevent excessively large logs
-	const size = 64 << 10
-	stacktrace := make([]byte, size)
-	stacktrace = stacktrace[:runtime.Stack(stacktrace, false)]
-	log.Errorf("Observed a panic: %#v (%v)\n%s", r, r, stacktrace)
-}
-
-// HandleCrash catches the crash and calls additional handlers.
-func HandleCrash(handlers ...func()) {
-	if r := recover(); r != nil {
-		logPanic(r)
-		for _, handler := range handlers {
-			handler()
-		}
-	}
 }
 
 // BuildLbEndpointMetadata adds metadata values to a lb endpoint

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -622,35 +622,6 @@ func TestMergeAnyWithStruct(t *testing.T) {
 	}
 }
 
-func TestHandleCrash(t *testing.T) {
-	defer func() {
-		if x := recover(); x != nil {
-			t.Errorf("Expected no panic ")
-		}
-	}()
-
-	defer HandleCrash()
-	panic("test")
-}
-
-func TestCustomHandleCrash(t *testing.T) {
-	ch := make(chan struct{}, 1)
-	defer func() {
-		select {
-		case <-ch:
-			t.Logf("crash handler called")
-		case <-time.After(1 * time.Second):
-			t.Errorf("Custom handler not called")
-		}
-	}()
-
-	defer HandleCrash(func() {
-		ch <- struct{}{}
-	})
-
-	panic("test")
-}
-
 func TestIsAllowAnyOutbound(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pilot/pkg/util/goutils/util.go
+++ b/pilot/pkg/util/goutils/util.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goutils
+
+import (
+	"runtime"
+
+	"istio.io/pkg/log"
+)
+
+// logPanic logs the caller tree when a panic occurs.
+func logPanic(r interface{}) {
+	// Same as stdlib http server code. Manually allocate stack trace buffer size
+	// to prevent excessively large logs
+	const size = 64 << 10
+	stacktrace := make([]byte, size)
+	stacktrace = stacktrace[:runtime.Stack(stacktrace, false)]
+	log.Errorf("Observed a panic: %#v (%v)\n%s", r, r, stacktrace)
+}
+
+// HandleCrash catches the crash and calls additional handlers.
+func HandleCrash(handlers ...func()) {
+	if r := recover(); r != nil {
+		logPanic(r)
+		for _, handler := range handlers {
+			handler()
+		}
+	}
+}

--- a/pilot/pkg/util/goutils/utils_test.go
+++ b/pilot/pkg/util/goutils/utils_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goutils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHandleCrash(t *testing.T) {
+	defer func() {
+		if x := recover(); x != nil {
+			t.Errorf("Expected no panic ")
+		}
+	}()
+
+	defer HandleCrash()
+	panic("test")
+}
+
+func TestCustomHandleCrash(t *testing.T) {
+	ch := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case <-ch:
+			t.Logf("crash handler called")
+		case <-time.After(1 * time.Second):
+			t.Errorf("Custom handler not called")
+		}
+	}()
+
+	defer HandleCrash(func() {
+		ch <- struct{}{}
+	})
+
+	panic("test")
+}


### PR DESCRIPTION
There was an error in one of the Virtual Services in our env which was added by mistake to K8S and it caused Pilot to Panic - bringing down the whole cluster.  I think Pilot should handle crash while initializing/updating push context where it process all the external resources - they can be in bad state for variety of reasons.