### PR TITLE
Remove unreachable code after os.Exit

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -168,7 +168,6 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 		if err != nil {
 			log.Errora("Failed to generate bootstrap config: ", err)
 			os.Exit(1) // Prevent infinite loop attempting to write the file, let k8s/systemd report
-			return err
 		}
 		fname = out
 	}


### PR DESCRIPTION
This patch makes a tiny change which removes unreachable code after `os.Exit()`.
