### PR TITLE
Cleaning up mesh and network watchers

### DIFF
--- a/cmd/istiod/istiod.go
+++ b/cmd/istiod/istiod.go
@@ -98,7 +98,7 @@ func main() {
 	// Options based on the current 'defaults' in istio.
 	// If adjustments are needed - env or mesh.config ( if of general interest ).
 	istiod.RunCA(istiods.SecureGRPCServer, client, &istiod.CAOptions{
-		TrustDomain: istiods.Environment.Mesh.TrustDomain,
+		TrustDomain: istiods.Environment.Mesh().TrustDomain,
 	})
 
 	istiods.Serve(stop)
@@ -111,7 +111,7 @@ func initCerts(server *istiod.Server, client *kubernetes.Clientset) {
 	// TODO: fallback to citadel (or custom CA) if K8S signing is broken
 
 	// discAddr configured in mesh config - this is what we'll inject into pods.
-	discAddr := server.Environment.Mesh.DefaultConfig.DiscoveryAddress
+	discAddr := server.Environment.Mesh().DefaultConfig.DiscoveryAddress
 	if istiodAddress.Get() != "" {
 		discAddr = istiodAddress.Get()
 	}
@@ -134,7 +134,7 @@ func initCerts(server *istiod.Server, client *kubernetes.Clientset) {
 		"istio-ca" + ns,
 	}
 
-	certChain, keyPEM, err := k8s.GenKeyCertK8sCA(client.CertificatesV1beta1(), istiod.IstiodNamespace.Get(),
+	certChain, keyPEM, err := k8s.GenKeyCertK8sCA(client.CertificatesV1beta1(),
 		strings.Join(names, ","))
 	if err != nil {
 		log.Fatal("Failed to initialize certs")

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -48,13 +48,14 @@ func (s *Server) initCertController(args *PilotArgs) error {
 	// Whether a key and cert are generated for Pilot
 	var pilotCertGenerated bool
 
-	if s.environment.Mesh.GetCertificates() == nil || len(s.environment.Mesh.GetCertificates()) == 0 {
+	meshConfig := s.environment.Mesh()
+	if meshConfig.GetCertificates() == nil || len(meshConfig.GetCertificates()) == 0 {
 		log.Info("nil certificate config")
 		return nil
 	}
 
 	k8sClient := s.kubeClient
-	for _, c := range s.environment.Mesh.GetCertificates() {
+	for _, c := range meshConfig.GetCertificates() {
 		name := strings.Join(c.GetDnsNames(), ",")
 		if len(name) == 0 { // must have a DNS name
 			continue

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -30,6 +30,8 @@ import (
 	mcpapi "istio.io/api/mcp/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networkingapi "istio.io/api/networking/v1alpha3"
+	"istio.io/pkg/log"
+
 	configaggregate "istio.io/istio/pilot/pkg/config/aggregate"
 	"istio.io/istio/pilot/pkg/config/coredatamodel"
 	"istio.io/istio/pilot/pkg/config/kube/crd/controller"
@@ -43,7 +45,6 @@ import (
 	"istio.io/istio/pkg/mcp/creds"
 	"istio.io/istio/pkg/mcp/monitoring"
 	"istio.io/istio/pkg/mcp/sink"
-	"istio.io/pkg/log"
 )
 
 const (
@@ -56,7 +57,8 @@ const (
 
 // initConfigController creates the config controller in the pilotConfig.
 func (s *Server) initConfigController(args *PilotArgs) error {
-	if len(s.environment.Mesh.ConfigSources) > 0 {
+	meshConfig := s.environment.Mesh()
+	if len(meshConfig.ConfigSources) > 0 {
 		if err := s.initMCPConfigController(args); err != nil {
 			return err
 		}
@@ -80,11 +82,11 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 	}
 
 	// If running in ingress mode (requires k8s), wrap the config controller.
-	if hasKubeRegistry(args.Service.Registries) && s.environment.Mesh.IngressControllerMode != meshconfig.MeshConfig_OFF {
+	if hasKubeRegistry(args.Service.Registries) && meshConfig.IngressControllerMode != meshconfig.MeshConfig_OFF {
 		// Wrap the config controller with a cache.
 		configController, err := configaggregate.MakeCache([]model.ConfigStoreCache{
 			s.configController,
-			ingress.NewController(s.kubeClient, s.environment.Mesh, args.Config.ControllerOptions),
+			ingress.NewController(s.kubeClient, meshConfig, args.Config.ControllerOptions),
 		})
 		if err != nil {
 			return err
@@ -93,7 +95,7 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 		// Update the config controller
 		s.configController = configController
 
-		if ingressSyncer, errSyncer := ingress.NewStatusSyncer(s.environment.Mesh, s.kubeClient,
+		if ingressSyncer, errSyncer := ingress.NewStatusSyncer(meshConfig, s.kubeClient,
 			args.Namespace, args.Config.ControllerOptions); errSyncer != nil {
 			log.Warnf("Disabled ingress status syncer due to %v", errSyncer)
 		} else {
@@ -128,7 +130,7 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 	}
 	reporter := monitoring.NewStatsContext("pilot")
 
-	for _, configSource := range s.environment.Mesh.ConfigSources {
+	for _, configSource := range s.environment.Mesh().ConfigSources {
 		if strings.Contains(configSource.Address, fsScheme+"://") {
 			srcAddress, err := url.Parse(configSource.Address)
 			if err != nil {
@@ -324,11 +326,11 @@ func (s *Server) sseMCPController(args *PilotArgs,
 	s.incrementalMcpOptions = &coredatamodel.Options{
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 	}
-	controller := coredatamodel.NewSyntheticServiceEntryController(s.incrementalMcpOptions)
+	ctl := coredatamodel.NewSyntheticServiceEntryController(s.incrementalMcpOptions)
 	s.discoveryOptions = &coredatamodel.DiscoveryOptions{
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 	}
-	s.mcpDiscovery = coredatamodel.NewMCPDiscovery(controller, s.discoveryOptions)
+	s.mcpDiscovery = coredatamodel.NewMCPDiscovery(ctl, s.discoveryOptions)
 	incrementalSinkOptions := &sink.Options{
 		CollectionOptions: []sink.CollectionOptions{
 			{
@@ -336,7 +338,7 @@ func (s *Server) sseMCPController(args *PilotArgs,
 				Incremental: true,
 			},
 		},
-		Updater:  controller,
+		Updater:  ctl,
 		ID:       clientNodeID,
 		Reporter: reporter,
 	}
@@ -344,7 +346,7 @@ func (s *Server) sseMCPController(args *PilotArgs,
 	incMcpClient := sink.NewClient(incSrcClient, incrementalSinkOptions)
 	configz.Register(incMcpClient)
 	*clients = append(*clients, incMcpClient)
-	*configStores = append(*configStores, controller)
+	*configStores = append(*configStores, ctl)
 }
 
 func (s *Server) makeKubeConfigController(args *PilotArgs) (model.ConfigStoreCache, error) {

--- a/pilot/pkg/bootstrap/multicluster.go
+++ b/pilot/pkg/bootstrap/multicluster.go
@@ -23,7 +23,6 @@ import (
 // clusters and initialize the multicluster structures.
 func (s *Server) initClusterRegistries(args *PilotArgs) (err error) {
 	if hasKubeRegistry(args.Service.Registries) {
-
 		mc, err := clusterregistry.NewMulticluster(s.kubeClient,
 			args.Config.ClusterRegistriesNamespace,
 			args.Config.ControllerOptions.WatchedNamespace,
@@ -31,7 +30,7 @@ func (s *Server) initClusterRegistries(args *PilotArgs) (err error) {
 			args.Config.ControllerOptions.ResyncPeriod,
 			s.ServiceController(),
 			s.EnvoyXdsServer,
-			s.environment.MeshNetworks)
+			s.environment)
 
 		if err != nil {
 			log.Info("Unable to create new Multicluster object")

--- a/pilot/pkg/config/clusterregistry/multicluster.go
+++ b/pilot/pkg/config/clusterregistry/multicluster.go
@@ -20,12 +20,12 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
-	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/kube/secretcontroller"
 )
@@ -45,14 +45,14 @@ type Multicluster struct {
 
 	m                     sync.Mutex // protects remoteKubeControllers
 	remoteKubeControllers map[string]*kubeController
-	meshNetworks          *meshconfig.MeshNetworks
+	networksWatcher       mesh.NetworksWatcher
 }
 
 // NewMulticluster initializes data structure to store multicluster information
 // It also starts the secret controller
 func NewMulticluster(kc kubernetes.Interface, secretNamespace string,
 	watchedNamespace string, domainSuffix string, resyncPeriod time.Duration,
-	serviceController *aggregate.Controller, xds model.XDSUpdater, meshNetworks *meshconfig.MeshNetworks) (*Multicluster, error) {
+	serviceController *aggregate.Controller, xds model.XDSUpdater, networksWatcher mesh.NetworksWatcher) (*Multicluster, error) {
 
 	remoteKubeController := make(map[string]*kubeController)
 	if resyncPeriod == 0 {
@@ -67,7 +67,7 @@ func NewMulticluster(kc kubernetes.Interface, secretNamespace string,
 		serviceController:     serviceController,
 		XDSUpdater:            xds,
 		remoteKubeControllers: remoteKubeController,
-		meshNetworks:          meshNetworks,
+		networksWatcher:       networksWatcher,
 	}
 
 	err := secretcontroller.StartSecretController(kc,
@@ -92,8 +92,10 @@ func (m *Multicluster) AddMemberCluster(clientset kubernetes.Interface, clusterI
 		DomainSuffix:     m.DomainSuffix,
 		XDSUpdater:       m.XDSUpdater,
 		ClusterID:        clusterID,
+		NetworksWatcher: &model.Environment{
+			NetworksWatcher: m.networksWatcher,
+		},
 	})
-	kubectl.InitNetworkLookup(m.meshNetworks)
 
 	remoteKubeController.rc = kubectl
 	m.serviceController.AddRegistry(kubectl)
@@ -126,19 +128,6 @@ func (m *Multicluster) DeleteMemberCluster(clusterID string) error {
 	}
 
 	return nil
-}
-
-// Hot reload mesh networks for remote clusters
-func (m *Multicluster) ReloadNetworkLookup(meshNetworks *meshconfig.MeshNetworks) {
-	m.m.Lock()
-	defer m.m.Unlock()
-
-	m.meshNetworks = meshNetworks
-	for _, controller := range m.remoteKubeControllers {
-		if controller != nil && controller.rc != nil {
-			controller.rc.InitNetworkLookup(meshNetworks)
-		}
-	}
 }
 
 func (m *Multicluster) updateHandler() {

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"istio.io/api/security/v1beta1"
+
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schemas"
 )
@@ -68,7 +69,7 @@ func initAuthenticationPolicies(env *Environment) *AuthenticationPolicies {
 	policy := &AuthenticationPolicies{
 		requestAuthentications: map[string][]Config{},
 		namespaceMTLSMode:      map[string]MutualTLSMode{},
-		rootNamespace:          env.Mesh.GetRootNamespace(),
+		rootNamespace:          env.Mesh().GetRootNamespace(),
 	}
 
 	if configs, err := env.List(schemas.RequestAuthentication.Type, NamespaceAll); err == nil {
@@ -95,7 +96,7 @@ func (policy *AuthenticationPolicies) addRequestAuthentication(configs []Config)
 // GetJwtPoliciesForWorkload returns a list of JWT policies matching to labels.
 func (policy *AuthenticationPolicies) GetJwtPoliciesForWorkload(namespace string,
 	workloadLabels labels.Collection) []*Config {
-	configs := []*Config{}
+	configs := make([]*Config, 0)
 	if nsConfig, ok := policy.requestAuthentications[namespace]; ok {
 		for idx := range nsConfig {
 			cfg := &nsConfig[idx]

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -19,8 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	mesh "istio.io/api/mesh/v1alpha1"
-	security_beta "istio.io/api/security/v1beta1"
+	"istio.io/istio/pkg/config/mesh"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	securityBeta "istio.io/api/security/v1beta1"
 	selectorpb "istio.io/api/type/v1beta1"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schemas"
@@ -50,7 +52,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "foo",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
 					ConfigMeta: ConfigMeta{
@@ -58,7 +60,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 			},
 		},
@@ -73,7 +75,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "bar",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
 					ConfigMeta: ConfigMeta{
@@ -81,7 +83,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 			},
 		},
@@ -96,7 +98,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 			},
 		},
@@ -111,7 +113,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "foo",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
 					ConfigMeta: ConfigMeta{
@@ -119,7 +121,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "with-selector",
 						Namespace: "foo",
 					},
-					Spec: &security_beta.RequestAuthentication{
+					Spec: &securityBeta.RequestAuthentication{
 						Selector: &selectorpb.WorkloadSelector{
 							MatchLabels: map[string]string{
 								"app":     "httpbin",
@@ -134,7 +136,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 			},
 		},
@@ -149,7 +151,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "bar",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
 					ConfigMeta: ConfigMeta{
@@ -157,7 +159,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 			},
 		},
@@ -172,7 +174,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "foo",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
 					ConfigMeta: ConfigMeta{
@@ -180,7 +182,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &security_beta.RequestAuthentication{},
+					Spec: &securityBeta.RequestAuthentication{},
 				},
 			},
 		},
@@ -205,7 +207,7 @@ func getTestAuthenticationPolicies(configs []*Config, t *testing.T) *Authenticat
 	}
 	environment := &Environment{
 		IstioConfigStore: MakeIstioStore(configStore),
-		Mesh:             &mesh.MeshConfig{RootNamespace: rootNamespace},
+		Watcher:          mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: rootNamespace}),
 	}
 	return initAuthenticationPolicies(environment)
 }
@@ -214,14 +216,14 @@ func createTestConfig(name string, namespace string, selector *selectorpb.Worklo
 	return &Config{
 		ConfigMeta: ConfigMeta{
 			Type: schemas.RequestAuthentication.Type, Name: name, Namespace: namespace},
-		Spec: &security_beta.RequestAuthentication{
+		Spec: &securityBeta.RequestAuthentication{
 			Selector: selector,
 		},
 	}
 }
 
 func createTestConfigs() []*Config {
-	configs := []*Config{}
+	configs := make([]*Config, 0)
 
 	selector := &selectorpb.WorkloadSelector{
 		MatchLabels: map[string]string{

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -70,7 +70,7 @@ func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) 
 	policy := &AuthorizationPolicies{
 		NamespaceToV1alpha1Policies: map[string]*RolesAndBindings{},
 		NamespaceToV1beta1Policies:  map[string][]AuthorizationPolicyConfig{},
-		RootNamespace:               env.Mesh.GetRootNamespace(),
+		RootNamespace:               env.Mesh().GetRootNamespace(),
 	}
 
 	rbacConfig := env.IstioConfigStore.ClusterRbacConfig()

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -23,11 +23,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	mesh "istio.io/api/mesh/v1alpha1"
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	rbacproto "istio.io/api/rbac/v1alpha1"
 	authpb "istio.io/api/security/v1beta1"
 	selectorpb "istio.io/api/type/v1beta1"
+
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schemas"
 )
@@ -759,7 +761,7 @@ func createFakeAuthorizationPolicies(configs []Config, t *testing.T) *Authorizat
 	}
 	environment := &Environment{
 		IstioConfigStore: MakeIstioStore(store),
-		Mesh:             &mesh.MeshConfig{RootNamespace: "istio-config"},
+		Watcher:          mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-config"}),
 	}
 	authzPolicies, err := GetAuthorizationPolicies(environment)
 	if err != nil {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -24,6 +24,7 @@ import (
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/pkg/monitoring"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/constants"
@@ -32,7 +33,6 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/config/visibility"
-	"istio.io/pkg/monitoring"
 )
 
 // Metrics is an interface for capturing metrics on a per-node basis.
@@ -744,8 +744,8 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 		return nil
 	}
 
-	ps.Mesh = env.Mesh
-	ps.Networks = env.MeshNetworks
+	ps.Mesh = env.Mesh()
+	ps.Networks = env.Networks()
 	ps.ServiceDiscovery = env
 	ps.IstioConfigStore = env
 	ps.Version = env.Version()

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -23,10 +23,12 @@ import (
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schemas"
 )
@@ -132,8 +134,8 @@ func TestMergeUpdateRequest(t *testing.T) {
 func TestAuthNPolicies(t *testing.T) {
 	const testNamespace string = "test-namespace"
 	ps := NewPushContext()
-	env := &Environment{Mesh: &meshconfig.MeshConfig{RootNamespace: "istio-system"}}
-	ps.Mesh = env.Mesh
+	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"})}
+	ps.Mesh = env.Mesh()
 	ps.ServiceDiscovery = env
 	authNPolicies := map[string]*authn.Policy{
 		constants.DefaultAuthenticationPolicyName: {},
@@ -329,14 +331,14 @@ func TestAuthNPolicies(t *testing.T) {
 
 func TestJwtAuthNPolicy(t *testing.T) {
 	ms, err := test.StartNewServer()
-	defer ms.Stop()
+	defer func() { _ = ms.Stop() }()
 	if err != nil {
 		t.Fatal("failed to start a mock server")
 	}
 
 	ps := NewPushContext()
-	env := &Environment{Mesh: &meshconfig.MeshConfig{RootNamespace: "istio-system"}}
-	ps.Mesh = env.Mesh
+	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"})}
+	ps.Mesh = env.Mesh()
 	ps.ServiceDiscovery = env
 	authNPolicies := map[string]*authn.Policy{
 		constants.DefaultAuthenticationPolicyName: {},
@@ -490,8 +492,8 @@ func TestEnvoyFilters(t *testing.T) {
 
 func TestSidecarScope(t *testing.T) {
 	ps := NewPushContext()
-	env := &Environment{Mesh: &meshconfig.MeshConfig{RootNamespace: "istio-system"}}
-	ps.Mesh = env.Mesh
+	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"})}
+	ps.Mesh = env.Mesh()
 	ps.ServiceDiscovery = env
 	ps.ServiceByHostnameAndNamespace[host.Name("svc1.default.cluster.local")] = map[string]*Service{"default": nil}
 	ps.ServiceByHostnameAndNamespace[host.Name("svc2.nosidecar.cluster.local")] = map[string]*Service{"nosidecar": nil}

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -21,9 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pkg/test/env"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -40,9 +37,12 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 
+	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/fakes"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/test/env"
 )
 
 var (
@@ -78,22 +78,22 @@ func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyCo
 
 func buildPatchStruct(config string) *types.Struct {
 	val := &types.Struct{}
-	jsonpb.Unmarshal(strings.NewReader(config), val)
+	_ = jsonpb.Unmarshal(strings.NewReader(config), val)
 	return val
 }
 
 func newTestEnvironment(serviceDiscovery model.ServiceDiscovery, meshConfig meshconfig.MeshConfig,
 	configStore model.IstioConfigStore) *model.Environment {
-	env := &model.Environment{
+	e := &model.Environment{
 		ServiceDiscovery: serviceDiscovery,
 		IstioConfigStore: configStore,
-		Mesh:             &meshConfig,
+		Watcher:          mesh.NewFixedWatcher(&meshConfig),
 	}
 
-	env.PushContext = model.NewPushContext()
-	_ = env.PushContext.InitContext(env, nil, nil)
+	e.PushContext = model.NewPushContext()
+	_ = e.PushContext.InitContext(e, nil, nil)
 
-	return env
+	return e
 }
 
 func TestApplyListenerPatches(t *testing.T) {
@@ -649,9 +649,9 @@ func TestApplyListenerPatches(t *testing.T) {
 	}
 	gatewayProxy := &model.Proxy{Type: model.Router, ConfigNamespace: "not-default"}
 	serviceDiscovery := &fakes.ServiceDiscovery{}
-	env := newTestEnvironment(serviceDiscovery, testMesh, buildEnvoyFilterConfigStore(configPatches))
+	e := newTestEnvironment(serviceDiscovery, testMesh, buildEnvoyFilterConfigStore(configPatches))
 	push := model.NewPushContext()
-	push.InitContext(env, nil, nil)
+	_ = push.InitContext(e, nil, nil)
 
 	type args struct {
 		patchContext networking.EnvoyFilter_PatchContext
@@ -724,7 +724,7 @@ func TestApplyListenerPatches(t *testing.T) {
 // This benchmark measures the performance of Telemetry V2 EnvoyFilter patches. The intent here is to
 // measure overhead of using EnvoyFilters rather than native code.
 func BenchmarkTelemetryV2Filters(b *testing.B) {
-	listener := []*xdsapi.Listener{
+	l := []*xdsapi.Listener{
 		{
 			Name: "another-listener",
 			Address: &core.Address{
@@ -795,15 +795,15 @@ func BenchmarkTelemetryV2Filters(b *testing.B) {
 		},
 	}
 	serviceDiscovery := &fakes.ServiceDiscovery{}
-	env := newTestEnvironment(serviceDiscovery, testMesh, buildEnvoyFilterConfigStore(configPatches))
+	e := newTestEnvironment(serviceDiscovery, testMesh, buildEnvoyFilterConfigStore(configPatches))
 	push := model.NewPushContext()
-	push.InitContext(env, nil, nil)
+	_ = push.InitContext(e, nil, nil)
 
 	var got interface{}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		got = ApplyListenerPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, sidecarProxy, push,
-			listener, false)
+			l, false)
 	}
 	_ = got
 }

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -968,7 +968,7 @@ func buildEnv(t *testing.T, gateways []pilot_model.Config, virtualServices []pil
 		PushContext:      pilot_model.NewPushContext(),
 		ServiceDiscovery: serviceDiscovery,
 		IstioConfigStore: configStore,
-		Mesh:             &m,
+		Watcher:          mesh.NewFixedWatcher(&m),
 	}
 
 	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -661,7 +661,7 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 		t.Fatalf("failed to initialize push context")
 	}
 	if registryOnly {
-		env.Mesh.OutboundTrafficPolicy = &meshapi.MeshConfig_OutboundTrafficPolicy{Mode: meshapi.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY}
+		env.Mesh().OutboundTrafficPolicy = &meshapi.MeshConfig_OutboundTrafficPolicy{Mode: meshapi.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY}
 	}
 	if sidecarConfig == nil {
 		proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
@@ -674,14 +674,14 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 	}
 
 	vHostCache := make(map[int][]*route.VirtualHost)
-	route := configgen.buildSidecarOutboundHTTPRouteConfig(&proxy, env.PushContext, routeName, vHostCache)
-	if route == nil {
+	routeCfg := configgen.buildSidecarOutboundHTTPRouteConfig(&proxy, env.PushContext, routeName, vHostCache)
+	if routeCfg == nil {
 		t.Fatalf("got nil route for %s", routeName)
 	}
 
 	expectedNumberOfRoutes := len(expectedHosts)
 	numberOfRoutes := 0
-	for _, vhost := range route.VirtualHosts {
+	for _, vhost := range routeCfg.VirtualHosts {
 		numberOfRoutes += len(vhost.Routes)
 		if _, found := expectedHosts[vhost.Name]; !found {
 			t.Fatalf("unexpected vhost block %s for route %s",

--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -32,6 +32,7 @@ import (
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
@@ -251,10 +252,10 @@ func initRegistry(server *bootstrap.Server, clusterNum int, gatewaysIP []string,
 	gws := make([]*meshconfig.Network_IstioNetworkGateway, 0)
 	for _, gatewayIP := range gatewaysIP {
 		if gatewayIP != "" {
-			if server.EnvoyXdsServer.Env.MeshNetworks == nil {
-				server.EnvoyXdsServer.Env.MeshNetworks = &meshconfig.MeshNetworks{
+			if server.EnvoyXdsServer.Env.Networks() == nil {
+				server.EnvoyXdsServer.Env.NetworksWatcher = mesh.NewFixedNetworksWatcher(&meshconfig.MeshNetworks{
 					Networks: map[string]*meshconfig.Network{},
-				}
+				})
 			}
 			gw := &meshconfig.Network_IstioNetworkGateway{
 				Gw: &meshconfig.Network_IstioNetworkGateway_Address{
@@ -267,7 +268,7 @@ func initRegistry(server *bootstrap.Server, clusterNum int, gatewaysIP []string,
 	}
 
 	if len(gws) != 0 {
-		server.EnvoyXdsServer.Env.MeshNetworks.Networks[id] = &meshconfig.Network{
+		server.EnvoyXdsServer.Env.Networks().Networks[id] = &meshconfig.Network{
 			Gateways: gws,
 		}
 	}

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -32,6 +32,7 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 
 	"istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
@@ -58,7 +59,7 @@ func TestEds(t *testing.T) {
 	addUdsEndpoint(server)
 
 	// enable locality load balancing and add relevant endpoints in order to test
-	server.EnvoyXdsServer.Env.Mesh.LocalityLbSetting = &v1alpha3.LocalityLoadBalancerSetting{}
+	server.EnvoyXdsServer.Env.Mesh().LocalityLbSetting = &v1alpha3.LocalityLoadBalancerSetting{}
 	addLocalityEndpoints(server, "locality.cluster.local")
 	addLocalityEndpoints(server, "locality-no-outlier-detection.cluster.local")
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
@@ -76,7 +77,7 @@ func (fx *FakeXdsUpdater) ConfigUpdate(*model.PushRequest) {
 	}
 }
 
-func (fx *FakeXdsUpdater) ProxyUpdate(clusterID, ip string) {
+func (fx *FakeXdsUpdater) ProxyUpdate(_, _ string) {
 	select {
 	case fx.Events <- XdsEvent{Type: "proxy"}:
 	default:
@@ -105,7 +106,7 @@ func NewFakeXDS() *FakeXdsUpdater {
 	}
 }
 
-func (fx *FakeXdsUpdater) EDSUpdate(shard, hostname string, namespace string, entry []*model.IstioEndpoint) error {
+func (fx *FakeXdsUpdater) EDSUpdate(_, hostname string, _ string, entry []*model.IstioEndpoint) error {
 	if len(entry) > 0 {
 		select {
 		case fx.Events <- XdsEvent{Type: "eds", ID: hostname}:
@@ -120,7 +121,7 @@ func (fx *FakeXdsUpdater) EDSUpdate(shard, hostname string, namespace string, en
 // This interface is WIP - labels, annotations and other changes to service may be
 // updated to force a EDS and CDS recomputation and incremental push, as it doesn't affect
 // LDS/RDS.
-func (fx *FakeXdsUpdater) SvcUpdate(shard, hostname string, namespace string, event model.Event) {
+func (fx *FakeXdsUpdater) SvcUpdate(_, hostname string, _ string, _ model.Event) {
 	select {
 	case fx.Events <- XdsEvent{Type: "service", ID: hostname}:
 	default:
@@ -167,8 +168,13 @@ func newLocalController(t *testing.T) (*Controller, *FakeXdsUpdater) {
 	return ctl, fx
 }
 
-func newFakeController(_ *testing.T) (*Controller, *FakeXdsUpdater) {
+func newFakeController() (*Controller, *FakeXdsUpdater) {
+	return newFakeControllerWithWatcher(nil)
+}
+
+func newFakeControllerWithWatcher(networksWatcher mesh.NetworksWatcher) (*Controller, *FakeXdsUpdater) {
 	fx := NewFakeXDS()
+
 	clientSet := fake.NewSimpleClientset()
 	c := NewController(clientSet, Options{
 		WatchedNamespace: "", // tests create resources in multiple ns
@@ -176,6 +182,7 @@ func newFakeController(_ *testing.T) (*Controller, *FakeXdsUpdater) {
 		DomainSuffix:     domainSuffix,
 		XDSUpdater:       fx,
 		Metrics:          &model.Environment{},
+		NetworksWatcher:  networksWatcher,
 	})
 	_ = c.AppendInstanceHandler(func(instance *model.ServiceInstance, event model.Event) {})
 	_ = c.AppendServiceHandler(func(service *model.Service, event model.Event) {})
@@ -184,7 +191,30 @@ func newFakeController(_ *testing.T) (*Controller, *FakeXdsUpdater) {
 }
 
 func TestServices(t *testing.T) {
-	ctl, fx := newFakeController(t)
+	networksWatcher := mesh.NewFixedNetworksWatcher(&meshconfig.MeshNetworks{
+		Networks: map[string]*meshconfig.Network{
+			"network1": {
+				Endpoints: []*meshconfig.Network_NetworkEndpoints{
+					{
+						Ne: &meshconfig.Network_NetworkEndpoints_FromCidr{
+							FromCidr: "10.10.1.1/24",
+						},
+					},
+				},
+			},
+			"network2": {
+				Endpoints: []*meshconfig.Network_NetworkEndpoints{
+					{
+						Ne: &meshconfig.Network_NetworkEndpoints_FromCidr{
+							FromCidr: "10.11.1.1/24",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	ctl, fx := newFakeControllerWithWatcher(networksWatcher)
 	defer ctl.Stop()
 	t.Parallel()
 	ns := "ns-test"
@@ -216,47 +246,24 @@ func TestServices(t *testing.T) {
 		return false
 	})
 
-	ctl.InitNetworkLookup(&meshconfig.MeshNetworks{
-		Networks: map[string]*meshconfig.Network{
-			"network1": {
-				Endpoints: []*meshconfig.Network_NetworkEndpoints{
-					{
-						Ne: &meshconfig.Network_NetworkEndpoints_FromCidr{
-							FromCidr: "10.10.1.1/24",
-						},
-					},
-				},
-			},
-			"network2": {
-				Endpoints: []*meshconfig.Network_NetworkEndpoints{
-					{
-						Ne: &meshconfig.Network_NetworkEndpoints_FromCidr{
-							FromCidr: "10.11.1.1/24",
-						},
-					},
-				},
-			},
-		},
-	})
-
 	// 2 ports 1001, 2 IPs
 	createEndpoints(ctl, testService, ns, []string{"http-example", "foo"}, []string{"10.10.1.1", "10.11.1.2"}, t)
 
 	svc, err := sds.GetService(hostname)
 	if err != nil {
-		t.Errorf("GetService(%q) encountered unexpected error: %v", hostname, err)
+		t.Fatalf("GetService(%q) encountered unexpected error: %v", hostname, err)
 	}
 	if svc == nil {
-		t.Errorf("GetService(%q) => should exists", hostname)
+		t.Fatalf("GetService(%q) => should exists", hostname)
 	}
 	if svc.Hostname != hostname {
-		t.Errorf("GetService(%q) => %q", hostname, svc.Hostname)
+		t.Fatalf("GetService(%q) => %q", hostname, svc.Hostname)
 	}
 
 	test.Eventually(t, "successfully created endpoints", func() bool {
 		ep, anotherErr := sds.InstancesByPort(svc, 80, nil)
 		if anotherErr != nil {
-			t.Errorf("error gettings instance by port: %v", anotherErr)
+			t.Fatalf("error gettings instance by port: %v", anotherErr)
 			return false
 		}
 		if len(ep) == 2 {
@@ -267,27 +274,27 @@ func TestServices(t *testing.T) {
 
 	ep, err := sds.InstancesByPort(svc, 80, nil)
 	if err != nil {
-		t.Errorf("GetInstancesByPort() encountered unexpected error: %v", err)
+		t.Fatalf("GetInstancesByPort() encountered unexpected error: %v", err)
 	}
 	if len(ep) != 2 {
-		t.Errorf("Invalid response for GetInstancesByPort %v", ep)
+		t.Fatalf("Invalid response for GetInstancesByPort %v", ep)
 	}
 
 	if ep[0].Endpoint.Address == "10.10.1.1" && ep[0].Endpoint.Network != "network1" {
-		t.Errorf("Endpoint with IP 10.10.1.1 is expected to be in network1 but get: %s", ep[0].Endpoint.Network)
+		t.Fatalf("Endpoint with IP 10.10.1.1 is expected to be in network1 but get: %s", ep[0].Endpoint.Network)
 	}
 
 	if ep[1].Endpoint.Address == "10.11.1.2" && ep[1].Endpoint.Network != "network2" {
-		t.Errorf("Endpoint with IP 10.11.1.2 is expected to be in network2 but get: %s", ep[1].Endpoint.Network)
+		t.Fatalf("Endpoint with IP 10.11.1.2 is expected to be in network2 but get: %s", ep[1].Endpoint.Network)
 	}
 
 	missing := kube.ServiceHostname("does-not-exist", ns, domainSuffix)
 	svc, err = sds.GetService(missing)
 	if err != nil {
-		t.Errorf("GetService(%q) encountered unexpected error: %v", missing, err)
+		t.Fatalf("GetService(%q) encountered unexpected error: %v", missing, err)
 	}
 	if svc != nil {
-		t.Errorf("GetService(%q) => %s, should not exist", missing, svc.Hostname)
+		t.Fatalf("GetService(%q) => %s, should not exist", missing, svc.Hostname)
 	}
 }
 
@@ -401,13 +408,13 @@ func TestController_GetPodLocality(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 
 			// Setup kube caches
-			controller, fx := newFakeController(t)
+			controller, fx := newFakeController()
 			defer controller.Stop()
 			addNodes(t, controller, c.nodes...)
 			addPods(t, controller, c.pods...)
 			for _, pod := range c.pods {
 				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-					t.Errorf("wait for pod err: %v", err)
+					t.Fatalf("wait for pod err: %v", err)
 				}
 				// pod first time occur will trigger xds push
 				fx.Wait("xds")
@@ -418,11 +425,11 @@ func TestController_GetPodLocality(t *testing.T) {
 				az := controller.GetPodLocality(pod)
 				if wantAZ != "" {
 					if !reflect.DeepEqual(az, wantAZ) {
-						t.Errorf("Wanted az: %s, got: %s", wantAZ, az)
+						t.Fatalf("Wanted az: %s, got: %s", wantAZ, az)
 					}
 				} else {
 					if az != "" {
-						t.Errorf("Unexpectedly found az: %s for pod: %s", az, pod.ObjectMeta.Name)
+						t.Fatalf("Unexpectedly found az: %s for pod: %s", az, pod.ObjectMeta.Name)
 					}
 				}
 			}
@@ -432,12 +439,12 @@ func TestController_GetPodLocality(t *testing.T) {
 }
 
 func TestGetProxyServiceInstances(t *testing.T) {
-	controller, fx := newFakeController(t)
+	controller, fx := newFakeController()
 	defer controller.Stop()
 	p := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
 	addPods(t, controller, p)
 	if err := waitForPod(controller, p.Status.PodIP); err != nil {
-		t.Errorf("wait for pod err: %v", err)
+		t.Fatalf("wait for pod err: %v", err)
 	}
 
 	k8sSaOnVM := "acct4"
@@ -487,16 +494,16 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	svcNode.Metadata = &model.NodeMetadata{}
 	services, err := controller.GetProxyServiceInstances(&svcNode)
 	if err != nil {
-		t.Errorf("client encountered error during GetProxyServiceInstances(): %v", err)
+		t.Fatalf("client encountered error during GetProxyServiceInstances(): %v", err)
 	}
 
 	if len(services) != fakeSvcCounts+1 {
-		t.Errorf("GetProxyServiceInstances() returned wrong # of endpoints => %d, want %d", len(services), fakeSvcCounts+1)
+		t.Fatalf("GetProxyServiceInstances() returned wrong # of endpoints => %d, want %d", len(services), fakeSvcCounts+1)
 	}
 
 	hostname := kube.ServiceHostname("svc1", "nsa", domainSuffix)
 	if services[0].Service.Hostname != hostname {
-		t.Errorf("GetProxyServiceInstances() wrong service instance returned => hostname %q, want %q",
+		t.Fatalf("GetProxyServiceInstances() wrong service instance returned => hostname %q, want %q",
 			services[0].Service.Hostname, hostname)
 	}
 
@@ -550,7 +557,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 		map[string]string{"app": "prod-app"}, nil)
 	addPods(t, controller, p)
 	if err := waitForPod(controller, p.Status.PodIP); err != nil {
-		t.Errorf("wait for pod err: %v", err)
+		t.Fatalf("wait for pod err: %v", err)
 	}
 
 	podServices, err := controller.GetProxyServiceInstances(&model.Proxy{
@@ -599,7 +606,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 		map[string]string{"app": "prod-app", "istio-locality": "region.zone"}, nil)
 	addPods(t, controller, p)
 	if err := waitForPod(controller, p.Status.PodIP); err != nil {
-		t.Errorf("wait for pod err: %v", err)
+		t.Fatalf("wait for pod err: %v", err)
 	}
 
 	podServices, err = controller.GetProxyServiceInstances(&model.Proxy{
@@ -686,12 +693,12 @@ func TestGetProxyServiceInstancesWithMultiIPs(t *testing.T) {
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 			// Setup kube caches
-			controller, fx := newFakeController(t)
+			controller, fx := newFakeController()
 			defer controller.Stop()
 			addPods(t, controller, c.pods...)
 			for _, pod := range c.pods {
 				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-					t.Errorf("wait for pod err: %v", err)
+					t.Fatalf("wait for pod err: %v", err)
 				}
 			}
 
@@ -702,14 +709,14 @@ func TestGetProxyServiceInstancesWithMultiIPs(t *testing.T) {
 				c.ports, map[string]string{"app": "test-app"}, t)
 			ev := fx.Wait("service")
 			if ev == nil {
-				t.Error("Timeout creating service")
+				t.Fatal("Timeout creating service")
 			}
 			serviceInstances, err := controller.GetProxyServiceInstances(&model.Proxy{Metadata: &model.NodeMetadata{}, IPAddresses: c.ips})
 			if err != nil {
-				t.Errorf("client encountered error during GetProxyServiceInstances(): %v", err)
+				t.Fatalf("client encountered error during GetProxyServiceInstances(): %v", err)
 			}
 			if len(serviceInstances) != c.wantNum {
-				t.Errorf("GetProxyServiceInstances() returned wrong # of endpoints => %q, want %q", len(serviceInstances), c.wantNum)
+				t.Fatalf("GetProxyServiceInstances() returned wrong # of endpoints => %q, want %q", len(serviceInstances), c.wantNum)
 			}
 		})
 	}
@@ -720,7 +727,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 	spiffe.SetTrustDomain(domainSuffix)
 	defer spiffe.SetTrustDomain(oldTrustDomain)
 
-	controller, fx := newFakeController(t)
+	controller, fx := newFakeController()
 	defer controller.Stop()
 
 	sa1 := "acct1"
@@ -737,7 +744,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 	addPods(t, controller, pods...)
 	for _, pod := range pods {
 		if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-			t.Errorf("wait for pod err: %v", err)
+			t.Fatalf("wait for pod err: %v", err)
 		}
 	}
 
@@ -774,7 +781,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 		"spiffe://company.com/ns/nsA/sa/" + k8sSaOnVM,
 	}
 	if !reflect.DeepEqual(sa, expected) {
-		t.Errorf("Unexpected service accounts %v (expecting %v)", sa, expected)
+		t.Fatalf("Unexpected service accounts %v (expecting %v)", sa, expected)
 	}
 
 	hostname = kube.ServiceHostname("svc2", "nsA", domainSuffix)
@@ -784,19 +791,19 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 	}
 	sa = controller.GetIstioServiceAccounts(svc, []int{})
 	if len(sa) != 0 {
-		t.Error("Failure: Expected to resolve 0 service accounts, but got: ", sa)
+		t.Fatal("Failure: Expected to resolve 0 service accounts, but got: ", sa)
 	}
 }
 
 func TestWorkloadHealthCheckInfo(t *testing.T) {
-	controller, _ := newFakeController(t)
+	controller, _ := newFakeController()
 	defer controller.Stop()
 
 	pod := generatePodWithProbes("128.0.0.1", "pod1", "nsa1", "", "node1", "/ready", intstr.Parse("8080"), "/live", intstr.Parse("9090"))
 	addPods(t, controller, pod)
 
 	if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-		t.Errorf("wait for pod err: %v", err)
+		t.Fatalf("wait for pod err: %v", err)
 	}
 	probes := controller.WorkloadHealthCheckInfo("128.0.0.1")
 
@@ -820,26 +827,26 @@ func TestWorkloadHealthCheckInfo(t *testing.T) {
 	}
 
 	if len(probes) != len(expected) {
-		t.Errorf("Expecting %d probes but got %d\r\n", len(expected), len(probes))
+		t.Fatalf("Expecting %d probes but got %d\r\n", len(expected), len(probes))
 		return
 	}
 
 	for i, exp := range expected {
 		if !reflect.DeepEqual(exp, probes[i]) {
-			t.Errorf("Probe %d, got:\n%#v\nwanted:\n%#v\n", i, probes[i], exp)
+			t.Fatalf("Probe %d, got:\n%#v\nwanted:\n%#v\n", i, probes[i], exp)
 		}
 	}
 }
 
 func TestWorkloadHealthCheckInfoPrometheusScrape(t *testing.T) {
-	controller, _ := newFakeController(t)
+	controller, _ := newFakeController()
 	defer controller.Stop()
 
 	pod := generatePod("128.0.1.6", "pod1", "nsA", "", "node1", map[string]string{"app": "test-app"},
 		map[string]string{PrometheusScrape: "true"})
 	addPods(t, controller, pod)
 	if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-		t.Errorf("wait for pod err: %v", err)
+		t.Fatalf("wait for pod err: %v", err)
 	}
 
 	controller.pods.podsByIP["128.0.1.6"] = "nsA/pod1"
@@ -851,21 +858,21 @@ func TestWorkloadHealthCheckInfoPrometheusScrape(t *testing.T) {
 	}
 
 	if len(probes) != 1 {
-		t.Errorf("Expecting 1 probe but got %d\r\n", len(probes))
+		t.Fatalf("Expecting 1 probe but got %d\r\n", len(probes))
 	} else if !reflect.DeepEqual(expected, probes[0]) {
-		t.Errorf("Probe got:\n%#v\nwanted:\n%#v\n", probes[0], expected)
+		t.Fatalf("Probe got:\n%#v\nwanted:\n%#v\n", probes[0], expected)
 	}
 }
 
 func TestWorkloadHealthCheckInfoPrometheusPath(t *testing.T) {
-	controller, _ := newFakeController(t)
+	controller, _ := newFakeController()
 	defer controller.Stop()
 
 	pod := generatePod("128.0.1.7", "pod1", "nsA", "", "node1", map[string]string{"app": "test-app"},
 		map[string]string{PrometheusScrape: "true", PrometheusPath: "/other"})
 	addPods(t, controller, pod)
 	if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-		t.Errorf("wait for pod err: %v", err)
+		t.Fatalf("wait for pod err: %v", err)
 	}
 	controller.pods.podsByIP["128.0.1.7"] = "nsA/pod1"
 
@@ -876,21 +883,21 @@ func TestWorkloadHealthCheckInfoPrometheusPath(t *testing.T) {
 	}
 
 	if len(probes) != 1 {
-		t.Errorf("Expecting 1 probe but got %d\r\n", len(probes))
+		t.Fatalf("Expecting 1 probe but got %d\r\n", len(probes))
 	} else if !reflect.DeepEqual(expected, probes[0]) {
-		t.Errorf("Probe got:\n%#v\nwanted:\n%#v\n", probes[0], expected)
+		t.Fatalf("Probe got:\n%#v\nwanted:\n%#v\n", probes[0], expected)
 	}
 }
 
 func TestWorkloadHealthCheckInfoPrometheusPort(t *testing.T) {
-	controller, _ := newFakeController(t)
+	controller, _ := newFakeController()
 	defer controller.Stop()
 
 	pod := generatePod("128.0.1.8", "pod1", "nsA", "", "node1", map[string]string{"app": "test-app"},
 		map[string]string{PrometheusScrape: "true", PrometheusPort: "3210"})
 	addPods(t, controller, pod)
 	if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-		t.Errorf("wait for pod err: %v", err)
+		t.Fatalf("wait for pod err: %v", err)
 	}
 	controller.pods.podsByIP["128.0.1.8"] = "nsA/pod1"
 
@@ -904,19 +911,19 @@ func TestWorkloadHealthCheckInfoPrometheusPort(t *testing.T) {
 	}
 
 	if len(probes) != 1 {
-		t.Errorf("Expecting 1 probe but got %d\r\n", len(probes))
+		t.Fatalf("Expecting 1 probe but got %d\r\n", len(probes))
 	} else if !reflect.DeepEqual(expected, probes[0]) {
-		t.Errorf("Probe got:\n%#v\nwanted:\n%#v\n", probes[0], expected)
+		t.Fatalf("Probe got:\n%#v\nwanted:\n%#v\n", probes[0], expected)
 	}
 }
 
 func TestManagementPorts(t *testing.T) {
-	controller, _ := newFakeController(t)
+	controller, _ := newFakeController()
 
 	pod := generatePodWithProbes("128.0.0.1", "pod1", "nsA", "", "node1", "/ready", intstr.Parse("8080"), "/live", intstr.Parse("9090"))
 	addPods(t, controller, pod)
 	if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-		t.Errorf("wait for pod err: %v", err)
+		t.Fatalf("wait for pod err: %v", err)
 	}
 	controller.pods.podsByIP["128.0.0.1"] = "nsA/pod1"
 
@@ -936,16 +943,16 @@ func TestManagementPorts(t *testing.T) {
 	}
 
 	if len(portList) != len(expected) {
-		t.Errorf("Expecting %d port but got %d\r\n", len(expected), len(portList))
+		t.Fatalf("Expecting %d port but got %d\r\n", len(expected), len(portList))
 	}
 
 	if !reflect.DeepEqual(expected, portList) {
-		t.Errorf("got port, got:\n%#v\nwanted:\n%#v\n", portList, expected)
+		t.Fatalf("got port, got:\n%#v\nwanted:\n%#v\n", portList, expected)
 	}
 }
 
 func TestController_Service(t *testing.T) {
-	controller, fx := newFakeController(t)
+	controller, fx := newFakeController()
 	// Use a timeout to keep the test from hanging.
 
 	createService(controller, "svc1", "nsA",
@@ -1018,19 +1025,19 @@ func TestController_Service(t *testing.T) {
 	}
 	for i, exp := range expectedSvcList {
 		if exp.Hostname != svcList[i].Hostname {
-			t.Errorf("got hostname of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Hostname, exp.Hostname)
+			t.Fatalf("got hostname of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Hostname, exp.Hostname)
 		}
 		if exp.Address != svcList[i].Address {
-			t.Errorf("got address of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Address, exp.Address)
+			t.Fatalf("got address of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Address, exp.Address)
 		}
 		if !reflect.DeepEqual(exp.Ports, svcList[i].Ports) {
-			t.Errorf("got ports of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Ports, exp.Ports)
+			t.Fatalf("got ports of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Ports, exp.Ports)
 		}
 	}
 }
 
 func TestController_ExternalNameService(t *testing.T) {
-	controller, fx := newFakeController(t)
+	controller, fx := newFakeController()
 	// Use a timeout to keep the test from hanging.
 
 	k8sSvcs := []*coreV1.Service{
@@ -1101,27 +1108,26 @@ func TestController_ExternalNameService(t *testing.T) {
 	}
 	for i, exp := range expectedSvcList {
 		if exp.Hostname != svcList[i].Hostname {
-			t.Errorf("got hostname of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Hostname, exp.Hostname)
+			t.Fatalf("got hostname of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Hostname, exp.Hostname)
 		}
 		if !reflect.DeepEqual(exp.Ports, svcList[i].Ports) {
-			t.Errorf("got ports of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Ports, exp.Ports)
+			t.Fatalf("got ports of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Ports, exp.Ports)
 		}
 		if svcList[i].MeshExternal != exp.MeshExternal {
-			t.Errorf("i=%v, MeshExternal==%v, should be %v: externalName='%s'", i, exp.MeshExternal, svcList[i].MeshExternal, k8sSvcs[i].Spec.ExternalName)
+			t.Fatalf("i=%v, MeshExternal==%v, should be %v: externalName='%s'", i, exp.MeshExternal, svcList[i].MeshExternal, k8sSvcs[i].Spec.ExternalName)
 		}
 		if svcList[i].Resolution != exp.Resolution {
-			t.Errorf("i=%v, Resolution=='%v', should be '%v'", i, svcList[i].Resolution, exp.Resolution)
+			t.Fatalf("i=%v, Resolution=='%v', should be '%v'", i, svcList[i].Resolution, exp.Resolution)
 		}
 		instances, err := controller.InstancesByPort(svcList[i], svcList[i].Ports[0].Port, labels.Collection{})
 		if err != nil {
-			t.Errorf("error getting instances by port: %s", err)
-			continue
+			t.Fatalf("error getting instances by port: %s", err)
 		}
 		if len(instances) != 1 {
-			t.Errorf("should be exactly 1 instance: len(instances) = %v", len(instances))
+			t.Fatalf("should be exactly 1 instance: len(instances) = %v", len(instances))
 		}
 		if instances[0].Endpoint.Address != k8sSvcs[i].Spec.ExternalName {
-			t.Errorf("wrong instance endpoint address: '%s' != '%s'", instances[0].Endpoint.Address, k8sSvcs[i].Spec.ExternalName)
+			t.Fatalf("wrong instance endpoint address: '%s' != '%s'", instances[0].Endpoint.Address, k8sSvcs[i].Spec.ExternalName)
 		}
 	}
 
@@ -1146,11 +1152,10 @@ func TestController_ExternalNameService(t *testing.T) {
 	for _, exp := range expectedSvcList {
 		instances, err := controller.InstancesByPort(exp, exp.Ports[0].Port, labels.Collection{})
 		if err != nil {
-			t.Errorf("error getting instances by port: %s", err)
-			continue
+			t.Fatalf("error getting instances by port: %s", err)
 		}
 		if len(instances) != 0 {
-			t.Errorf("should be exactly 0 instance: len(instances) = %v", len(instances))
+			t.Fatalf("should be exactly 0 instance: len(instances) = %v", len(instances))
 		}
 	}
 }
@@ -1224,10 +1229,10 @@ func TestCompareEndpoints(t *testing.T) {
 			got := compareEndpoints(tt.a, tt.b)
 			inverse := compareEndpoints(tt.b, tt.a)
 			if got != tt.want {
-				t.Errorf("Compare endpoints got %v, want %v", got, tt.want)
+				t.Fatalf("Compare endpoints got %v, want %v", got, tt.want)
 			}
 			if got != inverse {
-				t.Errorf("Expected to be commutative, but was not")
+				t.Fatalf("Expected to be commutative, but was not")
 			}
 		})
 	}
@@ -1259,7 +1264,7 @@ func createEndpoints(controller *Controller, name, namespace string, portNames, 
 		}},
 	}
 	if _, err := controller.client.CoreV1().Endpoints(namespace).Create(endpoint); err != nil {
-		t.Errorf("failed to create endpoints %s in namespace %s (error %v)", name, namespace, err)
+		t.Fatalf("failed to create endpoints %s in namespace %s (error %v)", name, namespace, err)
 	}
 }
 
@@ -1285,7 +1290,7 @@ func updateEndpoints(controller *Controller, name, namespace string, portNames, 
 		}},
 	}
 	if _, err := controller.client.CoreV1().Endpoints(namespace).Update(endpoint); err != nil {
-		t.Errorf("failed to update endpoints %s in namespace %s (error %v)", name, namespace, err)
+		t.Fatalf("failed to update endpoints %s in namespace %s (error %v)", name, namespace, err)
 	}
 }
 
@@ -1316,7 +1321,7 @@ func createService(controller *Controller, name, namespace string, annotations m
 
 	_, err := controller.client.CoreV1().Services(namespace).Create(service)
 	if err != nil {
-		t.Errorf("Cannot create service %s in namespace %s (error: %v)", name, namespace, err)
+		t.Fatalf("Cannot create service %s in namespace %s (error: %v)", name, namespace, err)
 	}
 }
 
@@ -1347,7 +1352,7 @@ func createServiceWithoutClusterIP(controller *Controller, name, namespace strin
 
 	_, err := controller.client.CoreV1().Services(namespace).Create(service)
 	if err != nil {
-		t.Errorf("Cannot create service %s in namespace %s (error: %v)", name, namespace, err)
+		t.Fatalf("Cannot create service %s in namespace %s (error: %v)", name, namespace, err)
 	}
 }
 
@@ -1402,7 +1407,7 @@ func addPods(t *testing.T, controller *Controller, pods ...*coreV1.Pod) {
 	for _, pod := range pods {
 		newPod, err := controller.client.CoreV1().Pods(pod.Namespace).Create(pod)
 		if err != nil {
-			t.Errorf("Cannot create %s in namespace %s (error: %v)", pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, err)
+			t.Fatalf("Cannot create %s in namespace %s (error: %v)", pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, err)
 		}
 		// Apiserver doesn't allow Create/Update to modify the pod status. Creating doesn't result in
 		// events - since PodIP will be "".
@@ -1493,13 +1498,13 @@ func addNodes(t *testing.T, controller *Controller, nodes ...*coreV1.Node) {
 	for _, node := range nodes {
 		if _, err := controller.client.CoreV1().Nodes().Create(node); err != nil {
 			// if err := controller.nodes.informer.GetStore().Add(node); err != nil {
-			t.Errorf("Cannot create node %s (error: %v)", node.Name, err)
+			t.Fatalf("Cannot create node %s (error: %v)", node.Name, err)
 		}
 	}
 }
 
 func TestEndpointUpdate(t *testing.T) {
-	controller, fx := newFakeController(t)
+	controller, fx := newFakeController()
 	defer controller.Stop()
 
 	pod1 := generatePod("128.0.0.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
@@ -1507,7 +1512,7 @@ func TestEndpointUpdate(t *testing.T) {
 	addPods(t, controller, pods...)
 	for _, pod := range pods {
 		if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-			t.Errorf("wait for pod err: %v", err)
+			t.Fatalf("wait for pod err: %v", err)
 		}
 		// pod first time occur will trigger xds push
 		fx.Wait("xds")
@@ -1527,16 +1532,16 @@ func TestEndpointUpdate(t *testing.T) {
 	// Create 1 endpoint that refers to a pod in the same namespace.
 	createEndpoints(controller, "svc1", "nsa", portNames, svc1Ips, t)
 	if ev := fx.Wait("eds"); ev == nil {
-		t.Errorf("Timeout incremental eds")
+		t.Fatalf("Timeout incremental eds")
 	}
 
 	// delete normal service
 	err := controller.client.CoreV1().Services("nsa").Delete("svc1", &metaV1.DeleteOptions{})
 	if err != nil {
-		t.Errorf("Cannot delete service (error: %v)", err)
+		t.Fatalf("Cannot delete service (error: %v)", err)
 	}
 	if ev := fx.Wait("service"); ev == nil {
-		t.Errorf("Timeout deleting service")
+		t.Fatalf("Timeout deleting service")
 	}
 
 	// 2. full xds push request for headless service endpoint update
@@ -1545,21 +1550,21 @@ func TestEndpointUpdate(t *testing.T) {
 	createServiceWithoutClusterIP(controller, "svc1", "nsa", nil,
 		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
 	if ev := fx.Wait("service"); ev == nil {
-		t.Errorf("Timeout creating service")
+		t.Fatalf("Timeout creating service")
 	}
 
 	// Create 1 endpoint that refers to a pod in the same namespace.
 	svc1Ips = append(svc1Ips, "128.0.0.2")
 	updateEndpoints(controller, "svc1", "nsa", portNames, svc1Ips, t)
 	if ev := fx.Wait("xds"); ev == nil {
-		t.Errorf("Timeout xds push")
+		t.Fatalf("Timeout xds push")
 	}
 }
 
 // Validates that when Pilot sees Endpoint before the corresponding Pod, it loads Pod from K8S and proceed.
 func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 	// Setup kube caches
-	controller, fx := newFakeController(t)
+	controller, fx := newFakeController()
 	defer controller.Stop()
 	pod1 := generatePod("172.0.1.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
 	pod2 := generatePod("172.0.1.2", "pod2", "nsA", "", "node2", map[string]string{"app": "prod-app"}, map[string]string{})
@@ -1573,7 +1578,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 	addPods(t, controller, pods...)
 	for _, pod := range pods {
 		if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-			t.Errorf("wait for pod err: %v", err)
+			t.Fatalf("wait for pod err: %v", err)
 		}
 		// pod first time occur will trigger xds push
 		fx.Wait("xds")
@@ -1584,18 +1589,18 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 	portNames := []string{"tcp-port"}
 	createEndpoints(controller, "pod1", "nsA", portNames, pod1Ips, t)
 	if ev := fx.Wait("eds"); ev == nil {
-		t.Errorf("Timeout incremental eds")
+		t.Fatalf("Timeout incremental eds")
 	}
 
 	// Now delete pod2, from PodCache and send Endpoints. This simulates the case that endpoint comes
 	// when PodCache does not yet have entry for the pod.
-	controller.pods.event(nil, pod2, model.EventDelete)
+	_ = controller.pods.event(nil, pod2, model.EventDelete)
 
 	pod2Ips := []string{"172.0.1.2"}
 	createEndpoints(controller, "pod2", "nsA", portNames, pod2Ips, t)
 
 	// Validate that EDS is triggered with endpoints.
 	if ev := fx.Wait("eds"); ev == nil {
-		t.Errorf("Timeout incremental eds")
+		t.Fatalf("Timeout incremental eds")
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -109,7 +109,7 @@ func TestPodCache(t *testing.T) {
 	})
 	t.Run("fakeApiserver", func(t *testing.T) {
 		t.Parallel()
-		c, fx := newFakeController(t)
+		c, fx := newFakeController()
 		defer c.Stop()
 		testPodCache(t, c, fx)
 	})
@@ -142,7 +142,7 @@ func testPodCache(t *testing.T, c *Controller, fx *FakeXdsUpdater) {
 		pod := pod
 		addPods(t, c, pod)
 		// Wait for the workload event
-		waitForPod(c, pod.Status.PodIP)
+		_ = waitForPod(c, pod.Status.PodIP)
 	}
 
 	// Verify podCache
@@ -173,7 +173,7 @@ func testPodCache(t *testing.T, c *Controller, fx *FakeXdsUpdater) {
 func TestPodCacheEvents(t *testing.T) {
 	t.Parallel()
 	handler := &kube.ChainHandler{}
-	c, fx := newFakeController(t)
+	c, fx := newFakeController()
 	podCache := newPodCache(cacheHandler{handler: handler}, c)
 
 	f := podCache.event

--- a/pkg/config/mesh/networks_watcher.go
+++ b/pkg/config/mesh/networks_watcher.go
@@ -1,0 +1,115 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/davecgh/go-spew/spew"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/filewatcher"
+	"istio.io/pkg/log"
+)
+
+// NetworksHolder is a holder of a mesh networks configuration.
+type NetworksHolder interface {
+	Networks() *meshconfig.MeshNetworks
+}
+
+// NetworkWatcher watches changes to the mesh networks config.
+type NetworksWatcher interface {
+	NetworksHolder
+
+	AddNetworksHandler(func())
+}
+
+var _ NetworksWatcher = &networksWatcher{}
+
+type networksWatcher struct {
+	mutex    sync.Mutex
+	handlers []func()
+	networks *meshconfig.MeshNetworks
+}
+
+// NewFixedNetworksWatcher creates a new NetworksWatcher that always returns the given config.
+// It will never fire any events, since the config never changes.
+func NewFixedNetworksWatcher(networks *meshconfig.MeshNetworks) NetworksWatcher {
+	return &networksWatcher{
+		networks: networks,
+	}
+}
+
+// NewNetworksWatcher creates a new watcher for changes to the given networks config file.
+func NewNetworksWatcher(fileWatcher filewatcher.FileWatcher, filename string) (NetworksWatcher, error) {
+	meshNetworks, err := ReadMeshNetworks(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read mesh networks configuration from %q: %v", filename, err)
+	}
+
+	log.Infof("mesh networks configuration %s", spew.Sdump(meshNetworks))
+	ResolveHostsInNetworksConfig(meshNetworks)
+	log.Infof("mesh networks configuration post-resolution %s", spew.Sdump(meshNetworks))
+
+	w := &networksWatcher{
+		networks: meshNetworks,
+	}
+
+	// Watch the networks config file for changes and reload if it got modified
+	addFileWatcher(fileWatcher, filename, func() {
+		// Reload the config file
+		meshNetworks, err := ReadMeshNetworks(filename)
+		if err != nil {
+			log.Warnf("failed to read mesh networks configuration from %q", filename)
+			return
+		}
+
+		var handlers []func()
+
+		w.mutex.Lock()
+		if !reflect.DeepEqual(meshNetworks, w.networks) {
+			log.Infof("mesh networks configuration file updated to: %s", spew.Sdump(meshNetworks))
+			ResolveHostsInNetworksConfig(meshNetworks)
+			log.Infof("mesh networks configuration post-resolution %s", spew.Sdump(meshNetworks))
+
+			// Store the new config.
+			atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&w.networks)), unsafe.Pointer(meshNetworks))
+			handlers = append([]func(){}, w.handlers...)
+		}
+		w.mutex.Unlock()
+
+		// Notify the handlers of the change.
+		for _, h := range handlers {
+			h()
+		}
+	})
+	return w, nil
+}
+
+// Config returns the latest network configuration for the mesh.
+func (w *networksWatcher) Networks() *meshconfig.MeshNetworks {
+	return (*meshconfig.MeshNetworks)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&w.networks))))
+}
+
+// AddMeshHandler registers a callback handler for changes to the mesh network config.
+func (w *networksWatcher) AddNetworksHandler(h func()) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	w.handlers = append(w.handlers, h)
+}

--- a/pkg/config/mesh/networks_watcher_test.go
+++ b/pkg/config/mesh/networks_watcher_test.go
@@ -1,0 +1,78 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/filewatcher"
+
+	"istio.io/istio/pkg/config/mesh"
+)
+
+func TestNewNetworksWatcherWithBadInputShouldFail(t *testing.T) {
+	g := NewGomegaWithT(t)
+	_, err := mesh.NewNetworksWatcher(filewatcher.NewWatcher(), "")
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestNetworksWatcherShouldNotifyHandlers(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	path := newTempFile(t)
+	defer removeSilent(path)
+
+	n := meshconfig.MeshNetworks{
+		Networks: make(map[string]*meshconfig.Network),
+	}
+	writeMessage(t, path, &n)
+
+	w := newNetworksWatcher(t, path)
+	g.Expect(w.Networks()).To(Equal(&n))
+
+	doneCh := make(chan struct{}, 1)
+
+	var newN *meshconfig.MeshNetworks
+	w.AddNetworksHandler(func() {
+		newN = w.Networks()
+		close(doneCh)
+	})
+
+	// Change the file to trigger the update.
+	n.Networks["test"] = &meshconfig.Network{}
+	writeMessage(t, path, &n)
+
+	select {
+	case <-doneCh:
+		g.Expect(newN).To(Equal(&n))
+		g.Expect(w.Networks()).To(Equal(newN))
+		break
+	case <-time.After(time.Second * 5):
+		t.Fatal("timed out waiting for update")
+	}
+}
+
+func newNetworksWatcher(t *testing.T, filename string) mesh.NetworksWatcher {
+	t.Helper()
+	w, err := mesh.NewNetworksWatcher(filewatcher.NewWatcher(), filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w
+}

--- a/pkg/config/mesh/watcher.go
+++ b/pkg/config/mesh/watcher.go
@@ -1,0 +1,114 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/davecgh/go-spew/spew"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/filewatcher"
+	"istio.io/pkg/log"
+)
+
+// Holder of a mesh configuration.
+type Holder interface {
+	Mesh() *meshconfig.MeshConfig
+}
+
+// Watcher is a Holder whose mesh config can be updated asynchronously.
+type Watcher interface {
+	Holder
+
+	// AddMeshHandler registers a callback handler for changes to the mesh config.
+	AddMeshHandler(func())
+}
+
+var _ Watcher = &watcher{}
+
+type watcher struct {
+	mutex    sync.Mutex
+	handlers []func()
+	mesh     *meshconfig.MeshConfig
+}
+
+// NewFixedWatcher creates a new Watcher that always returns the given mesh config. It will never
+// fire any events, since the config never changes.
+func NewFixedWatcher(mesh *meshconfig.MeshConfig) Watcher {
+	return &watcher{
+		mesh: mesh,
+	}
+}
+
+// NewWatcher creates a new Watcher for changes to the given mesh config file. Returns an error
+// if the given file does not exist or failed during parsing.
+func NewWatcher(fileWatcher filewatcher.FileWatcher, filename string) (Watcher, error) {
+	meshConfig, err := ReadMeshConfig(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &watcher{
+		mesh: meshConfig,
+	}
+
+	// Watch the config file for changes and reload if it got modified
+	addFileWatcher(fileWatcher, filename, func() {
+		// Reload the config file
+		meshConfig, err = ReadMeshConfig(filename)
+		if err != nil {
+			log.Warnf("failed to read mesh configuration, using default: %v", err)
+			return
+		}
+
+		var handlers []func()
+
+		w.mutex.Lock()
+		if !reflect.DeepEqual(meshConfig, w.mesh) {
+			log.Infof("mesh configuration updated to: %s", spew.Sdump(meshConfig))
+			if !reflect.DeepEqual(meshConfig.ConfigSources, w.mesh.ConfigSources) {
+				log.Infof("mesh configuration sources have changed")
+				//TODO Need to re-create or reload initConfigController()
+			}
+
+			// Store the new mesh.
+			atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&w.mesh)), unsafe.Pointer(meshConfig))
+			handlers = append([]func(){}, w.handlers...)
+		}
+		w.mutex.Unlock()
+
+		// Notify the handlers of the change.
+		for _, h := range handlers {
+			h()
+		}
+	})
+	return w, nil
+}
+
+// Config returns the latest mesh config.
+func (w *watcher) Mesh() *meshconfig.MeshConfig {
+	return (*meshconfig.MeshConfig)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&w.mesh))))
+}
+
+// AddMeshHandler registers a callback handler for changes to the mesh config.
+func (w *watcher) AddMeshHandler(h func()) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	w.handlers = append(w.handlers, h)
+}

--- a/pkg/config/mesh/watcher_test.go
+++ b/pkg/config/mesh/watcher_test.go
@@ -1,0 +1,143 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh_test
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	. "github.com/onsi/gomega"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/filewatcher"
+
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/util/protomarshal"
+)
+
+func TestNewWatcherWithBadInputShouldFail(t *testing.T) {
+	g := NewGomegaWithT(t)
+	_, err := mesh.NewWatcher(filewatcher.NewWatcher(), "")
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestWatcherShouldNotifyHandlers(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	path := newTempFile(t)
+	defer removeSilent(path)
+
+	m := mesh.DefaultMeshConfig()
+	writeMessage(t, path, &m)
+
+	w := newWatcher(t, path)
+	g.Expect(w.Mesh()).To(Equal(&m))
+
+	doneCh := make(chan struct{}, 1)
+
+	var newM *meshconfig.MeshConfig
+	w.AddMeshHandler(func() {
+		newM = w.Mesh()
+		close(doneCh)
+	})
+
+	// Change the file to trigger the update.
+	m.IngressClass = "istio"
+	writeMessage(t, path, &m)
+
+	select {
+	case <-doneCh:
+		g.Expect(newM).To(Equal(&m))
+		g.Expect(w.Mesh()).To(Equal(newM))
+		break
+	case <-time.After(time.Second * 5):
+		t.Fatal("timed out waiting for update")
+	}
+}
+
+func newWatcher(t testing.TB, filename string) mesh.Watcher {
+	t.Helper()
+	w, err := mesh.NewWatcher(filewatcher.NewWatcher(), filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w
+}
+
+func newTempFile(t testing.TB) string {
+	t.Helper()
+	f, err := ioutil.TempFile("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSilent(f)
+
+	path, err := filepath.Abs(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeMessage(t testing.TB, path string, msg proto.Message) {
+	t.Helper()
+	yml, err := protomarshal.ToYAML(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, path, yml)
+}
+
+func writeFile(t testing.TB, path, content string) {
+	t.Helper()
+	if err := ioutil.WriteFile(path, []byte(content), 0666); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func closeSilent(c io.Closer) {
+	_ = c.Close()
+}
+
+func removeSilent(path string) {
+	_ = os.RemoveAll(path)
+}
+
+func BenchmarkGetMesh(b *testing.B) {
+	b.StopTimer()
+
+	path := newTempFile(b)
+	defer removeSilent(path)
+
+	m := mesh.DefaultMeshConfig()
+	writeMessage(b, path, &m)
+
+	w := newWatcher(b, path)
+
+	b.StartTimer()
+
+	handler := func(mc *meshconfig.MeshConfig) {
+		// Do nothing
+	}
+
+	for i := 0; i < b.N; i++ {
+		handler(w.Mesh())
+	}
+}

--- a/pkg/istiod/k8s/k8sstart.go
+++ b/pkg/istiod/k8s/k8sstart.go
@@ -18,9 +18,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -39,7 +36,6 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	controller2 "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
-	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/istiod"
 )
@@ -67,7 +63,7 @@ func InitK8S(is *istiod.Server, clientset kubernetes.Interface, config *rest.Con
 		args:        args,
 		ControllerOptions: controller2.Options{
 			DomainSuffix: args.DomainSuffix,
-			TrustDomain:  args.MeshConfig.TrustDomain,
+			TrustDomain:  args.MeshWatcher.Mesh().TrustDomain,
 			Metrics:      is.Environment,
 		},
 	}
@@ -91,9 +87,6 @@ func (s *Controllers) InitK8SDiscovery(is *istiod.Server, config *rest.Config, a
 		return nil, fmt.Errorf("cluster registries: %v", err)
 	}
 
-	// kubeRegistry may use the environment for push status reporting.
-	// TODO: maybe all registries should have this as an optional field ?
-	s.kubeRegistry.InitNetworkLookup(s.IstioServer.Environment.MeshNetworks)
 	// EnvoyXDSServer is not initialized yet - since initialization adds all 'service' handlers, which depends
 	// on this being done. Instead we use the callback.
 	//s.kubeRegistry.XDSUpdater = s.IstioServer.EnvoyXdsServer
@@ -123,7 +116,7 @@ func (s *Controllers) initClusterRegistries(args *istiod.PilotArgs) (err error) 
 		s.ControllerOptions.ResyncPeriod,
 		s.IstioServer.ServiceController(),
 		s.IstioServer.EnvoyXdsServer,
-		s.IstioServer.Environment.MeshNetworks)
+		s.IstioServer.Environment)
 
 	if err != nil {
 		log.Info("Unable to create new Multicluster object")
@@ -152,11 +145,11 @@ func (s *Controllers) initConfigController(args *istiod.PilotArgs) error {
 	})
 
 	// If running in ingress mode (requires k8s), wrap the config controller.
-	if s.IstioServer.Environment.Mesh.IngressControllerMode != meshconfig.MeshConfig_OFF {
-		s.IstioServer.ConfigStores = append(s.IstioServer.ConfigStores, ingress.NewController(s.kubeClient,
-			s.IstioServer.Environment.Mesh, s.ControllerOptions))
+	meshConfig := s.IstioServer.Environment.Mesh()
+	if meshConfig.IngressControllerMode != meshconfig.MeshConfig_OFF {
+		s.IstioServer.ConfigStores = append(s.IstioServer.ConfigStores, ingress.NewController(s.kubeClient, meshConfig, s.ControllerOptions))
 
-		if ingressSyncer, errSyncer := ingress.NewStatusSyncer(s.IstioServer.Environment.Mesh, s.kubeClient,
+		if ingressSyncer, errSyncer := ingress.NewStatusSyncer(meshConfig, s.kubeClient,
 			args.Namespace, s.ControllerOptions); errSyncer != nil {
 			log.Warnf("Disabled ingress status syncer due to %v", errSyncer)
 		} else {
@@ -194,42 +187,6 @@ func (s *Controllers) makeKubeConfigController(args *istiod.PilotArgs) (model.Co
 	}
 
 	return controller.NewController(configClient, s.ControllerOptions), nil
-}
-
-const (
-	// ConfigMapKey should match the expected MeshConfig file name
-	ConfigMapKey = "mesh"
-)
-
-// GetMeshConfig fetches the ProxyMesh configuration from Kubernetes ConfigMap.
-func GetMeshConfig(kube kubernetes.Interface, namespace, name string) (*v1.ConfigMap, *meshconfig.MeshConfig, error) {
-
-	if kube == nil {
-		defaultMesh := mesh.DefaultMeshConfig()
-		return nil, &defaultMesh, nil
-	}
-
-	cfg, err := kube.CoreV1().ConfigMaps(namespace).Get(name, meta_v1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			defaultMesh := mesh.DefaultMeshConfig()
-			return nil, &defaultMesh, nil
-		}
-		return nil, nil, err
-	}
-
-	// values in the data are strings, while proto might use a different data type.
-	// therefore, we have to get a value by a key
-	cfgYaml, exists := cfg.Data[ConfigMapKey]
-	if !exists {
-		return nil, nil, fmt.Errorf("missing configuration map key %q", ConfigMapKey)
-	}
-
-	meshConfig, err := mesh.ApplyMeshConfigDefaults(cfgYaml)
-	if err != nil {
-		return nil, nil, err
-	}
-	return cfg, meshConfig, nil
 }
 
 type testHandler struct {


### PR DESCRIPTION
This current file watcher code is duplicated between istiod and pilot. It also has hard-coded logic for updating each component that needs to know. This is a bit hacky and error prone, and will likely become a maintenance burden when more components need to know about updates to these resources.

This change makes the watchers for mesh config and networks a first-class citizen. Components that need to know about updates now register themselves and handle the events accordingly.