### PR TITLE
crd: add validation in list function of controller

### DIFF
--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -182,9 +182,10 @@ func (c *controller) createInformer(
 	handler := &kube.ChainHandler{}
 	handler.Append(c.notify)
 
-	// Add validation during list read here.
+	// Enhance list function with supplied validation function, so that invalid CRD does not enter store.
 	vlf := func(opts meta_v1.ListOptions) (result runtime.Object, err error) {
 		if result, err = lf(opts); err == nil {
+			// This check is primarily needed for tests which use mock config - but helps otherwise also.
 			if obj, ok := result.(crd.IstioObject); ok {
 				err = vf(obj)
 			}

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -313,11 +313,9 @@ func (c *controller) Get(typ, name, namespace string) *model.Config {
 		return nil
 	}
 
-	var config *model.Config
-	if features.EnableCRDValidation.Get() {
-		config, err = crd.StrictConvertObject(s, obj, c.client.domainSuffix)
-	} else {
-		config, err = crd.ConvertObject(s, obj, c.client.domainSuffix)
+	config, err := crd.ConvertObject(s, obj, c.client.domainSuffix)
+	if err == nil && features.EnableCRDValidation.Get() {
+		err = s.Validate(config.Name, config.Namespace, config.Spec)
 	}
 
 	if err != nil {
@@ -365,12 +363,10 @@ func (c *controller) List(typ, namespace string) ([]model.Config, error) {
 			continue
 		}
 
-		var config *model.Config
-		var err error
-		if features.EnableCRDValidation.Get() {
-			config, err = crd.StrictConvertObject(s, item, c.client.domainSuffix)
-		} else {
-			config, err = crd.ConvertObject(s, item, c.client.domainSuffix)
+		config, err := crd.ConvertObject(s, item, c.client.domainSuffix)
+
+		if err == nil && features.EnableCRDValidation.Get() {
+			err = s.Validate(config.Name, config.Namespace, config.Spec)
 		}
 
 		if err != nil {

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -190,7 +190,7 @@ func (c *controller) createInformer(
 			if obj, ok := result.(crd.IstioObject); ok {
 				if err = vf(obj); err != nil {
 					key := obj.GetObjectMeta().Namespace + "/" + obj.GetObjectMeta().Name
-					log.Errorf("Failed to validate object: %s %s %v", obj.GetObjectKind().GroupVersionKind().GroupKind().Kind,
+					log.Errorf("CRD validation failed: %s %s %v", obj.GetObjectKind().GroupVersionKind().GroupKind().Kind,
 						key, err)
 					k8sErrors.With(nameTag.Value(key)).Record(1)
 					return nil, err

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -185,7 +185,9 @@ func (c *controller) createInformer(
 	// Add validation during list read here.
 	vlf := func(opts meta_v1.ListOptions) (result runtime.Object, err error) {
 		if result, err = lf(opts); err == nil {
-			err = vf(result)
+			if obj, ok := result.(crd.IstioObject); ok {
+				err = vf(obj)
+			}
 		}
 		if err != nil {
 			log.Errorf("failed to add CRD while listing. Value: %v, error: %v", result, err)
@@ -364,7 +366,7 @@ func (c *controller) List(typ, namespace string) ([]model.Config, error) {
 		config, err := crd.ConvertObject(s, item, c.client.domainSuffix)
 		if err != nil {
 			key := item.GetObjectMeta().Namespace + "/" + item.GetObjectMeta().Name
-			log.Errorf("Failed to convert/validate %s object, ignoring: %s %v %v", typ, key, err, item.GetSpec())
+			log.Errorf("Failed to convert %s object, ignoring: %s %v %v", typ, key, err, item.GetSpec())
 			// DO NOT RETURN ERROR: if a single object is bad, it'll be ignored (with a log message), but
 			// the rest should still be processed.
 			// TODO: find a way to reset and represent the error !!

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -348,10 +348,10 @@ func (c *controller) List(typ, namespace string) ([]model.Config, error) {
 			continue
 		}
 
-		config, err := crd.ConvertObject(s, item, c.client.domainSuffix)
+		config, err := crd.StrictConvertObject(s, item, c.client.domainSuffix)
 		if err != nil {
 			key := item.GetObjectMeta().Namespace + "/" + item.GetObjectMeta().Name
-			log.Errorf("Failed to convert %s object, ignoring: %s %v %v", typ, key, err, item.GetSpec())
+			log.Errorf("Failed to convert/validate %s object, ignoring: %s %v %v", typ, key, err, item.GetSpec())
 			// DO NOT RETURN ERROR: if a single object is bad, it'll be ignored (with a log message), but
 			// the rest should still be processed.
 			// TODO: find a way to reset and represent the error !!

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -36,22 +36,13 @@ import (
 
 // ConvertObject converts an IstioObject k8s-style object to the internal configuration model.
 func ConvertObject(schema schema.Instance, object IstioObject, domain string) (*model.Config, error) {
-	return convertObjectInternal(schema, object, domain, false)
-}
-
-// StrictConvertObject converts an IstioObject k8s-style object to the internal configuration model and enforces validation.
-func StrictConvertObject(schema schema.Instance, object IstioObject, domain string) (*model.Config, error) {
-	return convertObjectInternal(schema, object, domain, true)
-}
-
-func convertObjectInternal(schema schema.Instance, object IstioObject, domain string, validate bool) (*model.Config, error) {
 	data, err := schema.FromJSONMap(object.GetSpec())
 	if err != nil {
 		return nil, err
 	}
 	meta := object.GetObjectMeta()
 
-	config := &model.Config{
+	return &model.Config{
 		ConfigMeta: model.ConfigMeta{
 			Type:              schema.Type,
 			Group:             ResourceGroup(&schema),
@@ -65,12 +56,7 @@ func convertObjectInternal(schema schema.Instance, object IstioObject, domain st
 			CreationTimestamp: meta.CreationTimestamp.Time,
 		},
 		Spec: data,
-	}
-
-	if validate {
-		err = schema.Validate(config.Name, config.Namespace, config.Spec)
-	}
-	return config, err
+	}, nil
 }
 
 // ConvertObjectFromUnstructured converts an IstioObject k8s-style object to the

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -36,13 +36,22 @@ import (
 
 // ConvertObject converts an IstioObject k8s-style object to the internal configuration model.
 func ConvertObject(schema schema.Instance, object IstioObject, domain string) (*model.Config, error) {
+	return convertObjectInternal(schema, object, domain, false)
+}
+
+// StrictConvertObject converts an IstioObject k8s-style object to the internal configuration model and enforces validation.
+func StrictConvertObject(schema schema.Instance, object IstioObject, domain string) (*model.Config, error) {
+	return convertObjectInternal(schema, object, domain, true)
+}
+
+func convertObjectInternal(schema schema.Instance, object IstioObject, domain string, validate bool) (*model.Config, error) {
 	data, err := schema.FromJSONMap(object.GetSpec())
 	if err != nil {
 		return nil, err
 	}
 	meta := object.GetObjectMeta()
 
-	return &model.Config{
+	config := &model.Config{
 		ConfigMeta: model.ConfigMeta{
 			Type:              schema.Type,
 			Group:             ResourceGroup(&schema),
@@ -56,7 +65,12 @@ func ConvertObject(schema schema.Instance, object IstioObject, domain string) (*
 			CreationTimestamp: meta.CreationTimestamp.Time,
 		},
 		Spec: data,
-	}, nil
+	}
+
+	if validate {
+		err = schema.Validate(config.Name, config.Namespace, config.Spec)
+	}
+	return config, err
 }
 
 // ConvertObjectFromUnstructured converts an IstioObject k8s-style object to the

--- a/pilot/pkg/config/kube/crd/conversion_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_test.go
@@ -79,41 +79,6 @@ func TestConvert(t *testing.T) {
 	}
 }
 
-func TestStrictConvertObject(t *testing.T) {
-	// Validate that StringConvertObject rejects invalid spec.
-	if _, err := StrictConvertObject(schemas.VirtualService, &IstioKind{Spec: map[string]interface{}{"x": 1}}, "local"); err == nil {
-		t.Error("Expected to fail the validation but was success")
-	}
-
-	// Validate that StrictConvertObject accepts valid spec.
-	config := model.Config{
-		ConfigMeta: model.ConfigMeta{
-			Type:            schemas.VirtualService.Type,
-			Group:           "networking.istio.io",
-			Version:         "v1alpha3",
-			Name:            "test",
-			Namespace:       "default",
-			Domain:          "cluster",
-			ResourceVersion: "1234",
-			Labels:          map[string]string{"label": "value"},
-			Annotations:     map[string]string{"annotation": "value"},
-		},
-		Spec: mock.ExampleVirtualService,
-	}
-
-	obj, err := ConvertConfig(schemas.VirtualService, config)
-	if err != nil {
-		t.Errorf("ConvertConfig() => unexpected error %v", err)
-	}
-	got, err := StrictConvertObject(schemas.VirtualService, obj, "cluster")
-	if err != nil {
-		t.Errorf("StrictConvertObject() => unexpected error %v", err)
-	}
-	if !reflect.DeepEqual(&config, got) {
-		t.Errorf("StrictConvertObject(ConvertConfig(%#v)) => got %#v", config, got)
-	}
-}
-
 func TestParseInputs(t *testing.T) {
 	if varr, _, err := ParseInputs(""); len(varr) > 0 || err != nil {
 		t.Errorf(`ParseInput("") => got %v, %v, want nil, nil`, varr, err)

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -253,6 +253,14 @@ var (
 			"but the older, deprecated regex field. This should only be enabled to support "+
 			"legacy deployments that have not yet been migrated to the new safe regular expressions.",
 	)
+
+	EnableCRDValidation = env.RegisterBoolVar(
+		"PILOT_ENABLE_CRD_VALIDATION",
+		false,
+		"If enabled, pilot will validate CRDs while retrieving resources from cache."+
+			"By default pilot will validate them during event processing."+
+			"Enable this flag, if galley is not used so that Pilot does not process invalid CRDs.",
+	)
 )
 
 var (

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -257,9 +257,9 @@ var (
 	EnableCRDValidation = env.RegisterBoolVar(
 		"PILOT_ENABLE_CRD_VALIDATION",
 		false,
-		"If enabled, pilot will validate CRDs while retrieving resources from cache."+
-			"By default pilot will validate them during event processing."+
-			"Enable this flag, if galley is not used so that Pilot does not process invalid CRDs.",
+		"If enabled, pilot will validate CRDs while retrieving CRDs from kubernetes cache."+
+			"Use this flag to enable validation of CRDs in Pilot, especially in deployments "+
+			"that do not have galley installed.",
 	)
 )
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2393,6 +2393,20 @@ func TestValidateVirtualService(t *testing.T) {
 				}},
 			}},
 		}, valid: false},
+		{name: "with no destination", in: &networking.VirtualService{
+			Hosts: []string{"*.foo.bar", "*.bar"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{}},
+			}},
+		}, valid: false},
+		{name: "destination with out hosts", in: &networking.VirtualService{
+			Hosts: []string{"*.foo.bar", "*.bar"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{},
+				}},
+			}},
+		}, valid: false},
 		{name: "no hosts", in: &networking.VirtualService{
 			Hosts: nil,
 			Http: []*networking.HTTPRoute{{


### PR DESCRIPTION
Pilot specially (PushContext) uses `List` to get the list of Istio objects. However, `List` does not validate the object - if Object is invalid, Pilot panics during processing. This PR adds validation to `List`.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
