### PR TITLE
Return error when galley probe command is failed

### DIFF
--- a/galley/cmd/galley/cmd/probe.go
+++ b/galley/cmd/galley/cmd/probe.go
@@ -30,15 +30,15 @@ func probeCmd() *cobra.Command {
 	prb := &cobra.Command{
 		Use:   "probe",
 		Short: "Check the liveness or readiness of a locally-running server",
-		Run: func(cmd *cobra.Command, _ []string) {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !probeOptions.IsValid() {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "some options are not valid")
-				return
+				return fmt.Errorf("some options are not valid")
 			}
 			if err := probe.NewFileClient(&probeOptions).GetStatus(); err != nil {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "fail on inspecting path %s: %v", probeOptions.Path, err)
+				return fmt.Errorf("fail on inspecting path %s: %v", probeOptions.Path, err)
 			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK")
+			fmt.Println("OK")
+			return nil
 		},
 	}
 	prb.PersistentFlags().StringVar(&probeOptions.Path, "probe-path", "",

--- a/galley/cmd/galley/cmd/probe.go
+++ b/galley/cmd/galley/cmd/probe.go
@@ -37,7 +37,7 @@ func probeCmd() *cobra.Command {
 			if err := probe.NewFileClient(&probeOptions).GetStatus(); err != nil {
 				return fmt.Errorf("fail on inspecting path %s: %v", probeOptions.Path, err)
 			}
-			fmt.Println("OK")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK")
 			return nil
 		},
 	}

--- a/galley/cmd/galley/cmd/probe.go
+++ b/galley/cmd/galley/cmd/probe.go
@@ -37,7 +37,7 @@ func probeCmd() *cobra.Command {
 			if err := probe.NewFileClient(&probeOptions).GetStatus(); err != nil {
 				return fmt.Errorf("fail on inspecting path %s: %v", probeOptions.Path, err)
 			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK")
+			fmt.Fprintf(cmd.OutOrStdout(), "OK")
 			return nil
 		},
 	}

--- a/galley/pkg/crd/validation/validation.go
+++ b/galley/pkg/crd/validation/validation.go
@@ -132,26 +132,21 @@ func RunValidation(ready chan<- struct{}, stopCh chan struct{}, vc *WebhookParam
 						ready = true
 					}
 				}
-				select {
-				case <-time.After(httpsHandlerReadinessFreq):
-					// check again
-				}
+				<-time.After(httpsHandlerReadinessFreq)
+				// check again
 			}
 		}()
 	}
 
 	go func() {
-		for {
-			select {
-			case <-stopCh:
-				if livenessProbeController != nil {
-					validationLivenessProbe.SetAvailable(errors.New("stopped"))
-				}
-				if readinessProbeController != nil {
-					validationReadinessProbe.SetAvailable(errors.New("stopped"))
-				}
-				return
+		for range stopCh {
+			if livenessProbeController != nil {
+				validationLivenessProbe.SetAvailable(errors.New("stopped"))
 			}
+			if readinessProbeController != nil {
+				validationReadinessProbe.SetAvailable(errors.New("stopped"))
+			}
+			return
 		}
 	}()
 	go wh.Run(ready, stopCh)

--- a/galley/pkg/crd/validation/validation.go
+++ b/galley/pkg/crd/validation/validation.go
@@ -146,7 +146,7 @@ func RunValidation(ready chan<- struct{}, stopCh chan struct{}, vc *WebhookParam
 			if readinessProbeController != nil {
 				validationReadinessProbe.SetAvailable(errors.New("stopped"))
 			}
-			return
+			break
 		}
 	}()
 	go wh.Run(ready, stopCh)


### PR DESCRIPTION
When `galley probe` command failed, it does not return error and does
produce error code `0`. Please see following simple command test:

```
$ ./galley probe --interval=10s --probe-path="foo"
fail on inspecting path foo: stat foo: no such file or directoryOK
$ echo $?
0
```

Due to this, galley's liveness/readiness probe on k8s does not work.

To fix it, this patch returns error when `galley probe` failed.

Fixes https://github.com/istio/istio/issues/19173