### PR TITLE
Correct if statement for macOS

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -180,7 +180,7 @@ mkdir -p "${ISTIO_BIN}"
 # Set the value of DOWNLOAD_COMMAND (either curl or wget)
 set_download_command
 
-if [[ -v DEBUG_IMAGE ]]; then
+if [[ ! -z "${DEBUG_IMAGE:-}" ]]; then
   # Download and extract the Envoy linux debug binary.
   download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_DEBUG_URL}" "$ISTIO_ENVOY_LINUX_DEBUG_PATH"
 else

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -180,7 +180,7 @@ mkdir -p "${ISTIO_BIN}"
 # Set the value of DOWNLOAD_COMMAND (either curl or wget)
 set_download_command
 
-if [[ ! -z "${DEBUG_IMAGE:-}" ]]; then
+if [[ -n "${DEBUG_IMAGE:-}" ]]; then
   # Download and extract the Envoy linux debug binary.
   download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_DEBUG_URL}" "$ISTIO_ENVOY_LINUX_DEBUG_PATH"
 else


### PR DESCRIPTION
Before this patch I always get the following error message on macOS:

```bash
make build
Building with your local toolchain.
ISTIO_OUT=/Users/jscheuermann/go/out/darwin_amd64/release bin/init.sh
bin/init.sh: line 183: conditional binary operator expected
make: *** [/Users/jscheuermann/go/out/darwin_amd64/release/istio_is_init] Error 2
```

with this patch everything works as expected `make build` will build all istio artifacts.