### PR TITLE
Remove unused badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/istio/istio)](https://goreportcard.com/report/github.com/istio/istio)
 [![GoDoc](https://godoc.org/istio.io/istio?status.svg)](https://godoc.org/istio.io/istio)
-[![codecov.io](https://codecov.io/github/istio/istio/coverage.svg?branch=master)](https://codecov.io/github/istio/istio?branch=master)
-[![GolangCI](https://golangci.com/badges/github.com/istio/istio.svg)](https://golangci.com/r/github.com/istio/istio)
 
 # Istio
 


### PR DESCRIPTION
We don't use either of these tools anymore. The golangci one in particular goes does every week or so causing lint issues