### PR TITLE
Fix pilot e2e istio-egressgateway test case

### DIFF
--- a/tests/e2e/tests/pilot/testdata/rbac/v1alpha1/istio-egressgateway.yaml
+++ b/tests/e2e/tests/pilot/testdata/rbac/v1alpha1/istio-egressgateway.yaml
@@ -21,6 +21,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istio-egressgateway
+  namespace: istio-system
 spec:
   selector:
     istio: egressgateway


### PR DESCRIPTION
Fix a minor test case bug. The test case defines istio-egressgateway, but doesn't specify a namespace. The test is probably succeeding because the Istio setup used by this test happens to include an egress gateway already, separate from the one defined in this file. 

Discovered via https://github.com/istio/istio/issues/17442. 