### PR TITLE
feat(bootstrap): add support for AWS platform to bootstrap

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -100,7 +100,13 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 		cfg.PilotSubjectAltName = defaultPilotSAN()
 	}
 	if cfg.PlatEnv == nil {
-		cfg.PlatEnv = platform.NewGCP()
+		if platform.IsGCP() {
+			cfg.PlatEnv = platform.NewGCP()
+		} else if platform.IsAWS() {
+			cfg.PlatEnv = platform.NewAWS()
+		} else {
+			cfg.PlatEnv = &platform.Unknown{}
+		}
 	}
 
 	// Remove duplicates from the node IPs.

--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -1,0 +1,87 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+)
+
+const (
+	AWSRegion           = "aws_region"
+	AWSAvailabilityZone = "aws_availability_zone"
+	AWSInstanceID       = "aws_instance_id"
+	AWSAccountID        = "aws_account_id"
+)
+
+// IsAWS returns whether or not the platform for bootstrapping is Amazon Web Services.
+func IsAWS() bool {
+	if client := getEC2MetadataClient(); client != nil {
+		return client.Available()
+	}
+	return false
+}
+
+type awsEnv struct {
+	identity ec2metadata.EC2InstanceIdentityDocument
+}
+
+// NewAWS returns a platform environment customized for AWS.
+// Metadata returned by the AWS Environment is taken from the EC2 metadata
+// service.
+func NewAWS() Environment {
+	client := getEC2MetadataClient()
+	if client == nil {
+		return &awsEnv{}
+	}
+
+	doc, _ := client.GetInstanceIdentityDocument()
+	return &awsEnv{
+		identity: doc,
+	}
+}
+
+func (a *awsEnv) Metadata() map[string]string {
+	md := map[string]string{}
+	if len(a.identity.AccountID) > 0 {
+		md[AWSAccountID] = a.identity.AccountID
+	}
+	if len(a.identity.AvailabilityZone) > 0 {
+		md[AWSAvailabilityZone] = a.identity.AvailabilityZone
+	}
+	if len(a.identity.InstanceID) > 0 {
+		md[AWSInstanceID] = a.identity.InstanceID
+	}
+	if len(a.identity.Region) > 0 {
+		md[AWSRegion] = a.identity.Region
+	}
+	return md
+}
+
+func (a *awsEnv) Locality() *core.Locality {
+	return &core.Locality{
+		Zone:   a.identity.AvailabilityZone,
+		Region: a.identity.Region,
+	}
+}
+
+func getEC2MetadataClient() *ec2metadata.EC2Metadata {
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil
+	}
+	return ec2metadata.New(sess)
+}

--- a/pkg/bootstrap/platform/aws_test.go
+++ b/pkg/bootstrap/platform/aws_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+)
+
+var (
+	localityIdentity = ec2metadata.EC2InstanceIdentityDocument{Region: "region", AvailabilityZone: "zone"}
+	fullIdentity     = ec2metadata.EC2InstanceIdentityDocument{Region: "region", AvailabilityZone: "zone", AccountID: "account", InstanceID: "instance"}
+)
+
+func TestAWSMetadata(t *testing.T) {
+	cases := []struct {
+		name string
+		env  *awsEnv
+		want map[string]string
+	}{
+		{"empty", &awsEnv{}, map[string]string{}},
+		{"locality", &awsEnv{identity: localityIdentity}, map[string]string{AWSAvailabilityZone: "zone", AWSRegion: "region"}},
+		{"full", &awsEnv{identity: fullIdentity},
+			map[string]string{AWSAvailabilityZone: "zone", AWSRegion: "region", AWSAccountID: "account", AWSInstanceID: "instance"}},
+	}
+
+	for _, v := range cases {
+		t.Run(v.name, func(tt *testing.T) {
+			got := v.env.Metadata()
+			if !reflect.DeepEqual(got, v.want) {
+				t.Errorf("awsEnv.Metadata() => '%#v', wanted '%#v'", got, v.want)
+			}
+		})
+	}
+}
+
+func TestAWSLocality(t *testing.T) {
+	cases := []struct {
+		name string
+		env  *awsEnv
+		want *core.Locality
+	}{
+		{"empty", &awsEnv{}, &core.Locality{}},
+		{"locality", &awsEnv{identity: localityIdentity}, &core.Locality{Region: "region", Zone: "zone"}},
+	}
+
+	for _, v := range cases {
+		t.Run(v.name, func(tt *testing.T) {
+			got := v.env.Locality()
+			if !reflect.DeepEqual(got, v.want) {
+				t.Errorf("awsEnv.Locality() => '%#v', wanted '%#v'", got, v.want)
+			}
+		})
+	}
+}

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -59,6 +59,11 @@ type gcpEnv struct {
 	instanceIDFn       metadataFn
 }
 
+// IsGCP returns whether or not the platform for bootstrapping is Google Cloud Platform.
+func IsGCP() bool {
+	return metadata.OnGCE()
+}
+
 // NewGCP returns a platform environment customized for Google Cloud Platform.
 // Metadata returned by the GCP Environment is taken from the GCE metadata
 // service.

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestMetadata(t *testing.T) {
+func TestGCPMetadata(t *testing.T) {
 	tests := []struct {
 		name          string
 		shouldFill    shouldFillFn
@@ -93,7 +93,7 @@ func TestMetadata(t *testing.T) {
 			mg := gcpEnv{tt.shouldFill, tt.projectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceIDFn}
 			got := mg.Metadata()
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Unexpected generated metadata: want %v got %v", tt.want, got)
+				t.Errorf("gcpEnv.Metadata() => '%v'; want '%v'", got, tt.want)
 			}
 		})
 	}

--- a/pkg/bootstrap/platform/platform.go
+++ b/pkg/bootstrap/platform/platform.go
@@ -31,3 +31,17 @@ type Environment interface {
 	// platform-specific representation into the Envoy Locality schema.
 	Locality() *core.Locality
 }
+
+// Unknown provides a default platform environment for cases in wich the platform
+// on which the bootstrapping is taking place cannot be determined.
+type Unknown struct{}
+
+// Metadata returns an empty map.
+func (*Unknown) Metadata() map[string]string {
+	return map[string]string{}
+}
+
+// Locality returns an empty core.Locality struct.
+func (*Unknown) Locality() *core.Locality {
+	return &core.Locality{}
+}

--- a/pkg/bootstrap/platform/platform.go
+++ b/pkg/bootstrap/platform/platform.go
@@ -32,7 +32,7 @@ type Environment interface {
 	Locality() *core.Locality
 }
 
-// Unknown provides a default platform environment for cases in wich the platform
+// Unknown provides a default platform environment for cases in which the platform
 // on which the bootstrapping is taking place cannot be determined.
 type Unknown struct{}
 


### PR DESCRIPTION
This PR expands the set of platforms considered as part of the bootstrap configuration process to include AWS. This will enable the population of the AWS EC2 metadata for Envoy nodes running on EC2 instances in the Envoy node metadata.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>