### PR TITLE
add base-id support for pilot-agent

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -93,6 +93,7 @@ var (
 	proxyComponentLogLevel   string
 	dnsRefreshRate           string
 	concurrency              int
+	baseId                   int
 	templateFile             string
 	disableInternalTelemetry bool
 	tlsCertsToWatch          []string
@@ -492,6 +493,7 @@ var (
 				PodIP:               podIP,
 				SDSUDSPath:          sdsUDSPath,
 				SDSTokenPath:        sdsTokenPath,
+				BaseId:              baseId,
 				ControlPlaneAuth:    controlPlaneAuthEnabled,
 				DisableReportCalls:  disableInternalTelemetry,
 			})
@@ -734,6 +736,8 @@ func init() {
 		"The dns_refresh_rate for bootstrap STRICT_DNS clusters")
 	proxyCmd.PersistentFlags().IntVar(&concurrency, "concurrency", int(values.Concurrency),
 		"number of worker threads to run")
+	proxyCmd.PersistentFlags().IntVar(&baseId, "baseId", 0,
+		"base ID so that multiple envoys can run on the same host if needed")
 	proxyCmd.PersistentFlags().StringVar(&templateFile, "templateFile", "",
 		"Go template bootstrap config")
 	proxyCmd.PersistentFlags().BoolVar(&disableInternalTelemetry, "disableInternalTelemetry", false,

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -57,6 +57,7 @@ type ProxyConfig struct {
 	PodIP               net.IP
 	SDSUDSPath          string
 	SDSTokenPath        string
+	BaseId              int
 	ControlPlaneAuth    bool
 	DisableReportCalls  bool
 }
@@ -71,6 +72,7 @@ func NewProxy(cfg ProxyConfig) Proxy {
 	if cfg.ComponentLogLevel != "" {
 		args = append(args, "--component-log-level", cfg.ComponentLogLevel)
 	}
+	args = append(args, "--base-id", fmt.Sprint(cfg.BaseId))
 
 	return &envoy{
 		ProxyConfig: cfg,

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -39,11 +39,12 @@ func TestEnvoyArgs(t *testing.T) {
 		PodIP:             nil,
 		SDSUDSPath:        "udspath",
 		SDSTokenPath:      "tokenpath",
+		BaseId:            1,
 	}
 
 	test := &envoy{
 		ProxyConfig: cfg,
-		extraArgs:   []string{"-l", "trace", "--component-log-level", "misc:error"},
+		extraArgs:   []string{"-l", "trace", "--component-log-level", "misc:error", "--base-id", "1"},
 	}
 
 	testProxy := NewProxy(cfg)
@@ -64,6 +65,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--log-format", "[Envoy (Epoch 5)] [%Y-%m-%d %T.%e][%t][%l][%n] %v",
 		"-l", "trace",
 		"--component-log-level", "misc:error",
+		"--base-id", "1",
 		"--config-yaml", `{"key": "value"}`,
 		"--concurrency", "8",
 	}


### PR DESCRIPTION
In my cluster I need to inject the sidecar to gateway, but it failed, then I found if I want to have multiple envoys in one pod, I need to add different base-id for every envoy, however, the pilot-agent does not currently support this field. I hope this PR can solve this.
see #11189