### PR TITLE
Fix mixer source namespace attribute when dot in pod nam

### DIFF
--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -696,7 +696,7 @@ func attrUID(node *model.Proxy) attribute {
 func attrNamespace(node *model.Proxy) attribute {
 	parts := strings.Split(node.ID, ".")
 	if len(parts) >= 2 {
-		return attrStringValue(parts[1])
+		return attrStringValue(parts[len(parts)-1])
 	}
 	return attrStringValue("")
 }

--- a/pilot/pkg/networking/plugin/mixer/mixer_test.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer_test.go
@@ -224,3 +224,23 @@ func TestOnOutboundListener(t *testing.T) {
 		})
 	}
 }
+
+func Test_attrNamespace(t *testing.T) {
+	testcases := []struct {
+		name      string
+		nodeID    string
+		namespace string
+	}{
+		{"standard pod name", "foo.bar", "bar"},
+		{"pod name with dot", "foo.123.bar", "bar"},
+	}
+	for _, v := range testcases {
+		t.Run(v.name, func(t *testing.T) {
+			node := model.Proxy{ID: v.nodeID}
+			ns := attrNamespace(&node).GetStringValue()
+			if ns != v.namespace {
+				t.Errorf("%s: expecting %v but got %v", v.name, ns, v.namespace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
cherry-pick https://github.com/istio/istio/pull/19022 into release-1.3