### PR TITLE
Split Horizon EDS: add support for meshNetwork without gateway 

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1480,6 +1480,11 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 	return MergeGateways(out...)
 }
 
+// Only used by test
+func (ps *PushContext) InitMeshNetworks(env *Environment) {
+	ps.initMeshNetworks(env)
+}
+
 // pre computes gateways for each network
 func (ps *PushContext) initMeshNetworks(env *Environment) {
 	if env.MeshNetworks == nil || len(env.MeshNetworks.Networks) == 0 {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -16,11 +16,13 @@ package model
 
 import (
 	"encoding/json"
+	"net"
 	"sort"
 	"sync"
 	"time"
 
 	authn "istio.io/api/authentication/v1alpha1"
+	"istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/features"
@@ -105,6 +107,18 @@ type PushContext struct {
 	initDone bool
 
 	Version string
+
+	// cache gateways addresses for each network
+	// this is mainly used for kubernetes multi-cluster scenario
+	networkGateways map[string][]*Gateway
+}
+
+// Gateway is the gateway of a network
+type Gateway struct {
+	// gateway ip address
+	Addr string
+	// gateway port
+	Port uint32
 }
 
 type processedDestRules struct {
@@ -723,6 +737,9 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 			return nil
 		}
 	}
+
+	// TODO: only do this when meshnetworks or gateway service changed
+	ps.initMeshNetworks(env)
 
 	ps.initDone = true
 	return nil
@@ -1461,4 +1478,76 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 		return nil
 	}
 	return MergeGateways(out...)
+}
+
+// pre computes gateways for each network
+func (ps *PushContext) initMeshNetworks(env *Environment) {
+	if env.MeshNetworks == nil || len(env.MeshNetworks.Networks) == 0 {
+		return
+	}
+
+	ps.networkGateways = map[string][]*Gateway{}
+	for network, networkConf := range env.MeshNetworks.Networks {
+		gws := networkConf.Gateways
+		if len(gws) == 0 {
+			log.Debugf("the endpoints within network %s will be ignored because of invalid MeshNetworks", network)
+			continue
+		}
+
+		registryName := getNetworkRegistry(networkConf)
+		gateways := []*Gateway{}
+		for _, gw := range gws {
+			gatewayAddresses := getGatewayAddresses(gw, registryName, env)
+			for _, addr := range gatewayAddresses {
+				gateways = append(gateways, &Gateway{addr, gw.Port})
+			}
+		}
+
+		ps.networkGateways[network] = gateways
+	}
+
+	return
+}
+
+func getNetworkRegistry(network *v1alpha1.Network) string {
+	var registryName string
+	for _, eps := range network.Endpoints {
+		if eps != nil && len(eps.GetFromRegistry()) > 0 {
+			registryName = eps.GetFromRegistry()
+			break
+		}
+	}
+
+	return registryName
+}
+
+func getGatewayAddresses(gw *v1alpha1.Network_IstioNetworkGateway, registryName string, env *Environment) []string {
+	// First, if a gateway address is provided in the configuration use it. If the gateway address
+	// in the config was a hostname it got already resolved and replaced with an IP address
+	// when loading the config
+	if gwIP := net.ParseIP(gw.GetAddress()); gwIP != nil {
+		return []string{gw.GetAddress()}
+	}
+
+	// Second, try to find the gateway addresses by the provided service name
+	if gwSvcName := gw.GetRegistryServiceName(); len(gwSvcName) > 0 && len(registryName) > 0 {
+		svc, _ := env.GetService(host.Name(gwSvcName))
+		if svc != nil {
+			return svc.Attributes.ClusterExternalAddresses[registryName]
+		}
+	}
+
+	return nil
+}
+
+func (ps *PushContext) NetworkGateways() map[string][]*Gateway {
+	return ps.networkGateways
+}
+
+func (ps *PushContext) NetworkGatewaysByNetwork(network string) []*Gateway {
+	if ps.networkGateways != nil {
+		return ps.networkGateways[network]
+	}
+
+	return nil
 }

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -699,7 +699,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 		// If networks are set (by default they aren't) apply the Split Horizon
 		// EDS filter on the endpoints
 		if s.Env.MeshNetworks != nil && len(s.Env.MeshNetworks.Networks) > 0 {
-			endpoints := EndpointsByNetworkFilter(con.node.Metadata.Network, l.Endpoints, s.Env)
+			endpoints := EndpointsByNetworkFilter(push, con.node.Metadata.Network, l.Endpoints)
 			filteredCLA := &xdsapi.ClusterLoadAssignment{
 				ClusterName: l.ClusterName,
 				Endpoints:   endpoints,

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -699,7 +699,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 		// If networks are set (by default they aren't) apply the Split Horizon
 		// EDS filter on the endpoints
 		if s.Env.MeshNetworks != nil && len(s.Env.MeshNetworks.Networks) > 0 {
-			endpoints := EndpointsByNetworkFilter(l.Endpoints, con, s.Env)
+			endpoints := EndpointsByNetworkFilter(con.node.Metadata.Network, l.Endpoints, s.Env)
 			filteredCLA := &xdsapi.ClusterLoadAssignment{
 				ClusterName: l.ClusterName,
 				Endpoints:   endpoints,

--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -63,7 +63,7 @@ func TestSplitHorizonEds(t *testing.T) {
 	// Network has 2 gateways
 	initRegistry(server, 3, []string{"159.122.219.3", "179.114.119.3"}, 3)
 	// Set up a cluster registry for network 4 with 4 instances for the service 'service5'
-	// but without any gateway
+	// but without any gateway, which is treated as accessible directly.
 	initRegistry(server, 4, []string{}, 4)
 
 	// Push contexts needs to be updated
@@ -86,6 +86,10 @@ func TestSplitHorizonEds(t *testing.T) {
 					"159.122.219.2": 4,
 					"159.122.219.3": 3,
 					"179.114.119.3": 3,
+					"10.4.0.1":      2,
+					"10.4.0.2":      2,
+					"10.4.0.3":      2,
+					"10.4.0.4":      2,
 				},
 			},
 		},
@@ -101,6 +105,10 @@ func TestSplitHorizonEds(t *testing.T) {
 					"159.122.219.1": 2,
 					"159.122.219.3": 3,
 					"179.114.119.3": 3,
+					"10.4.0.1":      2,
+					"10.4.0.2":      2,
+					"10.4.0.3":      2,
+					"10.4.0.4":      2,
 				},
 			},
 		},
@@ -116,6 +124,10 @@ func TestSplitHorizonEds(t *testing.T) {
 					"10.3.0.1":      2,
 					"10.3.0.2":      2,
 					"10.3.0.3":      2,
+					"10.4.0.1":      2,
+					"10.4.0.2":      2,
+					"10.4.0.3":      2,
+					"10.4.0.4":      2,
 				},
 			},
 		},

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -31,9 +31,7 @@ import (
 // of the connected sidecar. The filter will filter out all endpoints which are not present within the
 // sidecar network and add a gateway endpoint to remote networks that have endpoints (if gateway exists).
 // Information for the mesh networks is provided as a MeshNetwork config map.
-func EndpointsByNetworkFilter(endpoints []*endpoint.LocalityLbEndpoints, conn *XdsConnection, env *model.Environment) []*endpoint.LocalityLbEndpoints {
-	// If the sidecar does not specify a network, ignore Split Horizon EDS and return all
-	network := conn.node.Metadata.Network
+func EndpointsByNetworkFilter(proxyNetwork string, endpoints []*endpoint.LocalityLbEndpoints, env *model.Environment) []*endpoint.LocalityLbEndpoints {
 	meshNetworks := env.MeshNetworks.Networks
 
 	// calculate the multiples of weight.
@@ -65,7 +63,7 @@ func EndpointsByNetworkFilter(endpoints []*endpoint.LocalityLbEndpoints, conn *X
 		lbEndpoints := make([]*endpoint.LbEndpoint, 0)
 		for _, lbEp := range ep.LbEndpoints {
 			epNetwork := istioMetadata(lbEp, "network")
-			if epNetwork == network {
+			if epNetwork == proxyNetwork {
 				// This is a local endpoint
 				lbEp.LoadBalancingWeight = &wrappers.UInt32Value{
 					Value: uint32(multiples),

--- a/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
@@ -20,7 +20,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"

--- a/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
@@ -20,7 +20,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -144,7 +144,7 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			push := model.NewPushContext()
-			push.InitContext(tt.env, nil, nil)
+			push.InitMeshNetworks(tt.env)
 			filtered := EndpointsByNetworkFilter(push, tt.conn.node.Metadata.Network, tt.endpoints)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
@@ -314,7 +314,7 @@ func TestEndpointsByNetworkFilter_RegistryServiceName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			push := model.NewPushContext()
-			push.InitContext(tt.env, nil, nil)
+			push.InitMeshNetworks(tt.env)
 			filtered := EndpointsByNetworkFilter(push, tt.conn.node.Metadata.Network, tt.endpoints)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))

--- a/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
@@ -143,7 +143,7 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filtered := EndpointsByNetworkFilter(tt.endpoints, tt.conn, tt.env)
+			filtered := EndpointsByNetworkFilter(tt.conn.node.Metadata.Network, tt.endpoints, tt.env)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
 				return
@@ -311,7 +311,7 @@ func TestEndpointsByNetworkFilter_RegistryServiceName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filtered := EndpointsByNetworkFilter(tt.endpoints, tt.conn, tt.env)
+			filtered := EndpointsByNetworkFilter(tt.conn.node.Metadata.Network, tt.endpoints, tt.env)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
 				return

--- a/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
@@ -80,8 +80,10 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 						// 1 endpoint to gateway of network2 with weight 1 because it has 1 endpoint
 						{address: "2.2.2.2", weight: 1},
 						{address: "2.2.2.20", weight: 1},
+						// network4 has no gateway, which means it can be accessed from network1
+						{address: "40.0.0.1", weight: 2},
 					},
-					weight: 6,
+					weight: 8,
 				},
 			},
 		},
@@ -97,8 +99,9 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 						{address: "20.0.0.1", weight: 2},
 						// 1 endpoint to gateway of network1 with weight 4 because it has 2 endpoints
 						{address: "1.1.1.1", weight: 4},
+						{address: "40.0.0.1", weight: 2},
 					},
-					weight: 6,
+					weight: 8,
 				},
 			},
 		},
@@ -115,8 +118,9 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 						// 1 endpoint to gateway of network2 with weight 2 because it has 1 endpoint
 						{address: "2.2.2.2", weight: 1},
 						{address: "2.2.2.20", weight: 1},
+						{address: "40.0.0.1", weight: 2},
 					},
-					weight: 6,
+					weight: 8,
 				},
 			},
 		},
@@ -252,8 +256,9 @@ func TestEndpointsByNetworkFilter_RegistryServiceName(t *testing.T) {
 						{address: "10.0.0.2", weight: 1},
 						// 1 endpoint to gateway of network2 with weight 1 because it has 1 endpoint
 						{address: "2.2.2.2", weight: 1},
+						{address: "40.0.0.1", weight: 1},
 					},
-					weight: 3,
+					weight: 4,
 				},
 			},
 		},
@@ -269,8 +274,9 @@ func TestEndpointsByNetworkFilter_RegistryServiceName(t *testing.T) {
 						{address: "20.0.0.1", weight: 1},
 						// 1 endpoint to gateway of network1 with weight 2 because it has 2 endpoints
 						{address: "1.1.1.1", weight: 2},
+						{address: "40.0.0.1", weight: 1},
 					},
-					weight: 3,
+					weight: 4,
 				},
 			},
 		},
@@ -286,8 +292,9 @@ func TestEndpointsByNetworkFilter_RegistryServiceName(t *testing.T) {
 						{address: "1.1.1.1", weight: 2},
 						// 1 endpoint to gateway of network2 with weight 1 because it has 1 endpoint
 						{address: "2.2.2.2", weight: 1},
+						{address: "40.0.0.1", weight: 1},
 					},
-					weight: 3,
+					weight: 4,
 				},
 			},
 		},

--- a/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
@@ -143,7 +143,9 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filtered := EndpointsByNetworkFilter(tt.conn.node.Metadata.Network, tt.endpoints, tt.env)
+			push := model.NewPushContext()
+			push.InitContext(tt.env, nil, nil)
+			filtered := EndpointsByNetworkFilter(push, tt.conn.node.Metadata.Network, tt.endpoints)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
 				return
@@ -311,7 +313,9 @@ func TestEndpointsByNetworkFilter_RegistryServiceName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filtered := EndpointsByNetworkFilter(tt.conn.node.Metadata.Network, tt.endpoints, tt.env)
+			push := model.NewPushContext()
+			push.InitContext(tt.env, nil, nil)
+			filtered := EndpointsByNetworkFilter(push, tt.conn.node.Metadata.Network, tt.endpoints)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
 				return


### PR DESCRIPTION


This support networking for below scenario:

1. network1 can talk to all endpoints directly in network2.
1. network2 can only talk to endpoints in network1 through gateway.

We can imagine a k8s cluster as network1, and vms within same vpc with k8s nodes as network2. 

This is not possible today as spilt horizon will ignore the endpoint from a different network. 




Depend on #19130, this should not be merged before.