### PR TITLE
Resolve regression in tracing

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
@@ -21,7 +21,7 @@ items:
       release: {{ .Release.Name }}
   spec:
     ports:
-      - port: {{ .Values.service.externalPort }}
+      - port: {{ .Values.zipkin.queryPort }}
         targetPort: {{ .Values.zipkin.queryPort }}
         protocol: TCP
         name: {{ .Values.service.name }}

--- a/install/kubernetes/helm/istio/charts/tracing/values.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/values.yaml
@@ -69,7 +69,7 @@ service:
   annotations: {}
   name: http
   type: ClusterIP
-  externalPort: 9411
+  externalPort: 80
 
 ingress:
   enabled: false


### PR DESCRIPTION
Fixes: #19227

The tracing and zipkin services both point to the same workload with
the same port. Each service must use different ports. 1.4.0 has a
regression in this area.