### PR TITLE
add test to help enforce that new analyzers are added to All()

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -382,6 +382,20 @@ func TestAnalyzers(t *testing.T) {
 	})
 }
 
+// Verify that all of the analyzers tested here are also registered in All()
+func TestAnalyzersInAll(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var allNames []string
+	for _, a := range All() {
+		allNames = append(allNames, a.Metadata().Name)
+	}
+
+	for _, tc := range testGrid {
+		g.Expect(allNames).To(ContainElement(tc.analyzer.Metadata().Name))
+	}
+}
+
 func TestAnalyzersHaveUniqueNames(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
Add a basic unit test to help enforce that new analyzers are included in All(). e.g. in https://github.com/istio/istio/pull/18364, this change was accidentally lost during a rebase, and this test would have caught that. 