### PR TITLE
Remove dockerx.save, fixing release

### DIFF
--- a/tools/buildx-gen.sh
+++ b/tools/buildx-gen.sh
@@ -49,11 +49,6 @@ for file in "$@"; do
       tag+="-${variant}"
       output+="-${variant}"
     fi
-    # Add output only if docker save is specified
-    outputfield=""
-    if [[ -n "${DOCKER_SAVE:-}" ]]; then
-      outputfield="output = [\"type=tar,dest=${ISTIO_DOCKER_TAR}/${output}.tar\"]"
-    fi
     cat <<EOF >> "${config}"
 target "$image-$variant" {
     context = "${out}/${file}"
@@ -63,7 +58,6 @@ target "$image-$variant" {
       BASE_VERSION = "${BASE_VERSION}"
       BASE_DISTRIBUTION = "${variant}"
     }
-    ${outputfield}
 }
 EOF
     # For the default variant, create an alias so we can do things like `build pilot` instead of `build pilot-default`


### PR DESCRIPTION
This doesn't work as expected, the tar output here is different than
docker save