### PR TITLE
Add proxyID parameter to edsz

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -749,11 +749,48 @@ func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
 	if req.Form.Get("push") != "" {
 		AdsPushAll(s)
 	}
+	var con *XdsConnection
+	if proxyID := req.URL.Query().Get("proxyID"); proxyID != "" {
+		adsClientsMutex.RLock()
+		defer adsClientsMutex.RUnlock()
+		connections, ok := adsSidecarIDConnectionsMap[proxyID]
+		// We can't guarantee the Pilot we are connected to has a connection to the proxy we requested
+		// There isn't a great way around this, but for debugging purposes its suitable to have the caller retry.
+		if !ok || len(connections) == 0 {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("Proxy not connected to this Pilot instance. It may be connected to another instance."))
+			return
+		}
+
+		mostRecent := ""
+		for key := range connections {
+			if mostRecent == "" || key > mostRecent {
+				mostRecent = key
+			}
+		}
+		con = connections[mostRecent]
+	}
 
 	edsClusterMutex.RLock()
 	defer edsClusterMutex.RUnlock()
 	comma := false
-	if len(edsClusters) > 0 {
+	if con != nil {
+		_, _ = fmt.Fprintln(w, "[")
+		for _, clusterName := range con.Clusters {
+			if comma {
+				_, _ = fmt.Fprint(w, ",\n")
+			} else {
+				comma = true
+			}
+			cla := s.generateEndpoints(clusterName, con.node, s.globalPushContext(), nil)
+			jsonm := &jsonpb.Marshaler{Indent: "  "}
+			dbgString, _ := jsonm.MarshalToString(cla)
+			if _, err := w.Write([]byte(dbgString)); err != nil {
+				return
+			}
+		}
+		_, _ = fmt.Fprintln(w, "]")
+	} else if len(edsClusters) > 0 {
 		_, _ = fmt.Fprintln(w, "[")
 		for cluster := range edsClusters {
 			if comma {

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -656,7 +656,9 @@ func (s *DiscoveryServer) loadAssignmentsForClusterIsolated(proxy *model.Proxy, 
 	}
 }
 
-func (s *DiscoveryServer) generateEndpoints(clusterName string, proxy *model.Proxy, push *model.PushContext, edsUpdatedServices map[string]struct{}) *xdsapi.ClusterLoadAssignment {
+func (s *DiscoveryServer) generateEndpoints(
+	clusterName string, proxy *model.Proxy, push *model.PushContext, edsUpdatedServices map[string]struct{},
+) *xdsapi.ClusterLoadAssignment {
 	_, _, hostname, _ := model.ParseSubsetKey(clusterName)
 	if edsUpdatedServices != nil {
 		if _, ok := edsUpdatedServices[string(hostname)]; !ok {

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -656,6 +656,52 @@ func (s *DiscoveryServer) loadAssignmentsForClusterIsolated(proxy *model.Proxy, 
 	}
 }
 
+func (s *DiscoveryServer) generateEndpoints(clusterName string, proxy *model.Proxy, push *model.PushContext, edsUpdatedServices map[string]struct{}) *xdsapi.ClusterLoadAssignment {
+	_, _, hostname, _ := model.ParseSubsetKey(clusterName)
+	if edsUpdatedServices != nil {
+		if _, ok := edsUpdatedServices[string(hostname)]; !ok {
+			// Cluster was not updated, skip recomputing. This happens when we get an incremental update for a
+			// specific Hostname. On connect or for full push edsUpdatedServices will be empty.
+			return nil
+		}
+	}
+
+	l := s.loadAssignmentsForClusterIsolated(proxy, push, clusterName)
+
+	if l == nil {
+		return nil
+	}
+
+		// If networks are set (by default they aren't) apply the Split Horizon
+		// EDS filter on the endpoints
+		if push.Networks != nil && len(push.Networks.Networks) > 0 {
+			endpoints := EndpointsByNetworkFilter(push, proxy.Metadata.Network, l.Endpoints)
+			filteredCLA := &xdsapi.ClusterLoadAssignment{
+				ClusterName: l.ClusterName,
+				Endpoints:   endpoints,
+				Policy:      l.Policy,
+			}
+			l = filteredCLA
+		}
+
+	// If locality aware routing is enabled, prioritize endpoints or set their lb weight.
+	if push.Mesh.LocalityLbSetting != nil {
+		// Make a shallow copy of the cla as we are mutating the endpoints with priorities/weights relative to the calling proxy
+		clonedCLA := util.CloneClusterLoadAssignment(l)
+		l = &clonedCLA
+
+		// Failover should only be enabled when there is an outlier detection, otherwise Envoy
+		// will never detect the hosts are unhealthy and redirect traffic.
+		enableFailover, loadBalancerSettings := getOutlierDetectionAndLoadBalancerSettings(push, proxy, clusterName)
+		var localityLbSettings = push.Mesh.LocalityLbSetting
+		if loadBalancerSettings != nil && loadBalancerSettings.LocalityLbSetting != nil {
+			localityLbSettings = loadBalancerSettings.LocalityLbSetting
+		}
+		loadbalancer.ApplyLocalityLBSetting(proxy.Locality, l, localityLbSettings, enableFailover)
+	}
+	return l
+}
+
 // pushEds is pushing EDS updates for a single connection. Called the first time
 // a client connects, for incremental updates and for full periodic updates.
 func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, version string, edsUpdatedServices map[string]struct{}) error {
@@ -668,48 +714,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 	// For 1.1+Sidecar - it's the small set of explicitly imported clusters, using the isolated DestinationRules
 	for _, clusterName := range con.Clusters {
 
-		_, _, hostname, _ := model.ParseSubsetKey(clusterName)
-		if edsUpdatedServices != nil {
-			if _, ok := edsUpdatedServices[string(hostname)]; !ok {
-				// Cluster was not updated, skip recomputing. This happens when we get an incremental update for a
-				// specific Hostname. On connect or for full push edsUpdatedServices will be empty.
-				continue
-			}
-		}
-
-		l := s.loadAssignmentsForClusterIsolated(con.node, push, clusterName)
-
-		if l == nil {
-			continue
-		}
-
-		// If networks are set (by default they aren't) apply the Split Horizon
-		// EDS filter on the endpoints
-		if push.Networks != nil && len(push.Networks.Networks) > 0 {
-			endpoints := EndpointsByNetworkFilter(push, con.node.Metadata.Network, l.Endpoints)
-			filteredCLA := &xdsapi.ClusterLoadAssignment{
-				ClusterName: l.ClusterName,
-				Endpoints:   endpoints,
-				Policy:      l.Policy,
-			}
-			l = filteredCLA
-		}
-
-		// If locality aware routing is enabled, prioritize endpoints or set their lb weight.
-		if push.Mesh.LocalityLbSetting != nil {
-			// Make a shallow copy of the cla as we are mutating the endpoints with priorities/weights relative to the calling proxy
-			clonedCLA := util.CloneClusterLoadAssignment(l)
-			l = &clonedCLA
-
-			// Failover should only be enabled when there is an outlier detection, otherwise Envoy
-			// will never detect the hosts are unhealthy and redirect traffic.
-			enableFailover, loadBalancerSettings := getOutlierDetectionAndLoadBalancerSettings(push, con.node, clusterName)
-			var localityLbSettings = push.Mesh.LocalityLbSetting
-			if loadBalancerSettings != nil && loadBalancerSettings.LocalityLbSetting != nil {
-				localityLbSettings = loadBalancerSettings.LocalityLbSetting
-			}
-			loadbalancer.ApplyLocalityLBSetting(con.node.Locality, l, localityLbSettings, enableFailover)
-		}
+		l := s.generateEndpoints(clusterName, con.node, push, edsUpdatedServices)
 
 		for _, e := range l.Endpoints {
 			endpoints += len(e.LbEndpoints)


### PR DESCRIPTION
Right now edsz isn't very useful since its using the legacy eds output
that isn't even accurate often. We are also doing a lot of processing
after the code we call, so it doesn't have info like locality lb, etc.

This adds both of those.