### PR TITLE
Fix hub and tag for statefulsets test

### DIFF
--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -407,8 +407,8 @@ func getStatefulSet(service string, port int, injectProxy bool) framework.App {
 	return framework.App{
 		AppYamlTemplate: "testdata/statefulset.yaml.tmpl",
 		Template: map[string]string{
-			"Hub":             tc.Kube.PilotHub(),
-			"Tag":             tc.Kube.PilotTag(),
+			"Hub":             tc.Kube.AppHub(),
+			"Tag":             tc.Kube.AppTag(),
 			"service":         service,
 			"port":            strconv.Itoa(port),
 			"istioNamespace":  tc.Kube.Namespace,


### PR DESCRIPTION
While running distroless tests, pilot_test:statefulset test was failing due to image pull issues.