### PR TITLE
WIP: Cherry-pick mTLS analyzer for 1.4

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -31,6 +31,7 @@ func All() []analysis.Analyzer {
 	analyzers := []analysis.Analyzer{
 		// Please keep this list sorted alphabetically by pkg.name for convenience
 		&annotations.K8sAnalyzer{},
+		&auth.MTLSAnalyzer{},
 		&auth.ServiceRoleBindingAnalyzer{},
 		&auth.ServiceRoleServicesAnalyzer{},
 		&deprecation.FieldAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -259,7 +259,7 @@ func TestAnalyzers(t *testing.T) {
 				requestedInputsByAnalyzer[analyzerName][col] = struct{}{}
 			}
 
-			sa := local.NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("testCombined", testCase.analyzer), "", cr, true)
+			sa := local.NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("testCombined", testCase.analyzer), "", "istio-system", cr, true)
 
 			err := sa.AddFileKubeSource(testCase.inputFiles)
 			if err != nil {

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -167,6 +167,79 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name:       "mtlsAnalyzerGlobalDestinationRuleNoMeshPolicy",
+		inputFiles: []string{"testdata/mtls-global-dr-no-meshpolicy.yaml"},
+		analyzer:   &auth.MTLSAnalyzer{},
+		expected: []message{
+			{msg.MTLSPolicyConflict, "DestinationRule default.istio-system"},
+		},
+	},
+	{
+		name:       "mtlsAnalyzerIgnoresIstioSystemNamespace",
+		inputFiles: []string{"testdata/mtls-ignores-istio-system.yaml"},
+		analyzer:   &auth.MTLSAnalyzer{},
+		expected:   []message{
+			// no messages, this test case verifies no false positives
+		},
+	},
+	{
+		name:       "mtlsAnalyzerNoDestinationRule",
+		inputFiles: []string{"testdata/mtls-no-dr.yaml"},
+		analyzer:   &auth.MTLSAnalyzer{},
+		expected: []message{
+			{msg.MTLSPolicyConflict, "Policy default.missing-dr"},
+		},
+	},
+	{
+		name:       "mtlsAnalyzerNoPolicy",
+		inputFiles: []string{"testdata/mtls-no-policy.yaml"},
+		analyzer:   &auth.MTLSAnalyzer{},
+		expected: []message{
+			{msg.MTLSPolicyConflict, "DestinationRule no-policy-service-dr.no-policy"},
+		},
+	},
+	{
+		name:       "mtlsAnalyzerNoSidecar",
+		inputFiles: []string{"testdata/mtls-no-sidecar.yaml"},
+		analyzer:   &auth.MTLSAnalyzer{},
+		expected:   []message{
+			// no messages, this test case verifies no false positives
+		},
+	},
+	{
+		name:       "mtlsAnalyzerWithExports",
+		inputFiles: []string{"testdata/mtls-exports.yaml"},
+		analyzer:   &auth.MTLSAnalyzer{},
+		expected: []message{
+			{msg.MTLSPolicyConflict, "Policy default.primary"},
+		},
+	},
+	{
+		name:       "mtlsAnalyzerWithMeshPolicy",
+		inputFiles: []string{"testdata/mtls-meshpolicy.yaml"},
+		analyzer:   &auth.MTLSAnalyzer{},
+		expected: []message{
+			{msg.MTLSPolicyConflict, "MeshPolicy default"},
+		},
+	},
+	{
+		name:       "mtlsAnalyzerWithPermissiveMeshPolicy",
+		inputFiles: []string{"testdata/mtls-meshpolicy-permissive.yaml"},
+		analyzer:   &auth.MTLSAnalyzer{},
+		expected:   []message{
+			// no messages, this test case verifies no false positives
+		},
+	},
+	{
+		name:       "mtlsAnalyzerWithPort",
+		inputFiles: []string{"testdata/mtls-with-port.yaml"},
+		analyzer:   &auth.MTLSAnalyzer{},
+		expected: []message{
+			{msg.MTLSPolicyConflict, "DestinationRule default.my-namespace"},
+			{msg.MTLSPolicyConflict, "Policy default.my-namespace"},
+		},
+	},
+	{
 		name:       "sidecarDefaultSelector",
 		inputFiles: []string{"testdata/sidecar-default-selector.yaml"},
 		analyzer:   &sidecar.DefaultSelectorAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/auth/mtls.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls.go
@@ -1,0 +1,362 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"fmt"
+
+	"istio.io/api/authentication/v1alpha1"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
+
+	v1 "k8s.io/api/core/v1"
+	k8s_labels "k8s.io/apimachinery/pkg/labels"
+
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/auth/mtls"
+	"istio.io/istio/galley/pkg/config/meta/metadata"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+)
+
+const missingResourceName = "(none)"
+
+// MTLSAnalyzer checks for misconfigurations of MTLS policy when autoMtls is
+// disabled. More specifically, it detects situations where a DestinationRule's
+// MTLS usage is in conflict with mTLS specified by a policy.
+//
+// The most common situations that this detects are: 1. A MeshPolicy exists that
+// requires mTLS, but no global destination rule
+//    says to use mTLS.
+// 2. mTLS is used throughout the mesh, but a DestinationRule is added that
+//    doesn't specify mTLS (usually because it was forgotten).
+//
+// The analyzer tries to act more generally by imagining service-to-service
+// traffic and detecting whether or not there's a conflict with regards to mTLS
+// policy. This means it will also detect explicit misconfigurations as well.
+//
+// Note this is very similar to `istioctl authn tls-check`; however this
+// inspection is all done via analyzing configuration rather than requiring a
+// connection to pilot.
+type MTLSAnalyzer struct{}
+
+// Compile-time check that this Analyzer correctly implements the interface
+var _ analysis.Analyzer = &MTLSAnalyzer{}
+
+// Metadata implements Analyzer
+func (s *MTLSAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name: "auth.MTLSAnalyzer",
+
+		// Each analyzer should register the collections that it needs to use as input.
+		Inputs: collection.Names{
+			metadata.K8SCoreV1Pods,
+			metadata.K8SCoreV1Namespaces,
+			metadata.K8SCoreV1Services,
+			metadata.IstioAuthenticationV1Alpha1Meshpolicies,
+			metadata.IstioAuthenticationV1Alpha1Policies,
+			metadata.IstioMeshV1Alpha1MeshConfig,
+			metadata.IstioNetworkingV1Alpha3Destinationrules,
+		},
+	}
+}
+
+// Analyze implements Analyzer
+func (s *MTLSAnalyzer) Analyze(c analysis.Context) {
+	// TODO Reuse pilot logic as a library rather than reproducing its logic
+	// here.
+
+	// If autoMTLS is turned on, bail out early as the logic used below does not
+	// reason about its usage.
+	autoMtlsEnabled := false
+	rootNamespace := "istio-system"
+
+	// Only one MeshConfig should exist in practice - we use ForEach to avoid
+	// specifying where to look for the MeshConfig (which allows the Context
+	// object to provide it to us).
+	c.ForEach(metadata.IstioMeshV1Alpha1MeshConfig, func(r *resource.Entry) bool {
+		mc := r.Item.(*meshconfig.MeshConfig)
+		if mc.GetEnableAutoMtls() != nil && mc.GetEnableAutoMtls().Value {
+			autoMtlsEnabled = true
+		}
+
+		if mc.GetRootNamespace() != "" {
+			rootNamespace = mc.GetRootNamespace()
+		}
+		return true
+	})
+
+	if autoMtlsEnabled {
+		return
+	}
+
+	// Loop over all services, building up a list of selectors for each. This is
+	// used to determine which pods are in which services, and determine whether
+	// or not the sidecar is fully enmeshed. If a service doesn't have a
+	// sidecar, then we always treat it as having an explicit "plaintext" policy
+	// regardless of the service/namespace/mesh policy.
+
+	var targetServices []mtls.TargetService
+	fqdnsWithoutSidecars := make(map[string]struct{})
+	// Keep track of each fqdn -> port name -> port number. This is because
+	// the Policy object lets you target a port name, but DR requires port
+	// number. Tracking this means we can normalize to port number later.
+	fqdnToNameToPort := make(map[string]map[string]uint32)
+
+	c.ForEach(metadata.K8SCoreV1Services, func(r *resource.Entry) bool {
+		svcNs, svcName := r.Metadata.Name.InterpretAsNamespaceAndName()
+
+		// Skip the istio control plane. It doesn't obey Policy/MeshPolicy MTLS
+		// rules in general and instead is controlled by the mesh option
+		// 'controlPlaneSecurityEnabled'.
+		if svcNs == "istio-system" {
+			return true
+		}
+		svc := r.Item.(*v1.ServiceSpec)
+
+		svcSelector := k8s_labels.SelectorFromSet(svc.Selector)
+		fqdn := util.ConvertHostToFQDN(svcNs, svcName)
+		for _, port := range svc.Ports {
+			portNumber := uint32(port.Port)
+			// portName is optional, but we note it so we can translate later.
+			if port.Name != "" {
+				// allocate a new map if necessary
+				if _, ok := fqdnToNameToPort[fqdn]; !ok {
+					fqdnToNameToPort[fqdn] = make(map[string]uint32)
+				}
+				fqdnToNameToPort[fqdn][port.Name] = portNumber
+			}
+
+			targetServices = append(targetServices, mtls.NewTargetServiceWithPortNumber(fqdn, portNumber))
+		}
+
+		// Now we loop over all pods looking for sidecars that match our
+		// service. If we find a single pod without a sidecar, we label the
+		// service as not having a sidecar (which means we bypass policy
+		// checking). If we find no pods at all that match, also assume there's
+		// no sidecar.
+		var foundMatchingPods bool
+		c.ForEach(metadata.K8SCoreV1Pods, func(pr *resource.Entry) bool {
+			// If it's not in our namespace, we're not interested
+			podNs, _ := pr.Metadata.Name.InterpretAsNamespaceAndName()
+			if podNs != svcNs {
+				return true
+			}
+			pod := pr.Item.(*v1.Pod)
+			podLabels := k8s_labels.Set(pod.ObjectMeta.Labels)
+
+			if svcSelector.Empty() || !svcSelector.Matches(podLabels) {
+				return true
+			}
+
+			// This pod is selected for this service - ensure there's a sidecar.
+			foundMatchingPods = true
+			sidecarFound := false
+			for _, container := range pod.Spec.Containers {
+				if container.Name == "istio-proxy" {
+					sidecarFound = true
+				}
+			}
+
+			if !sidecarFound {
+				fqdnsWithoutSidecars[fqdn] = struct{}{}
+			}
+			return true
+		})
+
+		if !foundMatchingPods {
+			fqdnsWithoutSidecars[fqdn] = struct{}{}
+		}
+
+		return true
+	})
+
+	// While we visit every item, collect the set of namespaces that exist. Note
+	// that we will collect the namespace name for all resource types - this
+	// ensures our analyzer still behaves correctly even if namespaces are
+	// implicitly defined.
+	namespaces := make(map[string]struct{})
+
+	c.ForEach(metadata.K8SCoreV1Namespaces, func(r *resource.Entry) bool {
+		_, name := r.Metadata.Name.InterpretAsNamespaceAndName()
+		namespaces[name] = struct{}{}
+		return true
+	})
+
+	pc := mtls.NewPolicyChecker(fqdnToNameToPort)
+	meshPolicyResource := c.Find(metadata.IstioAuthenticationV1Alpha1Meshpolicies, resource.NewName("", "default"))
+	if meshPolicyResource != nil {
+		pc.AddMeshPolicy(meshPolicyResource, meshPolicyResource.Item.(*v1alpha1.Policy))
+	}
+
+	c.ForEach(metadata.IstioAuthenticationV1Alpha1Policies, func(r *resource.Entry) bool {
+		ns, _ := r.Metadata.Name.InterpretAsNamespaceAndName()
+		namespaces[ns] = struct{}{}
+
+		err := pc.AddPolicy(r, r.Item.(*v1alpha1.Policy))
+		if err != nil {
+			// AddPolicy can return a NamedPortInPolicyNotFoundError - if it
+			// does we can print a useful message.
+			// TODO this should be in its own analyzer, and ignored here.
+			if missingPortNameErr, ok := err.(mtls.NamedPortInPolicyNotFoundError); ok {
+				c.Report(metadata.IstioAuthenticationV1Alpha1Meshpolicies,
+					msg.NewPolicySpecifiesPortNameThatDoesntExist(r, missingPortNameErr.PortName, missingPortNameErr.FQDN))
+				return true
+			} else {
+				c.Report(metadata.IstioAuthenticationV1Alpha1Meshpolicies, msg.NewInternalError(r, err.Error()))
+				return false
+			}
+		}
+		return true
+	})
+
+	drc := mtls.NewDestinationRuleChecker(rootNamespace)
+	c.ForEach(metadata.IstioNetworkingV1Alpha3Destinationrules, func(r *resource.Entry) bool {
+		ns, _ := r.Metadata.Name.InterpretAsNamespaceAndName()
+		namespaces[ns] = struct{}{}
+
+		drc.AddDestinationRule(r, r.Item.(*v1alpha3.DestinationRule))
+		return true
+	})
+
+	// Here we explicitly handle the common case where a user specifies a
+	// MeshPolicy with no global DestinationRule. We also track if we report a
+	// problem with the global configuration. This is used later to suppress
+	// reporting a message for every service/namespace combination due to the
+	// same misconfiguration.
+	anyK8sServiceHost := fmt.Sprintf("%s.%s", util.Wildcard, util.DefaultKubernetesDomain)
+	globalMTLSMisconfigured := false
+	mpr := pc.MeshPolicy()
+	globalMtls, globalDR := drc.DoesNamespaceUseMTLSToService(rootNamespace, rootNamespace, mtls.NewTargetService(anyK8sServiceHost))
+	if mpr.MTLSMode == mtls.ModeStrict && !globalMtls {
+		// We may or may not have a matching DR. If we don't, use the special
+		// missing resource string
+		globalDRName := missingResourceName
+		if globalDR != nil {
+			globalDRName = globalDR.Metadata.Name.String()
+		}
+		c.Report(
+			metadata.IstioAuthenticationV1Alpha1Meshpolicies,
+			msg.NewMTLSPolicyConflict(
+				mpr.Resource,
+				anyK8sServiceHost,
+				rootNamespace,
+				globalDRName,
+				globalMtls,
+				mpr.Resource.Metadata.Name.String(),
+				mpr.MTLSMode.String()))
+		globalMTLSMisconfigured = true
+	}
+
+	// Also handle the less-common case where a global DR exists that specifies
+	// mtls, but MTLS is off
+	if mpr.MTLSMode == mtls.ModePlaintext && globalMtls {
+		// We may or may not have a matching policy. If we don't, use the
+		// special missing resource string
+		globalPolicyName := missingResourceName
+		if mpr.Resource != nil {
+			globalPolicyName = mpr.Resource.Metadata.Name.String()
+		}
+		c.Report(
+			metadata.IstioNetworkingV1Alpha3Destinationrules,
+			msg.NewMTLSPolicyConflict(
+				globalDR,
+				anyK8sServiceHost,
+				rootNamespace,
+				globalDR.Metadata.Name.String(),
+				globalMtls,
+				globalPolicyName,
+				mpr.MTLSMode.String()))
+		globalMTLSMisconfigured = true
+	}
+
+	// Iterate over all fqdns and namespaces, and check that the mtls mode
+	// specified by the destination rule and the policy are not in conflict.
+	for _, ts := range targetServices {
+		var tsPolicy mtls.ModeAndResource
+		// If we don't have a sidecar, don't check policy and treat as plaintext
+		if _, ok := fqdnsWithoutSidecars[ts.FQDN()]; ok {
+			tsPolicy = mtls.ModeAndResource{
+				MTLSMode: mtls.ModePlaintext,
+				Resource: nil,
+			}
+		} else {
+			var err error
+			tsPolicy, err = pc.IsServiceMTLSEnforced(ts)
+			if err != nil {
+				c.Report(metadata.IstioAuthenticationV1Alpha1Policies, msg.NewInternalError(nil, err.Error()))
+				return
+			}
+		}
+
+		// Extract out the namespace for the target service
+		tsNamespace, _ := util.GetNamespaceAndNameFromFQDN(ts.FQDN())
+
+		for ns := range namespaces {
+			mtlsUsed, matchingDR := drc.DoesNamespaceUseMTLSToService(ns, tsNamespace, ts)
+			if (tsPolicy.MTLSMode == mtls.ModeStrict && !mtlsUsed) ||
+				(tsPolicy.MTLSMode == mtls.ModePlaintext && mtlsUsed) {
+
+				// If global mTLS is misconfigured, and one of the resources we
+				// are about to complain about is missing, it's almost certainly
+				// due to the same underlying problem (a missing global
+				// DR/MeshPolicy). In that case, don't emit since it's redundant.
+				if globalMTLSMisconfigured && (tsPolicy.Resource == nil || matchingDR == nil) {
+					continue
+				}
+				if tsPolicy.Resource != nil {
+					// We may or may not have a matching DR. If we don't, use
+					// the special missing resource string
+					matchingDRName := missingResourceName
+					if matchingDR != nil {
+						matchingDRName = matchingDR.Metadata.Name.String()
+					}
+					c.Report(
+						metadata.IstioAuthenticationV1Alpha1Policies,
+						msg.NewMTLSPolicyConflict(
+							tsPolicy.Resource,
+							ts.String(),
+							ns,
+							matchingDRName,
+							mtlsUsed,
+							tsPolicy.Resource.Metadata.Name.String(),
+							tsPolicy.MTLSMode.String()))
+				}
+				if matchingDR != nil {
+					// We may or may not have a matching policy. If we don't, use
+					// the special missing resource string
+					policyName := missingResourceName
+					if tsPolicy.Resource != nil {
+						policyName = tsPolicy.Resource.Metadata.Name.String()
+					}
+					c.Report(
+						metadata.IstioNetworkingV1Alpha3Destinationrules,
+						msg.NewMTLSPolicyConflict(
+							matchingDR,
+							ts.String(),
+							ns,
+							matchingDR.Metadata.Name.String(),
+							mtlsUsed,
+							policyName,
+							tsPolicy.MTLSMode.String()))
+				}
+			}
+		}
+	}
+}

--- a/galley/pkg/config/analysis/analyzers/auth/mtls/destination_rule_checker.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls/destination_rule_checker.go
@@ -1,0 +1,215 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtls
+
+import (
+	"sort"
+
+	"istio.io/istio/galley/pkg/config/resource"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/pkg/config/host"
+)
+
+// DestinationRuleChecker computes whether or not MTLS is used according to
+// DestinationRules added to the instance. It handles the complicated logic of
+// looking up which DestinationRule takes effect for a given source namespace,
+// destination namespace and host name.
+type DestinationRuleChecker struct {
+	namespaceToDestinations map[string]destinations
+	rootNamespace           string
+}
+
+// destination represents a destination specified in a DestinationRule.
+type destination struct {
+	targetService TargetService
+	usesMTLS      bool
+	isPrivate     bool
+	resource      *resource.Entry
+}
+
+// destinations is a list of destinations that supports being sorted by
+// hostname. This means that, once sorted, you can iterate over the list going
+// from most-specific rules to least-specific. This matches how the API behaves.
+type destinations []destination
+
+// destinations implements sort.Interface
+var _ sort.Interface = destinations{}
+
+func (d destinations) Len() int {
+	return len(d)
+}
+
+func (d destinations) Less(i, j int) bool {
+	// First, check to see if we have a tie on FQDN. If we do, we want to break
+	// ties so that target services with a port specified come before those that
+	// don't.
+	ts1 := d[i].targetService
+	ts2 := d[j].targetService
+	if ts1.FQDN() == ts2.FQDN() {
+		return ts1.PortNumber() != 0
+	}
+
+	// Defer to the sort order for target service hostname
+	hosts := []string{d[i].targetService.FQDN(), d[j].targetService.FQDN()}
+	return host.NewNames(hosts).Less(0, 1)
+}
+
+func (d destinations) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+
+// NewDestinationRuleChecker creates a new instance with the given config root
+// namespace.
+func NewDestinationRuleChecker(rootNamespace string) *DestinationRuleChecker {
+	return &DestinationRuleChecker{
+		namespaceToDestinations: make(map[string]destinations),
+		rootNamespace:           rootNamespace,
+	}
+}
+
+// TargetServices returns the list of TargetServices known to the checker. These
+// services are generated from DestinationRules previously added to the checker.
+func (dc *DestinationRuleChecker) TargetServices() []TargetService {
+	var targetServices []TargetService
+	for _, destinations := range dc.namespaceToDestinations {
+		for _, destination := range destinations {
+			targetServices = append(targetServices, destination.targetService)
+		}
+	}
+
+	return targetServices
+}
+
+// AddDestinationRule adds a DestinationRule to the checker.
+func (dc *DestinationRuleChecker) AddDestinationRule(resource *resource.Entry, rule *v1alpha3.DestinationRule) {
+	// By default Destination rules are exported publicly.
+	isPrivate := false
+	for _, export := range rule.ExportTo {
+		if export == "." {
+			isPrivate = true
+		}
+	}
+
+	namespace, _ := resource.Metadata.Name.InterpretAsNamespaceAndName()
+	fqdn := util.ConvertHostToFQDN(namespace, rule.GetHost())
+	// By default, we are not using MTLS
+	usesMTLS := false
+	if rule.TrafficPolicy != nil && rule.TrafficPolicy.Tls != nil && rule.TrafficPolicy.Tls.Mode == v1alpha3.TLSSettings_ISTIO_MUTUAL {
+		usesMTLS = true
+	}
+
+	dc.namespaceToDestinations[namespace] = append(dc.namespaceToDestinations[namespace], destination{
+		targetService: NewTargetService(fqdn),
+		usesMTLS:      usesMTLS,
+		isPrivate:     isPrivate,
+		resource:      resource,
+	})
+
+	if rule.TrafficPolicy == nil {
+		// No overrides to check
+		return
+	}
+	// TODO Support checking subsets.
+	// Now check if we have any overrides
+	for _, pls := range rule.TrafficPolicy.PortLevelSettings {
+		portUsesMTLS := false
+		if pls.Tls != nil && pls.Tls.Mode == v1alpha3.TLSSettings_ISTIO_MUTUAL {
+			portUsesMTLS = true
+		}
+
+		dc.namespaceToDestinations[namespace] = append(dc.namespaceToDestinations[namespace], destination{
+			targetService: NewTargetServiceWithPortNumber(fqdn, pls.Port.GetNumber()),
+			usesMTLS:      portUsesMTLS,
+			isPrivate:     isPrivate,
+		})
+	}
+}
+
+// DoesNamespaceUseMTLSToService returns true if, according to DestinationRules
+// added to the checker, mTLS will be used when communicating to the specified
+// TargetService from the source namespace to the destinaton namespace.
+//
+// If the TargetService's FQDN has a wildcard, then the set of DestinationRules
+// considered for routing are only rules that match a superset of the hosts
+// specified by the TargetService FQDN. This means you can check, for example,
+// the hostname '*.svc.cluster.local' to see if strict MTLS is enforced globally.
+func (dc *DestinationRuleChecker) DoesNamespaceUseMTLSToService(srcNamespace, dstNamespace string, ts TargetService) (bool, *resource.Entry) {
+	var matchingDestination *destination
+	// First, check for a destination rule for src namespace only if the
+	// namespace isn't the root namespace. Pilot has this behavior to ensure that the
+	// rules in the root namespace don't override other rules.
+	if srcNamespace != dc.rootNamespace {
+		matchingDestination = dc.findMatchingRuleInNamespace(srcNamespace, ts, true)
+		if matchingDestination != nil {
+			return matchingDestination.usesMTLS, matchingDestination.resource
+		}
+	}
+
+	// Now check destination namespace
+	matchingDestination = dc.findMatchingRuleInNamespace(dstNamespace, ts, false)
+	if matchingDestination != nil {
+		return matchingDestination.usesMTLS, matchingDestination.resource
+	}
+
+	// Finally, try the root namespace
+	matchingDestination = dc.findMatchingRuleInNamespace(dc.rootNamespace, ts, false)
+	if matchingDestination != nil {
+		return matchingDestination.usesMTLS, matchingDestination.resource
+	}
+
+	// no matches found - just return false
+	return false, nil
+}
+
+// findMatchingRuleInNamespace looks up a DestinationRule in a namespace for a
+// specified target service, optionally including privately-exported rules. Note
+// that if target service has a wildcard in it, then matched rules must be a
+// strict superset of the target service hostnames.
+func (dc *DestinationRuleChecker) findMatchingRuleInNamespace(namespace string, ts TargetService, includePrivate bool) *destination {
+	// TODO Port name should be handled at some point.
+	// TODO We should really presort these ahead of time.
+	var ds destinations
+	for _, d := range dc.namespaceToDestinations[namespace] {
+		if !includePrivate && d.isPrivate {
+			continue
+		}
+		ds = append(ds, d)
+	}
+	// Sort our destinations, which allows us to find the first match by iterating.
+	sort.Sort(ds)
+
+	for _, d := range ds {
+		if !host.Name(ts.FQDN()).SubsetOf(host.Name(d.targetService.FQDN())) {
+			continue
+		}
+
+		// If a port is specified for ts, then skip if destination also has a
+		// port number and it doesn't match.
+		if ts.PortNumber() != 0 && d.targetService.PortNumber() != 0 && ts.PortNumber() != d.targetService.PortNumber() {
+			continue
+		}
+		// If target service doesn't specify a port, then skip if destination
+		// does specify a port.
+		if ts.PortNumber() == 0 && d.targetService.PortNumber() != 0 {
+			continue
+		}
+		return &d
+	}
+
+	// No match
+	return nil
+}

--- a/galley/pkg/config/analysis/analyzers/auth/mtls/destination_rule_checker.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls/destination_rule_checker.go
@@ -141,7 +141,7 @@ func (dc *DestinationRuleChecker) AddDestinationRule(resource *resource.Entry, r
 
 // DoesNamespaceUseMTLSToService returns true if, according to DestinationRules
 // added to the checker, mTLS will be used when communicating to the specified
-// TargetService from the source namespace to the destinaton namespace.
+// TargetService from the source namespace to the destination namespace.
 //
 // If the TargetService's FQDN has a wildcard, then the set of DestinationRules
 // considered for routing are only rules that match a superset of the hosts

--- a/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker.go
@@ -271,7 +271,7 @@ func parsePolicyMTLSMode(p *v1alpha1.Policy) (Mode, error) {
 				mode = ModeStrict
 			default:
 				// Shouldn't happen!
-				return mode, fmt.Errorf("Unknown MTLS mode when analyzing policy: %s", mtlsParams.Mtls.GetMode().String())
+				return mode, fmt.Errorf("unknown MTLS mode when analyzing policy: %s", mtlsParams.Mtls.GetMode().String())
 			}
 		}
 		// Now check for modifiers that might downgrade strict to permissive.

--- a/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker.go
@@ -17,31 +17,24 @@ package mtls
 import (
 	"fmt"
 
+	"istio.io/api/authentication/v1alpha1"
+
+	"istio.io/istio/galley/pkg/config/resource"
+
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
-	"istio.io/istio/security/proto/authentication/v1alpha1"
 )
 
 // TargetService is a simple struct type for representing a service
 // targeted by an Authentication policy.
 type TargetService struct {
-	fQDN string
-
-	// Either portNumber/portName will be set, or neither. The constructors
-	// prevent both from ever being set.
+	fQDN       string
 	portNumber uint32
-	portName   string
 }
 
 // NewTargetServiceWithPortNumber creates a new TargetService using the specified
 // fqdn and portNumber.
 func NewTargetServiceWithPortNumber(fqdn string, portNumber uint32) TargetService {
 	return TargetService{fQDN: fqdn, portNumber: portNumber}
-}
-
-// NewTargetServiceWithPortName creates a new TargetService using the specified fqdn
-// and portName.
-func NewTargetServiceWithPortName(fqdn, portName string) TargetService {
-	return TargetService{fQDN: fqdn, portName: portName}
 }
 
 // NewTargetService creates a new TargetService using the specified fqdn. Because no
@@ -56,16 +49,16 @@ func (w TargetService) FQDN() string {
 	return w.fQDN
 }
 
-// PortNumber is the port used by the service. If set (non-zero), then
-// PortName must be the default value ("").
+// PortNumber is the port used by the service.
 func (w TargetService) PortNumber() uint32 {
 	return w.portNumber
 }
 
-// PortName is the name of the port used by the service. If set (not ""),
-// then PortNumber must be the default value (0).
-func (w TargetService) PortName() string {
-	return w.portName
+func (w TargetService) String() string {
+	if w.PortNumber() != 0 {
+		return fmt.Sprintf("%s:%d", w.fQDN, w.portNumber)
+	}
+	return w.FQDN()
 }
 
 // PolicyChecker allows callers to add a set of v1alpha1.Policy objects in the
@@ -73,52 +66,98 @@ func (w TargetService) PortName() string {
 // TargetService will require MTLS when an incoming connection occurs using the
 // IsServiceMTLSEnforced() call.
 type PolicyChecker struct {
-	// meshHasStrictMTLSPolicy tracks whether or not mTLS is strictly enforced on the mesh.
-	meshHasStrictMTLSPolicy bool
+	meshMTLSModeAndResource ModeAndResource
 
-	namespaceToMTLSMode map[string]strictMTLSMode
-	serviceToMTLSMode   map[TargetService]strictMTLSMode
+	namespaceToMTLSMode        map[string]ModeAndResource
+	serviceToMTLSMode          map[TargetService]ModeAndResource
+	fqdnToPortNameToPortNumber map[string]map[string]uint32
 }
 
-// strictMTLSMode is a helper type used to represent whether or not MTLS was
-// explicitly enabled, explicitly disabled, or just not present. Useful for the
-// IsServiceMTLSEnforced check to determine which policy applies.
-type strictMTLSMode int
+// Mode is a special type used to distinguish between MTLS being off
+// (unsupported), permissive (supported but not required), and strict (required).
+type Mode int
 
 const (
-	strictMTLSUnset strictMTLSMode = iota
-	strictMTLSExplicitlyEnabled
-	strictMTLSExplicitlyDisabled
+	// ModePlaintext means MTLS is off (unsupported).
+	ModePlaintext Mode = iota
+	// ModePermissive means MTLS is permissive (supported but not required)
+	ModePermissive
+	// ModeStrict means MTLS is strict (required)
+	ModeStrict
 )
 
+func (m Mode) String() string {
+	switch m {
+	case ModePlaintext:
+		return "Plaintext"
+	case ModePermissive:
+		return "Permissive"
+	case ModeStrict:
+		return "Strict"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ModeAndResource is a simple tuple type of mode and the resource that
+// specified the mode.
+type ModeAndResource struct {
+	MTLSMode Mode
+	Resource *resource.Entry
+}
+
 // NewPolicyChecker creates a new PolicyChecker instance.
-func NewPolicyChecker() *PolicyChecker {
+func NewPolicyChecker(fqdnToPortNameToPortNumber map[string]map[string]uint32) *PolicyChecker {
 	return &PolicyChecker{
-		namespaceToMTLSMode: make(map[string]strictMTLSMode),
-		serviceToMTLSMode:   make(map[TargetService]strictMTLSMode),
+		namespaceToMTLSMode:        make(map[string]ModeAndResource),
+		serviceToMTLSMode:          make(map[TargetService]ModeAndResource),
+		fqdnToPortNameToPortNumber: fqdnToPortNameToPortNumber,
 	}
 }
 
 // AddMeshPolicy adds a mesh-level policy to the checker. Note that there can
 // only be at most one mesh level policy in effect.
-func (pc *PolicyChecker) AddMeshPolicy(p *v1alpha1.Policy) {
-	pc.meshHasStrictMTLSPolicy = doesPolicyEnforceMTLS(p)
+func (pc *PolicyChecker) AddMeshPolicy(r *resource.Entry, p *v1alpha1.Policy) error {
+	mode, err := parsePolicyMTLSMode(p)
+	if err != nil {
+		return err
+	}
+	pc.meshMTLSModeAndResource = ModeAndResource{Resource: r, MTLSMode: mode}
+	return nil
+}
+
+// MeshPolicy returns the current recognized MeshPolicy (as added by AddMeshPolicy).
+func (pc *PolicyChecker) MeshPolicy() ModeAndResource {
+	return pc.meshMTLSModeAndResource
+}
+
+type NamedPortInPolicyNotFoundError struct {
+	PortName     string
+	PolicyOrigin string
+	FQDN         string
+}
+
+func (e NamedPortInPolicyNotFoundError) Error() string {
+	return fmt.Sprintf("named port '%s' not found for fqdn '%s', unable to analyze policy '%s'", e.PortName, e.FQDN, e.PolicyOrigin)
 }
 
 // AddPolicy adds a new policy object to the PolicyChecker to use when later
 // determining if a service is MTLS-enforced. The namespace of the policy is
 // also provided as some policies can target the local namespace.
-func (pc *PolicyChecker) AddPolicy(namespace string, p *v1alpha1.Policy) error {
-	var policyMode strictMTLSMode
-	if doesPolicyEnforceMTLS(p) {
-		policyMode = strictMTLSExplicitlyEnabled
-	} else {
-		policyMode = strictMTLSExplicitlyDisabled
+//
+// If the Policy uses a named port, and the port cannot be looked up in the map
+// provided to NewPolicyChecker, then an error of type
+// NamedPortInPolicyNotFoundError is returned.
+func (pc *PolicyChecker) AddPolicy(r *resource.Entry, p *v1alpha1.Policy) error {
+	mode, err := parsePolicyMTLSMode(p)
+	if err != nil {
+		return err
 	}
-
+	modeAndResource := ModeAndResource{Resource: r, MTLSMode: mode}
+	namespace, _ := r.Metadata.Name.InterpretAsNamespaceAndName()
 	if len(p.Targets) == 0 {
 		// Rule targets the namespace.
-		pc.namespaceToMTLSMode[namespace] = policyMode
+		pc.namespaceToMTLSMode[namespace] = modeAndResource
 		return nil
 	}
 	// Discover the targeted service and take note. Should normalize.
@@ -127,14 +166,33 @@ func (pc *PolicyChecker) AddPolicy(namespace string, p *v1alpha1.Policy) error {
 
 		if len(target.Ports) == 0 {
 			// Policy targets all ports on service
-			pc.serviceToMTLSMode[NewTargetService(fqdn)] = policyMode
+			pc.serviceToMTLSMode[NewTargetService(fqdn)] = modeAndResource
 		}
 
 		for _, port := range target.Ports {
 			if port.GetName() != "" {
-				pc.serviceToMTLSMode[NewTargetServiceWithPortName(fqdn, port.GetName())] = policyMode
+				// Look up the port number for the name. If we can't find it, we
+				// need to complain about a different error
+				// TODO handle missing reference error.
+				if _, ok := pc.fqdnToPortNameToPortNumber[fqdn]; !ok {
+					return NamedPortInPolicyNotFoundError{
+						PortName:     port.GetName(),
+						PolicyOrigin: r.Origin.FriendlyName(),
+						FQDN:         fqdn,
+					}
+				}
+				portNumber := pc.fqdnToPortNameToPortNumber[fqdn][port.GetName()]
+				if portNumber == 0 {
+					return NamedPortInPolicyNotFoundError{
+						PortName:     port.GetName(),
+						PolicyOrigin: r.Origin.FriendlyName(),
+						FQDN:         fqdn,
+					}
+				}
+
+				pc.serviceToMTLSMode[NewTargetServiceWithPortNumber(fqdn, portNumber)] = modeAndResource
 			} else if port.GetNumber() != 0 {
-				pc.serviceToMTLSMode[NewTargetServiceWithPortNumber(fqdn, port.GetNumber())] = policyMode
+				pc.serviceToMTLSMode[NewTargetServiceWithPortNumber(fqdn, port.GetNumber())] = modeAndResource
 			} else {
 				// Unhandled case!
 				return fmt.Errorf("policy has a port with no name/number for target %s", target.Name)
@@ -149,59 +207,52 @@ func (pc *PolicyChecker) AddPolicy(namespace string, p *v1alpha1.Policy) error {
 // connections to use MTLS, or false if MTLS is not a hard-requirement (e.g.
 // mode is permissive, peerIsOptional is true, etc). Only call this after adding
 // all policy resources in effect via AddPolicy or AddMeshPolicy.
-func (pc *PolicyChecker) IsServiceMTLSEnforced(w TargetService) (bool, error) {
+func (pc *PolicyChecker) IsServiceMTLSEnforced(w TargetService) (ModeAndResource, error) {
 	// TODO support understanding port name -> port number mappings
-	switch pc.serviceToMTLSMode[w] {
-	case strictMTLSExplicitlyEnabled:
-		return true, nil
-	case strictMTLSExplicitlyDisabled:
-		return false, nil
-	case strictMTLSUnset:
-		// Fall through switch case
-	default:
-		return false, fmt.Errorf("unknown strictMTLSMode: %v", pc.serviceToMTLSMode[w])
+	var modeAndResource ModeAndResource
+	modeAndResource = pc.serviceToMTLSMode[w]
+	if modeAndResource.Resource != nil {
+		return modeAndResource, nil
 	}
 
 	// Try checking if its enforced on any ports
 	serviceNoPort := NewTargetService(w.FQDN())
-	switch pc.serviceToMTLSMode[serviceNoPort] {
-	case strictMTLSExplicitlyEnabled:
-		return true, nil
-	case strictMTLSExplicitlyDisabled:
-		return false, nil
-	case strictMTLSUnset:
-		// Fall through switch case
-	default:
-		return false, fmt.Errorf("unknown strictMTLSMode: %v", pc.serviceToMTLSMode[serviceNoPort])
+	modeAndResource = pc.serviceToMTLSMode[serviceNoPort]
+	if modeAndResource.Resource != nil {
+		return modeAndResource, nil
 	}
 
 	// Check if enforced on namespace
 	namespace, _ := util.GetResourceNameFromHost("", w.FQDN()).InterpretAsNamespaceAndName()
 	if namespace == "" {
-		return false, fmt.Errorf("unable to extract namespace from fqdn: %s", w.FQDN())
+		return ModeAndResource{}, fmt.Errorf("unable to extract namespace from fqdn: %s", w.FQDN())
 	}
-	switch pc.namespaceToMTLSMode[namespace] {
-	case strictMTLSExplicitlyEnabled:
-		return true, nil
-	case strictMTLSExplicitlyDisabled:
-		return false, nil
-	case strictMTLSUnset:
-		// Fall through switch case
-	default:
-		return false, fmt.Errorf("unknown strictMTLSMode: %v", pc.namespaceToMTLSMode[namespace])
+	modeAndResource = pc.namespaceToMTLSMode[namespace]
+	if modeAndResource.Resource != nil {
+		return modeAndResource, nil
 	}
 
-	// Finally, defer to mesh level policy
-	return pc.meshHasStrictMTLSPolicy, nil
+	// Finally, defer to mesh level policy. No need to check for a nil resource
+	// since the default value is correct.
+	return pc.meshMTLSModeAndResource, nil
 }
 
-// doesPolicyEnforceMTLS is a helper function to determine whether or not a
-// Policy implies Strict MTLS mode.
-func doesPolicyEnforceMTLS(p *v1alpha1.Policy) bool {
-	if p.PeerIsOptional {
-		// Connection can still occur.
-		return false
+// TargetServices returns the list of services known to the policy checker (in
+// no particular order).
+func (pc *PolicyChecker) TargetServices() []TargetService {
+	tss := make([]TargetService, len(pc.serviceToMTLSMode))
+	i := 0
+	for ts := range pc.serviceToMTLSMode {
+		tss[i] = ts
+		i++
 	}
+
+	return tss
+}
+
+// parsePolicyMTLSMode is a helper function to determine what mtls mode a Policy
+// implies.
+func parsePolicyMTLSMode(p *v1alpha1.Policy) (Mode, error) {
 	for _, peer := range p.Peers {
 		mtlsParams, ok := peer.Params.(*v1alpha1.PeerAuthenticationMethod_Mtls)
 		if !ok {
@@ -209,12 +260,30 @@ func doesPolicyEnforceMTLS(p *v1alpha1.Policy) bool {
 			continue
 		}
 
-		// The default value if no Mtls is specified on mtlsParams is strict.
-		// If we do have parameters, though, ensure they do not imply permissive mode.
-		return mtlsParams.Mtls == nil ||
-			(!mtlsParams.Mtls.AllowTls && mtlsParams.Mtls.Mode != v1alpha1.MutualTls_PERMISSIVE)
+		var mode Mode
+		if mtlsParams.Mtls == nil {
+			mode = ModeStrict
+		} else {
+			switch mtlsParams.Mtls.GetMode() {
+			case v1alpha1.MutualTls_PERMISSIVE:
+				mode = ModePermissive
+			case v1alpha1.MutualTls_STRICT:
+				mode = ModeStrict
+			default:
+				// Shouldn't happen!
+				return mode, fmt.Errorf("Unknown MTLS mode when analyzing policy: %s", mtlsParams.Mtls.GetMode().String())
+			}
+		}
+		// Now check for modifiers that might downgrade strict to permissive.
+		if mode == ModeStrict && mtlsParams.Mtls != nil && mtlsParams.Mtls.AllowTls {
+			mode = ModePermissive
+		}
+		if mode == ModeStrict && p.PeerIsOptional {
+			mode = ModePermissive
+		}
+		return mode, nil
 	}
 
 	// No MTLS configuration found
-	return false
+	return ModePlaintext, nil
 }

--- a/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker.go
@@ -1,0 +1,220 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtls
+
+import (
+	"fmt"
+
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/security/proto/authentication/v1alpha1"
+)
+
+// TargetService is a simple struct type for representing a service
+// targeted by an Authentication policy.
+type TargetService struct {
+	fQDN string
+
+	// Either portNumber/portName will be set, or neither. The constructors
+	// prevent both from ever being set.
+	portNumber uint32
+	portName   string
+}
+
+// NewTargetServiceWithPortNumber creates a new TargetService using the specified
+// fqdn and portNumber.
+func NewTargetServiceWithPortNumber(fqdn string, portNumber uint32) TargetService {
+	return TargetService{fQDN: fqdn, portNumber: portNumber}
+}
+
+// NewTargetServiceWithPortName creates a new TargetService using the specified fqdn
+// and portName.
+func NewTargetServiceWithPortName(fqdn, portName string) TargetService {
+	return TargetService{fQDN: fqdn, portName: portName}
+}
+
+// NewTargetService creates a new TargetService using the specified fqdn. Because no
+// port is specified, this implicitly represents the service bound to any port.
+func NewTargetService(fqdn string) TargetService {
+	return TargetService{fQDN: fqdn}
+}
+
+// FQDN is the fully-qualified domain name for the service (e.g.
+// foobar.my-namespace.svc.cluster.local).
+func (w TargetService) FQDN() string {
+	return w.fQDN
+}
+
+// PortNumber is the port used by the service. If set (non-zero), then
+// PortName must be the default value ("").
+func (w TargetService) PortNumber() uint32 {
+	return w.portNumber
+}
+
+// PortName is the name of the port used by the service. If set (not ""),
+// then PortNumber must be the default value (0).
+func (w TargetService) PortName() string {
+	return w.portName
+}
+
+// PolicyChecker allows callers to add a set of v1alpha1.Policy objects in the
+// mesh. Once these are loaded, you can query whether or not a specific
+// TargetService will require MTLS when an incoming connection occurs using the
+// IsServiceMTLSEnforced() call.
+type PolicyChecker struct {
+	// meshHasStrictMTLSPolicy tracks whether or not mTLS is strictly enforced on the mesh.
+	meshHasStrictMTLSPolicy bool
+
+	namespaceToMTLSMode map[string]strictMTLSMode
+	serviceToMTLSMode   map[TargetService]strictMTLSMode
+}
+
+// strictMTLSMode is a helper type used to represent whether or not MTLS was
+// explicitly enabled, explicitly disabled, or just not present. Useful for the
+// IsServiceMTLSEnforced check to determine which policy applies.
+type strictMTLSMode int
+
+const (
+	strictMTLSUnset strictMTLSMode = iota
+	strictMTLSExplicitlyEnabled
+	strictMTLSExplicitlyDisabled
+)
+
+// NewPolicyChecker creates a new PolicyChecker instance.
+func NewPolicyChecker() *PolicyChecker {
+	return &PolicyChecker{
+		namespaceToMTLSMode: make(map[string]strictMTLSMode),
+		serviceToMTLSMode:   make(map[TargetService]strictMTLSMode),
+	}
+}
+
+// AddMeshPolicy adds a mesh-level policy to the checker. Note that there can
+// only be at most one mesh level policy in effect.
+func (pc *PolicyChecker) AddMeshPolicy(p *v1alpha1.Policy) {
+	pc.meshHasStrictMTLSPolicy = doesPolicyEnforceMTLS(p)
+}
+
+// AddPolicy adds a new policy object to the PolicyChecker to use when later
+// determining if a service is MTLS-enforced. The namespace of the policy is
+// also provided as some policies can target the local namespace.
+func (pc *PolicyChecker) AddPolicy(namespace string, p *v1alpha1.Policy) error {
+	var policyMode strictMTLSMode
+	if doesPolicyEnforceMTLS(p) {
+		policyMode = strictMTLSExplicitlyEnabled
+	} else {
+		policyMode = strictMTLSExplicitlyDisabled
+	}
+
+	if len(p.Targets) == 0 {
+		// Rule targets the namespace.
+		pc.namespaceToMTLSMode[namespace] = policyMode
+		return nil
+	}
+	// Discover the targeted service and take note. Should normalize.
+	for _, target := range p.Targets {
+		fqdn := util.ConvertHostToFQDN(namespace, target.Name)
+
+		if len(target.Ports) == 0 {
+			// Policy targets all ports on service
+			pc.serviceToMTLSMode[NewTargetService(fqdn)] = policyMode
+		}
+
+		for _, port := range target.Ports {
+			if port.GetName() != "" {
+				pc.serviceToMTLSMode[NewTargetServiceWithPortName(fqdn, port.GetName())] = policyMode
+			} else if port.GetNumber() != 0 {
+				pc.serviceToMTLSMode[NewTargetServiceWithPortNumber(fqdn, port.GetNumber())] = policyMode
+			} else {
+				// Unhandled case!
+				return fmt.Errorf("policy has a port with no name/number for target %s", target.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// IsServiceMTLSEnforced returns true if a service requires incoming
+// connections to use MTLS, or false if MTLS is not a hard-requirement (e.g.
+// mode is permissive, peerIsOptional is true, etc). Only call this after adding
+// all policy resources in effect via AddPolicy or AddMeshPolicy.
+func (pc *PolicyChecker) IsServiceMTLSEnforced(w TargetService) (bool, error) {
+	// TODO support understanding port name -> port number mappings
+	switch pc.serviceToMTLSMode[w] {
+	case strictMTLSExplicitlyEnabled:
+		return true, nil
+	case strictMTLSExplicitlyDisabled:
+		return false, nil
+	case strictMTLSUnset:
+		// Fall through switch case
+	default:
+		return false, fmt.Errorf("unknown strictMTLSMode: %v", pc.serviceToMTLSMode[w])
+	}
+
+	// Try checking if its enforced on any ports
+	serviceNoPort := NewTargetService(w.FQDN())
+	switch pc.serviceToMTLSMode[serviceNoPort] {
+	case strictMTLSExplicitlyEnabled:
+		return true, nil
+	case strictMTLSExplicitlyDisabled:
+		return false, nil
+	case strictMTLSUnset:
+		// Fall through switch case
+	default:
+		return false, fmt.Errorf("unknown strictMTLSMode: %v", pc.serviceToMTLSMode[serviceNoPort])
+	}
+
+	// Check if enforced on namespace
+	namespace, _ := util.GetResourceNameFromHost("", w.FQDN()).InterpretAsNamespaceAndName()
+	if namespace == "" {
+		return false, fmt.Errorf("unable to extract namespace from fqdn: %s", w.FQDN())
+	}
+	switch pc.namespaceToMTLSMode[namespace] {
+	case strictMTLSExplicitlyEnabled:
+		return true, nil
+	case strictMTLSExplicitlyDisabled:
+		return false, nil
+	case strictMTLSUnset:
+		// Fall through switch case
+	default:
+		return false, fmt.Errorf("unknown strictMTLSMode: %v", pc.namespaceToMTLSMode[namespace])
+	}
+
+	// Finally, defer to mesh level policy
+	return pc.meshHasStrictMTLSPolicy, nil
+}
+
+// doesPolicyEnforceMTLS is a helper function to determine whether or not a
+// Policy implies Strict MTLS mode.
+func doesPolicyEnforceMTLS(p *v1alpha1.Policy) bool {
+	if p.PeerIsOptional {
+		// Connection can still occur.
+		return false
+	}
+	for _, peer := range p.Peers {
+		mtlsParams, ok := peer.Params.(*v1alpha1.PeerAuthenticationMethod_Mtls)
+		if !ok {
+			// Only looking for mtls methods
+			continue
+		}
+
+		// The default value if no Mtls is specified on mtlsParams is strict.
+		// If we do have parameters, though, ensure they do not imply permissive mode.
+		return mtlsParams.Mtls == nil ||
+			(!mtlsParams.Mtls.AllowTls && mtlsParams.Mtls.Mode != v1alpha1.MutualTls_PERMISSIVE)
+	}
+
+	// No MTLS configuration found
+	return false
+}

--- a/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker_test.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker_test.go
@@ -1,0 +1,392 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtls
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ghodss/yaml"
+
+	"github.com/golang/protobuf/jsonpb"
+
+	"istio.io/istio/security/proto/authentication/v1alpha1"
+)
+
+func TestMTLSPolicyChecker_singleResource(t *testing.T) {
+	type PolicyResource struct {
+		namespace string
+		policy    string
+	}
+
+	tests := map[string]struct {
+		meshPolicy string
+		policy     PolicyResource
+		service    TargetService
+		want       bool
+	}{
+		"no policies means no strict mtls": {
+			// Note no policies specified
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+		"service specific policy": {
+			policy: PolicyResource{
+				namespace: "my-namespace",
+				policy: `
+targets:
+- name: foobar
+  ports:
+  - number: 8080
+peers:
+- mtls:
+`,
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    true,
+		},
+		"service specific policy uses only the first mtls configuration found": {
+			policy: PolicyResource{
+				namespace: "my-namespace",
+				policy: `
+targets:
+- name: foobar
+  ports:
+  - number: 8080
+peers:
+# Oops, we specified mtls twice!
+- mtls:
+    mode: PERMISSIVE
+- mtls:
+`,
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+		"service specific policy using port name": {
+			policy: PolicyResource{
+
+				namespace: "my-namespace",
+				policy: `
+targets:
+- name: foobar
+  ports:
+  - name: https
+peers:
+- mtls:
+`,
+			},
+			service: NewTargetServiceWithPortName("foobar.my-namespace.svc.cluster.local", "https"),
+			want:    true,
+		},
+		"non-matching host service specific policy": {
+			policy: PolicyResource{
+
+				namespace: "my-namespace",
+				policy: `
+targets:
+- name: baz
+  ports:
+  - number: 8080
+peers:
+- mtls:
+`,
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+		"non-matching namespace service specific policy": {
+			policy: PolicyResource{
+				namespace: "my-other-namespace",
+				policy: `
+targets:
+- name: foobar
+  ports:
+  - number: 8080
+peers:
+- mtls:
+`,
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+		"policy matches service but is not strict": {
+			policy: PolicyResource{
+
+				namespace: "my-namespace",
+				policy: `
+targets:
+- name: foobar
+  ports:
+  - number: 8080
+peers:
+- mtls:
+    mode: PERMISSIVE
+`,
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+		"policy matches service but uses deprecated field": {
+			policy: PolicyResource{
+
+				namespace: "my-namespace",
+				policy: `
+targets:
+- name: foobar
+  ports:
+  - number: 8080
+peers:
+- mtls:
+    allowTls: true
+    mode: STRICT
+`,
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+		"policy matches service but peer is optional": {
+			policy: PolicyResource{
+
+				namespace: "my-namespace",
+				policy: `
+targets:
+- name: foobar
+  ports:
+  - number: 8080
+peers:
+- mtls:
+    mode: STRICT
+peerIsOptional: true
+`,
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+		"policy matches service but does not use mtls": {
+			policy: PolicyResource{
+
+				namespace: "my-namespace",
+				policy: `
+targets:
+- name: foobar
+  ports:
+  - number: 8080
+peers:
+- jwt: # undocumented setting?
+`,
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+		"policy matches every port on service": {
+			policy: PolicyResource{
+
+				namespace: "my-namespace",
+				policy: `
+targets:
+- name: foobar
+peers:
+- mtls:
+`,
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    true,
+		},
+		"policy matches every service in namespace": {
+			policy: PolicyResource{
+				namespace: "my-namespace",
+				policy: `
+peers:
+- mtls:
+`,
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    true,
+		},
+		"policy matches entire mesh": {
+			meshPolicy: `
+peers:
+- mtls:
+`,
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pc := NewPolicyChecker()
+
+			if tc.meshPolicy != "" {
+				meshpb, err := yAMLToPolicy(tc.meshPolicy)
+				if err != nil {
+					t.Fatalf("expected: %v, got error when parsing yaml: %v", tc.want, err)
+				}
+				pc.AddMeshPolicy(meshpb)
+			}
+
+			if tc.policy.policy != "" {
+				pb, err := yAMLToPolicy(tc.policy.policy)
+				if err != nil {
+					t.Fatalf("expected: %v, got error when parsing yaml: %v", tc.want, err)
+				}
+				pc.AddPolicy(tc.policy.namespace, pb)
+			}
+
+			got, err := pc.IsServiceMTLSEnforced(tc.service)
+			if err != nil {
+				t.Fatalf("expected: %v, got error: %v", tc.want, err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected: %v, got: %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestMTLSPolicyChecker_multipleResources(t *testing.T) {
+	type PolicyResource struct {
+		namespace string
+		policy    string
+	}
+
+	tests := map[string]struct {
+		meshPolicy string
+		policies   []PolicyResource
+		service    TargetService
+		want       bool
+	}{
+		"namespace policy overrides mesh policy": {
+			meshPolicy: `
+peers:
+- mtls:
+`,
+			policies: []PolicyResource{
+				{
+					namespace: "my-namespace",
+					policy: `
+targets:
+- name: foobar
+  ports:
+  - number: 8080
+peers:
+- mtls:
+    mode: PERMISSIVE
+`,
+				},
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+		"service policy overrides namespace policy": {
+			policies: []PolicyResource{
+				{
+					namespace: "my-namespace",
+					policy: `
+peers:
+- mtls:
+    mode: STRICT
+`,
+				},
+				{
+					namespace: "my-namespace",
+					policy: `
+targets:
+- name: foobar
+  ports:
+  - number: 8080
+peers:
+- mtls:
+    mode: PERMISSIVE
+`,
+				},
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+		"port-specific policy overrides service-level policy": {
+			policies: []PolicyResource{
+				{
+					namespace: "my-namespace",
+					policy: `
+targets:
+- name: foobar
+peers:
+- mtls:
+    mode: STRICT
+`,
+				},
+				{
+					namespace: "my-namespace",
+					policy: `
+targets:
+- name: foobar
+  ports:
+  - number: 8080
+peers:
+- mtls:
+    mode: PERMISSIVE
+`,
+				},
+			},
+			service: NewTargetServiceWithPortNumber("foobar.my-namespace.svc.cluster.local", 8080),
+			want:    false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pc := NewPolicyChecker()
+			// Add mesh policy, if it exists.
+			meshpb, err := yAMLToPolicy(tc.meshPolicy)
+			if err != nil {
+				t.Fatalf("expected: %v, got error when parsing yaml: %v", tc.want, err)
+			}
+			pc.AddMeshPolicy(meshpb)
+
+			// Add in all other policies
+			for _, p := range tc.policies {
+				pb, err := yAMLToPolicy(p.policy)
+				if err != nil {
+					t.Fatalf("expected: %v, got error when parsing yaml: %v", tc.want, err)
+				}
+				pc.AddPolicy(p.namespace, pb)
+			}
+
+			got, err := pc.IsServiceMTLSEnforced(tc.service)
+			if err != nil {
+				t.Fatalf("expected: %v, got error: %v", tc.want, err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected: %v, got: %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func yAMLToPolicy(yml string) (*v1alpha1.Policy, error) {
+	js, err := yaml.YAMLToJSON([]byte(yml))
+	if err != nil {
+		return nil, err
+	}
+	var pb v1alpha1.Policy
+	err = jsonpb.Unmarshal(bytes.NewReader(js), &pb)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb, nil
+}

--- a/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker_test.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker_test.go
@@ -87,7 +87,7 @@ peers:
 		},
 		"service specific policy using port name": {
 			portNameMappings: []PortNameMapping{
-				PortNameMapping{
+				{
 					fqdn:   "foobar.my-namespace.svc.cluster.local",
 					name:   "https",
 					number: 8080,

--- a/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker_test.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls/policy_checker_test.go
@@ -243,7 +243,10 @@ peers:
 				if err != nil {
 					t.Fatalf("expected: %v, got error when parsing yaml: %v", tc.want, err)
 				}
-				pc.AddPolicy(tc.policy.namespace, pb)
+				err = pc.AddPolicy(tc.policy.namespace, pb)
+				if err != nil {
+					t.Fatalf("expected: %v, got error when adding policy: %v", tc.want, err)
+				}
 			}
 
 			got, err := pc.IsServiceMTLSEnforced(tc.service)
@@ -363,7 +366,10 @@ peers:
 				if err != nil {
 					t.Fatalf("expected: %v, got error when parsing yaml: %v", tc.want, err)
 				}
-				pc.AddPolicy(p.namespace, pb)
+				err = pc.AddPolicy(p.namespace, pb)
+				if err != nil {
+					t.Fatalf("expected: %v, got error when adding policy: %v", tc.want, err)
+				}
 			}
 
 			got, err := pc.IsServiceMTLSEnforced(tc.service)

--- a/galley/pkg/config/analysis/analyzers/testdata/mtls-exports.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/mtls-exports.yaml
@@ -1,0 +1,109 @@
+# We have two namespaces. A service in primary has MTLS specified and a DR, but
+# its not exported. This should cause traffic from secondary to fail.
+# Note that we also have a service in secondary with an identical DR, but its
+# exported publicly so no problems occur.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: primary
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: secondary
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myservice
+  namespace: primary
+spec:
+  selector:
+    app: myservice
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myservice-pod
+  namespace: primary
+  labels:
+    app: myservice
+spec:
+  containers:
+  - name: istio-proxy
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: default
+  namespace: primary
+spec:
+  targets:
+  - name: myservice
+  peers:
+  - mtls:
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: default
+  namespace: primary
+spec:
+  host: myservice.primary.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  exportTo:
+  - "."
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myotherservice
+  namespace: secondary
+spec:
+  selector:
+    app: myotherservice
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myotherservice-pod
+  namespace: secondary
+  labels:
+    app: myotherservice
+spec:
+  containers:
+  - name: istio-proxy
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: default
+  namespace: secondary
+spec:
+  targets:
+  - name: myotherservice
+  peers:
+  - mtls:
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: default
+  namespace: secondary
+spec:
+  host: myotherservice.secondary.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  exportTo:
+  - "*"

--- a/galley/pkg/config/analysis/analyzers/testdata/mtls-global-dr-no-meshpolicy.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/mtls-global-dr-no-meshpolicy.yaml
@@ -1,0 +1,12 @@
+# A rule for all traffic specifies MTLS, but we don't have a global mesh policy.
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---

--- a/galley/pkg/config/analysis/analyzers/testdata/mtls-ignores-istio-system.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/mtls-ignores-istio-system.yaml
@@ -1,0 +1,64 @@
+# Within the istio-system namespace, we have a control plane component with a DR
+# that would normally violate policy. However the istio-system namespace is
+# not controlled via Policy declarations, and is therefore exempt. We don't
+# expect the validator to complain about this either.
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: default
+spec:
+  peers:
+  - mtls:
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-telemetry
+  namespace: istio-system
+spec:
+  selector:
+    app: istio-telemetry
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: istio-telemetry-pod
+  namespace: istio-system
+  labels:
+    app: istio-telemetry
+spec:
+  containers:
+  - name: istio-proxy
+---
+# This destination rule would normally break mtls, but it doesn't in practice
+# due to the control plane having its own setup.
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: istio-policy
+  namespace: istio-system
+spec:
+  host: istio-policy.istio-system.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      http:
+        http2MaxRequests: 10000
+        maxRequestsPerConnection: 10000

--- a/galley/pkg/config/analysis/analyzers/testdata/mtls-meshpolicy-permissive.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/mtls-meshpolicy-permissive.yaml
@@ -1,0 +1,10 @@
+# A global mesh policy with no DRs should not cause an error when in permissive mode.
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: default
+spec:
+  peers:
+  - mtls:
+      mode: PERMISSIVE
+---

--- a/galley/pkg/config/analysis/analyzers/testdata/mtls-meshpolicy.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/mtls-meshpolicy.yaml
@@ -1,0 +1,10 @@
+# A global mesh policy with no DRs should cause an error
+# Require mTLS for our service
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: default
+spec:
+  peers:
+  - mtls:
+---

--- a/galley/pkg/config/analysis/analyzers/testdata/mtls-no-dr.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/mtls-no-dr.yaml
@@ -1,0 +1,97 @@
+# A service exists called missing-dr-service
+apiVersion: v1
+kind: Service
+metadata:
+  name: missing-dr-service
+  namespace: missing-dr
+spec:
+  selector:
+    app: missing-dr-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: missing-dr-service-pod
+  namespace: missing-dr
+  labels:
+    app: missing-dr-service
+spec:
+  containers:
+  - name: istio-proxy
+---
+# Require mTLS for our service
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: default
+  namespace: missing-dr
+spec:
+  targets:
+  - name: missing-dr-service
+  peers:
+  - mtls:
+# Without a DR, this will fail.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: has-dr-service
+  namespace: has-dr
+spec:
+  selector:
+    app: has-dr-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: has-dr-service-pod
+  namespace: has-dr
+  labels:
+    app: has-dr-service
+spec:
+  containers:
+  - name: istio-proxy
+---
+# We also specify another mtls for another service, but this one has a DR.
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: default
+  namespace: has-dr
+spec:
+  targets:
+  - name: has-dr-service
+  peers:
+  - mtls:
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: default
+  namespace: has-dr
+spec:
+  host: has-dr-service.has-dr.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+# We also add a DR explicitly in here for missing-dr-service to ensure we only
+# see one error message.
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: missing-dr-service-dr
+  namespace: has-dr
+spec:
+  host: missing-dr-service.missing-dr.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/galley/pkg/config/analysis/analyzers/testdata/mtls-no-policy.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/mtls-no-policy.yaml
@@ -1,0 +1,38 @@
+# We have a DR for our service, but no policy
+# A service exists called missing-dr-service
+apiVersion: v1
+kind: Service
+metadata:
+  name: missing-policy-service
+  namespace: no-policy
+spec:
+  selector:
+    app: missing-policy-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: missing-policy-service-pod
+  namespace: no-policy
+  labels:
+    app: missing-policy-service
+spec:
+  containers:
+  - name: istio-proxy
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: no-policy-service-dr
+  namespace: no-policy
+spec:
+  host: missing-policy-service.no-policy.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+# Nothing else specified. Without a Policy, this will fail.
+---

--- a/galley/pkg/config/analysis/analyzers/testdata/mtls-no-sidecar.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/mtls-no-sidecar.yaml
@@ -1,0 +1,82 @@
+# We have a global mesh policy, and a global DR to use mTLS. We also have a DR
+# to override that for a specific service with no sidecar. This shouldn't cause
+# any errors. 
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: default
+spec:
+  peers:
+  - mtls:
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: missing-sidecar-service
+  namespace: no-sidecar
+spec:
+  selector:
+    app: missing-sidecar-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: missing-sidecar-service-pod
+  namespace: no-sidecar
+  labels:
+    app: missing-sidecar-service
+spec:
+  containers:
+  - name: some-other-container-not-the-proxy
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: no-sidecar-service-dr
+  namespace: istio-system
+spec:
+  host: missing-sidecar-service.no-sidecar.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+# Also handle the case where a service exists with no pods. Assume it has no
+# sidecar.
+apiVersion: v1
+kind: Service
+metadata:
+  name: missing-pod-service
+  namespace: no-sidecar
+spec:
+  selector:
+    app: missing-pod-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: missing-pod-service-dr
+  namespace: istio-system
+spec:
+  host: missing-pod-service.no-sidecar.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/galley/pkg/config/analysis/analyzers/testdata/mtls-with-port.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/mtls-with-port.yaml
@@ -1,0 +1,56 @@
+# Our service has two secure mtls ports, but the DR only specifies one.
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: default
+  namespace: my-namespace
+spec:
+  targets:
+  - name: my-service
+    ports:
+    - number: 8080
+    - number: 8081
+  peers:
+  - mtls:
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: my-namespace
+spec:
+  selector:
+    app: my-service
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-service-pod
+  namespace: my-namespace
+  labels:
+    app: my-service
+spec:
+  containers:
+  - name: istio-proxy
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: default
+  namespace: my-namespace
+spec:
+  host: my-service.my-namespace.svc.cluster.local
+  trafficPolicy:
+    portLevelSettings:
+    - port: 
+        number: 8080
+      tls:
+        mode: ISTIO_MUTUAL
+---

--- a/galley/pkg/config/analysis/analyzers/util/hosts.go
+++ b/galley/pkg/config/analysis/analyzers/util/hosts.go
@@ -30,7 +30,7 @@ func (s ScopedFqdn) GetScopeAndFqdn() (string, string) {
 
 // NewScopedFqdn converts the passed host to FQDN if needed and applies the passed scope.
 func NewScopedFqdn(scope, namespace, host string) ScopedFqdn {
-	fqdn := convertHostToFQDN(namespace, host)
+	fqdn := ConvertHostToFQDN(namespace, host)
 	return ScopedFqdn(scope + "/" + fqdn)
 }
 
@@ -58,7 +58,8 @@ func getNamespaceAndNameFromFQDN(fqdn string) (string, string) {
 	return result[0][2], result[0][1]
 }
 
-func convertHostToFQDN(namespace, host string) string {
+// ConvertHostToFQDN returns the given host as a FQDN, if it isn't already.
+func ConvertHostToFQDN(namespace, host string) string {
 	fqdn := host
 	// Convert to FQDN only if host is not a wildcard or a FQDN
 	if !strings.HasPrefix(host, "*") &&

--- a/galley/pkg/config/analysis/analyzers/util/hosts.go
+++ b/galley/pkg/config/analysis/analyzers/util/hosts.go
@@ -40,7 +40,7 @@ func NewScopedFqdn(scope, namespace, host string) ScopedFqdn {
 func GetResourceNameFromHost(defaultNamespace, host string) resource.Name {
 
 	// First, try to parse as FQDN (which can be cross-namespace)
-	namespace, name := getNamespaceAndNameFromFQDN(host)
+	namespace, name := GetNamespaceAndNameFromFQDN(host)
 
 	//Otherwise, treat this as a short name and use the assumed namespace
 	if namespace == "" {
@@ -50,7 +50,9 @@ func GetResourceNameFromHost(defaultNamespace, host string) resource.Name {
 	return resource.NewName(namespace, name)
 }
 
-func getNamespaceAndNameFromFQDN(fqdn string) (string, string) {
+// GetNamespaceAndNameFromFQDN tries to parse namespace and name from a fqdn.
+// Empty strings are returned if either namespace or name cannot be parsed.
+func GetNamespaceAndNameFromFQDN(fqdn string) (string, string) {
 	result := fqdnPattern.FindAllStringSubmatch(fqdn, -1)
 	if len(result) == 0 {
 		return "", ""

--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -15,6 +15,7 @@
 package diag
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"istio.io/istio/galley/pkg/config/resource"
@@ -74,6 +75,11 @@ func (m *Message) String() string {
 	}
 	return fmt.Sprintf(
 		"%v [%v]%s %s", m.Type.Level(), m.Type.Code(), origin, fmt.Sprintf(m.Type.Template(), m.Parameters...))
+}
+
+// MarshalJSON satisfies the Marshaler interface
+func (m *Message) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.Unstructured(true))
 }
 
 // NewMessageType returns a new MessageType instance.

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -15,6 +15,7 @@
 package diag
 
 import (
+	"encoding/json"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -49,4 +50,14 @@ func TestMessage_Unstructured(t *testing.T) {
 
 	g.Expect(m.Unstructured(true)).To((HaveKey("origin")))
 	g.Expect(m.Unstructured(false)).To(Not(HaveKey("origin")))
+}
+
+func TestMessage_JSON(t *testing.T) {
+	g := NewGomegaWithT(t)
+	o := testOrigin("toppings/cheese")
+	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
+	m := NewMessage(mt, o, "Feta")
+
+	json_bytes, _ := json.Marshal(&m)
+	g.Expect(string(json_bytes)).To(Equal(`{"code":"IST-0042","level":"Error","message":"Cheese type not found: \"Feta\"","origin":"toppings/cheese"}`))
 }

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -21,12 +21,17 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/galley/pkg/config/meshcfg"
 	"istio.io/istio/galley/pkg/config/meta/metadata"
 	"istio.io/istio/galley/pkg/config/meta/schema/collection"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver"
+	"istio.io/istio/galley/pkg/config/source/kube/inmemory"
 	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/k8smeta"
@@ -64,7 +69,7 @@ func TestAbortWithNoSources(t *testing.T) {
 
 	cancel := make(chan struct{})
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", "", nil, false)
 	_, err := sa.Analyze(cancel)
 	g.Expect(err).To(Not(BeNil()))
 }
@@ -74,7 +79,7 @@ func TestAnalyzersRun(t *testing.T) {
 
 	cancel := make(chan struct{})
 
-	r := createTestResource("ns", "resource", "v1")
+	r := createTestResource(t, "ns", "resource", "v1")
 	msg := msg.NewInternalError(r, "msg")
 	a := &testAnalyzer{
 		fn: func(ctx analysis.Context) {
@@ -88,7 +93,7 @@ func TestAnalyzersRun(t *testing.T) {
 		collectionAccessed = col
 	}
 
-	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), "", cr, false)
+	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), "", "", cr, false)
 	err := sa.AddFileKubeSource([]string{})
 	g.Expect(err).To(BeNil())
 
@@ -104,8 +109,8 @@ func TestFilterOutputByNamespace(t *testing.T) {
 
 	cancel := make(chan struct{})
 
-	r1 := createTestResource("ns1", "resource", "v1")
-	r2 := createTestResource("ns2", "resource", "v1")
+	r1 := createTestResource(t, "ns1", "resource", "v1")
+	r2 := createTestResource(t, "ns2", "resource", "v1")
 	msg1 := msg.NewInternalError(r1, "msg")
 	msg2 := msg.NewInternalError(r2, "msg")
 	a := &testAnalyzer{
@@ -115,7 +120,7 @@ func TestFilterOutputByNamespace(t *testing.T) {
 		},
 	}
 
-	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), "ns1", nil, false)
+	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), "ns1", "", nil, false)
 	err := sa.AddFileKubeSource([]string{})
 	g.Expect(err).To(BeNil())
 
@@ -129,49 +134,94 @@ func TestAddRunningKubeSource(t *testing.T) {
 
 	mk := mock.NewKube()
 
-	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", "", nil, false)
 
 	sa.AddRunningKubeSource(mk)
-	g.Expect(sa.sources).To(HaveLen(1))
+	g.Expect(sa.sources).To(HaveLen(2))
+	g.Expect(sa.sources[0].src).To(BeAssignableToTypeOf(&meshcfg.InMemorySource{})) // Base default meshcfg
+	g.Expect(sa.sources[1].src).To(BeAssignableToTypeOf(&apiserver.Source{}))       // All other resources via api server
+}
+
+func TestAddRunningKubeSourceWithMeshCfg(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	istioNamespace := "istio-system"
+
+	cfg := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: meshConfigMapName,
+		},
+		Data: map[string]string{
+			meshConfigMapKey: "",
+		},
+	}
+
+	mk := mock.NewKube()
+	client, err := mk.KubeClient()
+	if err != nil {
+		t.Fatalf("Error getting client for mock kube: %v", err)
+	}
+	if _, err := client.CoreV1().ConfigMaps(istioNamespace).Create(cfg); err != nil {
+		t.Fatalf("Error creating mesh config configmap: %v", err)
+	}
+
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", istioNamespace, nil, false)
+
+	sa.AddRunningKubeSource(mk)
+	g.Expect(sa.sources).To(HaveLen(3))
+	g.Expect(sa.sources[0].src).To(BeAssignableToTypeOf(&meshcfg.InMemorySource{})) // Base default meshcfg
+	g.Expect(sa.sources[1].src).To(BeAssignableToTypeOf(&meshcfg.InMemorySource{})) // in-cluster meshcfg
+	g.Expect(sa.sources[2].src).To(BeAssignableToTypeOf(&apiserver.Source{}))       // All other resources via api server
 }
 
 func TestAddFileKubeSource(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
+	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", "", nil, false)
 
 	tmpfile := tempFileFromString(t, data.YamlN1I1V1)
 	defer func() { _ = os.Remove(tmpfile.Name()) }()
 
 	err := sa.AddFileKubeSource([]string{tmpfile.Name()})
 	g.Expect(err).To(BeNil())
-	g.Expect(sa.sources).To(HaveLen(1))
+	g.Expect(sa.sources).To(HaveLen(2))
+	g.Expect(sa.sources[0].src).To(BeAssignableToTypeOf(&meshcfg.InMemorySource{})) // Base default meshcfg
+	g.Expect(sa.sources[1].src).To(BeAssignableToTypeOf(&inmemory.KubeSource{}))    // All other resources via files
+
+	// Note that a blank file for mesh cfg is equivalent to specifying all the defaults
+	tmpMeshFile := tempFileFromString(t, "")
+	defer func() { _ = os.Remove(tmpMeshFile.Name()) }()
+
+	err = sa.AddFileKubeMeshConfigSource(tmpMeshFile.Name())
+	g.Expect(err).To(BeNil())
+	g.Expect(sa.sources).To(HaveLen(3))
+	g.Expect(sa.sources[2].src).To(BeAssignableToTypeOf(&meshcfg.InMemorySource{})) // meshcfg read from a file
 }
 
 func TestAddFileKubeSourceSkipsBadEntries(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
+	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", "", nil, false)
 
 	tmpfile := tempFileFromString(t, kubeyaml.JoinString(data.YamlN1I1V1, "bogus resource entry\n"))
 	defer func() { _ = os.Remove(tmpfile.Name()) }()
 
 	err := sa.AddFileKubeSource([]string{tmpfile.Name()})
 	g.Expect(err).To(Not(BeNil()))
-	g.Expect(sa.sources).To(HaveLen(1))
+	g.Expect(sa.sources).To(HaveLen(2))
 }
 
 func TestAddFileKubeSourceSkipsBadFiles(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", nil, false)
+	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", "", nil, false)
 
 	tmpfile := tempFileFromString(t, data.YamlN1I1V1)
 	defer func() { _ = os.Remove(tmpfile.Name()) }()
 
 	err := sa.AddFileKubeSource([]string{tmpfile.Name(), "nonexistent-file.yaml"})
 	g.Expect(err).To(Not(BeNil()))
-	g.Expect(sa.sources).To(HaveLen(1))
+	g.Expect(sa.sources).To(HaveLen(2))
 }
 
 func TestResourceFiltering(t *testing.T) {
@@ -193,7 +243,7 @@ func TestResourceFiltering(t *testing.T) {
 	}
 	mk := mock.NewKube()
 
-	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), "", nil, true)
+	sa := NewSourceAnalyzer(metadata.MustGet(), analysis.Combine("a", a), "", "", nil, true)
 	sa.AddRunningKubeSource(mk)
 
 	// All but the used collection should be disabled

--- a/galley/pkg/config/analysis/local/helpers_test.go
+++ b/galley/pkg/config/analysis/local/helpers_test.go
@@ -16,6 +16,8 @@ package local
 // Test helpers common to this package
 
 import (
+	"testing"
+
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/istio/galley/pkg/config/event"
@@ -24,7 +26,8 @@ import (
 	"istio.io/istio/galley/pkg/config/testing/data"
 )
 
-func createTestEvent(k event.Kind, r *resource.Entry) event.Event {
+func createTestEvent(t *testing.T, k event.Kind, r *resource.Entry) event.Event {
+	t.Helper()
 	return event.Event{
 		Kind:   k,
 		Source: data.Collection1,
@@ -32,7 +35,8 @@ func createTestEvent(k event.Kind, r *resource.Entry) event.Event {
 	}
 }
 
-func createTestResource(ns, name, version string) *resource.Entry {
+func createTestResource(t *testing.T, ns, name, version string) *resource.Entry {
+	t.Helper()
 	rname := resource.NewName(ns, name)
 	return &resource.Entry{
 		Metadata: resource.Metadata{

--- a/galley/pkg/config/analysis/local/source_test.go
+++ b/galley/pkg/config/analysis/local/source_test.go
@@ -19,6 +19,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 )
 
@@ -27,7 +29,8 @@ func TestBasicSingleSource(t *testing.T) {
 
 	s1 := &fixtures.Source{}
 
-	ps := newPrecedenceSource([]event.Source{s1})
+	psi := precedenceSourceInput{src: s1, cols: collection.Names{data.Collection1}}
+	ps := newPrecedenceSource([]precedenceSourceInput{psi})
 
 	h := &fixtures.Accumulator{}
 	ps.Dispatch(h)
@@ -35,8 +38,8 @@ func TestBasicSingleSource(t *testing.T) {
 	ps.Start()
 	defer ps.Stop()
 
-	e1 := createTestEvent(event.Added, createTestResource("ns", "resource1", "v1"))
-	e2 := createTestEvent(event.FullSync, nil)
+	e1 := createTestEvent(t, event.Added, createTestResource(t, "ns", "resource1", "v1"))
+	e2 := createTestEvent(t, event.FullSync, nil)
 
 	s1.Handle(e1)
 	s1.Handle(e2)
@@ -49,7 +52,10 @@ func TestWaitAndCombineFullSync(t *testing.T) {
 	s1 := &fixtures.Source{}
 	s2 := &fixtures.Source{}
 
-	ps := newPrecedenceSource([]event.Source{s1, s2})
+	psi1 := precedenceSourceInput{src: s1, cols: collection.Names{data.Collection1, data.Collection2}}
+	psi2 := precedenceSourceInput{src: s2, cols: collection.Names{data.Collection1}}
+
+	ps := newPrecedenceSource([]precedenceSourceInput{psi1, psi2})
 
 	h := &fixtures.Accumulator{}
 	ps.Dispatch(h)
@@ -57,13 +63,21 @@ func TestWaitAndCombineFullSync(t *testing.T) {
 	ps.Start()
 	defer ps.Stop()
 
-	e := createTestEvent(event.FullSync, nil)
+	// For collections in more than one source, wait for all sources before publishing fullsync
+	e1 := createTestEvent(t, event.FullSync, nil)
 
-	s1.Handle(e)
+	s1.Handle(e1)
 	g.Expect(h.Events()).To(BeEmpty())
 
-	s2.Handle(e)
-	g.Expect(h.Events()).To(Equal([]event.Event{e}))
+	s2.Handle(e1)
+	g.Expect(h.Events()).To(Equal([]event.Event{e1}))
+
+	// Collection2 is only in one source, so we shouldn't wait for an event from both sources
+	e2 := createTestEvent(t, event.FullSync, nil)
+	e2.Source = data.Collection2
+
+	s1.Handle(e2)
+	g.Expect(h.Events()).To(Equal([]event.Event{e1, e2}))
 }
 
 func TestPrecedence(t *testing.T) {
@@ -73,7 +87,11 @@ func TestPrecedence(t *testing.T) {
 	s2 := &fixtures.Source{}
 	s3 := &fixtures.Source{}
 
-	ps := newPrecedenceSource([]event.Source{s1, s2, s3})
+	psi1 := precedenceSourceInput{src: s1, cols: collection.Names{data.Collection1}}
+	psi2 := precedenceSourceInput{src: s2, cols: collection.Names{data.Collection1}}
+	psi3 := precedenceSourceInput{src: s3, cols: collection.Names{data.Collection1}}
+
+	ps := newPrecedenceSource([]precedenceSourceInput{psi1, psi2, psi3})
 
 	h := &fixtures.Accumulator{}
 	ps.Dispatch(h)
@@ -81,8 +99,8 @@ func TestPrecedence(t *testing.T) {
 	ps.Start()
 	defer ps.Stop()
 
-	e1 := createTestEvent(event.Added, createTestResource("ns", "resource1", "v1"))
-	e2 := createTestEvent(event.Added, createTestResource("ns", "resource1", "v2"))
+	e1 := createTestEvent(t, event.Added, createTestResource(t, "ns", "resource1", "v1"))
+	e2 := createTestEvent(t, event.Added, createTestResource(t, "ns", "resource1", "v2"))
 
 	s2.Handle(e1)
 	g.Expect(h.Events()).To(Equal([]event.Event{e1}))

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -64,6 +64,14 @@ var (
 	// VirtualServiceDestinationPortSelectorRequired defines a diag.MessageType for message "VirtualServiceDestinationPortSelectorRequired".
 	// Description: A VirtualService routes to a service with more than one port exposed, but does not specify which to use.
 	VirtualServiceDestinationPortSelectorRequired = diag.NewMessageType(diag.Error, "IST0112", "This VirtualService routes to a service %q that exposes multiple ports %v. Specifying a port in the destination is required to disambiguate.")
+
+	// MTLSPolicyConflict defines a diag.MessageType for message "MTLSPolicyConflict".
+	// Description: A DestinationRule and Policy are in conflict with regards to mTLS.
+	MTLSPolicyConflict = diag.NewMessageType(diag.Error, "IST0113", "A DestinationRule and Policy are in conflict with regards to mTLS for host %s in namespace %s. The DestinationRule %q specifies that mTLS must be %t but the Policy object %q specifies %s.")
+
+	// PolicySpecifiesPortNameThatDoesntExist defines a diag.MessageType for message "PolicySpecifiesPortNameThatDoesntExist".
+	// Description: A Policy targets a port name that cannot be found.
+	PolicySpecifiesPortNameThatDoesntExist = diag.NewMessageType(diag.Warning, "IST0114", "Port name %s could not be found for host %s, which means the Policy won't be enforced.")
 )
 
 // NewInternalError returns a new diag.Message based on InternalError.
@@ -200,6 +208,30 @@ func NewVirtualServiceDestinationPortSelectorRequired(entry *resource.Entry, des
 		originOrNil(entry),
 		destHost,
 		destPorts,
+	)
+}
+
+// NewMTLSPolicyConflict returns a new diag.Message based on MTLSPolicyConflict.
+func NewMTLSPolicyConflict(entry *resource.Entry, host string, namespace string, destinationRuleName string, destinationRuleMTLSMode bool, policyName string, policyMTLSMode string) diag.Message {
+	return diag.NewMessage(
+		MTLSPolicyConflict,
+		originOrNil(entry),
+		host,
+		namespace,
+		destinationRuleName,
+		destinationRuleMTLSMode,
+		policyName,
+		policyMTLSMode,
+	)
+}
+
+// NewPolicySpecifiesPortNameThatDoesntExist returns a new diag.Message based on PolicySpecifiesPortNameThatDoesntExist.
+func NewPolicySpecifiesPortNameThatDoesntExist(entry *resource.Entry, portName string, host string) diag.Message {
+	return diag.NewMessage(
+		PolicySpecifiesPortNameThatDoesntExist,
+		originOrNil(entry),
+		portName,
+		host,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -148,3 +148,33 @@ messages:
         type: string
       - name: destPorts
         type: "[]int"
+
+  - name: "MTLSPolicyConflict"
+    code: IST0113
+    level: Error
+    description: "A DestinationRule and Policy are in conflict with regards to mTLS."
+    template: "A DestinationRule and Policy are in conflict with regards to mTLS for host %s in namespace %s. The DestinationRule %q specifies that mTLS must be %t but the Policy object %q specifies %s."
+    args:
+      - name: host
+        type: string
+      - name: namespace
+        type: string
+      - name: destinationRuleName
+        type: string
+      - name: destinationRuleMTLSMode
+        type: bool
+      - name: policyName
+        type: string
+      - name: policyMTLSMode
+        type: string
+
+  - name: "PolicySpecifiesPortNameThatDoesntExist"
+    code: IST0114
+    level: Warning
+    description: "A Policy targets a port name that cannot be found."
+    template: "Port name %s could not be found for host %s, which means the Policy won't be enforced."
+    args:
+      - name: portName
+        type: string
+      - name: host
+        type: string

--- a/galley/pkg/config/meta/metadata/metadata.gen.go
+++ b/galley/pkg/config/meta/metadata/metadata.gen.go
@@ -813,12 +813,6 @@ sources:
       group: "config.istio.io"
       version: "v1alpha2"
 
-    - collection: "k8s/authentication.istio.io/v1alpha1/meshpolicies"
-      kind: "MeshPolicy"
-      plural: "meshpolicies"
-      group: "authentication.istio.io"
-      version: "v1alpha1"
-
     # Legacy Mixer CRD Types
     - collection: "k8s/config.istio.io/v1alpha2/apikeys"
       kind: "apikey"

--- a/galley/pkg/config/meta/metadata/metadata.gen.go
+++ b/galley/pkg/config/meta/metadata/metadata.gen.go
@@ -614,6 +614,8 @@ snapshots:
   - name: "localAnalysis"
     strategy: immediate
     collections:
+      - "istio/authentication/v1alpha1/meshpolicies"
+      - "istio/authentication/v1alpha1/policies"
       - "istio/rbac/v1alpha1/servicerolebindings"
       - "istio/rbac/v1alpha1/serviceroles"
       - "istio/mesh/v1alpha1/MeshConfig"

--- a/galley/pkg/config/meta/metadata/metadata.yaml
+++ b/galley/pkg/config/meta/metadata/metadata.yaml
@@ -568,6 +568,8 @@ snapshots:
   - name: "localAnalysis"
     strategy: immediate
     collections:
+      - "istio/authentication/v1alpha1/meshpolicies"
+      - "istio/authentication/v1alpha1/policies"
       - "istio/rbac/v1alpha1/servicerolebindings"
       - "istio/rbac/v1alpha1/serviceroles"
       - "istio/mesh/v1alpha1/MeshConfig"

--- a/galley/pkg/config/meta/metadata/metadata.yaml
+++ b/galley/pkg/config/meta/metadata/metadata.yaml
@@ -767,12 +767,6 @@ sources:
       group: "config.istio.io"
       version: "v1alpha2"
 
-    - collection: "k8s/authentication.istio.io/v1alpha1/meshpolicies"
-      kind: "MeshPolicy"
-      plural: "meshpolicies"
-      group: "authentication.istio.io"
-      version: "v1alpha1"
-
     # Legacy Mixer CRD Types
     - collection: "k8s/config.istio.io/v1alpha2/apikeys"
       kind: "apikey"

--- a/galley/pkg/config/processing/session.go
+++ b/galley/pkg/config/processing/session.go
@@ -260,6 +260,7 @@ func (s *session) handleMeshEvent(e event.Event) {
 		go s.terminate()
 
 	case starting:
+		scope.Processing.Infof("session.handleMeshEvent: Received initial mesh event, applying it: %+v", e)
 		s.applyMeshEvent(e)
 
 	case buffering:

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -140,15 +140,16 @@ func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name
 	d.s.Analyzer.Analyze(ctx)
 	scope.Analysis.Debugf("Finished analyzing the current snapshot, found messages: %v", ctx.messages)
 
-	// Only keep messages for resources in namespaces we want to analyze
-	// If the message doesn't have an origin (meaning we can't determine the namespace) fail open and keep it
-	// If no such limit is specified, keep them all.
+	// Only keep messages for resources in namespaces we want to analyze if the
+	// message doesn't have an origin (meaning we can't determine the
+	// namespace). Also kept are cluster-level resources where the namespace is
+	// the empty string. If no such limit is specified, keep them all.
 	var msgs diag.Messages
 	if len(namespaces) == 0 {
 		msgs = ctx.messages
 	} else {
 		for _, m := range ctx.messages {
-			if m.Origin != nil {
+			if m.Origin != nil && m.Origin.Namespace() != "" {
 				if _, ok := namespaces[m.Origin.Namespace()]; !ok {
 					continue
 				}

--- a/galley/pkg/testing/mock/configmaps.go
+++ b/galley/pkg/testing/mock/configmaps.go
@@ -1,0 +1,133 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package mock
+
+import (
+	"fmt"
+	"sync"
+
+	apicorev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var _ corev1.ConfigMapInterface = &configMapImpl{}
+
+type configMapImpl struct {
+	mux        sync.Mutex
+	configMaps map[string]*apicorev1.ConfigMap
+	watches    Watches
+}
+
+func newConfigMapInterface() corev1.ConfigMapInterface {
+	return &configMapImpl{
+		configMaps: make(map[string]*apicorev1.ConfigMap),
+	}
+}
+
+func (c *configMapImpl) Create(obj *v1.ConfigMap) (*v1.ConfigMap, error) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	c.configMaps[obj.Name] = obj
+
+	c.watches.Send(watch.Event{
+		Type:   watch.Added,
+		Object: obj,
+	})
+
+	return obj, nil
+}
+
+func (c *configMapImpl) Update(obj *v1.ConfigMap) (*v1.ConfigMap, error) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	c.configMaps[obj.Name] = obj
+
+	c.watches.Send(watch.Event{
+		Type:   watch.Modified,
+		Object: obj,
+	})
+
+	return obj, nil
+}
+
+func (c *configMapImpl) Delete(name string, options *metav1.DeleteOptions) error {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	obj := c.configMaps[name]
+	if obj == nil {
+		return fmt.Errorf("unable to delete configMap %s", name)
+	}
+
+	delete(c.configMaps, name)
+
+	c.watches.Send(watch.Event{
+		Type:   watch.Deleted,
+		Object: obj,
+	})
+	return nil
+}
+
+func (c *configMapImpl) List(opts metav1.ListOptions) (*v1.ConfigMapList, error) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	out := &apicorev1.ConfigMapList{}
+
+	for _, v := range c.configMaps {
+		out.Items = append(out.Items, *v)
+	}
+
+	return out, nil
+}
+
+func (c *configMapImpl) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	w := NewWatch()
+	c.watches = append(c.watches, w)
+
+	// Send add events for all current resources.
+	for _, cm := range c.configMaps {
+		w.Send(watch.Event{
+			Type:   watch.Added,
+			Object: cm,
+		})
+	}
+
+	return w, nil
+}
+
+func (c *configMapImpl) Get(name string, options metav1.GetOptions) (*v1.ConfigMap, error) {
+	obj, ok := c.configMaps[name]
+	if !ok {
+		return nil, fmt.Errorf("configmap %q not found", name)
+	}
+	return obj, nil
+}
+
+func (c *configMapImpl) DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	panic("not implemented")
+}
+
+func (c *configMapImpl) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ConfigMap, err error) {
+	panic("not implemented")
+}

--- a/galley/pkg/testing/mock/corev1.go
+++ b/galley/pkg/testing/mock/corev1.go
@@ -27,6 +27,7 @@ type corev1Impl struct {
 	services   corev1.ServiceInterface
 	endpoints  corev1.EndpointsInterface
 	namespaces corev1.NamespaceInterface
+	configmaps corev1.ConfigMapInterface
 }
 
 func (c *corev1Impl) Nodes() corev1.NodeInterface {
@@ -54,7 +55,7 @@ func (c *corev1Impl) ComponentStatuses() corev1.ComponentStatusInterface {
 }
 
 func (c *corev1Impl) ConfigMaps(namespace string) corev1.ConfigMapInterface {
-	panic("not implemented")
+	return c.configmaps
 }
 
 func (c *corev1Impl) Events(namespace string) corev1.EventInterface {

--- a/galley/pkg/testing/mock/kube_interface.go
+++ b/galley/pkg/testing/mock/kube_interface.go
@@ -75,6 +75,7 @@ func newKubeInterface() kubernetes.Interface {
 			services:   newServiceInterface(),
 			endpoints:  newEndpointsInterface(),
 			namespaces: newNamespaceInterface(),
+			configmaps: newConfigMapInterface(),
 		},
 
 		extensions: &extensionsv1Impl{

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -15,10 +15,12 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/ghodss/yaml"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
@@ -38,6 +40,9 @@ type FileParseError struct{}
 const (
 	FoundIssueString = "Analyzer found issues."
 	FileParseString  = "Some files couldn't be parsed."
+	LogOutput        = "log"
+	JsonOutput       = "json"
+	YamlOutput       = "yaml"
 )
 
 func (f AnalyzerFoundIssuesError) Error() string {
@@ -49,11 +54,12 @@ func (f FileParseError) Error() string {
 }
 
 var (
-	useKube      bool
-	useDiscovery bool
-	failureLevel = messageThreshold{diag.Warning} // messages at least this level will generate an error exit code
-	outputLevel  = messageThreshold{diag.Info}    // messages at least this level will be included in the output
-	colorize     bool
+	useKube         bool
+	useDiscovery    bool
+	failureLevel    = messageThreshold{diag.Warning} // messages at least this level will generate an error exit code
+	outputLevel     = messageThreshold{diag.Info}    // messages at least this level will be included in the output
+	colorize        bool
+	msgOutputFormat string
 
 	termEnvVar = env.RegisterStringVar("TERM", "", "Specifies terminal type.  Use 'dumb' to suppress color output")
 
@@ -68,6 +74,14 @@ var (
 // Once we're ready to move this functionality out of the "experimental" subtree, we should merge
 // with `istioctl validate`. https://github.com/istio/istio/issues/16777
 func Analyze() *cobra.Command {
+	// Validate the output format before doing potentially expensive work to fail earlier
+	msgOutputFormats := map[string]bool{LogOutput: true, JsonOutput: true, YamlOutput: true}
+	var msgOutputFormatKeys []string
+
+	for k, _ := range msgOutputFormats {
+		msgOutputFormatKeys = append(msgOutputFormatKeys, k)
+	}
+
 	analysisCmd := &cobra.Command{
 		Use:   "analyze <file>...",
 		Short: "Analyze Istio configuration and print validation messages",
@@ -88,6 +102,14 @@ istioctl experimental analyze -d true a.yaml b.yaml services.yaml
 istioctl experimental analyze -k -d false
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			msgOutputFormat = strings.ToLower(msgOutputFormat)
+			_, ok := msgOutputFormats[msgOutputFormat]
+			if !ok {
+				return CommandParseError{
+					fmt.Errorf("%s not a valid option for format. See istioctl x analyze --help", msgOutputFormat),
+				}
+			}
+
 			files, err := gatherFiles(args)
 			if err != nil {
 				return err
@@ -179,25 +201,42 @@ istioctl experimental analyze -k -d false
 				}
 			}
 
-			// Print validation message output, or a line indicating that none were found
-			if len(outputMessages) == 0 {
-				if parseErrors == 0 {
-					fmt.Fprintln(cmd.ErrOrStderr(), "\u2714 No validation issues found.")
-				} else {
-					fileOrFiles := "files"
-					if parseErrors == 1 {
-						fileOrFiles = "file"
+			switch msgOutputFormat {
+			case LogOutput:
+				// Print validation message output, or a line indicating that none were found
+				if len(outputMessages) == 0 {
+					if parseErrors == 0 {
+						fmt.Fprintln(cmd.ErrOrStderr(), "\u2714 No validation issues found.")
+					} else {
+						fileOrFiles := "files"
+						if parseErrors == 1 {
+							fileOrFiles = "file"
+						}
+						fmt.Fprintf(cmd.ErrOrStderr(),
+							"No validation issues found (but %d %s could not be parsed)\n",
+							parseErrors,
+							fileOrFiles,
+						)
 					}
-					fmt.Fprintf(cmd.ErrOrStderr(),
-						"No validation issues found (but %d %s could not be parsed)\n",
-						parseErrors,
-						fileOrFiles,
-					)
+				} else {
+					for _, m := range outputMessages {
+						fmt.Fprintln(cmd.OutOrStdout(), renderMessage(m))
+					}
 				}
-			} else {
-				for _, m := range outputMessages {
-					fmt.Fprintln(cmd.OutOrStdout(), renderMessage(m))
+			case JsonOutput:
+				jsonOutput, err := json.MarshalIndent(outputMessages, "", "\t")
+				if err != nil {
+					return err
 				}
+				fmt.Fprintln(cmd.OutOrStdout(), string(jsonOutput))
+			case YamlOutput:
+				yamlOutput, err := yaml.Marshal(outputMessages)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), string(yamlOutput))
+			default: // This should never happen since we validate this already
+				panic(fmt.Sprintf("%q not found in output format switch statement post validate?", msgOutputFormat))
 			}
 
 			// Return code is based on the unfiltered validation message list/parse errors
@@ -223,6 +262,7 @@ istioctl experimental analyze -k -d false
 		fmt.Sprintf("The severity level of analysis at which to set a non-zero exit code. Valid values: %v", diag.GetAllLevelStrings()))
 	analysisCmd.PersistentFlags().Var(&outputLevel, "output-threshold",
 		fmt.Sprintf("The severity level of analysis at which to display messages. Valid values: %v", diag.GetAllLevelStrings()))
+	analysisCmd.PersistentFlags().StringVarP(&msgOutputFormat, "output", "o", LogOutput, fmt.Sprintf("Output format: one of %v", msgOutputFormatKeys))
 	return analysisCmd
 }
 


### PR DESCRIPTION
Including these PRs: #18700, #19055, #18350, #18478, #18917, #18935, #19244 

Note that this adds the structured format options to istioctl analyze. It's not needed for the mTLS analyzer, but including it means the cherry-picks apply cleanly.

I briefly tested it by hand and both structured output and the mTLS analyzer seem to work as expected:

```
jsselman-imacpro:~/g/s/i/istio (mtls-analyzer-1.4|✔) $ ~/go/out/darwin_amd64/release/istioctl  x analyze -k -o json
[
        {
                "code": "IST0113",
                "level": "Error",
                "message": "A DestinationRule and Policy are in conflict with regards to mTLS for host *.svc.cluster.local in namespace istio-system. The DestinationRule \"(none)\" specifies that mTLS must be false but the Policy object \"default\" specifies Strict.",
                "origin": "MeshPolicy default"
        }
]
Error: Analyzer found issues.
```