### PR TITLE
Fix lint error underscore in package name sds_ingress

### DIFF
--- a/tests/integration/security/sds_ingress/main_test.go
+++ b/tests/integration/security/sds_ingress/main_test.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package sds_ingress
+package sdsingress
 
 import (
 	"testing"

--- a/tests/integration/security/sds_ingress/multi_mtls_gateway_invalid_secret_test.go
+++ b/tests/integration/security/sds_ingress/multi_mtls_gateway_invalid_secret_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package sdsingress
 
 import (
 	"testing"

--- a/tests/integration/security/sds_ingress/multi_tls_gateway_invalid_secret_test.go
+++ b/tests/integration/security/sds_ingress/multi_tls_gateway_invalid_secret_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package sdsingress
 
 import (
 	"testing"

--- a/tests/integration/security/sds_ingress/multiple_mtls_gateway_test.go
+++ b/tests/integration/security/sds_ingress/multiple_mtls_gateway_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package sdsingress
 
 import (
 	"testing"

--- a/tests/integration/security/sds_ingress/multiple_tls_gateways_test.go
+++ b/tests/integration/security/sds_ingress/multiple_tls_gateways_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package sdsingress
 
 import (
 	"testing"

--- a/tests/integration/security/sds_ingress/single_mtls_gateway_compound_secret_test.go
+++ b/tests/integration/security/sds_ingress/single_mtls_gateway_compound_secret_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package sdsingress
 
 import (
 	"testing"

--- a/tests/integration/security/sds_ingress/single_mtls_gateway_separate_secret_test.go
+++ b/tests/integration/security/sds_ingress/single_mtls_gateway_separate_secret_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package sdsingress
 
 import (
 	"testing"

--- a/tests/integration/security/sds_ingress/single_tls_gateway_test.go
+++ b/tests/integration/security/sds_ingress/single_tls_gateway_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package sdsingress
 
 import (
 	"testing"


### PR DESCRIPTION
This patch fixes lint error underscore in package name sds_ingress.
Please refer to the error in https://github.com/istio/istio/pull/19261

/cc @pitlv2109 @myidpt 

