### PR TITLE
Revert "Move sds ingress tests to a single suite"

### DIFF
--- a/tests/integration/security/sds_ingress/multi_mtls_gateway_invalid_secret/main_test.go
+++ b/tests/integration/security/sds_ingress/multi_mtls_gateway_invalid_secret/main_test.go
@@ -1,0 +1,63 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package multimtlsgatewayinvalidsecret
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst istio.Instance
+	g    galley.Instance
+	p    pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	// Integration test for the ingress SDS Gateway flow.
+	framework.
+		NewSuite("sds_ingress_multi_mtls_gateway_invalid_secret_test", m).
+		Label(label.CustomSetup).
+		Label(label.Flaky).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// Enable SDS key/certificate provisioning for ingress gateway.
+	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
+}

--- a/tests/integration/security/sds_ingress/multi_mtls_gateway_invalid_secret/multi_mtls_gateway_invalid_secret_test.go
+++ b/tests/integration/security/sds_ingress/multi_mtls_gateway_invalid_secret/multi_mtls_gateway_invalid_secret_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package multimtlsgatewayinvalidsecret
 
 import (
 	"testing"

--- a/tests/integration/security/sds_ingress/multi_tls_gateway_invalid_secret/main_test.go
+++ b/tests/integration/security/sds_ingress/multi_tls_gateway_invalid_secret/main_test.go
@@ -1,0 +1,63 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package multitlsgatewayinvalidsecret
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst istio.Instance
+	g    galley.Instance
+	p    pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	// Integration test for the ingress SDS Gateway flow.
+	framework.
+		NewSuite("sds_ingress_multi_tls_gateway_invalid_secret_test", m).
+		Label(label.CustomSetup).
+		Label(label.Flaky).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// Enable SDS key/certificate provisioning for ingress gateway.
+	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
+}

--- a/tests/integration/security/sds_ingress/multi_tls_gateway_invalid_secret/multi_tls_gateway_invalid_secret_test.go
+++ b/tests/integration/security/sds_ingress/multi_tls_gateway_invalid_secret/multi_tls_gateway_invalid_secret_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package multitlsgatewayinvalidsecret
 
 import (
 	"testing"

--- a/tests/integration/security/sds_ingress/multiple_mtls_gateway/main_test.go
+++ b/tests/integration/security/sds_ingress/multiple_mtls_gateway/main_test.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package sds_ingress
+package multiplemtlsgateway
 
 import (
 	"testing"
@@ -32,21 +32,10 @@ var (
 	p    pilot.Instance
 )
 
-var (
-	singleTLSCredName  = []string{"bookinfo-credential-1"}
-	singleTLCredCAName = []string{"bookinfo-credential-1-cacert"}
-	singleTLSHost      = "bookinfo1.example.com"
-
-	multipleTLSCredNames = []string{"bookinfo-credential-1", "bookinfo-credential-2", "bookinfo-credential-3",
-		"bookinfo-credential-4", "bookinfo-credential-5"}
-	multipleTLSHosts = []string{"bookinfo1.example.com", "bookinfo2.example.com", "bookinfo3.example.com",
-		"bookinfo4.example.com", "bookinfo5.example.com"}
-)
-
 func TestMain(m *testing.M) {
-	// Integration test for the ingress SDS Gateway flow.
+	// Integration test for the ingress SDS multiple Gateway flow.
 	framework.
-		NewSuite("sds_ingress_multi_mtls_gateway_invalid_secret_test", m).
+		NewSuite("sds_ingress_multiple_mtls_gateways_test", m).
 		Label(label.CustomSetup).
 		Label(label.Flaky).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).

--- a/tests/integration/security/sds_ingress/multiple_mtls_gateway/multiple_mtls_gateway_test.go
+++ b/tests/integration/security/sds_ingress/multiple_mtls_gateway/multiple_mtls_gateway_test.go
@@ -12,16 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package multiplemtlsgateway
 
 import (
-	"testing"
 	"time"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
+
+	"testing"
+)
+
+var (
+	credNames = []string{"bookinfo-credential-1", "bookinfo-credential-2", "bookinfo-credential-3",
+		"bookinfo-credential-4", "bookinfo-credential-5"}
+	hosts = []string{"bookinfo1.example.com", "bookinfo2.example.com", "bookinfo3.example.com",
+		"bookinfo4.example.com", "bookinfo5.example.com"}
 )
 
 // testMultiMtlsGateways deploys multiple mTLS gateways with SDS enabled, and creates kubernetes that store
@@ -30,14 +38,14 @@ import (
 func testMultiMtlsGateways(t *testing.T, ctx framework.TestContext) { // nolint:interfacer
 	t.Helper()
 
-	ingressutil.CreateIngressKubeSecret(t, ctx, multipleTLSCredNames, ingress.Mtls, ingressutil.IngressCredentialA)
+	ingressutil.CreateIngressKubeSecret(t, ctx, credNames, ingress.Mtls, ingressutil.IngressCredentialA)
 	ingressutil.DeployBookinfo(t, ctx, g, ingressutil.MultiMTLSGateway)
 
 	ing := ingress.NewOrFail(t, ctx, ingress.Config{
 		Istio: inst,
 	})
 	// Expect 2 SDS updates for each listener, one for server key/cert, and one for CA cert.
-	err := ingressutil.WaitUntilGatewaySdsStatsGE(t, ing, 2*len(multipleTLSCredNames), 30*time.Second)
+	err := ingressutil.WaitUntilGatewaySdsStatsGE(t, ing, 2*len(credNames), 30*time.Second)
 	if err != nil {
 		t.Errorf("sds update stats does not match: %v", err)
 	}
@@ -53,7 +61,7 @@ func testMultiMtlsGateways(t *testing.T, ctx framework.TestContext) { // nolint:
 	}
 	callType := ingress.Mtls
 
-	for _, h := range multipleTLSHosts {
+	for _, h := range hosts {
 		err := ingressutil.VisitProductPage(ing, h, callType, tlsContext, 30*time.Second,
 			ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""}, t)
 		if err != nil {

--- a/tests/integration/security/sds_ingress/multiple_tls_gateway/main_test.go
+++ b/tests/integration/security/sds_ingress/multiple_tls_gateway/main_test.go
@@ -1,0 +1,63 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package multipletlsgateway
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst istio.Instance
+	g    galley.Instance
+	p    pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	// Integration test for the ingress SDS multiple Gateway flow.
+	framework.
+		NewSuite("sds_ingress_multiple_tls_gateways_test", m).
+		Label(label.CustomSetup).
+		Label(label.Flaky).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// Enable SDS key/certificate provisioning for ingress gateway.
+	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
+}

--- a/tests/integration/security/sds_ingress/multiple_tls_gateway/multiple_tls_gateways_test.go
+++ b/tests/integration/security/sds_ingress/multiple_tls_gateway/multiple_tls_gateways_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package multipletlsgateway
 
 import (
 	"testing"
@@ -24,17 +24,24 @@ import (
 	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
 )
 
+var (
+	credNames = []string{"bookinfo-credential-1", "bookinfo-credential-2", "bookinfo-credential-3",
+		"bookinfo-credential-4", "bookinfo-credential-5"}
+	hosts = []string{"bookinfo1.example.com", "bookinfo2.example.com", "bookinfo3.example.com",
+		"bookinfo4.example.com", "bookinfo5.example.com"}
+)
+
 // testMultiTlsGateways deploys multiple TLS gateways with SDS enabled, and creates kubernetes that store
 // private key and server certificate for each TLS gateway. Verifies that all gateways are able to terminate
 // SSL connections successfully.
 func testMultiTLSGateways(t *testing.T, ctx framework.TestContext) { // nolint:interfacer
 	t.Helper()
 
-	ingressutil.CreateIngressKubeSecret(t, ctx, multipleTLSCredNames, ingress.TLS, ingressutil.IngressCredentialA)
+	ingressutil.CreateIngressKubeSecret(t, ctx, credNames, ingress.TLS, ingressutil.IngressCredentialA)
 	ingressutil.DeployBookinfo(t, ctx, g, ingressutil.MultiTLSGateway)
 
 	ing := ingress.NewOrFail(t, ctx, ingress.Config{Istio: inst})
-	err := ingressutil.WaitUntilGatewaySdsStatsGE(t, ing, len(multipleTLSCredNames), 30*time.Second)
+	err := ingressutil.WaitUntilGatewaySdsStatsGE(t, ing, len(credNames), 30*time.Second)
 	if err != nil {
 		t.Errorf("sds update stats does not match: %v", err)
 	}
@@ -48,7 +55,7 @@ func testMultiTLSGateways(t *testing.T, ctx framework.TestContext) { // nolint:i
 	}
 	callType := ingress.TLS
 
-	for _, h := range multipleTLSHosts {
+	for _, h := range hosts {
 		err := ingressutil.VisitProductPage(ing, h, callType, tlsContext, 30*time.Second,
 			ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""}, t)
 		if err != nil {

--- a/tests/integration/security/sds_ingress/single_mtls_gateway_compound_secret/main_test.go
+++ b/tests/integration/security/sds_ingress/single_mtls_gateway_compound_secret/main_test.go
@@ -1,0 +1,63 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package singlemtlsgatewaycompoundsecret
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst istio.Instance
+	g    galley.Instance
+	p    pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	// Integration test for the ingress SDS Gateway flow.
+	framework.
+		NewSuite("sds_ingress_single_mtls_gateway_compound_secret_test", m).
+		Label(label.CustomSetup).
+		Label(label.Flaky).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// Enable SDS key/certificate provisioning for ingress gateway.
+	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
+}

--- a/tests/integration/security/sds_ingress/single_mtls_gateway_compound_secret/single_mtls_gateway_compound_secret_test.go
+++ b/tests/integration/security/sds_ingress/single_mtls_gateway_compound_secret/single_mtls_gateway_compound_secret_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package singlemtlsgatewaycompoundsecret
 
 import (
 	"testing"
@@ -22,6 +22,11 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
+)
+
+var (
+	credName = []string{"bookinfo-credential-1"}
+	host     = "bookinfo1.example.com"
 )
 
 // TestSingleMTLSGateway_CompoundSecretRotation tests a single mTLS ingress gateway with SDS enabled.
@@ -36,7 +41,7 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			// Add kubernetes secret to provision key/cert for ingress gateway.
-			ingressutil.CreateIngressKubeSecret(t, ctx, singleTLSCredName, ingress.Mtls, ingressutil.IngressCredentialA)
+			ingressutil.CreateIngressKubeSecret(t, ctx, credName, ingress.Mtls, ingressutil.IngressCredentialA)
 			ingressutil.DeployBookinfo(t, ctx, g, ingressutil.SingleMTLSGateway)
 			// Wait for ingress gateway to fetch key/cert from Gateway agent via SDS.
 			ingA := ingress.NewOrFail(t, ctx, ingress.Config{Istio: inst})
@@ -55,24 +60,24 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 				PrivateKey: ingressutil.TLSClientKeyA,
 				Cert:       ingressutil.TLSClientCertA,
 			}
-			err = ingressutil.VisitProductPage(ingA, singleTLSHost, ingress.Mtls, tlsContext, 30*time.Second,
+			err = ingressutil.VisitProductPage(ingA, host, ingress.Mtls, tlsContext, 30*time.Second,
 				ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""}, t)
 			if err != nil {
-				t.Errorf("unable to retrieve 200 from product page at host %s: %v", singleTLSHost, err)
+				t.Errorf("unable to retrieve 200 from product page at host %s: %v", host, err)
 			}
 
 			// key/cert rotation
-			ingressutil.RotateSecrets(t, ctx, singleTLSCredName, ingress.Mtls, ingressutil.IngressCredentialB)
+			ingressutil.RotateSecrets(t, ctx, credName, ingress.Mtls, ingressutil.IngressCredentialB)
 			// Expect 2 more SDS updates, one for the server key/cert update, and one for the CA cert update.
 			err = ingressutil.WaitUntilGatewaySdsStatsGE(t, ingA, 4, 30*time.Second)
 			if err != nil {
 				t.Errorf("sds update stats does not match: %v", err)
 			}
 			// Use old server CA cert to set up SSL connection would fail.
-			err = ingressutil.VisitProductPage(ingA, singleTLSHost, ingress.Mtls, tlsContext, 30*time.Second,
+			err = ingressutil.VisitProductPage(ingA, host, ingress.Mtls, tlsContext, 30*time.Second,
 				ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"}, t)
 			if err != nil {
-				t.Errorf("unable to retrieve 404 from product page at host %s: %v", singleTLSHost, err)
+				t.Errorf("unable to retrieve 404 from product page at host %s: %v", host, err)
 			}
 
 			// Use new server CA cert to set up SSL connection.
@@ -82,10 +87,10 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 				PrivateKey: ingressutil.TLSClientKeyB,
 				Cert:       ingressutil.TLSClientCertB,
 			}
-			err = ingressutil.VisitProductPage(ingB, singleTLSHost, ingress.Mtls, tlsContext, 30*time.Second,
+			err = ingressutil.VisitProductPage(ingB, host, ingress.Mtls, tlsContext, 30*time.Second,
 				ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""}, t)
 			if err != nil {
-				t.Errorf("unable to retrieve 200 from product page at host %s: %v", singleTLSHost, err)
+				t.Errorf("unable to retrieve 200 from product page at host %s: %v", host, err)
 			}
 		})
 }

--- a/tests/integration/security/sds_ingress/single_mtls_gateway_separate_secret/main_test.go
+++ b/tests/integration/security/sds_ingress/single_mtls_gateway_separate_secret/main_test.go
@@ -1,0 +1,63 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package singlemtlsgatewayseparatesecret
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst istio.Instance
+	g    galley.Instance
+	p    pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	// Integration test for the ingress SDS Gateway flow.
+	framework.
+		NewSuite("sds_ingress_single_mtls_gateway_separate_secret_test", m).
+		Label(label.CustomSetup).
+		Label(label.Flaky).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// Enable SDS key/certificate provisioning for ingress gateway.
+	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
+}

--- a/tests/integration/security/sds_ingress/single_mtls_gateway_separate_secret/single_mtls_gateway_separate_secret_test.go
+++ b/tests/integration/security/sds_ingress/single_mtls_gateway_separate_secret/single_mtls_gateway_separate_secret_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package singlemtlsgatewayseparatesecret
 
 import (
 	"testing"
@@ -22,6 +22,12 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
+)
+
+var (
+	credName   = []string{"bookinfo-credential-1"}
+	credCaName = []string{"bookinfo-credential-1-cacert"}
+	host       = "bookinfo1.example.com"
 )
 
 // TestSingleMTLSGateway_ServerKeyCertRotation tests a single mTLS ingress gateway with SDS enabled.
@@ -41,8 +47,8 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 			ingressutil.DeployBookinfo(t, ctx, g, ingressutil.SingleMTLSGateway)
 
 			// Add two kubernetes secrets to provision server key/cert and client CA cert for ingress gateway.
-			ingressutil.CreateIngressKubeSecret(t, ctx, singleTLCredCAName, ingress.Mtls, ingressutil.IngressCredentialCaCertA)
-			ingressutil.CreateIngressKubeSecret(t, ctx, singleTLSCredName, ingress.Mtls,
+			ingressutil.CreateIngressKubeSecret(t, ctx, credCaName, ingress.Mtls, ingressutil.IngressCredentialCaCertA)
+			ingressutil.CreateIngressKubeSecret(t, ctx, credName, ingress.Mtls,
 				ingressutil.IngressCredentialServerKeyCertA)
 
 			ingA := ingress.NewOrFail(t, ctx, ingress.Config{Istio: inst})
@@ -61,40 +67,40 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 				PrivateKey: ingressutil.TLSClientKeyA,
 				Cert:       ingressutil.TLSClientCertA,
 			}
-			err = ingressutil.VisitProductPage(ingA, singleTLSHost, ingress.Mtls, tlsContext, 30*time.Second,
+			err = ingressutil.VisitProductPage(ingA, host, ingress.Mtls, tlsContext, 30*time.Second,
 				ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""}, t)
 			if err != nil {
-				t.Errorf("unable to retrieve code 200 from product page at host %s: %v", singleTLSHost, err)
+				t.Errorf("unable to retrieve code 200 from product page at host %s: %v", host, err)
 			}
 
 			// key/cert rotation using mis-matched server key/cert. The server cert cannot pass validation
 			// at client side.
-			ingressutil.RotateSecrets(t, ctx, singleTLSCredName, ingress.Mtls, ingressutil.IngressCredentialServerKeyCertB)
+			ingressutil.RotateSecrets(t, ctx, credName, ingress.Mtls, ingressutil.IngressCredentialServerKeyCertB)
 			// Expect 1 more SDS updates for the server key/cert update.
 			err = ingressutil.WaitUntilGatewaySdsStatsGE(t, ingA, 3, 30*time.Second)
 			if err != nil {
 				t.Errorf("sds update stats does not match: %v", err)
 			}
 			// Client uses old server CA cert to set up SSL connection would fail.
-			err = ingressutil.VisitProductPage(ingA, singleTLSHost, ingress.Mtls, tlsContext, 30*time.Second,
+			err = ingressutil.VisitProductPage(ingA, host, ingress.Mtls, tlsContext, 30*time.Second,
 				ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"}, t)
 			if err != nil {
-				t.Errorf("unable to retrieve 0 from product page at host %s: %v", singleTLSHost, err)
+				t.Errorf("unable to retrieve 0 from product page at host %s: %v", host, err)
 			}
 
 			// key/cert rotation using matched server key/cert. This time the server cert is able to pass
 			// validation at client side.
-			ingressutil.RotateSecrets(t, ctx, singleTLSCredName, ingress.Mtls, ingressutil.IngressCredentialServerKeyCertA)
+			ingressutil.RotateSecrets(t, ctx, credName, ingress.Mtls, ingressutil.IngressCredentialServerKeyCertA)
 			// Expect 1 more SDS updates for the server key/cert update.
 			err = ingressutil.WaitUntilGatewaySdsStatsGE(t, ingA, 4, 30*time.Second)
 			if err != nil {
 				t.Errorf("sds update stats does not match: %v", err)
 			}
 			// Use old CA cert to set up SSL connection would succeed this time.
-			err = ingressutil.VisitProductPage(ingA, singleTLSHost, ingress.Mtls, tlsContext, 30*time.Second,
+			err = ingressutil.VisitProductPage(ingA, host, ingress.Mtls, tlsContext, 30*time.Second,
 				ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""}, t)
 			if err != nil {
-				t.Errorf("unable to retrieve code 200 from product page at host %s: %v", singleTLSHost, err)
+				t.Errorf("unable to retrieve code 200 from product page at host %s: %v", host, err)
 			}
 		})
 }

--- a/tests/integration/security/sds_ingress/single_tls_gateway/main_test.go
+++ b/tests/integration/security/sds_ingress/single_tls_gateway/main_test.go
@@ -1,0 +1,63 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package singletlsgateway
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst istio.Instance
+	g    galley.Instance
+	p    pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	// Integration test for the ingress SDS Gateway flow.
+	framework.
+		NewSuite("sds_ingress_single_tls_gateway_test", m).
+		Label(label.CustomSetup).
+		Label(label.Flaky).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// Enable SDS key/certificate provisioning for ingress gateway.
+	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
+}

--- a/tests/integration/security/sds_ingress/single_tls_gateway/single_tls_gateway_test.go
+++ b/tests/integration/security/sds_ingress/single_tls_gateway/single_tls_gateway_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sds_ingress
+package singletlsgateway
 
 import (
 	"testing"
@@ -22,6 +22,11 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
+)
+
+var (
+	credName = []string{"bookinfo-credential-1"}
+	host     = "bookinfo1.example.com"
 )
 
 // TestSingleTlsGateway_SecretRotation tests a single TLS ingress gateway with SDS enabled.
@@ -36,7 +41,7 @@ func TestSingleTlsGateway_SecretRotation(t *testing.T) {
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 			// Add kubernetes secret to provision key/cert for ingress gateway.
-			ingressutil.CreateIngressKubeSecret(t, ctx, singleTLSCredName, ingress.TLS, ingressutil.IngressCredentialA)
+			ingressutil.CreateIngressKubeSecret(t, ctx, credName, ingress.TLS, ingressutil.IngressCredentialA)
 			ingressutil.DeployBookinfo(t, ctx, g, ingressutil.SingleTLSGateway)
 
 			ingA := ingress.NewOrFail(t, ctx, ingress.Config{Istio: inst})
@@ -50,33 +55,33 @@ func TestSingleTlsGateway_SecretRotation(t *testing.T) {
 				t.Errorf("total active listener stats does not match: %v", err)
 			}
 			tlsContext := ingressutil.TLSContext{CaCert: ingressutil.CaCertA}
-			err = ingressutil.VisitProductPage(ingA, singleTLSHost, ingress.TLS, tlsContext, 30*time.Second,
+			err = ingressutil.VisitProductPage(ingA, host, ingress.TLS, tlsContext, 30*time.Second,
 				ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""}, t)
 			if err != nil {
-				t.Errorf("unable to retrieve 200 from product page at host %s: %v", singleTLSHost, err)
+				t.Errorf("unable to retrieve 200 from product page at host %s: %v", host, err)
 			}
 
 			// key/cert rotation
-			ingressutil.RotateSecrets(t, ctx, singleTLSCredName, ingress.TLS, ingressutil.IngressCredentialB)
+			ingressutil.RotateSecrets(t, ctx, credName, ingress.TLS, ingressutil.IngressCredentialB)
 			err = ingressutil.WaitUntilGatewaySdsStatsGE(t, ingA, 2, 10*time.Second)
 			if err != nil {
 				t.Errorf("sds update stats does not match: %v", err)
 			}
 
 			// Client use old server CA cert to set up SSL connection would fail.
-			err = ingressutil.VisitProductPage(ingA, singleTLSHost, ingress.TLS, tlsContext, 30*time.Second,
+			err = ingressutil.VisitProductPage(ingA, host, ingress.TLS, tlsContext, 30*time.Second,
 				ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"}, t)
 			if err != nil {
-				t.Errorf("unable to retrieve 404 from product page at host %s: %v", singleTLSHost, err)
+				t.Errorf("unable to retrieve 404 from product page at host %s: %v", host, err)
 			}
 
 			// Client use new server CA cert to set up SSL connection.
 			tlsContext = ingressutil.TLSContext{CaCert: ingressutil.CaCertB}
 			ingB := ingress.NewOrFail(t, ctx, ingress.Config{Istio: inst})
-			err = ingressutil.VisitProductPage(ingB, singleTLSHost, ingress.TLS, tlsContext, 30*time.Second,
+			err = ingressutil.VisitProductPage(ingB, host, ingress.TLS, tlsContext, 30*time.Second,
 				ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""}, t)
 			if err != nil {
-				t.Errorf("unable to retrieve 200 from product page at host %s: %v", singleTLSHost, err)
+				t.Errorf("unable to retrieve 200 from product page at host %s: %v", host, err)
 			}
 		})
 }


### PR DESCRIPTION
Reverts istio/istio#19270

Some tests check if some secrets exist or not first. Each test needs to be cleaned up first before moving to the next test.