### PR TITLE
Support IstioControlPlane cr and --set for istioctl verify-install

### DIFF
--- a/istioctl/pkg/install/testdata/istio_v1alpha2_istiocontrolplane_cr.yaml
+++ b/istioctl/pkg/install/testdata/istio_v1alpha2_istiocontrolplane_cr.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: install.istio.io/v1alpha2
+kind: IstioControlPlane
+metadata:
+  namespace: istio-operator
+  name: example-istiocontrolplane
+spec:
+  profile: demo
+  defaultNamespace: istio-system
+  trafficManagement:
+    components:
+      namespace: istio-pilot
+...

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -20,6 +20,12 @@ import (
 	"io"
 	"strings"
 
+	"istio.io/pkg/log"
+
+	"istio.io/operator/cmd/mesh"
+	"istio.io/operator/pkg/name"
+	"istio.io/operator/pkg/object"
+
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
 	v1batch "k8s.io/api/batch/v1"
@@ -31,39 +37,154 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"istio.io/istio/galley/pkg/config/meta/metadata"
-	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 )
 
 var (
 	verifyInstallCmd *cobra.Command
 )
 
-func verifyInstall(enableVerbose bool, istioNamespaceFlag string,
-	restClientGetter genericclioptions.RESTClientGetter, options resource.FilenameOptions,
-	writer io.Writer, args []string) error {
-	if len(options.Filenames) == 0 {
-		if len(args) != 0 {
-			_, _ = fmt.Fprint(writer, verifyInstallCmd.UsageString())
-			return fmt.Errorf("verify-install takes no arguments to perform installation pre-check")
-		}
-		return installPreCheck(istioNamespaceFlag, restClientGetter, writer)
+type verifyInstallArgs struct {
+	kubeConfigFlags *genericclioptions.ConfigFlags
+	fileNameFlags   *genericclioptions.FileNameFlags
+	istioNamespace  string
+	set             []string
+	enableVerbose   bool
+	preCheck        bool
+}
+
+// NewVerifyCommand creates a new command for verifying Istio Installation Status
+func NewVerifyCommand() *cobra.Command {
+	vArgs := &verifyInstallArgs{}
+	verifyInstallCmd = &cobra.Command{
+		Use:   "verify-install",
+		Short: "Verifies Istio Installation Status or performs pre-check for the cluster before Istio installation",
+		Long: `
+		verify-install verifies Istio installation status against the installation file or the IstioControlPlane 
+		CustomResource you specified when you installed Istio. It loops through all the installation
+		resources defined in your installation file and reports whether all of them are
+		in ready status. It will report failure when any of them are not ready.
+
+		If you do not specify installation file or specify --pre-check it will perform pre-check for your cluster
+		and report whether the cluster is ready for Istio installation.
+`,
+		Example: `
+		# Verify that Istio can be freshly installed
+		istioctl verify-install
+
+		# Verify that Istio can be freshly installed into 'istio-system' namespace
+		istioctl verify-install --pre-check -s defaultNamespace=istio-system
+		
+		# Verify the deployment matches a custom Istio deployment configuration
+		istioctl verify-install -f $HOME/istio.yaml
+
+		# Verify the deployment matches an IstioControlPlane CustomResource
+		istioctl verify-install -f $HOME/istio_v1alpha2_istiocontrolplane_cr.yaml
+
+		# Verify the deployment matches minimal profile for IstioControlPlane CustomResource
+		istioctl verify-install -s profile=minimal
+`,
+		RunE: func(c *cobra.Command, args []string) error {
+			l := mesh.NewLogger(false, c.OutOrStderr(), c.OutOrStderr())
+			return verifyInstall(vArgs, c.OutOrStderr(), args, l)
+		},
 	}
-	return verifyPostInstall(enableVerbose, istioNamespaceFlag, restClientGetter,
-		options, writer)
+
+	addVerifyInstallFlags(verifyInstallCmd, vArgs)
+	return verifyInstallCmd
+}
+
+func addVerifyInstallFlags(cmd *cobra.Command, v *verifyInstallArgs) {
+	var (
+		filenames     = []string{}
+		fileNameFlags = &genericclioptions.FileNameFlags{
+			Filenames: &filenames,
+			Recursive: boolPtr(false),
+			Usage:     "Istio YAML installation file or IstioControlPlane CustomResource file",
+		}
+		kubeConfigFlags = &genericclioptions.ConfigFlags{
+			Context:    strPtr(""),
+			Namespace:  strPtr(""),
+			KubeConfig: strPtr(""),
+		}
+	)
+	flags := cmd.PersistentFlags()
+	flags.StringVarP(&v.istioNamespace, "istioNamespace", "i", "istio-system",
+		"Istio system namespace")
+	verifyInstallCmd.PersistentFlags().StringSliceVarP(&v.set, "set", "s", nil, mesh.SetFlagHelpStr)
+	verifyInstallCmd.PersistentFlags().BoolVar(&v.enableVerbose, "enableVerbose", true,
+		"Enable verbose output")
+	verifyInstallCmd.PersistentFlags().BoolVar(&v.preCheck, "pre-check", false,
+		"perform pre-check for your cluster ")
+	kubeConfigFlags.AddFlags(flags)
+	v.kubeConfigFlags = kubeConfigFlags
+	fileNameFlags.AddFlags(flags)
+	v.fileNameFlags = fileNameFlags
+}
+
+func verifyInstall(v *verifyInstallArgs, writer io.Writer, args []string, l *mesh.Logger) error {
+	options := v.fileNameFlags.ToOptions()
+	noargs := len(options.Filenames) == 0 && v.set == nil && len(args) == 0
+	fileName := ""
+	compareFile := strings.Join(v.set, ",")
+	var manifest name.ManifestMap
+	if len(options.Filenames) != 0 || v.set != nil {
+		overlayFromSet, err := mesh.MakeTreeFromSetList(v.set, true, l)
+		if err != nil {
+			return err
+		}
+		options := v.fileNameFlags.ToOptions()
+		if len(options.Filenames) != 0 {
+			fileName = options.Filenames[0]
+			compareFile = fileName
+		}
+		manifest, _, _ = mesh.GenManifests(fileName, overlayFromSet, true, l)
+	}
+	if v.preCheck || noargs {
+		nsList := []string{}
+		if manifest != nil {
+			base := manifest[name.IstioBaseComponentName]
+			objects, err := object.ParseK8sObjectsFromYAMLManifest(base)
+			if err != nil {
+				log.Debugf("fails to parse base yaml: %v", err)
+			}
+			for _, v := range objects {
+				if v.Kind == "Namespace" {
+					nsList = append(nsList, v.Name)
+				}
+			}
+		}
+		return installPreCheck(v, nsList, writer)
+	}
+	return verifyPostInstall(v, compareFile, manifest, writer)
 
 }
 
-func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
-	restClientGetter resource.RESTClientGetter, options resource.FilenameOptions, writer io.Writer) error {
-	crdCount := 0
-	istioDeploymentCount := 0
-	r := resource.NewBuilder(restClientGetter).
-		Unstructured().
-		FilenameParam(false, &options).
-		Flatten().
-		Do()
-	if err := r.Err(); err != nil {
-		return err
+func verifyPostInstall(v *verifyInstallArgs, c string, m name.ManifestMap, writer io.Writer) error {
+	var crdCount, istioDeploymentCount int
+	var r *resource.Result
+	options := v.fileNameFlags.ToOptions()
+	manifestStr := ""
+	if m != nil {
+		for _, v := range m {
+			manifestStr += v
+		}
+		r = resource.NewBuilder(v.kubeConfigFlags).
+			Unstructured().
+			Stream(strings.NewReader(manifestStr), "manifest").
+			Flatten().
+			Do()
+		if err := r.Err(); err != nil {
+			return err
+		}
+	} else {
+		r = resource.NewBuilder(v.kubeConfigFlags).
+			Unstructured().
+			FilenameParam(false, &options).
+			Flatten().
+			Do()
+		if err := r.Err(); err != nil {
+			return err
+		}
 	}
 	err := r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
@@ -102,7 +223,7 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 			if err != nil {
 				return err
 			}
-			if namespace == istioNamespaceFlag && strings.HasPrefix(name, "istio-") {
+			if namespace == v.istioNamespace && strings.HasPrefix(name, "istio-") {
 				istioDeploymentCount++
 			}
 		case "Job":
@@ -121,7 +242,7 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 			for _, c := range job.Status.Conditions {
 				if c.Type == v1batch.JobFailed {
 					msg := fmt.Sprintf("Istio installation failed, incomplete or"+
-						" does not match \"%s\" - the required Job  %s failed", options.Filenames[0], name)
+						" does not match %q - the required Job  %s failed", c, name)
 					return errors.New(msg)
 				}
 			}
@@ -140,7 +261,7 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 					Do()
 				if result.Error() != nil {
 					msg := fmt.Sprintf("Istio installation failed, incomplete or"+
-						" does not match \"%s\" - the required %s:%s is not ready due to: %v", options.Filenames[0], kind, name, result.Error())
+						" does not match %q - the required %s:%s is not ready due to: %v", c, kind, name, result.Error())
 					return errors.New(msg)
 				}
 			}
@@ -148,7 +269,7 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 				crdCount++
 			}
 		}
-		if enableVerbose {
+		if v.enableVerbose {
 			_, _ = fmt.Fprintf(writer, "%s: %s.%s checked successfully\n", kind, name, namespace)
 		}
 		return nil
@@ -162,59 +283,6 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 	return nil
 }
 
-// NewVerifyCommand creates a new command for verifying Istio Installation Status
-func NewVerifyCommand() *cobra.Command {
-	var (
-		kubeConfigFlags = &genericclioptions.ConfigFlags{
-			Context:    strPtr(""),
-			Namespace:  strPtr(""),
-			KubeConfig: strPtr(""),
-		}
-
-		filenames     = []string{}
-		fileNameFlags = &genericclioptions.FileNameFlags{
-			Filenames: &filenames,
-			Recursive: boolPtr(false),
-			Usage:     "Istio YAML installation file.",
-		}
-		enableVerbose  bool
-		istioNamespace string
-	)
-	verifyInstallCmd = &cobra.Command{
-		Use:   "verify-install",
-		Short: "Verifies Istio Installation Status or performs pre-check for the cluster before Istio installation",
-		Long: `
-		verify-install verifies Istio installation status against the installation file
-		you specified when you installed Istio. It loops through all the installation
-		resources defined in your installation file and reports whether all of them are
-		in ready status. It will report failure when any of them are not ready.
-
-		If you do not specify installation file it will perform pre-check for your cluster
-		and report whether the cluster is ready for Istio installation.
-`,
-		Example: `
-		# Verify that Istio can be freshly installed
-		istioctl verify-install
-		
-		# Verify the deployment matches a custom Istio deployment configuration
-		istioctl verify-install -f $HOME/istio.yaml
-`,
-		RunE: func(c *cobra.Command, args []string) error {
-			return verifyInstall(enableVerbose, istioNamespace, kubeConfigFlags,
-				fileNameFlags.ToOptions(), c.OutOrStderr(), args)
-		},
-	}
-
-	flags := verifyInstallCmd.PersistentFlags()
-	flags.StringVarP(&istioNamespace, "istioNamespace", "i", controller.IstioNamespace,
-		"Istio system namespace")
-	kubeConfigFlags.AddFlags(flags)
-	fileNameFlags.AddFlags(flags)
-	verifyInstallCmd.Flags().BoolVar(&enableVerbose, "enableVerbose", true,
-		"Enable verbose output")
-	return verifyInstallCmd
-}
-
 func strPtr(val string) *string {
 	return &val
 }
@@ -226,24 +294,24 @@ func boolPtr(val bool) *bool {
 func getDeploymentStatus(deployment *appsv1.Deployment, name, fileName string) error {
 	cond := getDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing)
 	if cond != nil && cond.Reason == "ProgressDeadlineExceeded" {
-		msg := fmt.Sprintf("Istio installation failed, incomplete or does not match \"%s\""+
+		msg := fmt.Sprintf("Istio installation failed, incomplete or does not match %q"+
 			" - deployment %q exceeded its progress deadline", fileName, name)
 		return errors.New(msg)
 	}
 	if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
-		msg := fmt.Sprintf("Istio installation failed, incomplete or does not match \"%s\""+
+		msg := fmt.Sprintf("Istio installation failed, incomplete or does not match %q"+
 			" - waiting for deployment %q rollout to finish: %d out of %d new replicas have been updated",
 			fileName, name, deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas)
 		return errors.New(msg)
 	}
 	if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
-		msg := fmt.Sprintf("Istio installation failed, incomplete or does not match \"%s\""+
+		msg := fmt.Sprintf("Istio installation failed, incomplete or does not match %q"+
 			" - waiting for deployment %q rollout to finish: %d old replicas are pending termination",
 			fileName, name, deployment.Status.Replicas-deployment.Status.UpdatedReplicas)
 		return errors.New(msg)
 	}
 	if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
-		msg := fmt.Sprintf("Istio installation failed, incomplete or does not match \"%s\""+
+		msg := fmt.Sprintf("Istio installation failed, incomplete or does not match %q"+
 			" - waiting for deployment %q rollout to finish: %d of %d updated replicas are available",
 			fileName, name, deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas)
 		return errors.New(msg)


### PR DESCRIPTION
Add two support for istioctl verify-install

- Support IstioControlPlane cr as input: eg: `verify-install -f example-istiocontrolplane.cr.yaml`

- Support --set as input, eg: `verify-install -s profile=minimal`

- Support --set and -f for pre-check `verify-install --pre-check -s defaultNamespace=istio-system`