### PR TITLE
Support probe option for MCP client

### DIFF
--- a/mixer/pkg/config/mcp/backend.go
+++ b/mixer/pkg/config/mcp/backend.go
@@ -200,6 +200,7 @@ func (b *backend) Init(kinds []string) error {
 		Updater:           b,
 		ID:                mixerNodeID,
 		Reporter:          b.mcpReporter,
+		Probe:             b.Probe,
 	}
 
 	cl := mcp.NewResourceSourceClient(conn)

--- a/pkg/mcp/sink/sink.go
+++ b/pkg/mcp/sink/sink.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/mcp/monitoring"
 	"istio.io/istio/pkg/mcp/status"
 	"istio.io/pkg/log"
+	"istio.io/pkg/probe"
 )
 
 var scope = log.RegisterScope("mcp", "mcp debugging", 0)
@@ -351,6 +352,7 @@ type Options struct {
 	ID                string
 	Metadata          map[string]string
 	Reporter          monitoring.Reporter
+	*probe.Probe
 }
 
 // Stream is for sending RequestResources messages and receiving Resource messages.


### PR DESCRIPTION
This patch supports probe option for MCP client.

mixer supports readiness probe for config store currently, but MCP
client does not update probe. Hence, readinessProbe always does not
work when MCP is enabled. This patch fixes it.

Fixes https://github.com/istio/istio/issues/19290