### PR TITLE
listener: return early if egress listener does not have services

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -854,6 +854,11 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 	for _, egressListener := range node.SidecarScope.EgressListeners {
 
 		services := egressListener.Services()
+
+		// There is a possibility that egress listener might not have selected any service - early return from here.
+		if len(services) == 0 {
+			continue
+		}
 		virtualServices := egressListener.VirtualServices()
 
 		// determine the bindToPort setting for listeners


### PR DESCRIPTION
If egress listener does not have any services, just return early while building listeners. It is not  regular case for a listener not to have services - so not a big deal.