### PR TITLE
instruct K8s to garbage collect the validatingwebhookconfiguration

### DIFF
--- a/galley/pkg/crd/validation/config_test.go
+++ b/galley/pkg/crd/validation/config_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/onsi/gomega"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -103,9 +103,9 @@ func createTestWebhookConfigController(
 		CACertFile:                    caFile,
 		Clientset:                     cl,
 		WebhookName:                   config.Name,
-		DeploymentName:                dummyNamespace.Name,
-		ServiceName:                   dummyNamespace.Name,
-		DeploymentAndServiceNamespace: dummyNamespace.Namespace,
+		DeploymentName:                dummyClusterRole.Name,
+		ServiceName:                   dummyClusterRole.Name,
+		DeploymentAndServiceNamespace: dummyNamespace,
 	}
 	whc, err := NewWebhookConfigController(options)
 	if err != nil {
@@ -239,7 +239,7 @@ func TestValidatingWebhookConfig(t *testing.T) {
 	for _, tc := range ts {
 		t.Run(tc.name, func(t *testing.T) {
 			whc, cancel := createTestWebhookConfigController(t,
-				fake.NewSimpleClientset(dummyNamespace, tc.configs.DeepCopyObject()),
+				fake.NewSimpleClientset(dummyClusterRole, tc.configs.DeepCopyObject()),
 				createFakeWebhookSource(), want)
 			defer cancel()
 
@@ -295,8 +295,8 @@ func initValidatingWebhookConfiguration() *admissionregistrationv1beta1.Validati
 			Name: "config1",
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(
-					dummyNamespace,
-					corev1.SchemeGroupVersion.WithKind("Namespace"),
+					dummyClusterRole,
+					rbacv1.SchemeGroupVersion.WithKind("ClusterRole"),
 				),
 			},
 		},

--- a/galley/pkg/crd/validation/webhook_test.go
+++ b/galley/pkg/crd/validation/webhook_test.go
@@ -34,6 +34,7 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -101,22 +102,23 @@ var (
 		},
 	}
 
-	dummyNamespace = &v1.Namespace{
+	dummyNamespace   = "istio-system"
+	dummyClusterRole = &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "istio-system",
+			Name: "istio-galley-istio-system",
 			UID:  "deadbeef",
 		},
 	}
 
-	dummyClient = fake.NewSimpleClientset(dummyNamespace)
+	dummyClient = fake.NewSimpleClientset(dummyClusterRole)
 
 	createFakeWebhookSource   = fcache.NewFakeControllerSource
 	createFakeEndpointsSource = func() cache.ListerWatcher {
 		source := fcache.NewFakeControllerSource()
 		source.Add(&v1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      dummyNamespace.Name,
-				Namespace: dummyNamespace.Namespace,
+				Name:      dummyClusterRole.Name,
+				Namespace: dummyNamespace,
 			},
 			Subsets: []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
@@ -194,9 +196,9 @@ func createTestWebhook(
 		CACertFile:                    caFile,
 		Clientset:                     cl,
 		WebhookName:                   config.Name,
-		DeploymentName:                dummyNamespace.Name,
-		ServiceName:                   dummyNamespace.Name,
-		DeploymentAndServiceNamespace: dummyNamespace.Namespace,
+		DeploymentName:                dummyClusterRole.Name,
+		ServiceName:                   dummyClusterRole.Name,
+		DeploymentAndServiceNamespace: dummyNamespace,
 	}
 	wh, err := NewWebhook(options)
 	if err != nil {

--- a/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
@@ -48,3 +48,6 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION

resolve: https://github.com/istio/istio/issues/19073

Update the owner refs of `istio-galley` validatingwebhookconfiguration from `namespace` to `clusterrole`, since istio chart will be deleted but the `istio-system` namespace will be kept, in that case, the `istio-galley` validatingwebhookconfiguration will not be cleaned.