### PR TITLE
service entry: optimize service entry updates

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -502,22 +502,15 @@ func (s *Server) initEventHandlers() error {
 	}
 
 	instanceHandler := func(si *model.ServiceInstance, _ model.Event) {
-		endpoints := make([]*model.IstioEndpoint, 0)
-		for _, port := range si.Service.Ports {
-			endpoints = append(endpoints, &model.IstioEndpoint{
-				Address:         si.Endpoint.Address,
-				EndpointPort:    uint32(port.Port),
-				ServicePortName: port.Name,
-				Labels:          si.Labels,
-				UID:             si.Endpoint.UID,
-				ServiceAccount:  si.ServiceAccount,
-				Network:         si.Endpoint.Network,
-				Locality:        si.Endpoint.Locality,
-				Attributes:      model.ServiceAttributes{Name: si.Service.Attributes.Name, Namespace: si.Service.Attributes.Namespace},
-				TLSMode:         si.TLSMode,
-			})
-		}
-		s.EnvoyXdsServer.EDSUpdate("", si.Service.Attributes.Name, si.Service.Attributes.Namespace, endpoints)
+		// TODO: This is an incomplete code. This code path is called for consul, etc.
+		// In all cases, this is simply an instance update and not a config update. So, we need to update
+		// EDS in all proxies, and do a full config push for the instance that just changed (add/update only).
+		s.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{
+			Full:              true,
+			NamespacesUpdated: map[string]struct{}{si.Service.Attributes.Namespace: {}},
+			// TODO: extend and set service instance type, so no need re-init push context
+			ConfigTypesUpdated: map[string]struct{}{schemas.ServiceEntry.Type: {}},
+		})
 	}
 	if err := s.ServiceController.AppendInstanceHandler(instanceHandler); err != nil {
 		return fmt.Errorf("append instance handler failed: %v", err)

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -61,7 +61,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 		}
 	}
 
-	serviceEntryStore := external.NewServiceDiscovery(s.configController, s.istioConfigStore)
+	serviceEntryStore := external.NewServiceDiscovery(s.configController, s.istioConfigStore, s.EnvoyXdsServer)
 	serviceControllers.AddRegistry(serviceEntryStore)
 
 	s.ServiceController = serviceControllers

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -65,6 +65,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 	serviceControllers.AddRegistry(serviceEntryStore)
 
 	s.ServiceController = serviceControllers
+	s.serviceEntryStore = serviceEntryStore
 
 	// Defer running of the service controllers.
 	s.addStartFunc(func(stop <-chan struct{}) error {

--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -171,7 +171,7 @@ func (cr *storeCache) HasSynced() bool {
 	return true
 }
 
-func (cr *storeCache) RegisterEventHandler(typ string, handler func(model.Config, model.Event)) {
+func (cr *storeCache) RegisterEventHandler(typ string, handler func(model.Config, model.Config, model.Event)) {
 	for _, cache := range cr.caches {
 		if _, exists := cache.ConfigDescriptor().GetByType(typ); exists {
 			cache.RegisterEventHandler(typ, handler)

--- a/pilot/pkg/config/aggregate/config_test.go
+++ b/pilot/pkg/config/aggregate/config_test.go
@@ -242,7 +242,7 @@ func TestAggregateStoreCache(t *testing.T) {
 	t.Run("it registers an event handler", func(t *testing.T) {
 		g := gomega.NewGomegaWithT(t)
 
-		cacheStore.RegisterEventHandler("some-config", func(model.Config, model.Event) {})
+		cacheStore.RegisterEventHandler("some-config", func(model.Config, model.Config, model.Event) {})
 
 		typ, h := storeOne.RegisterEventHandlerArgsForCall(0)
 		g.Expect(typ).To(gomega.Equal("some-config"))

--- a/pilot/pkg/config/aggregate/fakes/config_store_cache.gen.go
+++ b/pilot/pkg/config/aggregate/fakes/config_store_cache.gen.go
@@ -96,11 +96,11 @@ type ConfigStoreCache struct {
 		result1 []model.Config
 		result2 error
 	}
-	RegisterEventHandlerStub        func(string, func(model.Config, model.Event))
+	RegisterEventHandlerStub        func(string, func(model.Config, model.Config, model.Event))
 	registerEventHandlerMutex       sync.RWMutex
 	registerEventHandlerArgsForCall []struct {
 		arg1 string
-		arg2 func(model.Config, model.Event)
+		arg2 func(model.Config, model.Config, model.Event)
 	}
 	RunStub        func(<-chan struct{})
 	runMutex       sync.RWMutex
@@ -553,11 +553,11 @@ func (fake *ConfigStoreCache) ListReturnsOnCall(i int, result1 []model.Config, r
 	}{result1, result2}
 }
 
-func (fake *ConfigStoreCache) RegisterEventHandler(arg1 string, arg2 func(model.Config, model.Event)) {
+func (fake *ConfigStoreCache) RegisterEventHandler(arg1 string, arg2 func(model.Config, model.Config, model.Event)) {
 	fake.registerEventHandlerMutex.Lock()
 	fake.registerEventHandlerArgsForCall = append(fake.registerEventHandlerArgsForCall, struct {
 		arg1 string
-		arg2 func(model.Config, model.Event)
+		arg2 func(model.Config, model.Config, model.Event)
 	}{arg1, arg2})
 	fake.recordInvocation("RegisterEventHandler", []interface{}{arg1, arg2})
 	fake.registerEventHandlerMutex.Unlock()
@@ -572,13 +572,13 @@ func (fake *ConfigStoreCache) RegisterEventHandlerCallCount() int {
 	return len(fake.registerEventHandlerArgsForCall)
 }
 
-func (fake *ConfigStoreCache) RegisterEventHandlerCalls(stub func(string, func(model.Config, model.Event))) {
+func (fake *ConfigStoreCache) RegisterEventHandlerCalls(stub func(string, func(model.Config, model.Config, model.Event))) {
 	fake.registerEventHandlerMutex.Lock()
 	defer fake.registerEventHandlerMutex.Unlock()
 	fake.RegisterEventHandlerStub = stub
 }
 
-func (fake *ConfigStoreCache) RegisterEventHandlerArgsForCall(i int) (string, func(model.Config, model.Event)) {
+func (fake *ConfigStoreCache) RegisterEventHandlerArgsForCall(i int) (string, func(model.Config, model.Config, model.Event)) {
 	fake.registerEventHandlerMutex.RLock()
 	defer fake.registerEventHandlerMutex.RUnlock()
 	argsForCall := fake.registerEventHandlerArgsForCall[i]

--- a/pilot/pkg/config/coredatamodel/controller_test.go
+++ b/pilot/pkg/config/coredatamodel/controller_test.go
@@ -639,7 +639,7 @@ func TestEventHandler(t *testing.T) {
 		model.EventUpdate: {},
 		model.EventDelete: {},
 	}
-	controller.RegisterEventHandler(schemas.ServiceEntry.Type, func(m model.Config, e model.Event) {
+	controller.RegisterEventHandler(schemas.ServiceEntry.Type, func(_, m model.Config, e model.Event) {
 		gotEvents[e][makeName(m.Namespace, m.Name)] = m
 	})
 

--- a/pilot/pkg/config/coredatamodel/discovery.go
+++ b/pilot/pkg/config/coredatamodel/discovery.go
@@ -66,7 +66,7 @@ func NewMCPDiscovery(controller CoreDataModel, options *DiscoveryOptions) *MCPDi
 		cacheByHostName:                 make(map[host.Name][]*model.ServiceInstance),
 		cacheServices:                   make(map[string]*model.Service),
 	}
-	discovery.RegisterEventHandler(schemas.SyntheticServiceEntry.Type, func(config model.Config, event model.Event) {
+	discovery.RegisterEventHandler(schemas.SyntheticServiceEntry.Type, func(_, config model.Config, event model.Event) {
 		discovery.HandleCacheEvents(config, event)
 	})
 	return discovery

--- a/pilot/pkg/config/coredatamodel/syntheticserviceentrycontroller.go
+++ b/pilot/pkg/config/coredatamodel/syntheticserviceentrycontroller.go
@@ -45,7 +45,7 @@ type SyntheticServiceEntryController struct {
 	configStoreMu sync.RWMutex
 	// keys [namespace][name]
 	configStore  map[string]map[string]*model.Config
-	eventHandler func(model.Config, model.Event)
+	eventHandler func(model.Config, model.Config, model.Event)
 	synced       uint32
 	*Options
 }
@@ -126,16 +126,15 @@ func (c *SyntheticServiceEntryController) HasSynced() bool {
 
 func (c *SyntheticServiceEntryController) dispatch(config model.Config, event model.Event) {
 	if c.eventHandler != nil {
-		c.eventHandler(config, event)
+		c.eventHandler(model.Config{}, config, event)
 	}
 }
 
 // RegisterEventHandler registers a handler using the type as a key
-func (c *SyntheticServiceEntryController) RegisterEventHandler(typ string, handler func(model.Config, model.Event)) {
+func (c *SyntheticServiceEntryController) RegisterEventHandler(typ string, handler func(model.Config, model.Config, model.Event)) {
 	// TODO: investigate why it is called more than one
 	if c.eventHandler == nil {
 		c.eventHandler = handler
-
 	}
 }
 

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -100,21 +100,21 @@ func NewController(client kubernetes.Interface, mesh *meshconfig.MeshConfig,
 	informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				queue.Push(kube.NewTask(handler.Apply, obj, model.EventAdd))
+				queue.Push(kube.NewTask(handler.Apply, nil, obj, model.EventAdd))
 			},
 			UpdateFunc: func(old, cur interface{}) {
 				if !reflect.DeepEqual(old, cur) {
-					queue.Push(kube.NewTask(handler.Apply, cur, model.EventUpdate))
+					queue.Push(kube.NewTask(handler.Apply, old, cur, model.EventUpdate))
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				queue.Push(kube.NewTask(handler.Apply, obj, model.EventDelete))
+				queue.Push(kube.NewTask(handler.Apply, nil, obj, model.EventDelete))
 			},
 		})
 
 	// first handler in the chain blocks until the cache is fully synchronized
 	// it does this by returning an error to the chain handler
-	handler.Append(func(obj interface{}, event model.Event) error {
+	handler.Append(func(_, obj interface{}, event model.Event) error {
 		if !informer.HasSynced() {
 			return errors.New("waiting till full synchronization")
 		}
@@ -134,9 +134,9 @@ func NewController(client kubernetes.Interface, mesh *meshconfig.MeshConfig,
 	}
 }
 
-func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model.Event)) {
-	c.handler.Append(func(obj interface{}, event model.Event) error {
-		ingress, ok := obj.(*extensionsv1beta1.Ingress)
+func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model.Config, model.Event)) {
+	c.handler.Append(func(_, curr interface{}, event model.Event) error {
+		ingress, ok := curr.(*extensionsv1beta1.Ingress)
 		if !ok || !shouldProcessIngress(c.mesh, ingress) {
 			return nil
 		}
@@ -151,7 +151,7 @@ func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model
 		// An updated ingress may also trigger an Add or Delete for one of its constituent sub-rules.
 		switch typ {
 		case schemas.VirtualService.Type:
-			f(model.Config{
+			f(model.Config{}, model.Config{
 				ConfigMeta: model.ConfigMeta{
 					Type: typ,
 				},

--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -121,7 +121,7 @@ func NewStatusSyncer(mesh *meshconfig.MeshConfig,
 			log.Infof("I am the new status update leader")
 			go st.queue.Run(ctx.Done())
 			err := wait.PollUntil(updateInterval, func() (bool, error) {
-				st.queue.Push(kube.NewTask(st.handler.Apply, "Start leading", model.EventUpdate))
+				st.queue.Push(kube.NewTask(st.handler.Apply, "", "Start leading", model.EventUpdate))
 				return false, nil
 			}, ctx.Done())
 
@@ -171,7 +171,7 @@ func NewStatusSyncer(mesh *meshconfig.MeshConfig,
 	st.elector = le
 
 	// Register handler at the beginning
-	handler.Append(func(obj interface{}, event model.Event) error {
+	handler.Append(func(old, curr interface{}, event model.Event) error {
 		addrs, err := st.runningAddresses(ingressNamespace)
 		if err != nil {
 			return err

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -37,7 +37,7 @@ func NewController(cs model.ConfigStore) model.ConfigStoreCache {
 	return out
 }
 
-func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model.Event)) {
+func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model.Config, model.Event)) {
 	c.monitor.AppendEventHandler(typ, f)
 }
 

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -77,8 +77,10 @@ func (c *controller) Create(config model.Config) (revision string, err error) {
 }
 
 func (c *controller) Update(config model.Config) (newRevision string, err error) {
+	oldconfig := c.configStore.Get(config.Type, config.Name, config.Namespace)
 	if newRevision, err = c.configStore.Update(config); err == nil {
 		c.monitor.ScheduleProcessEvent(ConfigEvent{
+			old:    *oldconfig,
 			config: config,
 			event:  model.EventUpdate,
 		})

--- a/pilot/pkg/config/memory/monitor.go
+++ b/pilot/pkg/config/memory/monitor.go
@@ -37,6 +37,7 @@ type Monitor interface {
 // ConfigEvent defines the event to be processed
 type ConfigEvent struct {
 	config model.Config
+	old    model.Config
 	event  model.Event
 }
 
@@ -91,15 +92,15 @@ func (m *configstoreMonitor) processConfigEvent(ce ConfigEvent) {
 		log.Warnf("Config Type %s does not exist in config store", ce.config.Type)
 		return
 	}
-	m.applyHandlers(ce.config, ce.event)
+	m.applyHandlers(ce.old, ce.config, ce.event)
 }
 
 func (m *configstoreMonitor) AppendEventHandler(typ string, h Handler) {
 	m.handlers[typ] = append(m.handlers[typ], h)
 }
 
-func (m *configstoreMonitor) applyHandlers(config model.Config, e model.Event) {
+func (m *configstoreMonitor) applyHandlers(old model.Config, config model.Config, e model.Event) {
 	for _, f := range m.handlers[config.Type] {
-		f(model.Config{}, config, e)
+		f(old, config, e)
 	}
 }

--- a/pilot/pkg/config/memory/monitor.go
+++ b/pilot/pkg/config/memory/monitor.go
@@ -25,7 +25,7 @@ const (
 )
 
 // Handler specifies a function to apply on a Config for a given event type
-type Handler func(model.Config, model.Event)
+type Handler func(model.Config, model.Config, model.Event)
 
 // Monitor provides methods of manipulating changes in the config store
 type Monitor interface {
@@ -100,6 +100,6 @@ func (m *configstoreMonitor) AppendEventHandler(typ string, h Handler) {
 
 func (m *configstoreMonitor) applyHandlers(config model.Config, e model.Event) {
 	for _, f := range m.handlers[config.Type] {
-		f(config, e)
+		f(model.Config{}, config, e)
 	}
 }

--- a/pilot/pkg/config/memory/monitor_test.go
+++ b/pilot/pkg/config/memory/monitor_test.go
@@ -35,7 +35,7 @@ func TestEventConsistency(t *testing.T) {
 
 	lock := sync.Mutex{}
 
-	controller.RegisterEventHandler(schemas.MockConfig.Type, func(config model.Config, event model.Event) {
+	controller.RegisterEventHandler(schemas.MockConfig.Type, func(_, config model.Config, event model.Event) {
 
 		lock.Lock()
 		tc := testConfig

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -184,7 +184,7 @@ type ConfigStoreCache interface {
 
 	// RegisterEventHandler adds a handler to receive config update events for a
 	// configuration type
-	RegisterEventHandler(typ string, handler func(Config, Event))
+	RegisterEventHandler(typ string, handler func(Config, Config, Event))
 
 	// Run until a signal is received
 	Run(stop <-chan struct{})

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -103,8 +103,11 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 							ServiceAccount:  instance.ServiceAccount,
 							Network:         instance.Endpoint.Network,
 							Locality:        instance.Endpoint.Locality,
-							Attributes:      model.ServiceAttributes{Name: instance.Service.Attributes.Name, Namespace: instance.Service.Attributes.Namespace},
-							TLSMode:         instance.TLSMode,
+							Attributes: model.ServiceAttributes{
+								Name:      instance.Service.Attributes.Name,
+								Namespace: instance.Service.Attributes.Namespace,
+							},
+							TLSMode: instance.TLSMode,
 						})
 					}
 				}

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -108,7 +108,7 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 						})
 					}
 				}
-				c.XdsUpdater.EDSUpdate(c.Cluster(), curr.Name, curr.Namespace, endpoints)
+				_ = c.XdsUpdater.EDSUpdate(c.Cluster(), curr.Name, curr.Namespace, endpoints)
 			}
 		})
 	}

--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -244,7 +244,7 @@ func TestNonServiceConfig(t *testing.T) {
 
 func TestServicesChanged(t *testing.T) {
 
-	var updatedHttpDNS = &model.Config{
+	var updatedHTTPDNS = &model.Config{
 		ConfigMeta: model.ConfigMeta{
 			Type:              schemas.ServiceEntry.Type,
 			Name:              "httpDNS",
@@ -279,7 +279,7 @@ func TestServicesChanged(t *testing.T) {
 		},
 	}
 
-	var updatedHttpDNSPort = &model.Config{
+	var updatedHTTPDNSPort = &model.Config{
 		ConfigMeta: model.ConfigMeta{
 			Type:              schemas.ServiceEntry.Type,
 			Name:              "httpDNS",
@@ -380,18 +380,18 @@ func TestServicesChanged(t *testing.T) {
 		{
 			"config modified with additional host",
 			httpDNS,
-			updatedHttpDNS,
+			updatedHTTPDNS,
 			true,
 		},
 		{
 			"config modified with additional port",
-			updatedHttpDNS,
-			updatedHttpDNSPort,
+			updatedHTTPDNS,
+			updatedHTTPDNSPort,
 			true,
 		},
 		{
 			"same config with additional endpoint",
-			updatedHttpDNS,
+			updatedHTTPDNS,
 			updatedEndpoint,
 			false,
 		},

--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -42,6 +42,23 @@ func createServiceEntries(configs []*model.Config, store model.IstioConfigStore,
 type channelTerminal struct {
 }
 
+// FakeXdsUpdater is used to test the event handlers.
+type FakeXdsUpdater struct {
+}
+
+func (fx *FakeXdsUpdater) EDSUpdate(shard, hostname string, namespace string, entry []*model.IstioEndpoint) error {
+	return nil
+}
+
+func (fx *FakeXdsUpdater) ConfigUpdate(*model.PushRequest) {
+}
+
+func (fx *FakeXdsUpdater) ProxyUpdate(clusterID, ip string) {
+}
+
+func (fx *FakeXdsUpdater) SvcUpdate(shard, hostname string, namespace string, event model.Event) {
+}
+
 func initServiceDiscovery() (model.IstioConfigStore, *ServiceEntryStore, func()) {
 	store := memory.Make(schemas.Istio)
 	configController := memory.NewController(store)
@@ -50,7 +67,8 @@ func initServiceDiscovery() (model.IstioConfigStore, *ServiceEntryStore, func())
 	go configController.Run(stop)
 
 	istioStore := model.MakeIstioStore(configController)
-	serviceController := NewServiceDiscovery(configController, istioStore)
+	xdsUpdater := &FakeXdsUpdater{}
+	serviceController := NewServiceDiscovery(configController, istioStore, xdsUpdater)
 	return istioStore, serviceController, func() {
 		stop <- channelTerminal{}
 	}
@@ -261,6 +279,80 @@ func TestServicesChanged(t *testing.T) {
 		},
 	}
 
+	var updatedHttpDNSPort = &model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Type:              schemas.ServiceEntry.Type,
+			Name:              "httpDNS",
+			Namespace:         "httpDNS",
+			CreationTimestamp: GlobalTime,
+			Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		},
+		Spec: &networking.ServiceEntry{
+			Hosts: []string{"*.google.com", "*.mail.com"},
+			Ports: []*networking.Port{
+				{Number: 80, Name: "http-port", Protocol: "http"},
+				{Number: 8080, Name: "http-alt-port", Protocol: "http"},
+				{Number: 9090, Name: "http-new-port", Protocol: "http"},
+			},
+			Endpoints: []*networking.ServiceEntry_Endpoint{
+				{
+					Address: "us.google.com",
+					Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
+					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				},
+				{
+					Address: "uk.google.com",
+					Ports:   map[string]uint32{"http-port": 1080},
+					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				},
+				{
+					Address: "de.google.com",
+					Labels:  map[string]string{"foo": "bar", model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				},
+			},
+			Location:   networking.ServiceEntry_MESH_EXTERNAL,
+			Resolution: networking.ServiceEntry_DNS,
+		},
+	}
+
+	var updatedEndpoint = &model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Type:              schemas.ServiceEntry.Type,
+			Name:              "httpDNS",
+			Namespace:         "httpDNS",
+			CreationTimestamp: GlobalTime,
+			Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		},
+		Spec: &networking.ServiceEntry{
+			Hosts: []string{"*.google.com", "*.mail.com"},
+			Ports: []*networking.Port{
+				{Number: 80, Name: "http-port", Protocol: "http"},
+				{Number: 8080, Name: "http-alt-port", Protocol: "http"},
+			},
+			Endpoints: []*networking.ServiceEntry_Endpoint{
+				{
+					Address: "us.google.com",
+					Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
+					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				},
+				{
+					Address: "uk.google.com",
+					Ports:   map[string]uint32{"http-port": 1080},
+					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				},
+				{
+					Address: "de.google.com",
+					Labels:  map[string]string{"foo": "bar", model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				},
+				{
+					Address: "in.google.com",
+					Labels:  map[string]string{"foo": "bar", model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				},
+			},
+			Location:   networking.ServiceEntry_MESH_EXTERNAL,
+			Resolution: networking.ServiceEntry_DNS,
+		},
+	}
 	cases := []struct {
 		name string
 		a    *model.Config
@@ -286,10 +378,22 @@ func TestServicesChanged(t *testing.T) {
 			true,
 		},
 		{
-			"same config with additional host",
+			"config modified with additional host",
 			httpDNS,
 			updatedHttpDNS,
 			true,
+		},
+		{
+			"config modified with additional port",
+			updatedHttpDNS,
+			updatedHttpDNSPort,
+			true,
+		},
+		{
+			"same config with additional endpoint",
+			updatedHttpDNS,
+			updatedEndpoint,
+			false,
 		},
 	}
 	for _, tt := range cases {

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1603,7 +1603,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 
 	// Now delete pod2, from PodCache and send Endpoints. This simulates the case that endpoint comes
 	// when PodCache does not yet have entry for the pod.
-	controller.pods.event(pod2, model.EventDelete)
+	controller.pods.event(nil, pod2, model.EventDelete)
 
 	pod2Ips := []string{"172.0.1.2"}
 	createEndpoints(controller, "pod2", "nsA", portNames, pod2Ips, t)

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -55,20 +55,20 @@ func newPodCache(ch cacheHandler, c *Controller) *PodCache {
 }
 
 // event updates the IP-based index (pc.podsByIP).
-func (pc *PodCache) event(obj interface{}, ev model.Event) error {
+func (pc *PodCache) event(old, curr interface{}, ev model.Event) error {
 	pc.Lock()
 	defer pc.Unlock()
 
 	// When a pod is deleted obj could be an *v1.Pod or a DeletionFinalStateUnknown marker item.
-	pod, ok := obj.(*v1.Pod)
+	pod, ok := curr.(*v1.Pod)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		tombstone, ok := curr.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			return fmt.Errorf("couldn't get object from tombstone %+v", obj)
+			return fmt.Errorf("couldn't get object from tombstone %+v", curr)
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			return fmt.Errorf("tombstone contained object that is not a pod %#v", obj)
+			return fmt.Errorf("tombstone contained object that is not a pod %#v", curr)
 		}
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -181,14 +181,14 @@ func TestPodCacheEvents(t *testing.T) {
 	ns := "default"
 	ip := "172.0.3.35"
 	pod1 := metav1.ObjectMeta{Name: "pod1", Namespace: ns}
-	if err := f(&v1.Pod{ObjectMeta: pod1}, model.EventAdd); err != nil {
+	if err := f(nil, &v1.Pod{ObjectMeta: pod1}, model.EventAdd); err != nil {
 		t.Error(err)
 	}
 
 	// The first time pod occur
 	fx.Wait("xds")
 
-	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodPending}}, model.EventUpdate); err != nil {
+	if err := f(&v1.Pod{ObjectMeta: pod1}, &v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodPending}}, model.EventUpdate); err != nil {
 		t.Error(err)
 	}
 
@@ -197,18 +197,10 @@ func TestPodCacheEvents(t *testing.T) {
 	}
 
 	pod2 := metav1.ObjectMeta{Name: "pod2", Namespace: ns}
-	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventUpdate); err != nil {
+	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodPending}}, &v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventUpdate); err != nil {
 		t.Error(err)
 	}
-	if err := f(&v1.Pod{ObjectMeta: pod2, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodRunning}}, model.EventAdd); err != nil {
-		t.Error(err)
-	}
-
-	if pod, exists := podCache.getPodKey(ip); !exists || pod != "default/pod2" {
-		t.Errorf("getPodKey => got %s, pod2 not found or incorrect", pod)
-	}
-
-	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventDelete); err != nil {
+	if err := f(nil, &v1.Pod{ObjectMeta: pod2, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodRunning}}, model.EventAdd); err != nil {
 		t.Error(err)
 	}
 
@@ -216,7 +208,15 @@ func TestPodCacheEvents(t *testing.T) {
 		t.Errorf("getPodKey => got %s, pod2 not found or incorrect", pod)
 	}
 
-	if err := f(&v1.Pod{ObjectMeta: pod2, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventDelete); err != nil {
+	if err := f(nil, &v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventDelete); err != nil {
+		t.Error(err)
+	}
+
+	if pod, exists := podCache.getPodKey(ip); !exists || pod != "default/pod2" {
+		t.Errorf("getPodKey => got %s, pod2 not found or incorrect", pod)
+	}
+
+	if err := f(nil, &v1.Pod{ObjectMeta: pod2, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventDelete); err != nil {
 		t.Error(err)
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -197,7 +197,8 @@ func TestPodCacheEvents(t *testing.T) {
 	}
 
 	pod2 := metav1.ObjectMeta{Name: "pod2", Namespace: ns}
-	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodPending}}, &v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventUpdate); err != nil {
+	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodPending}},
+		&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventUpdate); err != nil {
 		t.Error(err)
 	}
 	if err := f(nil, &v1.Pod{ObjectMeta: pod2, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodRunning}}, model.EventAdd); err != nil {

--- a/pilot/test/mock/config.go
+++ b/pilot/test/mock/config.go
@@ -479,7 +479,7 @@ func CheckCacheEvents(store model.ConfigStore, cache model.ConfigStoreCache, nam
 	stop := make(chan struct{})
 	defer close(stop)
 	added, deleted := atomic.NewInt64(0), atomic.NewInt64(0)
-	cache.RegisterEventHandler(schemas.MockConfig.Type, func(_ model.Config, ev model.Event) {
+	cache.RegisterEventHandler(schemas.MockConfig.Type, func(_, _ model.Config, ev model.Event) {
 		switch ev {
 		case model.EventAdd:
 			if deleted.Load() != 0 {
@@ -512,7 +512,7 @@ func CheckCacheFreshness(cache model.ConfigStoreCache, namespace string, t *test
 	o := Make(namespace, 0)
 
 	// validate cache consistency
-	cache.RegisterEventHandler(schemas.MockConfig.Type, func(config model.Config, ev model.Event) {
+	cache.RegisterEventHandler(schemas.MockConfig.Type, func(_, config model.Config, ev model.Event) {
 		elts, _ := cache.List(schemas.MockConfig.Type, namespace)
 		elt := cache.Get(o.Type, o.Name, o.Namespace)
 		switch ev {

--- a/pkg/istiod/pilotstart.go
+++ b/pkg/istiod/pilotstart.go
@@ -549,7 +549,7 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 // addConfig2ServiceEntry creates and initializes the ServiceController used for translating
 // ServiceEntries from config store to discovery.
 func (s *Server) addConfig2ServiceEntry() {
-	serviceEntryStore := external.NewServiceDiscovery(s.ConfigController, s.IstioConfigStore)
+	serviceEntryStore := external.NewServiceDiscovery(s.ConfigController, s.IstioConfigStore, s.EnvoyXdsServer)
 	s.ServiceController.AddRegistry(serviceEntryStore)
 }
 

--- a/pkg/istiod/pilotstart.go
+++ b/pkg/istiod/pilotstart.go
@@ -697,7 +697,7 @@ func (s *Server) initEventHandlers() error {
 	if s.ConfigController != nil {
 		// TODO: changes should not trigger a full recompute of LDS/RDS/CDS/EDS
 		// (especially mixerclient HTTP and quota)
-		configHandler := func(c model.Config, _ model.Event) {
+		configHandler := func(_, c model.Config, _ model.Event) {
 			pushReq := &model.PushRequest{
 				Full:               true,
 				ConfigTypesUpdated: map[string]struct{}{c.Type: {}},


### PR DESCRIPTION
Currently any Service Entry update does a full push. This PR optimizes that behaviour and update trigger full push only if services have changed, otherwise it does eds update. This requires reworking of event handlers to pass old and curr object across all the event handlers.