### PR TITLE
Disable redirect calls to app itself via envoy

### DIFF
--- a/tests/scripts/testdata/golang/empty_parameter_golden.txt
+++ b/tests/scripts/testdata/golang/empty_parameter_golden.txt
@@ -34,10 +34,17 @@ iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-port 15001
 iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-port 15001
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 0 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 0 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 0 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
 iptables-save 

--- a/tests/scripts/testdata/golang/mode_redirect_golden.txt
+++ b/tests/scripts/testdata/golang/mode_redirect_golden.txt
@@ -38,8 +38,11 @@ iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5555 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 6666 -j ISTIO_IN_REDIRECT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 4321 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 4444 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 9.9.0.0/16 -j RETURN

--- a/tests/scripts/testdata/golang/mode_tproxy_and_ipv6_golden.txt
+++ b/tests/scripts/testdata/golang/mode_tproxy_and_ipv6_golden.txt
@@ -49,8 +49,11 @@ iptables -t mangle -A ISTIO_INBOUND -p tcp -m socket -j ISTIO_DIVERT
 iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 4321 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 4444 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
 iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
@@ -68,8 +71,11 @@ ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 8888 -j RETURN
 ip6tables -t nat -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
-ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 4321 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4321 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
+ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 4444 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 4444 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d 2019:db8::/32 -j RETURN

--- a/tests/scripts/testdata/golang/mode_tproxy_and_wildcard_port_golden.txt
+++ b/tests/scripts/testdata/golang/mode_tproxy_and_wildcard_port_golden.txt
@@ -48,8 +48,11 @@ iptables -t mangle -A ISTIO_INBOUND -p tcp -m socket -j ISTIO_DIVERT
 iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 4321 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 4444 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 9.9.0.0/16 -j RETURN

--- a/tests/scripts/testdata/golang/mode_tproxy_golden.txt
+++ b/tests/scripts/testdata/golang/mode_tproxy_golden.txt
@@ -49,8 +49,11 @@ iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 6666 -m socket -j ISTIO_DIVER
 iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 6666 -j ISTIO_TPROXY
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 4321 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 4444 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 9.9.0.0/16 -j RETURN

--- a/tests/scripts/testdata/golang/outbound_port_exclude_golden.txt
+++ b/tests/scripts/testdata/golang/outbound_port_exclude_golden.txt
@@ -40,8 +40,11 @@ iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 1024 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 21 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 4321 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 4444 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 9.9.0.0/16 -j RETURN

--- a/tests/scripts/testdata/golang/wildcard_include_ip_range_golden.txt
+++ b/tests/scripts/testdata/golang/wildcard_include_ip_range_golden.txt
@@ -38,8 +38,11 @@ iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5555 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 6666 -j ISTIO_IN_REDIRECT
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 4321 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4321 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4321 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 4444 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 4444 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 9.9.0.0/16 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -22,18 +22,10 @@ import (
 	"strings"
 	"time"
 
-	"istio.io/pkg/env"
-
 	"istio.io/istio/tools/istio-iptables/pkg/builder"
-	"istio.io/istio/tools/istio-iptables/pkg/constants"
-
 	"istio.io/istio/tools/istio-iptables/pkg/config"
+	"istio.io/istio/tools/istio-iptables/pkg/constants"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
-)
-
-var (
-	// TODO: Add a description.
-	disableRedirectionOnLocalLoopbackVar = env.RegisterBoolVar(constants.DisableRedirectionOnLocalLoopback, false, "")
 )
 
 type IptablesConfigurator struct {

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -65,8 +65,11 @@ func TestHandleInboundIpv6RulesWithEmptyInboundPorts(t *testing.T) {
 		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-port 15001",
 		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
 		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
 	}
@@ -97,8 +100,11 @@ func TestHandleInboundIpv6RulesWithInboundPorts(t *testing.T) {
 		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
 		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
 		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
 	}
@@ -132,8 +138,11 @@ func TestHandleInboundIpv6RulesWithWildcardRanges(t *testing.T) {
 		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
 		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
 		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT",
@@ -170,8 +179,11 @@ func TestHandleInboundIpv6RulesWithIpNets(t *testing.T) {
 		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
 		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
 		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j RETURN",
@@ -212,10 +224,17 @@ func TestHandleInboundIpv6RulesWithUidGid(t *testing.T) {
 		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
 		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
 		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 2 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
 		"ip6tables -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j RETURN",
@@ -499,5 +518,42 @@ func TestHandleInboundPortsIncludeWithWildcardInboundPortsAndTproxy(t *testing.T
 	}
 	if !reflect.DeepEqual(ip4Rules, expectedIpv4Rules) {
 		t.Errorf("Output mismatch\nExpected: %#v\nActual: %#v", expectedIpv4Rules, ip4Rules)
+	}
+}
+
+func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
+	cfg := constructConfig()
+	cfg.DryRun = true
+	iptConfigurator := NewIptablesConfigurator(cfg, &dep.StdoutStubDependencies{})
+	iptConfigurator.cfg.EnableInboundIPv6 = false
+	iptConfigurator.cfg.ProxyGID = "1,2"
+	iptConfigurator.cfg.ProxyUID = "3,4"
+	iptConfigurator.run()
+	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
+	expected := []string{
+		"iptables -t nat -N ISTIO_REDIRECT",
+		"iptables -t nat -N ISTIO_IN_REDIRECT",
+		"iptables -t nat -N ISTIO_OUTPUT",
+		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-port 15001",
+		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-port 15001",
+		"iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
+		"iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
+		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
+		"iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN",
+		"iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
+		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT",
+		"iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4 -j RETURN",
+		"iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN",
+		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT",
+		"iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1 -j RETURN",
+		"iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN",
+		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT",
+		"iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 2 -j RETURN",
+		"iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
+		"iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Output mismatch.\nExpected: %#v\nActual: %#v", expected, actual)
 	}
 }


### PR DESCRIPTION
 It makes calls from the app by the pod ip to itself bypasses the envoy proxy. 
This can fix headless service instances accessing themselves when mtls enabled.