### PR TITLE
Print default health check values

### DIFF
--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -128,8 +128,8 @@ func DefaultArgs() *Args {
 		ConfigWaitTimeout:      2 * time.Minute,
 		LoggingOptions:         log.DefaultOptions(),
 		TracingOptions:         tracing.DefaultOptions(),
-		LivenessProbeOptions:   &probe.Options{},
-		ReadinessProbeOptions:  &probe.Options{},
+		LivenessProbeOptions:   &probe.Options{Path: "/tmp/healthLiveness", UpdateInterval: -1 * time.Second},
+		ReadinessProbeOptions:  &probe.Options{Path: "/tmp/healthReadiness", UpdateInterval: -1 * time.Second},
 		IntrospectionOptions:   ctrlz.DefaultOptions(),
 		EnableProfiling:        true,
 		NumCheckCacheEntries:   5000 * 5 * 60, // 5000 QPS with average TTL of 5 minutes

--- a/sidecar-injector/cmd/sidecar-injector/main.go
+++ b/sidecar-injector/cmd/sidecar-injector/main.go
@@ -255,9 +255,9 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&flags.port, "port", 9443, "Webhook port")
 	rootCmd.PersistentFlags().IntVar(&flags.monitoringPort, "monitoringPort", 15014, "Webhook monitoring port")
 
-	rootCmd.PersistentFlags().DurationVar(&flags.healthCheckInterval, "healthCheckInterval", 0,
+	rootCmd.PersistentFlags().DurationVar(&flags.healthCheckInterval, "healthCheckInterval", -1*time.Second,
 		"Configure how frequently the health check file specified by --healthCheckFile should be updated")
-	rootCmd.PersistentFlags().StringVar(&flags.healthCheckFile, "healthCheckFile", "",
+	rootCmd.PersistentFlags().StringVar(&flags.healthCheckFile, "healthCheckFile", "/tmp/health",
 		"File that should be periodically updated if health checking is enabled")
 	rootCmd.PersistentFlags().StringVar(&flags.kubeconfigFile, "kubeconfig", "",
 		"Specifies path to kubeconfig file. This must be specified when not running inside a Kubernetes pod.")


### PR DESCRIPTION
Currently `mixs server -h` and `sidecar-injector -h` does not output
default values of health check related config because they set empty
values.

This patch adds `-1` sec for interval which means "disabled" and show
default values in help message.

[X] Configuration Infrastructure

BEFORE:
```
$ ./mixs server -h |grep Probe
      --livenessProbeInterval duration          Interval of updating file for the liveness probe.
      --livenessProbePath string                Path to the file for the liveness probe.
      --readinessProbeInterval duration         Interval of updating file for the readiness probe.
      --readinessProbePath string               Path to the file for the readiness probe.
$ ./sidecar-injector -h |grep health
      --healthCheckFile string         File that should be periodically updated if health checking is enabled
      --healthCheckInterval duration   Configure how frequently the health check file specified by --healthCheckFile should be updated
```

AFTER:
```
$ ./mixs server -h |grep Probe
      --livenessProbeInterval duration          Interval of updating file for the liveness probe. (default -1s)
      --livenessProbePath string                Path to the file for the liveness probe. (default "/tmp/healthLiveness")
      --readinessProbeInterval duration         Interval of updating file for the readiness probe. (default -1s)
      --readinessProbePath string               Path to the file for the readiness probe. (default "/tmp/healthReadiness")
$ ./sidecar-injector -h |grep health
      --healthCheckFile string         File that should be periodically updated if health checking is enabled (default "/tmp/health")
      --healthCheckInterval duration   Configure how frequently the health check file specified by --healthCheckFile should be updated (default -1s)
```
