### PR TITLE
Add a reference marker to analyzer message doc URL

### DIFF
--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/galley/pkg/config/resource"
 )
 
+// DocPrefix is the root URL for validation message docs
 const DocPrefix = "https://istio.io/docs/reference/config/analysis"
 
 // MessageType is a type of diagnostic message
@@ -53,6 +54,9 @@ type Message struct {
 
 	// Origin of the message
 	Origin resource.Origin
+
+	// DocRef is an optional reference tracker for the documentation URL
+	DocRef string
 }
 
 // Unstructured returns this message as a JSON-style unstructured map
@@ -65,7 +69,12 @@ func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 		result["origin"] = m.Origin.FriendlyName()
 	}
 	result["message"] = fmt.Sprintf(m.Type.Template(), m.Parameters...)
-	result["documentation_url"] = fmt.Sprintf("%s/%s", DocPrefix, m.Type.Code())
+
+	docQueryString := ""
+	if m.DocRef != "" {
+		docQueryString = fmt.Sprintf("?ref=%s", m.DocRef)
+	}
+	result["documentation_url"] = fmt.Sprintf("%s/%s%s", DocPrefix, m.Type.Code(), docQueryString)
 
 	return result
 }

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -52,6 +52,14 @@ func TestMessage_Unstructured(t *testing.T) {
 	g.Expect(m.Unstructured(false)).To(Not(HaveKey("origin")))
 }
 
+func TestMessageWithDocRef(t *testing.T) {
+	g := NewGomegaWithT(t)
+	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
+	m := NewMessage(mt, nil, "Feta")
+	m.DocRef = "test-ref"
+	g.Expect(m.Unstructured(false)["documentation_url"]).To(Equal("https://istio.io/docs/reference/config/analysis/IST-0042?ref=test-ref"))
+}
+
 func TestMessage_JSON(t *testing.T) {
 	g := NewGomegaWithT(t)
 	o := testOrigin("toppings/cheese")

--- a/galley/pkg/config/source/kube/apiserver/status/controller_test.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller_test.go
@@ -215,7 +215,8 @@ func TestBasicReconcilation_NewStatus(t *testing.T) {
 	u := cl.Actions()[1].(k8stesting.UpdateActionImpl).Object.(*unstructured.Unstructured)
 
 	actualStatusMap := u.Object["status"].(map[string]interface{})
-	g.Expect(actualStatusMap[subfield]).To(ConsistOf(m.Unstructured(false)))
+
+	g.Expect(actualStatusMap[subfield]).To(ConsistOf(expectedMessage(m).Unstructured(false)))
 }
 
 func TestBasicReconcilation_NewStatusOldNonMap(t *testing.T) {
@@ -254,7 +255,7 @@ func TestBasicReconcilation_NewStatusOldNonMap(t *testing.T) {
 	u := cl.Actions()[1].(k8stesting.UpdateActionImpl).Object.(*unstructured.Unstructured)
 
 	actualStatusMap := u.Object["status"].(map[string]interface{})
-	g.Expect(actualStatusMap[subfield]).To(ConsistOf(m.Unstructured(false)))
+	g.Expect(actualStatusMap[subfield]).To(ConsistOf(expectedMessage(m).Unstructured(false)))
 }
 
 func TestBasicReconcilation_UpdateError(t *testing.T) {
@@ -290,7 +291,7 @@ func TestBasicReconcilation_UpdateError(t *testing.T) {
 	u := cl.Actions()[1].(k8stesting.UpdateActionImpl).Object.(*unstructured.Unstructured)
 
 	actualStatusMap := u.Object["status"].(map[string]interface{})
-	g.Expect(actualStatusMap[subfield]).To(ConsistOf(m.Unstructured(false)))
+	g.Expect(actualStatusMap[subfield]).To(ConsistOf(expectedMessage(m).Unstructured(false)))
 }
 
 func TestBasicReconcilation_GetError(t *testing.T) {
@@ -384,4 +385,13 @@ func setupClientWithReactors(retVal runtime.Object, updateErrVal error) (*mock.K
 	})
 
 	return k, cl
+}
+
+func expectedMessage(m diag.Message) *diag.Message {
+	return &diag.Message{
+		Type:       m.Type,
+		Parameters: m.Parameters,
+		Origin:     m.Origin,
+		DocRef:     DocRef,
+	}
 }

--- a/galley/pkg/config/source/kube/apiserver/status/util.go
+++ b/galley/pkg/config/source/kube/apiserver/status/util.go
@@ -18,6 +18,9 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 )
 
+// DocRef is the doc ref value used by the status controller
+const DocRef = "status-controller"
+
 // toStatusValue converts a set of diag.Messages to a status value.
 func toStatusValue(msgs diag.Messages) interface{} {
 	if len(msgs) == 0 {
@@ -26,6 +29,7 @@ func toStatusValue(msgs diag.Messages) interface{} {
 
 	result := make([]interface{}, 0)
 	for _, m := range msgs {
+		m.DocRef = DocRef
 		// For the purposes of status update, the origin field is redundant
 		// since we're attaching the message to the origin resource.
 		result = append(result, m.Unstructured(false))

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -214,10 +214,11 @@ istioctl experimental analyze -k -d false
 				fmt.Fprintln(cmd.ErrOrStderr())
 			}
 
-			// Filter outputMessages by specified level
+			// Filter outputMessages by specified level, and append a ref arg to the doc URL
 			var outputMessages diag.Messages
 			for _, m := range result.Messages {
 				if m.Type.Level().IsWorseThanOrEqualTo(outputLevel.Level) {
+					m.DocRef = "istioctl-analyze"
 					outputMessages = append(outputMessages, m)
 				}
 			}


### PR DESCRIPTION
Add a reference marker to the doc URL generated for analysis messages. This will hopefully allow us to collect some usage metrics for this tooling and its associated docs. 

e.g.

From `istioctl x analyze -o yaml`:
```
- code: IST0101
  documentation_url: https://istio.io/docs/reference/config/analysis/IST0101?ref=istioctl-analyze
  level: Error
  message: 'Referenced gateway not found: "first-bogus-gateway"'
  origin: VirtualService ratings.default
```

From resource status field (with Galley `enableAnalysis` on):
```yaml
status:
  validationMessages:
  - code: IST0101
    documentation_url: https://istio.io/docs/reference/config/analysis/IST0101?ref=status-controller
    level: Error
    message: 'Referenced gateway not found: "bogus-reviews-gateway-2"'
```