### PR TITLE
Add beta AuthenticationPolicies to push context

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -16,8 +16,6 @@ package model
 
 import (
 	"istio.io/api/security/v1beta1"
-	// Cannot import cycle
-	// authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schemas"
 )
@@ -41,14 +39,16 @@ const (
 
 // String converts MutualTLSMode to human readable string for debugging.
 func (mode MutualTLSMode) String() string {
-	// declare an array of strings
-	names := [...]string{
-		"UNKNOWN",
-		"DISABLE",
-		"PERMISSIVE",
-		"STRICT"}
-
-	return names[mode]
+	switch mode {
+	case MTLSDisable:
+		return "DISABLE"
+	case MTLSPermissive:
+		return "PERMISSIVE"
+	case MTLSStrict:
+		return "STRICT"
+	default:
+		return "UNKNOWN"
+	}
 }
 
 // AuthenticationPolicies organizes authentication (mTLS + JWT) policies by namespace.

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -62,7 +62,7 @@ type AuthenticationPolicies struct {
 	rootNamespace string
 }
 
-// initAuthenticationPolicies creates a new AuthenticationPolicies structand populates with the
+// initAuthenticationPolicies creates a new AuthenticationPolicies struct and populates with the
 // authentication policies in the mesh environment.
 func initAuthenticationPolicies(env *Environment) *AuthenticationPolicies {
 	policy := &AuthenticationPolicies{

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -99,6 +99,8 @@ func (policy *AuthenticationPolicies) GetJwtPoliciesForWorkload(namespace string
 		for idx := range nsConfig {
 			cfg := &nsConfig[idx]
 			if namespace != cfg.Namespace {
+				// Should never come here. Log warning just in case.
+				log.Warnf("Seeing config %s with namespace %s in map entry for %s. Ignored", cfg.Name, cfg.Namespace, namespace)
 				continue
 			}
 			spec := cfg.Spec.(*v1beta1.RequestAuthentication)

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -62,8 +62,9 @@ type AuthenticationPolicies struct {
 	rootNamespace string
 }
 
-// processAuthenticationPolicies gets the authentication policies in the mesh.
-func processAuthenticationPolicies(env *Environment) *AuthenticationPolicies {
+// initAuthenticationPolicies creates a new AuthenticationPolicies structand populates with the
+// authentication policies in the mesh environment.
+func initAuthenticationPolicies(env *Environment) *AuthenticationPolicies {
 	policy := &AuthenticationPolicies{
 		requestAuthentications: map[string][]Config{},
 		namespaceMTLSMode:      map[string]MutualTLSMode{},

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -1,0 +1,118 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"istio.io/api/security/v1beta1"
+	// Cannot import cycle
+	// authn_model "istio.io/istio/pilot/pkg/security/model"
+	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/config/schemas"
+)
+
+// MutualTLSMode is the mutule TLS mode specified by authentication policy.
+type MutualTLSMode int
+
+const (
+	// MTLSUnknown is used to indicate the variable hasn't been initialized correctly (with the authentication policy).
+	MTLSUnknown MutualTLSMode = iota
+
+	// MTLSDisable if authentication policy disable mTLS.
+	MTLSDisable
+
+	// MTLSPermissive if authentication policy enable mTLS in permissive mode.
+	MTLSPermissive
+
+	// MTLSStrict if authentication policy enable mTLS in strict mode.
+	MTLSStrict
+)
+
+// String converts MutualTLSMode to human readable string for debugging.
+func (mode MutualTLSMode) String() string {
+	// declare an array of strings
+	names := [...]string{
+		"UNKNOWN",
+		"DISABLE",
+		"PERMISSIVE",
+		"STRICT"}
+
+	return names[mode]
+}
+
+// AuthenticationPolicies organizes authentication (mTLS + JWT) policies by namespace.
+type AuthenticationPolicies struct {
+	// Maps from namespace to the v1beta1 authentication policies.
+	requestAuthentications map[string][]Config
+
+	// Maps from namespace to mTLS mode.
+	namespaceMTLSMode map[string]MutualTLSMode
+
+	rootNamespace string
+}
+
+// processAuthenticationPolicies gets the authentication policies in the mesh.
+func processAuthenticationPolicies(env *Environment) *AuthenticationPolicies {
+	policy := &AuthenticationPolicies{
+		requestAuthentications: map[string][]Config{},
+		namespaceMTLSMode:      map[string]MutualTLSMode{},
+		rootNamespace:          env.Mesh.GetRootNamespace(),
+	}
+
+	if configs, err := env.List(schemas.RequestAuthentication.Type, NamespaceAll); err == nil {
+		sortConfigByCreationTime(configs)
+		policy.addRequestAuthentication(configs)
+	}
+
+	// TODO(diemtvu): populate mTLS mode from mesh config and namespace labels.
+	return policy
+}
+
+func (policy *AuthenticationPolicies) addRequestAuthentication(configs []Config) {
+	for _, config := range configs {
+		if config.Namespace == policy.rootNamespace && config.Name != "default" {
+			// Validation should prevent non-singleton global policy, but it's ok to check and log just in case.
+			log.Warnf("Ignore non default RequestAuthentication config in root namespace: %s/%s", config.Namespace, config.Name)
+			continue
+		}
+		policy.requestAuthentications[config.Namespace] =
+			append(policy.requestAuthentications[config.Namespace], config)
+	}
+}
+
+// GetJwtPoliciesForWorkload returns a list of JWT policies matching to labels.
+func (policy *AuthenticationPolicies) GetJwtPoliciesForWorkload(namespace string,
+	workloadLabels labels.Collection) []*Config {
+	configs := []*Config{}
+	if nsConfig, ok := policy.requestAuthentications[namespace]; ok {
+		for idx := range nsConfig {
+			cfg := &nsConfig[idx]
+			if namespace != cfg.Namespace {
+				continue
+			}
+			spec := cfg.Spec.(*v1beta1.RequestAuthentication)
+			selector := labels.Instance(spec.GetSelector().GetMatchLabels())
+			if workloadLabels.IsSupersetOf(selector) {
+				configs = append(configs, cfg)
+			}
+		}
+	}
+
+	if rootConfig, ok := policy.requestAuthentications[policy.rootNamespace]; ok {
+		for idx := range rootConfig {
+			configs = append(configs, &rootConfig[idx])
+		}
+	}
+	return configs
+}

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -103,7 +103,7 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 		{
 			name:              "Match workload labels in foo",
 			workloadNamespace: "foo",
-			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1", "other": "lables"}},
+			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1", "other": "labels"}},
 			want: []*Config{
 				&Config{
 					ConfigMeta: ConfigMeta{

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -1,0 +1,131 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	mesh "istio.io/api/mesh/v1alpha1"
+	security_beta "istio.io/api/security/v1beta1"
+	selectorpb "istio.io/api/type/v1beta1"
+	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/config/schemas"
+)
+
+const (
+	rootNamespace = "istio-config"
+)
+
+func TestGetJwtPoliciesForWorkload(t *testing.T) {
+	policies := getTestAuthenticationPolicies(createTestConfigs(), t)
+
+	cases := []struct {
+		name              string
+		workloadNamespace string
+		workloadLabels    labels.Collection
+		want              int
+	}{
+		{
+			name:              "Empty workload labels in foo",
+			workloadNamespace: "foo",
+			workloadLabels:    labels.Collection{},
+			want:              2,
+		},
+		{
+			name:              "Empty workload labels in bar",
+			workloadNamespace: "bar",
+			workloadLabels:    labels.Collection{},
+			want:              2,
+		},
+		{
+			name:              "Empty workload labels in baz",
+			workloadNamespace: "baz",
+			workloadLabels:    labels.Collection{},
+			want:              1,
+		},
+		{
+			name:              "Match workload labels in foo",
+			workloadNamespace: "foo",
+			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1", "other": "lables"}},
+			want:              3,
+		},
+		{
+			name:              "Match workload labels in bar",
+			workloadNamespace: "bar",
+			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1"}},
+			want:              2,
+		},
+		{
+			name:              "Paritial match workload labels in foo",
+			workloadNamespace: "foo",
+			workloadLabels:    labels.Collection{{"app": "httpbin"}},
+			want:              2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := policies.GetJwtPoliciesForWorkload(tc.workloadNamespace, tc.workloadLabels); len(got) != tc.want {
+				t.Errorf("Want %d, got %d policies:\n", tc.want, len(got))
+				for _, gotCfg := range got {
+					t.Errorf("%s/%s", gotCfg.Namespace, gotCfg.Name)
+				}
+			}
+		})
+	}
+}
+
+func getTestAuthenticationPolicies(configs []*Config, t *testing.T) *AuthenticationPolicies {
+	configStore := newFakeStore()
+	for _, cfg := range configs {
+		log.Infof("add config %s\n", cfg.Name)
+		if _, err := configStore.Create(*cfg); err != nil {
+			t.Fatalf("getTestAuthenticationPolicies %v", err)
+		}
+	}
+	environment := &Environment{
+		IstioConfigStore: MakeIstioStore(configStore),
+		Mesh:             &mesh.MeshConfig{RootNamespace: rootNamespace},
+	}
+	return processAuthenticationPolicies(environment)
+}
+
+func createTestConfig(name string, namespace string, selector *selectorpb.WorkloadSelector) *Config {
+	return &Config{
+		ConfigMeta: ConfigMeta{
+			Type: schemas.RequestAuthentication.Type, Name: name, Namespace: namespace},
+		Spec: &security_beta.RequestAuthentication{
+			Selector: selector,
+		},
+	}
+}
+
+func createTestConfigs() []*Config {
+	configs := []*Config{}
+
+	selector := &selectorpb.WorkloadSelector{
+		MatchLabels: map[string]string{
+			"app":     "httpbin",
+			"version": "v1",
+		},
+	}
+	configs = append(configs, createTestConfig("default", rootNamespace, nil))
+	configs = append(configs, createTestConfig("should-be-ignored", rootNamespace, nil))
+	configs = append(configs, createTestConfig("default", "foo", nil))
+	configs = append(configs, createTestConfig("default", "bar", nil))
+	configs = append(configs, createTestConfig("with-selector", "foo", selector))
+
+	return configs
+}

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -99,7 +99,7 @@ func getTestAuthenticationPolicies(configs []*Config, t *testing.T) *Authenticat
 		IstioConfigStore: MakeIstioStore(configStore),
 		Mesh:             &mesh.MeshConfig{RootNamespace: rootNamespace},
 	}
-	return processAuthenticationPolicies(environment)
+	return initAuthenticationPolicies(environment)
 }
 
 func createTestConfig(name string, namespace string, selector *selectorpb.WorkloadSelector) *Config {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -102,7 +102,7 @@ type PushContext struct {
 	// AuthNPolicies contains a map of hostname and port to authentication policy
 	AuthnPolicies processedAuthnPolicies `json:"-"`
 
-	// (beta) Authn policies for each namespace.
+	// AuthnBetaPolicies contains (beta) Authn policies by namespace.
 	AuthnBetaPolicies *AuthenticationPolicies `json:"-"`
 
 	initDone bool
@@ -939,8 +939,8 @@ func (ps *PushContext) initServiceAccounts(env *Environment, services []*Service
 
 // Caches list of authentication policies
 func (ps *PushContext) initAuthnPolicies(env *Environment) error {
-	// Processing beta policy.
-	ps.AuthnBetaPolicies = processAuthenticationPolicies(env)
+	// Init beta policy.
+	ps.AuthnBetaPolicies = initAuthenticationPolicies(env)
 
 	// Processing alpha policy. This will be removed after beta API released.
 	authNPolicies, err := env.List(schemas.AuthenticationPolicy.Type, NamespaceAll)

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -782,9 +782,7 @@ func (ps *PushContext) updateContext(
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
 		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged bool
 
-	log.Infof(" @@@@ updateContext %v", pushReq)
 	for k := range pushReq.ConfigTypesUpdated {
-		log.Infof(" @@@@ updateContext pushReq type %v", k)
 		switch k {
 		case schemas.ServiceEntry.Type, schemas.SyntheticServiceEntry.Type:
 			servicesChanged = true
@@ -841,7 +839,6 @@ func (ps *PushContext) updateContext(
 
 	if authnChanged {
 		if err := ps.initAuthnPolicies(env); err != nil {
-			log.Errorf("failed to initialize authn policies %v", err)
 			return err
 		}
 	} else {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -103,7 +103,6 @@ type PushContext struct {
 	AuthnPolicies processedAuthnPolicies `json:"-"`
 
 	// (beta) Authn policies for each namespace.
-	// namepspaceAuthnBetaPolicies map[string]*processedAuthnBetaPolices
 	AuthnBetaPolicies *AuthenticationPolicies `json:"-"`
 
 	initDone bool
@@ -130,11 +129,6 @@ type authnPolicyByPort struct {
 	policy       *authn.Policy
 	// store the config metadata for debugging purposes.
 	configMeta *ConfigMeta
-}
-
-type processedAuthnBetaPolices struct {
-	mtlsPolicies []*Config
-	jwtPolicies  []*Config
 }
 
 // XDSUpdater is used for direct updates of the xDS model and incremental push.

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -218,7 +218,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 			}
 
 			setUpstreamProtocol(proxy, defaultCluster, port, model.TrafficDirectionOutbound)
-			serviceMTLSMode := authn_model.MTLSUnknown
+			serviceMTLSMode := model.MTLSUnknown
 			if !service.MeshExternal {
 				// Only need the authentication MTLS mode when service is not external.
 				policy, _ := push.AuthenticationPolicyForWorkload(service, port)
@@ -751,11 +751,11 @@ func conditionallyConvertToIstioMtls(
 	proxy *model.Proxy,
 	autoMTLSEnabled bool,
 	meshExternal bool,
-	serviceMTLSMode authn_model.MutualTLSMode,
+	serviceMTLSMode model.MutualTLSMode,
 ) (*networking.TLSSettings, mtlsContextType) {
 	mtlsCtx := userSupplied
 	if tls == nil {
-		if meshExternal || !autoMTLSEnabled || serviceMTLSMode == authn_model.MTLSUnknown || serviceMTLSMode == authn_model.MTLSDisable {
+		if meshExternal || !autoMTLSEnabled || serviceMTLSMode == model.MTLSUnknown || serviceMTLSMode == model.MTLSDisable {
 			return nil, mtlsCtx
 		}
 
@@ -854,7 +854,7 @@ type buildClusterOpts struct {
 	direction       model.TrafficDirection
 	proxy           *model.Proxy
 	meshExternal    bool
-	serviceMTLSMode authn_model.MutualTLSMode
+	serviceMTLSMode model.MutualTLSMode
 }
 
 func applyTrafficPolicy(opts buildClusterOpts, proxy *model.Proxy) {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -40,7 +40,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/fakes"
 	"istio.io/istio/pilot/pkg/networking/plugin"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
@@ -808,7 +807,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 		proxy           *model.Proxy
 		autoMTLSEnabled bool
 		meshExternal    bool
-		serviceMTLSMode authn_model.MutualTLSMode
+		serviceMTLSMode model.MutualTLSMode
 		want            *networking.TLSSettings
 		wantCtxType     mtlsContextType
 	}{
@@ -818,7 +817,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffe://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			false, false, authn_model.MTLSUnknown,
+			false, false, model.MTLSUnknown,
 			tlsSettings,
 			userSupplied,
 		},
@@ -835,7 +834,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffe://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			false, false, authn_model.MTLSUnknown,
+			false, false, model.MTLSUnknown,
 			&networking.TLSSettings{
 				Mode:              networking.TLSSettings_ISTIO_MUTUAL,
 				CaCertificates:    constants.DefaultRootCert,
@@ -856,7 +855,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 				TLSClientKey:       "/custom/key.pem",
 				TLSClientRootCert:  "/custom/root.pem",
 			}},
-			false, false, authn_model.MTLSUnknown,
+			false, false, model.MTLSUnknown,
 			&networking.TLSSettings{
 				Mode:              networking.TLSSettings_ISTIO_MUTUAL,
 				CaCertificates:    "/custom/root.pem",
@@ -873,7 +872,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffee://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			true, false, authn_model.MTLSStrict,
+			true, false, model.MTLSStrict,
 			&networking.TLSSettings{
 				Mode:              networking.TLSSettings_ISTIO_MUTUAL,
 				CaCertificates:    constants.DefaultRootCert,
@@ -890,7 +889,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffee://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			true, false, authn_model.MTLSPermissive,
+			true, false, model.MTLSPermissive,
 			&networking.TLSSettings{
 				Mode:              networking.TLSSettings_ISTIO_MUTUAL,
 				CaCertificates:    constants.DefaultRootCert,
@@ -907,7 +906,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffee://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			true, false, authn_model.MTLSDisable,
+			true, false, model.MTLSDisable,
 			nil,
 			userSupplied,
 		},
@@ -917,7 +916,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffee://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			true, false, authn_model.MTLSUnknown,
+			true, false, model.MTLSUnknown,
 			nil,
 			userSupplied,
 		},
@@ -927,7 +926,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffee://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			true, true, authn_model.MTLSUnknown,
+			true, true, model.MTLSUnknown,
 			nil,
 			userSupplied,
 		},
@@ -937,7 +936,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 			[]string{"spiffee://foo/serviceaccount/1"},
 			"foo.com",
 			&model.Proxy{Metadata: &model.NodeMetadata{}},
-			false, false, authn_model.MTLSDisable,
+			false, false, model.MTLSDisable,
 			nil,
 			userSupplied,
 		},

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -35,7 +35,6 @@ import (
 	networking_core "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/util"
 	authn_alpha1 "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pkg/config/host"
@@ -535,7 +534,7 @@ func AnalyzeMTLSSettings(autoMTLSEnabled bool, hostname host.Name, port *model.P
 // - "AUTO": auto mTLS feature is enabled, client TLS (destination rule) is not set and pilot can auto detect client (m)TLS settings.
 // - "OK": both client and server TLS settings are set correctly.
 // - "CONFLICT": both client and server TLS settings are set, but could be incompatible.
-func EvaluateTLSState(autoMTLSEnabled bool, clientMode *networking.TLSSettings, serverMode authn_model.MutualTLSMode) string {
+func EvaluateTLSState(autoMTLSEnabled bool, clientMode *networking.TLSSettings, serverMode model.MutualTLSMode) string {
 	const okState string = "OK"
 	const conflictState string = "CONFLICT"
 	const autoState string = "AUTO"
@@ -549,9 +548,9 @@ func EvaluateTLSState(autoMTLSEnabled bool, clientMode *networking.TLSSettings, 
 		return okState
 	}
 
-	if (serverMode == authn_model.MTLSDisable && clientMode.GetMode() == networking.TLSSettings_DISABLE) ||
-		(serverMode == authn_model.MTLSStrict && clientMode.GetMode() == networking.TLSSettings_ISTIO_MUTUAL) ||
-		(serverMode == authn_model.MTLSPermissive &&
+	if (serverMode == model.MTLSDisable && clientMode.GetMode() == networking.TLSSettings_DISABLE) ||
+		(serverMode == model.MTLSStrict && clientMode.GetMode() == networking.TLSSettings_ISTIO_MUTUAL) ||
+		(serverMode == model.MTLSPermissive &&
 			(clientMode.GetMode() == networking.TLSSettings_ISTIO_MUTUAL || clientMode.GetMode() == networking.TLSSettings_DISABLE)) {
 		return okState
 	}

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -28,7 +28,6 @@ import (
 	"istio.io/istio/istioctl/pkg/util/configdump"
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/tests/util"
 )
@@ -408,28 +407,28 @@ func TestEvaluateTLSState(t *testing.T) {
 	testCases := []struct {
 		name                        string
 		client                      *networking.TLSSettings
-		server                      authn_model.MutualTLSMode
+		server                      model.MutualTLSMode
 		expected                    string
 		expectedWithAutoMTLSEnabled string
 	}{
 		{
 			name:                        "Auto with mTLS disable",
 			client:                      nil,
-			server:                      authn_model.MTLSDisable,
+			server:                      model.MTLSDisable,
 			expected:                    "OK",
 			expectedWithAutoMTLSEnabled: "AUTO",
 		},
 		{
 			name:                        "Auto with mTLS permissive",
 			client:                      nil,
-			server:                      authn_model.MTLSPermissive,
+			server:                      model.MTLSPermissive,
 			expected:                    "OK",
 			expectedWithAutoMTLSEnabled: "AUTO",
 		},
 		{
 			name:                        "Auto with mTLS STRICT",
 			client:                      nil,
-			server:                      authn_model.MTLSStrict,
+			server:                      model.MTLSStrict,
 			expected:                    "OK",
 			expectedWithAutoMTLSEnabled: "AUTO",
 		},
@@ -438,7 +437,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_ISTIO_MUTUAL,
 			},
-			server:                      authn_model.MTLSStrict,
+			server:                      model.MTLSStrict,
 			expected:                    "OK",
 			expectedWithAutoMTLSEnabled: "OK",
 		},
@@ -447,7 +446,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_DISABLE,
 			},
-			server:                      authn_model.MTLSDisable,
+			server:                      model.MTLSDisable,
 			expected:                    "OK",
 			expectedWithAutoMTLSEnabled: "OK",
 		},
@@ -456,7 +455,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_DISABLE,
 			},
-			server:                      authn_model.MTLSPermissive,
+			server:                      model.MTLSPermissive,
 			expected:                    "OK",
 			expectedWithAutoMTLSEnabled: "OK",
 		},
@@ -465,7 +464,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_ISTIO_MUTUAL,
 			},
-			server:                      authn_model.MTLSPermissive,
+			server:                      model.MTLSPermissive,
 			expected:                    "OK",
 			expectedWithAutoMTLSEnabled: "OK",
 		},
@@ -474,7 +473,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_DISABLE,
 			},
-			server:                      authn_model.MTLSStrict,
+			server:                      model.MTLSStrict,
 			expected:                    "CONFLICT",
 			expectedWithAutoMTLSEnabled: "CONFLICT",
 		},
@@ -483,7 +482,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_MUTUAL,
 			},
-			server:                      authn_model.MTLSStrict,
+			server:                      model.MTLSStrict,
 			expected:                    "CONFLICT",
 			expectedWithAutoMTLSEnabled: "CONFLICT",
 		},
@@ -492,7 +491,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_SIMPLE,
 			},
-			server:                      authn_model.MTLSStrict,
+			server:                      model.MTLSStrict,
 			expected:                    "CONFLICT",
 			expectedWithAutoMTLSEnabled: "CONFLICT",
 		},
@@ -501,7 +500,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_SIMPLE,
 			},
-			server:                      authn_model.MTLSPermissive,
+			server:                      model.MTLSPermissive,
 			expected:                    "CONFLICT",
 			expectedWithAutoMTLSEnabled: "CONFLICT",
 		},
@@ -510,7 +509,7 @@ func TestEvaluateTLSState(t *testing.T) {
 			client: &networking.TLSSettings{
 				Mode: networking.TLSSettings_SIMPLE,
 			},
-			server:                      authn_model.MTLSPermissive,
+			server:                      model.MTLSPermissive,
 			expected:                    "CONFLICT",
 			expectedWithAutoMTLSEnabled: "CONFLICT",
 		},

--- a/pilot/pkg/security/authn/v1alpha1/model.go
+++ b/pilot/pkg/security/authn/v1alpha1/model.go
@@ -16,16 +16,16 @@ package v1alpha1
 
 import (
 	authn "istio.io/api/authentication/v1alpha1"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
+	"istio.io/istio/pilot/pkg/model"
 )
 
 // GetMutualTLSMode returns the mTLS mode for given. If the policy is nil, or doesn't define mTLS, it returns MTLSDisable.
-func GetMutualTLSMode(policy *authn.Policy) authn_model.MutualTLSMode {
+func GetMutualTLSMode(policy *authn.Policy) model.MutualTLSMode {
 	if mTLSSetting := GetMutualTLS(policy); mTLSSetting != nil {
 		if mTLSSetting.GetMode() == authn.MutualTls_STRICT {
-			return authn_model.MTLSStrict
+			return model.MTLSStrict
 		}
-		return authn_model.MTLSPermissive
+		return model.MTLSPermissive
 	}
-	return authn_model.MTLSDisable
+	return model.MTLSDisable
 }

--- a/pilot/pkg/security/authn/v1alpha1/model_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/model_test.go
@@ -18,24 +18,24 @@ import (
 	"testing"
 
 	authn "istio.io/api/authentication/v1alpha1"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
+	"istio.io/istio/pilot/pkg/model"
 )
 
 func TestGetMutualTLSMode(t *testing.T) {
 	cases := []struct {
 		name     string
 		in       *authn.Policy
-		expected authn_model.MutualTLSMode
+		expected model.MutualTLSMode
 	}{
 		{
 			name:     "Null policy",
 			in:       nil,
-			expected: authn_model.MTLSDisable,
+			expected: model.MTLSDisable,
 		},
 		{
 			name:     "Empty policy",
 			in:       &authn.Policy{},
-			expected: authn_model.MTLSDisable,
+			expected: model.MTLSDisable,
 		},
 		{
 			name: "Policy with default mTLS mode",
@@ -44,7 +44,7 @@ func TestGetMutualTLSMode(t *testing.T) {
 					Params: &authn.PeerAuthenticationMethod_Mtls{},
 				}},
 			},
-			expected: authn_model.MTLSStrict,
+			expected: model.MTLSStrict,
 		},
 		{
 			name: "Policy with strict mTLS mode",
@@ -57,7 +57,7 @@ func TestGetMutualTLSMode(t *testing.T) {
 					},
 				}},
 			},
-			expected: authn_model.MTLSStrict,
+			expected: model.MTLSStrict,
 		},
 		{
 			name: "Policy with permissive mTLS mode",
@@ -70,7 +70,7 @@ func TestGetMutualTLSMode(t *testing.T) {
 					},
 				}},
 			},
-			expected: authn_model.MTLSPermissive,
+			expected: model.MTLSPermissive,
 		},
 		{
 			name: "Policy with multi peer methods",
@@ -86,7 +86,7 @@ func TestGetMutualTLSMode(t *testing.T) {
 					},
 				},
 			},
-			expected: authn_model.MTLSStrict,
+			expected: model.MTLSStrict,
 		},
 		{
 			name: "Policy with non-mtls peer method",
@@ -97,7 +97,7 @@ func TestGetMutualTLSMode(t *testing.T) {
 					},
 				},
 			},
-			expected: authn_model.MTLSDisable,
+			expected: model.MTLSDisable,
 		},
 	}
 	for _, c := range cases {

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -68,35 +68,6 @@ const (
 	AuthnFilterName = "istio_authn"
 )
 
-// MutualTLSMode is the mutule TLS mode specified by authentication policy.
-type MutualTLSMode int
-
-const (
-	// MTLSUnknown is used to indicate the variable hasn't been initialized correctly (with the authentication policy).
-	MTLSUnknown MutualTLSMode = iota
-
-	// MTLSDisable if authentication policy disable mTLS.
-	MTLSDisable
-
-	// MTLSPermissive if authentication policy enable mTLS in permissive mode.
-	MTLSPermissive
-
-	// MTLSStrict if authentication policy enable mTLS in strict mode.
-	MTLSStrict
-)
-
-// String converts MutualTLSMode to human readable string for debugging.
-func (mode MutualTLSMode) String() string {
-	// declare an array of strings
-	names := [...]string{
-		"UNKNOWN",
-		"DISABLE",
-		"PERMISSIVE",
-		"STRICT"}
-
-	return names[mode]
-}
-
 // ConstructSdsSecretConfigForGatewayListener constructs SDS secret configuration for ingress gateway.
 func ConstructSdsSecretConfigForGatewayListener(name, sdsUdsPath string) *auth.SdsSecretConfig {
 	if name == "" || sdsUdsPath == "" {


### PR DESCRIPTION
Populate `RequestAuthentiation` (JWT beta API) to push context.

Also, move `MutualTLSMode` from security package to `pilot/model` so it can be used in push context in the future. Populate of this settings will be in the different PRs.

Issue: https://github.com/istio/istio/issues/18399