### PR TITLE
Clean up dead makefile targets

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -28,10 +28,6 @@ export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org
 export GOSUMDB ?= sum.golang.org
 
-# locations where artifacts are stored
-
-ISTIO_GCS ?= istio-release/releases/$(VERSION)
-ISTIO_URL ?= https://storage.googleapis.com/$(ISTIO_GCS)
 ISTIO_CNI_HUB ?= gcr.io/istio-testing
 export ISTIO_CNI_HUB
 ISTIO_CNI_TAG ?= latest
@@ -49,19 +45,7 @@ export GOPATH
 GO_TOP := $(shell echo ${GOPATH} | cut -d ':' -f1)
 export GO_TOP
 
-# Note that disabling cgo here adversely affects go get.  Instead we'll rely on this
-# to be handled in common/scripts/gobuild.sh
-# export CGO_ENABLED=0
-
-# It's more concise to use GO?=$(shell which go)
-# but the following approach uses a more efficient "simply expanded" :=
-# variable instead of a "recursively expanded" =
-ifeq ($(origin GO), undefined)
-  GO:=$(shell which go)
-endif
-ifeq ($(GO),)
-  $(error Could not find 'go' in path.  Please install go, or if already installed either add it to your path or set GO to point to its directory)
-endif
+GO ?= go
 
 LOCAL_ARCH := $(shell uname -m)
 ifeq ($(LOCAL_ARCH),x86_64)
@@ -82,15 +66,11 @@ else ifeq ($(LOCAL_OS),Darwin)
    export GOOS_LOCAL = darwin
 else
    $(error "This system's OS $(LOCAL_OS) isn't recognized/supported")
-   # export GOOS_LOCAL ?= windows
 endif
 
 export GOOS ?= $(GOOS_LOCAL)
 
 export ENABLE_COREDUMP ?= false
-
-# Enable Istio CNI in helm template commands
-export ENABLE_ISTIO_CNI ?= false
 
 # NOTE: env var EXTRA_HELM_SETTINGS can contain helm chart override settings, example:
 # EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set-string istio-cni.tag=v0.1-dev-foo"
@@ -105,30 +85,18 @@ Q = $(if $(filter 1,$VERBOSE),,@)
 # Use the variable H to add a header (equivalent to =>) to informational output
 H = $(shell printf "\033[34;1m=>\033[0m")
 
-# To build Pilot, Mixer and CA with debugger information, use DEBUG=1 when invoking make
-goVerStr := $(shell $(GO) version | awk '{split($$0,a," ")}; {print a[3]}')
-goVerNum := $(shell echo $(goVerStr) | awk '{split($$0,a,"go")}; {print a[2]}')
-goVerMajor := $(shell echo $(goVerNum) | awk '{split($$0, a, ".")}; {print a[1]}')
-goVerMinor := $(shell echo $(goVerNum) | awk '{split($$0, a, ".")}; {print a[2]}' | sed -e 's/\([0-9]\+\).*/\1/')
-gcflagsPattern := $(shell ( [ $(goVerMajor) -ge 1 ] && [ ${goVerMinor} -ge 10 ] ) && echo 'all=' || echo '')
-
 ifeq ($(origin DEBUG), undefined)
   BUILDTYPE_DIR:=release
 else ifeq ($(DEBUG),0)
   BUILDTYPE_DIR:=release
 else
   BUILDTYPE_DIR:=debug
-  export GCFLAGS:=$(gcflagsPattern)-N -l
+  export GCFLAGS:=all=-N -l
   $(info $(H) Build with debugger information)
 endif
 
 # Optional file including user-specific settings (HUB, TAG, etc)
 -include .istiorc.mk
-
-# @todo allow user to run for a single $PKG only?
-PACKAGES_CMD := GOPATH=$(GOPATH) $(GO) list ./...
-GO_EXCLUDE := /vendor/|.pb.go|.gen.go
-GO_FILES_CMD := find . -name '*.go' | grep -v -E '$(GO_EXCLUDE)'
 
 # Environment for tests, the directory containing istio and deps binaries.
 # Typically same as GOPATH/bin, so tests work seemlessly with IDEs.
@@ -144,8 +112,6 @@ export REPO_ROOT := $(shell git rev-parse --show-toplevel)
 
 # scratch dir: this shouldn't be simply 'docker' since that's used for docker.save to store tar.gz files
 ISTIO_DOCKER:=${ISTIO_OUT_LINUX}/docker_temp
-# Config file used for building istio:proxy container.
-DOCKER_PROXY_CFG?=Dockerfile.proxy
 
 # scratch dir for building isolated images. Please don't remove it again - using
 # ISTIO_DOCKER results in slowdown, all files (including multiple copies of envoy) will be
@@ -236,53 +202,14 @@ ifeq ($(PULL_POLICY),)
   $(error "PULL_POLICY cannot be empty")
 endif
 
-GEN_CERT := ${ISTIO_BIN}/generate_cert
-
-# Set Google Storage bucket if not set
-GS_BUCKET ?= istio-artifacts
 
 .PHONY: default
-default: depend build test
+default: init build test
 
-# The point of these is to allow scripts to query where artifacts
-# are stored so that tests and other consumers of the build don't
-# need to be updated to follow the changes in the Makefiles.
-# Note that the query needs to pass the same types of parameters
-# (e.g., DEBUG=0, GOOS=linux) as the actual build for the query
-# to provide an accurate result.
-.PHONY: where-is-out where-is-docker-temp where-is-docker-tar
-where-is-out:
-	@echo ${ISTIO_OUT}
-where-is-docker-temp:
-	@echo ${ISTIO_DOCKER}
-where-is-docker-tar:
-	@echo ${ISTIO_DOCKER_TAR}
-
-#-----------------------------------------------------------------------------
-# Target: depend
-#-----------------------------------------------------------------------------
-.PHONY: depend init
-
-# Parse out the x.y or x.y.z version and output a single value x*10000+y*100+z (e.g., 1.9 is 10900)
-# that allows the three components to be checked in a single comparison.
-VER_TO_INT:=awk '{split(substr($$0, match ($$0, /[0-9\.]+/)), a, "."); print a[1]*10000+a[2]*100+a[3]}'
-
-# using a sentinel file so this check is only performed once per version.  Performance is
-# being favored over the unlikely situation that go gets downgraded to an older version
-check-go-version: | $(ISTIO_BIN) ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED)
-${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED):
-	@if test $(shell $(GO) version | $(VER_TO_INT) ) -lt \
-                 $(shell echo "$(GO_VERSION_REQUIRED)" | $(VER_TO_INT) ); \
-                 then printf "go version $(GO_VERSION_REQUIRED)+ required, found: "; $(GO) version; exit 1; fi
-	@touch ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED)
-
-
+.PHONY: init
 # Downloads envoy, based on the SHA defined in the base pilot Dockerfile
-init: check-go-version $(ISTIO_OUT)/istio_is_init
+init: $(ISTIO_OUT)/istio_is_init
 	mkdir -p ${OUT_DIR}/logs
-
-# Sync is the same as init in release branch. In master this pulls from master.
-sync: init
 
 # I tried to make this dependent on what I thought was the appropriate
 # lock file, but it caused the rule for that file to get run (which
@@ -312,6 +239,7 @@ $(OUTPUT_DIRS):
 	@mkdir -p $@
 
 .PHONY: ${GEN_CERT}
+GEN_CERT := ${ISTIO_BIN}/generate_cert
 ${GEN_CERT}:
 	GOOS=$(GOOS_LOCAL) && GOARCH=$(GOARCH_LOCAL) && CGO_ENABLED=1 common/scripts/gobuild.sh $@ ./security/tools/generate_cert
 

--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -42,7 +42,7 @@ mkdir -p "$COVERAGEDIR"
 
 
 # Setup environment needed by some tests.
-make -f Makefile.core.mk sync
+make -f Makefile.core.mk init
 
 # coverage test needs to run one package per command.
 # This script runs nproc/2 in parallel.

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -24,6 +24,9 @@ DEFAULT_EXTRA_E2E_ARGS += --galley_hub=${HUB}
 DEFAULT_EXTRA_E2E_ARGS += --sidecar_injector_hub=${HUB}
 DEFAULT_EXTRA_E2E_ARGS += --app_hub=${HUB}
 
+# Enable Istio CNI in helm template commands
+export ENABLE_ISTIO_CNI ?= false
+
 EXTRA_E2E_ARGS ?= ${DEFAULT_EXTRA_E2E_ARGS}
 
 e2e_simple: build generate_e2e_yaml e2e_simple_run


### PR DESCRIPTION
There are a lot of targets that are not relevant anymore. This removes
them to get our makefile a little simpler