### PR TITLE
[release-1.4] Fix error return when STS returns empty token and improve logging

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -723,13 +723,13 @@ func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte,
 
 		// If non-retryable error, fail the request by returning err
 		if !isRetryableErr(status.Code(err), httpRespCode, isCSR) {
-			cacheLog.Errorf("%s hit non-retryable error %v", requestErrorString, err)
+			cacheLog.Errorf("%s hit non-retryable error (HTTP code: %d). Error: %v", requestErrorString, httpRespCode, err)
 			return nil, err
 		}
 
 		// If reach envoy timeout, fail the request by returning err
 		if startTime.Add(time.Millisecond * envoyDefaultTimeoutInMilliSec).Before(time.Now()) {
-			cacheLog.Errorf("%s retry timed out %v", requestErrorString, err)
+			cacheLog.Errorf("%s retrial timed out. Error: %v", requestErrorString, err)
 			return nil, err
 		}
 

--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
@@ -84,24 +84,31 @@ func (p Plugin) ExchangeToken(ctx context.Context, trustDomain, k8sSAjwt string)
 	req.Header.Set("Content-Type", contentType)
 
 	resp, err := p.hTTPClient.Do(req)
-	if err != nil {
-		stsClientLog.Errorf("Failed to call getfederatedtoken: %v", err)
+	errMsg := "failed to call getfederatedtoken. "
+	if err != nil || resp == nil {
 		statusCode := http.StatusServiceUnavailable
 		// If resp is not null, return the actually status code returned from the token service.
 		// If resp is null, return a service unavailable status and try again.
 		if resp != nil {
 			statusCode = resp.StatusCode
+			errMsg = errMsg + fmt.Sprintf("HTTP status: %s. Error: %v", resp.Status, err)
+		} else {
+			errMsg = errMsg + fmt.Sprintf("HTTP response empty. Error: %v", err)
 		}
-		return "", time.Now(), statusCode, errors.New("failed to exchange token")
+		return "", time.Now(), statusCode, errors.New(errMsg)
 	}
 	defer resp.Body.Close()
 
 	body, _ := ioutil.ReadAll(resp.Body)
 	respData := &federatedTokenResponse{}
 	if err := json.Unmarshal(body, respData); err != nil {
-		stsClientLog.Errorf("Failed to unmarshal response data: (HTTP status %d) %v",
-			resp.StatusCode, err)
-		return "", time.Now(), resp.StatusCode, errors.New("failed to exchange token")
+		return "", time.Now(), resp.StatusCode, fmt.Errorf(
+			"failed to unmarshal response data. HTTP status: %s. Error: %v", resp.Status, err)
+	}
+
+	if respData.AccessToken == "" {
+		return "", time.Now(), resp.StatusCode, fmt.Errorf(
+			"exchanged empty token. HTTP status: %s. Response: %v", resp.Status, respData)
 	}
 
 	return respData.AccessToken, time.Now().Add(time.Second * time.Duration(respData.ExpiresIn)), resp.StatusCode, nil


### PR DESCRIPTION
This PR fixes the issue that the node agent sends out an empty access token to the Google CA when the Google cloud token exchange service isn't working. It instead examines the returned access token and returns an error if the access token is empty.
This PR also improves node agent logging.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Change on master branch: https://github.com/istio/istio/pull/19341