### PR TITLE
Fix dump_kubernetes.sh script error by multiple pilot pods

### DIFF
--- a/tools/dump_kubernetes.sh
+++ b/tools/dump_kubernetes.sh
@@ -284,7 +284,7 @@ dump_pilot_url(){
   local dname=$3
   local outfile
 
-  outfile="${dname}/$(basename "${url}")"
+  outfile="${dname}/$(basename "${url}")-${pilot_pod}"
 
   log "Fetching ${url} from pilot"
   kubectl -n istio-system exec -i -t "${pilot_pod}" -c istio-proxy -- \
@@ -292,19 +292,21 @@ dump_pilot_url(){
 }
 
 dump_pilot() {
-  local pilot_pod
-  pilot_pod=$(kubectl -n istio-system get pods -l istio=pilot \
+  local pilot_pods
+  pilot_pods=$(kubectl -n istio-system get pods -l istio=pilot \
       -o jsonpath='{.items[*].metadata.name}')
 
-  if [ -n "${pilot_pod}" ]; then
+  if [ -n "${pilot_pods}" ]; then
     local pilot_dir="${OUT_DIR}/pilot"
     mkdir -p "${pilot_dir}"
-
-    dump_pilot_url "${pilot_pod}" debug/configz "${pilot_dir}"
-    dump_pilot_url "${pilot_pod}" debug/endpointz "${pilot_dir}"
-    dump_pilot_url "${pilot_pod}" debug/adsz "${pilot_dir}"
-    dump_pilot_url "${pilot_pod}" debug/authenticationz "${pilot_dir}"
-    dump_pilot_url "${pilot_pod}" metrics "${pilot_dir}"
+    for pilot_pod in ${pilot_pods}
+    do
+      dump_pilot_url "${pilot_pod}" debug/configz "${pilot_dir}"
+      dump_pilot_url "${pilot_pod}" debug/endpointz "${pilot_dir}"
+      dump_pilot_url "${pilot_pod}" debug/adsz "${pilot_dir}"
+      dump_pilot_url "${pilot_pod}" debug/authenticationz "${pilot_dir}"
+      dump_pilot_url "${pilot_pod}" metrics "${pilot_dir}"
+    done
   fi
 }
 


### PR DESCRIPTION
When we deployed multiple pilot pods, `dump_kubernetes.sh` fails to
run `dump_pilot()` as current script handles them as single pod.

To fix it, this patch changes the script to handle multiple pilot pods
by loop.

Current script error w/ `bash -x`
```
$ bash -x dump_kubernetes.sh -n istio-system
 ... snip ...
+ local 'pilot_pod=istio-pilot-7dbfbcf744-hqqvr istio-pilot-7dbfbcf744-k8fvw'
+ local url=debug/adsz
+ local dname=istio-dump/pilot
+ local outfile
++ basename debug/adsz
+ outfile=istio-dump/pilot/adsz
+ log 'Fetching debug/adsz from pilot'
+ local 'msg=Fetching debug/adsz from pilot'
+ '[' false = false ']'
+ printf '%s\n' 'Fetching debug/adsz from pilot'
Fetching debug/adsz from pilot
+ kubectl -n istio-system exec -i -t 'istio-pilot-7dbfbcf744-hqqvr istio-pilot-7dbfbcf744-k8fvw' -c istio-proxy -- curl http://localhost:8080/debug/adsz
Error from server (NotFound): pods "istio-pilot-7dbfbcf744-hqqvr istio-pilot-7dbfbcf744-k8fvw" not found
```