### PR TITLE
Put chunk count back into error message in kubesource

### DIFF
--- a/galley/pkg/config/source/kube/inmemory/kubesource.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource.go
@@ -202,14 +202,16 @@ func (s *KubeSource) parseContent(r schema.KubeResources, name, yamlText string)
 
 	reader := bufio.NewReader(strings.NewReader(yamlText))
 	decoder := yaml.NewYAMLReader(reader)
+	chunkCount := -1
 
 	for {
+		chunkCount++
 		doc, err := decoder.Read()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			e := fmt.Errorf("error reading documents in %s: %v", name, err)
+			e := fmt.Errorf("error reading documents in %s[%d]: %v", name, chunkCount, err)
 			scope.Source.Warnf("%v - skipping", e)
 			scope.Source.Debugf("Failed to parse yamlText chunk: %v", yamlText)
 			errs = multierror.Append(errs, e)
@@ -219,7 +221,7 @@ func (s *KubeSource) parseContent(r schema.KubeResources, name, yamlText string)
 		chunk := bytes.TrimSpace(doc)
 		r, err := s.parseChunk(r, chunk)
 		if err != nil {
-			e := fmt.Errorf("error processing %s: %v", name, err)
+			e := fmt.Errorf("error processing %s[%d]: %v", name, chunkCount, err)
 			scope.Source.Warnf("%v - skipping", e)
 			scope.Source.Debugf("Failed to parse yaml chunk: %v", string(chunk))
 			errs = multierror.Append(errs, e)


### PR DESCRIPTION
When failing to parse a yaml file, having the chunk number gives at least a hint at which document in the yaml file is failing. This was accidentally removed in https://github.com/istio/istio/commit/1ccf4dbdd724677dca7f8c60cd3aee967bd526c8#diff-7cd483599b0d374bfed504d4c0cd9328L203-R224 (although I did add it in one additional place).