### PR TITLE
Cleanup kube controller use of metrics

### DIFF
--- a/cmd/istiod/istiod.go
+++ b/cmd/istiod/istiod.go
@@ -98,7 +98,7 @@ func main() {
 	// Options based on the current 'defaults' in istio.
 	// If adjustments are needed - env or mesh.config ( if of general interest ).
 	istiod.RunCA(istiods.SecureGRPCServer, client, &istiod.CAOptions{
-		TrustDomain: istiods.Mesh.TrustDomain,
+		TrustDomain: istiods.Environment.Mesh.TrustDomain,
 	})
 
 	istiods.Serve(stop)
@@ -111,7 +111,7 @@ func initCerts(server *istiod.Server, client *kubernetes.Clientset) {
 	// TODO: fallback to citadel (or custom CA) if K8S signing is broken
 
 	// discAddr configured in mesh config - this is what we'll inject into pods.
-	discAddr := server.Mesh.DefaultConfig.DiscoveryAddress
+	discAddr := server.Environment.Mesh.DefaultConfig.DiscoveryAddress
 	if istiodAddress.Get() != "" {
 		discAddr = istiodAddress.Get()
 	}

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -48,13 +48,13 @@ func (s *Server) initCertController(args *PilotArgs) error {
 	// Whether a key and cert are generated for Pilot
 	var pilotCertGenerated bool
 
-	if s.mesh.GetCertificates() == nil || len(s.mesh.GetCertificates()) == 0 {
+	if s.environment.Mesh.GetCertificates() == nil || len(s.environment.Mesh.GetCertificates()) == 0 {
 		log.Info("nil certificate config")
 		return nil
 	}
 
 	k8sClient := s.kubeClient
-	for _, c := range s.mesh.GetCertificates() {
+	for _, c := range s.environment.Mesh.GetCertificates() {
 		name := strings.Join(c.GetDnsNames(), ",")
 		if len(name) == 0 { // must have a DNS name
 			continue

--- a/pilot/pkg/bootstrap/mesh.go
+++ b/pilot/pkg/bootstrap/mesh.go
@@ -51,7 +51,7 @@ func (s *Server) initMesh(args *PilotArgs) error {
 func (s *Server) initMeshConfiguration(args *PilotArgs) error {
 	// If a config file was specified, use it.
 	if args.MeshConfig != nil {
-		s.mesh = args.MeshConfig
+		s.environment.Mesh = args.MeshConfig
 		return nil
 	}
 	var meshConfig *meshconfig.MeshConfig
@@ -71,13 +71,13 @@ func (s *Server) initMeshConfiguration(args *PilotArgs) error {
 				log.Warnf("failed to read mesh configuration, using default: %v", err)
 				return
 			}
-			if !reflect.DeepEqual(meshConfig, s.mesh) {
+			if !reflect.DeepEqual(meshConfig, s.environment.Mesh) {
 				log.Infof("mesh configuration updated to: %s", spew.Sdump(meshConfig))
-				if !reflect.DeepEqual(meshConfig.ConfigSources, s.mesh.ConfigSources) {
+				if !reflect.DeepEqual(meshConfig.ConfigSources, s.environment.Mesh.ConfigSources) {
 					log.Infof("mesh configuration sources have changed")
 					//TODO Need to re-create or reload initConfigController()
 				}
-				s.mesh = meshConfig
+				s.environment.Mesh = meshConfig
 				if s.EnvoyXdsServer != nil {
 					s.EnvoyXdsServer.Env.Mesh = meshConfig
 					s.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{Full: true})
@@ -105,7 +105,7 @@ func (s *Server) initMeshConfiguration(args *PilotArgs) error {
 	log.Infof("version %s", version.Info.String())
 	log.Infof("flags %s", spew.Sdump(args))
 
-	s.mesh = meshConfig
+	s.environment.Mesh = meshConfig
 	return nil
 }
 
@@ -125,7 +125,7 @@ func (s *Server) initMeshNetworks(args *PilotArgs) error { //nolint: unparam
 	log.Infof("mesh networks configuration %s", spew.Sdump(meshNetworks))
 	mesh.ResolveHostsInNetworksConfig(meshNetworks)
 	log.Infof("mesh networks configuration post-resolution %s", spew.Sdump(meshNetworks))
-	s.meshNetworks = meshNetworks
+	s.environment.MeshNetworks = meshNetworks
 
 	// Watch the networks config file for changes and reload if it got modified
 	s.addFileWatcher(args.NetworksConfigFile, func() {
@@ -135,11 +135,11 @@ func (s *Server) initMeshNetworks(args *PilotArgs) error { //nolint: unparam
 			log.Warnf("failed to read mesh networks configuration from %q", args.NetworksConfigFile)
 			return
 		}
-		if !reflect.DeepEqual(meshNetworks, s.meshNetworks) {
+		if !reflect.DeepEqual(meshNetworks, s.environment.MeshNetworks) {
 			log.Infof("mesh networks configuration file updated to: %s", spew.Sdump(meshNetworks))
 			mesh.ResolveHostsInNetworksConfig(meshNetworks)
 			log.Infof("mesh networks configuration post-resolution %s", spew.Sdump(meshNetworks))
-			s.meshNetworks = meshNetworks
+			s.environment.MeshNetworks = meshNetworks
 			if s.kubeRegistry != nil {
 				s.kubeRegistry.InitNetworkLookup(meshNetworks)
 			}

--- a/pilot/pkg/bootstrap/multicluster.go
+++ b/pilot/pkg/bootstrap/multicluster.go
@@ -29,9 +29,9 @@ func (s *Server) initClusterRegistries(args *PilotArgs) (err error) {
 			args.Config.ControllerOptions.WatchedNamespace,
 			args.Config.ControllerOptions.DomainSuffix,
 			args.Config.ControllerOptions.ResyncPeriod,
-			s.ServiceController,
+			s.ServiceController(),
 			s.EnvoyXdsServer,
-			s.meshNetworks)
+			s.environment.MeshNetworks)
 
 		if err != nil {
 			log.Info("Unable to create new Multicluster object")

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -29,9 +29,13 @@ import (
 	"istio.io/istio/pkg/config/host"
 )
 
+func (s *Server) ServiceController() *aggregate.Controller {
+	return s.environment.ServiceDiscovery.(*aggregate.Controller)
+}
+
 // initServiceControllers creates and initializes the service controllers
 func (s *Server) initServiceControllers(args *PilotArgs) error {
-	serviceControllers := aggregate.NewController()
+	serviceControllers := s.ServiceController()
 	registered := make(map[serviceregistry.ProviderID]bool)
 	for _, r := range args.Service.Registries {
 		serviceRegistry := serviceregistry.ProviderID(r)
@@ -61,15 +65,12 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 		}
 	}
 
-	serviceEntryStore := external.NewServiceDiscovery(s.configController, s.istioConfigStore, s.EnvoyXdsServer)
-	serviceControllers.AddRegistry(serviceEntryStore)
-
-	s.ServiceController = serviceControllers
-	s.serviceEntryStore = serviceEntryStore
+	s.serviceEntryStore = external.NewServiceDiscovery(s.configController, s.environment.IstioConfigStore, s.EnvoyXdsServer)
+	serviceControllers.AddRegistry(s.serviceEntryStore)
 
 	// Defer running of the service controllers.
 	s.addStartFunc(func(stop <-chan struct{}) error {
-		go s.ServiceController.Run(stop)
+		go serviceControllers.Run(stop)
 		return nil
 	})
 
@@ -81,6 +82,7 @@ func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args
 	clusterID := string(serviceregistry.Kubernetes)
 	log.Infof("Primary Cluster name: %s", clusterID)
 	args.Config.ControllerOptions.ClusterID = clusterID
+	args.Config.ControllerOptions.Metrics = s.environment
 	kubectl := kubecontroller.NewController(s.kubeClient, args.Config.ControllerOptions)
 	s.kubeRegistry = kubectl
 	serviceControllers.AddRegistry(kubectl)

--- a/pilot/pkg/config/coredatamodel/discovery.go
+++ b/pilot/pkg/config/coredatamodel/discovery.go
@@ -39,7 +39,6 @@ var (
 
 // DiscoveryOptions stores the configurable attributes of a Control
 type DiscoveryOptions struct {
-	Env          *model.Environment
 	ClusterID    string
 	DomainSuffix string
 }

--- a/pilot/pkg/config/coredatamodel/discovery_test.go
+++ b/pilot/pkg/config/coredatamodel/discovery_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/onsi/gomega"
 
-	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/config/coredatamodel"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/host"
@@ -574,11 +574,6 @@ func initDiscovery() {
 	options := &coredatamodel.DiscoveryOptions{
 		ClusterID:    "test",
 		DomainSuffix: "cluster.local",
-		Env: &model.Environment{
-			Mesh: &meshconfig.MeshConfig{
-				MixerCheckServer: "mixer",
-			},
-		},
 	}
 	d = coredatamodel.NewMCPDiscovery(controller, options)
 }

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -29,6 +29,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/monitoring"
 
 	"istio.io/istio/pkg/config/labels"
 )
@@ -58,6 +59,12 @@ type Environment struct {
 	// routable L3 network. A single routable L3 network can have one or more
 	// service registries.
 	MeshNetworks *meshconfig.MeshNetworks
+}
+
+func (e *Environment) AddMetric(metric monitoring.Metric, key string, proxy *Proxy, msg string) {
+	if e != nil && e.PushContext != nil {
+		e.PushContext.AddMetric(metric, key, proxy, msg)
+	}
 }
 
 // Proxy contains information about an specific instance of a proxy (envoy sidecar, gateway,

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -42,7 +42,7 @@ func (ps *PushContext) combineSingleDestinationRule(
 				mdr.subsets[subset.Name] = struct{}{}
 				combinedRule.Subsets = append(combinedRule.Subsets, subset)
 			} else {
-				ps.Add(DuplicatedSubsets, string(resolvedHost), nil,
+				ps.AddMetric(DuplicatedSubsets, string(resolvedHost), nil,
 					fmt.Sprintf("Duplicate subset %s found while merging destination rules for %s",
 						subset.Name, string(resolvedHost)))
 			}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -35,6 +35,14 @@ import (
 	"istio.io/pkg/monitoring"
 )
 
+// Metrics is an interface for capturing metrics on a per-node basis.
+type Metrics interface {
+	// AddMetric will add an case to the metric for the given node.
+	AddMetric(metric monitoring.Metric, key string, proxy *Proxy, msg string)
+}
+
+var _ Metrics = &PushContext{}
+
 // PushContext tracks the status of a push - metrics and errors.
 // Metrics are reset after a push - at the beginning all
 // values are zero, and when push completes the status is reset.
@@ -302,8 +310,8 @@ func (ps *PushContext) IsMixerEnabled() bool {
 	return ps != nil && ps.Mesh != nil && (ps.Mesh.MixerCheckServer != "" || ps.Mesh.MixerReportServer != "")
 }
 
-// Add will add an case to the metric.
-func (ps *PushContext) Add(metric monitoring.Metric, key string, proxy *Proxy, msg string) {
+// AddMetric will add an case to the metric.
+func (ps *PushContext) AddMetric(metric monitoring.Metric, key string, proxy *Proxy, msg string) {
 	if ps == nil {
 		log.Infof("Metric without context %s %v %s", key, proxy, msg)
 		return

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -161,14 +161,14 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, push *mo
 
 // resolves cluster name conflicts. there can be duplicate cluster names if there are conflicting service definitions.
 // for any clusters that share the same name the first cluster is kept and the others are discarded.
-func normalizeClusters(push *model.PushContext, proxy *model.Proxy, clusters []*apiv2.Cluster) []*apiv2.Cluster {
+func normalizeClusters(metrics model.Metrics, proxy *model.Proxy, clusters []*apiv2.Cluster) []*apiv2.Cluster {
 	have := make(map[string]bool)
 	out := make([]*apiv2.Cluster, 0, len(clusters))
 	for _, cluster := range clusters {
 		if !have[cluster.Name] {
 			out = append(out, cluster)
 		} else {
-			push.Add(model.DuplicatedClusters, cluster.Name, proxy,
+			metrics.AddMetric(model.DuplicatedClusters, cluster.Name, proxy,
 				fmt.Sprintf("Duplicate cluster %s found while pushing CDS", cluster.Name))
 		}
 		have[cluster.Name] = true

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -316,7 +316,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(node *mod
 					Routes:  virtualHostWrapper.Routes,
 				})
 			} else {
-				push.Add(model.DuplicatedDomains, name, node, fmt.Sprintf("duplicate domain from virtual service: %s", name))
+				push.AddMetric(model.DuplicatedDomains, name, node, fmt.Sprintf("duplicate domain from virtual service: %s", name))
 			}
 		}
 
@@ -331,7 +331,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(node *mod
 					Routes:  virtualHostWrapper.Routes,
 				})
 			} else {
-				push.Add(model.DuplicatedDomains, name, node, fmt.Sprintf("duplicate domain from virtual service: %s", name))
+				push.AddMetric(model.DuplicatedDomains, name, node, fmt.Sprintf("duplicate domain from virtual service: %s", name))
 			}
 		}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -632,7 +632,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(no
 	if old, exists := listenerMap[listenerMapKey]; exists {
 		// For sidecar specified listeners, the caller is expected to supply a dummy service instance
 		// with the right port and a hostname constructed from the sidecar config's name+namespace
-		pluginParams.Push.Add(model.ProxyStatusConflictInboundListener, pluginParams.Node.ID, pluginParams.Node,
+		pluginParams.Push.AddMetric(model.ProxyStatusConflictInboundListener, pluginParams.Node.ID, pluginParams.Node,
 			fmt.Sprintf("Conflicting inbound listener:%s. existing: %s, incoming: %s", listenerMapKey,
 				old.instanceHostname, pluginParams.ServiceInstance.Service.Hostname))
 
@@ -801,13 +801,13 @@ type outboundListenerConflict struct {
 	newProtocol     protocol.Instance
 }
 
-func (c outboundListenerConflict) addMetric(node *model.Proxy, push *model.PushContext) {
+func (c outboundListenerConflict) addMetric(node *model.Proxy, metrics model.Metrics) {
 	currentHostnames := make([]string, len(c.currentServices))
 	for i, s := range c.currentServices {
 		currentHostnames[i] = string(s.Hostname)
 	}
 	concatHostnames := strings.Join(currentHostnames, ",")
-	push.Add(c.metric,
+	metrics.AddMetric(c.metric,
 		c.listenerName,
 		c.node,
 		fmt.Sprintf("Listener=%s Accepted%s=%s Rejected%s=%s %sServices=%d",
@@ -1326,7 +1326,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 		if listenerOpts.port == CanonicalHTTPSPort && pluginParams.Port.Protocol == protocol.HTTP {
 			msg := fmt.Sprintf("listener conflict detected: service %v specifies an HTTP service on HTTPS only port %d.",
 				pluginParams.Service.Hostname, CanonicalHTTPSPort)
-			pluginParams.Push.Add(model.ProxyStatusConflictOutboundListenerHTTPoverHTTPS, string(pluginParams.Service.Hostname), node, msg)
+			pluginParams.Push.AddMetric(model.ProxyStatusConflictOutboundListenerHTTPoverHTTPS, string(pluginParams.Service.Hostname), node, msg)
 			return
 		}
 	}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -337,7 +337,7 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 		}
 
 		if len(instances) == 0 {
-			push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
+			push.AddMetric(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
 			adsLog.Debugf("EDS: Cluster %q (host:%s ports:%v labels:%v) has no instances", clusterName, hostname, port, subsetLabels)
 		}
 		locEps = localityLbEndpointsFromInstances(instances, push)
@@ -942,7 +942,7 @@ func buildLocalityLbEndpointsFromShards(
 	}
 
 	if len(locEps) == 0 {
-		push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
+		push.AddMetric(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
 	}
 
 	updateEdsStats(locEps, clusterName)

--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -241,7 +241,7 @@ func initRegistry(server *bootstrap.Server, clusterNum int, gatewaysIP []string,
 	id := fmt.Sprintf("network%d", clusterNum)
 	memRegistry := v2.NewMemServiceDiscovery(
 		map[host.Name]*model.Service{}, 2)
-	server.ServiceController.AddRegistry(serviceregistry.Simple{
+	server.ServiceController().AddRegistry(serviceregistry.Simple{
 		ClusterID:        id,
 		ProviderID:       "memAdapter",
 		ServiceDiscovery: memRegistry,

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -583,11 +583,11 @@ func expectLuaFilter(t *testing.T, l *xdsapi.Listener, expected bool) {
 }
 
 func memServiceDiscovery(server *bootstrap.Server, t *testing.T) *v2.MemServiceDiscovery {
-	index, found := server.ServiceController.GetRegistryIndex("v2-debug")
+	index, found := server.ServiceController().GetRegistryIndex("v2-debug")
 	if !found {
 		t.Fatal("Could not find Mock ServiceRegistry")
 	}
-	registry, ok := server.ServiceController.GetRegistries()[index].(serviceregistry.Simple).ServiceDiscovery.(*v2.MemServiceDiscovery)
+	registry, ok := server.ServiceController().GetRegistries()[index].(serviceregistry.Simple).ServiceDiscovery.(*v2.MemServiceDiscovery)
 	if !ok {
 		t.Fatal("Unexpected type of Mock ServiceRegistry")
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -161,12 +161,8 @@ func newLocalController(t *testing.T) (*Controller, *FakeXdsUpdater) {
 		ResyncPeriod:     resync,
 		DomainSuffix:     domainSuffix,
 		XDSUpdater:       fx,
+		Metrics:          &model.Environment{},
 	})
-	ctl.Env = &model.Environment{
-		Mesh: &meshconfig.MeshConfig{
-			MixerCheckServer: "mixer",
-		},
-	}
 	go ctl.Run(ctl.stop)
 	return ctl, fx
 }
@@ -179,14 +175,10 @@ func newFakeController(_ *testing.T) (*Controller, *FakeXdsUpdater) {
 		ResyncPeriod:     resync,
 		DomainSuffix:     domainSuffix,
 		XDSUpdater:       fx,
+		Metrics:          &model.Environment{},
 	})
 	_ = c.AppendInstanceHandler(func(instance *model.ServiceInstance, event model.Event) {})
 	_ = c.AppendServiceHandler(func(service *model.Service, event model.Event) {})
-	c.Env = &model.Environment{
-		Mesh: &meshconfig.MeshConfig{
-			MixerCheckServer: "mixer",
-		},
-	}
 	go c.Run(c.stop)
 	return c, fx
 }
@@ -224,34 +216,28 @@ func TestServices(t *testing.T) {
 		return false
 	})
 
-	ctl.Env = &model.Environment{
-		Mesh: &meshconfig.MeshConfig{
-			MixerCheckServer: "mixer",
-		},
-		MeshNetworks: &meshconfig.MeshNetworks{
-			Networks: map[string]*meshconfig.Network{
-				"network1": {
-					Endpoints: []*meshconfig.Network_NetworkEndpoints{
-						{
-							Ne: &meshconfig.Network_NetworkEndpoints_FromCidr{
-								FromCidr: "10.10.1.1/24",
-							},
+	ctl.InitNetworkLookup(&meshconfig.MeshNetworks{
+		Networks: map[string]*meshconfig.Network{
+			"network1": {
+				Endpoints: []*meshconfig.Network_NetworkEndpoints{
+					{
+						Ne: &meshconfig.Network_NetworkEndpoints_FromCidr{
+							FromCidr: "10.10.1.1/24",
 						},
 					},
 				},
-				"network2": {
-					Endpoints: []*meshconfig.Network_NetworkEndpoints{
-						{
-							Ne: &meshconfig.Network_NetworkEndpoints_FromCidr{
-								FromCidr: "10.11.1.1/24",
-							},
+			},
+			"network2": {
+				Endpoints: []*meshconfig.Network_NetworkEndpoints{
+					{
+						Ne: &meshconfig.Network_NetworkEndpoints_FromCidr{
+							FromCidr: "10.11.1.1/24",
 						},
 					},
 				},
 			},
 		},
-	}
-	ctl.InitNetworkLookup(ctl.Env.MeshNetworks)
+	})
 
 	// 2 ports 1001, 2 IPs
 	createEndpoints(ctl, testService, ns, []string{"http-example", "foo"}, []string{"10.10.1.1", "10.11.1.2"}, t)


### PR DESCRIPTION
The only reason the kube controller has a dependency on the environment is for capturing metrics. This PR breaks out that interface so that the controller no longer has a direct dependency on the Environment or the PushContext.

Also moving the creation of the environment so that it can be passed into the controller during configuration.
