### PR TITLE
WIP: Add namespace model and its watcher

### DIFF
--- a/mixer/test/client/pilotplugin/pilotplugin_test.go
+++ b/mixer/test/client/pilotplugin/pilotplugin_test.go
@@ -318,6 +318,7 @@ func (mock) ManagementPorts(_ string) model.PortList                        { re
 func (mock) Services() ([]*model.Service, error)                            { return nil, nil }
 func (mock) WorkloadHealthCheckInfo(_ string) model.ProbeList               { return nil }
 func (mock) GetIstioServiceAccounts(_ *model.Service, ports []int) []string { return nil }
+func (mock) Namespaces() ([]*model.Namespace, error)                        { return nil, nil }
 
 const (
 	id = "id"

--- a/pilot/pkg/config/coredatamodel/discovery.go
+++ b/pilot/pkg/config/coredatamodel/discovery.go
@@ -520,3 +520,15 @@ func (d *MCPDiscovery) AppendInstanceHandler(f func(*model.ServiceInstance, mode
 	log.Warnf("AppendInstanceHandler %s", errUnsupported)
 	return nil
 }
+
+// AppendNamespaceHandler Not Supported
+func (d *MCPDiscovery) AppendNamespaceHandler(f func(*model.Namespace, model.Event)) error {
+	log.Warnf("AppendNamespaceHandler %s", errUnsupported)
+	return nil
+}
+
+// Namespaces Not supported
+func (d *MCPDiscovery) Namespaces() ([]*model.Namespace, error) {
+	log.Warnf("Namespaces %s", errUnsupported)
+	return nil, nil
+}

--- a/pilot/pkg/model/controller.go
+++ b/pilot/pkg/model/controller.go
@@ -36,6 +36,9 @@ type Controller interface {
 	// for a service.
 	AppendInstanceHandler(f func(*ServiceInstance, Event)) error
 
+	// AppendNamespaceHandler notifies about changes to the namespace
+	AppendNamespaceHandler(f func(*Namespace, Event)) error
+
 	// Run until a signal is received
 	Run(stop <-chan struct{})
 }

--- a/pilot/pkg/model/namespace.go
+++ b/pilot/pkg/model/namespace.go
@@ -1,0 +1,23 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import "istio.io/istio/pkg/config/labels"
+
+// Namespace represents an Istio namespace.
+type Namespace struct {
+	Name   string          `json:"endpoint,omitempty"`
+	Labels labels.Instance `json:"labels,omitempty"`
+}

--- a/pilot/pkg/model/namespace.go
+++ b/pilot/pkg/model/namespace.go
@@ -18,6 +18,7 @@ import "istio.io/istio/pkg/config/labels"
 
 // Namespace represents an Istio namespace.
 type Namespace struct {
-	Name   string          `json:"endpoint,omitempty"`
-	Labels labels.Instance `json:"labels,omitempty"`
+	Name        string          `json:"name,omitempty"`
+	Labels      labels.Instance `json:"labels,omitempty"`
+	Annotations labels.Instance `json:"annotations,omitempty"`
 }

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -476,6 +476,9 @@ type ServiceDiscovery interface {
 	// the specified service hostname and ports.
 	// Deprecated - service account tracking moved to XdsServer, incremental.
 	GetIstioServiceAccounts(svc *Service, ports []int) []string
+
+	// Namespaces returns a list of namespace in the system.
+	Namespaces() ([]*Namespace, error)
 }
 
 // Match returns true if port matches with authentication port selector criteria.

--- a/pilot/pkg/networking/core/v1alpha3/fakes/fake_service_discovery.gen.go
+++ b/pilot/pkg/networking/core/v1alpha3/fakes/fake_service_discovery.gen.go
@@ -87,6 +87,18 @@ type ServiceDiscovery struct {
 	managementPortsReturnsOnCall map[int]struct {
 		result1 model.PortList
 	}
+	NamespacesStub        func() ([]*model.Namespace, error)
+	namespacesMutex       sync.RWMutex
+	namespacesArgsForCall []struct {
+	}
+	namespacesReturns struct {
+		result1 []*model.Namespace
+		result2 error
+	}
+	namespacesReturnsOnCall map[int]struct {
+		result1 []*model.Namespace
+		result2 error
+	}
 	ServicesStub        func() ([]*model.Service, error)
 	servicesMutex       sync.RWMutex
 	servicesArgsForCall []struct {
@@ -494,6 +506,61 @@ func (fake *ServiceDiscovery) ManagementPortsReturnsOnCall(i int, result1 model.
 	}{result1}
 }
 
+func (fake *ServiceDiscovery) Namespaces() ([]*model.Namespace, error) {
+	fake.namespacesMutex.Lock()
+	ret, specificReturn := fake.namespacesReturnsOnCall[len(fake.namespacesArgsForCall)]
+	fake.namespacesArgsForCall = append(fake.namespacesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Namespaces", []interface{}{})
+	fake.namespacesMutex.Unlock()
+	if fake.NamespacesStub != nil {
+		return fake.NamespacesStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.namespacesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ServiceDiscovery) NamespacesCallCount() int {
+	fake.namespacesMutex.RLock()
+	defer fake.namespacesMutex.RUnlock()
+	return len(fake.namespacesArgsForCall)
+}
+
+func (fake *ServiceDiscovery) NamespacesCalls(stub func() ([]*model.Namespace, error)) {
+	fake.namespacesMutex.Lock()
+	defer fake.namespacesMutex.Unlock()
+	fake.NamespacesStub = stub
+}
+
+func (fake *ServiceDiscovery) NamespacesReturns(result1 []*model.Namespace, result2 error) {
+	fake.namespacesMutex.Lock()
+	defer fake.namespacesMutex.Unlock()
+	fake.NamespacesStub = nil
+	fake.namespacesReturns = struct {
+		result1 []*model.Namespace
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ServiceDiscovery) NamespacesReturnsOnCall(i int, result1 []*model.Namespace, result2 error) {
+	fake.namespacesMutex.Lock()
+	defer fake.namespacesMutex.Unlock()
+	fake.NamespacesStub = nil
+	if fake.namespacesReturnsOnCall == nil {
+		fake.namespacesReturnsOnCall = make(map[int]struct {
+			result1 []*model.Namespace
+			result2 error
+		})
+	}
+	fake.namespacesReturnsOnCall[i] = struct {
+		result1 []*model.Namespace
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ServiceDiscovery) Services() ([]*model.Service, error) {
 	fake.servicesMutex.Lock()
 	ret, specificReturn := fake.servicesReturnsOnCall[len(fake.servicesArgsForCall)]
@@ -624,6 +691,8 @@ func (fake *ServiceDiscovery) Invocations() map[string][][]interface{} {
 	defer fake.instancesByPortMutex.RUnlock()
 	fake.managementPortsMutex.RLock()
 	defer fake.managementPortsMutex.RUnlock()
+	fake.namespacesMutex.RLock()
+	defer fake.namespacesMutex.RUnlock()
 	fake.servicesMutex.RLock()
 	defer fake.servicesMutex.RUnlock()
 	fake.workloadHealthCheckInfoMutex.RLock()

--- a/pilot/pkg/proxy/envoy/v2/mem.go
+++ b/pilot/pkg/proxy/envoy/v2/mem.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/spiffe"
+	"istio.io/pkg/log"
 )
 
 // memregistry is based on mock/discovery - it is used for testing and debugging v2.
@@ -31,8 +32,9 @@ import (
 
 // MemServiceController is a mock service controller
 type MemServiceController struct {
-	svcHandlers  []func(*model.Service, model.Event)
-	instHandlers []func(*model.ServiceInstance, model.Event)
+	svcHandlers       []func(*model.Service, model.Event)
+	instHandlers      []func(*model.ServiceInstance, model.Event)
+	namespaceHandlers []func(*model.Namespace, model.Event)
 
 	sync.RWMutex
 }
@@ -49,6 +51,14 @@ func (c *MemServiceController) AppendServiceHandler(f func(*model.Service, model
 func (c *MemServiceController) AppendInstanceHandler(f func(*model.ServiceInstance, model.Event)) error {
 	c.Lock()
 	c.instHandlers = append(c.instHandlers, f)
+	c.Unlock()
+	return nil
+}
+
+// AppendNamespaceHandler appends a namespace handler to the controller
+func (c *MemServiceController) AppendNamespaceHandler(f func(*model.Namespace, model.Event)) error {
+	c.Lock()
+	c.namespaceHandlers = append(c.namespaceHandlers, f)
 	c.Unlock()
 	return nil
 }
@@ -348,6 +358,12 @@ func (sd *MemServiceDiscovery) GetProxyWorkloadLabels(proxy *model.Proxy) (label
 		}
 	}
 	return out, nil
+}
+
+// Namespaces list all namespace in the system
+func (sd *MemServiceDiscovery) Namespaces() ([]*model.Namespace, error) {
+	log.Warnf("TODO(diemtvu) Implement this")
+	return nil, nil
 }
 
 // ManagementPorts implements discovery interface

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -315,3 +315,29 @@ func (c *Controller) GetIstioServiceAccounts(svc *model.Service, ports []int) []
 	}
 	return nil
 }
+
+// AppendNamespaceHandler implements namespace catalog operation
+func (c *Controller) AppendNamespaceHandler(f func(*model.Namespace, model.Event)) error {
+	for _, r := range c.GetRegistries() {
+		if err := r.AppendNamespaceHandler(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Namespaces list all namespace in the system
+func (c *Controller) Namespaces() ([]*model.Namespace, error) {
+	namespaces := make([]*model.Namespace, 0)
+	var errs error
+	for _, r := range c.GetRegistries() {
+		ns, err := r.Namespaces()
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			continue
+		}
+		namespaces = append(namespaces, ns...)
+	}
+	return namespaces, errs
+
+}

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -15,6 +15,7 @@
 package consul
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -237,6 +238,12 @@ func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.
 	return nil
 }
 
+// AppendNamespaceHandler implements a namespace catalog operation
+func (c *Controller) AppendNamespaceHandler(f func(*model.Namespace, model.Event)) error {
+	log.Warnf("AppendNamespaceHandler %s", errors.New("this operation is not supported by consul controller"))
+	return nil
+}
+
 // GetIstioServiceAccounts implements model.ServiceAccounts operation TODO
 func (c *Controller) GetIstioServiceAccounts(svc *model.Service, ports []int) []string {
 	// Need to get service account of service registered with consul
@@ -323,4 +330,12 @@ func (c *Controller) InstanceChanged(instance *api.CatalogService, event model.E
 func (c *Controller) ServiceChanged(instances []*api.CatalogService, event model.Event) error {
 	c.refreshCache()
 	return nil
+}
+
+// Namespaces list all namespace in the system
+func (c *Controller) Namespaces() ([]*model.Namespace, error) {
+	// DONOTSUBMIT
+	// TODO(diemtvu): implement this
+	log.Warnf("Namespaces() is not supported on consul")
+	return nil, nil
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -178,6 +178,7 @@ func NewController(client kubernetes.Interface, options Options) *Controller {
 		XDSUpdater:                 options.XDSUpdater,
 		servicesMap:                make(map[host.Name]*model.Service),
 		externalNameSvcInstanceMap: make(map[host.Name][]*model.ServiceInstance),
+		namespacesMap:              make(map[string]*model.Namespace),
 	}
 
 	sharedInformers := informers.NewSharedInformerFactoryWithOptions(client, options.ResyncPeriod, informers.WithNamespace(options.WatchedNamespace))
@@ -968,8 +969,8 @@ func (c *Controller) AppendNamespaceHandler(f func(*model.Namespace, model.Event
 				return nil
 			}
 		}
-		nsConv := kube.ConvertNamespace(*ns)
 
+		nsConv := kube.ConvertNamespace(*ns)
 		switch event {
 		case model.EventDelete:
 			c.Lock()

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -271,7 +271,8 @@ func ConvertProbesToPorts(t *coreV1.PodSpec) (model.PortList, error) {
 // ConvertNamespace returns Istio namespace for a K8s namespace
 func ConvertNamespace(ns coreV1.Namespace) *model.Namespace {
 	return &model.Namespace{
-		Name:   ns.Name,
-		Labels: map[string]string(configKube.ConvertLabels(ns.ObjectMeta)),
+		Name:        ns.Name,
+		Labels:      map[string]string(configKube.ConvertLabels(ns.ObjectMeta)),
+		Annotations: map[string]string(configKube.ConvertAnnotations(ns.ObjectMeta)),
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/kube"
+	configKube "istio.io/istio/pkg/config/kube"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/spiffe"
@@ -265,4 +266,12 @@ func ConvertProbesToPorts(t *coreV1.PodSpec) (model.PortList, error) {
 	sort.Slice(mgmtPorts, func(i, j int) bool { return mgmtPorts[i].Port < mgmtPorts[j].Port })
 
 	return mgmtPorts, errs
+}
+
+// ConvertNamespace returns Istio namespace for a K8s namespace
+func ConvertNamespace(ns coreV1.Namespace) *model.Namespace {
+	return &model.Namespace{
+		Name:   ns.Name,
+		Labels: map[string]string(configKube.ConvertLabels(ns.ObjectMeta)),
+	}
 }

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -234,6 +234,12 @@ func (sd *ServiceDiscovery) GetProxyServiceInstances(node *model.Proxy) ([]*mode
 	return out, sd.GetProxyServiceInstancesError
 }
 
+// Namespaces list all namespace in the system
+func (sd *ServiceDiscovery) Namespaces() ([]*model.Namespace, error) {
+	// TODO(diemtvu): implement this
+	return nil, nil
+}
+
 func (sd *ServiceDiscovery) GetProxyWorkloadLabels(proxy *model.Proxy) (labels.Collection, error) {
 	if sd.GetProxyServiceInstancesError != nil {
 		return nil, sd.GetProxyServiceInstancesError
@@ -278,6 +284,10 @@ func (c *MockController) AppendServiceHandler(f func(*model.Service, model.Event
 }
 
 func (c *MockController) AppendInstanceHandler(f func(*model.ServiceInstance, model.Event)) error {
+	return nil
+}
+
+func (c *MockController) AppendNamespaceHandler(f func(*model.Namespace, model.Event)) error {
 	return nil
 }
 

--- a/pkg/config/kube/conversion.go
+++ b/pkg/config/kube/conversion.go
@@ -50,6 +50,14 @@ func ConvertLabels(obj metaV1.ObjectMeta) labels.Instance {
 	return out
 }
 
+func ConvertAnnotations(obj metaV1.ObjectMeta) labels.Instance {
+	out := make(labels.Instance, len(obj.Annotations))
+	for k, v := range obj.Annotations {
+		out[k] = v
+	}
+	return out
+}
+
 var grpcWeb = string(protocol.GRPCWeb)
 var grpcWebLen = len(grpcWeb)
 


### PR DESCRIPTION
We want to move namespace-level mTLS settings to namespace annotation. This requires pilot got inform of all namespaces (and their annotations/labels) changes. This PR introduces Istio namespace model and equip ServiceDiscovery to watch for the namespace resources.

Issue:
https://github.com/istio/istio/issues/19083