### PR TITLE
Add more validation rules for `RequestAuthentication`

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1530,6 +1530,14 @@ func ValidateRequestAuthentication(name, namespace string, msg proto.Message) er
 	}
 
 	var errs error
+	emptySelector := in.Selector == nil || len(in.Selector.MatchLabels) == 0
+	if name == constants.DefaultAuthenticationPolicyName && !emptySelector {
+		errs = appendErrors(errs, fmt.Errorf("default request authentication cannot have workload selector"))
+	} else if emptySelector && name != constants.DefaultAuthenticationPolicyName {
+		errs = appendErrors(errs,
+			fmt.Errorf("request authentication with empty workload selector must be named %q", constants.DefaultAuthenticationPolicyName))
+	}
+
 	errs = appendErrors(errs, validateWorkloadSelector(in.Selector))
 
 	for _, rule := range in.JwtRules {

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1550,17 +1550,16 @@ func validateJwtRule(rule *security_beta.JWT) (errs error) {
 	if rule == nil {
 		return nil
 	}
-	if rule.Issuer == "" {
+	if len(rule.Issuer) == 0 {
 		errs = multierror.Append(errs, errors.New("issuer must be set"))
 	}
 	for _, audience := range rule.Audiences {
-		if audience == "" {
+		if len(audience) == 0 {
 			errs = multierror.Append(errs, errors.New("audience must be non-empty string"))
 		}
 	}
 
 	if len(rule.JwksUri) != 0 {
-		// TODO: do more extensive check (e.g try to fetch JwksUri)
 		if _, err := security.ParseJwksURI(rule.JwksUri); err != nil {
 			errs = multierror.Append(errs, err)
 		}
@@ -1573,7 +1572,7 @@ func validateJwtRule(rule *security_beta.JWT) (errs error) {
 	}
 
 	for _, location := range rule.FromParams {
-		if location == "" {
+		if len(location) == 0 {
 			errs = multierror.Append(errs, errors.New("location query must be non-empty string"))
 		}
 	}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1505,8 +1505,9 @@ func ValidateAuthorizationPolicy(_, _ string, msg proto.Message) error {
 		return fmt.Errorf("cannot cast to AuthorizationPolicy")
 	}
 
-	var errs error
-	errs = appendErrors(errs, validateWorkloadSelector(in.Selector))
+	if err := validateWorkloadSelector(in.Selector); err != nil {
+		return err
+	}
 
 	for _, rule := range in.GetRules() {
 		for _, condition := range rule.GetWhen() {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -5036,12 +5036,128 @@ func TestValidateRequestAuthentication(t *testing.T) {
 			},
 			valid: false,
 		},
+		{
+			name:       "bad JwksUri - no protocol",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.RequestAuthentication{
+				JwtRules: []*security_beta.JWT{
+					{
+						Issuer:  "foo.com",
+						JwksUri: "foo.com",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name:       "bad JwksUri - invalid port",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.RequestAuthentication{
+				JwtRules: []*security_beta.JWT{
+					{
+						Issuer:  "foo.com",
+						JwksUri: "https://foo.com:not-a-number",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name:       "bad selector - empy value",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.RequestAuthentication{
+				Selector: &api.WorkloadSelector{
+					MatchLabels: map[string]string{
+						"app":     "httpbin",
+						"version": "",
+					},
+				},
+				JwtRules: []*security_beta.JWT{
+					{
+						Issuer:  "foo.com",
+						JwksUri: "https://foo.com/cert",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name:       "bad selector - empy key",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.RequestAuthentication{
+				Selector: &api.WorkloadSelector{
+					MatchLabels: map[string]string{
+						"app": "httpbin",
+						"":    "v1",
+					},
+				},
+				JwtRules: []*security_beta.JWT{
+					{
+						Issuer:  "foo.com",
+						JwksUri: "https://foo.com/cert",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name:       "bad header location",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.RequestAuthentication{
+				JwtRules: []*security_beta.JWT{
+					{
+						Issuer:  "foo.com",
+						JwksUri: "https://foo.com",
+						FromHeaders: []*security_beta.JWTHeader{
+							{
+								Name:   "",
+								Prefix: "Bearer ",
+							},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name:       "bad param location",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.RequestAuthentication{
+				JwtRules: []*security_beta.JWT{
+					{
+						Issuer:     "foo.com",
+						JwksUri:    "https://foo.com",
+						FromParams: []string{""},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name:       "good",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.RequestAuthentication{
+				JwtRules: []*security_beta.JWT{
+					{
+						Issuer:  "foo.com",
+						JwksUri: "https://foo.com",
+						FromHeaders: []*security_beta.JWTHeader{
+							{
+								Name:   "x-foo",
+								Prefix: "Bearer ",
+							},
+						},
+					},
+				},
+			},
+			valid: true,
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if got := ValidateRequestAuthentication(c.configName, someNamespace, c.in); (got == nil) != c.valid {
-				t.Errorf("got(%v) != want(%v)\n", c.valid, got)
+				t.Errorf("got(%v) != want(%v)\n", got, c.valid)
 			}
 		})
 	}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -5010,9 +5010,35 @@ func TestValidateRequestAuthentication(t *testing.T) {
 	}{
 		{
 			name:       "empty spec",
-			configName: someName,
+			configName: constants.DefaultAuthenticationPolicyName,
 			in:         &security_beta.RequestAuthentication{},
 			valid:      true,
+		},
+		{
+			name:       "another empty spec",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.RequestAuthentication{
+				Selector: &api.WorkloadSelector{},
+			},
+			valid: true,
+		},
+		{
+			name:       "empty spec with non default name",
+			configName: someName,
+			in:         &security_beta.RequestAuthentication{},
+			valid:      false,
+		},
+		{
+			name:       "default name with non empty selector",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.RequestAuthentication{
+				Selector: &api.WorkloadSelector{
+					MatchLabels: map[string]string{
+						"app": "httpbin",
+					},
+				},
+			},
+			valid: false,
 		},
 		{
 			name:       "empty jwt rule",


### PR DESCRIPTION
Verify basic JWT arguments (issuer, jwksUri) are valid. This is more or less the same as the existing (v1alpha1) validation.

Issue: https://github.com/istio/istio/issues/18399