### PR TITLE
Fallback to alpha JWT policy if RequestAuthentication is not found

### DIFF
--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -47,7 +47,6 @@ import (
 type v1beta1PolicyApplier struct {
 	jwtPolicies []*model.Config
 	// TODO: add mTLS configs.
-	// TODO: add v1alpha1 fallback configs.
 
 	// processedJwtRules is the consolidate JWT rules from all jwtPolicies.
 	processedJwtRules []*v1beta1.JWT
@@ -135,7 +134,9 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarsha
 =======
 	if len(a.processedJwtRules) == 0 {
 		log.Infof("RequestAuthentication (beta policy) not found, fallback to alpha if available")
-		return a.alphaApplier.AuthNFilter(proxyType, isXDSMarshalingToAnyEnabled)
+		// TODO(diemtvu) Should also check *beta* mTLS policy before fallback to
+		// a.alphaApplier.AuthNFilter(proxyType, isXDSMarshalingToAnyEnabled)
+		return nil
 	}
 	// TODO(diemtvu) implement this.
 	log.Errorf("AuthNFilter(%v, %v) is not yet implemented", proxyType, isXDSMarshalingToAnyEnabled)

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -25,14 +25,10 @@ import (
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/golang/protobuf/ptypes/empty"
 
-<<<<<<< HEAD
 	"istio.io/istio/pilot/pkg/features"
 	authn_alpha "istio.io/istio/security/proto/authentication/v1alpha1"
 	authn_filter "istio.io/istio/security/proto/envoy/config/filter/http/authn/v2alpha1"
-
-=======
-	authn_v1alpha1 "istio.io/api/authentication/v1alpha1"
->>>>>>> Add fallback to alpha JWT policy if RequestAuthentication is not found
+	authn_alpha_api "istio.io/api/authentication/v1alpha1"
 	"istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
@@ -117,7 +113,6 @@ func convertToIstioAuthnFilterConfig(jwtRules []*v1beta1.JWT) *authn_filter.Filt
 // ensure Authn Filter won't reject the request, but still transform the attributes, e.g. request.auth.principal.
 // proxyType does not matter here, exists only for legacy reason.
 func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarshalingToAnyEnabled bool) *http_conn.HttpFilter {
-<<<<<<< HEAD
 	out := &http_conn.HttpFilter{
 		Name: authn_model.AuthnFilterName,
 	}
@@ -131,17 +126,6 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarsha
 		out.ConfigType = &http_conn.HttpFilter_Config{Config: util.MessageToStruct(filterConfigProto)}
 	}
 	return out
-=======
-	if len(a.processedJwtRules) == 0 {
-		log.Infof("RequestAuthentication (beta policy) not found, fallback to alpha if available")
-		// TODO(diemtvu) Should also check *beta* mTLS policy before fallback to
-		// a.alphaApplier.AuthNFilter(proxyType, isXDSMarshalingToAnyEnabled)
-		return nil
-	}
-	// TODO(diemtvu) implement this.
-	log.Errorf("AuthNFilter(%v, %v) is not yet implemented", proxyType, isXDSMarshalingToAnyEnabled)
-	return nil
->>>>>>> Add fallback to alpha JWT policy if RequestAuthentication is not found
 }
 
 func (a *v1beta1PolicyApplier) InboundFilterChain(sdsUdsPath string, meta *model.NodeMetadata) []plugin.FilterChain {
@@ -151,7 +135,7 @@ func (a *v1beta1PolicyApplier) InboundFilterChain(sdsUdsPath string, meta *model
 }
 
 // NewPolicyApplier returns new applier for v1beta1 authentication policies.
-func NewPolicyApplier(jwtPolicies []*model.Config, policy *authn_v1alpha1.Policy) authn.PolicyApplier {
+func NewPolicyApplier(jwtPolicies []*model.Config, policy *authn_alpha_api.Policy) authn.PolicyApplier {
 	processedJwtRules := []*v1beta1.JWT{}
 
 	// TODO(diemtvu) should we need to deduplicate JWT with the same issuer.

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -25,17 +25,17 @@ import (
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/golang/protobuf/ptypes/empty"
 
-	"istio.io/istio/pilot/pkg/features"
-	authn_alpha "istio.io/istio/security/proto/authentication/v1alpha1"
-	authn_filter "istio.io/istio/security/proto/envoy/config/filter/http/authn/v2alpha1"
 	authn_alpha_api "istio.io/api/authentication/v1alpha1"
 	"istio.io/api/security/v1beta1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/security/authn"
 	alpha_applier "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
+	authn_alpha "istio.io/istio/security/proto/authentication/v1alpha1"
+	authn_filter "istio.io/istio/security/proto/envoy/config/filter/http/authn/v2alpha1"
 	"istio.io/pkg/log"
 )
 

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -56,7 +56,7 @@ type v1beta1PolicyApplier struct {
 
 func (a *v1beta1PolicyApplier) JwtFilter(isXDSMarshalingToAnyEnabled bool) *http_conn.HttpFilter {
 	if len(a.processedJwtRules) == 0 {
-		log.Infof("RequestAuthentication (beta policy) not found, fallback to alpha if available")
+		log.Debugf("RequestAuthentication (beta policy) not found, fallback to alpha if available")
 		return a.alphaApplier.JwtFilter(isXDSMarshalingToAnyEnabled)
 	}
 

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -25,15 +25,20 @@ import (
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/golang/protobuf/ptypes/empty"
 
+<<<<<<< HEAD
 	"istio.io/istio/pilot/pkg/features"
 	authn_alpha "istio.io/istio/security/proto/authentication/v1alpha1"
 	authn_filter "istio.io/istio/security/proto/envoy/config/filter/http/authn/v2alpha1"
 
+=======
+	authn_v1alpha1 "istio.io/api/authentication/v1alpha1"
+>>>>>>> Add fallback to alpha JWT policy if RequestAuthentication is not found
 	"istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/security/authn"
+	alpha_applier "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/pkg/log"
 )
@@ -46,9 +51,16 @@ type v1beta1PolicyApplier struct {
 
 	// processedJwtRules is the consolidate JWT rules from all jwtPolicies.
 	processedJwtRules []*v1beta1.JWT
+
+	alphaApplier authn.PolicyApplier
 }
 
 func (a *v1beta1PolicyApplier) JwtFilter(isXDSMarshalingToAnyEnabled bool) *http_conn.HttpFilter {
+	if len(a.processedJwtRules) == 0 {
+		log.Infof("RequestAuthentication (beta policy) not found, fallback to alpha if available")
+		return a.alphaApplier.JwtFilter(isXDSMarshalingToAnyEnabled)
+	}
+
 	filterConfigProto := convertToEnvoyJwtConfig(a.processedJwtRules)
 
 	if filterConfigProto == nil {
@@ -106,6 +118,7 @@ func convertToIstioAuthnFilterConfig(jwtRules []*v1beta1.JWT) *authn_filter.Filt
 // ensure Authn Filter won't reject the request, but still transform the attributes, e.g. request.auth.principal.
 // proxyType does not matter here, exists only for legacy reason.
 func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarshalingToAnyEnabled bool) *http_conn.HttpFilter {
+<<<<<<< HEAD
 	out := &http_conn.HttpFilter{
 		Name: authn_model.AuthnFilterName,
 	}
@@ -119,6 +132,15 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarsha
 		out.ConfigType = &http_conn.HttpFilter_Config{Config: util.MessageToStruct(filterConfigProto)}
 	}
 	return out
+=======
+	if len(a.processedJwtRules) == 0 {
+		log.Infof("RequestAuthentication (beta policy) not found, fallback to alpha if available")
+		return a.alphaApplier.AuthNFilter(proxyType, isXDSMarshalingToAnyEnabled)
+	}
+	// TODO(diemtvu) implement this.
+	log.Errorf("AuthNFilter(%v, %v) is not yet implemented", proxyType, isXDSMarshalingToAnyEnabled)
+	return nil
+>>>>>>> Add fallback to alpha JWT policy if RequestAuthentication is not found
 }
 
 func (a *v1beta1PolicyApplier) InboundFilterChain(sdsUdsPath string, meta *model.NodeMetadata) []plugin.FilterChain {
@@ -128,7 +150,7 @@ func (a *v1beta1PolicyApplier) InboundFilterChain(sdsUdsPath string, meta *model
 }
 
 // NewPolicyApplier returns new applier for v1beta1 authentication policies.
-func NewPolicyApplier(jwtPolicies []*model.Config) authn.PolicyApplier {
+func NewPolicyApplier(jwtPolicies []*model.Config, policy *authn_v1alpha1.Policy) authn.PolicyApplier {
 	processedJwtRules := []*v1beta1.JWT{}
 
 	// TODO(diemtvu) should we need to deduplicate JWT with the same issuer.
@@ -148,6 +170,7 @@ func NewPolicyApplier(jwtPolicies []*model.Config) authn.PolicyApplier {
 	return &v1beta1PolicyApplier{
 		jwtPolicies:       jwtPolicies,
 		processedJwtRules: processedJwtRules,
+		alphaApplier:      alpha_applier.NewPolicyApplier(policy),
 	}
 }
 

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -25,20 +25,20 @@ import (
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/golang/protobuf/ptypes/empty"
 
-	authn_alpha "istio.io/istio/security/proto/authentication/v1alpha1"
-	authn_filter "istio.io/istio/security/proto/envoy/config/filter/http/authn/v2alpha1"
 	authn_alpha_api "istio.io/api/authentication/v1alpha1"
 	v1beta1 "istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/test"
 	pilotutil "istio.io/istio/pilot/pkg/networking/util"
+	authn_alpha "istio.io/istio/security/proto/authentication/v1alpha1"
+	authn_filter "istio.io/istio/security/proto/envoy/config/filter/http/authn/v2alpha1"
 )
 
 type testCase struct {
-	name     string
-	in       []*model.Config
+	name          string
+	in            []*model.Config
 	alphaPolicyIn *authn_alpha_api.Policy
-	expected *http_conn.HttpFilter
+	expected      *http_conn.HttpFilter
 }
 
 func TestJwtFilter(t *testing.T) {

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -77,8 +77,21 @@ func TestJwtFilter(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "Fallback to alpha with no JWT",
+			alphaPolicy: &authn_v1alpha1.Policy{
+				Peers: []*authn_v1alpha1.PeerAuthenticationMethod{{
+					Params: &authn_v1alpha1.PeerAuthenticationMethod_Mtls{&authn_v1alpha1.MutualTls{}},
+				}},
+			},
+			in:       []*model.Config{},
+			expected: nil,
+		},
+		{
 			name: "Fallback to alpha JWT",
 			alphaPolicy: &authn_v1alpha1.Policy{
+				Peers: []*authn_v1alpha1.PeerAuthenticationMethod{{
+					Params: &authn_v1alpha1.PeerAuthenticationMethod_Mtls{&authn_v1alpha1.MutualTls{}},
+				}},
 				Origins: []*authn_v1alpha1.OriginAuthenticationMethod{
 					{
 						Jwt: &authn_v1alpha1.Jwt{


### PR DESCRIPTION
This allows users to slowly migrate to the beta policy:
- If there is a RequestAuthentication config for a given workload, it will be used (for Jwt validation)
- If not, it will try to use alpha1 applier and policy to generate Jwt filter.

This strategy will also be used for other part of the authN filter chain, including authN filter and (may be) mTLS.

Issue: 
https://github.com/istio/istio/issues/19084