### PR TITLE
tweak outlier detection stats

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -48,7 +48,8 @@ const (
 
 	// required stats are used by readiness checks.
 	requiredEnvoyStatsMatcherInclusionPrefixes = "cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grpc"
-	requiredEnvoyStatsMatcherInclusionSuffix   = "ssl_context_update_by_sds"
+	requiredEnvoyStatsMatcherInclusionSuffix   = "ssl_context_update_by_sds,outlier_detection.ejections_enforced_total," +
+		"outlier_detection.ejections_active,outlier_detection.ejections_overflow,consecutive_5xx,consecutive_gateway_failure"
 
 	// Prefixes of V2 metrics.
 	// "reporter" prefix is for istio standard metrics.


### PR DESCRIPTION
Add `outlier detection` stats in `inclusionList` of `bootstrap` config. the format of these stats is from: [outlier-detection-statistics](https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_stats#outlier-detection-statistics)

See https://github.com/istio/istio/issues/18973