### PR TITLE
Adding ServiceAssociation Analyzer

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -18,6 +18,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/annotations"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/auth"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/deployment"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
@@ -44,6 +45,7 @@ func All() []analysis.Analyzer {
 		&virtualservice.DestinationHostAnalyzer{},
 		&virtualservice.DestinationRuleAnalyzer{},
 		&virtualservice.GatewayAnalyzer{},
+		&deployment.ServiceAssociationAnalyzer{},
 	}
 
 	analyzers = append(analyzers, schema.AllValidationAnalyzers()...)

--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -35,6 +35,7 @@ func All() []analysis.Analyzer {
 		&auth.MTLSAnalyzer{},
 		&auth.ServiceRoleBindingAnalyzer{},
 		&auth.ServiceRoleServicesAnalyzer{},
+		&deployment.ServiceAssociationAnalyzer{},
 		&deprecation.FieldAnalyzer{},
 		&gateway.IngressGatewayPortAnalyzer{},
 		&injection.Analyzer{},
@@ -45,7 +46,6 @@ func All() []analysis.Analyzer {
 		&virtualservice.DestinationHostAnalyzer{},
 		&virtualservice.DestinationRuleAnalyzer{},
 		&virtualservice.GatewayAnalyzer{},
-		&deployment.ServiceAssociationAnalyzer{},
 	}
 
 	analyzers = append(analyzers, schema.AllValidationAnalyzers()...)

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -310,6 +310,7 @@ var testGrid = []testCase{
 		analyzer:   &deployment.ServiceAssociationAnalyzer{},
 		expected: []message{
 			{msg.DeploymentAssociatedToMultipleServices, "Deployment details-v1"},
+			{msg.DeploymentAssociatedToMultipleServices, "Deployment productpage-v1"},
 			{msg.DeploymentRequiresServiceAssociated, "Deployment ratings-v1"},
 		},
 	},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/annotations"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/auth"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/deployment"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
@@ -301,6 +302,15 @@ var testGrid = []testCase{
 		analyzer:   &virtualservice.GatewayAnalyzer{},
 		expected: []message{
 			{msg.ReferencedResourceNotFound, "VirtualService httpbin-bogus"},
+		},
+	},
+	{
+		name:       "serviceMultipleDeployments",
+		inputFiles: []string{"testdata/deployment-multi-service.yaml"},
+		analyzer:   &deployment.ServiceAssociationAnalyzer{},
+		expected: []message{
+			{msg.DeploymentAssociatedToMultipleServices, "Deployment details-v1"},
+			{msg.DeploymentRequiresServiceAssociated, "Deployment ratings-v1"},
 		},
 	},
 }

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -309,9 +309,10 @@ var testGrid = []testCase{
 		inputFiles: []string{"testdata/deployment-multi-service.yaml"},
 		analyzer:   &deployment.ServiceAssociationAnalyzer{},
 		expected: []message{
-			{msg.DeploymentAssociatedToMultipleServices, "Deployment details-v1"},
-			{msg.DeploymentAssociatedToMultipleServices, "Deployment productpage-v1"},
-			{msg.DeploymentRequiresServiceAssociated, "Deployment ratings-v1"},
+			{msg.DeploymentAssociatedToMultipleServices, "Deployment multiple-svc-multiple-prot.bookinfo"},
+			{msg.DeploymentAssociatedToMultipleServices, "Deployment multiple-without-port.bookinfo"},
+			{msg.DeploymentRequiresServiceAssociated, "Deployment no-services.bookinfo"},
+			{msg.DeploymentRequiresServiceAssociated, "Deployment ann-enabled-ns-disabled.injection-disabled-ns"},
 		},
 	},
 }

--- a/galley/pkg/config/analysis/analyzers/deployment/services.go
+++ b/galley/pkg/config/analysis/analyzers/deployment/services.go
@@ -18,7 +18,9 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	k8s_labels "k8s.io/apimachinery/pkg/labels"
 
+	"istio.io/api/annotation"
 	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/meta/metadata"
 	"istio.io/istio/galley/pkg/config/meta/schema/collection"
@@ -39,16 +41,20 @@ type ServiceSpecWithName struct {
 
 func (s *ServiceAssociationAnalyzer) Metadata() analysis.Metadata {
 	return analysis.Metadata{
-		Name: "deployment.MultiServiceAnalyzer",
+		Name:        "deployment.MultiServiceAnalyzer",
+		Description: "Checks association between services and pods",
 		Inputs: collection.Names{
 			metadata.K8SCoreV1Services,
 			metadata.K8SAppsV1Deployments,
+			metadata.K8SCoreV1Namespaces,
 		},
 	}
 }
 func (s *ServiceAssociationAnalyzer) Analyze(c analysis.Context) {
 	c.ForEach(metadata.K8SAppsV1Deployments, func(r *resource.Entry) bool {
-		s.analyzeDeployment(r, c)
+		if inMesh(r, c) {
+			s.analyzeDeployment(r, c)
+		}
 		return true
 	})
 }
@@ -131,4 +137,44 @@ func servicePortMap(svcs []ServiceSpecWithName) PortMap {
 	}
 
 	return portMap
+}
+
+// inMesh returns true if deployment is in the service mesh (has sidecar)
+func inMesh(r *resource.Entry, c analysis.Context) bool {
+	d := r.Item.(*apps_v1.Deployment)
+
+	// If Pod has annotation, return the injection annotation value
+	if piv, pivok := getPodSidecarInjectionStatus(d); pivok {
+		return piv
+	}
+
+	// In case the annotation is not present but there is a auto-injection label on the namespace,
+	// return the auto-injection label status
+	if niv, nivok := getNamesSidecarInjectionStatus(d.Namespace, c); nivok {
+		return niv
+	}
+
+	return false
+}
+
+// getPodSidecarInjectionStatus returns two booleans: enabled and ok.
+// enabled is true when deployment d PodSpec has either the annotation 'sidecar.istio.io/inject: "true"'
+// ok is true when the PodSpec doesn't have the 'sidecar.istio.io/inject' annotation present.
+func getPodSidecarInjectionStatus(d *apps_v1.Deployment) (enabled bool, ok bool) {
+	v, ok := d.Spec.Template.Annotations[annotation.SidecarInject.Name]
+	return v == "true", ok
+}
+
+// autoInjectionEnabled returns two booleans: enabled and ok.
+// enabled is true when namespace ns has 'istio-injection' label set to 'enabled'
+// ok is true when the namespace doesn't have the label 'istio-injection'
+func getNamesSidecarInjectionStatus(ns string, c analysis.Context) (enabled bool, ok bool) {
+	enabled, ok = false, false
+
+	namespace := c.Find(metadata.K8SCoreV1Namespaces, resource.NewName("", ns))
+	if namespace != nil {
+		enabled, ok = namespace.Metadata.Labels[injection.InjectionLabelName] == injection.InjectionLabelEnableValue, true
+	}
+
+	return enabled, ok
 }

--- a/galley/pkg/config/analysis/analyzers/deployment/services.go
+++ b/galley/pkg/config/analysis/analyzers/deployment/services.go
@@ -1,0 +1,128 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package deployment
+
+import (
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+	k8s_labels "k8s.io/apimachinery/pkg/labels"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/galley/pkg/config/meta/metadata"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+)
+
+type ServiceAssociationAnalyzer struct{}
+
+var _ analysis.Analyzer = &ServiceAssociationAnalyzer{}
+
+type PortMap map[int32]ProtocolMap
+type ProtocolMap map[core_v1.Protocol][]ServiceSpecWithName
+type ServiceNames []string
+type ServiceSpecWithName struct {
+	Name string
+	Spec *core_v1.ServiceSpec
+}
+
+func (s *ServiceAssociationAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name: "deployment.MultiServiceAnalyzer",
+		Inputs: collection.Names{
+			metadata.K8SCoreV1Services,
+			metadata.K8SAppsV1Deployments,
+		},
+	}
+}
+func (s *ServiceAssociationAnalyzer) Analyze(c analysis.Context) {
+	portMap := servicePortMap(c)
+
+	c.ForEach(metadata.K8SAppsV1Deployments, func(r *resource.Entry) bool {
+		s.analyzeDeployment(r, c, portMap)
+		return true
+	})
+}
+
+// servicePortMap build a map of ports and protocols for each Service. e.g. m[80]["TCP"] -> svcA, svcB, svcC
+func servicePortMap(c analysis.Context) PortMap {
+	portMap := PortMap{}
+
+	c.ForEach(metadata.K8SCoreV1Services, func(rs *resource.Entry) bool {
+		svc := rs.Item.(*core_v1.ServiceSpec)
+
+		for _, sPort := range svc.Ports {
+			// If it is the first occurrence of this port, create a ProtocolMap
+			if _, ok := portMap[sPort.Port]; !ok {
+				portMap[sPort.Port] = ProtocolMap{}
+			}
+
+			// Default protocol is TCP
+			protocol := sPort.Protocol
+			if protocol == "" {
+				protocol = core_v1.ProtocolTCP
+			}
+
+			// Appending the service information for the Port/Protocol combination
+			portMap[sPort.Port][protocol] = append(portMap[sPort.Port][protocol], ServiceSpecWithName{
+				rs.Metadata.Name.String(),
+				svc,
+			})
+		}
+
+		return true
+	})
+
+	return portMap
+}
+
+// analyzeDeployment analyzes the specific deployment given the service port map
+func (s *ServiceAssociationAnalyzer) analyzeDeployment(r *resource.Entry, c analysis.Context, pm PortMap) {
+	d := r.Item.(*apps_v1.Deployment)
+	for _, cont := range d.Spec.Template.Spec.Containers {
+		for _, portSt := range cont.Ports {
+			port := portSt.ContainerPort
+
+			// Collect Service names for each protocol
+			protSvcs := map[core_v1.Protocol]ServiceNames{}
+			for protocol := range pm[port] {
+				for _, svc := range pm[port][protocol] {
+					sSelector := k8s_labels.SelectorFromSet(svc.Spec.Selector)
+					dLabels := k8s_labels.Set(d.Labels)
+
+					if sSelector.Matches(dLabels) {
+						protSvcs[protocol] = append(protSvcs[protocol], svc.Name)
+					}
+				}
+			}
+
+			if len(protSvcs) == 0 {
+				// If there isn't any matching service, generate message. At least one service is needed.
+				c.Report(metadata.K8SAppsV1Deployments, msg.NewDeploymentRequiresServiceAssociated(r, d.Name))
+			} else if len(protSvcs) > 1 {
+				// If there are services for more than one protocol, generate a message.
+				// The services cannot use the same port number for different protocols.
+
+				// Collecting conflicting service names
+				svcNames := make(ServiceNames, 0)
+				for protocol := range protSvcs {
+					svcNames = append(svcNames, protSvcs[protocol]...)
+				}
+
+				// Deployment `d` at port `port` is used by the following services in different protocols: `svcNames1
+				c.Report(metadata.K8SAppsV1Deployments, msg.NewDeploymentAssociatedToMultipleServices(r, d.Name, port, svcNames))
+			}
+		}
+	}
+}

--- a/galley/pkg/config/analysis/analyzers/injection/injection-version.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection-version.go
@@ -59,7 +59,7 @@ func (a *VersionAnalyzer) Analyze(c analysis.Context) {
 
 	// Collect the list of namespaces that have istio injection enabled.
 	c.ForEach(metadata.K8SCoreV1Namespaces, func(r *resource.Entry) bool {
-		if r.Metadata.Labels[injectionLabelName] == injectionLabelEnableValue {
+		if r.Metadata.Labels[InjectionLabelName] == InjectionLabelEnableValue {
 			injectedNamespaces[r.Metadata.Name.String()] = struct{}{}
 		}
 

--- a/galley/pkg/config/analysis/analyzers/injection/injection.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection.go
@@ -36,8 +36,8 @@ var _ analysis.Analyzer = &Analyzer{}
 // In theory, there can be alternatives using Mutatingwebhookconfiguration, but they're very uncommon
 // See https://istio.io/docs/ops/troubleshooting/injection/ for more info.
 const (
-	injectionLabelName        = "istio-injection"
-	injectionLabelEnableValue = "enabled"
+	InjectionLabelName        = "istio-injection"
+	InjectionLabelEnableValue = "enabled"
 
 	istioProxyName = "istio-proxy"
 )
@@ -66,7 +66,7 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 			return true
 		}
 
-		injectionLabel := r.Metadata.Labels[injectionLabelName]
+		injectionLabel := r.Metadata.Labels[InjectionLabelName]
 
 		if injectionLabel == "" {
 			// TODO: if Istio is installed with sidecarInjectorWebhook.enableNamespacesByDefault=true
@@ -77,7 +77,7 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 		}
 
 		// If it has any value other than the enablement value, they are deliberately not injecting it, so ignore
-		if r.Metadata.Labels[injectionLabelName] != injectionLabelEnableValue {
+		if r.Metadata.Labels[InjectionLabelName] != InjectionLabelEnableValue {
 			return true
 		}
 

--- a/galley/pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml
@@ -1,0 +1,145 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: details-v1
+  labels:
+    app: details
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: details
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: details
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-details
+      containers:
+        - name: details
+          image: docker.io/istio/examples-bookinfo-details-v1:1.15.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: details-tcp-v1
+  labels:
+    app: details
+    service: details
+spec:
+  ports:
+    - port: 9080
+      name: tcp
+      protocol: TCP
+  selector:
+    app: details
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: details-http-v1
+  labels:
+    app: details
+    service: details
+spec:
+  ports:
+    - port: 9080
+      name: http
+      protocol: HTTP
+  selector:
+    app: details
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v2
+  labels:
+    app: reviews
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v2
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+        - name: reviews
+          image: docker.io/istio/examples-bookinfo-reviews-v2:1.15.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9080
+        - name: reviews-2
+          image: docker.io/istio/examples-bookinfo-reviews-v2:1.15.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9090
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews-http-9080
+  labels:
+    app: reviews
+    service: reviews
+spec:
+  ports:
+  - port: 9080
+    name: http
+    protocol: HTTP
+  selector:
+    app: reviews
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews-http-9090
+  labels:
+    app: reviews
+    service: reviews
+spec:
+  ports:
+    - port: 9090
+      name: http
+      protocol: HTTP
+  selector:
+    app: reviews
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings-v1
+  labels:
+    app: ratings
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: ratings
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-ratings
+      containers:
+        - name: ratings
+          image: docker.io/istio/examples-bookinfo-ratings-v1:1.15.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9080

--- a/galley/pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml
@@ -143,3 +143,58 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productpage-v1
+  labels:
+    app: productpage
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: productpage
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-productpage
+      containers:
+        - name: productpage
+          image: docker.io/istio/examples-bookinfo-productpage-v1:1.15.0
+          imagePullPolicy: IfNotPresent
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: productpage-tcp-v1
+  labels:
+    app: productpage
+    service: productpage
+spec:
+  ports:
+    - port: 9080
+      name: tcp
+      protocol: TCP
+  selector:
+    app: productpage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: productpage-http-v1
+  labels:
+    app: productpage
+    service: productpage
+spec:
+  ports:
+    - port: 9080
+      name: http
+      protocol: HTTP
+  selector:
+    app: productpage

--- a/galley/pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml
@@ -1,7 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+# Deployment should generate a warning: two services using that deployment
+# using the same port but different protocol.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: details-v1
+  name: multiple-svc-multiple-prot
+  namespace: bookinfo
   labels:
     app: details
     version: v1
@@ -29,6 +40,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: details-tcp-v1
+  namespace: bookinfo
   labels:
     app: details
     service: details
@@ -44,6 +56,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: details-http-v1
+  namespace: bookinfo
   labels:
     app: details
     service: details
@@ -55,10 +68,13 @@ spec:
   selector:
     app: details
 ---
+# Deployment has two ports exposed, there are two services pointing to different ports.
+# It shouldn't generate a warning.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v2
+  namespace: bookinfo
   labels:
     app: reviews
     version: v2
@@ -91,6 +107,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: reviews-http-9080
+  namespace: bookinfo
   labels:
     app: reviews
     service: reviews
@@ -106,6 +123,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: reviews-http-9090
+  namespace: bookinfo
   labels:
     app: reviews
     service: reviews
@@ -117,10 +135,12 @@ spec:
   selector:
     app: reviews
 ---
+# Deployment has no service attached. It should generate a warning.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ratings-v1
+  name: no-services
+  namespace: bookinfo
   labels:
     app: ratings
     version: v1
@@ -144,10 +164,13 @@ spec:
           ports:
             - containerPort: 9080
 ---
+# Deployment doesn't have any container port specified and has two services using same port but different protocol.
+# It should generate a warning.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: productpage-v1
+  name: multiple-without-port
+  namespace: bookinfo
   labels:
     app: productpage
     version: v1
@@ -173,6 +196,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: productpage-tcp-v1
+  namespace: bookinfo
   labels:
     app: productpage
     service: productpage
@@ -188,6 +212,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: productpage-http-v1
+  namespace: bookinfo
   labels:
     app: productpage
     service: productpage
@@ -198,3 +223,72 @@ spec:
       protocol: HTTP
   selector:
     app: productpage
+---
+# Deployment has no services attached but also is not in the service mesh.
+# It shouldn't generate a warning.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-out-mesh
+  namespace: bookinfo
+  labels:
+    app: productpage
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: productpage
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-productpage
+      containers:
+        - name: productpage
+          image: docker.io/istio/examples-bookinfo-productpage-v1:1.15.0
+          imagePullPolicy: IfNotPresent
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: injection-disabled-ns
+spec: {}
+---
+# Deployment has multiple service attached but using same port but different protocol.
+# Sidecar is enabled although the namespaced doesn't have automatic injection.
+# It should generate a warning.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ann-enabled-ns-disabled
+  namespace: injection-disabled-ns
+  labels:
+    app: ratings
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: ratings
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-ratings
+      containers:
+        - name: ratings
+          image: docker.io/istio/examples-bookinfo-ratings-v1:1.15.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9080

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -76,6 +76,14 @@ var (
 	// DestinationRuleUsesMTLSForWorkloadWithoutSidecar defines a diag.MessageType for message "DestinationRuleUsesMTLSForWorkloadWithoutSidecar".
 	// Description: A DestinationRule uses mTLS for a workload that has no sidecar.
 	DestinationRuleUsesMTLSForWorkloadWithoutSidecar = diag.NewMessageType(diag.Error, "IST0115", "DestinationRule %s uses mTLS for workload %s that has no sidecar. Traffic from enmeshed services will fail.")
+
+	// DeploymentAssociatedToMultipleServices defines a diag.MessageType for message "DeploymentAssociatedToMultipleServices".
+	// Description: The resulting pods of a Deployment can't be associated to multiple Services in the same port but different protocol
+	DeploymentAssociatedToMultipleServices = diag.NewMessageType(diag.Warning, "IST0115", "The following services are associated to deployment %s at port %d but different protocol: %v.")
+
+	// DeploymentRequiresServiceAssociated defines a diag.MessageType for message "DeploymentRequiresServiceAssociated".
+	// Description: The resulting pods of a Deployment must be associated to at least one service
+	DeploymentRequiresServiceAssociated = diag.NewMessageType(diag.Warning, "IST0116", "Deployment %s doesn't have any service associated.")
 )
 
 // NewInternalError returns a new diag.Message based on InternalError.
@@ -245,6 +253,26 @@ func NewDestinationRuleUsesMTLSForWorkloadWithoutSidecar(entry *resource.Entry, 
 		originOrNil(entry),
 		destinationRuleName,
 		host,
+	)
+}
+
+// NewDeploymentAssociatedToMultipleServices returns a new diag.Message based on DeploymentAssociatedToMultipleServices.
+func NewDeploymentAssociatedToMultipleServices(entry *resource.Entry, deployment string, port int32, services []string) diag.Message {
+	return diag.NewMessage(
+		DeploymentAssociatedToMultipleServices,
+		originOrNil(entry),
+		deployment,
+		port,
+		services,
+	)
+}
+
+// NewDeploymentRequiresServiceAssociated returns a new diag.Message based on DeploymentRequiresServiceAssociated.
+func NewDeploymentRequiresServiceAssociated(entry *resource.Entry, deployment string) diag.Message {
+	return diag.NewMessage(
+		DeploymentRequiresServiceAssociated,
+		originOrNil(entry),
+		deployment,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -78,12 +78,12 @@ var (
 	DestinationRuleUsesMTLSForWorkloadWithoutSidecar = diag.NewMessageType(diag.Error, "IST0115", "DestinationRule %s uses mTLS for workload %s that has no sidecar. Traffic from enmeshed services will fail.")
 
 	// DeploymentAssociatedToMultipleServices defines a diag.MessageType for message "DeploymentAssociatedToMultipleServices".
-	// Description: The resulting pods of a Deployment can't be associated to multiple Services in the same port but different protocol
-	DeploymentAssociatedToMultipleServices = diag.NewMessageType(diag.Warning, "IST0115", "The following services are associated to deployment %s at port %d but different protocol: %v.")
+	// Description: The resulting pods of a service mesh deployment can't be associated with multiple services using the same port but different protocols.
+	DeploymentAssociatedToMultipleServices = diag.NewMessageType(diag.Warning, "IST0116", "This deployment is associated with multiple services using port %d but different protocols: %v")
 
 	// DeploymentRequiresServiceAssociated defines a diag.MessageType for message "DeploymentRequiresServiceAssociated".
-	// Description: The resulting pods of a Deployment must be associated to at least one service
-	DeploymentRequiresServiceAssociated = diag.NewMessageType(diag.Warning, "IST0116", "Deployment %s doesn't have any service associated.")
+	// Description: The resulting pods of a service mesh deployment must be associated with at least one service.
+	DeploymentRequiresServiceAssociated = diag.NewMessageType(diag.Warning, "IST0117", "No service associated with this deployment. Service mesh deployments must be associated with a service.")
 )
 
 // NewInternalError returns a new diag.Message based on InternalError.

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -187,3 +187,25 @@ messages:
         type: string
       - name: host
         type: string
+
+  - name: "DeploymentAssociatedToMultipleServices"
+    code: IST0115
+    level: Warning
+    description: "The resulting pods of a Deployment can't be associated to multiple Services in the same port but different protocol"
+    template: "The following services are associated to deployment %s at port %d but different protocol: %v."
+    args:
+      - name: deployment
+        type: string
+      - name: port
+        type: int32
+      - name: services
+        type: "[]string"
+
+  - name: "DeploymentRequiresServiceAssociated"
+    code: IST0116
+    level: Warning
+    description: "The resulting pods of a Deployment must be associated to at least one service"
+    template: "Deployment %s doesn't have any service associated."
+    args:
+      - name: deployment
+        type: string

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -189,10 +189,10 @@ messages:
         type: string
 
   - name: "DeploymentAssociatedToMultipleServices"
-    code: IST0115
+    code: IST0116
     level: Warning
-    description: "The resulting pods of a Deployment can't be associated to multiple Services in the same port but different protocol"
-    template: "The following services are associated to deployment %s at port %d but different protocol: %v."
+    description: "The resulting pods of a service mesh deployment can't be associated with multiple services using the same port but different protocols."
+    template: "This deployment is associated with multiple services using port %d but different protocols: %v"
     args:
       - name: deployment
         type: string
@@ -202,10 +202,10 @@ messages:
         type: "[]string"
 
   - name: "DeploymentRequiresServiceAssociated"
-    code: IST0116
+    code: IST0117
     level: Warning
-    description: "The resulting pods of a Deployment must be associated to at least one service"
-    template: "Deployment %s doesn't have any service associated."
+    description: "The resulting pods of a service mesh deployment must be associated with at least one service."
+    template: "No service associated with this deployment. Service mesh deployments must be associated with a service."
     args:
       - name: deployment
         type: string


### PR DESCRIPTION
Adding the `ServiceAssociation` analyzer discussed in https://github.com/istio/istio/issues/17503.
It generates two messages that covers the following requirement:
> Service association: A pod must belong to at least one Kubernetes service even if the pod does NOT expose any port. If a pod belongs to multiple Kubernetes services, the services cannot use the same port number for different protocols, for instance HTTP and TCP.

`DeploymentRequiresServiceAssociated` message covers the scenario where there isn't any service associated to Deployments' pods.
The second one, `DeploymentAssociatedToMultipleServices`, it covers the scenario where there are two service using the same port but with different protocol.

Closes https://github.com/istio/istio/issues/17503