### PR TITLE
Cleanup controller startup

### DIFF
--- a/cmd/istiod/istiod.go
+++ b/cmd/istiod/istiod.go
@@ -24,9 +24,10 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
+	"istio.io/pkg/log"
+
 	"istio.io/istio/pkg/istiod"
 	"istio.io/istio/pkg/istiod/k8s"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -82,7 +83,7 @@ func main() {
 		log.Fatalf("Failed to init Kubernetes discovery: %v", err)
 	}
 
-	err = istiods.Start(stop, k8sServer.OnXDSStart)
+	err = istiods.Start(stop)
 	if err != nil {
 		log.Fatalf("Failed on start XDS server: %v", err)
 	}

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -127,6 +127,7 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 	s.mcpOptions = &coredatamodel.Options{
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 		ConfigLedger: buildLedger(args.Config),
+		XDSUpdater:   s.EnvoyXdsServer,
 	}
 	reporter := monitoring.NewStatsContext("pilot")
 
@@ -324,10 +325,13 @@ func (s *Server) sseMCPController(args *PilotArgs,
 	configStores *[]model.ConfigStoreCache) {
 	clientNodeID := "SSEMCP"
 	s.incrementalMcpOptions = &coredatamodel.Options{
+		ClusterID:    s.clusterID,
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
+		XDSUpdater:   s.EnvoyXdsServer,
 	}
 	ctl := coredatamodel.NewSyntheticServiceEntryController(s.incrementalMcpOptions)
 	s.discoveryOptions = &coredatamodel.DiscoveryOptions{
+		ClusterID:    s.clusterID,
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 	}
 	s.mcpDiscovery = coredatamodel.NewMCPDiscovery(ctl, s.discoveryOptions)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"istio.io/istio/pilot/pkg/serviceregistry"
+
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/hashicorp/go-multierror"
@@ -106,6 +108,7 @@ type Server struct {
 	// TODO(nmittler): Consider alternatives to exposing these directly
 	EnvoyXdsServer *envoyv2.DiscoveryServer
 
+	clusterID             string
 	environment           *model.Environment
 	configController      model.ConfigStoreCache
 	kubeClient            kubernetes.Interface
@@ -144,12 +147,18 @@ func NewServer(args PilotArgs) (*Server, error) {
 		}
 	}
 
-	s := &Server{
-		environment: &model.Environment{
-			ServiceDiscovery: aggregate.NewController(),
-			PushContext:      model.NewPushContext(),
-		},
+	e := &model.Environment{
+		ServiceDiscovery: aggregate.NewController(),
+		PushContext:      model.NewPushContext(),
 	}
+
+	s := &Server{
+		clusterID:      getClusterID(args),
+		environment:    e,
+		EnvoyXdsServer: envoyv2.NewDiscoveryServer(e, args.Plugins),
+	}
+
+	log.Infof("Primary Cluster name: %s", s.clusterID)
 
 	prometheus.EnableHandlingTimeHistogram()
 
@@ -194,6 +203,20 @@ func NewServer(args PilotArgs) (*Server, error) {
 	return s, nil
 }
 
+func getClusterID(args PilotArgs) string {
+	clusterID := args.Config.ControllerOptions.ClusterID
+	if clusterID == "" {
+		for _, registry := range args.Service.Registries {
+			if registry == string(serviceregistry.Kubernetes) {
+				clusterID = string(serviceregistry.Kubernetes)
+				break
+			}
+		}
+	}
+
+	return clusterID
+}
+
 // Start starts all components of the Pilot discovery service on the port specified in DiscoveryServiceOptions.
 // If Port == 0, a port number is automatically chosen. Content serving is started by this method,
 // but is executed asynchronously. Serving can be canceled at any time by closing the provided stop channel.
@@ -223,7 +246,6 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 }
 
 func (s *Server) initDiscoveryService(args *PilotArgs) error {
-	s.EnvoyXdsServer = envoyv2.NewDiscoveryServer(s.environment, args.Plugins)
 	s.mux = http.NewServeMux()
 	s.EnvoyXdsServer.InitDebug(s.mux, s.ServiceController(), args.DiscoveryOptions.EnableProfiling)
 
@@ -237,28 +259,6 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 
 	if err := s.initEventHandlers(); err != nil {
 		return err
-	}
-
-	if s.kubeRegistry != nil {
-		// kubeRegistry may use the environment for push status reporting.
-		// TODO: maybe all registries should have this as an optional field ?
-		s.kubeRegistry.XDSUpdater = s.EnvoyXdsServer
-	}
-
-	// TODO: Split initDiscoveryService method in to createDiscoveryServer and initDiscoveryService so that, this special
-	// handling is not needed. Because of dependency ordering problem, we need to set this explicitly here.
-	if s.serviceEntryStore != nil {
-		s.serviceEntryStore.XdsUpdater = s.EnvoyXdsServer
-	}
-
-	if s.mcpOptions != nil {
-		s.mcpOptions.XDSUpdater = s.EnvoyXdsServer
-	}
-	if s.incrementalMcpOptions != nil {
-		clusterID := args.Config.ControllerOptions.ClusterID
-		s.incrementalMcpOptions.XDSUpdater = s.EnvoyXdsServer
-		s.incrementalMcpOptions.ClusterID = clusterID
-		s.discoveryOptions.ClusterID = clusterID
 	}
 
 	// Implement EnvoyXdsServer grace shutdown

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -79,10 +79,9 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 
 // initKubeRegistry creates all the k8s service controllers under this pilot
 func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args *PilotArgs) (err error) {
-	clusterID := string(serviceregistry.Kubernetes)
-	log.Infof("Primary Cluster name: %s", clusterID)
-	args.Config.ControllerOptions.ClusterID = clusterID
+	args.Config.ControllerOptions.ClusterID = s.clusterID
 	args.Config.ControllerOptions.Metrics = s.environment
+	args.Config.ControllerOptions.XDSUpdater = s.EnvoyXdsServer
 	kubectl := kubecontroller.NewController(s.kubeClient, args.Config.ControllerOptions)
 	s.kubeRegistry = kubectl
 	serviceControllers.AddRegistry(kubectl)

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -55,7 +55,7 @@ func newPodCache(ch cacheHandler, c *Controller) *PodCache {
 }
 
 // event updates the IP-based index (pc.podsByIP).
-func (pc *PodCache) event(old, curr interface{}, ev model.Event) error {
+func (pc *PodCache) event(_, curr interface{}, ev model.Event) error {
 	pc.Lock()
 	defer pc.Unlock()
 
@@ -122,8 +122,8 @@ func (pc *PodCache) event(old, curr interface{}, ev model.Event) error {
 }
 
 func (pc *PodCache) proxyUpdates(ip string) {
-	if pc.c != nil && pc.c.XDSUpdater != nil {
-		pc.c.XDSUpdater.ProxyUpdate(pc.c.clusterID, ip)
+	if pc.c != nil && pc.c.xdsUpdater != nil {
+		pc.c.xdsUpdater.ProxyUpdate(pc.c.clusterID, ip)
 	}
 }
 

--- a/pkg/istiod/common.go
+++ b/pkg/istiod/common.go
@@ -93,15 +93,17 @@ var (
 func newServer(args *PilotArgs, configDir string) *Server {
 	meshCfgFile := baseDir + configDir + "/mesh"
 	fileWatcher := filewatcher.NewWatcher()
+	e := &model.Environment{
+		Watcher:          newMeshWatcher(args, fileWatcher, meshCfgFile),
+		NetworksWatcher:  newNetworksWatcher(args, fileWatcher),
+		ServiceDiscovery: aggregate.NewController(),
+		PushContext:      model.NewPushContext(),
+	}
 
 	return &Server{
-		Args: args,
-		Environment: &model.Environment{
-			Watcher:          newMeshWatcher(args, fileWatcher, meshCfgFile),
-			NetworksWatcher:  newNetworksWatcher(args, fileWatcher),
-			ServiceDiscovery: aggregate.NewController(),
-			PushContext:      model.NewPushContext(),
-		},
+		Args:           args,
+		Environment:    e,
+		EnvoyXdsServer: envoyv2.NewDiscoveryServer(e, args.Plugins),
 	}
 }
 


### PR DESCRIPTION
Right now the XDSUpater is set manually after the kube and coredatamodel controllers are created. This simplifies the API for the controllers.