### PR TITLE
Don't run buildx in CI - Fixes Resource leak in prow cluster that is causing tests to flake

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -66,7 +66,7 @@ function build_images() {
   targets="docker.pilot docker.proxyv2 "
   targets+="docker.app docker.test_policybackend docker.kubectl "
   targets+="docker.mixer docker.citadel docker.galley docker.sidecar_injector docker.node-agent-k8s"
-  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets}" make dockerx
+  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets}" make docker
 }
 
 function kind_load_images() {


### PR DESCRIPTION
I suspect this is the root cause of
https://github.com/istio/test-infra/issues/1988

For now, we will revert this and see if things improve