### PR TITLE
Remove namespace from mtls analyzer messages

### DIFF
--- a/galley/pkg/config/analysis/analyzers/auth/mtls.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls.go
@@ -259,7 +259,6 @@ func (s *MTLSAnalyzer) Analyze(c analysis.Context) {
 			msg.NewMTLSPolicyConflict(
 				mpr.Resource,
 				anyK8sServiceHost,
-				rootNamespace,
 				globalDRName,
 				globalMtls,
 				mpr.Resource.Metadata.Name.String(),
@@ -281,7 +280,6 @@ func (s *MTLSAnalyzer) Analyze(c analysis.Context) {
 			msg.NewMTLSPolicyConflict(
 				globalDR,
 				anyK8sServiceHost,
-				rootNamespace,
 				globalDR.Metadata.Name.String(),
 				globalMtls,
 				globalPolicyName,
@@ -335,7 +333,6 @@ func (s *MTLSAnalyzer) Analyze(c analysis.Context) {
 						msg.NewMTLSPolicyConflict(
 							tsPolicy.Resource,
 							ts.String(),
-							ns,
 							matchingDRName,
 							mtlsUsed,
 							tsPolicy.Resource.Metadata.Name.String(),
@@ -353,7 +350,6 @@ func (s *MTLSAnalyzer) Analyze(c analysis.Context) {
 						msg.NewMTLSPolicyConflict(
 							matchingDR,
 							ts.String(),
-							ns,
 							matchingDR.Metadata.Name.String(),
 							mtlsUsed,
 							policyName,

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -67,7 +67,7 @@ var (
 
 	// MTLSPolicyConflict defines a diag.MessageType for message "MTLSPolicyConflict".
 	// Description: A DestinationRule and Policy are in conflict with regards to mTLS.
-	MTLSPolicyConflict = diag.NewMessageType(diag.Error, "IST0113", "A DestinationRule and Policy are in conflict with regards to mTLS for host %s in namespace %s. The DestinationRule %q specifies that mTLS must be %t but the Policy object %q specifies %s.")
+	MTLSPolicyConflict = diag.NewMessageType(diag.Error, "IST0113", "A DestinationRule and Policy are in conflict with regards to mTLS for host %s. The DestinationRule %q specifies that mTLS must be %t but the Policy object %q specifies %s.")
 
 	// PolicySpecifiesPortNameThatDoesntExist defines a diag.MessageType for message "PolicySpecifiesPortNameThatDoesntExist".
 	// Description: A Policy targets a port name that cannot be found.
@@ -212,12 +212,11 @@ func NewVirtualServiceDestinationPortSelectorRequired(entry *resource.Entry, des
 }
 
 // NewMTLSPolicyConflict returns a new diag.Message based on MTLSPolicyConflict.
-func NewMTLSPolicyConflict(entry *resource.Entry, host string, namespace string, destinationRuleName string, destinationRuleMTLSMode bool, policyName string, policyMTLSMode string) diag.Message {
+func NewMTLSPolicyConflict(entry *resource.Entry, host string, destinationRuleName string, destinationRuleMTLSMode bool, policyName string, policyMTLSMode string) diag.Message {
 	return diag.NewMessage(
 		MTLSPolicyConflict,
 		originOrNil(entry),
 		host,
-		namespace,
 		destinationRuleName,
 		destinationRuleMTLSMode,
 		policyName,

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -153,11 +153,9 @@ messages:
     code: IST0113
     level: Error
     description: "A DestinationRule and Policy are in conflict with regards to mTLS."
-    template: "A DestinationRule and Policy are in conflict with regards to mTLS for host %s in namespace %s. The DestinationRule %q specifies that mTLS must be %t but the Policy object %q specifies %s."
+    template: "A DestinationRule and Policy are in conflict with regards to mTLS for host %s. The DestinationRule %q specifies that mTLS must be %t but the Policy object %q specifies %s."
     args:
       - name: host
-        type: string
-      - name: namespace
         type: string
       - name: destinationRuleName
         type: string


### PR DESCRIPTION
Showing the namespace is redundant, as the relevant namespace will either be mentioned in the name of the policy object or the destination rule.

Note that this will cause duplicate messages to be reported to `ctx.Report` since we still iterate over all namespaces (which is needed to find all misconfigurations). This isn't a problem now that we dedupe messages (#19419).