### PR TITLE
Use specific message when sidecar is missing

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -104,8 +104,8 @@ var testGrid = []testCase{
 		name:       "mtlsAnalyzerNoSidecar",
 		inputFiles: []string{"testdata/mtls-no-sidecar.yaml"},
 		analyzer:   &auth.MTLSAnalyzer{},
-		expected:   []message{
-			// no messages, this test case verifies no false positives
+		expected: []message{
+			{msg.DestinationRuleUsesMTLSForWorkloadWithoutSidecar, "DestinationRule default.istio-system"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/auth/mtls.go
+++ b/galley/pkg/config/analysis/analyzers/auth/mtls.go
@@ -323,6 +323,18 @@ func (s *MTLSAnalyzer) Analyze(c analysis.Context) {
 				if globalMTLSMisconfigured && (tsPolicy.Resource == nil || matchingDR == nil) {
 					continue
 				}
+
+				// Check to see if our mismatch is due to a missing sidecar. If
+				// so, use a different analyzer message.
+				if _, ok := fqdnsWithoutSidecars[ts.FQDN()]; ok {
+					c.Report(metadata.IstioNetworkingV1Alpha3Destinationrules,
+						msg.NewDestinationRuleUsesMTLSForWorkloadWithoutSidecar(
+							matchingDR,
+							matchingDR.Metadata.Name.String(),
+							ts.String()))
+					continue
+				}
+
 				if tsPolicy.Resource != nil {
 					// We may or may not have a matching DR. If we don't, use
 					// the special missing resource string

--- a/galley/pkg/config/analysis/analyzers/testdata/mtls-no-sidecar.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/mtls-no-sidecar.yaml
@@ -80,3 +80,29 @@ spec:
   trafficPolicy:
     tls:
       mode: DISABLE
+---
+# Finally, include a service with no sidecar and no policy disabling mTLS. We
+# should generate a warning for that.
+apiVersion: v1
+kind: Service
+metadata:
+  name: no-sidecar-or-dr-service
+  namespace: no-sidecar
+spec:
+  selector:
+    app: no-sidecar-or-dr-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: no-sidecar-or-dr-service-pod
+  namespace: no-sidecar
+  labels:
+    app: no-sidecar-or-dr-service
+spec:
+  containers:
+  - name: some-other-container-not-the-proxy

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -72,6 +72,10 @@ var (
 	// PolicySpecifiesPortNameThatDoesntExist defines a diag.MessageType for message "PolicySpecifiesPortNameThatDoesntExist".
 	// Description: A Policy targets a port name that cannot be found.
 	PolicySpecifiesPortNameThatDoesntExist = diag.NewMessageType(diag.Warning, "IST0114", "Port name %s could not be found for host %s, which means the Policy won't be enforced.")
+
+	// DestinationRuleUsesMTLSForWorkloadWithoutSidecar defines a diag.MessageType for message "DestinationRuleUsesMTLSForWorkloadWithoutSidecar".
+	// Description: A DestinationRule uses mTLS for a workload that has no sidecar.
+	DestinationRuleUsesMTLSForWorkloadWithoutSidecar = diag.NewMessageType(diag.Error, "IST0115", "DestinationRule %s uses mTLS for workload %s that has no sidecar. Traffic from enmeshed services will fail.")
 )
 
 // NewInternalError returns a new diag.Message based on InternalError.
@@ -231,6 +235,16 @@ func NewPolicySpecifiesPortNameThatDoesntExist(entry *resource.Entry, portName s
 		PolicySpecifiesPortNameThatDoesntExist,
 		originOrNil(entry),
 		portName,
+		host,
+	)
+}
+
+// NewDestinationRuleUsesMTLSForWorkloadWithoutSidecar returns a new diag.Message based on DestinationRuleUsesMTLSForWorkloadWithoutSidecar.
+func NewDestinationRuleUsesMTLSForWorkloadWithoutSidecar(entry *resource.Entry, destinationRuleName string, host string) diag.Message {
+	return diag.NewMessage(
+		DestinationRuleUsesMTLSForWorkloadWithoutSidecar,
+		originOrNil(entry),
+		destinationRuleName,
 		host,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -178,3 +178,14 @@ messages:
         type: string
       - name: host
         type: string
+
+  - name: "DestinationRuleUsesMTLSForWorkloadWithoutSidecar"
+    code: IST0115
+    level: Error
+    description: "A DestinationRule uses mTLS for a workload that has no sidecar."
+    template: "DestinationRule %s uses mTLS for workload %s that has no sidecar. Traffic from enmeshed services will fail."
+    args:
+      - name: destinationRuleName
+        type: string
+      - name: host
+        type: string


### PR DESCRIPTION
Currently the mTLS analyzer uses the same message for all conflicts. While this is technically correct, it's not easy to determine why there's a policy conflict, especially in the case of a missing sidecar. This commit introduces a new message specifically for the situation where the host does not have a sidecar and a destination rule enforces mTLS.

Relates to #19360 