### PR TITLE
export PATH from shell instead of makefile

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -411,7 +411,7 @@ lint: lint-go-split lint-python lint-copyright-banner lint-scripts lint-dockerfi
 go-gen:
 	@mkdir -p /tmp/bin
 	@go build -o /tmp/bin/mixgen "${REPO_ROOT}/mixer/tools/mixgen/main.go"
-	@PATH=${PATH}:/tmp/bin go generate ./...
+	@PATH=$$PATH:/tmp/bin go generate ./...
 
 gen: go-gen mirror-licenses format update-crds
 


### PR DESCRIPTION
the makefile PATH use makefile environment variable now,
if the PATH have some special character , the shell execution will  fail. 
`/bin/bash: -c: line 0: syntax error near unexpected token `('`
In general, we should use the shell's environment variables，or use quotation marks 。