### PR TITLE
Small workaround to allow istiod to not use values

### DIFF
--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -259,7 +259,7 @@ func (conf *SDSAgent) Start(isSidecar bool, podNamespace string) (*sds.Server, e
 				log.Warna("Failed to get certificate from CA", err)
 			}
 		} else {
-			log.Infoa("Got initial certificate ", si)
+			log.Infoa("Got initial certificate valid until ", si.ExpireTime)
 		}
 		if si != nil {
 			// For debugging and backward compat - we may not need it long term

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -1,4 +1,3 @@
-
 // Copyright 2018 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -577,7 +577,11 @@ func InjectionData(sidecarTemplate, valuesConfig, version string, typeMetadata *
 	// Istiod will use a custom template, without 'values.yaml', and the pod will have
 	// an optional 'vendor' configmap where additional settings can be defined.
 	funcMap["env"] = func(key string, def string) string {
-		return os.Getenv(key)
+		val := os.Getenv(key)
+		if val == "" {
+			return def
+		}
+		return val
 	}
 
 	// Need to use FuncMap and SidecarTemplateData context

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -259,6 +259,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				key.ConnectionID = con.conID
 				addConn(key, con)
 				firstRequestFlag = true
+				sdsServiceLog.Infoa("New connection ", discReq)
 			}
 			conID := con.conID
 			con.proxyID = discReq.Node.Id
@@ -341,6 +342,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 					conIDresourceNamePrefix, discReq.Node.Id, err)
 				return err
 			}
+			sdsServiceLog.Infoa("Pushed secret for ", discReq)
 		case <-con.pushChannel:
 			con.mutex.RLock()
 			proxyID := con.proxyID
@@ -370,6 +372,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 					conIDresourceNamePrefix, proxyID, err)
 				return err
 			}
+			sdsServiceLog.Infoa("Dynamic push for secret ", resourceName)
 		}
 	}
 }

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -259,7 +259,6 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				key.ConnectionID = con.conID
 				addConn(key, con)
 				firstRequestFlag = true
-				sdsServiceLog.Infoa("New connection ", discReq)
 			}
 			conID := con.conID
 			con.proxyID = discReq.Node.Id
@@ -342,7 +341,6 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 					conIDresourceNamePrefix, discReq.Node.Id, err)
 				return err
 			}
-			sdsServiceLog.Infoa("Pushed secret for ", discReq)
 		case <-con.pushChannel:
 			con.mutex.RLock()
 			proxyID := con.proxyID
@@ -372,7 +370,6 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 					conIDresourceNamePrefix, proxyID, err)
 				return err
 			}
-			sdsServiceLog.Infoa("Dynamic push for secret ", resourceName)
 		}
 	}
 }


### PR DESCRIPTION
Follow up to istiod install, this allows migrating the majority of 'values.yaml' settings from injector.

Note that https://github.com/istio/api/pull/1194 will add the inject env to mesh.yaml - and after it is 
merged I'll adjust this accordingly ( with the agreed name, and merging the env from mesh.yaml)
We will still need to support env overrides - istiod allows using a k8s configmap with 'vendor' specific settings, created for example when the cluster is created.  

The final plan is to use only mesh.yaml and merge 'vendor/cluster' mesh.yaml  with 'install' defaults and user overrides. 

But on the short term - this PR allows progress on cleaning up the injection template and removing 
the dep on values.yaml.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[*] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
