### PR TITLE
Graduate istioctl analyze out of experimental

### DIFF
--- a/galley/pkg/config/analysis/README.md
+++ b/galley/pkg/config/analysis/README.md
@@ -180,10 +180,10 @@ inputs in the analyzer metadata. This should help you find any unused inputs and
 
 ### 5. Testing via istioctl
 
-You can use `istioctl experimental analyze` to run all analyzers, including your new one. e.g.
+You can use `istioctl analyze` to run all analyzers, including your new one. e.g.
 
 ```sh
-make istioctl && $GOPATH/out/linux_amd64/release/istioctl experimental analyze
+make istioctl && $GOPATH/out/linux_amd64/release/istioctl analyze
 ```
 
 ### 6. Write a user-facing documentation page

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -80,8 +80,6 @@ var (
 )
 
 // Analyze command
-// Once we're ready to move this functionality out of the "experimental" subtree, we should merge
-// with `istioctl validate`. https://github.com/istio/istio/issues/16777
 func Analyze() *cobra.Command {
 	// Validate the output format before doing potentially expensive work to fail earlier
 	msgOutputFormats := map[string]bool{LogOutput: true, JSONOutput: true, YamlOutput: true}
@@ -96,29 +94,29 @@ func Analyze() *cobra.Command {
 		Short: "Analyze Istio configuration and print validation messages",
 		Example: `
 # Analyze yaml files
-istioctl experimental analyze a.yaml b.yaml
+istioctl analyze a.yaml b.yaml
 
 # Analyze the current live cluster
-istioctl experimental analyze -k
+istioctl analyze -k
 
 # Analyze the current live cluster, simulating the effect of applying additional yaml files
-istioctl experimental analyze -k a.yaml b.yaml
+istioctl analyze -k a.yaml b.yaml
 
 # Analyze yaml files, overriding service discovery to enabled
-istioctl experimental analyze -d true a.yaml b.yaml services.yaml
+istioctl analyze -d true a.yaml b.yaml services.yaml
 
 # Analyze the current live cluster, overriding service discovery to disabled
-istioctl experimental analyze -k -d false
+istioctl analyze -k -d false
 
 # List available analyzers
-istioctl experimental analyze -L
+istioctl analyze -L
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			msgOutputFormat = strings.ToLower(msgOutputFormat)
 			_, ok := msgOutputFormats[msgOutputFormat]
 			if !ok {
 				return CommandParseError{
-					fmt.Errorf("%s not a valid option for format. See istioctl x analyze --help", msgOutputFormat),
+					fmt.Errorf("%s not a valid option for format. See istioctl analyze --help", msgOutputFormat),
 				}
 			}
 
@@ -144,6 +142,7 @@ istioctl experimental analyze -L
 			// below since for the time being we want to keep changes isolated to experimental code. When we merge this into
 			// istioctl validate (see https://github.com/istio/istio/issues/16777) we should look into fixing getDefaultNamespace in root
 			// so it properly handles the --context option.
+			// TODO
 			selectedNamespace := namespace
 
 			var k cfgKube.Interfaces

--- a/istioctl/cmd/dashboard_test.go
+++ b/istioctl/cmd/dashboard_test.go
@@ -83,7 +83,7 @@ func TestDashboard(t *testing.T) {
 		},
 		{ // case 11
 			args:           strings.Split("experimental dashboard", " "),
-			expectedOutput: "Error: (dashboard has graduated.  Use `istioctl dashboard`)\n",
+			expectedOutput: "Error: (dashboard has graduated. Use `istioctl dashboard`)\n",
 			wantException:  true,
 		},
 		{ // case 12

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -240,7 +240,14 @@ func getDefaultNamespace(kubeconfig string) string {
 		return v1.NamespaceDefault
 	}
 
-	context, ok := config.Contexts[config.CurrentContext]
+	// If a specific context was specified, use that. Otherwise, just use the current context from the kube config.
+	selectedContext := config.CurrentContext
+	if configContext != "" {
+		selectedContext = configContext
+	}
+
+	// Use the namespace associated with the selected context as default, if the context has one
+	context, ok := config.Contexts[selectedContext]
 	if !ok {
 		return v1.NamespaceDefault
 	}

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -273,7 +273,7 @@ func NewValidateCommand(istioNamespace *string) *cobra.Command {
 
 	c := &cobra.Command{
 		Use:   "validate -f FILENAME [options]",
-		Short: "Validate Istio policy and rules",
+		Short: "Validate Istio policy and rules (NOTE: 'istioctl analyze' does a superset of this validation. 'validate' will be deprecated in the future.)",
 		Example: `
 		# Validate bookinfo-gateway.yaml
 		istioctl validate -f bookinfo-gateway.yaml
@@ -284,8 +284,8 @@ func NewValidateCommand(istioNamespace *string) *cobra.Command {
 		# Validate current services under 'default' namespace within the cluster
 		kubectl get services -o yaml |istioctl validate -f -
 
-		# Also see the related experimental command 'istioctl x analyze'
-		istioctl x analyze samples/bookinfo/networking/bookinfo-gateway.yaml
+		# Also see the related command 'istioctl analyze'
+		istioctl analyze samples/bookinfo/networking/bookinfo-gateway.yaml
 `,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -273,7 +273,7 @@ func NewValidateCommand(istioNamespace *string) *cobra.Command {
 
 	c := &cobra.Command{
 		Use:   "validate -f FILENAME [options]",
-		Short: "Validate Istio policy and rules (NOTE: 'istioctl analyze' does a superset of this validation. 'validate' will be deprecated in the future.)",
+		Short: "Validate Istio policy and rules (NOTE: validate is deprecated and will be removed in 1.6. Use 'istioctl analyze' to validate configuration.)",
 		Example: `
 		# Validate bookinfo-gateway.yaml
 		istioctl validate -f bookinfo-gateway.yaml

--- a/tests/integration/istioctl/versionanalyze/analyze_test.go
+++ b/tests/integration/istioctl/versionanalyze/analyze_test.go
@@ -238,7 +238,7 @@ func expectNoMessages(t *testing.T, g *GomegaWithT, output []string) {
 
 func istioctlSafe(t *testing.T, i istioctl.Instance, ns string, extraArgs ...string) ([]string, error) {
 	t.Helper()
-	args := []string{"experimental", "analyze"}
+	args := []string{"analyze"}
 	if ns != "" {
 		args = append(args, "--namespace", ns)
 	}


### PR DESCRIPTION
Graduate `istioctl analyze` out of experimental for 1.5. 

This PR proposes doing this as a "soft" graduation, where `istioctl analyze` becomes canonical but `istioctl experimental analyze` continues to work, but includes a run-time notice encouraging users to switch. The same message is also present in usage messages. Doing it this way, you'd naturally expect to make it a hard graduation in 1.6, then remove the experimental command in 1.7. I'm interested in feedback on whether this is a desirable approach, or if it just makes the migration ramp unnecessarily long.  

Also updated the usage for `istioctl validate` to more strongly indicate that users should move to `istioctl analyze`. 

This also includes a fix to `getDefaultNamespace` for istioctl, so that it correctly respects the `--context` option. 

See https://github.com/istio/istio/issues/16777

Some examples below to demonstrate how the soft graduation looks:

```
$ istioctl analyze /tmp/default.yaml 
✔ No validation issues found.
$ istioctl x analyze /tmp/default.yaml 
(analyze has graduated. Use `istioctl analyze`)
✔ No validation issues found.
```

```
$ istioctl analyze --help | head -n 10
Analyze Istio configuration and print validation messages

Usage:
  istioctl analyze <file>... [flags]

Examples:

# Analyze yaml files
istioctl analyze a.yaml b.yaml

$ istioctl x analyze --help | head -n 10
Analyze Istio configuration and print validation messages (analyze has graduated. Use `istioctl analyze`)

Usage:
  istioctl experimental analyze <file>... [flags]

Examples:

# Analyze yaml files
istioctl analyze a.yaml b.yaml

```