### PR TITLE
fix(kubernetesenv): establish a single watcher per builder

### DIFF
--- a/mixer/adapter/kubernetesenv/kubernetesenv.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv.go
@@ -96,8 +96,9 @@ var _ ktmpl.HandlerBuilder = &builder{}
 
 // GetInfo returns the Info associated with this adapter implementation.
 func GetInfo() adapter.Info {
+	singletonBuilder := newBuilder(newKubernetesClient)
 	info := metadata.GetInfo("kubernetesenv")
-	info.NewBuilder = func() adapter.HandlerBuilder { return newBuilder(newKubernetesClient) }
+	info.NewBuilder = func() adapter.HandlerBuilder { return singletonBuilder }
 	return info
 }
 

--- a/mixer/adapter/kubernetesenv/kubernetesenv_test.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv_test.go
@@ -144,7 +144,8 @@ func TestHandler_Close(t *testing.T) {
 	}
 
 	b.Lock()
-	if got, want := len(b.controllers), 0; got != want {
+	// should always have the local controller
+	if got, want := len(b.controllers), 1; got != want {
 		t.Errorf("Got %d controllers, want %d", got, want)
 	}
 	b.Unlock()


### PR DESCRIPTION
This PR attempts to prevent Mixer from creating an ever-growing number of watches against the k8s server for secrets in the case of repeated, regular calls to the `Build()` method of the `kubenetesenv` adapter.

I have not repro'd the issue in question, but here's my diagnosis:

`kubernetesenv.go` contains a block of code for closing handlers as follows:

```
func (h *handler) Close() error {
	for clusterID := range h.builder.controllers {
		_ = h.builder.deleteCacheController(clusterID)
	}
	h.builder.Lock()
	h.builder.kubeHandler = nil
	h.builder.Unlock()

	return nil
}
```

When handlers are removed, the `Close` method will clear *all* of the cached controllers from the *builder*. This includes the local kubeconfig, which I *think* is intentional.

However, the `Build` logic uses the presence of the local kubeconfig controller to determine whether or not set up a watch on the multicluster secrets:

```
path, exists := kubeConfigVar.Lookup()
if !exists {
	path = paramsProto.KubeconfigPath
}
...
_, found := b.controllers[path]
...
if !found {
	if err := initMultiClusterSecretController(b, path, env); err != nil {
		return nil, fmt.Errorf("could not create remote controllers: %v", err)
        }
}
```

In some running clusters, some unfortunate souls are seeing this `Close()` -> `Build()` cycle every ~5m. This means that something like ~300 new watchers are being added per day per Mixer in which the reconfigure cycle is happening (*despite no actual changes in config*).

We have a couple of options:
1) special case the local controller and prevent cleaning during Handler `Close()`. I'm a bit concerned about this option as, iirc, we specifically added that in response to another issue related to leaking `kubernetesenv` controllers
2) ensure that the watch is only setup (successfully) once.
3) ?? something else I'm not thinking of at the moment.

For this PR, I've chosen option 2 and thrown together an example approach.

Note: I've also made the `kubernetesenv` adapter use a singleton builder. So all state for the builder, which consists entirely of the watch should be preserved throughout the lifetime of the Mixer instance.

I'm looking for comments and/or better ideas.

Fixes: https://github.com/istio/istio/issues/19481