### PR TITLE
Enable headless service reachability test

### DIFF
--- a/tests/integration/security/mtls/strict_test.go
+++ b/tests/integration/security/mtls/strict_test.go
@@ -43,8 +43,10 @@ func TestMtlsStrict(t *testing.T) {
 					Namespace:           systemNM,
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						// Exclude calls to the headless TCP port.
-						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
+						// Exclude calls to the headless service.
+						// Auto mtls does not apply to headless service, because for headless service
+						// the cluster discovery type is ORIGINAL_DST, and it will not apply upstream tls setting
+						if opts.Target == rctx.Headless {
 							return false
 						}
 

--- a/tests/integration/security/mtls/strict_test.go
+++ b/tests/integration/security/mtls/strict_test.go
@@ -46,11 +46,7 @@ func TestMtlsStrict(t *testing.T) {
 						// Exclude calls to the headless service.
 						// Auto mtls does not apply to headless service, because for headless service
 						// the cluster discovery type is ORIGINAL_DST, and it will not apply upstream tls setting
-						if opts.Target == rctx.Headless {
-							return false
-						}
-
-						return true
+						return opts.Target != rctx.Headless
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						// When mTLS is in STRICT mode, DR's TLS settings are default to mTLS so the result would

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -49,7 +49,8 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 		Pilot:  p,
 	}
 
-	// for headless service, the port and target port must be equal
+	// for headless service with selector, the port and target port must be equal
+	// Ref: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
 	if headless {
 		out.Ports[0].ServicePort = 8090
 	}

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -23,7 +23,7 @@ import (
 )
 
 func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.Annotations, g galley.Instance, p pilot.Instance) echo.Config {
-	return echo.Config{
+	out := echo.Config{
 		Service:        name,
 		Namespace:      ns,
 		ServiceAccount: true,
@@ -48,4 +48,10 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 		Galley: g,
 		Pilot:  p,
 	}
+
+	// for headless service, the port and target port must be equal
+	if headless {
+		out.Ports[0].ServicePort = 8090
+	}
+	return out
 }

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -73,7 +73,7 @@ func CreateContext(ctx framework.TestContext, g galley.Instance, p pilot.Instanc
 	echoboot.NewBuilderOrFail(ctx, ctx).
 		With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
 		With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
-		With(&headless, util.EchoConfig("headless", ns, false, nil, g, p)).
+		With(&headless, util.EchoConfig("headless", ns, true, nil, g, p)).
 		With(&naked, util.EchoConfig("naked", ns, false, echo.NewAnnotations().
 			SetBool(echo.SidecarInject, false), g, p)).
 		BuildOrFail(ctx)


### PR DESCRIPTION
This enables test for headless service under plaintext.

- Start to actual deploy headless service. Previously EchoConfig(headless bool) is `false` for headless service.
- strict mTLS does not work since passthrough cluster is using ORIGIN_DST cluster type, thus we don't have TLS config on client side.
- and make the headless service port equals to targetport, per k8s doc.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
