### PR TITLE
Replace NetworkEndpoint with IstioEndpoint

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -158,7 +158,7 @@ type Port struct {
 
 	// Port number where the service can be reached. Does not necessarily
 	// map to the corresponding port numbers for the instances behind the
-	// service. See NetworkEndpoint definition below.
+	// service.
 	Port int `json:"port"`
 
 	// Protocol to be used for the port.
@@ -168,7 +168,7 @@ type Port struct {
 // PortList is a set of ports
 type PortList []*Port
 
-// AddressFamily indicates the kind of transport used to reach a NetworkEndpoint
+// AddressFamily indicates the kind of transport used to reach an IstioEndpoint
 type AddressFamily int
 
 const (
@@ -206,56 +206,6 @@ const (
 	trafficDirectionInboundSrvPrefix = string(TrafficDirectionInbound) + "_"
 )
 
-// NetworkEndpoint defines a network address (IP:port) associated with an instance of the
-// service. A service has one or more instances each running in a
-// container/VM/pod. If a service has multiple ports, then the same
-// instance IP is expected to be listening on multiple ports (one per each
-// service port). Note that the port associated with an instance does not
-// have to be the same as the port associated with the service. Depending
-// on the network setup (NAT, overlays), this could vary.
-//
-// For e.g., if catalog.mystore.com is accessible through port 80 and 8080,
-// and it maps to an instance with IP 172.16.0.1, such that connections to
-// port 80 are forwarded to port 55446, and connections to port 8080 are
-// forwarded to port 33333,
-//
-// then internally, we have two two endpoint structs for the
-// service catalog.mystore.com
-//  --> 172.16.0.1:54546 (with ServicePort pointing to 80) and
-//  --> 172.16.0.1:33333 (with ServicePort pointing to 8080)
-type NetworkEndpoint struct {
-	// Family indicates what type of endpoint, such as TCP or Unix Domain Socket.
-	Family AddressFamily
-
-	// Address of the network endpoint. If Family is `AddressFamilyTCP`, it is
-	// typically an IPv4 address. If Family is `AddressFamilyUnix`, it is the
-	// path to the domain socket.
-	Address string
-
-	// Port number where this instance is listening for connections This
-	// need not be the same as the port where the service is accessed.
-	// e.g., catalog.mystore.com:8080 -> 172.16.0.1:55446
-	// Ignored for `AddressFamilyUnix`.
-	Port int
-
-	// Port declaration from the service declaration This is the port for
-	// the service associated with this instance (e.g.,
-	// catalog.mystore.com)
-	ServicePort *Port
-
-	// Defines a platform-specific workload instance identifier (optional).
-	UID string
-
-	// The network where this endpoint is present
-	Network string
-
-	// The locality where the endpoint is present. / separated string
-	Locality string
-
-	// The load balancing weight associated with this endpoint.
-	LbWeight uint32
-}
-
 // Probe represents a health probe associated with an instance of service.
 type Probe struct {
 	Port *Port  `json:"port,omitempty"`
@@ -270,7 +220,7 @@ type ProbeList []*Probe
 // description (which is oblivious to various versions) and a set of labels
 // that describe the service version associated with this instance.
 //
-// Since a ServiceInstance has a single NetworkEndpoint, which has a single port,
+// Since a ServiceInstance has a single IstioEndpoint, which has a single port,
 // multiple ServiceInstances are required to represent a workload that listens
 // on multiple ports.
 //
@@ -279,16 +229,14 @@ type ProbeList []*Probe
 //
 // For example, the set of service instances associated with catalog.mystore.com
 // are modeled like this
-//      --> NetworkEndpoint(172.16.0.1:8888), Service(catalog.myservice.com), Labels(foo=bar)
-//      --> NetworkEndpoint(172.16.0.2:8888), Service(catalog.myservice.com), Labels(foo=bar)
-//      --> NetworkEndpoint(172.16.0.3:8888), Service(catalog.myservice.com), Labels(kitty=cat)
-//      --> NetworkEndpoint(172.16.0.4:8888), Service(catalog.myservice.com), Labels(kitty=cat)
+//      --> IstioEndpoint(172.16.0.1:8888), Service(catalog.myservice.com), Labels(foo=bar)
+//      --> IstioEndpoint(172.16.0.2:8888), Service(catalog.myservice.com), Labels(foo=bar)
+//      --> IstioEndpoint(172.16.0.3:8888), Service(catalog.myservice.com), Labels(kitty=cat)
+//      --> IstioEndpoint(172.16.0.4:8888), Service(catalog.myservice.com), Labels(kitty=cat)
 type ServiceInstance struct {
-	Endpoint       NetworkEndpoint `json:"endpoint,omitempty"`
-	Service        *Service        `json:"service,omitempty"`
-	Labels         labels.Instance `json:"labels,omitempty"`
-	ServiceAccount string          `json:"serviceaccount,omitempty"`
-	TLSMode        string          `json:"tlsMode,omitempty"`
+	Service     *Service       `json:"service,omitempty"`
+	ServicePort *Port          `json:"servicePort,omitempty"`
+	Endpoint    *IstioEndpoint `json:"endpoint,omitempty"`
 }
 
 // GetLocality returns the availability zone from an instance. If service instance label for locality
@@ -298,7 +246,7 @@ type ServiceInstance struct {
 //
 // This is used by CDS/EDS to group the endpoints by locality.
 func (instance *ServiceInstance) GetLocality() string {
-	return GetLocalityOrDefault(instance.Labels[LocalityLabel], instance.Endpoint.Locality)
+	return GetLocalityOrDefault(instance.Endpoint.Labels[LocalityLabel], instance.Endpoint.Locality)
 }
 
 // GetLocalityOrDefault returns the locality from the supplied label, or falls back to
@@ -316,22 +264,28 @@ func GetLocalityOrDefault(label, defaultLocality string) string {
 	return defaultLocality
 }
 
-// IstioEndpoint has the information about a single address+port for a specific
-// service and shard.
+// IstioEndpoint defines a network address (IP:port) associated with an instance of the
+// service. A service has one or more instances each running in a
+// container/VM/pod. If a service has multiple ports, then the same
+// instance IP is expected to be listening on multiple ports (one per each
+// service port). Note that the port associated with an instance does not
+// have to be the same as the port associated with the service. Depending
+// on the network setup (NAT, overlays), this could vary.
 //
-// TODO: Replace NetworkEndpoint and ServiceInstance with Istio endpoints
-// - ServicePortName replaces ServicePort, since port number and protocol may not
-// be available when endpoint callbacks are made.
-// - It no longer splits into one ServiceInstance and one NetworkEndpoint - both
-// are in a single struct
-// - doesn't have a pointer to Service - the full Service object may not be available at
-// the time the endpoint is received. The service name is used as a key and used to reconcile.
-// - it has a cached EnvoyEndpoint object - to avoid re-allocating it for each request and
-// client.
+// For e.g., if catalog.mystore.com is accessible through port 80 and 8080,
+// and it maps to an instance with IP 172.16.0.1, such that connections to
+// port 80 are forwarded to port 55446, and connections to port 8080 are
+// forwarded to port 33333,
+//
+// then internally, we have two two endpoint structs for the
+// service catalog.mystore.com
+//  --> 172.16.0.1:54546 (with ServicePort pointing to 80) and
+//  --> 172.16.0.1:33333 (with ServicePort pointing to 8080)
+//
+// TODO: Investigate removing ServiceInstance entirely.
 type IstioEndpoint struct {
-
 	// Labels points to the workload or deployment labels.
-	Labels map[string]string
+	Labels labels.Instance
 
 	// Family indicates what type of endpoint, such as TCP or Unix Domain Socket.
 	// Default is TCP.
@@ -417,17 +371,17 @@ type ServiceDiscovery interface {
 	// InstancesByPort retrieves instances for a service on the given ports with labels that match
 	// any of the supplied labels. All instances match an empty tag list.
 	//
-	// For example, consider the example of catalog.mystore.com as described in NetworkEndpoints
+	// For example, consider an example of catalog.mystore.com:
 	// Instances(catalog.myservice.com, 80) ->
-	//      --> NetworkEndpoint(172.16.0.1:8888), Service(catalog.myservice.com), Labels(foo=bar)
-	//      --> NetworkEndpoint(172.16.0.2:8888), Service(catalog.myservice.com), Labels(foo=bar)
-	//      --> NetworkEndpoint(172.16.0.3:8888), Service(catalog.myservice.com), Labels(kitty=cat)
-	//      --> NetworkEndpoint(172.16.0.4:8888), Service(catalog.myservice.com), Labels(kitty=cat)
+	//      --> IstioEndpoint(172.16.0.1:8888), Service(catalog.myservice.com), Labels(foo=bar)
+	//      --> IstioEndpoint(172.16.0.2:8888), Service(catalog.myservice.com), Labels(foo=bar)
+	//      --> IstioEndpoint(172.16.0.3:8888), Service(catalog.myservice.com), Labels(kitty=cat)
+	//      --> IstioEndpoint(172.16.0.4:8888), Service(catalog.myservice.com), Labels(kitty=cat)
 	//
 	// Calling Instances with specific labels returns a trimmed list.
 	// e.g., Instances(catalog.myservice.com, 80, foo=bar) ->
-	//      --> NetworkEndpoint(172.16.0.1:8888), Service(catalog.myservice.com), Labels(foo=bar)
-	//      --> NetworkEndpoint(172.16.0.2:8888), Service(catalog.myservice.com), Labels(foo=bar)
+	//      --> IstioEndpoint(172.16.0.1:8888), Service(catalog.myservice.com), Labels(foo=bar)
+	//      --> IstioEndpoint(172.16.0.2:8888), Service(catalog.myservice.com), Labels(foo=bar)
 	//
 	// Similar concepts apply for calling this function with a specific
 	// port, hostname and labels.
@@ -446,13 +400,13 @@ type ServiceDiscovery interface {
 	// will return an empty slice.
 	//
 	// There are two reasons why this returns multiple ServiceInstances instead of one:
-	// - A ServiceInstance has a single NetworkEndpoint which has a single Port.  But a Service
+	// - A ServiceInstance has a single IstioEndpoint which has a single Port.  But a Service
 	//   may have many ports.  So a workload implementing such a Service would need
 	//   multiple ServiceInstances, one for each port.
 	// - A single workload may implement multiple logical Services.
 	//
 	// In the second case, multiple services may be implemented by the same physical port number,
-	// though with a different ServicePort and NetworkEndpoint for each.  If any of these overlapping
+	// though with a different ServicePort and IstioEndpoint for each.  If any of these overlapping
 	// services are not HTTP or H2-based, behavior is undefined, since the listener may not be able to
 	// determine the intended destination of a connection without a Host header on the request.
 	GetProxyServiceInstances(*Proxy) ([]*ServiceInstance, error)

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -207,11 +207,11 @@ func TestGetLocality(t *testing.T) {
 		{
 			name: "endpoint with locality is overridden by label",
 			instance: ServiceInstance{
-				Endpoint: NetworkEndpoint{
+				Endpoint: &IstioEndpoint{
 					Locality: "region/zone/subzone-1",
-				},
-				Labels: labels.Instance{
-					LocalityLabel: "region/zone/subzone-2",
+					Labels: labels.Instance{
+						LocalityLabel: "region/zone/subzone-2",
+					},
 				},
 			},
 			expected: "region/zone/subzone-2",
@@ -219,11 +219,11 @@ func TestGetLocality(t *testing.T) {
 		{
 			name: "endpoint without label, use registry locality",
 			instance: ServiceInstance{
-				Endpoint: NetworkEndpoint{
+				Endpoint: &IstioEndpoint{
 					Locality: "region/zone/subzone-1",
-				},
-				Labels: labels.Instance{
-					LocalityLabel: "",
+					Labels: labels.Instance{
+						LocalityLabel: "",
+					},
 				},
 			},
 			expected: "region/zone/subzone-1",
@@ -231,11 +231,11 @@ func TestGetLocality(t *testing.T) {
 		{
 			name: "istio-locality label with k8s label separator",
 			instance: ServiceInstance{
-				Endpoint: NetworkEndpoint{
+				Endpoint: &IstioEndpoint{
 					Locality: "",
-				},
-				Labels: labels.Instance{
-					LocalityLabel: "region" + k8sSeparator + "zone" + k8sSeparator + "subzone-2",
+					Labels: labels.Instance{
+						LocalityLabel: "region" + k8sSeparator + "zone" + k8sSeparator + "subzone-2",
+					},
 				},
 			},
 			expected: "region/zone/subzone-2",
@@ -243,11 +243,11 @@ func TestGetLocality(t *testing.T) {
 		{
 			name: "istio-locality label with both k8s label separators and slashes",
 			instance: ServiceInstance{
-				Endpoint: NetworkEndpoint{
+				Endpoint: &IstioEndpoint{
 					Locality: "",
-				},
-				Labels: labels.Instance{
-					LocalityLabel: "region/zone/subzone.2",
+					Labels: labels.Instance{
+						LocalityLabel: "region/zone/subzone.2",
+					},
 				},
 			},
 			expected: "region/zone/subzone.2",

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -22,10 +22,9 @@ import (
 )
 
 var (
-	endpoint1 = NetworkEndpoint{
-		Address:     "192.168.1.1",
-		Port:        10001,
-		ServicePort: &Port{Name: "http", Port: 81, Protocol: protocol.HTTP},
+	endpoint1 = IstioEndpoint{
+		Address:      "192.168.1.1",
+		EndpointPort: 10001,
 	}
 
 	service1 = &Service{
@@ -39,6 +38,12 @@ var (
 )
 
 func TestServiceInstanceValidate(t *testing.T) {
+	endpointWithLabels := func(lbls labels.Instance) *IstioEndpoint {
+		cpy := endpoint1
+		cpy.Labels = lbls
+		return &cpy
+	}
+
 	cases := []struct {
 		name     string
 		instance *ServiceInstance
@@ -47,31 +52,30 @@ func TestServiceInstanceValidate(t *testing.T) {
 		{
 			name: "nil service",
 			instance: &ServiceInstance{
-				Labels:   labels.Instance{},
-				Endpoint: endpoint1,
+				Endpoint: endpointWithLabels(labels.Instance{}),
 			},
 		},
 		{
 			name: "bad label",
 			instance: &ServiceInstance{
 				Service:  service1,
-				Labels:   labels.Instance{"*": "-"},
-				Endpoint: endpoint1,
+				Endpoint: endpointWithLabels(labels.Instance{"*": "-"}),
 			},
 		},
 		{
 			name: "invalid service",
 			instance: &ServiceInstance{
-				Service: &Service{},
+				Service:  &Service{},
+				Endpoint: &IstioEndpoint{},
 			},
 		},
 		{
 			name: "invalid endpoint port and service port",
 			instance: &ServiceInstance{
 				Service: service1,
-				Endpoint: NetworkEndpoint{
-					Address: "192.168.1.2",
-					Port:    -80,
+				Endpoint: &IstioEndpoint{
+					Address:      "192.168.1.2",
+					EndpointPort: 1000000,
 				},
 			},
 		},
@@ -79,14 +83,14 @@ func TestServiceInstanceValidate(t *testing.T) {
 			name: "endpoint missing service port",
 			instance: &ServiceInstance{
 				Service: service1,
-				Endpoint: NetworkEndpoint{
-					Address: "192.168.1.2",
-					Port:    service1.Ports[1].Port,
-					ServicePort: &Port{
-						Name:     service1.Ports[1].Name + "-extra",
-						Port:     service1.Ports[1].Port,
-						Protocol: service1.Ports[1].Protocol,
-					},
+				ServicePort: &Port{
+					Name:     service1.Ports[1].Name + "-extra",
+					Port:     service1.Ports[1].Port,
+					Protocol: service1.Ports[1].Protocol,
+				},
+				Endpoint: &IstioEndpoint{
+					Address:      "192.168.1.2",
+					EndpointPort: uint32(service1.Ports[1].Port),
 				},
 			},
 		},
@@ -94,23 +98,24 @@ func TestServiceInstanceValidate(t *testing.T) {
 			name: "endpoint port and protocol mismatch",
 			instance: &ServiceInstance{
 				Service: service1,
-				Endpoint: NetworkEndpoint{
-					Address: "192.168.1.2",
-					Port:    service1.Ports[1].Port,
-					ServicePort: &Port{
-						Name:     "http",
-						Port:     service1.Ports[1].Port + 1,
-						Protocol: protocol.GRPC,
-					},
+				ServicePort: &Port{
+					Name:     "http",
+					Port:     service1.Ports[1].Port + 1,
+					Protocol: protocol.GRPC,
+				},
+				Endpoint: &IstioEndpoint{
+					Address:      "192.168.1.2",
+					EndpointPort: uint32(service1.Ports[1].Port),
 				},
 			},
 		},
 	}
 	for _, c := range cases {
-		t.Log("running case " + c.name)
-		if got := c.instance.Validate(); (got == nil) != c.valid {
-			t.Errorf("%s failed: got valid=%v but wanted valid=%v: %v", c.name, got == nil, c.valid, got)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.instance.Validate(); (got == nil) != c.valid {
+				t.Fatalf("%s failed: got valid=%v but wanted valid=%v: %v", c.name, got == nil, c.valid, got)
+			}
+		})
 	}
 }
 
@@ -156,36 +161,36 @@ func TestServiceValidate(t *testing.T) {
 	}
 }
 
-func TestValidateNetworkEndpointAddress(t *testing.T) {
+func TestValidateEndpointAddress(t *testing.T) {
 	testCases := []struct {
 		name  string
-		ne    *NetworkEndpoint
+		ep    *IstioEndpoint
 		valid bool
 	}{
 		{
-			"Unix OK",
-			&NetworkEndpoint{Family: AddressFamilyUnix, Address: "/absolute/path"},
-			true,
+			name:  "Unix OK",
+			ep:    &IstioEndpoint{Family: AddressFamilyUnix, Address: "/absolute/path"},
+			valid: true,
 		},
 		{
-			"IP OK",
-			&NetworkEndpoint{Address: "12.3.4.5", Port: 76},
-			true,
+			name:  "IP OK",
+			ep:    &IstioEndpoint{Address: "12.3.4.5", EndpointPort: 76},
+			valid: true,
 		},
 		{
-			"Unix not absolute",
-			&NetworkEndpoint{Family: AddressFamilyUnix, Address: "./socket"},
-			false,
+			name:  "Unix not absolute",
+			ep:    &IstioEndpoint{Family: AddressFamilyUnix, Address: "./socket"},
+			valid: false,
 		},
 		{
-			"IP invalid",
-			&NetworkEndpoint{Address: "260.3.4.5", Port: 76},
-			false,
+			name:  "IP invalid",
+			ep:    &IstioEndpoint{Address: "260.3.4.5", EndpointPort: 76},
+			valid: false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateNetworkEndpointAddress(tc.ne)
+			err := ValidateEndpointAddress(tc.ep)
 			if tc.valid && err != nil {
 				t.Fatalf("ValidateAddress() => want error nil got %v", err)
 			} else if !tc.valid && err == nil {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -292,48 +292,48 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 
 	instances := []*model.ServiceInstance{
 		{
-			Service: service,
-			Endpoint: model.NetworkEndpoint{
-				Address:     "192.168.1.1",
-				Port:        10001,
-				ServicePort: servicePort[0],
-				Locality:    "region1/zone1/subzone1",
-				LbWeight:    40,
+			Service:     service,
+			ServicePort: servicePort[0],
+			Endpoint: &model.IstioEndpoint{
+				Address:      "192.168.1.1",
+				EndpointPort: 10001,
+				Locality:     "region1/zone1/subzone1",
+				LbWeight:     40,
+				TLSMode:      model.IstioMutualTLSModeLabel,
 			},
-			TLSMode: model.IstioMutualTLSModeLabel,
 		},
 		{
-			Service: service,
-			Endpoint: model.NetworkEndpoint{
-				Address:     "192.168.1.2",
-				Port:        10001,
-				ServicePort: servicePort[0],
-				Locality:    "region1/zone1/subzone2",
-				LbWeight:    20,
+			Service:     service,
+			ServicePort: servicePort[0],
+			Endpoint: &model.IstioEndpoint{
+				Address:      "192.168.1.2",
+				EndpointPort: 10001,
+				Locality:     "region1/zone1/subzone2",
+				LbWeight:     20,
+				TLSMode:      model.IstioMutualTLSModeLabel,
 			},
-			TLSMode: model.IstioMutualTLSModeLabel,
 		},
 		{
-			Service: service,
-			Endpoint: model.NetworkEndpoint{
-				Address:     "192.168.1.3",
-				Port:        10001,
-				ServicePort: servicePort[0],
-				Locality:    "region2/zone1/subzone1",
-				LbWeight:    40,
+			Service:     service,
+			ServicePort: servicePort[0],
+			Endpoint: &model.IstioEndpoint{
+				Address:      "192.168.1.3",
+				EndpointPort: 10001,
+				Locality:     "region2/zone1/subzone1",
+				LbWeight:     40,
+				TLSMode:      model.IstioMutualTLSModeLabel,
 			},
-			TLSMode: model.IstioMutualTLSModeLabel,
 		},
 		{
-			Service: service,
-			Endpoint: model.NetworkEndpoint{
-				Address:     "192.168.1.1",
-				Port:        10001,
-				ServicePort: servicePort[1],
-				Locality:    "region1/zone1/subzone1",
-				LbWeight:    0,
+			Service:     service,
+			ServicePort: servicePort[1],
+			Endpoint: &model.IstioEndpoint{
+				Address:      "192.168.1.1",
+				EndpointPort: 10001,
+				Locality:     "region1/zone1/subzone1",
+				LbWeight:     0,
+				TLSMode:      model.IstioMutualTLSModeLabel,
 			},
-			TLSMode: model.IstioMutualTLSModeLabel,
 		},
 	}
 
@@ -1290,33 +1290,33 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 	}
 	instances := []*model.ServiceInstance{
 		{
-			Service: service,
-			Endpoint: model.NetworkEndpoint{
-				Address:     "192.168.1.1",
-				Port:        10001,
-				ServicePort: servicePort,
-				Locality:    "region1/zone1/subzone1",
-				LbWeight:    30,
+			Service:     service,
+			ServicePort: servicePort,
+			Endpoint: &model.IstioEndpoint{
+				Address:      "192.168.1.1",
+				EndpointPort: 10001,
+				Locality:     "region1/zone1/subzone1",
+				LbWeight:     30,
 			},
 		},
 		{
-			Service: service,
-			Endpoint: model.NetworkEndpoint{
-				Address:     "192.168.1.2",
-				Port:        10001,
-				ServicePort: servicePort,
-				Locality:    "region1/zone1/subzone1",
-				LbWeight:    30,
+			Service:     service,
+			ServicePort: servicePort,
+			Endpoint: &model.IstioEndpoint{
+				Address:      "192.168.1.2",
+				EndpointPort: 10001,
+				Locality:     "region1/zone1/subzone1",
+				LbWeight:     30,
 			},
 		},
 		{
-			Service: service,
-			Endpoint: model.NetworkEndpoint{
-				Address:     "192.168.1.3",
-				Port:        10001,
-				ServicePort: servicePort,
-				Locality:    "region2/zone1/subzone1",
-				LbWeight:    40,
+			Service:     service,
+			ServicePort: servicePort,
+			Endpoint: &model.IstioEndpoint{
+				Address:      "192.168.1.3",
+				EndpointPort: 10001,
+				Locality:     "region2/zone1/subzone1",
+				LbWeight:     40,
 			},
 		},
 	}
@@ -1462,11 +1462,11 @@ func TestBuildInboundClustersDefaultCircuitBreakerThresholds(t *testing.T) {
 
 	instances := []*model.ServiceInstance{
 		{
-			Service: service,
-			Endpoint: model.NetworkEndpoint{
-				Address:     "192.168.1.1",
-				Port:        10001,
-				ServicePort: servicePort,
+			Service:     service,
+			ServicePort: servicePort,
+			Endpoint: &model.IstioEndpoint{
+				Address:      "192.168.1.1",
+				EndpointPort: 10001,
 			},
 		},
 	}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -129,7 +129,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 		var si *model.ServiceInstance
 		services := make(map[host.Name]struct{}, len(node.ServiceInstances))
 		for _, w := range node.ServiceInstances {
-			if w.Endpoint.Port == int(portNumber) {
+			if w.Endpoint.EndpointPort == portNumber {
 				if si == nil {
 					si = w
 				}

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -82,11 +82,11 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(node *model.Proxy, push *m
 // TODO: trace decorators, inbound timeouts
 func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(
 	node *model.Proxy, push *model.PushContext, instance *model.ServiceInstance, clusterName string) *xdsapi.RouteConfiguration {
-	traceOperation := fmt.Sprintf("%s:%d/*", instance.Service.Hostname, instance.Endpoint.ServicePort.Port)
+	traceOperation := fmt.Sprintf("%s:%d/*", instance.Service.Hostname, instance.ServicePort.Port)
 	defaultRoute := istio_route.BuildDefaultHTTPInboundRoute(node, clusterName, traceOperation)
 
 	inboundVHost := &route.VirtualHost{
-		Name:    fmt.Sprintf("%s|http|%d", model.TrafficDirectionInbound, instance.Endpoint.ServicePort.Port),
+		Name:    fmt.Sprintf("%s|http|%d", model.TrafficDirectionInbound, instance.ServicePort.Port),
 		Domains: []string{"*"},
 		Routes:  []*route.Route{defaultRoute},
 	}
@@ -103,7 +103,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(
 		Node:             node,
 		ServiceInstance:  instance,
 		Service:          instance.Service,
-		Port:             instance.Endpoint.ServicePort,
+		Port:             instance.ServicePort,
 		Push:             push,
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -44,11 +44,11 @@ var (
 	blackholeStructMarshalling *listener.Filter
 
 	dummyServiceInstance = &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Port:        15006,
-			ServicePort: &model.Port{},
+		Service:     &model.Service{},
+		ServicePort: &model.Port{},
+		Endpoint: &model.IstioEndpoint{
+			EndpointPort: 15006,
 		},
-		Service: &model.Service{},
 	}
 )
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -76,8 +76,11 @@ func TestListenerBuilder(t *testing.T) {
 	instances := make([]*model.ServiceInstance, len(services))
 	for i, s := range services {
 		instances[i] = &model.ServiceInstance{
-			Service:  s,
-			Endpoint: buildEndpoint(s),
+			Service: s,
+			Endpoint: &model.IstioEndpoint{
+				EndpointPort: 8080,
+			},
+			ServicePort: s.Ports[0],
 		}
 	}
 	proxy := getDefaultProxy()
@@ -120,8 +123,11 @@ func TestVirtualListenerBuilder(t *testing.T) {
 	instances := make([]*model.ServiceInstance, len(services))
 	for i, s := range services {
 		instances[i] = &model.ServiceInstance{
-			Service:  s,
-			Endpoint: buildEndpoint(s),
+			Service: s,
+			Endpoint: &model.IstioEndpoint{
+				EndpointPort: 8080,
+			},
+			ServicePort: s.Ports[0],
 		}
 	}
 	proxy := getDefaultProxy()
@@ -166,8 +172,11 @@ func prepareListeners(t *testing.T) []*v2.Listener {
 	instances := make([]*model.ServiceInstance, len(services))
 	for i, s := range services {
 		instances[i] = &model.ServiceInstance{
-			Service:  s,
-			Endpoint: buildEndpoint(s),
+			Service: s,
+			Endpoint: &model.IstioEndpoint{
+				EndpointPort: 8080,
+			},
+			ServicePort: s.Ports[0],
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -127,7 +127,7 @@ var (
 					Namespace: "not-default",
 				},
 			},
-			Labels: nil,
+			Endpoint: &model.IstioEndpoint{},
 		},
 	}
 	virtualServiceSpec = &networking.VirtualService{
@@ -1702,16 +1702,9 @@ func buildServiceWithPort(hostname string, port int, protocol protocol.Instance,
 	}
 }
 
-func buildEndpoint(service *model.Service) model.NetworkEndpoint {
-	return model.NetworkEndpoint{
-		ServicePort: service.Ports[0],
-		Port:        8080,
-	}
-}
-
 func buildServiceInstance(service *model.Service, instanceIP string) *model.ServiceInstance {
 	return &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
+		Endpoint: &model.IstioEndpoint{
 			Address: instanceIP,
 		},
 		Service: service,
@@ -1729,8 +1722,11 @@ func buildListenerEnvWithVirtualServices(services []*model.Service, virtualServi
 	instances := make([]*model.ServiceInstance, len(services))
 	for i, s := range services {
 		instances[i] = &model.ServiceInstance{
-			Service:  s,
-			Endpoint: buildEndpoint(s),
+			Service: s,
+			Endpoint: &model.IstioEndpoint{
+				EndpointPort: 8080,
+			},
+			ServicePort: s.Ports[0],
 		}
 	}
 	serviceDiscovery.GetProxyServiceInstancesReturns(instances, nil)

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -44,14 +44,14 @@ var redisOpTimeout = 5 * time.Second
 
 // buildInboundNetworkFilters generates a TCP proxy network filter on the inbound path
 func buildInboundNetworkFilters(push *model.PushContext, node *model.Proxy, instance *model.ServiceInstance) []*listener.Filter {
-	clusterName := model.BuildSubsetKey(model.TrafficDirectionInbound, instance.Endpoint.ServicePort.Name,
-		instance.Service.Hostname, instance.Endpoint.ServicePort.Port)
+	clusterName := model.BuildSubsetKey(model.TrafficDirectionInbound, instance.ServicePort.Name,
+		instance.Service.Hostname, instance.ServicePort.Port)
 	tcpProxy := &tcp_proxy.TcpProxy{
 		StatPrefix:       clusterName,
 		ClusterSpecifier: &tcp_proxy.TcpProxy_Cluster{Cluster: clusterName},
 	}
 	tcpFilter := setAccessLogAndBuildTCPFilter(push, node, tcpProxy)
-	return buildNetworkFiltersStack(node, instance.Endpoint.ServicePort, tcpFilter, clusterName, clusterName)
+	return buildNetworkFiltersStack(node, instance.ServicePort, tcpFilter, clusterName, clusterName)
 }
 
 // setAccessLog sets the AccessLog configuration in the given TcpProxy instance.

--- a/pilot/pkg/networking/plugin/health/health.go
+++ b/pilot/pkg/networking/plugin/health/health.go
@@ -58,14 +58,14 @@ func buildHealthCheckFilter(probe *model.Probe) *http_conn.HttpFilter {
 	return out
 }
 
-func buildHealthCheckFilters(filterChain *plugin.FilterChain, probes model.ProbeList, endpoint *model.NetworkEndpoint) {
+func buildHealthCheckFilters(filterChain *plugin.FilterChain, probes model.ProbeList, endpoint *model.IstioEndpoint) {
 	for _, probe := range probes {
 		// Check that the probe matches the listener port. If not, then the probe will be handled
 		// as a management port and not traced. If the port does match, then we need to add a
 		// health check filter for the probe path, to ensure that health checks are not traced.
 		// If no probe port is defined, then port has not specifically been defined, so assume filter
 		// needs to be applied.
-		if probe.Port == nil || probe.Port.Port == endpoint.Port {
+		if probe.Port == nil || probe.Port.Port == int(endpoint.EndpointPort) {
 			filter := buildHealthCheckFilter(probe)
 			if !containsHTTPFilter(filterChain.HTTP, filter) {
 				filterChain.HTTP = append(filterChain.HTTP, filter)
@@ -115,7 +115,7 @@ func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableO
 		if mutable.FilterChains[i].ListenerProtocol == plugin.ListenerProtocolHTTP {
 			for _, ip := range in.Node.IPAddresses {
 				buildHealthCheckFilters(&mutable.FilterChains[i], in.Push.WorkloadHealthCheckInfo(ip),
-					&in.ServiceInstance.Endpoint)
+					in.ServiceInstance.Endpoint)
 			}
 		}
 	}

--- a/pilot/pkg/networking/plugin/health/health_test.go
+++ b/pilot/pkg/networking/plugin/health/health_test.go
@@ -31,7 +31,7 @@ import (
 func TestBuildHealthCheckFilters(t *testing.T) {
 	cases := []struct {
 		probes   model.ProbeList
-		endpoint *model.NetworkEndpoint
+		endpoint *model.IstioEndpoint
 		expected plugin.FilterChain
 	}{
 		{
@@ -43,8 +43,8 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 					Path: "/health",
 				},
 			},
-			endpoint: &model.NetworkEndpoint{
-				Port: 8080,
+			endpoint: &model.IstioEndpoint{
+				EndpointPort: 8080,
 			},
 			expected: plugin.FilterChain{
 				HTTP: []*http_conn.HttpFilter{
@@ -72,8 +72,8 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 					Path: "/health",
 				},
 			},
-			endpoint: &model.NetworkEndpoint{
-				Port: 8080,
+			endpoint: &model.IstioEndpoint{
+				EndpointPort: 8080,
 			},
 			expected: plugin.FilterChain{
 				HTTP: []*http_conn.HttpFilter{
@@ -109,8 +109,8 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 					Path: "/live",
 				},
 			},
-			endpoint: &model.NetworkEndpoint{
-				Port: 8080,
+			endpoint: &model.IstioEndpoint{
+				EndpointPort: 8080,
 			},
 			expected: plugin.FilterChain{
 				HTTP: []*http_conn.HttpFilter{
@@ -161,8 +161,8 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 					Path: "/health",
 				},
 			},
-			endpoint: &model.NetworkEndpoint{
-				Port: 8080,
+			endpoint: &model.IstioEndpoint{
+				EndpointPort: 8080,
 			},
 			expected: plugin.FilterChain{
 				HTTP: []*http_conn.HttpFilter{
@@ -193,8 +193,8 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 					Path: "/health",
 				},
 			},
-			endpoint: &model.NetworkEndpoint{
-				Port: 8080,
+			endpoint: &model.IstioEndpoint{
+				EndpointPort: 8080,
 			},
 			expected: plugin.FilterChain{},
 		},

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -170,11 +170,11 @@ func BuildAddress(bind string, port uint32) *core.Address {
 	}
 }
 
-// GetNetworkEndpointAddress returns an Envoy v2 API `Address` that represents this NetworkEndpoint
-func GetNetworkEndpointAddress(n *model.NetworkEndpoint) *core.Address {
+// GetEndpointAddress returns an Envoy v2 API `Address` that represents this IstioEndpoint
+func GetEndpointAddress(n *model.IstioEndpoint) *core.Address {
 	switch n.Family {
 	case model.AddressFamilyTCP:
-		return BuildAddress(n.Address, uint32(n.Port))
+		return BuildAddress(n.Address, n.EndpointPort)
 	case model.AddressFamilyUnix:
 		return &core.Address{Address: &core.Address_Pipe{Pipe: &core.Pipe{Path: n.Address}}}
 	default:

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -100,12 +100,12 @@ func TestConvertAddressToCidr(t *testing.T) {
 	}
 }
 
-func TestGetNetworkEndpointAddress(t *testing.T) {
-	neUnix := &model.NetworkEndpoint{
+func TestGetEndpointAddress(t *testing.T) {
+	neUnix := &model.IstioEndpoint{
 		Family:  model.AddressFamilyUnix,
 		Address: "/var/run/test/test.sock",
 	}
-	aUnix := GetNetworkEndpointAddress(neUnix)
+	aUnix := GetEndpointAddress(neUnix)
 	if aUnix.GetPipe() == nil {
 		t.Fatalf("GetAddress() => want Pipe, got %s", aUnix.String())
 	}
@@ -113,12 +113,12 @@ func TestGetNetworkEndpointAddress(t *testing.T) {
 		t.Fatalf("GetAddress() => want path %s, got %s", neUnix.Address, aUnix.GetPipe().GetPath())
 	}
 
-	neIP := &model.NetworkEndpoint{
-		Family:  model.AddressFamilyTCP,
-		Address: "192.168.10.45",
-		Port:    4558,
+	neIP := &model.IstioEndpoint{
+		Family:       model.AddressFamilyTCP,
+		Address:      "192.168.10.45",
+		EndpointPort: 4558,
 	}
-	aIP := GetNetworkEndpointAddress(neIP)
+	aIP := GetEndpointAddress(neIP)
 	sock := aIP.GetSocketAddress()
 	if sock == nil {
 		t.Fatalf("GetAddress() => want SocketAddress, got %s", aIP.String())
@@ -126,8 +126,8 @@ func TestGetNetworkEndpointAddress(t *testing.T) {
 	if sock.GetAddress() != neIP.Address {
 		t.Fatalf("GetAddress() => want %s, got %s", neIP.Address, sock.GetAddress())
 	}
-	if int(sock.GetPortValue()) != neIP.Port {
-		t.Fatalf("GetAddress() => want port %d, got port %d", neIP.Port, sock.GetPortValue())
+	if sock.GetPortValue() != neIP.EndpointPort {
+		t.Fatalf("GetAddress() => want port %d, got port %d", neIP.EndpointPort, sock.GetPortValue())
 	}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -240,8 +240,8 @@ func (s *DiscoveryServer) endpointz(w http.ResponseWriter, req *http.Request) {
 				}
 				for _, svc := range all {
 					_, _ = fmt.Fprintf(w, "%s:%s %v %s:%d %v %s\n", ss.Hostname,
-						p.Name, svc.Endpoint.Family, svc.Endpoint.Address, svc.Endpoint.Port, svc.Labels,
-						svc.ServiceAccount)
+						p.Name, svc.Endpoint.Family, svc.Endpoint.Address, svc.Endpoint.EndpointPort, svc.Endpoint.Labels,
+						svc.Endpoint.ServiceAccount)
 				}
 			}
 		}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -140,13 +140,13 @@ func buildEnvoyLbEndpoint(uid string, family model.AddressFamily, address string
 	return ep
 }
 
-func networkEndpointToEnvoyEndpoint(e *model.NetworkEndpoint, tlsMode string, push *model.PushContext) (*endpoint.LbEndpoint, error) {
-	err := model.ValidateNetworkEndpointAddress(e)
+func toEnvoyEndpoint(e *model.IstioEndpoint, push *model.PushContext) (*endpoint.LbEndpoint, error) {
+	err := model.ValidateEndpointAddress(e)
 	if err != nil {
 		return nil, err
 	}
 
-	addr := util.GetNetworkEndpointAddress(e)
+	addr := util.GetEndpointAddress(e)
 
 	epWeight := e.LbWeight
 	if epWeight == 0 {
@@ -166,7 +166,7 @@ func networkEndpointToEnvoyEndpoint(e *model.NetworkEndpoint, tlsMode string, pu
 	// Istio telemetry depends on the metadata value being set for endpoints in the mesh.
 	// Istio endpoint level tls transport socket configuation depends on this logic
 	// Do not remove
-	ep.Metadata = util.BuildLbEndpointMetadata(e.UID, e.Network, tlsMode, push)
+	ep.Metadata = util.BuildLbEndpointMetadata(e.UID, e.Network, e.TLSMode, push)
 
 	return ep, nil
 }
@@ -282,26 +282,13 @@ func (s *DiscoveryServer) updateServiceShards(push *model.PushContext) error {
 				}
 
 				// This loses track of grouping (shards)
-				endpoints, err := registry.InstancesByPort(svc, port.Port, labels.Collection{})
+				instances, err := registry.InstancesByPort(svc, port.Port, labels.Collection{})
 				if err != nil {
 					return err
 				}
 
-				for _, ep := range endpoints {
-					entries = append(entries, &model.IstioEndpoint{
-						Family:          ep.Endpoint.Family,
-						Address:         ep.Endpoint.Address,
-						EndpointPort:    uint32(ep.Endpoint.Port),
-						ServicePortName: port.Name,
-						Labels:          ep.Labels,
-						UID:             ep.Endpoint.UID,
-						ServiceAccount:  ep.ServiceAccount,
-						Network:         ep.Endpoint.Network,
-						Locality:        ep.GetLocality(),
-						LbWeight:        ep.Endpoint.LbWeight,
-						Attributes:      ep.Service.Attributes,
-						TLSMode:         ep.TLSMode,
-					})
+				for _, inst := range instances {
+					entries = append(entries, inst.Endpoint)
 				}
 			}
 
@@ -554,7 +541,7 @@ func (s *DiscoveryServer) deleteService(cluster, serviceName, namespace string) 
 func localityLbEndpointsFromInstances(instances []*model.ServiceInstance, push *model.PushContext) []*endpoint.LocalityLbEndpoints {
 	localityEpMap := make(map[string]*endpoint.LocalityLbEndpoints)
 	for _, instance := range instances {
-		lbEp, err := networkEndpointToEnvoyEndpoint(&instance.Endpoint, instance.TLSMode, push)
+		lbEp, err := toEnvoyEndpoint(instance.Endpoint, push)
 		if err != nil {
 			adsLog.Errorf("EDS: Unexpected pilot model endpoint v1 to v2 conversion: %v", err)
 			totalXDSInternalErrors.Increment()

--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -286,19 +286,19 @@ func initRegistry(server *bootstrap.Server, clusterNum int, gatewaysIP []string,
 	})
 	for i := 0; i < numOfEndpoints; i++ {
 		memRegistry.AddInstance("service5.default.svc.cluster.local", &model.ServiceInstance{
-			Endpoint: model.NetworkEndpoint{
-				Address: fmt.Sprintf("10.%d.0.%d", clusterNum, i+1),
-				Port:    2080,
-				ServicePort: &model.Port{
-					Name:     "http-main",
-					Port:     1080,
-					Protocol: protocol.HTTP,
-				},
-				Network:  id,
-				Locality: "az",
-				UID:      "kubernetes://dummy",
+			Endpoint: &model.IstioEndpoint{
+				Address:      fmt.Sprintf("10.%d.0.%d", clusterNum, i+1),
+				EndpointPort: 2080,
+				Network:      id,
+				Locality:     "az",
+				UID:          "kubernetes://dummy",
+				Labels:       svcLabels,
 			},
-			Labels: svcLabels,
+			ServicePort: &model.Port{
+				Name:     "http-main",
+				Port:     1080,
+				Protocol: protocol.HTTP,
+			},
 		})
 	}
 }

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -299,27 +299,29 @@ func addTestClientEndpoints(server *bootstrap.Server) {
 		},
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance("test-1.default", &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: fmt.Sprintf("10.10.10.10"),
-			Port:    80,
-			ServicePort: &model.Port{
-				Name:     "http",
-				Port:     80,
-				Protocol: protocol.HTTP,
-			},
-			Locality: asdcLocality,
+		Endpoint: &model.IstioEndpoint{
+			Address:         fmt.Sprintf("10.10.10.10"),
+			ServicePortName: "http",
+			EndpointPort:    80,
+			Locality:        asdcLocality,
+		},
+		ServicePort: &model.Port{
+			Name:     "http",
+			Port:     80,
+			Protocol: protocol.HTTP,
 		},
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance("test-1.default", &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: fmt.Sprintf("10.10.10.11"),
-			Port:    80,
-			ServicePort: &model.Port{
-				Name:     "http",
-				Port:     80,
-				Protocol: protocol.HTTP,
-			},
-			Locality: asdc2Locality,
+		Endpoint: &model.IstioEndpoint{
+			Address:         fmt.Sprintf("10.10.10.11"),
+			ServicePortName: "http",
+			EndpointPort:    80,
+			Locality:        asdc2Locality,
+		},
+		ServicePort: &model.Port{
+			Name:     "http",
+			Port:     80,
+			Protocol: protocol.HTTP,
 		},
 	})
 	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
@@ -686,18 +688,19 @@ func addUdsEndpoint(server *bootstrap.Server) {
 		Resolution:   model.ClientSideLB,
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance("localuds.cluster.local", &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Family:  model.AddressFamilyUnix,
-			Address: udsPath,
-			Port:    0,
-			ServicePort: &model.Port{
-				Name:     "grpc",
-				Port:     0,
-				Protocol: protocol.GRPC,
-			},
-			Locality: "localhost",
+		Endpoint: &model.IstioEndpoint{
+			Family:          model.AddressFamilyUnix,
+			Address:         udsPath,
+			EndpointPort:    0,
+			ServicePortName: "grpc",
+			Locality:        "localhost",
+			Labels:          map[string]string{"socket": "unix"},
 		},
-		Labels: map[string]string{"socket": "unix"},
+		ServicePort: &model.Port{
+			Name:     "grpc",
+			Port:     0,
+			Protocol: protocol.GRPC,
+		},
 	})
 
 	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
@@ -725,15 +728,16 @@ func addLocalityEndpoints(server *bootstrap.Server, hostname host.Name) {
 	}
 	for i, locality := range localities {
 		server.EnvoyXdsServer.MemRegistry.AddInstance(hostname, &model.ServiceInstance{
-			Endpoint: model.NetworkEndpoint{
-				Address: fmt.Sprintf("10.0.0.%v", i),
-				Port:    80,
-				ServicePort: &model.Port{
-					Name:     "http",
-					Port:     80,
-					Protocol: protocol.HTTP,
-				},
-				Locality: locality,
+			Endpoint: &model.IstioEndpoint{
+				Address:         fmt.Sprintf("10.0.0.%v", i),
+				EndpointPort:    80,
+				ServicePortName: "http",
+				Locality:        locality,
+			},
+			ServicePort: &model.Port{
+				Name:     "http",
+				Port:     80,
+				Protocol: protocol.HTTP,
 			},
 		})
 	}
@@ -753,14 +757,15 @@ func addEdsCluster(server *bootstrap.Server, hostName string, portName string, a
 	})
 
 	server.EnvoyXdsServer.MemRegistry.AddInstance(host.Name(hostName), &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: address,
-			Port:    port,
-			ServicePort: &model.Port{
-				Name:     portName,
-				Port:     port,
-				Protocol: protocol.HTTP,
-			},
+		Endpoint: &model.IstioEndpoint{
+			Address:         address,
+			EndpointPort:    uint32(port),
+			ServicePortName: portName,
+		},
+		ServicePort: &model.Port{
+			Name:     portName,
+			Port:     port,
+			Protocol: protocol.HTTP,
 		},
 	})
 	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
@@ -780,14 +785,15 @@ func updateServiceResolution(server *bootstrap.Server) {
 	})
 
 	server.EnvoyXdsServer.MemRegistry.AddInstance("edsdns.svc.cluster.local", &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: "somevip.com",
-			Port:    8080,
-			ServicePort: &model.Port{
-				Name:     "http",
-				Port:     8080,
-				Protocol: protocol.HTTP,
-			},
+		Endpoint: &model.IstioEndpoint{
+			Address:         "somevip.com",
+			EndpointPort:    8080,
+			ServicePortName: "http",
+		},
+		ServicePort: &model.Port{
+			Name:     "http",
+			Port:     8080,
+			Protocol: protocol.HTTP,
 		},
 	})
 	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
@@ -810,14 +816,15 @@ func addOverlappingEndpoints(server *bootstrap.Server) {
 		},
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance("overlapping.cluster.local", &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: "10.0.0.53",
-			Port:    53,
-			ServicePort: &model.Port{
-				Name:     "tcp-dns",
-				Port:     53,
-				Protocol: protocol.TCP,
-			},
+		Endpoint: &model.IstioEndpoint{
+			Address:         "10.0.0.53",
+			EndpointPort:    53,
+			ServicePortName: "tcp-dns",
+		},
+		ServicePort: &model.Port{
+			Name:     "tcp-dns",
+			Port:     53,
+			Protocol: protocol.TCP,
 		},
 	})
 	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})

--- a/pilot/pkg/proxy/envoy/v2/mem.go
+++ b/pilot/pkg/proxy/envoy/v2/mem.go
@@ -153,11 +153,11 @@ func (sd *MemServiceDiscovery) AddInstance(service host.Name, instance *model.Se
 	instance.Service = svc
 	sd.ip2instance[instance.Endpoint.Address] = []*model.ServiceInstance{instance}
 
-	key := fmt.Sprintf("%s:%d", service, instance.Endpoint.ServicePort.Port)
+	key := fmt.Sprintf("%s:%d", service, instance.ServicePort.Port)
 	instanceList := sd.instancesByPortNum[key]
 	sd.instancesByPortNum[key] = append(instanceList, instance)
 
-	key = fmt.Sprintf("%s:%s", service, instance.Endpoint.ServicePort.Name)
+	key = fmt.Sprintf("%s:%s", service, instance.ServicePort.Name)
 	instanceList = sd.instancesByPortName[key]
 	sd.instancesByPortName[key] = append(instanceList, instance)
 }
@@ -165,14 +165,15 @@ func (sd *MemServiceDiscovery) AddInstance(service host.Name, instance *model.Se
 // AddEndpoint adds an endpoint to a service.
 func (sd *MemServiceDiscovery) AddEndpoint(service host.Name, servicePortName string, servicePort int, address string, port int) *model.ServiceInstance {
 	instance := &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: address,
-			Port:    port,
-			ServicePort: &model.Port{
-				Name:     servicePortName,
-				Port:     servicePort,
-				Protocol: protocol.HTTP,
-			},
+		Endpoint: &model.IstioEndpoint{
+			Address:         address,
+			ServicePortName: servicePortName,
+			EndpointPort:    uint32(port),
+		},
+		ServicePort: &model.Port{
+			Name:     servicePortName,
+			Port:     servicePort,
+			Protocol: protocol.HTTP,
 		},
 	}
 	sd.AddInstance(service, instance)
@@ -214,27 +215,21 @@ func (sd *MemServiceDiscovery) SetEndpoints(service string, namespace string, en
 
 		instance := &model.ServiceInstance{
 			Service: svc,
-			Labels:  e.Labels,
-			Endpoint: model.NetworkEndpoint{
-				Address: e.Address,
-				ServicePort: &model.Port{
-					Name:     e.ServicePortName,
-					Port:     p.Port,
-					Protocol: protocol.HTTP,
-				},
-				Locality: e.Locality,
-				LbWeight: e.LbWeight,
+			ServicePort: &model.Port{
+				Name:     e.ServicePortName,
+				Port:     p.Port,
+				Protocol: protocol.HTTP,
 			},
-			ServiceAccount: e.ServiceAccount,
+			Endpoint: e,
 		}
 		sd.ip2instance[instance.Endpoint.Address] = []*model.ServiceInstance{instance}
 
-		key := fmt.Sprintf("%s:%d", service, instance.Endpoint.ServicePort.Port)
+		key := fmt.Sprintf("%s:%d", service, instance.ServicePort.Port)
 
 		instanceList := sd.instancesByPortNum[key]
 		sd.instancesByPortNum[key] = append(instanceList, instance)
 
-		key = fmt.Sprintf("%s:%s", service, instance.Endpoint.ServicePort.Name)
+		key = fmt.Sprintf("%s:%s", service, instance.ServicePort.Name)
 		instanceList = sd.instancesByPortName[key]
 		sd.instancesByPortName[key] = append(instanceList, instance)
 

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -159,17 +159,18 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 		},
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance(hostname, &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: "127.0.0.1",
-			Port:    int(testEnv.Ports().BackendPort),
-			ServicePort: &model.Port{
-				Name:     "http",
-				Port:     80,
-				Protocol: protocol.HTTP,
-			},
-			Locality: "az",
+		Endpoint: &model.IstioEndpoint{
+			Address:         "127.0.0.1",
+			EndpointPort:    uint32(testEnv.Ports().BackendPort),
+			ServicePortName: "http",
+			Locality:        "az",
+			ServiceAccount:  "hello-sa",
 		},
-		ServiceAccount: "hello-sa",
+		ServicePort: &model.Port{
+			Name:     "http",
+			Port:     80,
+			Protocol: protocol.HTTP,
+		},
 	})
 
 	// "local" service points to the current host and the in-process mixer http test endpoint
@@ -188,15 +189,16 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 		},
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance("local.default.svc.cluster.local", &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: localIP,
-			Port:    int(testEnv.Ports().BackendPort),
-			ServicePort: &model.Port{
-				Name:     "http",
-				Port:     80,
-				Protocol: protocol.HTTP,
-			},
-			Locality: "az",
+		Endpoint: &model.IstioEndpoint{
+			Address:         localIP,
+			EndpointPort:    uint32(testEnv.Ports().BackendPort),
+			ServicePortName: "http",
+			Locality:        "az",
+		},
+		ServicePort: &model.Port{
+			Name:     "http",
+			Port:     80,
+			Protocol: protocol.HTTP,
 		},
 	})
 
@@ -213,30 +215,32 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 	})
 
 	server.EnvoyXdsServer.MemRegistry.AddInstance("service3.default.svc.cluster.local", &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: app3Ip,
-			Port:    2080,
-			ServicePort: &model.Port{
-				Name:     "http-main",
-				Port:     1080,
-				Protocol: protocol.HTTP,
-			},
-			Locality: "az",
+		Endpoint: &model.IstioEndpoint{
+			Address:         app3Ip,
+			EndpointPort:    2080,
+			ServicePortName: "http-main",
+			Locality:        "az",
+			Labels:          map[string]string{"version": "v1"},
 		},
-		Labels: map[string]string{"version": "v1"},
+		ServicePort: &model.Port{
+			Name:     "http-main",
+			Port:     1080,
+			Protocol: protocol.HTTP,
+		},
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance("service3.default.svc.cluster.local", &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: gatewayIP,
-			Port:    2080,
-			ServicePort: &model.Port{
-				Name:     "http-main",
-				Port:     1080,
-				Protocol: protocol.HTTP,
-			},
-			Locality: "az",
+		Endpoint: &model.IstioEndpoint{
+			Address:         gatewayIP,
+			EndpointPort:    2080,
+			ServicePortName: "http-main",
+			Locality:        "az",
+			Labels:          map[string]string{"version": "v2", "app": "my-gateway-controller"},
 		},
-		Labels: map[string]string{"version": "v2", "app": "my-gateway-controller"},
+		ServicePort: &model.Port{
+			Name:     "http-main",
+			Port:     1080,
+			Protocol: protocol.HTTP,
+		},
 	})
 
 	// Mock ingress service
@@ -258,30 +262,32 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 		// TODO: set attribute for this service. It may affect TestLDSIsolated as we now having service defined in istio-system namespaces
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: ingressIP,
-			Port:    80,
-			ServicePort: &model.Port{
-				Name:     "http",
-				Port:     80,
-				Protocol: protocol.HTTP,
-			},
-			Locality: "az",
+		Endpoint: &model.IstioEndpoint{
+			Address:         ingressIP,
+			EndpointPort:    80,
+			ServicePortName: "http",
+			Locality:        "az",
+			Labels:          labels.Instance{constants.IstioLabel: constants.IstioIngressLabelValue},
 		},
-		Labels: labels.Instance{constants.IstioLabel: constants.IstioIngressLabelValue},
+		ServicePort: &model.Port{
+			Name:     "http",
+			Port:     80,
+			Protocol: protocol.HTTP,
+		},
 	})
 	server.EnvoyXdsServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address: ingressIP,
-			Port:    443,
-			ServicePort: &model.Port{
-				Name:     "https",
-				Port:     443,
-				Protocol: protocol.HTTPS,
-			},
-			Locality: "az",
+		Endpoint: &model.IstioEndpoint{
+			Address:         ingressIP,
+			EndpointPort:    443,
+			ServicePortName: "https",
+			Locality:        "az",
+			Labels:          labels.Instance{constants.IstioLabel: constants.IstioIngressLabelValue},
 		},
-		Labels: labels.Instance{constants.IstioLabel: constants.IstioIngressLabelValue},
+		ServicePort: &model.Port{
+			Name:     "https",
+			Port:     443,
+			Protocol: protocol.HTTPS,
+		},
 	})
 
 	// RouteConf Service4 is using port 80, to test that we generate multiple clusters (regression)

--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -26,7 +26,7 @@ import (
 func NewPolicyApplier(push *model.PushContext,
 	serviceInstance *model.ServiceInstance, namespace string, labels labels.Collection) authn.PolicyApplier {
 	service := serviceInstance.Service
-	port := serviceInstance.Endpoint.ServicePort
+	port := serviceInstance.ServicePort
 	authnPolicy, _ := push.AuthenticationPolicyForWorkload(service, port)
 	return v1beta1.NewPolicyApplier(push.AuthnBetaPolicies.GetJwtPoliciesForWorkload(
 		namespace, labels), authnPolicy)

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -47,7 +47,9 @@ func newService(hostname string, labels map[string]string, t *testing.T) *model.
 			},
 			Hostname: host.Name(hostname),
 		},
-		Labels: labels,
+		Endpoint: &model.IstioEndpoint{
+			Labels: labels,
+		},
 	}
 }
 

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -88,11 +88,11 @@ func NewServiceMetadata(name string, namespace string, service *model.ServiceIns
 
 	return &ServiceMetadata{
 		Name:   string(service.Service.Hostname),
-		Labels: service.Labels,
+		Labels: service.Endpoint.Labels,
 		Attributes: map[string]string{
 			attrDestName:      name,
 			attrDestNamespace: namespace,
-			attrDestUser:      extractActualServiceAccount(service.ServiceAccount),
+			attrDestUser:      extractActualServiceAccount(service.Endpoint.ServiceAccount),
 		},
 	}, nil
 }

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"testing"
 
+	"istio.io/istio/pkg/config/labels"
+
 	"github.com/davecgh/go-spew/spew"
 
 	istio_rbac "istio.io/api/rbac/v1alpha1"
@@ -27,7 +29,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
 	"istio.io/istio/pkg/config/host"
-	"istio.io/istio/pkg/config/labels"
 )
 
 func TestNewServiceMetadata(t *testing.T) {
@@ -50,8 +51,10 @@ func TestNewServiceMetadata(t *testing.T) {
 				Service: &model.Service{
 					Hostname: host.Name("svc-name.test-ns"),
 				},
-				Labels:         labels.Instance{"version": "v1"},
-				ServiceAccount: "spiffe://xyz.com/sa/service-account/ns/test-ns",
+				Endpoint: &model.IstioEndpoint{
+					Labels:         labels.Instance{"version": "v1"},
+					ServiceAccount: "spiffe://xyz.com/sa/service-account/ns/test-ns",
+				},
 			},
 			want: ServiceMetadata{
 				Name:   "svc-name.test-ns",
@@ -366,6 +369,7 @@ func TestModel_Generate(t *testing.T) {
 		Service: &model.Service{
 			Hostname: host.Name(serviceFoo),
 		},
+		Endpoint: &model.IstioEndpoint{},
 	}
 	serviceMetadata, _ := NewServiceMetadata("foo", "default", serviceInstance)
 	testCases := []struct {

--- a/pilot/pkg/security/authz/policy/helper.go
+++ b/pilot/pkg/security/authz/policy/helper.go
@@ -56,7 +56,13 @@ func NewServiceMetadata(hostname string, labels map[string]string, t mockTest) *
 			},
 			Hostname: host.Name(hostname),
 		},
-		Labels: labels,
+		Endpoint: &model.IstioEndpoint{
+			Attributes: model.ServiceAttributes{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Labels: labels,
+		},
 	}
 
 	serviceMetadata, err := authz_model.NewServiceMetadata(name, namespace, serviceInstance)

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -144,7 +144,7 @@ func (c *Controller) InstancesByPort(svc *model.Service, port int,
 	if serviceInstances, ok := c.serviceInstances[name]; ok {
 		var instances []*model.ServiceInstance
 		for _, instance := range serviceInstances {
-			if labels.HasSubsetOf(instance.Labels) && portMatch(instance, port) {
+			if labels.HasSubsetOf(instance.Endpoint.Labels) && portMatch(instance, port) {
 				instances = append(instances, instance)
 			}
 		}
@@ -156,7 +156,7 @@ func (c *Controller) InstancesByPort(svc *model.Service, port int,
 
 // returns true if an instance's port matches with any in the provided list
 func portMatch(instance *model.ServiceInstance, port int) bool {
-	return port == 0 || port == instance.Endpoint.ServicePort.Port
+	return port == 0 || port == instance.ServicePort.Port
 }
 
 // GetProxyServiceInstances lists service instances co-located with a given proxy
@@ -203,7 +203,7 @@ func (c *Controller) GetProxyWorkloadLabels(proxy *model.Proxy) (labels.Collecti
 			if len(proxy.IPAddresses) > 0 {
 				for _, ipAddress := range proxy.IPAddresses {
 					if ipAddress == addr {
-						out = append(out, instance.Labels)
+						out = append(out, instance.Endpoint.Labels)
 						break
 					}
 				}

--- a/pilot/pkg/serviceregistry/consul/controller_test.go
+++ b/pilot/pkg/serviceregistry/consul/controller_test.go
@@ -199,7 +199,7 @@ func TestInstances(t *testing.T) {
 	}
 	for _, inst := range instances {
 		found := false
-		for key, val := range inst.Labels {
+		for key, val := range inst.Endpoint.Labels {
 			if key == filterTagKey && val == filterTagVal {
 				found = true
 			}
@@ -219,9 +219,9 @@ func TestInstances(t *testing.T) {
 		t.Errorf("Instances() did not filter by port => %q, want 2", len(instances))
 	}
 	for _, inst := range instances {
-		if inst.Endpoint.ServicePort.Port != filterPort {
+		if inst.ServicePort.Port != filterPort {
 			t.Errorf("Instances() did not filter by port => %q, want %q",
-				inst.Endpoint.ServicePort.Name, filterPort)
+				inst.ServicePort.Name, filterPort)
 		}
 	}
 }

--- a/pilot/pkg/serviceregistry/consul/conversion.go
+++ b/pilot/pkg/serviceregistry/consul/conversion.go
@@ -129,12 +129,19 @@ func convertInstance(instance *api.CatalogService) *model.ServiceInstance {
 	tlsMode := model.GetTLSModeFromEndpointLabels(svcLabels)
 	hostname := serviceHostname(instance.ServiceName)
 	return &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address:     addr,
-			Port:        instance.ServicePort,
-			ServicePort: port,
-			Locality:    instance.Datacenter,
+		Endpoint: &model.IstioEndpoint{
+			Address:         addr,
+			EndpointPort:    uint32(instance.ServicePort),
+			ServicePortName: port.Name,
+			Locality:        instance.Datacenter,
+			Labels:          svcLabels,
+			TLSMode:         tlsMode,
+			Attributes: model.ServiceAttributes{
+				Name:      string(hostname),
+				Namespace: model.IstioDefaultConfigNamespace,
+			},
 		},
+		ServicePort: port,
 		Service: &model.Service{
 			Hostname:     hostname,
 			Address:      instance.ServiceAddress,
@@ -146,8 +153,6 @@ func convertInstance(instance *api.CatalogService) *model.ServiceInstance {
 				Namespace: model.IstioDefaultConfigNamespace,
 			},
 		},
-		Labels:  svcLabels,
-		TLSMode: tlsMode,
 	}
 }
 

--- a/pilot/pkg/serviceregistry/consul/conversion_test.go
+++ b/pilot/pkg/serviceregistry/consul/conversion_test.go
@@ -97,16 +97,16 @@ func TestConvertInstance(t *testing.T) {
 
 	out := convertInstance(&consulServiceInst)
 
-	if out.Endpoint.ServicePort.Protocol != protocol.UDP {
-		t.Errorf("convertInstance() => %v, want %v", out.Endpoint.ServicePort.Protocol, protocol.UDP)
+	if out.ServicePort.Protocol != protocol.UDP {
+		t.Errorf("convertInstance() => %v, want %v", out.ServicePort.Protocol, protocol.UDP)
 	}
 
-	if out.Endpoint.ServicePort.Name != p {
-		t.Errorf("convertInstance() => %v, want %v", out.Endpoint.ServicePort.Name, p)
+	if out.ServicePort.Name != p {
+		t.Errorf("convertInstance() => %v, want %v", out.ServicePort.Name, p)
 	}
 
-	if out.Endpoint.ServicePort.Port != port {
-		t.Errorf("convertInstance() => %v, want %v", out.Endpoint.ServicePort.Port, port)
+	if out.ServicePort.Port != port {
+		t.Errorf("convertInstance() => %v, want %v", out.ServicePort.Port, port)
 	}
 
 	if out.Endpoint.Locality != dc {
@@ -117,12 +117,12 @@ func TestConvertInstance(t *testing.T) {
 		t.Errorf("convertInstance() => %v, want %v", out.Endpoint.Address, ip)
 	}
 
-	if len(out.Labels) != 2 {
-		t.Errorf("convertInstance() len(Labels) => %v, want %v", len(out.Labels), 2)
+	if len(out.Endpoint.Labels) != 2 {
+		t.Errorf("convertInstance() len(Labels) => %v, want %v", len(out.Endpoint.Labels), 2)
 	}
 
-	if out.Labels[tagKey1] != tagVal1 || out.Labels[tagKey2] != tagVal2 {
-		t.Errorf("convertInstance() => missing or incorrect tag in %q", out.Labels)
+	if out.Endpoint.Labels[tagKey1] != tagVal1 || out.Endpoint.Labels[tagKey2] != tagVal2 {
+		t.Errorf("convertInstance() => missing or incorrect tag in %q", out.Endpoint.Labels)
 	}
 
 	if out.Service.Hostname != serviceHostname(name) {

--- a/pilot/pkg/serviceregistry/external/conversion.go
+++ b/pilot/pkg/serviceregistry/external/conversion.go
@@ -147,18 +147,23 @@ func convertEndpoint(service *model.Service, servicePort *networking.Port,
 	tlsMode := model.GetTLSModeFromEndpointLabels(endpoint.Labels)
 
 	return &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address:     addr,
-			Family:      family,
-			Port:        int(instancePort),
-			ServicePort: convertPort(servicePort),
-			Network:     endpoint.Network,
-			Locality:    endpoint.Locality,
-			LbWeight:    endpoint.Weight,
+		Endpoint: &model.IstioEndpoint{
+			Address:         addr,
+			Family:          family,
+			EndpointPort:    instancePort,
+			ServicePortName: servicePort.Name,
+			Network:         endpoint.Network,
+			Locality:        endpoint.Locality,
+			LbWeight:        endpoint.Weight,
+			Labels:          endpoint.Labels,
+			TLSMode:         tlsMode,
+			Attributes: model.ServiceAttributes{
+				Name:      service.Attributes.Name,
+				Namespace: service.Attributes.Namespace,
+			},
 		},
-		Service: service,
-		Labels:  endpoint.Labels,
-		TLSMode: tlsMode,
+		Service:     service,
+		ServicePort: convertPort(servicePort),
 	}
 }
 
@@ -177,14 +182,19 @@ func convertInstances(cfg model.Config, services []*model.Service) []*model.Serv
 				// Do not use serviceentry.hosts as a service entry is converted into
 				// multiple services (one for each host)
 				out = append(out, &model.ServiceInstance{
-					Endpoint: model.NetworkEndpoint{
-						Address:     string(service.Hostname),
-						Port:        int(serviceEntryPort.Number),
-						ServicePort: convertPort(serviceEntryPort),
+					Endpoint: &model.IstioEndpoint{
+						Address:         string(service.Hostname),
+						EndpointPort:    serviceEntryPort.Number,
+						ServicePortName: serviceEntryPort.Name,
+						Labels:          nil,
+						TLSMode:         model.DisabledTLSModeLabel,
+						Attributes: model.ServiceAttributes{
+							Name:      service.Attributes.Name,
+							Namespace: service.Attributes.Namespace,
+						},
 					},
-					Service: service,
-					Labels:  nil,
-					TLSMode: model.DisabledTLSModeLabel,
+					Service:     service,
+					ServicePort: convertPort(serviceEntryPort),
 				})
 			} else {
 				for _, endpoint := range serviceEntry.Endpoints {

--- a/pilot/pkg/serviceregistry/external/conversion_test.go
+++ b/pilot/pkg/serviceregistry/external/conversion_test.go
@@ -358,18 +358,23 @@ func makeInstance(cfg *model.Config, address string, port int,
 	}
 	return &model.ServiceInstance{
 		Service: svc,
-		Endpoint: model.NetworkEndpoint{
-			Family:  family,
-			Address: address,
-			Port:    port,
-			ServicePort: &model.Port{
-				Name:     svcPort.Name,
-				Port:     int(svcPort.Number),
-				Protocol: protocol.Parse(svcPort.Protocol),
+		Endpoint: &model.IstioEndpoint{
+			Family:          family,
+			Address:         address,
+			EndpointPort:    uint32(port),
+			ServicePortName: svcPort.Name,
+			Labels:          svcLabels,
+			TLSMode:         tlsMode,
+			Attributes: model.ServiceAttributes{
+				Name:      svc.Attributes.Name,
+				Namespace: svc.Attributes.Namespace,
 			},
 		},
-		Labels:  svcLabels,
-		TLSMode: tlsMode,
+		ServicePort: &model.Port{
+			Name:     svcPort.Name,
+			Port:     int(svcPort.Number),
+			Protocol: protocol.Parse(svcPort.Protocol),
+		},
 	}
 }
 

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -98,16 +98,16 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 							Address:         instance.Endpoint.Address,
 							EndpointPort:    uint32(port.Port),
 							ServicePortName: port.Name,
-							Labels:          instance.Labels,
+							Labels:          instance.Endpoint.Labels,
 							UID:             instance.Endpoint.UID,
-							ServiceAccount:  instance.ServiceAccount,
+							ServiceAccount:  instance.Endpoint.ServiceAccount,
 							Network:         instance.Endpoint.Network,
 							Locality:        instance.Endpoint.Locality,
 							Attributes: model.ServiceAttributes{
 								Name:      instance.Service.Attributes.Name,
 								Namespace: instance.Service.Attributes.Namespace,
 							},
-							TLSMode: instance.TLSMode,
+							TLSMode: instance.Endpoint.TLSMode,
 						})
 					}
 				}
@@ -198,7 +198,7 @@ func (d *ServiceEntryStore) InstancesByPort(svc *model.Service, port int,
 	if found {
 		for _, instance := range instances {
 			if instance.Service.Hostname == svc.Hostname &&
-				labels.HasSubsetOf(instance.Labels) &&
+				labels.HasSubsetOf(instance.Endpoint.Labels) &&
 				portMatchSingle(instance, port) {
 				out = append(out, instance)
 			}
@@ -259,7 +259,7 @@ func (d *ServiceEntryStore) update() {
 
 // returns true if an instance's port matches with any in the provided list
 func portMatchSingle(instance *model.ServiceInstance, port int) bool {
-	return port == 0 || port == instance.Endpoint.ServicePort.Port
+	return port == 0 || port == instance.ServicePort.Port
 }
 
 // GetProxyServiceInstances lists service instances co-located with a given proxy
@@ -290,7 +290,7 @@ func (d *ServiceEntryStore) GetProxyWorkloadLabels(proxy *model.Proxy) (labels.C
 		instances, found := d.ip2instance[ip]
 		if found {
 			for _, instance := range instances {
-				out = append(out, instance.Labels)
+				out = append(out, instance.Endpoint.Labels)
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -427,22 +427,22 @@ func sortServiceInstances(instances []*model.ServiceInstance) {
 
 	sort.Slice(instances, func(i, j int) bool {
 		if instances[i].Service.Hostname == instances[j].Service.Hostname {
-			if instances[i].Endpoint.Port == instances[j].Endpoint.Port {
+			if instances[i].Endpoint.EndpointPort == instances[j].Endpoint.EndpointPort {
 				if instances[i].Endpoint.Address == instances[j].Endpoint.Address {
-					if len(instances[i].Labels) == len(instances[j].Labels) {
-						iLabels := labelsToSlice(instances[i].Labels)
-						jLabels := labelsToSlice(instances[j].Labels)
+					if len(instances[i].Endpoint.Labels) == len(instances[j].Endpoint.Labels) {
+						iLabels := labelsToSlice(instances[i].Endpoint.Labels)
+						jLabels := labelsToSlice(instances[j].Endpoint.Labels)
 						for k := range iLabels {
 							if iLabels[k] < jLabels[k] {
 								return true
 							}
 						}
 					}
-					return len(instances[i].Labels) < len(instances[j].Labels)
+					return len(instances[i].Endpoint.Labels) < len(instances[j].Endpoint.Labels)
 				}
 				return instances[i].Endpoint.Address < instances[j].Endpoint.Address
 			}
-			return instances[i].Endpoint.Port < instances[j].Endpoint.Port
+			return instances[i].Endpoint.EndpointPort < instances[j].Endpoint.EndpointPort
 		}
 		return instances[i].Service.Hostname < instances[j].Service.Hostname
 	})

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -575,17 +575,19 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 			}
 			// Construct the ServiceInstance
 			out = append(out, &model.ServiceInstance{
-				Endpoint: model.NetworkEndpoint{
-					Address:     proxy.IPAddresses[0],
-					Port:        targetPort,
-					ServicePort: svcPort,
-					Network:     c.endpointNetwork(proxy.IPAddresses[0]),
-					Locality:    util.LocalityToString(proxy.Locality),
+				Service:     modelService,
+				ServicePort: svcPort,
+				Endpoint: &model.IstioEndpoint{
+					Address:         proxy.IPAddresses[0],
+					EndpointPort:    uint32(targetPort),
+					ServicePortName: svcPort.Name,
+					// Kubernetes service will only have a single instance of labels, and we return early if there are no labels.
+					Labels:         proxy.WorkloadLabels[0],
+					ServiceAccount: svcAccount,
+					Network:        c.endpointNetwork(proxy.IPAddresses[0]),
+					Locality:       util.LocalityToString(proxy.Locality),
+					Attributes:     model.ServiceAttributes{Name: svc.Name, Namespace: svc.Namespace},
 				},
-				Service: modelService,
-				// Kubernetes service will only have a single instance of labels, and we return early if there are no labels.
-				Labels:         proxy.WorkloadLabels[0],
-				ServiceAccount: svcAccount,
 			})
 		}
 	}
@@ -660,23 +662,27 @@ func (c *Controller) GetProxyWorkloadLabels(proxy *model.Proxy) (labels.Collecti
 func (c *Controller) getEndpoints(podIP, address string, endpointPort int32, svcPort *model.Port, svc *model.Service) *model.ServiceInstance {
 	podLabels, _ := c.pods.labelsByIP(podIP)
 	pod := c.pods.getPodByIP(podIP)
-	az, sa := "", ""
+	locality, sa, uid := "", "", ""
 	if pod != nil {
-		az = c.GetPodLocality(pod)
+		locality = c.GetPodLocality(pod)
 		sa = kube.SecureNamingSAN(pod)
+		uid = createUID(pod.Name, pod.Namespace)
 	}
 	return &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address:     address,
-			Port:        int(endpointPort),
-			ServicePort: svcPort,
-			Network:     c.endpointNetwork(address),
-			Locality:    az,
+		Service:     svc,
+		ServicePort: svcPort,
+		Endpoint: &model.IstioEndpoint{
+			Address:         address,
+			EndpointPort:    uint32(endpointPort),
+			ServicePortName: svcPort.Name,
+			Labels:          podLabels,
+			UID:             uid,
+			ServiceAccount:  sa,
+			Network:         c.endpointNetwork(address),
+			Locality:        locality,
+			Attributes:      model.ServiceAttributes{Name: svc.Attributes.Name, Namespace: svc.Attributes.Namespace},
+			TLSMode:         kube.PodTLSMode(pod),
 		},
-		Service:        svc,
-		Labels:         podLabels,
-		ServiceAccount: sa,
-		TLSMode:        kube.PodTLSMode(pod),
 	}
 }
 
@@ -700,8 +706,8 @@ func (c *Controller) GetIstioServiceAccounts(svc *model.Service, ports []int) []
 	}
 
 	for _, si := range instances {
-		if si.ServiceAccount != "" {
-			saSet[si.ServiceAccount] = true
+		if si.Endpoint.ServiceAccount != "" {
+			saSet[si.Endpoint.ServiceAccount] = true
 		}
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -488,11 +488,6 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	}
 
 	expected := &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{Family: 0,
-			Address:     "1.1.1.1",
-			ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
-			Locality:    "r/z",
-		},
 		Service: &model.Service{
 			Hostname:        "svc1.nsa.svc.company.com",
 			Address:         "10.0.0.1",
@@ -504,8 +499,20 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				Namespace:       "nsa",
 				UID:             "istio://nsa/services/svc1"},
 		},
-		Labels:         labels.Instance{"app": "prod-app"},
-		ServiceAccount: "account",
+		ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
+		Endpoint: &model.IstioEndpoint{
+			Labels:          labels.Instance{"app": "prod-app"},
+			ServiceAccount:  "account",
+			Family:          0,
+			Address:         "1.1.1.1",
+			EndpointPort:    0,
+			ServicePortName: "tcp-port",
+			Locality:        "r/z",
+			Attributes: model.ServiceAttributes{
+				Name:      "svc1",
+				Namespace: "nsa",
+			},
+		},
 	}
 	if len(metaServices) != 1 {
 		t.Fatalf("expected 1 instance, got %v", len(metaServices))
@@ -540,12 +547,6 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	}
 
 	expected = &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Family:      0,
-			Address:     "129.0.0.1",
-			ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
-			Locality:    "region1/zone1/subzone1",
-		},
 		Service: &model.Service{
 			Hostname:        "svc1.nsa.svc.company.com",
 			Address:         "10.0.0.1",
@@ -557,9 +558,22 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				Namespace:       "nsa",
 				UID:             "istio://nsa/services/svc1"},
 		},
-		Labels:         labels.Instance{"app": "prod-app"},
-		ServiceAccount: "spiffe://cluster.local/ns/nsa/sa/svcaccount",
-		TLSMode:        model.DisabledTLSModeLabel,
+		ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
+		Endpoint: &model.IstioEndpoint{
+			Family:          0,
+			Address:         "129.0.0.1",
+			EndpointPort:    0,
+			ServicePortName: "tcp-port",
+			Locality:        "region1/zone1/subzone1",
+			Labels:          labels.Instance{"app": "prod-app"},
+			ServiceAccount:  "spiffe://cluster.local/ns/nsa/sa/svcaccount",
+			TLSMode:         model.DisabledTLSModeLabel,
+			UID:             "kubernetes://pod2.nsa",
+			Attributes: model.ServiceAttributes{
+				Name:      "svc1",
+				Namespace: "nsa",
+			},
+		},
 	}
 	if len(podServices) != 1 {
 		t.Fatalf("expected 1 instance, got %v", len(podServices))
@@ -589,12 +603,6 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	}
 
 	expected = &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Family:      0,
-			Address:     "129.0.0.2",
-			ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
-			Locality:    "region/zone",
-		},
 		Service: &model.Service{
 			Hostname:        "svc1.nsa.svc.company.com",
 			Address:         "10.0.0.1",
@@ -606,9 +614,22 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				Namespace:       "nsa",
 				UID:             "istio://nsa/services/svc1"},
 		},
-		Labels:         labels.Instance{"app": "prod-app", "istio-locality": "region.zone"},
-		ServiceAccount: "spiffe://cluster.local/ns/nsa/sa/svcaccount",
-		TLSMode:        model.DisabledTLSModeLabel,
+		ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
+		Endpoint: &model.IstioEndpoint{
+			Family:          0,
+			Address:         "129.0.0.2",
+			EndpointPort:    0,
+			ServicePortName: "tcp-port",
+			Locality:        "region/zone",
+			Labels:          labels.Instance{"app": "prod-app", "istio-locality": "region.zone"},
+			ServiceAccount:  "spiffe://cluster.local/ns/nsa/sa/svcaccount",
+			TLSMode:         model.DisabledTLSModeLabel,
+			UID:             "kubernetes://pod3.nsa",
+			Attributes: model.ServiceAttributes{
+				Name:      "svc1",
+				Namespace: "nsa",
+			},
+		},
 	}
 	if len(podServices) != 1 {
 		t.Fatalf("expected 1 instance, got %v", len(podServices))

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -145,18 +145,19 @@ func (e *endpointsController) InstancesByPort(c *Controller, svc *model.Service,
 					svcPortEntry.Name == port.Name {
 
 					out = append(out, &model.ServiceInstance{
-						Endpoint: model.NetworkEndpoint{
-							Address:     ea.IP,
-							Port:        int(port.Port),
-							ServicePort: svcPortEntry,
-							UID:         uid,
-							Network:     c.endpointNetwork(ea.IP),
-							Locality:    az,
+						Endpoint: &model.IstioEndpoint{
+							Address:         ea.IP,
+							EndpointPort:    uint32(port.Port),
+							ServicePortName: svcPortEntry.Name,
+							UID:             uid,
+							Network:         c.endpointNetwork(ea.IP),
+							Locality:        az,
+							Labels:          podLabels,
+							ServiceAccount:  sa,
+							TLSMode:         tlsMode,
 						},
-						Service:        svc,
-						Labels:         podLabels,
-						ServiceAccount: sa,
-						TLSMode:        tlsMode,
+						ServicePort: svcPortEntry,
+						Service:     svc,
 					})
 				}
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -286,18 +286,19 @@ func (e *endpointSliceController) InstancesByPort(c *Controller, svc *model.Serv
 						svcPortEntry.Name == *port.Name {
 
 						out = append(out, &model.ServiceInstance{
-							Endpoint: model.NetworkEndpoint{
-								Address:     a,
-								Port:        int(portNum),
-								ServicePort: svcPortEntry,
-								UID:         uid,
-								Network:     c.endpointNetwork(a),
-								Locality:    az,
+							Endpoint: &model.IstioEndpoint{
+								Address:         a,
+								EndpointPort:    portNum,
+								ServicePortName: svcPortEntry.Name,
+								UID:             uid,
+								Network:         c.endpointNetwork(a),
+								Locality:        az,
+								Labels:          podLabels,
+								ServiceAccount:  sa,
+								TLSMode:         tlsMode,
 							},
-							Service:        svc,
-							Labels:         podLabels,
-							ServiceAccount: sa,
-							TLSMode:        tlsMode,
+							ServicePort: svcPortEntry,
+							Service:     svc,
 						})
 					}
 				}

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -142,13 +142,18 @@ func ExternalNameServiceInstances(k8sSvc coreV1.Service, svc *model.Service) []*
 	out := make([]*model.ServiceInstance, 0, len(svc.Ports))
 	for _, portEntry := range svc.Ports {
 		out = append(out, &model.ServiceInstance{
-			Endpoint: model.NetworkEndpoint{
-				Address:     k8sSvc.Spec.ExternalName,
-				Port:        portEntry.Port,
-				ServicePort: portEntry,
+			Service:     svc,
+			ServicePort: portEntry,
+			Endpoint: &model.IstioEndpoint{
+				Address:         k8sSvc.Spec.ExternalName,
+				EndpointPort:    uint32(portEntry.Port),
+				ServicePortName: portEntry.Name,
+				Labels:          k8sSvc.Labels,
+				Attributes: model.ServiceAttributes{
+					Name:      svc.Attributes.Name,
+					Namespace: svc.Attributes.Namespace,
+				},
 			},
-			Service: svc,
-			Labels:  k8sSvc.Labels,
 		})
 	}
 	return out

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -118,14 +118,19 @@ func MakeInstance(service *model.Service, port *model.Port, version int, az stri
 	}
 
 	return &model.ServiceInstance{
-		Endpoint: model.NetworkEndpoint{
-			Address:     MakeIP(service, version),
-			Port:        target,
-			ServicePort: port,
-			Locality:    az,
+		Endpoint: &model.IstioEndpoint{
+			Address:         MakeIP(service, version),
+			EndpointPort:    uint32(target),
+			ServicePortName: port.Name,
+			Labels:          map[string]string{"version": fmt.Sprintf("v%d", version)},
+			Locality:        az,
+			Attributes: model.ServiceAttributes{
+				Name:      service.Attributes.Name,
+				Namespace: service.Attributes.Namespace,
+			},
 		},
-		Service: service,
-		Labels:  map[string]string{"version": fmt.Sprintf("v%d", version)},
+		Service:     service,
+		ServicePort: port,
 	}
 }
 

--- a/pkg/config/labels/instance.go
+++ b/pkg/config/labels/instance.go
@@ -78,6 +78,9 @@ func (i Instance) Equals(that Instance) bool {
 
 // Validate ensures tag is well-formed
 func (i Instance) Validate() error {
+	if i == nil {
+		return nil
+	}
 	var errs error
 	for k, v := range i {
 		if err := validateTagKey(k); err != nil {


### PR DESCRIPTION
The new IstioEndpoint was meant to replace
both ServiceInstance and NetworkEndpoint. This PR
removes the latter. ServiceInstance has been
refactored to use IstioEndpoint.