### PR TITLE
Fix opertator e2e failures

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -91,7 +91,7 @@ const (
 	kubernetesReadinessInterval       = 200 * time.Millisecond
 	validationWebhookReadinessTimeout = time.Minute
 	istioOperatorTimeout              = time.Second * 300
-	istioOperatorFreq                 = time.Minute
+	istioOperatorFreq                 = time.Second * 10
 	validationWebhookReadinessFreq    = 100 * time.Millisecond
 )
 
@@ -1033,9 +1033,7 @@ EOF`, k.KubeConfig, dummyValidationRule)
 
 func (k *KubeInfo) waitForIstioOperator() error {
 
-	get := fmt.Sprintf(`cat << EOF | kubectl --kubeconfig=%s get icp example-istiocontrolplane -n istio-operator
--o yaml
-EOF`, k.KubeConfig)
+	get := fmt.Sprintf(`kubectl --kubeconfig=%s get icp example-istiocontrolplane -n istio-operator -o yaml`, k.KubeConfig)
 	timeout := time.Now().Add(istioOperatorTimeout)
 	for {
 		if time.Now().After(timeout) {
@@ -1047,7 +1045,7 @@ EOF`, k.KubeConfig)
 			break
 		}
 
-		log.Errorf("istio-operator is still deploying Istio: %v", err)
+		log.Warnf("istio-operator is still deploying Istio: %v", err)
 		time.Sleep(istioOperatorFreq)
 
 	}

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -90,8 +90,8 @@ const (
 	kubernetesReadinessTimeout        = time.Second * 180
 	kubernetesReadinessInterval       = 200 * time.Millisecond
 	validationWebhookReadinessTimeout = time.Minute
-	istioOperatorTimeout = time.Second * 300
-	istioOperatorFreq    =  time.Minute
+	istioOperatorTimeout              = time.Second * 300
+	istioOperatorFreq                 = time.Minute
 	validationWebhookReadinessFreq    = 100 * time.Millisecond
 )
 
@@ -1054,7 +1054,6 @@ EOF`, k.KubeConfig)
 	log.Info("istio operator succeeds to deploy Istio")
 	return nil
 }
-
 
 func (k *KubeInfo) deployCRDs(kubernetesCRD string) error {
 	yamlFileName := filepath.Join(istioInstallDir, helmInstallerName, "istio-init", "files", kubernetesCRD)


### PR DESCRIPTION
It take time for operator to init watch and finish reconcile especially for the 1st time. So this makes operator e2e flaky.   add sometime to make sure istio operator finished his work before start the e2e test.
