### PR TITLE
Remove Jobs in istio-init

### DIFF
--- a/install/kubernetes/helm/istio-init/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio-init/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.job.activated }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -9,3 +10,4 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["create", "get", "list", "watch", "patch"]
+{{ end }}

--- a/install/kubernetes/helm/istio-init/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio-init/templates/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
+{{ if .Values.use_jobs  }}
+piVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: istio-init-admin-role-binding-{{ .Release.Namespace }}
@@ -13,3 +14,4 @@ subjects:
   - kind: ServiceAccount
     name: istio-init-service-account
     namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/install/kubernetes/helm/istio-init/templates/configmap-crd-all.yaml
+++ b/install/kubernetes/helm/istio-init/templates/configmap-crd-all.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.job.activated }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,6 @@ metadata:
 data:
   crd-all.gen.yaml: |-
 {{.Files.Get "files/crd-all.gen.yaml" | printf "%s" | indent 4}}
+{{ else }}
+{{ .Files.Get "files/crd-all.gen.yaml" }}
+{{ end }}

--- a/install/kubernetes/helm/istio-init/templates/configmap-crd-certmanager-10.yaml
+++ b/install/kubernetes/helm/istio-init/templates/configmap-crd-certmanager-10.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.certmanager.enabled }}
+{{ if .Values.job.activated }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,4 +8,7 @@ metadata:
 data:
   crd-certmanager-10.yaml: |-
 {{.Files.Get "files/crd-certmanager-10.yaml" | printf "%s" | indent 4}}
+{{ else }}
+{{ .Files.Get "files/crd-certmanager-10.yaml" }}
+{{ end }}
 {{- end }}

--- a/install/kubernetes/helm/istio-init/templates/configmap-crd-certmanager-11.yaml
+++ b/install/kubernetes/helm/istio-init/templates/configmap-crd-certmanager-11.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.certmanager.enabled }}
+{{ if .Values.job.activated }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,4 +8,7 @@ metadata:
 data:
   crd-certmanager-11.yaml: |-
 {{.Files.Get "files/crd-certmanager-11.yaml" | printf "%s" | indent 4}}
+{{ else }}
+{{ .Files.Get "files/crd-certmanager-11.yaml" }}
+{{ end }}
 {{- end }}

--- a/install/kubernetes/helm/istio-init/templates/configmap-crd-mixer.yaml
+++ b/install/kubernetes/helm/istio-init/templates/configmap-crd-mixer.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.job.activated }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,6 @@ metadata:
 data:
   crd-mixer.yaml: |-
 {{.Files.Get "files/crd-mixer.yaml" | printf "%s" | indent 4}}
+{{ else }}
+{{ .Files.Get "files/crd-mixer.yaml" }}
+{{ end }}

--- a/install/kubernetes/helm/istio-init/templates/job-crd-all.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-all.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.job.activated }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,3 +29,4 @@ spec:
         configMap:
           name: istio-crd-all
       restartPolicy: OnFailure
+{{ end }}

--- a/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-10.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-10.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certmanager.enabled }}
+{{- if and .Values.certmanager.enabled .Values.job.activated }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-11.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-11.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certmanager.enabled }}
+{{- if and .Values.certmanager.enabled .Values.job.activated }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/install/kubernetes/helm/istio-init/templates/job-crd-mixer.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-mixer.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.job.activated }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,3 +29,4 @@ spec:
         configMap:
           name: istio-crd-mixer
       restartPolicy: OnFailure
+{{ end }}

--- a/install/kubernetes/helm/istio-init/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio-init/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.job.activated }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -12,4 +13,4 @@ metadata:
   labels:
     app: istio-init
     istio: init
-
+{{ end }}

--- a/install/kubernetes/helm/istio-init/values.yaml
+++ b/install/kubernetes/helm/istio-init/values.yaml
@@ -16,6 +16,8 @@ certmanager:
   enabled: false
 
 job:
+  # activated specifies if the CRD's should be created via Kubernetes jobs
+  # if you use helm and tiller this option is not backwards compatible.
   activated: true
   resources:
     requests:

--- a/install/kubernetes/helm/istio-init/values.yaml
+++ b/install/kubernetes/helm/istio-init/values.yaml
@@ -16,6 +16,7 @@ certmanager:
   enabled: false
 
 job:
+  activated: true
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
In the current helm setup the CRDs for Istio are installed via Jobs this has some drawbacks:

- If you are running in a restricted env you must ensure that the Jobs (actually the ServiceAccount) have an appropriate PSP associated
- If you delete a resource and you rerun the `istio-init` steps nothing will happen until you delete the Jobs
- Using `kubectl apply --prune` is nearly impossible which means you need to cleanup manually (e.g. if you upgrade to a new release which removes some CRDs)
- Also a benefit is that `istioctl verify-install` works now

It seems like others feel the same: https://github.com/istio/istio/issues/17638

In the current setup I removed the jobs completely (we could also add a variable "jobless" (hopefully with a better name). Are there any reasons not to completly remove the jobs ?

Running this locally against my GKE cluster seems fine:

```bash
$ kubectl apply -f <(helm template  ./install/kubernetes/helm/istio-init)
customresourcedefinition.apiextensions.k8s.io/destinationrules.networking.istio.io created
...
$ istioctl verify-install  -f <(helm template  ./install/kubernetes/helm/istio-init)
...
Checked 24 crds
Checked 0 Istio Deployments
Istio is installed successfully
$ kubectl create namespace istio-system
$ kubectl -n istio-system apply -f <(helm template install/kubernetes/helm/istio --namespace istio-system \
    --values install/kubernetes/helm/istio/values-istio-demo.yaml \
    --set global.controlPlaneSecurityEnabled=true \
    --set global.mtls.enabled=true)
...
$ istioctl verify-install -f <(helm template install/kubernetes/helm/istio --namespace istio-system \
    --values install/kubernetes/helm/istio/values-istio-demo.yaml \
    --set global.controlPlaneSecurityEnabled=true \
    --set global.mtls.enabled=true)
...
Checked 0 crds
Checked 9 Istio Deployments
Istio is installed successfully
```