### PR TITLE
Fix split-horizon routing and add meshNetworks test

### DIFF
--- a/install/kubernetes/helm/istio/test-values/values-istio-mesh-networks.yaml
+++ b/install/kubernetes/helm/istio/test-values/values-istio-mesh-networks.yaml
@@ -1,0 +1,16 @@
+# overrides to test the meshNetworks.
+global:
+  meshNetworks:
+    # NOTE: DO NOT CHANGE THIS! Its hardcoded in Pilot in different areas
+    Kubernetes:
+      endpoints:
+      - fromRegistry: Kubernetes
+      gateways:
+      - port: 15443
+        address: 2.2.2.2
+      vm: {}
+
+  #This will cause ISTIO_META_NETWORK to be set on the pods and the
+  #kube controller code to match endpoints from kubernetes with the default
+  #cluster ID of "Kubernetes". Need to fix this code
+  network: "Kubernetes"

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -82,6 +82,7 @@ func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args
 	args.Config.ControllerOptions.ClusterID = s.clusterID
 	args.Config.ControllerOptions.Metrics = s.environment
 	args.Config.ControllerOptions.XDSUpdater = s.EnvoyXdsServer
+	args.Config.ControllerOptions.NetworksWatcher = s.environment.NetworksWatcher
 	kubectl := kubecontroller.NewController(s.kubeClient, args.Config.ControllerOptions)
 	s.kubeRegistry = kubectl
 	serviceControllers.AddRegistry(kubectl)

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1524,7 +1524,7 @@ func (ps *PushContext) initMeshNetworks() {
 	for network, networkConf := range ps.Networks.Networks {
 		gws := networkConf.Gateways
 		if len(gws) == 0 {
-			log.Debugf("the endpoints within network %s will be ignored because of invalid MeshNetworks", network)
+			// all endpoints in this network are reachable directly from others. nothing to do.
 			continue
 		}
 

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -70,7 +70,9 @@ func EndpointsByNetworkFilter(push *model.PushContext, proxyNetwork string, endp
 
 		// Iterate over all networks that have the cluster endpoint (weight>0) and
 		// for each one of those add a new endpoint that points to the network's
-		// gateway with the relevant weight
+		// gateway with the relevant weight. For each gateway endpoint, set the tlsMode metadata so that
+		// we initiate mTLS automatically to this remote gateway. Split horizon to remote gateway cannot
+		// work with plaintext
 		for network, w := range remoteEps {
 			gateways := push.NetworkGatewaysByNetwork(network)
 
@@ -90,6 +92,8 @@ func EndpointsByNetworkFilter(push *model.PushContext, proxyNetwork string, endp
 						Value: weight,
 					},
 				}
+				// TODO: figure out a way to extract locality data from the gateway public endpoints in meshNetworks
+				gwEp.Metadata = util.BuildLbEndpointMetadata("", network, model.IstioMutualTLSModeLabel, push)
 				lbEndpoints = append(lbEndpoints, gwEp)
 			}
 		}

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -100,7 +100,7 @@ Kubernetes:
   gateways:
   - address: 2.2.2.2
     port: 15443
-  vm: {}
+vm: {}
 `
 	// This will cause ISTIO_META_NETWORK to be set on the pods and the
 	// kube controller code to match endpoints from kubernetes with the default

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -1,0 +1,240 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meshnetwork
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/gogo/protobuf/proto"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/structpath"
+)
+
+const (
+	VMService = `
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: vm
+spec:
+  hosts:
+  - httpbin.com
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  resolution: STATIC
+  location: MESH_INTERNAL
+  endpoints:
+  - address: 1.1.1.1
+    labels:
+      app: httpbin
+    network: vm
+`
+)
+
+var (
+	i istio.Instance
+	g galley.Instance
+	p pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("meshnetwork_test", m).
+		Label(label.CustomSetup).
+		SetupOnEnv(environment.Kube, istio.Setup(&i, setupConfig)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+
+	cfg.Values["global.meshNetworks"] = `
+Kubernetes:
+  endpoints:
+    # NOTE: Voodoo value. DO NOT CHANGE THIS! Its hardcoded in Pilot in different areas
+  - fromRegistry: Kubernetes
+  gateways:
+  - address: 2.2.2.2
+    port: 15443
+  vm: {}
+`
+	// This will cause ISTIO_META_NETWORK to be set on the pods and the
+	// kube controller code to match endpoints from kubernetes with the default
+	// cluster ID of "Kubernetes". Need to fix this code
+	cfg.Values["global.network"] = "Kubernetes"
+}
+
+func TestAsymmetricMeshNetworkWithGatewayIP(t *testing.T) {
+	framework.
+		NewTest(t).
+		Label(label.CustomSetup).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "meshnetwork",
+				Inject: true,
+			})
+			// First setup the VM service and its endpoints
+			if err := g.ApplyConfig(ns, VMService); err != nil {
+				t.Fatal(err)
+			}
+			// Now setup a K8S service
+			var instance echo.Instance
+			echoConfig := echo.Config{
+				Service:   "server",
+				Namespace: ns,
+				Pilot:     p,
+				Galley:    g,
+				Ports: []echo.Port{
+					{
+						Name:     "http",
+						Protocol: protocol.HTTP,
+						// We use a port > 1024 to not require root
+						InstancePort: 8090,
+					},
+				},
+			}
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&instance, echoConfig).
+				BuildOrFail(t)
+			if err := instance.WaitUntilCallable(instance); err != nil {
+				t.Fatal(err)
+			}
+
+			// Now get the EDS from the k8s pod to see if the VM IP is there.
+			if err := checkEDSInPod(instance, "httpbin.com", "1.1.1.1"); err != nil {
+				t.Fatal(err)
+			}
+			// Now get the EDS from the fake VM sidecar to see if the gateway IP is there for the echo service.
+			if err := checkEDSInVM(ns.Name(),
+				fmt.Sprintf("%s.%s.svc.cluster.local", echoConfig.Service, echoConfig.Namespace),
+				"1.1.1.1", "2.2.2.2", 15443); err != nil {
+				t.Fatal(err)
+			}
+		})
+}
+
+func checkEDSInPod(c echo.Instance, service string, endpointIP string) error {
+	clusterName := fmt.Sprintf("outbound|%d||%s", 80, service)
+	accept := func(cfg *envoyAdmin.ConfigDump) (bool, error) {
+		validator := structpath.ForProto(cfg)
+
+		if err := validator.
+			Exists("{.configs[*].dynamicActiveClusters[?(@.cluster.name == '%s')]}", clusterName).
+			Check(); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	workloads, _ := c.Workloads()
+	// Wait for the outbound config to be received by each workload from Pilot.
+	for _, w := range workloads {
+		if w.Sidecar() != nil {
+			if err := w.Sidecar().WaitForConfig(accept, retry.Timeout(time.Second*10)); err != nil {
+				return err
+			}
+			// Now that we have the desired cluster, get the cluster status to see if the VM IP made it to envoy
+			if clusters, err := w.Sidecar().Clusters(); err != nil {
+				return err
+			} else {
+				for _, clusterStatus := range clusters.ClusterStatuses {
+					if clusterStatus.Name == clusterName {
+						for _, host := range clusterStatus.HostStatuses {
+							if host.Address != nil && host.Address.GetSocketAddress() != nil &&
+								host.Address.GetSocketAddress().Address == endpointIP {
+								return nil
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return fmt.Errorf("could not find cluster %s on %s or cluster did not have VM IP %s", c.ID(), clusterName, endpointIP)
+}
+
+func checkEDSInVM(ns, service, endpointIP, gatewayIP string, gatewayPort uint32) error {
+	clusterName := fmt.Sprintf("outbound|%d||%s", 80, service)
+
+	node := &model.Proxy{
+		Type:            model.SidecarProxy,
+		IPAddresses:     []string{endpointIP},
+		ID:              fmt.Sprintf("httpbin.com"),
+		ConfigNamespace: ns,
+		Metadata: &model.NodeMetadata{
+			InstanceIPs:      nil,
+			ConfigNamespace:  ns,
+			Namespace:        ns,
+			InterceptionMode: "NONE",
+			Network:          "vm",
+		},
+	}
+	if resp, err := p.CallDiscovery(pilot.NewDiscoveryRequest(node.ID, pilot.ClusterLoadAssignment)); err != nil {
+		return err
+	} else {
+		for _, res := range resp.Resources {
+			c := &xdsapi.ClusterLoadAssignment{}
+			if err := proto.Unmarshal(res.Value, c); err != nil {
+				return err
+			}
+			if c.ClusterName == clusterName {
+				if len(c.Endpoints) != 1 || len(c.Endpoints[0].LbEndpoints) != 1 {
+					return fmt.Errorf("more than one endpoint and LB endpoint in cluster load assignment")
+				}
+				sockAddress := c.Endpoints[0].LbEndpoints[0].GetEndpoint().Address.GetSocketAddress()
+				if sockAddress.Address != gatewayIP && sockAddress.GetPortValue() != gatewayPort {
+					return fmt.Errorf("eds for VM does not have the expected IP:port (want %s:%d, got %s:%d)",
+						gatewayIP, gatewayPort, sockAddress.Address, sockAddress.GetPortValue())
+				}
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("did not find the expected gateway IP/port in VM eds response")
+}

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -210,7 +210,7 @@ func checkEDSInVM(t *testing.T, ns, service, endpointIP, gatewayIP string, gatew
 		ID:              fmt.Sprintf("httpbin.com"),
 		ConfigNamespace: ns,
 		Metadata: &model.NodeMetadata{
-			InstanceIPs:      nil,
+			InstanceIPs:      []string{endpointIP},
 			ConfigNamespace:  ns,
 			Namespace:        ns,
 			InterceptionMode: "NONE",
@@ -218,7 +218,10 @@ func checkEDSInVM(t *testing.T, ns, service, endpointIP, gatewayIP string, gatew
 		},
 	}
 
-	if err := p.StartDiscovery(pilot.NewDiscoveryRequest(node.ServiceNode(), pilot.ClusterLoadAssignment)); err != nil {
+	// make an eds request, simulating a VM, asking for a cluster on k8s
+	request := pilot.NewDiscoveryRequest(node.ServiceNode(), pilot.ClusterLoadAssignment)
+	request.ResourceNames = []string{clusterName}
+	if err := p.StartDiscovery(request); err != nil {
 		return err
 	}
 

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -93,14 +93,15 @@ func setupConfig(cfg *istio.Config) {
 	}
 
 	cfg.Values["global.meshNetworks"] = `
-Kubernetes:
-  endpoints:
+networks:
+  Kubernetes:
+    endpoints:
     # NOTE: Voodoo value. DO NOT CHANGE THIS! Its hardcoded in Pilot in different areas
-  - fromRegistry: Kubernetes
-  gateways:
-  - address: 2.2.2.2
-    port: 15443
-vm: {}
+    - fromRegistry: Kubernetes
+    gateways:
+    - port: 15443
+      address: 2.2.2.2
+  vm: {}
 `
 	// This will cause ISTIO_META_NETWORK to be set on the pods and the
 	// kube controller code to match endpoints from kubernetes with the default


### PR DESCRIPTION
Split Horizon routing was broken due to recent changes regarding network watcher and auto mTLS. This PR fixes it, and also adds a couple of tests for mesh networks to test this feature.

Signed-off-by: Shriram Rajagopalan <rshriram@tetrate.io>