### PR TITLE
[release-1.4] update operator dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.4
 	istio.io/api v0.0.0-20191115173247-e1a1952e5b81
 	istio.io/gogo-genproto v0.0.0-20191029161641-f7d19ec0141d
-	istio.io/operator v0.0.0-20191210002328-336085291b17
+	istio.io/operator v0.0.0-20191211193103-1b9a09ed7510
 	istio.io/pkg v0.0.0-20191030005435-10d06b6b315e
 	k8s.io/api v0.0.0
 	k8s.io/apiextensions-apiserver v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -923,6 +923,8 @@ istio.io/gogo-genproto v0.0.0-20191029161641-f7d19ec0141d h1:OCJTcFsWtB/2RBM8iZa
 istio.io/gogo-genproto v0.0.0-20191029161641-f7d19ec0141d/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
 istio.io/operator v0.0.0-20191210002328-336085291b17 h1:IVwel0J35j+92SjqlfkaYqO6jO/XtyCfEqMvfwAa5bY=
 istio.io/operator v0.0.0-20191210002328-336085291b17/go.mod h1:dLssahRjoKKYFosavVSViIqf5xZ00BN0pOfXyWumiI0=
+istio.io/operator v0.0.0-20191211193103-1b9a09ed7510 h1:fOWvHjB1WgXEvTe+pmcaPbPf3AHLbez4CP1SG6KQLFA=
+istio.io/operator v0.0.0-20191211193103-1b9a09ed7510/go.mod h1:dLssahRjoKKYFosavVSViIqf5xZ00BN0pOfXyWumiI0=
 istio.io/pkg v0.0.0-20191030005435-10d06b6b315e h1:xOrrel2PBjAFHPLvF2tRty6Z/jZ/FF4+LdKv93Z8T+I=
 istio.io/pkg v0.0.0-20191030005435-10d06b6b315e/go.mod h1:O7Uqtzc1w7+NiEV2TUeO2yPoR+4GlwlDgSocYZMjBfs=
 k8s.io/api v0.0.0-20191003000013-35e20aa79eb8 h1:cJZ/+fVFIFQDkUewZeim5OhZ8X+h48lMtMsZgQMdxOo=


### PR DESCRIPTION
Pulling in the latest updates to the operator on 1.4.

```
$ go get istio.io/operator@release-1.4
```