### PR TITLE
traffic direction: set egress to INBOUND

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -441,6 +441,11 @@ func IsApplicationNodeType(nType NodeType) bool {
 	}
 }
 
+// IsEgressGateway checks that the proxy is an egress gateway.
+func IsEgressGateway(node *Proxy) bool {
+	return node.Type == Router && node.Metadata.Labels["istio"] == "egressgateway"
+}
+
 // ServiceNode encodes the proxy node attributes into a URI-acceptable string
 func (node *Proxy) ServiceNode() string {
 	ip := ""

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -72,7 +72,11 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 		}
 
 		p := protocol.Parse(servers[0].Port.Protocol)
-		listenerProtocol := plugin.ModelProtocolToListenerProtocol(node, p, core.TrafficDirection_OUTBOUND)
+		trafficDirection := core.TrafficDirection_OUTBOUND
+		if model.IsEgressGateway(node) {
+			trafficDirection = core.TrafficDirection_INBOUND
+		}
+		listenerProtocol := plugin.ModelProtocolToListenerProtocol(node, p, trafficDirection)
 		if p.IsHTTP() {
 			// We have a list of HTTP servers on this port. Build a single listener for the server port.
 			// We only need to look at the first server in the list as the merge logic
@@ -102,7 +106,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 		}
 
 		l := buildListener(opts)
-		l.TrafficDirection = core.TrafficDirection_OUTBOUND
+		l.TrafficDirection = trafficDirection
 
 		mutable := &plugin.MutableObjects{
 			Listener: l,


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Set traffic direction to INBOUND for egress gateway. This is needed to avoid security issues with leaking cluster details outside of the cluster. INBOUND makes a proxy dis-trust the upstream (the same way we dis-trust applications on sidecars), and not forward the peer metadata. It also works better on the downstream: ingress gateway distrusts the downstream by not accepting peer metadata. For the egress we want the opposite, we want to accept the forwarded metadata for telemetry since the traffic to an egress gateway is from within the cluster.

I have not found a better way to detect an egress gateway than comparing "istio" label to "egressgateway".

/cc @douglas-reid @mandarjog 
/assign @howardjohn 