### PR TITLE
pilot agent not exit when coredump is enabled

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -197,6 +197,10 @@ containers:
   - name: ISTIO_AUTO_MTLS_ENABLED
     value: "true"
   {{- end }}
+  {{- if .Values.global.proxy.enableCoreDump }}
+  - name: AGENT_KEEP_ALIVE
+    value: "true"
+  {{- end }}
 {{- if eq .Values.global.proxy.tracer "datadog" }}
   - name: HOST_IP
     valueFrom:

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -121,6 +121,8 @@ var (
 	stackdriverTracingMaxNumberOfMessageEvents = env.RegisterIntVar("STACKDRIVER_TRACING_MAX_NUMBER_OF_MESSAGE_EVENTS", 200, "Sets the "+
 		"max number of message events for stackdriver")
 
+	keepAlive = env.RegisterBoolVar("AGENT_KEEP_ALIVE", false, "If true, pilot agent would not exit when envoy exit")
+
 	sdsUdsWaitTimeout = time.Minute
 
 	// Indicates if any the remote services like AccessLogService, MetricsService have enabled tls.
@@ -498,7 +500,7 @@ var (
 				OutlierLogPath:      outlierLogPath,
 			})
 
-			agent := envoy.NewAgent(envoyProxy, features.TerminationDrainDuration())
+			agent := envoy.NewAgent(envoyProxy, features.TerminationDrainDuration(), keepAlive.Get())
 
 			if nodeAgentSDSEnabled && role.Type == model.SidecarProxy {
 				tlsCertsToWatch = []string{}


### PR DESCRIPTION
To solve https://github.com/istio/istio/issues/19411, so that when coredump is enabled, pilot agent would not exit when envoy exit. The alternative way is to wait sometime before quit for the core dump to finish and then transfer them into some other storage.
