### PR TITLE
Remove legacy networkview

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -191,16 +191,7 @@ istio-egressgateway:
     mountPath: /etc/istio/egressgateway-ca-certs
   #### Advanced options ########
   env:
-    # Set this to "external" if and only if you want the egress gateway to
-    # act as a transparent SNI gateway that routes mTLS/TLS traffic to
-    # external services defined using service entries, where the service
-    # entry has resolution set to DNS, has one or more endpoints with
-    # network field set to "external". By default its set to "" so that
-    # the egress gateway sees the same set of endpoints as the sidecars
-    # preserving backward compatibility
-    # ISTIO_META_REQUESTED_NETWORK_VIEW: ""
-
-    # By default, a gateway is in "standard" mode. If the mode is set to "sni-dnat", 
+    # By default, a gateway is in "standard" mode. If the mode is set to "sni-dnat",
     # pilot generates an additional 
     # set of clusters for internal services but without Istio mTLS, to
     # enable cross cluster routing.

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -266,9 +266,6 @@ type NodeMetadata struct {
 	// will be replaced with the gateway defined in the settings.
 	Network string `json:"NETWORK,omitempty"`
 
-	// RequestedNetworkView specifies the networks that the proxy wants to see
-	RequestedNetworkView StringList `json:"REQUESTED_NETWORK_VIEW,omitempty"`
-
 	// ExchangeKeys specifies a list of metadata keys that should be used for Node Metadata Exchange.
 	ExchangeKeys StringList `json:"EXCHANGE_KEYS,omitempty"`
 
@@ -551,32 +548,6 @@ func (node *Proxy) SetWorkloadLabels(env *Environment) error {
 
 	node.WorkloadLabels = l
 	return nil
-}
-
-// UnnamedNetwork is the default network that proxies in the mesh
-// get when they don't request a specific network view.
-const UnnamedNetwork = ""
-
-// GetNetworkView returns the networks that the proxy requested.
-// When sending EDS/CDS-with-dns-endpoints, Pilot will only send
-// endpoints corresponding to the networks that the proxy wants to see.
-// If not set, we assume that the proxy wants to see endpoints from the default
-// unnamed network.
-func GetNetworkView(node *Proxy) map[string]bool {
-	if node == nil {
-		return map[string]bool{UnnamedNetwork: true}
-	}
-
-	nmap := make(map[string]bool)
-	for _, n := range node.Metadata.RequestedNetworkView {
-		nmap[n] = true
-	}
-
-	if len(nmap) == 0 {
-		// Proxy sees endpoints from the default unnamed network only
-		nmap[UnnamedNetwork] = true
-	}
-	return nmap
 }
 
 // ParseMetadata parses the opaque Metadata from an Envoy Node into string key-value pairs.

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1339,7 +1339,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 	configStore := &fakes.IstioConfigStore{}
 	env := newTestEnvironment(serviceDiscovery, testMesh, configStore)
 
-	localityLbEndpoints := buildLocalityLbEndpoints(env.PushContext, model.GetNetworkView(nil), service, 8080, nil)
+	localityLbEndpoints := buildLocalityLbEndpoints(env.PushContext, service, 8080, nil)
 	g.Expect(len(localityLbEndpoints)).To(Equal(2))
 	for _, ep := range localityLbEndpoints {
 		if ep.Locality.Region == "region1" {


### PR DESCRIPTION
Please provide a description for what this PR is for.

Can not find any uses of `NetworkView`, so clean it up in case it misleading users.
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
