### PR TITLE
use unified circuit breaker threshold for both inbound and outbound

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -68,23 +68,15 @@ const (
 )
 
 var (
-	defaultInboundCircuitBreakerThresholds = v2Cluster.CircuitBreakers_Thresholds{
-		// This disables circuit breaking by default by setting highest possible values.
-		// See: https://www.envoyproxy.io/docs/envoy/v1.11.1/faq/disable_circuit_breaking
-		MaxRetries:         &wrappers.UInt32Value{Value: math.MaxUint32},
-		MaxRequests:        &wrappers.UInt32Value{Value: math.MaxUint32},
-		MaxConnections:     &wrappers.UInt32Value{Value: math.MaxUint32},
-		MaxPendingRequests: &wrappers.UInt32Value{Value: math.MaxUint32},
-	}
-	defaultOutboundCircuitBreakerThresholds = v2Cluster.CircuitBreakers_Thresholds{
+	// This disables circuit breaking by default by setting highest possible values.
+	// See: https://www.envoyproxy.io/docs/envoy/v1.11.1/faq/disable_circuit_breaking
+	defaultCircuitBreakerThresholds = v2Cluster.CircuitBreakers_Thresholds{
 		// DefaultMaxRetries specifies the default for the Envoy circuit breaker parameter max_retries. This
 		// defines the maximum number of parallel retries a given Envoy will allow to the upstream cluster. Envoy defaults
 		// this value to 3, however that has shown to be insufficient during periods of pod churn (e.g. rolling updates),
 		// where multiple endpoints in a cluster are terminated. In these scenarios the circuit breaker can kick
 		// in before Pilot is able to deliver an updated endpoint list to Envoy, leading to client-facing 503s.
-		MaxRetries: &wrappers.UInt32Value{Value: math.MaxUint32},
-		// This disables circuit breaking by default by setting highest possible values.
-		// See: https://www.envoyproxy.io/docs/envoy/v1.11.1/faq/disable_circuit_breaking
+		MaxRetries:         &wrappers.UInt32Value{Value: math.MaxUint32},
 		MaxRequests:        &wrappers.UInt32Value{Value: math.MaxUint32},
 		MaxConnections:     &wrappers.UInt32Value{Value: math.MaxUint32},
 		MaxPendingRequests: &wrappers.UInt32Value{Value: math.MaxUint32},
@@ -104,16 +96,10 @@ var (
 )
 
 // getDefaultCircuitBreakerThresholds returns a copy of the default circuit breaker thresholds for the given traffic direction.
-func getDefaultCircuitBreakerThresholds(direction model.TrafficDirection) *v2Cluster.CircuitBreakers_Thresholds {
-	if direction == model.TrafficDirectionInbound {
-		thresholds := defaultInboundCircuitBreakerThresholds
-		return &thresholds
-	}
-	thresholds := defaultOutboundCircuitBreakerThresholds
+func getDefaultCircuitBreakerThresholds() *v2Cluster.CircuitBreakers_Thresholds {
+	thresholds := defaultCircuitBreakerThresholds
 	return &thresholds
 }
-
-// TODO: Need to do inheritance of DestRules based on domain suffix match
 
 // BuildClusters returns the list of clusters for the given proxy. This is the CDS output
 // For outbound: Cluster for each service/subset hostname or cidr with SNI set to service hostname
@@ -706,8 +692,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusterForPortOrUDS(pluginPara
 		if destinationRule.TrafficPolicy != nil {
 			// only connection pool settings make sense on the inbound path.
 			// upstream TLS settings/outlier detection/load balancer don't apply here.
-			applyConnectionPool(pluginParams.Push, localCluster, destinationRule.TrafficPolicy.ConnectionPool,
-				model.TrafficDirectionInbound)
+			applyConnectionPool(pluginParams.Push, localCluster, destinationRule.TrafficPolicy.ConnectionPool)
 			localCluster.Metadata = util.BuildConfigInfoMetadata(cfg.ConfigMeta)
 		}
 	}
@@ -857,7 +842,7 @@ type buildClusterOpts struct {
 func applyTrafficPolicy(opts buildClusterOpts, proxy *model.Proxy) {
 	connectionPool, outlierDetection, loadBalancer, tls := SelectTrafficPolicyComponents(opts.policy, opts.port)
 
-	applyConnectionPool(opts.push, opts.cluster, connectionPool, opts.direction)
+	applyConnectionPool(opts.push, opts.cluster, connectionPool)
 	applyOutlierDetection(opts.cluster, outlierDetection)
 	applyLoadBalancer(opts.cluster, loadBalancer, opts.port, proxy, opts.push.Mesh)
 
@@ -871,12 +856,12 @@ func applyTrafficPolicy(opts buildClusterOpts, proxy *model.Proxy) {
 }
 
 // FIXME: there isn't a way to distinguish between unset values and zero values
-func applyConnectionPool(push *model.PushContext, cluster *apiv2.Cluster, settings *networking.ConnectionPoolSettings, direction model.TrafficDirection) {
+func applyConnectionPool(push *model.PushContext, cluster *apiv2.Cluster, settings *networking.ConnectionPoolSettings) {
 	if settings == nil {
 		return
 	}
 
-	threshold := getDefaultCircuitBreakerThresholds(direction)
+	threshold := getDefaultCircuitBreakerThresholds()
 	var idleTimeout *types.Duration
 
 	if settings.Http != nil {
@@ -1276,7 +1261,7 @@ func buildDefaultPassthroughCluster(push *model.PushContext, proxy *model.Proxy)
 		LbPolicy:             lbPolicyClusterProvided(proxy),
 	}
 	passthroughSettings := &networking.ConnectionPoolSettings{}
-	applyConnectionPool(push, cluster, passthroughSettings, model.TrafficDirectionOutbound)
+	applyConnectionPool(push, cluster, passthroughSettings)
 	return cluster
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -74,18 +74,7 @@ var (
 )
 
 func TestHTTPCircuitBreakerThresholds(t *testing.T) {
-	directionInfos := []struct {
-		direction    model.TrafficDirection
-		clusterIndex int
-	}{
-		{
-			direction:    model.TrafficDirectionOutbound,
-			clusterIndex: 0,
-		}, {
-			direction:    model.TrafficDirectionInbound,
-			clusterIndex: 4,
-		},
-	}
+	clusterIndexes := []int{0, 4}
 	settings := []*networking.ConnectionPoolSettings{
 		nil,
 		{
@@ -97,31 +86,30 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 			},
 		}}
 
-	for _, directionInfo := range directionInfos {
-		for _, s := range settings {
-			settingsName := "default"
-			if s != nil {
-				settingsName = "override"
-			}
-			testName := fmt.Sprintf("%s-%s", directionInfo.direction, settingsName)
-			t.Run(testName, func(t *testing.T) {
-				g := NewGomegaWithT(t)
-				clusters, err := buildTestClusters("*.example.org", 0, model.SidecarProxy, nil, testMesh,
-					&networking.DestinationRule{
-						Host: "*.example.org",
-						TrafficPolicy: &networking.TrafficPolicy{
-							ConnectionPool: s,
-						},
-					})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(clusters)).To(Equal(8))
-				cluster := clusters[directionInfo.clusterIndex]
+	for _, s := range settings {
+		testName := "default"
+		if s != nil {
+			testName = "override"
+		}
+		t.Run(testName, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			clusters, err := buildTestClusters("*.example.org", 0, model.SidecarProxy, nil, testMesh,
+				&networking.DestinationRule{
+					Host: "*.example.org",
+					TrafficPolicy: &networking.TrafficPolicy{
+						ConnectionPool: s,
+					},
+				})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(clusters)).To(Equal(8))
+			for _, index := range clusterIndexes {
+				cluster := clusters[index]
 				g.Expect(len(cluster.CircuitBreakers.Thresholds)).To(Equal(1))
 				thresholds := cluster.CircuitBreakers.Thresholds[0]
 
 				if s == nil {
 					// Assume the correct defaults for this direction.
-					g.Expect(thresholds).To(Equal(getDefaultCircuitBreakerThresholds(directionInfo.direction)))
+					g.Expect(thresholds).To(Equal(getDefaultCircuitBreakerThresholds()))
 				} else {
 					// Verify that the values were set correctly.
 					g.Expect(thresholds.MaxPendingRequests).To(Not(BeNil()))
@@ -133,8 +121,8 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 					g.Expect(thresholds.MaxRetries).To(Not(BeNil()))
 					g.Expect(thresholds.MaxRetries.Value).To(Equal(uint32(s.Http.MaxRetries)))
 				}
-			})
-		}
+			}
+		})
 	}
 }
 
@@ -1440,7 +1428,7 @@ func TestBuildClustersDefaultCircuitBreakerThresholds(t *testing.T) {
 		if cluster.Name != "BlackHoleCluster" {
 			fmt.Println(cluster.CircuitBreakers)
 			g.Expect(cluster.CircuitBreakers).NotTo(BeNil())
-			g.Expect(cluster.CircuitBreakers.Thresholds[0]).To(Equal(getDefaultCircuitBreakerThresholds(model.TrafficDirectionOutbound)))
+			g.Expect(cluster.CircuitBreakers.Thresholds[0]).To(Equal(getDefaultCircuitBreakerThresholds()))
 		}
 	}
 }
@@ -1489,7 +1477,7 @@ func TestBuildInboundClustersDefaultCircuitBreakerThresholds(t *testing.T) {
 	for _, cluster := range clusters {
 		fmt.Println(cluster.CircuitBreakers)
 		g.Expect(cluster.CircuitBreakers).NotTo(BeNil())
-		g.Expect(cluster.CircuitBreakers.Thresholds[0]).To(Equal(getDefaultCircuitBreakerThresholds(model.TrafficDirectionInbound)))
+		g.Expect(cluster.CircuitBreakers.Thresholds[0]).To(Equal(getDefaultCircuitBreakerThresholds()))
 	}
 }
 


### PR DESCRIPTION

The inbound and outbound circuit breaker thresholds are the same, so use the unified one.