### PR TITLE
reduce crd validation log level

### DIFF
--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -223,11 +223,11 @@ func (c *controller) createInformer(
 func handleValidationFailure(obj interface{}, err error) {
 	if obj, ok := obj.(crd.IstioObject); ok {
 		key := obj.GetObjectMeta().Namespace + "/" + obj.GetObjectMeta().Name
-		log.Errorf("CRD validation failed: %s %s %v", obj.GetObjectKind().GroupVersionKind().GroupKind().Kind,
+		log.Debugf("CRD validation failed: %s %s %v", obj.GetObjectKind().GroupVersionKind().GroupKind().Kind,
 			key, err)
 		k8sErrors.With(nameTag.Value(key)).Record(1)
 	} else {
-		log.Errorf("CRD validation failed for unknown Kind: %s", err)
+		log.Debugf("CRD validation failed for unknown Kind: %s", err)
 		k8sErrors.With(nameTag.Value("unknown")).Record(1)
 	}
 }


### PR DESCRIPTION
Since CRD validation is happening on every push based on `ENABLE_CRD_VALIDATION` flag, any CRD validation errors are spamming the logs. Since we have a metric `pilot_k8s_object_errors` that captures the validation errors, this PR downgrades the log level from `Error` to `Debug`. People who needs the detailed message can enable debug to get the detailed log.