### PR TITLE
fix gateway validation for tcp termination

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -345,8 +345,6 @@ func validateServer(server *networking.Server) (errs error) {
 					server.Tls.CaCertificates != "" || server.Tls.PrivateKey != "" || server.Tls.ServerCertificate != "" {
 					errs = appendErrors(errs, fmt.Errorf("server cannot have TLS settings for plain text HTTP ports"))
 				}
-			} else {
-				errs = appendErrors(errs, fmt.Errorf("server cannot have TLS settings for non HTTPS/TLS ports"))
 			}
 		}
 	}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1123,6 +1123,34 @@ func TestValidateGateway(t *testing.T) {
 					}},
 			},
 			""},
+		{"https with out tls settings",
+			&networking.Gateway{
+				Servers: []*networking.Server{{
+					Hosts: []string{"foo.bar.com"},
+					Port:  &networking.Port{Name: "name1", Number: 7, Protocol: "https"},
+				}},
+			},
+			"server must have TLS settings for HTTPS/TLS protocols"},
+		{"tls with out tls settings",
+			&networking.Gateway{
+				Servers: []*networking.Server{{
+					Hosts: []string{"foo.bar.com"},
+					Port:  &networking.Port{Name: "name1", Number: 7, Protocol: "tls"},
+				}},
+			},
+			"server must have TLS settings for HTTPS/TLS protocols"},
+		{"tcp with tls",
+			&networking.Gateway{
+				Servers: []*networking.Server{{
+					Hosts: []string{"foo.bar.com"},
+					Port:  &networking.Port{Name: "name1", Number: 7, Protocol: "tcp"},
+					Tls: &networking.Server_TLSOptions{Mode: networking.Server_TLSOptions_SIMPLE,
+						ServerCertificate: "/server_cert.cer",
+						PrivateKey:        "/private_key.key",
+					},
+				}},
+			},
+			""},
 		{"invalid port",
 			&networking.Gateway{
 				Servers: []*networking.Server{


### PR DESCRIPTION
Gateway validation incorrectly rejects TCP protocol with TLS settings.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
