### PR TITLE
Remove configStore by namespace if value length is 0

### DIFF
--- a/pilot/pkg/config/coredatamodel/syntheticserviceentrycontroller.go
+++ b/pilot/pkg/config/coredatamodel/syntheticserviceentrycontroller.go
@@ -195,7 +195,7 @@ func (c *SyntheticServiceEntryController) removeConfig(configName []string) {
 			}
 			// clear parent map also
 			if len(byNamespace) == 0 {
-				delete(byNamespace, namespace)
+				delete(c.configStore, namespace)
 			}
 		}
 	}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Remove SyntheticServiceEntryController configStore by namespace, UT TestApplyIncrementalChangeRemove has covered it.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ x ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
