### PR TITLE
Add analyzer for missing credentialName on Gateway

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -39,6 +39,7 @@ func All() []analysis.Analyzer {
 		&deployment.ServiceAssociationAnalyzer{},
 		&deprecation.FieldAnalyzer{},
 		&gateway.IngressGatewayPortAnalyzer{},
+		&gateway.SecretAnalyzer{},
 		&injection.Analyzer{},
 		&injection.VersionAnalyzer{},
 		&service.PortNameAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -235,6 +235,14 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name:       "gatewaySecret",
+		inputFiles: []string{"testdata/gateway-secrets.yaml"},
+		analyzer:   &gateway.SecretAnalyzer{},
+		expected: []message{
+			{msg.ReferencedResourceNotFound, "Gateway mygateway-bogusCredentialName"},
+		},
+	},
+	{
 		name:       "istioInjection",
 		inputFiles: []string{"testdata/injection.yaml"},
 		analyzer:   &injection.Analyzer{},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -241,6 +241,7 @@ var testGrid = []testCase{
 		expected: []message{
 			{msg.ReferencedResourceNotFound, "Gateway defaultgateway-bogusCredentialName"},
 			{msg.ReferencedResourceNotFound, "Gateway customgateway-wrongnamespace"},
+			{msg.ReferencedResourceNotFound, "Gateway bogusgateway"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -239,7 +239,8 @@ var testGrid = []testCase{
 		inputFiles: []string{"testdata/gateway-secrets.yaml"},
 		analyzer:   &gateway.SecretAnalyzer{},
 		expected: []message{
-			{msg.ReferencedResourceNotFound, "Gateway mygateway-bogusCredentialName"},
+			{msg.ReferencedResourceNotFound, "Gateway defaultgateway-bogusCredentialName"},
+			{msg.ReferencedResourceNotFound, "Gateway customgateway-wrongnamespace"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/gateway/gateway.go
+++ b/galley/pkg/config/analysis/analyzers/gateway/gateway.go
@@ -111,6 +111,7 @@ func (*IngressGatewayPortAnalyzer) analyzeGateway(r *resource.Entry, c analysis.
 		// the Istio system ingress gateway complain about a missing referenced resource.  (We
 		// don't want to complain about missing system resources, because a user may want to analyze
 		// only his own application files.)
+		// https://github.com/istio/istio/issues/19579 should make this unnecessary
 		if len(gw.Selector) != 1 || gw.Selector["istio"] != "ingressgateway" {
 			c.Report(metadata.IstioNetworkingV1Alpha3Gateways, msg.NewReferencedResourceNotFound(r, "selector", gwSelector.String()))
 			return

--- a/galley/pkg/config/analysis/analyzers/gateway/secret.go
+++ b/galley/pkg/config/analysis/analyzers/gateway/secret.go
@@ -52,6 +52,13 @@ func (a *SecretAnalyzer) Analyze(ctx analysis.Context) {
 
 		gwNs := getGatewayNamespace(ctx, gw)
 
+		// If we can't find a namespace for the gateway, it's because there's no matching selector. Exit early with a different message.
+		if gwNs == "" {
+			ctx.Report(metadata.IstioNetworkingV1Alpha3Gateways,
+				msg.NewReferencedResourceNotFound(r, "selector", labels.SelectorFromSet(gw.Selector).String()))
+			return true
+		}
+
 		for _, srv := range gw.GetServers() {
 			tls := srv.GetTls()
 			if tls == nil {

--- a/galley/pkg/config/analysis/analyzers/gateway/secret.go
+++ b/galley/pkg/config/analysis/analyzers/gateway/secret.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/meta/metadata"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+)
+
+// SecretAnalyzer checks a gateway's referenced secrets for correctness
+type SecretAnalyzer struct{}
+
+var _ analysis.Analyzer = &SecretAnalyzer{}
+
+// Metadata implements analysis.Analyzer
+func (*SecretAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "gateway.SecretAnalyzer",
+		Description: "Checks a gateway's referenced secrets for correctness",
+		Inputs: collection.Names{
+			metadata.IstioNetworkingV1Alpha3Gateways,
+			metadata.K8SCoreV1Secrets,
+		},
+	}
+}
+
+// Analyze implements analysis.Analyzer
+func (s *SecretAnalyzer) Analyze(c analysis.Context) {
+	c.ForEach(metadata.IstioNetworkingV1Alpha3Gateways, func(r *resource.Entry) bool {
+		//TODO
+		return true
+	})
+}

--- a/galley/pkg/config/analysis/analyzers/testdata/gateway-secrets.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/gateway-secrets.yaml
@@ -8,13 +8,20 @@ metadata:
   namespace: istio-system
 type: Opaque
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    myapp: custom-gateway
+  name: custom-gateway
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: mygateway-noerrors
+  name: defaultgateway-noerrors
 spec:
   selector:
-    istio: ingressgateway # use istio default ingress gateway
+    istio: ingressgateway # use istio default ingress gateway, so we expect the credential in istio-system
   servers:
   - port:
       number: 443
@@ -29,17 +36,35 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: mygateway-bogusCredentialName
+  name: defaultgateway-bogusCredentialName
 spec:
   selector:
-    istio: ingressgateway # use istio default ingress gateway
+    istio: ingressgateway # use istio default ingress gateway, so we expect the credential in istio-system
   servers:
   - port:
-      number: 4430
+      number: 443
       name: https
       protocol: HTTPS
     tls:
       mode: SIMPLE
       credentialName: "httpbin-credential-bogus" # Should break, wrong credential name
+    hosts:
+    - "httpbin.example.com"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: customgateway-wrongnamespace
+spec:
+  selector:
+    istio: custom-gateway # Custom gateway
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: "httpbin-credential" # Should break, doesn't exist in custom-gateway's namespace
     hosts:
     - "httpbin.example.com"

--- a/galley/pkg/config/analysis/analyzers/testdata/gateway-secrets.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/gateway-secrets.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+data:
+  cert: aHVzaCBodXNoIGh1c2gK
+  key: c2VjcmV0IHNlY3JldAo=
+kind: Secret
+metadata:
+  name: httpbin-credential
+  namespace: istio-system
+type: Opaque
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: mygateway-noerrors
+spec:
+  selector:
+    istio: ingressgateway # use istio default ingress gateway
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: "httpbin-credential" # Correct credential, should not produce an error message
+    hosts:
+    - "httpbin.example.com"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: mygateway-bogusCredentialName
+spec:
+  selector:
+    istio: ingressgateway # use istio default ingress gateway
+  servers:
+  - port:
+      number: 4430
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: "httpbin-credential-bogus" # Should break, wrong credential name
+    hosts:
+    - "httpbin.example.com"

--- a/galley/pkg/config/analysis/analyzers/testdata/gateway-secrets.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/gateway-secrets.yaml
@@ -68,3 +68,21 @@ spec:
       credentialName: "httpbin-credential" # Should break, doesn't exist in custom-gateway's namespace
     hosts:
     - "httpbin.example.com"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: bogusgateway
+spec:
+  selector:
+    istio: custom-gateway # Nothing matches this, should generate an error
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: "httpbin-credential"
+    hosts:
+    - "httpbin.example.com"

--- a/galley/pkg/config/meta/metadata/collections.gen.go
+++ b/galley/pkg/config/meta/metadata/collections.gen.go
@@ -138,6 +138,9 @@ var (
 	// K8SCoreV1Pods is the name of collection k8s/core/v1/pods
 	K8SCoreV1Pods = collection.NewName("k8s/core/v1/pods")
 
+	// K8SCoreV1Secrets is the name of collection k8s/core/v1/secrets
+	K8SCoreV1Secrets = collection.NewName("k8s/core/v1/secrets")
+
 	// K8SCoreV1Services is the name of collection k8s/core/v1/services
 	K8SCoreV1Services = collection.NewName("k8s/core/v1/services")
 
@@ -227,6 +230,7 @@ func CollectionNames() []collection.Name {
 		K8SCoreV1Namespaces,
 		K8SCoreV1Nodes,
 		K8SCoreV1Pods,
+		K8SCoreV1Secrets,
 		K8SCoreV1Services,
 		K8SExtensionsV1Beta1Ingresses,
 		K8SNetworkingIstioIoV1Alpha3Destinationrules,

--- a/galley/pkg/config/meta/metadata/metadata.gen.go
+++ b/galley/pkg/config/meta/metadata/metadata.gen.go
@@ -182,6 +182,10 @@ collections:
   ### K8s collections ###
 
   # Built-in K8s collections
+  - name: "k8s/apps/v1/deployments"
+    proto: "k8s.io.api.apps.v1.Deployment"
+    protoPackage: "k8s.io/api/apps/v1"
+
   - name: "k8s/core/v1/endpoints"
     proto: "k8s.io.api.core.v1.Endpoints"
     protoPackage: "k8s.io/api/core/v1"
@@ -198,9 +202,9 @@ collections:
     proto: "k8s.io.api.core.v1.Pod"
     protoPackage: "k8s.io/api/core/v1"
 
-  - name: "k8s/apps/v1/deployments"
-    proto: "k8s.io.api.apps.v1.Deployment"
-    protoPackage: "k8s.io/api/apps/v1"
+  - name: "k8s/core/v1/secrets"
+    proto: "k8s.io.api.core.v1.Secret"
+    protoPackage: "k8s.io/api/core/v1"
 
   - name: "k8s/core/v1/services"
     proto: "k8s.io.api.core.v1.ServiceSpec"
@@ -361,25 +365,26 @@ snapshots:
       - "istio/networking/v1alpha3/sidecars"
       - "istio/networking/v1alpha3/virtualservices"
       - "istio/networking/v1alpha3/synthetic/serviceentries"
-      - "k8s/core/v1/namespaces"
-      - "k8s/core/v1/services"
-      - "k8s/core/v1/pods"
       - "k8s/apps/v1/deployments"
+      - "k8s/core/v1/namespaces"
+      - "k8s/core/v1/pods"
+      - "k8s/core/v1/secrets"
+      - "k8s/core/v1/services"
 
 # Configuration for input sources
 sources:
   # Kubernetes specific configuration.
   - type: kubernetes
     resources:
-    - collection: "k8s/extensions/v1beta1/ingresses"
-      kind: "Ingress"
-      plural: "ingresses"
-      group: "extensions"
-      version: "v1beta1"
+    - collection: "k8s/apps/v1/deployments"
+      kind: "Deployment"
+      plural: "Deployments"
+      group: "apps"
+      version: "v1"
 
-    - collection: "k8s/core/v1/services"
-      kind: "Service"
-      plural: "services"
+    - collection: "k8s/core/v1/endpoints"
+      kind: "Endpoints"
+      plural: "endpoints"
       version: "v1"
 
     - collection: "k8s/core/v1/namespaces"
@@ -399,16 +404,23 @@ sources:
       plural: "pods"
       version: "v1"
 
-    - collection: "k8s/apps/v1/deployments"
-      kind: "Deployment"
-      plural: "Deployments"
-      group: "apps"
+    - collection: "k8s/core/v1/secrets"
+      kind: "Secret"
+      plural: "secrets"
       version: "v1"
 
-    - collection: "k8s/core/v1/endpoints"
-      kind: "Endpoints"
-      plural: "endpoints"
+    - collection: "k8s/core/v1/services"
+      kind: "Service"
+      plural: "services"
       version: "v1"
+
+    - collection: "k8s/extensions/v1beta1/ingresses"
+      kind: "Ingress"
+      plural: "ingresses"
+      group: "extensions"
+      version: "v1beta1"
+
+
 
     - collection: "k8s/networking.istio.io/v1alpha3/virtualservices"
       kind: "VirtualService"
@@ -582,11 +594,13 @@ transforms:
       "k8s/rbac.istio.io/v1alpha1/serviceroles": "istio/rbac/v1alpha1/serviceroles"
       "k8s/security.istio.io/v1beta1/authorizationpolicies": "istio/security/v1beta1/authorizationpolicies"
       "k8s/security.istio.io/v1beta1/requestauthentications": "istio/security/v1beta1/requestauthentications"
-      "k8s/core/v1/namespaces": "k8s/core/v1/namespaces"
-      "k8s/core/v1/services": "k8s/core/v1/services"
-      "k8s/core/v1/pods": "k8s/core/v1/pods"
       "k8s/apps/v1/deployments": "k8s/apps/v1/deployments"
-      "istio/mesh/v1alpha1/MeshConfig": "istio/mesh/v1alpha1/MeshConfig"`)
+      "k8s/core/v1/namespaces": "k8s/core/v1/namespaces"
+      "k8s/core/v1/pods": "k8s/core/v1/pods"
+      "k8s/core/v1/secrets": "k8s/core/v1/secrets"
+      "k8s/core/v1/services": "k8s/core/v1/services"
+      "istio/mesh/v1alpha1/MeshConfig": "istio/mesh/v1alpha1/MeshConfig"
+`)
 
 func metadataYamlBytes() ([]byte, error) {
 	return _metadataYaml, nil

--- a/galley/pkg/config/meta/metadata/metadata.yaml
+++ b/galley/pkg/config/meta/metadata/metadata.yaml
@@ -127,6 +127,10 @@ collections:
   ### K8s collections ###
 
   # Built-in K8s collections
+  - name: "k8s/apps/v1/deployments"
+    proto: "k8s.io.api.apps.v1.Deployment"
+    protoPackage: "k8s.io/api/apps/v1"
+
   - name: "k8s/core/v1/endpoints"
     proto: "k8s.io.api.core.v1.Endpoints"
     protoPackage: "k8s.io/api/core/v1"
@@ -143,9 +147,9 @@ collections:
     proto: "k8s.io.api.core.v1.Pod"
     protoPackage: "k8s.io/api/core/v1"
 
-  - name: "k8s/apps/v1/deployments"
-    proto: "k8s.io.api.apps.v1.Deployment"
-    protoPackage: "k8s.io/api/apps/v1"
+  - name: "k8s/core/v1/secrets"
+    proto: "k8s.io.api.core.v1.Secret"
+    protoPackage: "k8s.io/api/core/v1"
 
   - name: "k8s/core/v1/services"
     proto: "k8s.io.api.core.v1.ServiceSpec"
@@ -306,25 +310,26 @@ snapshots:
       - "istio/networking/v1alpha3/sidecars"
       - "istio/networking/v1alpha3/virtualservices"
       - "istio/networking/v1alpha3/synthetic/serviceentries"
-      - "k8s/core/v1/namespaces"
-      - "k8s/core/v1/services"
-      - "k8s/core/v1/pods"
       - "k8s/apps/v1/deployments"
+      - "k8s/core/v1/namespaces"
+      - "k8s/core/v1/pods"
+      - "k8s/core/v1/secrets"
+      - "k8s/core/v1/services"
 
 # Configuration for input sources
 sources:
   # Kubernetes specific configuration.
   - type: kubernetes
     resources:
-    - collection: "k8s/extensions/v1beta1/ingresses"
-      kind: "Ingress"
-      plural: "ingresses"
-      group: "extensions"
-      version: "v1beta1"
+    - collection: "k8s/apps/v1/deployments"
+      kind: "Deployment"
+      plural: "Deployments"
+      group: "apps"
+      version: "v1"
 
-    - collection: "k8s/core/v1/services"
-      kind: "Service"
-      plural: "services"
+    - collection: "k8s/core/v1/endpoints"
+      kind: "Endpoints"
+      plural: "endpoints"
       version: "v1"
 
     - collection: "k8s/core/v1/namespaces"
@@ -344,16 +349,23 @@ sources:
       plural: "pods"
       version: "v1"
 
-    - collection: "k8s/apps/v1/deployments"
-      kind: "Deployment"
-      plural: "Deployments"
-      group: "apps"
+    - collection: "k8s/core/v1/secrets"
+      kind: "Secret"
+      plural: "secrets"
       version: "v1"
 
-    - collection: "k8s/core/v1/endpoints"
-      kind: "Endpoints"
-      plural: "endpoints"
+    - collection: "k8s/core/v1/services"
+      kind: "Service"
+      plural: "services"
       version: "v1"
+
+    - collection: "k8s/extensions/v1beta1/ingresses"
+      kind: "Ingress"
+      plural: "ingresses"
+      group: "extensions"
+      version: "v1beta1"
+
+
 
     - collection: "k8s/networking.istio.io/v1alpha3/virtualservices"
       kind: "VirtualService"
@@ -527,8 +539,9 @@ transforms:
       "k8s/rbac.istio.io/v1alpha1/serviceroles": "istio/rbac/v1alpha1/serviceroles"
       "k8s/security.istio.io/v1beta1/authorizationpolicies": "istio/security/v1beta1/authorizationpolicies"
       "k8s/security.istio.io/v1beta1/requestauthentications": "istio/security/v1beta1/requestauthentications"
-      "k8s/core/v1/namespaces": "k8s/core/v1/namespaces"
-      "k8s/core/v1/services": "k8s/core/v1/services"
-      "k8s/core/v1/pods": "k8s/core/v1/pods"
       "k8s/apps/v1/deployments": "k8s/apps/v1/deployments"
+      "k8s/core/v1/namespaces": "k8s/core/v1/namespaces"
+      "k8s/core/v1/pods": "k8s/core/v1/pods"
+      "k8s/core/v1/secrets": "k8s/core/v1/secrets"
+      "k8s/core/v1/services": "k8s/core/v1/services"
       "istio/mesh/v1alpha1/MeshConfig": "istio/mesh/v1alpha1/MeshConfig"

--- a/galley/pkg/config/source/kube/apiserver/source.go
+++ b/galley/pkg/config/source/kube/apiserver/source.go
@@ -198,6 +198,7 @@ func (s *Source) startWatchers() {
 		scope.Source.Infof("  Source:       %s", r.CanonicalResourceName())
 		scope.Source.Infof("  Name:  		 %s", r.Collection)
 		scope.Source.Infof("  Built-in:     %v", a.IsBuiltIn())
+		scope.Source.Infof("  Disabled:     %v", r.Disabled)
 		if !a.IsBuiltIn() {
 			scope.Source.Infof("  Found:  %v", found)
 		}

--- a/galley/pkg/config/source/kube/rt/known.go
+++ b/galley/pkg/config/source/kube/rt/known.go
@@ -159,6 +159,34 @@ func (p *Provider) initKnownAdapters() {
 			isRequiredForServiceDiscovery: true,
 		},
 
+		asTypesKey("", "Secret"): {
+			extractObject: defaultExtractObject,
+			extractResource: func(o interface{}) (proto.Message, error) {
+				if obj, ok := o.(*v1.Secret); ok {
+					return obj, nil
+				}
+				return nil, fmt.Errorf("unable to convert to v1.Secret: %T", o)
+			},
+			newInformer: func() (cache.SharedIndexInformer, error) {
+				informer, err := p.sharedInformerFactory()
+				if err != nil {
+					return nil, err
+				}
+
+				return informer.Core().V1().Secrets().Informer(), nil
+			},
+			parseJSON: func(input []byte) (interface{}, error) {
+				out := &v1.Secret{}
+				if _, _, err := deserializer.Decode(input, nil, out); err != nil {
+					return nil, err
+				}
+				return out, nil
+			},
+			getStatus: noStatus,
+			isEqual:   resourceVersionsMatch,
+			isBuiltIn: true,
+		},
+
 		asTypesKey("", "Endpoints"): {
 			extractObject: defaultExtractObject,
 			extractResource: func(o interface{}) (proto.Message, error) {

--- a/tests/integration/galley/validation_test.go
+++ b/tests/integration/galley/validation_test.go
@@ -140,13 +140,14 @@ func TestValidation(t *testing.T) {
 
 var ignoredCRDs = []string{
 	// We don't validate K8s resources
+	"/v1/Endpoints",
 	"/v1/Namespace",
 	"/v1/Node",
 	"/v1/Pod",
-	"/v1/Endpoints",
+	"/v1/Secret",
 	"/v1/Service",
-	"extensions/v1beta1/Ingress",
 	"apps/v1/Deployment",
+	"extensions/v1beta1/Ingress",
 	"networking.istio.io/v1alpha3/SyntheticServiceEntry",
 }
 


### PR DESCRIPTION
Adds an analyzer to detect if a Gateway references a Secret (via `Gateway.Server.TLSOptions.credentialName`) that doesn't exist in the correct namespace. The expected namespace is the namespace of the pod backing the Gateway, not the namespace of the Gateway CR itself. 
This fixes https://github.com/istio/istio/issues/19097

This shares a bit of workaround ugliness with the other Gateway analyzer. We should be able to fix that with https://github.com/istio/istio/issues/19579. 