### PR TITLE
Don't instruct users to delete the pod

### DIFF
--- a/galley/pkg/config/analysis/analyzers/injection/injection.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection.go
@@ -107,7 +107,7 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 		}
 
 		if proxyImage == "" {
-			c.Report(metadata.K8SCoreV1Pods, msg.NewPodMissingProxy(r, pod.Name, pod.GetNamespace()))
+			c.Report(metadata.K8SCoreV1Pods, msg.NewPodMissingProxy(r))
 		}
 
 		return true

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -27,7 +27,7 @@ var (
 
 	// PodMissingProxy defines a diag.MessageType for message "PodMissingProxy".
 	// Description: A pod is missing the Istio proxy.
-	PodMissingProxy = diag.NewMessageType(diag.Warning, "IST0103", "The pod is missing its Istio proxy. Run 'kubectl delete pod %s -n %s' to restart it")
+	PodMissingProxy = diag.NewMessageType(diag.Warning, "IST0103", "The pod is missing the Istio proxy. This can often be resolved by restarting or redeploying the workload.")
 
 	// GatewayPortNotOnWorkload defines a diag.MessageType for message "GatewayPortNotOnWorkload".
 	// Description: Unhandled gateway port
@@ -125,12 +125,10 @@ func NewNamespaceNotInjected(entry *resource.Entry, namespace string, namespace2
 }
 
 // NewPodMissingProxy returns a new diag.Message based on PodMissingProxy.
-func NewPodMissingProxy(entry *resource.Entry, pod string, namespace string) diag.Message {
+func NewPodMissingProxy(entry *resource.Entry) diag.Message {
 	return diag.NewMessage(
 		PodMissingProxy,
 		originOrNil(entry),
-		pod,
-		namespace,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -45,12 +45,8 @@ messages:
     code: IST0103
     level: Warning
     description: "A pod is missing the Istio proxy."
-    template: "The pod is missing its Istio proxy. Run 'kubectl delete pod %s -n %s' to restart it"
+    template: "The pod is missing the Istio proxy. This can often be resolved by restarting or redeploying the workload."
     args:
-      - name: pod
-        type: string
-      - name: namespace
-        type: string
 
   - name: "GatewayPortNotOnWorkload"
     code: IST0104


### PR DESCRIPTION
This could potentially be disruptful to the user's application (and in fact, on the docs site we instruct users to use kubectl deploy restart instead).