### PR TITLE
Fix segfaults: unaligned atomics on 32bit architectures

### DIFF
--- a/galley/pkg/config/processing/snapshotter/snapshotter.go
+++ b/galley/pkg/config/processing/snapshotter/snapshotter.go
@@ -30,6 +30,15 @@ import (
 
 // Snapshotter is a processor that handles input events and creates snapshotImpl collections.
 type Snapshotter struct {
+	// pendingEvents must be at start of struct to ensure 64bit alignment for atomics on
+	// 32bit architectures. See also: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+
+	// pendingEvents counts the number of events awaiting publishing.
+	pendingEvents int64
+
+	// lastSnapshotTime records the last time a snapshotImpl was published.
+	lastSnapshotTime atomic.Value
+
 	accumulators   map[collection.Name]*accumulator
 	selector       event.Router
 	xforms         []event.Transformer
@@ -38,12 +47,6 @@ type Snapshotter struct {
 
 	// lastEventTime records the last time an event was received.
 	lastEventTime time.Time
-
-	// pendingEvents counts the number of events awaiting publishing.
-	pendingEvents int64
-
-	// lastSnapshotTime records the last time a snapshotImpl was published.
-	lastSnapshotTime atomic.Value
 }
 
 var _ event.Processor = &Snapshotter{}

--- a/pkg/mcp/source/source.go
+++ b/pkg/mcp/source/source.go
@@ -126,11 +126,13 @@ type Stream interface {
 // Source implements the resource source message exchange for MCP.
 // It can be instantiated by client and server
 type Source struct {
+	// nextStreamID and connections must be at start of struct to ensure 64bit alignment for atomics on
+	// 32bit architectures. See also: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	nextStreamID   int64
+	connections    int64
 	watcher        Watcher
 	collections    []CollectionOptions
-	nextStreamID   int64
 	reporter       monitoring.Reporter
-	connections    int64
 	requestLimiter rate.LimitFactory
 }
 


### PR DESCRIPTION
I recently compiled istio (including envoy) for arm, specifically for the Raspberry Pi.

cross compiled using go version `go1.13.4 linux/amd64`

Per the [atomic library docs](https://golang.org/pkg/sync/atomic/#pkg-note-BUG):

> On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned. 

Running istio on the Raspberry Pi I (so far) noticed three reproduciable segfaults (all of them in galley):

```
2019-12-13T10:47:02.006773Z	info	source	CRD Discovery complete, starting listening to resources...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11e34]

goroutine 111 [running]:
runtime/internal/atomic.goXadd64(0x45b2164, 0x1, 0x0, 0x0, 0x2b54118)
	runtime/internal/atomic/atomic_arm.go:103 +0x1c
istio.io/istio/galley/pkg/config/processing/snapshotter.(*Snapshotter).Handle(0x45b2120, 0x1, 0x186b96c, 0x1e, 0x459e3c0)
	istio.io/istio@/galley/pkg/config/processing/snapshotter/snapshotter.go:247 +0xa4
istio.io/istio/galley/pkg/config/event.(*Buffer).Process(0x44786c0)
	istio.io/istio@/galley/pkg/config/event/buffer.go:105 +0xcc
created by istio.io/istio/galley/pkg/config/processing.(*session).startProcessing
	istio.io/istio@/galley/pkg/config/processing/session.go:216 +0x238
```

```
2019-12-13T11:25:58.578517Z	info	validation	istio-galley validatingwebhookconfiguration updated
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11e34]

goroutine 520 [running]:
runtime/internal/atomic.goXadd64(0x51eea14, 0x1, 0x0, 0x14f2ff0, 0x532eca0)
	runtime/internal/atomic/atomic_arm.go:103 +0x1c
istio.io/istio/pkg/mcp/source.(*Source).newConnection(0x51eea00, 0x66b53918, 0x4c9aae0, 0x1)
	istio.io/istio@/pkg/mcp/source/source.go:197 +0xd4
istio.io/istio/pkg/mcp/source.(*Source).ProcessStream(0x51eea00, 0x66b53918, 0x4c9aae0, 0x0, 0x0)
	istio.io/istio@/pkg/mcp/source/source.go:222 +0x40
istio.io/istio/pkg/mcp/source.(*Server).EstablishResourceStream(0x5172480, 0x1bc40d0, 0x4c9aae0, 0x1b8c198, 0x5172480)
	istio.io/istio@/pkg/mcp/source/server_source.go:94 +0x180
istio.io/api/mcp/v1alpha1._ResourceSource_EstablishResourceStream_Handler(0x15d30f0, 0x5172480, 0x1bbebf8, 0x52b56c0, 0x2b64880, 0x4ca2a20)
	istio.io/api@v0.0.0-20191120195622-f0abe0c81e59/mcp/v1alpha1/mcp.pb.go:1355 +0x8c
google.golang.org/grpc.(*Server).processStreamingRPC(0x51fc0f0, 0x1bc6468, 0x52a60f0, 0x4ca2a20, 0x5172540, 0x2b3e9d0, 0x0, 0x0, 0x0)
	google.golang.org/grpc@v1.25.1/server.go:1211 +0x88c
google.golang.org/grpc.(*Server).handleStream(0x51fc0f0, 0x1bc6468, 0x52a60f0, 0x4ca2a20, 0x0)
	google.golang.org/grpc@v1.25.1/server.go:1291 +0xabc
google.golang.org/grpc.(*Server).serveStreams.func1.1(0x5267830, 0x51fc0f0, 0x1bc6468, 0x52a60f0, 0x4ca2a20)
	google.golang.org/grpc@v1.25.1/server.go:722 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.25.1/server.go:720 +0x7c
```

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11e34]

goroutine 724 [running]:
runtime/internal/atomic.goXadd64(0x36a0564, 0x1, 0x0, 0x14, 0x3dfb27c)
	runtime/internal/atomic/atomic_arm.go:103 +0x1c
istio.io/istio/pkg/mcp/source.(*Source).newConnection(0x36a0540, 0x66c29820, 0x37feea8, 0xc)
	istio.io/istio@/pkg/mcp/source/source.go:214 +0x4c4
istio.io/istio/pkg/mcp/source.(*Source).ProcessStream(0x36a0540, 0x66c29820, 0x37feea8, 0x0, 0x0)
	istio.io/istio@/pkg/mcp/source/source.go:222 +0x40
istio.io/istio/pkg/mcp/source.(*Server).EstablishResourceStream(0x34a0da0, 0x1bc40d0, 0x37feea8, 0x1b8c198, 0x34a0da0)
	istio.io/istio@/pkg/mcp/source/server_source.go:94 +0x180
istio.io/api/mcp/v1alpha1._ResourceSource_EstablishResourceStream_Handler(0x15d30f0, 0x34a0da0, 0x1bbebf8, 0x3b322a0, 0x2b64880, 0x3724cf0)
	istio.io/api@v0.0.0-20191120195622-f0abe0c81e59/mcp/v1alpha1/mcp.pb.go:1355 +0x8c
google.golang.org/grpc.(*Server).processStreamingRPC(0x36881e0, 0x1bc6468, 0x3abe0f0, 0x3724cf0, 0x34a0ea0, 0x2b3e9d0, 0x0, 0x0, 0x0)
	google.golang.org/grpc@v1.25.1/server.go:1211 +0x88c
google.golang.org/grpc.(*Server).handleStream(0x36881e0, 0x1bc6468, 0x3abe0f0, 0x3724cf0, 0x0)
	google.golang.org/grpc@v1.25.1/server.go:1291 +0xabc
google.golang.org/grpc.(*Server).serveStreams.func1.1(0x3acbae0, 0x36881e0, 0x1bc6468, 0x3abe0f0, 0x3724cf0)
	google.golang.org/grpc@v1.25.1/server.go:722 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.25.1/server.go:720 +0x7c
```

All three seem to be caused by misalignment. Moving the fields in question to the beginning of the enclosing structs (so they are properly aligned), seems to fix the problem.
