### PR TITLE
New MCP->Handler adapter in Galley

### DIFF
--- a/galley/pkg/config/source/mcp/cache.go
+++ b/galley/pkg/config/source/mcp/cache.go
@@ -1,0 +1,217 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"fmt"
+	"sync"
+
+	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/scope"
+	"istio.io/istio/pkg/mcp/sink"
+)
+
+var _ event.Source = &cache{}
+
+// cache is an in-memory cache for a single collection.
+type cache struct {
+	mu                 sync.RWMutex
+	collection         collection.Name
+	handler            event.Handler
+	resources          map[resource.Name]*resource.Entry
+	synced             bool
+	started            bool
+	fullUpdateReceived bool
+}
+
+func newCache(c collection.Name) *cache {
+	scope.Source.Debuga("  Creating mcp cache for collection: ", c)
+
+	return &cache{
+		collection: c,
+		resources:  make(map[resource.Name]*resource.Entry),
+	}
+}
+
+func (c *cache) apply(change *sink.Change) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Make sure the event is for this collection. This will always be the case in practice.
+	if c.collection.String() != change.Collection {
+		return fmt.Errorf("failed applying change for unexpected collection (%v)", change.Collection)
+	}
+
+	if change.Incremental {
+		return c.applyIncremental(change)
+	}
+	return c.applyFull(change)
+}
+
+func (c *cache) applyFull(change *sink.Change) error {
+	// For full updates, save off the old resources and clear out the map.
+	oldResources := c.resources
+	c.resources = make(map[resource.Name]*resource.Entry)
+	c.fullUpdateReceived = true
+
+	// Add/update resources.
+	for _, obj := range change.Objects {
+		e, err := deserializeEntry(obj)
+		if err != nil {
+			return fmt.Errorf("failed parsing entry for collection (%v): %v", c.collection, err)
+		}
+
+		// Notify the handler if we've already synced.
+		if c.synced {
+			if _, ok := oldResources[e.Metadata.Name]; ok {
+				c.dispatchFor(e, event.Updated)
+				delete(oldResources, e.Metadata.Name)
+			} else {
+				c.dispatchFor(e, event.Added)
+			}
+		}
+
+		c.resources[e.Metadata.Name] = e
+	}
+
+	if c.synced {
+		// Send Delete events for all remaining resources in oldResources
+		for _, removed := range oldResources {
+			c.dispatchFor(removed, event.Deleted)
+		}
+	}
+
+	// Sync if necessary.
+	c.sync()
+
+	return nil
+}
+
+func (c *cache) applyIncremental(change *sink.Change) error {
+	if !c.synced {
+		return fmt.Errorf("mcp: incremental change received before full for collection (%v)", change.Collection)
+	}
+
+	// Add/update resources.
+	for _, obj := range change.Objects {
+		e, err := deserializeEntry(obj)
+		if err != nil {
+			return fmt.Errorf("failed parsing entry for collection (%v): %v", c.collection, err)
+		}
+
+		// Notify the handler if we've already synced.
+		if c.synced {
+			if _, ok := c.resources[e.Metadata.Name]; ok {
+				c.dispatchFor(e, event.Updated)
+			} else {
+				c.dispatchFor(e, event.Added)
+			}
+		}
+
+		c.resources[e.Metadata.Name] = e
+	}
+
+	// Remove resources.
+	for _, removed := range change.Removed {
+		name, err := resource.NewFullName(removed)
+		if err != nil {
+			return fmt.Errorf("failed removing resource due to parsing error: %v", err)
+		}
+
+		if e, ok := c.resources[name]; ok {
+			if c.synced {
+				c.dispatchFor(e, event.Deleted)
+			}
+			delete(c.resources, name)
+		} else {
+			return fmt.Errorf("incremental update attempting to delete missing resource (%v)", name)
+		}
+	}
+
+	return nil
+}
+
+// Start dispatching events for the collection.
+func (c *cache) Start() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.started = true
+	c.sync()
+}
+
+// Stop dispatching events and reset internal state.
+func (c *cache) Stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.started = false
+	c.fullUpdateReceived = false
+	c.synced = false
+}
+
+// Dispatch an event handler to receive resource events.
+func (c *cache) Dispatch(handler event.Handler) {
+	if scope.Source.DebugEnabled() {
+		scope.Source.Debugf("cache.Dispatch: (collection: %-50v, handler: %T)", c.collection, handler)
+	}
+
+	c.handler = event.CombineHandlers(c.handler, handler)
+}
+
+func (c *cache) sync() {
+	if c.synced || !c.started || !c.fullUpdateReceived {
+		return
+	}
+	c.synced = true
+
+	for _, e := range c.resources {
+		c.dispatchFor(e, event.Added)
+	}
+
+	c.dispatchEvent(event.FullSyncFor(c.collection))
+}
+
+func (c *cache) dispatchEvent(e event.Event) {
+	if scope.Source.DebugEnabled() {
+		scope.Source.Debugf(">>> cache.dispatchEvent: (col: %-50s): %v", c.collection, e)
+	}
+	if c.handler != nil {
+		c.handler.Handle(e)
+	}
+}
+
+func (c *cache) dispatchFor(entry *resource.Entry, kind event.Kind) {
+	e := event.Event{
+		Source: c.collection,
+		Entry:  entry,
+		Kind:   kind,
+	}
+	c.dispatchEvent(e)
+}
+
+func deserializeEntry(obj *sink.Object) (*resource.Entry, error) {
+	metadata, err := resource.DeserializeMetadata(obj.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	return &resource.Entry{
+		Metadata: metadata,
+		Item:     obj.Body,
+		Origin:   defaultOrigin,
+	}, nil
+}

--- a/galley/pkg/config/source/mcp/cache_test.go
+++ b/galley/pkg/config/source/mcp/cache_test.go
@@ -1,0 +1,443 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/proto"
+
+	mcp "istio.io/api/mcp/v1alpha1"
+	"istio.io/api/networking/v1alpha3"
+
+	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/pkg/mcp/sink"
+)
+
+var (
+	colName   = name("ns/mycol")
+	eventTime = time.Now().UTC()
+	fullSync  = output{
+		kind: event.FullSync,
+	}
+)
+
+func TestWrongCollectionShouldFail(t *testing.T) {
+	c := newCacheHelper()
+	c.applyExpectError(t, change{
+		collection: "ns/wrong",
+	})
+}
+
+func TestEventsBeforeStart(t *testing.T) {
+	c := newCacheHelper()
+
+	// Add r1
+	c.applyExpectNoError(t, change{
+		input: []input{
+			{
+				name: "ns/r1",
+				body: &v1alpha3.Gateway{},
+			},
+		}})
+	c.expectNoEvents(t)
+
+	// Add r2, Update r1
+	c.applyExpectNoError(t, change{
+		input: []input{
+			{
+				name: "ns/r1",
+				body: &v1alpha3.Gateway{},
+			},
+			{
+				name: "ns/r2",
+				body: &v1alpha3.Gateway{},
+			},
+		}})
+	c.expectNoEvents(t)
+
+	// Delete r2
+	c.applyExpectNoError(t, change{
+		input: []input{
+			{
+				name: "ns/r1",
+				body: &v1alpha3.Gateway{},
+			},
+		}})
+	c.expectNoEvents(t)
+
+	c.Start()
+	defer c.Stop()
+
+	c.expect(t,
+		output{
+			kind: event.Added,
+			name: "ns/r1",
+			body: &v1alpha3.Gateway{},
+		},
+		fullSync)
+}
+
+func TestStartBeforeEvents(t *testing.T) {
+	c := newCacheHelper()
+	c.Start()
+	defer c.Stop()
+
+	c.expectNoEvents(t)
+}
+
+func TestEmptyUpdateShouldSendFullSync(t *testing.T) {
+	c := newCacheHelper()
+	c.Start()
+	defer c.Stop()
+
+	c.applyExpectNoError(t, change{})
+	c.expect(t, fullSync)
+}
+
+func TestIncrementalUpdateBeforeFullShouldFail(t *testing.T) {
+	c := newCacheHelper()
+	c.Start()
+	defer c.Stop()
+
+	c.applyExpectError(t, change{incremental: true})
+}
+
+func TestIncremental(t *testing.T) {
+	c := newCacheHelper()
+
+	// Start it and apply an initial empty update.
+	c.Start()
+	defer c.Stop()
+	c.applyExpectNoError(t, change{})
+	c.expect(t, fullSync)
+
+	// Add r1, r2
+	c.applyExpectNoError(t, change{
+		incremental: true,
+		input: inputList{
+			{
+				name: "ns/r1",
+				body: &v1alpha3.Gateway{},
+			},
+			{
+				name: "ns/r2",
+				body: &v1alpha3.Gateway{},
+			},
+		},
+	})
+	c.expect(t,
+		output{
+			kind: event.Added,
+			name: "ns/r1",
+			body: &v1alpha3.Gateway{},
+		},
+		output{
+			kind: event.Added,
+			name: "ns/r2",
+			body: &v1alpha3.Gateway{},
+		})
+
+	// Delete r1, Update r2, delete r3
+	c.applyExpectNoError(t, change{
+		incremental: true,
+		removed:     []string{"ns/r1"},
+		input: inputList{
+			{
+				name: "ns/r2",
+				body: &v1alpha3.Gateway{},
+			},
+			{
+				name: "ns/r3",
+				body: &v1alpha3.Gateway{},
+			},
+		},
+	})
+	c.expect(t,
+		output{
+			kind: event.Deleted,
+			name: "ns/r1",
+			body: &v1alpha3.Gateway{},
+		},
+		output{
+			kind: event.Updated,
+			name: "ns/r2",
+			body: &v1alpha3.Gateway{},
+		},
+		output{
+			kind: event.Added,
+			name: "ns/r3",
+			body: &v1alpha3.Gateway{},
+		})
+}
+
+func TestIncrementalDeleteMissingResourceShouldFail(t *testing.T) {
+	c := newCacheHelper()
+
+	// Start it and apply an initial empty update.
+	c.Start()
+	defer c.Stop()
+	c.applyExpectNoError(t, change{})
+	c.expect(t, fullSync)
+
+	// Delete non-existent resource.
+	c.applyExpectError(t, change{
+		incremental: true,
+		removed:     []string{"ns/r1"},
+	})
+}
+
+func TestFullUpdate(t *testing.T) {
+	c := newCacheHelper()
+
+	// Start it and apply an initial empty update.
+	c.Start()
+	c.applyExpectNoError(t, change{})
+	c.expect(t, fullSync)
+
+	// Add r1, r2
+	c.applyExpectNoError(t, change{
+		input: inputList{
+			{
+				name: "ns/r1",
+				body: &v1alpha3.Gateway{},
+			},
+			{
+				name: "ns/r2",
+				body: &v1alpha3.Gateway{},
+			},
+		},
+	})
+	c.expect(t,
+		output{
+			kind: event.Added,
+			name: "ns/r1",
+			body: &v1alpha3.Gateway{},
+		},
+		output{
+			kind: event.Added,
+			name: "ns/r2",
+			body: &v1alpha3.Gateway{},
+		})
+
+	// Delete r1, Update r2, add r3
+	c.applyExpectNoError(t, change{
+		input: inputList{
+			{
+				name: "ns/r2",
+				body: &v1alpha3.Gateway{},
+			},
+			{
+				name: "ns/r3",
+				body: &v1alpha3.Gateway{},
+			},
+		},
+	})
+	c.expect(t,
+		output{
+			kind: event.Deleted,
+			name: "ns/r1",
+			body: &v1alpha3.Gateway{},
+		},
+		output{
+			kind: event.Updated,
+			name: "ns/r2",
+			body: &v1alpha3.Gateway{},
+		},
+		output{
+			kind: event.Added,
+			name: "ns/r3",
+			body: &v1alpha3.Gateway{},
+		})
+}
+
+func name(n string) collection.Name {
+	return collection.NewName(n)
+}
+
+type cacheHelper struct {
+	*cache
+
+	events []event.Event
+}
+
+func newCacheHelper() *cacheHelper {
+	c := &cacheHelper{
+		cache: newCache(colName),
+	}
+	c.Dispatch(event.HandlerFromFn(func(e event.Event) {
+		c.events = append(c.events, e)
+	}))
+	return c
+}
+
+func (c *cacheHelper) applyExpectNoError(t *testing.T, ch change) {
+	t.Helper()
+
+	// Clear any previous events.
+	c.clearEvents()
+
+	if err := c.apply(ch.toMCP()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (c *cacheHelper) applyExpectError(t *testing.T, ch change) {
+	t.Helper()
+
+	// Clear any previous events.
+	c.clearEvents()
+
+	if err := c.apply(ch.toMCP()); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func (c *cacheHelper) expect(t *testing.T, expectedOutput ...output) {
+	t.Helper()
+	if len(c.events) != len(expectedOutput) {
+		t.Fatalf("expected num events %d to be %d", len(c.events), len(expectedOutput))
+	}
+
+	// Convert the output to events.
+	expectedEvents := outputList(expectedOutput).toEvents()
+
+	sortEvents(c.events)
+	sortEvents(expectedEvents)
+
+	for i, actual := range c.events {
+		expected := expectedEvents[i]
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("expected:\n%v\nto equal:\n%v", actual, expected)
+		}
+	}
+}
+
+func (c *cacheHelper) expectNoEvents(t *testing.T) {
+	t.Helper()
+	c.expect(t)
+}
+
+func (c *cacheHelper) clearEvents() {
+	c.events = c.events[:0]
+}
+
+func sortEvents(events []event.Event) {
+	sort.SliceStable(events, func(i, j int) bool {
+		return strings.Compare(resourceName(events[i]), resourceName(events[j])) < 0
+	})
+}
+
+func resourceName(e event.Event) string {
+	if e.Entry == nil {
+		return ""
+	}
+	return e.Entry.Metadata.Name.String()
+}
+
+func protoTime(t time.Time) *types.Timestamp {
+	out, _ := types.TimestampProto(t)
+	return out
+}
+
+type change struct {
+	incremental bool
+	input       inputList
+	removed     []string
+	collection  string
+}
+
+func (c change) toMCP() *sink.Change {
+	col := c.collection
+	if col == "" {
+		col = colName.String()
+	}
+	return &sink.Change{
+		Incremental: c.incremental,
+		Collection:  col,
+		Objects:     c.input.toObjects(),
+		Removed:     c.removed,
+	}
+}
+
+type inputList []input
+
+func (l inputList) toObjects() []*sink.Object {
+	out := make([]*sink.Object, 0, len(l))
+	for _, in := range l {
+		out = append(out, in.toObject())
+	}
+	return out
+}
+
+type input struct {
+	name string
+	body proto.Message
+}
+
+func (i input) toObject() *sink.Object {
+	return &sink.Object{
+		Metadata: &mcp.Metadata{
+			Name:       i.name,
+			CreateTime: protoTime(eventTime),
+			Version:    "v1",
+		},
+		Body: i.body,
+	}
+}
+
+type outputList []output
+
+func (l outputList) toEvents() []event.Event {
+	events := make([]event.Event, 0, len(l))
+	for _, o := range l {
+		events = append(events, o.toEvent())
+	}
+	return events
+}
+
+type output struct {
+	kind event.Kind
+	name string
+	body proto.Message
+}
+
+func (e output) toEvent() event.Event {
+	if e.kind == event.FullSync {
+		return event.FullSyncFor(colName)
+	}
+
+	fullName, _ := resource.NewFullName(e.name)
+	return event.Event{
+		Kind:   e.kind,
+		Source: colName,
+		Entry: &resource.Entry{
+			Metadata: resource.Metadata{
+				Name:       fullName,
+				CreateTime: eventTime,
+				Version:    "v1",
+			},
+			Item:   e.body,
+			Origin: defaultOrigin,
+		},
+	}
+}

--- a/galley/pkg/config/source/mcp/origin.go
+++ b/galley/pkg/config/source/mcp/origin.go
@@ -1,0 +1,35 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"istio.io/istio/galley/pkg/config/resource"
+)
+
+const (
+	defaultOrigin = origin("mcp")
+)
+
+var _ resource.Origin = defaultOrigin
+
+type origin string
+
+func (o origin) FriendlyName() string {
+	return string(o)
+}
+
+func (o origin) Namespace() string {
+	return ""
+}

--- a/galley/pkg/config/source/mcp/origin_test.go
+++ b/galley/pkg/config/source/mcp/origin_test.go
@@ -1,0 +1,31 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/galley/pkg/config/resource"
+)
+
+func TestOrigin(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	o := resource.Origin(origin("hello"))
+	g.Expect(o.Namespace()).Should(Equal(""))
+	g.Expect(o.FriendlyName()).Should(Equal("hello"))
+}

--- a/galley/pkg/config/source/mcp/source.go
+++ b/galley/pkg/config/source/mcp/source.go
@@ -1,0 +1,69 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"fmt"
+
+	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/pkg/mcp/sink"
+)
+
+var _ event.Source = &Source{}
+var _ sink.Updater = &Source{}
+
+// Source for events from an MCP endpoint.
+type Source struct {
+	caches map[string]*cache
+}
+
+// NewSource creates a new MCP event Source.
+func NewSource(collections collection.Names) *Source {
+	caches := make(map[string]*cache, len(collections))
+	for _, c := range collections {
+		caches[c.String()] = newCache(c)
+	}
+
+	return &Source{
+		caches: caches,
+	}
+}
+
+func (s Source) Apply(change *sink.Change) error {
+	c := s.caches[change.Collection]
+	if c == nil {
+		return fmt.Errorf("failed applying change for unknown collection (%v)", change.Collection)
+	}
+	return c.apply(change)
+}
+
+func (s Source) Dispatch(handler event.Handler) {
+	for _, c := range s.caches {
+		c.Dispatch(handler)
+	}
+}
+
+func (s Source) Start() {
+	for _, c := range s.caches {
+		c.Start()
+	}
+}
+
+func (s Source) Stop() {
+	for _, c := range s.caches {
+		c.Stop()
+	}
+}

--- a/galley/pkg/config/source/mcp/source_test.go
+++ b/galley/pkg/config/source/mcp/source_test.go
@@ -1,0 +1,58 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/pkg/mcp/sink"
+)
+
+func TestApplyUnknownCollection(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := NewSource(collection.Names{})
+	s.Start()
+	defer s.Stop()
+
+	err := s.Apply(&sink.Change{
+		Collection: "ns/unknown",
+	})
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestApply(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := NewSource(collection.Names{colName})
+	s.Start()
+	defer s.Stop()
+
+	var events []event.Event
+	s.Dispatch(event.HandlerFromFn(func(e event.Event) {
+		events = append(events, e)
+	}))
+
+	err := s.Apply(&sink.Change{
+		Collection: colName.String(),
+	})
+	g.Expect(err).To(BeNil())
+	g.Expect(len(events)).To(Equal(1))
+	g.Expect(events[0]).To(Equal(event.FullSyncFor(colName)))
+}


### PR DESCRIPTION
This is in preparation of refactoring of the coredatamodel for better performance with istiod.

 With this in place we can shim around the coredatamodel so that we can easily slip out MCP and use direct in-memory events in Pilot.