### PR TITLE
Moving coredatamodel classes to serviceregistry

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -33,12 +33,12 @@ import (
 	"istio.io/pkg/log"
 
 	configaggregate "istio.io/istio/pilot/pkg/config/aggregate"
-	"istio.io/istio/pilot/pkg/config/coredatamodel"
 	"istio.io/istio/pilot/pkg/config/kube/crd/controller"
 	"istio.io/istio/pilot/pkg/config/kube/ingress"
 	"istio.io/istio/pilot/pkg/config/memory"
 	configmonitor "istio.io/istio/pilot/pkg/config/monitor"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schemas"
 	configz "istio.io/istio/pkg/mcp/configz/client"
@@ -122,7 +122,7 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 	var conns []*grpc.ClientConn
 	var configStores []model.ConfigStoreCache
 
-	s.mcpOptions = &coredatamodel.Options{
+	s.mcpOptions = &mcp.Options{
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 		ConfigLedger: buildLedger(args.Config),
 		XDSUpdater:   s.EnvoyXdsServer,
@@ -296,7 +296,7 @@ func (s *Server) mcpController(
 		collections = append(collections, sink.CollectionOptions{Name: c.Collection, Incremental: false})
 	}
 
-	mcpController := coredatamodel.NewController(s.mcpOptions)
+	mcpController := mcp.NewController(s.mcpOptions)
 	sinkOptions := &sink.Options{
 		CollectionOptions: collections,
 		Updater:           mcpController,
@@ -317,17 +317,17 @@ func (s *Server) sseMCPController(args *PilotArgs,
 	clients *[]*sink.Client,
 	configStores *[]model.ConfigStoreCache) {
 	clientNodeID := "SSEMCP"
-	s.incrementalMcpOptions = &coredatamodel.Options{
+	s.incrementalMcpOptions = &mcp.Options{
 		ClusterID:    s.clusterID,
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 		XDSUpdater:   s.EnvoyXdsServer,
 	}
-	ctl := coredatamodel.NewSyntheticServiceEntryController(s.incrementalMcpOptions)
-	s.discoveryOptions = &coredatamodel.DiscoveryOptions{
+	ctl := mcp.NewSyntheticServiceEntryController(s.incrementalMcpOptions)
+	s.discoveryOptions = &mcp.DiscoveryOptions{
 		ClusterID:    s.clusterID,
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 	}
-	s.mcpDiscovery = coredatamodel.NewMCPDiscovery(ctl, s.discoveryOptions)
+	s.mcpDiscovery = mcp.NewDiscovery(ctl, s.discoveryOptions)
 	incrementalSinkOptions := &sink.Options{
 		CollectionOptions: []sink.CollectionOptions{
 			{

--- a/pilot/pkg/bootstrap/multicluster.go
+++ b/pilot/pkg/bootstrap/multicluster.go
@@ -15,7 +15,8 @@
 package bootstrap
 
 import (
-	"istio.io/istio/pilot/pkg/config/clusterregistry"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+
 	"istio.io/pkg/log"
 )
 
@@ -23,7 +24,7 @@ import (
 // clusters and initialize the multicluster structures.
 func (s *Server) initClusterRegistries(args *PilotArgs) (err error) {
 	if hasKubeRegistry(args.Service.Registries) {
-		mc, err := clusterregistry.NewMulticluster(s.kubeClient,
+		mc, err := controller.NewMulticluster(s.kubeClient,
 			args.Config.ClusterRegistriesNamespace,
 			args.Config.ControllerOptions.WatchedNamespace,
 			args.Config.ControllerOptions.DomainSuffix,

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -33,6 +33,7 @@ import (
 
 	"istio.io/istio/galley/pkg/server"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
 
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -54,8 +55,6 @@ import (
 	"istio.io/pkg/log"
 	"istio.io/pkg/version"
 
-	"istio.io/istio/pilot/pkg/config/clusterregistry"
-	"istio.io/istio/pilot/pkg/config/coredatamodel"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
@@ -122,7 +121,7 @@ type Server struct {
 	configController      model.ConfigStoreCache
 	kubeClient            kubernetes.Interface
 	startFuncs            []startFunc
-	multicluster          *clusterregistry.Multicluster
+	multicluster          *kubecontroller.Multicluster
 	httpServer            *http.Server
 	grpcServer            *grpc.Server
 	secureHTTPServer      *http.Server
@@ -131,10 +130,10 @@ type Server struct {
 	secureGRPCServerDNS   *grpc.Server
 	mux                   *http.ServeMux
 	kubeRegistry          *kubecontroller.Controller
-	mcpDiscovery          *coredatamodel.MCPDiscovery
-	discoveryOptions      *coredatamodel.DiscoveryOptions
-	incrementalMcpOptions *coredatamodel.Options
-	mcpOptions            *coredatamodel.Options
+	mcpDiscovery          *mcp.Discovery
+	discoveryOptions      *mcp.DiscoveryOptions
+	incrementalMcpOptions *mcp.Options
+	mcpOptions            *mcp.Options
 	certController        *chiron.WebhookController
 	kubeRestConfig        *rest.Config
 

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package clusterregistry
+package controller
 
 import (
 	"sync"
@@ -24,14 +24,13 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
-	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/kube/secretcontroller"
 )
 
 type kubeController struct {
-	rc     *controller.Controller
+	rc     *Controller
 	stopCh chan struct{}
 }
 
@@ -86,7 +85,7 @@ func (m *Multicluster) AddMemberCluster(clientset kubernetes.Interface, clusterI
 	var remoteKubeController kubeController
 	remoteKubeController.stopCh = stopCh
 	m.m.Lock()
-	kubectl := controller.NewController(clientset, controller.Options{
+	kubectl := NewController(clientset, Options{
 		WatchedNamespace: m.WatchedNamespace,
 		ResyncPeriod:     m.ResyncPeriod,
 		DomainSuffix:     m.DomainSuffix,

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package clusterregistry
+package controller
 
 import (
 	"os"

--- a/pilot/pkg/serviceregistry/mcp/controller_test.go
+++ b/pilot/pkg/serviceregistry/mcp/controller_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package coredatamodel_test
+package mcp_test
 
 import (
 	"fmt"
@@ -28,8 +28,8 @@ import (
 	mcpapi "istio.io/api/mcp/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 
-	"istio.io/istio/pilot/pkg/config/coredatamodel"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
 	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/mcp/sink"
 )
@@ -178,7 +178,7 @@ var (
 		},
 	}
 
-	testControllerOptions = &coredatamodel.Options{
+	testControllerOptions = &mcp.Options{
 		DomainSuffix: "cluster.local",
 		ConfigLedger: &model.DisabledLedger{},
 	}
@@ -187,7 +187,7 @@ var (
 func TestOptions(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g,
 		schemas.ServiceEntry.MessageName,
@@ -210,14 +210,14 @@ func TestOptions(t *testing.T) {
 
 func TestHasSynced(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	g.Expect(controller.HasSynced()).To(gomega.BeFalse())
 }
 
 func TestConfigDescriptor(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 	descriptors := controller.ConfigDescriptor()
 	for _, descriptor := range descriptors {
 		g.Expect(descriptor.Collection).ToNot(gomega.Equal(schemas.SyntheticServiceEntry.Collection))
@@ -226,7 +226,7 @@ func TestConfigDescriptor(t *testing.T) {
 
 func TestListInvalidType(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	c, err := controller.List("bad-type", "some-phony-name-space.com")
 	g.Expect(c).To(gomega.BeNil())
@@ -236,7 +236,7 @@ func TestListInvalidType(t *testing.T) {
 
 func TestListCorrectTypeNoData(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	c, err := controller.List("virtual-service", "some-phony-name-space.com")
 	g.Expect(c).To(gomega.BeNil())
@@ -248,7 +248,7 @@ func TestListAllNameSpace(t *testing.T) {
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	messages := convertToResources(g,
 		schemas.Gateway.MessageName,
@@ -286,7 +286,7 @@ func TestListAllNameSpace(t *testing.T) {
 
 func TestListSpecificNameSpace(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	messages := convertToResources(g,
 		schemas.Gateway.MessageName,
@@ -321,7 +321,7 @@ func TestListSpecificNameSpace(t *testing.T) {
 
 func TestApplyInvalidType(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g,
 		schemas.Gateway.MessageName,
@@ -339,9 +339,9 @@ func TestApplyInvalidType(t *testing.T) {
 
 func TestApplyValidTypeWithNoNamespace(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
-	var createAndCheckGateway = func(g *gomega.GomegaWithT, controller coredatamodel.CoreDataModel, port uint32) {
+	var createAndCheckGateway = func(g *gomega.GomegaWithT, controller mcp.Controller, port uint32) {
 		gateway := &networking.Gateway{
 			Servers: []*networking.Server{
 				{
@@ -382,7 +382,7 @@ func TestApplyValidTypeWithNoNamespace(t *testing.T) {
 
 func TestApplyMetadataNameIncludesNamespace(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g,
 		schemas.Gateway.MessageName,
@@ -406,7 +406,7 @@ func TestApplyMetadataNameIncludesNamespace(t *testing.T) {
 
 func TestApplyMetadataNameWithoutNamespace(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g,
 		schemas.Gateway.MessageName,
@@ -433,7 +433,7 @@ func TestApplyChangeNoObjects(t *testing.T) {
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g,
 		schemas.Gateway.MessageName,
@@ -470,7 +470,7 @@ func TestApplyConfigUpdate(t *testing.T) {
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g,
 		schemas.Gateway.MessageName,
@@ -490,7 +490,7 @@ func TestApplyConfigUpdate(t *testing.T) {
 
 func TestApplyClusterScopedAuthPolicy(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	message0 := convertToResource(g,
 		schemas.AuthenticationPolicy.MessageName,
@@ -582,7 +582,7 @@ func TestApplyClusterScopedAuthPolicy(t *testing.T) {
 
 func TestInvalidResource(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	gw := proto.Clone(gateway).(*networking.Gateway)
 	gw.Servers[0].Hosts = nil
@@ -605,7 +605,7 @@ func TestInvalidResource(t *testing.T) {
 
 func TestInvalidResource_BadTimestamp(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g, schemas.Gateway.MessageName, gateway)
 	change := convertToChange(
@@ -628,7 +628,7 @@ func TestInvalidResource_BadTimestamp(t *testing.T) {
 }
 
 func TestEventHandler(t *testing.T) {
-	controller := coredatamodel.NewController(testControllerOptions)
+	controller := mcp.NewController(testControllerOptions)
 
 	makeName := func(namespace, name string) string {
 		return namespace + "/" + name

--- a/pilot/pkg/serviceregistry/mcp/discovery_test.go
+++ b/pilot/pkg/serviceregistry/mcp/discovery_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package coredatamodel_test
+package mcp_test
 
 import (
 	"fmt"
@@ -24,8 +24,8 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 
-	"istio.io/istio/pilot/pkg/config/coredatamodel"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	d          *coredatamodel.MCPDiscovery
-	controller coredatamodel.CoreDataModel
+	d          *mcp.Discovery
+	controller mcp.Controller
 	fx         *FakeXdsUpdater
 	namespace  = "random-namespace"
 	name       = "test-synthetic-se"
@@ -570,12 +570,12 @@ func initDiscovery() {
 	fx = NewFakeXDS()
 	fx.EDSErr <- nil
 	testControllerOptions.XDSUpdater = fx
-	controller = coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
-	options := &coredatamodel.DiscoveryOptions{
+	controller = mcp.NewSyntheticServiceEntryController(testControllerOptions)
+	options := &mcp.DiscoveryOptions{
 		ClusterID:    "test",
 		DomainSuffix: "cluster.local",
 	}
-	d = coredatamodel.NewMCPDiscovery(controller, options)
+	d = mcp.NewDiscovery(controller, options)
 }
 
 func testSetup(g *gomega.GomegaWithT) {

--- a/pilot/pkg/serviceregistry/mcp/syntheticserviceentrycontroller.go
+++ b/pilot/pkg/serviceregistry/mcp/syntheticserviceentrycontroller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package coredatamodel
+package mcp
 
 import (
 	"errors"
@@ -50,8 +50,8 @@ type SyntheticServiceEntryController struct {
 	*Options
 }
 
-// NewSyntheticServiceEntryController provides a new incremental CoreDataModel controller
-func NewSyntheticServiceEntryController(options *Options) CoreDataModel {
+// NewSyntheticServiceEntryController provides a new incremental Controller controller
+func NewSyntheticServiceEntryController(options *Options) Controller {
 	return &SyntheticServiceEntryController{
 		configStore: make(map[string]map[string]*model.Config),
 		Options:     options,

--- a/pilot/pkg/serviceregistry/mcp/syntheticserviceentrycontroller_test.go
+++ b/pilot/pkg/serviceregistry/mcp/syntheticserviceentrycontroller_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package coredatamodel_test
+package mcp_test
 
 import (
 	"fmt"
@@ -25,8 +25,8 @@ import (
 	"istio.io/api/annotation"
 	networking "istio.io/api/networking/v1alpha3"
 
-	"istio.io/istio/pilot/pkg/config/coredatamodel"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
 	"istio.io/istio/pkg/config/schemas"
 )
 
@@ -65,7 +65,7 @@ func (f *FakeXdsUpdater) ProxyUpdate(clusterID, ip string) {
 
 func TestIncrementalControllerHasSynced(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 	g.Expect(controller.HasSynced()).To(gomega.BeFalse())
 
 	for i, se := range []*networking.ServiceEntry{syntheticServiceEntry0, syntheticServiceEntry1} {
@@ -84,7 +84,7 @@ func TestIncrementalControllerHasSynced(t *testing.T) {
 
 func TestIncrementalControllerConfigDescriptor(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	descriptor := controller.ConfigDescriptor()
 	g.Expect(descriptor.Types()).To(gomega.HaveLen(1))
@@ -93,7 +93,7 @@ func TestIncrementalControllerConfigDescriptor(t *testing.T) {
 
 func TestIncrementalControllerListInvalidType(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	c, err := controller.List("gateway", "some-phony-name-space")
 	g.Expect(c).To(gomega.BeNil())
@@ -103,7 +103,7 @@ func TestIncrementalControllerListInvalidType(t *testing.T) {
 
 func TestIncrementalControllerListCorrectTypeNoData(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	c, err := controller.List(schemas.SyntheticServiceEntry.Type, "some-phony-name-space")
 	g.Expect(c).To(gomega.BeNil())
@@ -112,7 +112,7 @@ func TestIncrementalControllerListCorrectTypeNoData(t *testing.T) {
 
 func TestIncrementalControllerListAllNameSpace(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	syntheticServiceEntry2 := proto.Clone(syntheticServiceEntry1).(*networking.ServiceEntry)
 	syntheticServiceEntry2.Ports = serviceEntry.Ports
@@ -154,7 +154,7 @@ func TestIncrementalControllerListAllNameSpace(t *testing.T) {
 
 func TestIncrementalControllerListSpecificNameSpace(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	syntheticServiceEntry2 := proto.Clone(syntheticServiceEntry1).(*networking.ServiceEntry)
 	syntheticServiceEntry2.Ports = serviceEntry.Ports
@@ -199,7 +199,7 @@ func TestIncrementalControllerListSpecificNameSpace(t *testing.T) {
 
 func TestIncrementalControllerApplyInvalidType(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	message := convertToResource(g,
 		schemas.Gateway.MessageName,
@@ -218,7 +218,7 @@ func TestIncrementalControllerApplyInvalidType(t *testing.T) {
 
 func TestIncrementalControllerApplyMetadataNameIncludesNamespace(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	message := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry0)
 
@@ -244,7 +244,7 @@ func TestIncrementalControllerApplyMetadataNameWithoutNamespace(t *testing.T) {
 	fx := NewFakeXDS()
 	fx.EDSErr <- nil
 	testControllerOptions.XDSUpdater = fx
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	message0 := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry0)
 	change0 := convertToChange([]proto.Message{message0},
@@ -282,7 +282,7 @@ func TestIncrementalControllerApplyMetadataNameWithoutNamespace(t *testing.T) {
 
 func TestIncrementalControllerApplyChangeNoObjects(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	message := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry0)
 	change := convertToChange([]proto.Message{message},
@@ -317,7 +317,7 @@ func TestIncrementalControllerApplyChangeNoObjects(t *testing.T) {
 
 func TestIncrementalControllerApplyInvalidResource(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	se := proto.Clone(syntheticServiceEntry1).(*networking.ServiceEntry)
 	se.Hosts = nil
@@ -340,7 +340,7 @@ func TestIncrementalControllerApplyInvalidResource(t *testing.T) {
 
 func TestIncrementalControllerApplyInvalidResource_BadTimestamp(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	message0 := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry0)
 	change := convertToChange(
@@ -366,7 +366,7 @@ func TestApplyNonIncrementalChange(t *testing.T) {
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	message := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry0)
 
@@ -409,7 +409,7 @@ func TestApplyNonIncrementalAnnotations(t *testing.T) {
 	fx := NewFakeXDS()
 	fx.EDSErr <- nil
 	testControllerOptions.XDSUpdater = fx
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 	message := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry0)
 
 	steps := []struct {
@@ -477,7 +477,7 @@ func TestApplyIncrementalChangeRemove(t *testing.T) {
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	message0 := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry0)
 
@@ -560,7 +560,7 @@ func TestApplyIncrementalChange(t *testing.T) {
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	message0 := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry0)
 
@@ -614,7 +614,7 @@ func TestApplyIncrementalChangeEndpiontVersionWithoutServiceVersion(t *testing.T
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	message0 := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry0)
 
@@ -664,7 +664,7 @@ func TestApplyIncrementalChangesAnnotations(t *testing.T) {
 	fx := NewFakeXDS()
 	fx.EDSErr <- nil
 	testControllerOptions.XDSUpdater = fx
-	controller := coredatamodel.NewSyntheticServiceEntryController(testControllerOptions)
+	controller := mcp.NewSyntheticServiceEntryController(testControllerOptions)
 
 	message := convertToResource(g, schemas.SyntheticServiceEntry.MessageName, syntheticServiceEntry0)
 


### PR DESCRIPTION
This moves the classes to a more appropriate location. Also doing some minor renaming to make things a bit more clear and to avoid stutter with the new `mcp` package.