### PR TITLE
call event handler only if conversion is successful

### DIFF
--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -206,28 +206,28 @@ func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model
 		return
 	}
 	c.kinds[typ].handler.Append(func(old, curr interface{}, ev model.Event) error {
-		var curritem, olditem crd.IstioObject
-		var currconfig, oldconfig *model.Config
+		var currItem, oldItem crd.IstioObject
+		var currConfig, oldConfig *model.Config
 		ok := false
 		var err error
 
-		if curritem, ok = curr.(crd.IstioObject); !ok {
+		if currItem, ok = curr.(crd.IstioObject); !ok {
 			log.Warnf("New Object can not be converted to Istio Object %v", curr)
 			return nil
 		}
-		if currconfig, err = crd.ConvertObject(s, curritem, c.client.domainSuffix); err != nil {
+		if currConfig, err = crd.ConvertObject(s, currItem, c.client.domainSuffix); err != nil {
 			log.Warnf("error translating new object for schema %#v : %v\n Object:\n%#v", s, err, curr)
 			return nil
 		}
-		// olditem can be nil for new entries. So we should default it.
-		if olditem, ok = old.(crd.IstioObject); !ok {
-			oldconfig = &model.Config{}
-		} else if oldconfig, err = crd.ConvertObject(s, olditem, c.client.domainSuffix); err != nil {
+		// oldItem can be nil for new entries. So we should default it.
+		if oldItem, ok = old.(crd.IstioObject); !ok {
+			oldConfig = &model.Config{}
+		} else if oldConfig, err = crd.ConvertObject(s, oldItem, c.client.domainSuffix); err != nil {
 			log.Warnf("error translating old object for schema %#v : %v\n Object:\n%#v", s, err, old)
 			return nil
 		}
 
-		f(*oldconfig, *currconfig, ev)
+		f(*oldConfig, *currConfig, ev)
 
 		return nil
 	})

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -222,11 +222,9 @@ func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model
 		// olditem can be nil for new entries. So we should default it.
 		if olditem, ok = old.(crd.IstioObject); !ok {
 			oldconfig = &model.Config{}
-		} else {
-			if oldconfig, err = crd.ConvertObject(s, olditem, c.client.domainSuffix); err != nil {
-				log.Warnf("error translating old object for schema %#v : %v\n Object:\n%#v", s, err, old)
-				return nil
-			}
+		} else if oldconfig, err = crd.ConvertObject(s, olditem, c.client.domainSuffix); err != nil {
+			log.Warnf("error translating old object for schema %#v : %v\n Object:\n%#v", s, err, old)
+			return nil
 		}
 
 		f(*oldconfig, *currconfig, ev)

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -208,8 +208,9 @@ func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model
 	c.kinds[typ].handler.Append(func(old, curr interface{}, ev model.Event) error {
 		var currItem, oldItem crd.IstioObject
 		var currConfig, oldConfig *model.Config
-		ok := false
 		var err error
+
+		ok := false
 
 		if currItem, ok = curr.(crd.IstioObject); !ok {
 			log.Warnf("New Object can not be converted to Istio Object %v", curr)

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -206,23 +206,31 @@ func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model
 		return
 	}
 	c.kinds[typ].handler.Append(func(old, curr interface{}, ev model.Event) error {
-		curritem, ok := curr.(crd.IstioObject)
-		if ok {
-			config, err := crd.ConvertObject(s, curritem, c.client.domainSuffix)
-			if err != nil {
-				log.Warnf("error translating object for schema %#v : %v\n Object:\n%#v", s, err, curr)
-			} else {
-				olditem, ok := old.(crd.IstioObject)
-				oldconfig := &model.Config{}
-				if ok {
-					oldconfig, err = crd.ConvertObject(s, olditem, c.client.domainSuffix)
-					if err != nil {
-						log.Warnf("error translating object for schema %#v : %v\n Object:\n%#v", s, err, old)
-					}
-				}
-				f(*oldconfig, *config, ev)
+		var curritem, olditem crd.IstioObject
+		var currconfig, oldconfig *model.Config
+		ok := false
+		var err error
+
+		if curritem, ok = curr.(crd.IstioObject); !ok {
+			log.Warnf("New Object can not be converted to Istio Object %v", curr)
+			return nil
+		}
+		if currconfig, err = crd.ConvertObject(s, curritem, c.client.domainSuffix); err != nil {
+			log.Warnf("error translating new object for schema %#v : %v\n Object:\n%#v", s, err, curr)
+			return nil
+		}
+		// olditem can be nil for new entries. So we should default it.
+		if olditem, ok = old.(crd.IstioObject); !ok {
+			oldconfig = &model.Config{}
+		} else {
+			if oldconfig, err = crd.ConvertObject(s, olditem, c.client.domainSuffix); err != nil {
+				log.Warnf("error translating old object for schema %#v : %v\n Object:\n%#v", s, err, old)
+				return nil
 			}
 		}
+
+		f(*oldconfig, *currconfig, ev)
+
 		return nil
 	})
 }


### PR DESCRIPTION
Currently event handler is called even if the old object conversion has an error. This PR fixes it and calls it only both current and old objects are successfully converted.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
