### PR TITLE
Test both endpoints and slices for unit tests

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -126,7 +126,6 @@ type Options struct {
 type EndpointMode int
 
 const (
-
 	// EndpointsOnly type will use only Kubernetes Endpoints
 	EndpointsOnly EndpointMode = iota
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -126,6 +126,7 @@ type Options struct {
 type EndpointMode int
 
 const (
+
 	// EndpointsOnly type will use only Kubernetes Endpoints
 	EndpointsOnly EndpointMode = iota
 
@@ -136,6 +137,15 @@ const (
 	// Kubernetes Controller (e.g. made by user and not duplicated with Endpoints), or a mode with both that
 	// does deduping. Simply doing both won't work for now, since not all Kubernetes components support EndpointSlice.
 )
+
+var EndpointModeNames = map[EndpointMode]string{
+	EndpointsOnly:     "EndpointsOnly",
+	EndpointSliceOnly: "EndpointSliceOnly",
+}
+
+func (m EndpointMode) String() string {
+	return EndpointModeNames[m]
+}
 
 var _ serviceregistry.Instance = &Controller{}
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -135,14 +135,11 @@ func (fx *FakeXdsUpdater) Clear() {
 	}
 }
 
-func newFakeController() (*Controller, *FakeXdsUpdater) {
-	return newFakeControllerWithOptions(fakeControllerOptions{})
-}
-
 type fakeControllerOptions struct {
 	networksWatcher mesh.NetworksWatcher
 	serviceHandler  func(service *model.Service, event model.Event)
 	instanceHandler func(instance *model.ServiceInstance, event model.Event)
+	mode            EndpointMode
 }
 
 func newFakeControllerWithOptions(opts fakeControllerOptions) (*Controller, *FakeXdsUpdater) {
@@ -156,6 +153,7 @@ func newFakeControllerWithOptions(opts fakeControllerOptions) (*Controller, *Fak
 		XDSUpdater:       fx,
 		Metrics:          &model.Environment{},
 		NetworksWatcher:  opts.networksWatcher,
+		EndpointMode:     opts.mode,
 	})
 
 	if opts.instanceHandler != nil {
@@ -169,6 +167,7 @@ func newFakeControllerWithOptions(opts fakeControllerOptions) (*Controller, *Fak
 }
 
 func TestServices(t *testing.T) {
+
 	networksWatcher := mesh.NewFixedNetworksWatcher(&meshconfig.MeshNetworks{
 		Networks: map[string]*meshconfig.Network{
 			"network1": {
@@ -192,87 +191,91 @@ func TestServices(t *testing.T) {
 		},
 	})
 
-	ctl, fx := newFakeControllerWithOptions(fakeControllerOptions{networksWatcher: networksWatcher})
-	defer ctl.Stop()
-	t.Parallel()
-	ns := "ns-test"
+	for mode, name := range EndpointModeNames {
+		t.Run(name, func(t *testing.T) {
+			ctl, fx := newFakeControllerWithOptions(fakeControllerOptions{networksWatcher: networksWatcher, mode: mode})
+			defer ctl.Stop()
+			t.Parallel()
+			ns := "ns-test"
 
-	hostname := kube.ServiceHostname(testService, ns, domainSuffix)
+			hostname := kube.ServiceHostname(testService, ns, domainSuffix)
 
-	var sds model.ServiceDiscovery = ctl
-	// "test", ports: http-example on 80
-	makeService(testService, ns, ctl.client, t)
-	<-fx.Events
+			var sds model.ServiceDiscovery = ctl
+			// "test", ports: http-example on 80
+			makeService(testService, ns, ctl.client, t)
+			<-fx.Events
 
-	test.Eventually(t, "successfully added a service", func() bool {
-		out, clientErr := sds.Services()
-		if clientErr != nil {
-			return false
-		}
-		log.Infof("Services: %#v", out)
+			test.Eventually(t, "successfully added a service", func() bool {
+				out, clientErr := sds.Services()
+				if clientErr != nil {
+					return false
+				}
+				log.Infof("Services: %#v", out)
 
-		// Original test was checking for 'protocolTCP' - which is incorrect (the
-		// port name is 'http'. It was working because the Service was created with
-		// an invalid protocol, and the code was ignoring that ( not TCP/UDP).
-		for _, item := range out {
-			if item.Hostname == hostname &&
-				len(item.Ports) == 1 &&
-				item.Ports[0].Protocol == protocol.HTTP {
-				return true
+				// Original test was checking for 'protocolTCP' - which is incorrect (the
+				// port name is 'http'. It was working because the Service was created with
+				// an invalid protocol, and the code was ignoring that ( not TCP/UDP).
+				for _, item := range out {
+					if item.Hostname == hostname &&
+						len(item.Ports) == 1 &&
+						item.Ports[0].Protocol == protocol.HTTP {
+						return true
+					}
+				}
+				return false
+			})
+
+			// 2 ports 1001, 2 IPs
+			createEndpoints(ctl, testService, ns, []string{"http-example", "foo"}, []string{"10.10.1.1", "10.11.1.2"}, t)
+
+			svc, err := sds.GetService(hostname)
+			if err != nil {
+				t.Fatalf("GetService(%q) encountered unexpected error: %v", hostname, err)
 			}
-		}
-		return false
-	})
+			if svc == nil {
+				t.Fatalf("GetService(%q) => should exists", hostname)
+			}
+			if svc.Hostname != hostname {
+				t.Fatalf("GetService(%q) => %q", hostname, svc.Hostname)
+			}
 
-	// 2 ports 1001, 2 IPs
-	createEndpoints(ctl, testService, ns, []string{"http-example", "foo"}, []string{"10.10.1.1", "10.11.1.2"}, t)
+			test.Eventually(t, "successfully created endpoints", func() bool {
+				ep, anotherErr := sds.InstancesByPort(svc, 80, nil)
+				if anotherErr != nil {
+					t.Fatalf("error gettings instance by port: %v", anotherErr)
+					return false
+				}
+				if len(ep) == 2 {
+					return true
+				}
+				return false
+			})
 
-	svc, err := sds.GetService(hostname)
-	if err != nil {
-		t.Fatalf("GetService(%q) encountered unexpected error: %v", hostname, err)
-	}
-	if svc == nil {
-		t.Fatalf("GetService(%q) => should exists", hostname)
-	}
-	if svc.Hostname != hostname {
-		t.Fatalf("GetService(%q) => %q", hostname, svc.Hostname)
-	}
+			ep, err := sds.InstancesByPort(svc, 80, nil)
+			if err != nil {
+				t.Fatalf("GetInstancesByPort() encountered unexpected error: %v", err)
+			}
+			if len(ep) != 2 {
+				t.Fatalf("Invalid response for GetInstancesByPort %v", ep)
+			}
 
-	test.Eventually(t, "successfully created endpoints", func() bool {
-		ep, anotherErr := sds.InstancesByPort(svc, 80, nil)
-		if anotherErr != nil {
-			t.Fatalf("error gettings instance by port: %v", anotherErr)
-			return false
-		}
-		if len(ep) == 2 {
-			return true
-		}
-		return false
-	})
+			if ep[0].Endpoint.Address == "10.10.1.1" && ep[0].Endpoint.Network != "network1" {
+				t.Fatalf("Endpoint with IP 10.10.1.1 is expected to be in network1 but get: %s", ep[0].Endpoint.Network)
+			}
 
-	ep, err := sds.InstancesByPort(svc, 80, nil)
-	if err != nil {
-		t.Fatalf("GetInstancesByPort() encountered unexpected error: %v", err)
-	}
-	if len(ep) != 2 {
-		t.Fatalf("Invalid response for GetInstancesByPort %v", ep)
-	}
+			if ep[1].Endpoint.Address == "10.11.1.2" && ep[1].Endpoint.Network != "network2" {
+				t.Fatalf("Endpoint with IP 10.11.1.2 is expected to be in network2 but get: %s", ep[1].Endpoint.Network)
+			}
 
-	if ep[0].Endpoint.Address == "10.10.1.1" && ep[0].Endpoint.Network != "network1" {
-		t.Fatalf("Endpoint with IP 10.10.1.1 is expected to be in network1 but get: %s", ep[0].Endpoint.Network)
-	}
-
-	if ep[1].Endpoint.Address == "10.11.1.2" && ep[1].Endpoint.Network != "network2" {
-		t.Fatalf("Endpoint with IP 10.11.1.2 is expected to be in network2 but get: %s", ep[1].Endpoint.Network)
-	}
-
-	missing := kube.ServiceHostname("does-not-exist", ns, domainSuffix)
-	svc, err = sds.GetService(missing)
-	if err != nil {
-		t.Fatalf("GetService(%q) encountered unexpected error: %v", missing, err)
-	}
-	if svc != nil {
-		t.Fatalf("GetService(%q) => %s, should not exist", missing, svc.Hostname)
+			missing := kube.ServiceHostname("does-not-exist", ns, domainSuffix)
+			svc, err = sds.GetService(missing)
+			if err != nil {
+				t.Fatalf("GetService(%q) encountered unexpected error: %v", missing, err)
+			}
+			if svc != nil {
+				t.Fatalf("GetService(%q) => %s, should not exist", missing, svc.Hostname)
+			}
+		})
 	}
 }
 
@@ -386,7 +389,8 @@ func TestController_GetPodLocality(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 
 			// Setup kube caches
-			controller, fx := newFakeController()
+			// Pod locality only matters for Endpoints
+			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
 			defer controller.Stop()
 			addNodes(t, controller, c.nodes...)
 			addPods(t, controller, c.pods...)
@@ -417,236 +421,237 @@ func TestController_GetPodLocality(t *testing.T) {
 }
 
 func TestGetProxyServiceInstances(t *testing.T) {
-	controller, fx := newFakeController()
-	defer controller.Stop()
-	p := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
-	addPods(t, controller, p)
-	if err := waitForPod(controller, p.Status.PodIP); err != nil {
-		t.Fatalf("wait for pod err: %v", err)
-	}
+	for mode, name := range EndpointModeNames {
+		t.Run(name, func(t *testing.T) {
+			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			defer controller.Stop()
+			p := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
+			addPods(t, controller, p)
+			if err := waitForPod(controller, p.Status.PodIP); err != nil {
+				t.Fatalf("wait for pod err: %v", err)
+			}
 
-	k8sSaOnVM := "acct4"
-	canonicalSaOnVM := "acctvm2@gserviceaccount2.com"
+			k8sSaOnVM := "acct4"
+			canonicalSaOnVM := "acctvm2@gserviceaccount2.com"
 
-	createService(controller, "svc1", "nsa",
-		map[string]string{
-			annotation.AlphaKubernetesServiceAccounts.Name: k8sSaOnVM,
-			annotation.AlphaCanonicalServiceAccounts.Name:  canonicalSaOnVM},
-		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
-	ev := fx.Wait("service")
-	if ev == nil {
-		t.Fatal("Timeout creating service")
-	}
+			createService(controller, "svc1", "nsa",
+				map[string]string{
+					annotation.AlphaKubernetesServiceAccounts.Name: k8sSaOnVM,
+					annotation.AlphaCanonicalServiceAccounts.Name:  canonicalSaOnVM},
+				[]int32{8080}, map[string]string{"app": "prod-app"}, t)
+			ev := fx.Wait("service")
+			if ev == nil {
+				t.Fatal("Timeout creating service")
+			}
 
-	// Endpoints are generated by Kubernetes from pod labels and service selectors.
-	// Here we manually create them for mocking purpose.
-	svc1Ips := []string{"128.0.0.1"}
-	portNames := []string{"tcp-port"}
-	// Create 1 endpoint that refers to a pod in the same namespace.
-	createEndpoints(controller, "svc1", "nsA", portNames, svc1Ips, t)
+			// Endpoints are generated by Kubernetes from pod labels and service selectors.
+			// Here we manually create them for mocking purpose.
+			svc1Ips := []string{"128.0.0.1"}
+			portNames := []string{"tcp-port"}
+			// Create 1 endpoint that refers to a pod in the same namespace.
+			createEndpoints(controller, "svc1", "nsA", portNames, svc1Ips, t)
 
-	// Creates 100 endpoints that refers to a pod in a different namespace.
-	fakeSvcCounts := 100
-	for i := 0; i < fakeSvcCounts; i++ {
-		svcName := fmt.Sprintf("svc-fake-%d", i)
-		createService(controller, svcName, "nsfake",
-			map[string]string{
-				annotation.AlphaKubernetesServiceAccounts.Name: k8sSaOnVM,
-				annotation.AlphaCanonicalServiceAccounts.Name:  canonicalSaOnVM},
-			[]int32{8080}, map[string]string{"app": "prod-app"}, t)
-		fx.Wait("service")
+			// Creates 100 endpoints that refers to a pod in a different namespace.
+			fakeSvcCounts := 100
+			for i := 0; i < fakeSvcCounts; i++ {
+				svcName := fmt.Sprintf("svc-fake-%d", i)
+				createService(controller, svcName, "nsfake",
+					map[string]string{
+						annotation.AlphaKubernetesServiceAccounts.Name: k8sSaOnVM,
+						annotation.AlphaCanonicalServiceAccounts.Name:  canonicalSaOnVM},
+					[]int32{8080}, map[string]string{"app": "prod-app"}, t)
+				fx.Wait("service")
 
-		createEndpoints(controller, svcName, "nsfake", portNames, svc1Ips, t)
-		fx.Wait("eds")
-	}
+				createEndpoints(controller, svcName, "nsfake", portNames, svc1Ips, t)
+				fx.Wait("eds")
+			}
 
-	// Create 1 endpoint that refers to a pod in the same namespace.
-	createEndpoints(controller, "svc1", "nsa", portNames, svc1Ips, t)
-	fx.Wait("eds")
+			// Create 1 endpoint that refers to a pod in the same namespace.
+			createEndpoints(controller, "svc1", "nsa", portNames, svc1Ips, t)
+			fx.Wait("eds")
 
-	var svcNode model.Proxy
-	svcNode.Type = model.Router
-	svcNode.IPAddresses = []string{"128.0.0.1"}
-	svcNode.ID = "pod1.nsa"
-	svcNode.DNSDomain = "nsa.svc.cluster.local"
-	svcNode.Metadata = &model.NodeMetadata{}
-	services, err := controller.GetProxyServiceInstances(&svcNode)
-	if err != nil {
-		t.Fatalf("client encountered error during GetProxyServiceInstances(): %v", err)
-	}
+			var svcNode model.Proxy
+			svcNode.Type = model.Router
+			svcNode.IPAddresses = []string{"128.0.0.1"}
+			svcNode.ID = "pod1.nsa"
+			svcNode.DNSDomain = "nsa.svc.cluster.local"
+			svcNode.Metadata = &model.NodeMetadata{}
+			services, err := controller.GetProxyServiceInstances(&svcNode)
+			if err != nil {
+				t.Fatalf("client encountered error during GetProxyServiceInstances(): %v", err)
+			}
 
-	if len(services) != fakeSvcCounts+1 {
-		t.Fatalf("GetProxyServiceInstances() returned wrong # of endpoints => %d, want %d", len(services), fakeSvcCounts+1)
-	}
+			if len(services) != fakeSvcCounts+1 {
+				t.Fatalf("GetProxyServiceInstances() returned wrong # of endpoints => %d, want %d", len(services), fakeSvcCounts+1)
+			}
 
-	hostname := kube.ServiceHostname("svc1", "nsa", domainSuffix)
-	if services[0].Service.Hostname != hostname {
-		t.Fatalf("GetProxyServiceInstances() wrong service instance returned => hostname %q, want %q",
-			services[0].Service.Hostname, hostname)
-	}
+			hostname := kube.ServiceHostname("svc1", "nsa", domainSuffix)
+			if services[0].Service.Hostname != hostname {
+				t.Fatalf("GetProxyServiceInstances() wrong service instance returned => hostname %q, want %q",
+					services[0].Service.Hostname, hostname)
+			}
 
-	// Test that we can look up instances just by Proxy metadata
-	metaServices, err := controller.GetProxyServiceInstances(&model.Proxy{
-		Type:            "sidecar",
-		IPAddresses:     []string{"1.1.1.1"},
-		Locality:        &core.Locality{Region: "r", Zone: "z"},
-		ConfigNamespace: "nsa",
-		Metadata:        &model.NodeMetadata{ServiceAccount: "account"},
-		WorkloadLabels:  labels.Collection{labels.Instance{"app": "prod-app"}},
-	})
-	if err != nil {
-		t.Fatalf("got err getting service instances")
-	}
+			// Test that we can look up instances just by Proxy metadata
+			metaServices, err := controller.GetProxyServiceInstances(&model.Proxy{
+				Type:            "sidecar",
+				IPAddresses:     []string{"1.1.1.1"},
+				Locality:        &core.Locality{Region: "r", Zone: "z"},
+				ConfigNamespace: "nsa",
+				Metadata:        &model.NodeMetadata{ServiceAccount: "account"},
+				WorkloadLabels:  labels.Collection{labels.Instance{"app": "prod-app"}},
+			})
+			if err != nil {
+				t.Fatalf("got err getting service instances")
+			}
 
-	expected := &model.ServiceInstance{
-		Service: &model.Service{
-			Hostname:        "svc1.nsa.svc.company.com",
-			Address:         "10.0.0.1",
-			Ports:           []*model.Port{{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP}},
-			ServiceAccounts: []string{"acctvm2@gserviceaccount2.com", "spiffe://cluster.local/ns/nsa/sa/acct4"},
-			Attributes: model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.Kubernetes),
-				Name:            "svc1",
-				Namespace:       "nsa",
-				UID:             "istio://nsa/services/svc1"},
-		},
-		ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
-		Endpoint: &model.IstioEndpoint{
-			Labels:          labels.Instance{"app": "prod-app"},
-			ServiceAccount:  "account",
-			Family:          0,
-			Address:         "1.1.1.1",
-			EndpointPort:    0,
-			ServicePortName: "tcp-port",
-			Locality:        "r/z",
-			Attributes: model.ServiceAttributes{
-				Name:      "svc1",
-				Namespace: "nsa",
-			},
-		},
-	}
-	if len(metaServices) != 1 {
-		t.Fatalf("expected 1 instance, got %v", len(metaServices))
-	}
-	if !reflect.DeepEqual(expected, metaServices[0]) {
-		t.Fatalf("expected instance %v, got %v", expected, metaServices[0])
-	}
+			expected := &model.ServiceInstance{
 
-	// Test that we first look up instances by Proxy pod
+				Service: &model.Service{
+					Hostname:        "svc1.nsa.svc.company.com",
+					Address:         "10.0.0.1",
+					Ports:           []*model.Port{{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP}},
+					ServiceAccounts: []string{"acctvm2@gserviceaccount2.com", "spiffe://cluster.local/ns/nsa/sa/acct4"},
+					Attributes: model.ServiceAttributes{
+						ServiceRegistry: string(serviceregistry.Kubernetes),
+						Name:            "svc1",
+						Namespace:       "nsa",
+						UID:             "istio://nsa/services/svc1"},
+				},
+				ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
+				Endpoint: &model.IstioEndpoint{Labels: labels.Instance{"app": "prod-app"},
+					ServiceAccount: "account", Family: 0,
+					Address:         "1.1.1.1",
+					EndpointPort:    0,
+					ServicePortName: "tcp-port",
+					Locality:        "r/z",
+					Attributes: model.ServiceAttributes{
+						Name:      "svc1",
+						Namespace: "nsa",
+					},
+				},
+			}
+			if len(metaServices) != 1 {
+				t.Fatalf("expected 1 instance, got %v", len(metaServices))
+			}
+			if !reflect.DeepEqual(expected, metaServices[0]) {
+				t.Fatalf("expected instance %v, got %v", expected, metaServices[0])
+			}
 
-	node := generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", IstioSubzoneLabel: "subzone1"})
-	addNodes(t, controller, node)
+			// Test that we first look up instances by Proxy pod
 
-	// 1. pod without `istio-locality` label, get locality from node label.
-	p = generatePod("129.0.0.1", "pod2", "nsa", "svcaccount", "node1",
-		map[string]string{"app": "prod-app"}, nil)
-	addPods(t, controller, p)
-	if err := waitForPod(controller, p.Status.PodIP); err != nil {
-		t.Fatalf("wait for pod err: %v", err)
-	}
+			node := generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", IstioSubzoneLabel: "subzone1"})
+			addNodes(t, controller, node)
 
-	podServices, err := controller.GetProxyServiceInstances(&model.Proxy{
-		Type:            "sidecar",
-		IPAddresses:     []string{"129.0.0.1"},
-		Locality:        &core.Locality{Region: "r", Zone: "z"},
-		ConfigNamespace: "nsa",
-		Metadata:        &model.NodeMetadata{ServiceAccount: "account"},
-		WorkloadLabels:  labels.Collection{labels.Instance{"app": "prod-app"}},
-	})
-	if err != nil {
-		t.Fatalf("got err getting service instances")
-	}
+			// 1. pod without `istio-locality` label, get locality from node label.
+			p = generatePod("129.0.0.1", "pod2", "nsa", "svcaccount", "node1",
+				map[string]string{"app": "prod-app"}, nil)
+			addPods(t, controller, p)
+			if err := waitForPod(controller, p.Status.PodIP); err != nil {
+				t.Fatalf("wait for pod err: %v", err)
+			}
 
-	expected = &model.ServiceInstance{
-		Service: &model.Service{
-			Hostname:        "svc1.nsa.svc.company.com",
-			Address:         "10.0.0.1",
-			Ports:           []*model.Port{{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP}},
-			ServiceAccounts: []string{"acctvm2@gserviceaccount2.com", "spiffe://cluster.local/ns/nsa/sa/acct4"},
-			Attributes: model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.Kubernetes),
-				Name:            "svc1",
-				Namespace:       "nsa",
-				UID:             "istio://nsa/services/svc1"},
-		},
-		ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
-		Endpoint: &model.IstioEndpoint{
-			Family:          0,
-			Address:         "129.0.0.1",
-			EndpointPort:    0,
-			ServicePortName: "tcp-port",
-			Locality:        "region1/zone1/subzone1",
-			Labels:          labels.Instance{"app": "prod-app"},
-			ServiceAccount:  "spiffe://cluster.local/ns/nsa/sa/svcaccount",
-			TLSMode:         model.DisabledTLSModeLabel,
-			UID:             "kubernetes://pod2.nsa",
-			Attributes: model.ServiceAttributes{
-				Name:      "svc1",
-				Namespace: "nsa",
-			},
-		},
-	}
-	if len(podServices) != 1 {
-		t.Fatalf("expected 1 instance, got %v", len(podServices))
-	}
-	if !reflect.DeepEqual(expected, podServices[0]) {
-		t.Fatalf("expected instance %v, got %v", expected, podServices[0])
-	}
+			podServices, err := controller.GetProxyServiceInstances(&model.Proxy{
+				Type:            "sidecar",
+				IPAddresses:     []string{"129.0.0.1"},
+				Locality:        &core.Locality{Region: "r", Zone: "z"},
+				ConfigNamespace: "nsa",
+				Metadata:        &model.NodeMetadata{ServiceAccount: "account"},
+				WorkloadLabels:  labels.Collection{labels.Instance{"app": "prod-app"}},
+			})
+			if err != nil {
+				t.Fatalf("got err getting service instances")
+			}
 
-	// 2. pod with `istio-locality` label, ignore node label.
-	p = generatePod("129.0.0.2", "pod3", "nsa", "svcaccount", "node1",
-		map[string]string{"app": "prod-app", "istio-locality": "region.zone"}, nil)
-	addPods(t, controller, p)
-	if err := waitForPod(controller, p.Status.PodIP); err != nil {
-		t.Fatalf("wait for pod err: %v", err)
-	}
+			expected = &model.ServiceInstance{
 
-	podServices, err = controller.GetProxyServiceInstances(&model.Proxy{
-		Type:            "sidecar",
-		IPAddresses:     []string{"129.0.0.2"},
-		Locality:        &core.Locality{Region: "r", Zone: "z"},
-		ConfigNamespace: "nsa",
-		Metadata:        &model.NodeMetadata{ServiceAccount: "account"},
-		WorkloadLabels:  labels.Collection{labels.Instance{"app": "prod-app"}},
-	})
-	if err != nil {
-		t.Fatalf("got err getting service instances")
-	}
+				Service: &model.Service{
+					Hostname:        "svc1.nsa.svc.company.com",
+					Address:         "10.0.0.1",
+					Ports:           []*model.Port{{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP}},
+					ServiceAccounts: []string{"acctvm2@gserviceaccount2.com", "spiffe://cluster.local/ns/nsa/sa/acct4"},
+					Attributes: model.ServiceAttributes{
+						ServiceRegistry: string(serviceregistry.Kubernetes),
+						Name:            "svc1",
+						Namespace:       "nsa",
+						UID:             "istio://nsa/services/svc1"},
+				},
+				ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
+				Endpoint: &model.IstioEndpoint{
+					Family:          0,
+					Address:         "129.0.0.1",
+					EndpointPort:    0,
+					ServicePortName: "tcp-port",
+					Locality:        "region1/zone1/subzone1", Labels: labels.Instance{"app": "prod-app"},
+					ServiceAccount: "spiffe://cluster.local/ns/nsa/sa/svcaccount",
+					TLSMode:        model.DisabledTLSModeLabel, UID: "kubernetes://pod2.nsa",
+					Attributes: model.ServiceAttributes{
+						Name:      "svc1",
+						Namespace: "nsa",
+					},
+				},
+			}
+			if len(podServices) != 1 {
+				t.Fatalf("expected 1 instance, got %v", len(podServices))
+			}
+			if !reflect.DeepEqual(expected, podServices[0]) {
+				t.Fatalf("expected instance %v, got %v", expected, podServices[0])
+			}
 
-	expected = &model.ServiceInstance{
-		Service: &model.Service{
-			Hostname:        "svc1.nsa.svc.company.com",
-			Address:         "10.0.0.1",
-			Ports:           []*model.Port{{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP}},
-			ServiceAccounts: []string{"acctvm2@gserviceaccount2.com", "spiffe://cluster.local/ns/nsa/sa/acct4"},
-			Attributes: model.ServiceAttributes{
-				ServiceRegistry: string(serviceregistry.Kubernetes),
-				Name:            "svc1",
-				Namespace:       "nsa",
-				UID:             "istio://nsa/services/svc1"},
-		},
-		ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
-		Endpoint: &model.IstioEndpoint{
-			Family:          0,
-			Address:         "129.0.0.2",
-			EndpointPort:    0,
-			ServicePortName: "tcp-port",
-			Locality:        "region/zone",
-			Labels:          labels.Instance{"app": "prod-app", "istio-locality": "region.zone"},
-			ServiceAccount:  "spiffe://cluster.local/ns/nsa/sa/svcaccount",
-			TLSMode:         model.DisabledTLSModeLabel,
-			UID:             "kubernetes://pod3.nsa",
-			Attributes: model.ServiceAttributes{
-				Name:      "svc1",
-				Namespace: "nsa",
-			},
-		},
-	}
-	if len(podServices) != 1 {
-		t.Fatalf("expected 1 instance, got %v", len(podServices))
-	}
-	if !reflect.DeepEqual(expected, podServices[0]) {
-		t.Fatalf("expected instance %v, got %v", expected, podServices[0])
+			// 2. pod with `istio-locality` label, ignore node label.
+			p = generatePod("129.0.0.2", "pod3", "nsa", "svcaccount", "node1",
+				map[string]string{"app": "prod-app", "istio-locality": "region.zone"}, nil)
+			addPods(t, controller, p)
+			if err := waitForPod(controller, p.Status.PodIP); err != nil {
+				t.Fatalf("wait for pod err: %v", err)
+			}
+
+			podServices, err = controller.GetProxyServiceInstances(&model.Proxy{
+				Type:            "sidecar",
+				IPAddresses:     []string{"129.0.0.2"},
+				Locality:        &core.Locality{Region: "r", Zone: "z"},
+				ConfigNamespace: "nsa",
+				Metadata:        &model.NodeMetadata{ServiceAccount: "account"},
+				WorkloadLabels:  labels.Collection{labels.Instance{"app": "prod-app"}},
+			})
+			if err != nil {
+				t.Fatalf("got err getting service instances")
+			}
+
+			expected = &model.ServiceInstance{
+
+				Service: &model.Service{
+					Hostname:        "svc1.nsa.svc.company.com",
+					Address:         "10.0.0.1",
+					Ports:           []*model.Port{{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP}},
+					ServiceAccounts: []string{"acctvm2@gserviceaccount2.com", "spiffe://cluster.local/ns/nsa/sa/acct4"},
+					Attributes: model.ServiceAttributes{
+						ServiceRegistry: string(serviceregistry.Kubernetes),
+						Name:            "svc1",
+						Namespace:       "nsa",
+						UID:             "istio://nsa/services/svc1"},
+				},
+				ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
+				Endpoint: &model.IstioEndpoint{
+					Family:          0,
+					Address:         "129.0.0.2",
+					EndpointPort:    0,
+					ServicePortName: "tcp-port",
+					Locality:        "region/zone", Labels: labels.Instance{"app": "prod-app", "istio-locality": "region.zone"},
+					ServiceAccount: "spiffe://cluster.local/ns/nsa/sa/svcaccount",
+					TLSMode:        model.DisabledTLSModeLabel, UID: "kubernetes://pod3.nsa",
+					Attributes: model.ServiceAttributes{
+						Name:      "svc1",
+						Namespace: "nsa",
+					},
+				},
+			}
+			if len(podServices) != 1 {
+				t.Fatalf("expected 1 instance, got %v", len(podServices))
+			}
+			if !reflect.DeepEqual(expected, podServices[0]) {
+				t.Fatalf("expected instance %v, got %v", expected, podServices[0])
+			}
+		})
 	}
 }
 
@@ -690,34 +695,36 @@ func TestGetProxyServiceInstancesWithMultiIPs(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		t.Run(c.name, func(t *testing.T) {
-			// Setup kube caches
-			controller, fx := newFakeController()
-			defer controller.Stop()
-			addPods(t, controller, c.pods...)
-			for _, pod := range c.pods {
-				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-					t.Fatalf("wait for pod err: %v", err)
+		for mode, name := range EndpointModeNames {
+			t.Run(fmt.Sprintf("%s_%s", c.name, name), func(t *testing.T) {
+				// Setup kube caches
+				controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+				defer controller.Stop()
+				addPods(t, controller, c.pods...)
+				for _, pod := range c.pods {
+					if err := waitForPod(controller, pod.Status.PodIP); err != nil {
+						t.Fatalf("wait for pod err: %v", err)
+					}
 				}
-			}
 
-			createService(controller, "svc1", "nsa",
-				map[string]string{
-					annotation.AlphaKubernetesServiceAccounts.Name: "acct4",
-					annotation.AlphaCanonicalServiceAccounts.Name:  "acctvm2@gserviceaccount2.com"},
-				c.ports, map[string]string{"app": "test-app"}, t)
-			ev := fx.Wait("service")
-			if ev == nil {
-				t.Fatal("Timeout creating service")
-			}
-			serviceInstances, err := controller.GetProxyServiceInstances(&model.Proxy{Metadata: &model.NodeMetadata{}, IPAddresses: c.ips})
-			if err != nil {
-				t.Fatalf("client encountered error during GetProxyServiceInstances(): %v", err)
-			}
-			if len(serviceInstances) != c.wantNum {
-				t.Fatalf("GetProxyServiceInstances() returned wrong # of endpoints => %q, want %q", len(serviceInstances), c.wantNum)
-			}
-		})
+				createService(controller, "svc1", "nsa",
+					map[string]string{
+						annotation.AlphaKubernetesServiceAccounts.Name: "acct4",
+						annotation.AlphaCanonicalServiceAccounts.Name:  "acctvm2@gserviceaccount2.com"},
+					c.ports, map[string]string{"app": "test-app"}, t)
+				ev := fx.Wait("service")
+				if ev == nil {
+					t.Fatal("Timeout creating service")
+				}
+				serviceInstances, err := controller.GetProxyServiceInstances(&model.Proxy{Metadata: &model.NodeMetadata{}, IPAddresses: c.ips})
+				if err != nil {
+					t.Fatalf("client encountered error during GetProxyServiceInstances(): %v", err)
+				}
+				if len(serviceInstances) != c.wantNum {
+					t.Fatalf("GetProxyServiceInstances() returned wrong # of endpoints => %q, want %q", len(serviceInstances), c.wantNum)
+				}
+			})
+		}
 	}
 }
 
@@ -726,198 +733,158 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 	spiffe.SetTrustDomain(domainSuffix)
 	defer spiffe.SetTrustDomain(oldTrustDomain)
 
-	controller, fx := newFakeController()
-	defer controller.Stop()
+	for mode, name := range EndpointModeNames {
+		t.Run(name, func(t *testing.T) {
+			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			defer controller.Stop()
 
-	sa1 := "acct1"
-	sa2 := "acct2"
-	sa3 := "acct3"
-	k8sSaOnVM := "acct4"
-	canonicalSaOnVM := "acctvm@gserviceaccount.com"
+			sa1 := "acct1"
+			sa2 := "acct2"
+			sa3 := "acct3"
+			k8sSaOnVM := "acct4"
+			canonicalSaOnVM := "acctvm@gserviceaccount.com"
 
-	pods := []*coreV1.Pod{
-		generatePod("128.0.0.1", "pod1", "nsA", sa1, "node1", map[string]string{"app": "test-app"}, map[string]string{}),
-		generatePod("128.0.0.2", "pod2", "nsA", sa2, "node2", map[string]string{"app": "prod-app"}, map[string]string{}),
-		generatePod("128.0.0.3", "pod3", "nsB", sa3, "node1", map[string]string{"app": "prod-app"}, map[string]string{}),
-	}
-	addPods(t, controller, pods...)
-	for _, pod := range pods {
-		if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-			t.Fatalf("wait for pod err: %v", err)
-		}
-	}
+			pods := []*coreV1.Pod{
+				generatePod("128.0.0.1", "pod1", "nsA", sa1, "node1", map[string]string{"app": "test-app"}, map[string]string{}),
+				generatePod("128.0.0.2", "pod2", "nsA", sa2, "node2", map[string]string{"app": "prod-app"}, map[string]string{}),
+				generatePod("128.0.0.3", "pod3", "nsB", sa3, "node1", map[string]string{"app": "prod-app"}, map[string]string{}),
+			}
+			addPods(t, controller, pods...)
+			for _, pod := range pods {
+				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
+					t.Fatalf("wait for pod err: %v", err)
+				}
+			}
 
-	createService(controller, "svc1", "nsA",
-		map[string]string{
-			annotation.AlphaKubernetesServiceAccounts.Name: k8sSaOnVM,
-			annotation.AlphaCanonicalServiceAccounts.Name:  canonicalSaOnVM},
-		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
-	fx.Wait("service")
-	createService(controller, "svc2", "nsA", nil, []int32{8080}, map[string]string{"app": "staging-app"}, t)
-	fx.Wait("service")
+			createService(controller, "svc1", "nsA",
+				map[string]string{
+					annotation.AlphaKubernetesServiceAccounts.Name: k8sSaOnVM,
+					annotation.AlphaCanonicalServiceAccounts.Name:  canonicalSaOnVM},
+				[]int32{8080}, map[string]string{"app": "prod-app"}, t)
+			fx.Wait("service")
+			createService(controller, "svc2", "nsA", nil, []int32{8080}, map[string]string{"app": "staging-app"}, t)
+			fx.Wait("service")
 
-	// Endpoints are generated by Kubernetes from pod labels and service selectors.
-	// Here we manually create them for mocking purpose.
-	svc1Ips := []string{"128.0.0.2"}
-	svc2Ips := make([]string, 0)
-	portNames := []string{"tcp-port"}
-	createEndpoints(controller, "svc1", "nsA", portNames, svc1Ips, t)
-	createEndpoints(controller, "svc2", "nsA", portNames, svc2Ips, t)
+			// Endpoints are generated by Kubernetes from pod labels and service selectors.
+			// Here we manually create them for mocking purpose.
+			svc1Ips := []string{"128.0.0.2"}
+			svc2Ips := make([]string, 0)
+			portNames := []string{"tcp-port"}
+			createEndpoints(controller, "svc1", "nsA", portNames, svc1Ips, t)
+			createEndpoints(controller, "svc2", "nsA", portNames, svc2Ips, t)
 
-	// We expect only one EDS update with Endpoints.
-	<-fx.Events
+			// We expect only one EDS update with Endpoints.
+			<-fx.Events
 
-	hostname := kube.ServiceHostname("svc1", "nsA", domainSuffix)
-	svc, err := controller.GetService(hostname)
-	if err != nil {
-		t.Fatalf("failed to get service: %v", err)
-	}
-	sa := controller.GetIstioServiceAccounts(svc, []int{8080})
-	sort.Strings(sa)
-	expected := []string{
-		canonicalSaOnVM,
-		"spiffe://company.com/ns/nsA/sa/" + sa2,
-		"spiffe://company.com/ns/nsA/sa/" + k8sSaOnVM,
-	}
-	if !reflect.DeepEqual(sa, expected) {
-		t.Fatalf("Unexpected service accounts %v (expecting %v)", sa, expected)
-	}
+			hostname := kube.ServiceHostname("svc1", "nsA", domainSuffix)
+			svc, err := controller.GetService(hostname)
+			if err != nil {
+				t.Fatalf("failed to get service: %v", err)
+			}
+			sa := controller.GetIstioServiceAccounts(svc, []int{8080})
+			sort.Strings(sa)
+			expected := []string{
+				canonicalSaOnVM,
+				"spiffe://company.com/ns/nsA/sa/" + sa2,
+				"spiffe://company.com/ns/nsA/sa/" + k8sSaOnVM,
+			}
+			if !reflect.DeepEqual(sa, expected) {
+				t.Fatalf("Unexpected service accounts %v (expecting %v)", sa, expected)
+			}
 
-	hostname = kube.ServiceHostname("svc2", "nsA", domainSuffix)
-	svc, err = controller.GetService(hostname)
-	if err != nil {
-		t.Fatalf("failed to get service: %v", err)
-	}
-	sa = controller.GetIstioServiceAccounts(svc, []int{})
-	if len(sa) != 0 {
-		t.Fatal("Failure: Expected to resolve 0 service accounts, but got: ", sa)
+			hostname = kube.ServiceHostname("svc2", "nsA", domainSuffix)
+			svc, err = controller.GetService(hostname)
+			if err != nil {
+				t.Fatalf("failed to get service: %v", err)
+			}
+			sa = controller.GetIstioServiceAccounts(svc, []int{})
+			if len(sa) != 0 {
+				t.Fatal("Failure: Expected to resolve 0 service accounts, but got: ", sa)
+			}
+		})
 	}
 }
 
 func TestWorkloadHealthCheckInfo(t *testing.T) {
-	controller, _ := newFakeController()
-	defer controller.Stop()
-
-	pod := generatePodWithProbes("128.0.0.1", "pod1", "nsa1", "", "node1", "/ready", intstr.Parse("8080"), "/live", intstr.Parse("9090"))
-	addPods(t, controller, pod)
-
-	if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-		t.Fatalf("wait for pod err: %v", err)
-	}
-	probes := controller.WorkloadHealthCheckInfo("128.0.0.1")
-
-	expected := []*model.Probe{
+	cases := []struct {
+		name     string
+		pod      *v1.Pod
+		expected model.ProbeList
+	}{
 		{
-			Path: "/ready",
-			Port: &model.Port{
-				Name:     "mgmt-8080",
-				Port:     8080,
-				Protocol: protocol.HTTP,
+			"health check",
+			generatePodWithProbes("128.0.0.1", "pod1", "nsa1", "", "node1", "/ready", intstr.Parse("8080"), "/live", intstr.Parse("9090")),
+			model.ProbeList{
+				{
+					Path: "/ready",
+					Port: &model.Port{
+						Name:     "mgmt-8080",
+						Port:     8080,
+						Protocol: protocol.HTTP,
+					},
+				},
+				{
+					Path: "/live",
+					Port: &model.Port{
+						Name:     "mgmt-9090",
+						Port:     9090,
+						Protocol: protocol.HTTP,
+					},
+				},
 			},
 		},
 		{
-			Path: "/live",
-			Port: &model.Port{
-				Name:     "mgmt-9090",
-				Port:     9090,
-				Protocol: protocol.HTTP,
-			},
+			"prometheus scrape",
+			generatePod("128.0.0.1", "pod1", "nsA", "", "node1", map[string]string{"app": "test-app"},
+				map[string]string{PrometheusScrape: "true"}),
+			model.ProbeList{{
+				Path: PrometheusPathDefault,
+			}},
+		},
+		{
+			"prometheus path",
+			generatePod("128.0.0.1", "pod1", "nsA", "", "node1", map[string]string{"app": "test-app"},
+				map[string]string{PrometheusScrape: "true", PrometheusPath: "/other"}),
+			model.ProbeList{{
+				Path: "/other",
+			}},
+		},
+		{
+			"prometheus port",
+			generatePod("128.0.0.1", "pod1", "nsA", "", "node1", map[string]string{"app": "test-app"},
+				map[string]string{PrometheusScrape: "true", PrometheusPort: "3210"}),
+			model.ProbeList{{
+				Port: &model.Port{
+					Port: 3210,
+				},
+				Path: PrometheusPathDefault,
+			}},
 		},
 	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			controller, _ := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
+			defer controller.Stop()
 
-	if len(probes) != len(expected) {
-		t.Fatalf("Expecting %d probes but got %d\r\n", len(expected), len(probes))
-		return
-	}
+			addPods(t, controller, tt.pod)
+			if err := waitForPod(controller, tt.pod.Status.PodIP); err != nil {
+				t.Fatalf("wait for pod err: %v", err)
+			}
 
-	for i, exp := range expected {
-		if !reflect.DeepEqual(exp, probes[i]) {
-			t.Fatalf("Probe %d, got:\n%#v\nwanted:\n%#v\n", i, probes[i], exp)
-		}
-	}
-}
+			probes := controller.WorkloadHealthCheckInfo("128.0.0.1")
 
-func TestWorkloadHealthCheckInfoPrometheusScrape(t *testing.T) {
-	controller, _ := newFakeController()
-	defer controller.Stop()
-
-	pod := generatePod("128.0.1.6", "pod1", "nsA", "", "node1", map[string]string{"app": "test-app"},
-		map[string]string{PrometheusScrape: "true"})
-	addPods(t, controller, pod)
-	if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-		t.Fatalf("wait for pod err: %v", err)
-	}
-
-	controller.pods.podsByIP["128.0.1.6"] = "nsA/pod1"
-
-	probes := controller.WorkloadHealthCheckInfo("128.0.1.6")
-
-	expected := &model.Probe{
-		Path: PrometheusPathDefault,
-	}
-
-	if len(probes) != 1 {
-		t.Fatalf("Expecting 1 probe but got %d\r\n", len(probes))
-	} else if !reflect.DeepEqual(expected, probes[0]) {
-		t.Fatalf("Probe got:\n%#v\nwanted:\n%#v\n", probes[0], expected)
-	}
-}
-
-func TestWorkloadHealthCheckInfoPrometheusPath(t *testing.T) {
-	controller, _ := newFakeController()
-	defer controller.Stop()
-
-	pod := generatePod("128.0.1.7", "pod1", "nsA", "", "node1", map[string]string{"app": "test-app"},
-		map[string]string{PrometheusScrape: "true", PrometheusPath: "/other"})
-	addPods(t, controller, pod)
-	if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-		t.Fatalf("wait for pod err: %v", err)
-	}
-	controller.pods.podsByIP["128.0.1.7"] = "nsA/pod1"
-
-	probes := controller.WorkloadHealthCheckInfo("128.0.1.7")
-
-	expected := &model.Probe{
-		Path: "/other",
-	}
-
-	if len(probes) != 1 {
-		t.Fatalf("Expecting 1 probe but got %d\r\n", len(probes))
-	} else if !reflect.DeepEqual(expected, probes[0]) {
-		t.Fatalf("Probe got:\n%#v\nwanted:\n%#v\n", probes[0], expected)
-	}
-}
-
-func TestWorkloadHealthCheckInfoPrometheusPort(t *testing.T) {
-	controller, _ := newFakeController()
-	defer controller.Stop()
-
-	pod := generatePod("128.0.1.8", "pod1", "nsA", "", "node1", map[string]string{"app": "test-app"},
-		map[string]string{PrometheusScrape: "true", PrometheusPort: "3210"})
-	addPods(t, controller, pod)
-	if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-		t.Fatalf("wait for pod err: %v", err)
-	}
-	controller.pods.podsByIP["128.0.1.8"] = "nsA/pod1"
-
-	probes := controller.WorkloadHealthCheckInfo("128.0.1.8")
-
-	expected := &model.Probe{
-		Port: &model.Port{
-			Port: 3210,
-		},
-		Path: PrometheusPathDefault,
-	}
-
-	if len(probes) != 1 {
-		t.Fatalf("Expecting 1 probe but got %d\r\n", len(probes))
-	} else if !reflect.DeepEqual(expected, probes[0]) {
-		t.Fatalf("Probe got:\n%#v\nwanted:\n%#v\n", probes[0], expected)
+			if len(probes) != len(tt.expected) {
+				t.Fatalf("Expecting 1 probe but got %d\r\n", len(probes))
+			}
+			if !reflect.DeepEqual(tt.expected, probes) {
+				t.Fatalf("Probe got:\n%#v\nwanted:\n%#v\n", probes, tt.expected)
+			}
+		})
 	}
 }
 
 func TestManagementPorts(t *testing.T) {
-	controller, _ := newFakeController()
+	controller, _ := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
 	defer controller.Stop()
 
 	pod := generatePodWithProbes("128.0.0.1", "pod1", "nsA", "", "node1", "/ready", intstr.Parse("8080"), "/live", intstr.Parse("9090"))
@@ -952,212 +919,221 @@ func TestManagementPorts(t *testing.T) {
 }
 
 func TestController_Service(t *testing.T) {
-	controller, fx := newFakeController()
-	defer controller.Stop()
-	// Use a timeout to keep the test from hanging.
+	for mode, name := range EndpointModeNames {
+		t.Run(name, func(t *testing.T) {
+			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			defer controller.Stop()
+			// Use a timeout to keep the test from hanging.
 
-	createService(controller, "svc1", "nsA",
-		map[string]string{},
-		[]int32{8080}, map[string]string{"test-app": "test-app-1"}, t)
-	<-fx.Events
-	createService(controller, "svc2", "nsA",
-		map[string]string{},
-		[]int32{8081}, map[string]string{"test-app": "test-app-2"}, t)
-	<-fx.Events
-	createService(controller, "svc3", "nsA",
-		map[string]string{},
-		[]int32{8082}, map[string]string{"test-app": "test-app-3"}, t)
-	<-fx.Events
-	createService(controller, "svc4", "nsA",
-		map[string]string{},
-		[]int32{8083}, map[string]string{"test-app": "test-app-4"}, t)
-	<-fx.Events
+			createService(controller, "svc1", "nsA",
+				map[string]string{},
+				[]int32{8080}, map[string]string{"test-app": "test-app-1"}, t)
+			<-fx.Events
+			createService(controller, "svc2", "nsA",
+				map[string]string{},
+				[]int32{8081}, map[string]string{"test-app": "test-app-2"}, t)
+			<-fx.Events
+			createService(controller, "svc3", "nsA",
+				map[string]string{},
+				[]int32{8082}, map[string]string{"test-app": "test-app-3"}, t)
+			<-fx.Events
+			createService(controller, "svc4", "nsA",
+				map[string]string{},
+				[]int32{8083}, map[string]string{"test-app": "test-app-4"}, t)
+			<-fx.Events
 
-	expectedSvcList := []*model.Service{
-		{
-			Hostname: kube.ServiceHostname("svc1", "nsA", domainSuffix),
-			Address:  "10.0.0.1",
-			Ports: model.PortList{
-				&model.Port{
-					Name:     "tcp-port",
-					Port:     8080,
-					Protocol: protocol.TCP,
+			expectedSvcList := []*model.Service{
+				{
+					Hostname: kube.ServiceHostname("svc1", "nsA", domainSuffix),
+					Address:  "10.0.0.1",
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "tcp-port",
+							Port:     8080,
+							Protocol: protocol.TCP,
+						},
+					},
 				},
-			},
-		},
-		{
-			Hostname: kube.ServiceHostname("svc2", "nsA", domainSuffix),
-			Address:  "10.0.0.1",
-			Ports: model.PortList{
-				&model.Port{
-					Name:     "tcp-port",
-					Port:     8081,
-					Protocol: protocol.TCP,
+				{
+					Hostname: kube.ServiceHostname("svc2", "nsA", domainSuffix),
+					Address:  "10.0.0.1",
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "tcp-port",
+							Port:     8081,
+							Protocol: protocol.TCP,
+						},
+					},
 				},
-			},
-		},
-		{
-			Hostname: kube.ServiceHostname("svc3", "nsA", domainSuffix),
-			Address:  "10.0.0.1",
-			Ports: model.PortList{
-				&model.Port{
-					Name:     "tcp-port",
-					Port:     8082,
-					Protocol: protocol.TCP,
+				{
+					Hostname: kube.ServiceHostname("svc3", "nsA", domainSuffix),
+					Address:  "10.0.0.1",
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "tcp-port",
+							Port:     8082,
+							Protocol: protocol.TCP,
+						},
+					},
 				},
-			},
-		},
-		{
-			Hostname: kube.ServiceHostname("svc4", "nsA", domainSuffix),
-			Address:  "10.0.0.1",
-			Ports: model.PortList{
-				&model.Port{
-					Name:     "tcp-port",
-					Port:     8083,
-					Protocol: protocol.TCP,
+				{
+					Hostname: kube.ServiceHostname("svc4", "nsA", domainSuffix),
+					Address:  "10.0.0.1",
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "tcp-port",
+							Port:     8083,
+							Protocol: protocol.TCP,
+						},
+					},
 				},
-			},
-		},
-	}
+			}
 
-	svcList, _ := controller.Services()
-	if len(svcList) != len(expectedSvcList) {
-		t.Fatalf("Expecting %d service but got %d\r\n", len(expectedSvcList), len(svcList))
-	}
-	for i, exp := range expectedSvcList {
-		if exp.Hostname != svcList[i].Hostname {
-			t.Fatalf("got hostname of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Hostname, exp.Hostname)
-		}
-		if exp.Address != svcList[i].Address {
-			t.Fatalf("got address of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Address, exp.Address)
-		}
-		if !reflect.DeepEqual(exp.Ports, svcList[i].Ports) {
-			t.Fatalf("got ports of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Ports, exp.Ports)
-		}
+			svcList, _ := controller.Services()
+			if len(svcList) != len(expectedSvcList) {
+				t.Fatalf("Expecting %d service but got %d\r\n", len(expectedSvcList), len(svcList))
+			}
+			for i, exp := range expectedSvcList {
+				if exp.Hostname != svcList[i].Hostname {
+					t.Fatalf("got hostname of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Hostname, exp.Hostname)
+				}
+				if exp.Address != svcList[i].Address {
+					t.Fatalf("got address of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Address, exp.Address)
+				}
+				if !reflect.DeepEqual(exp.Ports, svcList[i].Ports) {
+					t.Fatalf("got ports of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Ports, exp.Ports)
+				}
+			}
+		})
 	}
 }
 
 func TestController_ExternalNameService(t *testing.T) {
-	deleteWg := sync.WaitGroup{}
-	controller, fx := newFakeControllerWithOptions(fakeControllerOptions{
-		serviceHandler: func(_ *model.Service, e model.Event) {
-			if e == model.EventDelete {
-				deleteWg.Done()
+	for mode, name := range EndpointModeNames {
+		t.Run(name, func(t *testing.T) {
+			deleteWg := sync.WaitGroup{}
+			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{
+				mode: mode,
+				serviceHandler: func(_ *model.Service, e model.Event) {
+					if e == model.EventDelete {
+						deleteWg.Done()
+					}
+				},
+			})
+			defer controller.Stop()
+			// Use a timeout to keep the test from hanging.
+
+			k8sSvcs := []*coreV1.Service{
+				createExternalNameService(controller, "svc1", "nsA",
+					[]int32{8080}, "test-app-1.test.svc."+domainSuffix, t, fx.Events),
+				createExternalNameService(controller, "svc2", "nsA",
+					[]int32{8081}, "test-app-2.test.svc."+domainSuffix, t, fx.Events),
+				createExternalNameService(controller, "svc3", "nsA",
+					[]int32{8082}, "test-app-3.test.pod."+domainSuffix, t, fx.Events),
+				createExternalNameService(controller, "svc4", "nsA",
+					[]int32{8083}, "g.co", t, fx.Events),
 			}
-		},
-	})
-	defer controller.Stop()
-	// Use a timeout to keep the test from hanging.
 
-	k8sSvcs := []*coreV1.Service{
-		createExternalNameService(controller, "svc1", "nsA",
-			[]int32{8080}, "test-app-1.test.svc."+domainSuffix, t, fx.Events),
-		createExternalNameService(controller, "svc2", "nsA",
-			[]int32{8081}, "test-app-2.test.svc."+domainSuffix, t, fx.Events),
-		createExternalNameService(controller, "svc3", "nsA",
-			[]int32{8082}, "test-app-3.test.pod."+domainSuffix, t, fx.Events),
-		createExternalNameService(controller, "svc4", "nsA",
-			[]int32{8083}, "g.co", t, fx.Events),
-	}
-
-	expectedSvcList := []*model.Service{
-		{
-			Hostname: kube.ServiceHostname("svc1", "nsA", domainSuffix),
-			Ports: model.PortList{
-				&model.Port{
-					Name:     "tcp-port",
-					Port:     8080,
-					Protocol: protocol.TCP,
+			expectedSvcList := []*model.Service{
+				{
+					Hostname: kube.ServiceHostname("svc1", "nsA", domainSuffix),
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "tcp-port",
+							Port:     8080,
+							Protocol: protocol.TCP,
+						},
+					},
+					MeshExternal: true,
+					Resolution:   model.DNSLB,
 				},
-			},
-			MeshExternal: true,
-			Resolution:   model.DNSLB,
-		},
-		{
-			Hostname: kube.ServiceHostname("svc2", "nsA", domainSuffix),
-			Ports: model.PortList{
-				&model.Port{
-					Name:     "tcp-port",
-					Port:     8081,
-					Protocol: protocol.TCP,
+				{
+					Hostname: kube.ServiceHostname("svc2", "nsA", domainSuffix),
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "tcp-port",
+							Port:     8081,
+							Protocol: protocol.TCP,
+						},
+					},
+					MeshExternal: true,
+					Resolution:   model.DNSLB,
 				},
-			},
-			MeshExternal: true,
-			Resolution:   model.DNSLB,
-		},
-		{
-			Hostname: kube.ServiceHostname("svc3", "nsA", domainSuffix),
-			Ports: model.PortList{
-				&model.Port{
-					Name:     "tcp-port",
-					Port:     8082,
-					Protocol: protocol.TCP,
+				{
+					Hostname: kube.ServiceHostname("svc3", "nsA", domainSuffix),
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "tcp-port",
+							Port:     8082,
+							Protocol: protocol.TCP,
+						},
+					},
+					MeshExternal: true,
+					Resolution:   model.DNSLB,
 				},
-			},
-			MeshExternal: true,
-			Resolution:   model.DNSLB,
-		},
-		{
-			Hostname: kube.ServiceHostname("svc4", "nsA", domainSuffix),
-			Ports: model.PortList{
-				&model.Port{
-					Name:     "tcp-port",
-					Port:     8083,
-					Protocol: protocol.TCP,
+				{
+					Hostname: kube.ServiceHostname("svc4", "nsA", domainSuffix),
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "tcp-port",
+							Port:     8083,
+							Protocol: protocol.TCP,
+						},
+					},
+					MeshExternal: true,
+					Resolution:   model.DNSLB,
 				},
-			},
-			MeshExternal: true,
-			Resolution:   model.DNSLB,
-		},
-	}
+			}
 
-	svcList, _ := controller.Services()
-	if len(svcList) != len(expectedSvcList) {
-		t.Fatalf("Expecting %d service but got %d\r\n", len(expectedSvcList), len(svcList))
-	}
-	for i, exp := range expectedSvcList {
-		if exp.Hostname != svcList[i].Hostname {
-			t.Fatalf("got hostname of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Hostname, exp.Hostname)
-		}
-		if !reflect.DeepEqual(exp.Ports, svcList[i].Ports) {
-			t.Fatalf("got ports of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Ports, exp.Ports)
-		}
-		if svcList[i].MeshExternal != exp.MeshExternal {
-			t.Fatalf("i=%v, MeshExternal==%v, should be %v: externalName='%s'", i, exp.MeshExternal, svcList[i].MeshExternal, k8sSvcs[i].Spec.ExternalName)
-		}
-		if svcList[i].Resolution != exp.Resolution {
-			t.Fatalf("i=%v, Resolution=='%v', should be '%v'", i, svcList[i].Resolution, exp.Resolution)
-		}
-		instances, err := controller.InstancesByPort(svcList[i], svcList[i].Ports[0].Port, labels.Collection{})
-		if err != nil {
-			t.Fatalf("error getting instances by port: %s", err)
-		}
-		if len(instances) != 1 {
-			t.Fatalf("should be exactly 1 instance: len(instances) = %v", len(instances))
-		}
-		if instances[0].Endpoint.Address != k8sSvcs[i].Spec.ExternalName {
-			t.Fatalf("wrong instance endpoint address: '%s' != '%s'", instances[0].Endpoint.Address, k8sSvcs[i].Spec.ExternalName)
-		}
-	}
+			svcList, _ := controller.Services()
+			if len(svcList) != len(expectedSvcList) {
+				t.Fatalf("Expecting %d service but got %d\r\n", len(expectedSvcList), len(svcList))
+			}
+			for i, exp := range expectedSvcList {
+				if exp.Hostname != svcList[i].Hostname {
+					t.Fatalf("got hostname of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Hostname, exp.Hostname)
+				}
+				if !reflect.DeepEqual(exp.Ports, svcList[i].Ports) {
+					t.Fatalf("got ports of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Ports, exp.Ports)
+				}
+				if svcList[i].MeshExternal != exp.MeshExternal {
+					t.Fatalf("i=%v, MeshExternal==%v, should be %v: externalName='%s'", i, exp.MeshExternal, svcList[i].MeshExternal, k8sSvcs[i].Spec.ExternalName)
+				}
+				if svcList[i].Resolution != exp.Resolution {
+					t.Fatalf("i=%v, Resolution=='%v', should be '%v'", i, svcList[i].Resolution, exp.Resolution)
+				}
+				instances, err := controller.InstancesByPort(svcList[i], svcList[i].Ports[0].Port, labels.Collection{})
+				if err != nil {
+					t.Fatalf("error getting instances by port: %s", err)
+				}
+				if len(instances) != 1 {
+					t.Fatalf("should be exactly 1 instance: len(instances) = %v", len(instances))
+				}
+				if instances[0].Endpoint.Address != k8sSvcs[i].Spec.ExternalName {
+					t.Fatalf("wrong instance endpoint address: '%s' != '%s'", instances[0].Endpoint.Address, k8sSvcs[i].Spec.ExternalName)
+				}
+			}
 
-	deleteWg.Add(len(k8sSvcs))
-	for _, s := range k8sSvcs {
-		deleteExternalNameService(controller, s.Name, s.Namespace, t, fx.Events)
-	}
-	deleteWg.Wait()
+			deleteWg.Add(len(k8sSvcs))
+			for _, s := range k8sSvcs {
+				deleteExternalNameService(controller, s.Name, s.Namespace, t, fx.Events)
+			}
+			deleteWg.Wait()
 
-	svcList, _ = controller.Services()
-	if len(svcList) != 0 {
-		t.Fatalf("Should have 0 services at this point")
-	}
-	for _, exp := range expectedSvcList {
-		instances, err := controller.InstancesByPort(exp, exp.Ports[0].Port, labels.Collection{})
-		if err != nil {
-			t.Fatalf("error getting instances by port: %s", err)
-		}
-		if len(instances) != 0 {
-			t.Fatalf("should be exactly 0 instance: len(instances) = %v", len(instances))
-		}
+			svcList, _ = controller.Services()
+			if len(svcList) != 0 {
+				t.Fatalf("Should have 0 services at this point")
+			}
+			for _, exp := range expectedSvcList {
+				instances, err := controller.InstancesByPort(exp, exp.Ports[0].Port, labels.Collection{})
+				if err != nil {
+					t.Fatalf("error getting instances by port: %s", err)
+				}
+				if len(instances) != 0 {
+					t.Fatalf("should be exactly 0 instance: len(instances) = %v", len(instances))
+				}
+			}
+		})
 	}
 }
 
@@ -1557,103 +1533,111 @@ func addNodes(t *testing.T, controller *Controller, nodes ...*coreV1.Node) {
 }
 
 func TestEndpointUpdate(t *testing.T) {
-	controller, fx := newFakeController()
-	defer controller.Stop()
+	for mode, name := range EndpointModeNames {
+		t.Run(name, func(t *testing.T) {
+			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			defer controller.Stop()
 
-	pod1 := generatePod("128.0.0.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
-	pods := []*coreV1.Pod{pod1}
-	addPods(t, controller, pods...)
-	for _, pod := range pods {
-		if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-			t.Fatalf("wait for pod err: %v", err)
-		}
-		// pod first time occur will trigger xds push
-		fx.Wait("xds")
-	}
+			pod1 := generatePod("128.0.0.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
+			pods := []*coreV1.Pod{pod1}
+			addPods(t, controller, pods...)
+			for _, pod := range pods {
+				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
+					t.Fatalf("wait for pod err: %v", err)
+				}
+				// pod first time occur will trigger xds push
+				fx.Wait("xds")
+			}
 
-	// 1. incremental eds for normal service endpoint update
-	createService(controller, "svc1", "nsa", nil,
-		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
-	if ev := fx.Wait("service"); ev == nil {
-		t.Fatal("Timeout creating service")
-	}
+			// 1. incremental eds for normal service endpoint update
+			createService(controller, "svc1", "nsa", nil,
+				[]int32{8080}, map[string]string{"app": "prod-app"}, t)
+			if ev := fx.Wait("service"); ev == nil {
+				t.Fatal("Timeout creating service")
+			}
 
-	// Endpoints are generated by Kubernetes from pod labels and service selectors.
-	// Here we manually create them for mocking purpose.
-	svc1Ips := []string{"128.0.0.1"}
-	portNames := []string{"tcp-port"}
-	// Create 1 endpoint that refers to a pod in the same namespace.
-	createEndpoints(controller, "svc1", "nsa", portNames, svc1Ips, t)
-	if ev := fx.Wait("eds"); ev == nil {
-		t.Fatalf("Timeout incremental eds")
-	}
+			// Endpoints are generated by Kubernetes from pod labels and service selectors.
+			// Here we manually create them for mocking purpose.
+			svc1Ips := []string{"128.0.0.1"}
+			portNames := []string{"tcp-port"}
+			// Create 1 endpoint that refers to a pod in the same namespace.
+			createEndpoints(controller, "svc1", "nsa", portNames, svc1Ips, t)
+			if ev := fx.Wait("eds"); ev == nil {
+				t.Fatalf("Timeout incremental eds")
+			}
 
-	// delete normal service
-	err := controller.client.CoreV1().Services("nsa").Delete("svc1", &metaV1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("Cannot delete service (error: %v)", err)
-	}
-	if ev := fx.Wait("service"); ev == nil {
-		t.Fatalf("Timeout deleting service")
-	}
+			// delete normal service
+			err := controller.client.CoreV1().Services("nsa").Delete("svc1", &metaV1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("Cannot delete service (error: %v)", err)
+			}
+			if ev := fx.Wait("service"); ev == nil {
+				t.Fatalf("Timeout deleting service")
+			}
 
-	// 2. full xds push request for headless service endpoint update
+			// 2. full xds push request for headless service endpoint update
 
-	// create a headless service
-	createServiceWithoutClusterIP(controller, "svc1", "nsa", nil,
-		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
-	if ev := fx.Wait("service"); ev == nil {
-		t.Fatalf("Timeout creating service")
-	}
+			// create a headless service
+			createServiceWithoutClusterIP(controller, "svc1", "nsa", nil,
+				[]int32{8080}, map[string]string{"app": "prod-app"}, t)
+			if ev := fx.Wait("service"); ev == nil {
+				t.Fatalf("Timeout creating service")
+			}
 
-	// Create 1 endpoint that refers to a pod in the same namespace.
-	svc1Ips = append(svc1Ips, "128.0.0.2")
-	updateEndpoints(controller, "svc1", "nsa", portNames, svc1Ips, t)
-	if ev := fx.Wait("xds"); ev == nil {
-		t.Fatalf("Timeout xds push")
+			// Create 1 endpoint that refers to a pod in the same namespace.
+			svc1Ips = append(svc1Ips, "128.0.0.2")
+			updateEndpoints(controller, "svc1", "nsa", portNames, svc1Ips, t)
+			if ev := fx.Wait("xds"); ev == nil {
+				t.Fatalf("Timeout xds push")
+			}
+		})
 	}
 }
 
 // Validates that when Pilot sees Endpoint before the corresponding Pod, it loads Pod from K8S and proceed.
 func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
-	// Setup kube caches
-	controller, fx := newFakeController()
-	defer controller.Stop()
-	pod1 := generatePod("172.0.1.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
-	pod2 := generatePod("172.0.1.2", "pod2", "nsA", "", "node2", map[string]string{"app": "prod-app"}, map[string]string{})
+	for mode, name := range EndpointModeNames {
+		t.Run(name, func(t *testing.T) {
+			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			// Setup kube caches
+			defer controller.Stop()
+			pod1 := generatePod("172.0.1.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
+			pod2 := generatePod("172.0.1.2", "pod2", "nsA", "", "node2", map[string]string{"app": "prod-app"}, map[string]string{})
 
-	pods := []*coreV1.Pod{pod1, pod2}
-	nodes := []*coreV1.Node{
-		generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", IstioSubzoneLabel: "subzone1"}),
-		generateNode("node2", map[string]string{NodeZoneLabel: "zone2", NodeRegionLabel: "region2", IstioSubzoneLabel: "subzone2"}),
-	}
-	addNodes(t, controller, nodes...)
-	addPods(t, controller, pods...)
-	for _, pod := range pods {
-		if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-			t.Fatalf("wait for pod err: %v", err)
-		}
-		// pod first time occur will trigger xds push
-		fx.Wait("xds")
-	}
+			pods := []*coreV1.Pod{pod1, pod2}
+			nodes := []*coreV1.Node{
+				generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", IstioSubzoneLabel: "subzone1"}),
+				generateNode("node2", map[string]string{NodeZoneLabel: "zone2", NodeRegionLabel: "region2", IstioSubzoneLabel: "subzone2"}),
+			}
+			addNodes(t, controller, nodes...)
+			addPods(t, controller, pods...)
+			for _, pod := range pods {
+				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
+					t.Fatalf("wait for pod err: %v", err)
+				}
+				// pod first time occur will trigger xds push
+				fx.Wait("xds")
+			}
 
-	// Create Endpoints for pod1 and validate that EDS is triggered.
-	pod1Ips := []string{"172.0.1.1"}
-	portNames := []string{"tcp-port"}
-	createEndpoints(controller, "pod1", "nsA", portNames, pod1Ips, t)
-	if ev := fx.Wait("eds"); ev == nil {
-		t.Fatalf("Timeout incremental eds")
-	}
+			// Create Endpoints for pod1 and validate that EDS is triggered.
+			pod1Ips := []string{"172.0.1.1"}
+			portNames := []string{"tcp-port"}
+			createEndpoints(controller, "pod1", "nsA", portNames, pod1Ips, t)
+			if ev := fx.Wait("eds"); ev == nil {
+				t.Fatalf("Timeout incremental eds")
+			}
 
-	// Now delete pod2, from PodCache and send Endpoints. This simulates the case that endpoint comes
-	// when PodCache does not yet have entry for the pod.
-	_ = controller.pods.onEvent(pod2, model.EventDelete)
+			// Now delete pod2, from PodCache and send Endpoints. This simulates the case that endpoint comes
+			// when PodCache does not yet have entry for the pod.
+			_ = controller.pods.onEvent(pod2, model.EventDelete)
 
-	pod2Ips := []string{"172.0.1.2"}
-	createEndpoints(controller, "pod2", "nsA", portNames, pod2Ips, t)
+			pod2Ips := []string{"172.0.1.2"}
+			createEndpoints(controller, "pod2", "nsA", portNames, pod2Ips, t)
 
-	// Validate that EDS is triggered with endpoints.
-	if ev := fx.Wait("eds"); ev == nil {
-		t.Fatalf("Timeout incremental eds")
+			// Validate that EDS is triggered with endpoints.
+			if ev := fx.Wait("eds"); ev == nil {
+				t.Fatalf("Timeout incremental eds")
+			}
+		})
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -192,6 +192,7 @@ func TestServices(t *testing.T) {
 	})
 
 	for mode, name := range EndpointModeNames {
+		mode := mode
 		t.Run(name, func(t *testing.T) {
 			ctl, fx := newFakeControllerWithOptions(fakeControllerOptions{networksWatcher: networksWatcher, mode: mode})
 			defer ctl.Stop()
@@ -422,6 +423,7 @@ func TestController_GetPodLocality(t *testing.T) {
 
 func TestGetProxyServiceInstances(t *testing.T) {
 	for mode, name := range EndpointModeNames {
+		mode := mode
 		t.Run(name, func(t *testing.T) {
 			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
 			defer controller.Stop()
@@ -696,6 +698,7 @@ func TestGetProxyServiceInstancesWithMultiIPs(t *testing.T) {
 
 	for _, c := range testCases {
 		for mode, name := range EndpointModeNames {
+			mode := mode
 			t.Run(fmt.Sprintf("%s_%s", c.name, name), func(t *testing.T) {
 				// Setup kube caches
 				controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
@@ -734,6 +737,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 	defer spiffe.SetTrustDomain(oldTrustDomain)
 
 	for mode, name := range EndpointModeNames {
+		mode := mode
 		t.Run(name, func(t *testing.T) {
 			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
 			defer controller.Stop()
@@ -920,6 +924,7 @@ func TestManagementPorts(t *testing.T) {
 
 func TestController_Service(t *testing.T) {
 	for mode, name := range EndpointModeNames {
+		mode := mode
 		t.Run(name, func(t *testing.T) {
 			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
 			defer controller.Stop()
@@ -1010,6 +1015,7 @@ func TestController_Service(t *testing.T) {
 
 func TestController_ExternalNameService(t *testing.T) {
 	for mode, name := range EndpointModeNames {
+		mode := mode
 		t.Run(name, func(t *testing.T) {
 			deleteWg := sync.WaitGroup{}
 			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{
@@ -1534,6 +1540,7 @@ func addNodes(t *testing.T, controller *Controller, nodes ...*coreV1.Node) {
 
 func TestEndpointUpdate(t *testing.T) {
 	for mode, name := range EndpointModeNames {
+		mode := mode
 		t.Run(name, func(t *testing.T) {
 			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
 			defer controller.Stop()
@@ -1597,6 +1604,7 @@ func TestEndpointUpdate(t *testing.T) {
 // Validates that when Pilot sees Endpoint before the corresponding Pod, it loads Pod from K8S and proceed.
 func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 	for mode, name := range EndpointModeNames {
+		mode := mode
 		t.Run(name, func(t *testing.T) {
 			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
 			// Setup kube caches

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -51,7 +51,7 @@ func newEndpointSliceController(c *Controller, sharedInformers informers.SharedI
 		informer:      informer,
 		endpointCache: newEndpointSliceCache(),
 	}
-	registerHandlers(c.services, c.queue, "EndpointSlice", out.onEvent)
+	registerHandlers(informer, c.queue, "EndpointSlice", out.onEvent)
 	return out
 }
 
@@ -145,7 +145,7 @@ func (e *endpointSliceController) onEvent(curr interface{}, event model.Event) e
 	if !ok {
 		tombstone, ok := curr.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			log.Errorf("Couldn't get object from tombstone %#v", curr)
+			log.Errorf("1 Couldn't get object from tombstone %#v", curr)
 			return nil
 		}
 		ep, ok = tombstone.Obj.(*discoveryv1alpha1.EndpointSlice)

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -102,7 +102,7 @@ func cleanup(ki kubernetes.Interface) {
 func TestPodCache(t *testing.T) {
 	t.Run("fakeApiserver", func(t *testing.T) {
 		t.Parallel()
-		c, fx := newFakeController()
+		c, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
 		defer c.Stop()
 		testPodCache(t, c, fx)
 	})
@@ -165,7 +165,7 @@ func testPodCache(t *testing.T, c *Controller, fx *FakeXdsUpdater) {
 // Checks that events from the watcher create the proper internal structures
 func TestPodCacheEvents(t *testing.T) {
 	t.Parallel()
-	c, fx := newFakeController()
+	c, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
 	defer c.Stop()
 	podCache := newPodCache(nil, c)
 


### PR DESCRIPTION
This change makes our controller tests run twice, once with endpoints
and once with endpoint slice. A few tests are not relevant to this, so
they are just using Endpoints as before. Additionally, the probing tests
were combined to use a table driven test to make this change simpler.