### PR TITLE
Support -A as alternative to --all-namespaces

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -286,7 +286,7 @@ istioctl analyze -L
 		fmt.Sprintf("Output format: one of %v", msgOutputFormatKeys))
 	analysisCmd.PersistentFlags().StringVar(&meshCfgFile, "meshConfigFile", "",
 		"Overrides the mesh config values to use for analysis.")
-	analysisCmd.PersistentFlags().BoolVar(&allNamespaces, "all-namespaces", false,
+	analysisCmd.PersistentFlags().BoolVarP(&allNamespaces, "all-namespaces", "A", false,
 		"Analyze all namespaces")
 	return analysisCmd
 }


### PR DESCRIPTION
`-A` is used as an alias in kubectl for `--all-namespaces` as well.