### PR TITLE
Add location to generated ServiceEntry

### DIFF
--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -408,6 +408,7 @@ func generateServiceEntry(u *unstructured.Unstructured, o *vmServiceOpts) error 
 		Ports:      ports,
 		Endpoints:  eps,
 		Resolution: v1alpha3.ServiceEntry_STATIC,
+		Location:   v1alpha3.ServiceEntry_MESH_INTERNAL,
 	}
 
 	// Because we are placing into an Unstructured, place as a map instead


### PR DESCRIPTION

`istioctl x add-to-mesh` should add the location to the `ServiceEntry` since some tools (Kiali) evaluates the value. Without this value the SE will not be shown in Kiali.