### PR TITLE
Check label matching against all JWT policies in the root namespace

### DIFF
--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -138,6 +138,20 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 					},
 					Spec: &securityBeta.RequestAuthentication{},
 				},
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      "request-authentication",
+						Name:      "global-with-selector",
+						Namespace: "istio-config",
+					},
+					Spec: &securityBeta.RequestAuthentication{
+						Selector: &selectorpb.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "httpbin",
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -161,6 +175,20 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 					},
 					Spec: &securityBeta.RequestAuthentication{},
 				},
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      "request-authentication",
+						Name:      "global-with-selector",
+						Namespace: "istio-config",
+					},
+					Spec: &securityBeta.RequestAuthentication{
+						Selector: &selectorpb.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "httpbin",
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -183,6 +211,20 @@ func TestGetJwtPoliciesForWorkload(t *testing.T) {
 						Namespace: "istio-config",
 					},
 					Spec: &securityBeta.RequestAuthentication{},
+				},
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      "request-authentication",
+						Name:      "global-with-selector",
+						Namespace: "istio-config",
+					},
+					Spec: &securityBeta.RequestAuthentication{
+						Selector: &selectorpb.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "httpbin",
+							},
+						},
+					},
 				},
 			},
 		},
@@ -232,7 +274,11 @@ func createTestConfigs() []*Config {
 		},
 	}
 	configs = append(configs, createTestConfig("default", rootNamespace, nil),
-		createTestConfig("should-be-ignored", rootNamespace, nil),
+		createTestConfig("global-with-selector", rootNamespace, &selectorpb.WorkloadSelector{
+			MatchLabels: map[string]string{
+				"app": "httpbin",
+			},
+		}),
 		createTestConfig("default", "foo", nil),
 		createTestConfig("default", "bar", nil),
 		createTestConfig("with-selector", "foo", selector))


### PR DESCRIPTION
In the current implementation, we assume JWT policy in root namespace does not have selector (and also is singleton - only one with name `default` should be considered); webhook validation should reject configs in the root namespace that have selector. However, the current validation framework doesn't have root namespace information, thus it cannot enforce such rule (yet). 

This PR drops that assumption, allow any request authentication policy in the root config can be applied (if the selector match)