### PR TITLE
Fix reloading of mutating webhook CA

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -36,7 +36,7 @@ const (
 
 	// Default CA certificate path
 	// Currently, custom CA path is not supported; no API to get custom CA cert yet.
-	defaultCACertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	defaultCACertPath = "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
 
 var (

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -133,7 +133,7 @@ func patchCertLoop(client kubernetes.Interface, stopCh <-chan struct{}) error {
 
 				if oldConfig.ResourceVersion != newConfig.ResourceVersion {
 					for i, w := range newConfig.Webhooks {
-						if w.Name == webhookConfigName.Get() && !bytes.Equal(newConfig.Webhooks[i].ClientConfig.CABundle, caCertPem) {
+						if w.Name == webhookName && !bytes.Equal(newConfig.Webhooks[i].ClientConfig.CABundle, caCertPem) {
 							log.Infof("Detected a change in CABundle, patching MutatingWebhookConfiguration again")
 							shouldPatch <- struct{}{}
 							break


### PR DESCRIPTION
Wrong name, updating the mutating webhook was ignored.

The "." in path allows local debugging - on K8S base dir is "/", but when running istiod locally
you can copy the files to relative paths to avoid running as root. 