### PR TITLE
Reuse values from old root cert

### DIFF
--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -169,7 +169,8 @@ func (rotator *SelfSignedCARootCertRotator) checkAndRotateRootCertForSigningCert
 
 	oldCertOptions, err := util.GetCertOptionsFromExistingCert(caSecret.Data[caCertID])
 	if err != nil {
-		rootCertRotatorLog.Warnf("Failed to extract org information from old root cert, uses org (%s) from config", org)
+		rootCertRotatorLog.Warnf("Failed to generate cert options from existing root certificate (%v), " +
+			"new root certificate may not match old root certificate", err)
 	}
 	options := util.CertOptions{
 		TTL:           rotator.config.caCertTTL,
@@ -180,6 +181,9 @@ func (rotator *SelfSignedCARootCertRotator) checkAndRotateRootCertForSigningCert
 		RSAKeySize:    caKeySize,
 		IsDualUse:     rotator.config.dualUse,
 	}
+	// options should be consistent with the one used in NewSelfSignedIstioCAOptions().
+	// This is to make sure when rotate the root cert, we don't make unnecessary changes
+	// to the certificate or add extra fields to the certificate.
 	options = util.MergeCertOptions(options, oldCertOptions)
 	pemCert, pemKey, ckErr := util.GenRootCertFromExistingKey(options)
 	if ckErr != nil {

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -169,7 +169,7 @@ func (rotator *SelfSignedCARootCertRotator) checkAndRotateRootCertForSigningCert
 
 	oldCertOptions, err := util.GetCertOptionsFromExistingCert(caSecret.Data[caCertID])
 	if err != nil {
-		rootCertRotatorLog.Warnf("Failed to generate cert options from existing root certificate (%v), " +
+		rootCertRotatorLog.Warnf("Failed to generate cert options from existing root certificate (%v), "+
 			"new root certificate may not match old root certificate", err)
 	}
 	options := util.CertOptions{

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -166,6 +166,11 @@ func (rotator *SelfSignedCARootCertRotator) checkAndRotateRootCertForSigningCert
 	}
 
 	rootCertRotatorLog.Infof("Refresh root certificate, root cert is about to expire: %s", err.Error())
+
+	oldCertOptions, err := util.GetCertOptionsFromExistingCert(caSecret.Data[caCertID])
+	if err != nil {
+		rootCertRotatorLog.Warnf("Failed to extract org information from old root cert, uses org (%s) from config", org)
+	}
 	options := util.CertOptions{
 		TTL:           rotator.config.caCertTTL,
 		SignerPrivPem: caSecret.Data[caPrivateKeyID],
@@ -175,6 +180,7 @@ func (rotator *SelfSignedCARootCertRotator) checkAndRotateRootCertForSigningCert
 		RSAKeySize:    caKeySize,
 		IsDualUse:     rotator.config.dualUse,
 	}
+	options = util.MergeCertOptions(options, oldCertOptions)
 	pemCert, pemKey, ckErr := util.GenRootCertFromExistingKey(options)
 	if ckErr != nil {
 		rootCertRotatorLog.Errorf("unable to generate CA cert and key for self-signed CA: %s", ckErr.Error())

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
@@ -17,6 +17,7 @@ package ca
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"testing"
 	"time"
 
@@ -130,6 +131,103 @@ func TestRootCertRotatorForSigningCitadel(t *testing.T) {
 	rotator.checkAndRotateRootCert()
 	certItem2 := loadCert(rotator)
 	verifyRootCertAndPrivateKey(t, false, certItem1, certItem2)
+}
+
+// TestRootCertRotatorKeepCertFieldsUnchanged verifies that rotator
+// extracts information from existing certificate and passes then into new root
+// certificate.
+func TestRootCertRotatorKeepCertFieldsUnchanged(t *testing.T) {
+	rotator := getRootCertRotator(getDefaultSelfSignedIstioCAOptions(nil))
+	// Update CASecret with a new root cert generated from custom cert options. The
+	// cert options differ from default cert options used by rotator.
+	oldCertOrg := "old cert org"
+	oldCertRSAKeySize := 512
+	customCertOptions := util.CertOptions{
+		TTL:           rotator.config.caCertTTL,
+		Org:           oldCertOrg,
+		IsCA:          true,
+		IsSelfSigned:  true,
+		RSAKeySize:    oldCertRSAKeySize,
+	}
+	updateRootCertWithCustomCertOptions(t, rotator, customCertOptions)
+
+	// Make a copy of CA secret, a copy of root cert form key cert bundle, and
+	// a copy of root cert from config map for verification.
+	certItem0 := loadCert(rotator)
+
+	// Change grace period percentage to 100, so that root cert is guarantee to rotate.
+	rotator.config.certInspector = certutil.NewCertUtil(100)
+	// Rotate the root certificate now.
+	rotator.checkAndRotateRootCert()
+	certItem1 := loadCert(rotator)
+
+	if !bytes.Equal(certItem0.caSecret.Data[caPrivateKeyID], certItem1.caSecret.Data[caPrivateKeyID]) {
+		t.Errorf("private key should not change")
+	}
+	// verifyRootCertFields verifies that new root cert and private key matches the
+	// old root cert and private key.
+	verifyRootCertFields(t, certItem0, certItem1)
+}
+
+// updateRootCertWithCustomCertOptions generate root cert and private key with
+// custom cert options, and replaces root cert and key in CA secret.
+func updateRootCertWithCustomCertOptions(t *testing.T,
+		rotator *SelfSignedCARootCertRotator, options util.CertOptions) {
+	certItem := loadCert(rotator)
+
+	pemCert, pemKey, err := util.GenCertKeyFromOptions(options)
+	if err != nil {
+		t.Fatalf("failed to rotate secret: %v", err)
+	}
+	newSecret := certItem.caSecret
+	newSecret.Data[caCertID] = pemCert
+	newSecret.Data[caPrivateKeyID] = pemKey
+	rotator.config.client.Secrets(rotator.config.caStorageNamespace).Update(newSecret)
+}
+
+// verifyRootCertFields verifies that certain fields in both new and old root
+// cert and key should not change.
+func verifyRootCertFields(t *testing.T, oldCertItem, newCertItem rootCertItem) {
+	if !bytes.Equal(oldCertItem.caSecret.Data[caPrivateKeyID],
+		newCertItem.caSecret.Data[caPrivateKeyID]) {
+		t.Errorf("private key should not change")
+	}
+	oldKeyLen := getPublicKeySizeInBits(oldCertItem.caSecret.Data[caPrivateKeyID])
+	newKeyLen := getPublicKeySizeInBits(newCertItem.caSecret.Data[caPrivateKeyID])
+
+	if oldKeyLen != newKeyLen {
+		t.Errorf("Public key size should not change, (got %d) vs (expected %d)",
+			newKeyLen, oldKeyLen)
+	}
+
+	oldRootCert, _ := util.ParsePemEncodedCertificate(oldCertItem.caSecret.Data[caCertID])
+	newRootCert, _ := util.ParsePemEncodedCertificate(newCertItem.caSecret.Data[caCertID])
+	if oldRootCert.Subject.String() != newRootCert.Subject.String() {
+		t.Errorf("certificate Subject does not match (old: %s) vs (new: %s)",
+			oldRootCert.Subject.String(), newRootCert.Subject.String())
+	}
+	if oldRootCert.Issuer.String() != newRootCert.Issuer.String() {
+		t.Errorf("certificate Issuer does not match (old: %s) vs (new: %s)",
+			oldRootCert.Issuer.String(), newRootCert.Issuer.String())
+	}
+	if oldRootCert.IsCA != newRootCert.IsCA {
+		t.Errorf("certificate IsCA does not match (old: %t) vs (new: %t)",
+			oldRootCert.IsCA, newRootCert.IsCA)
+	}
+	if oldRootCert.Version != newRootCert.Version {
+		t.Errorf("certificate Version does not match (old: %d) vs (new: %d)",
+			oldRootCert.Version, newRootCert.Version)
+	}
+	if oldRootCert.PublicKeyAlgorithm != newRootCert.PublicKeyAlgorithm {
+		t.Errorf("public key algorithm does not match (old: %s) vs (new: %s)",
+			oldRootCert.PublicKeyAlgorithm.String(), newRootCert.PublicKeyAlgorithm.String())
+	}
+}
+
+func getPublicKeySizeInBits(keyPem []byte) int {
+	privateKey, _ := util.ParsePemEncodedKey(keyPem)
+	k := privateKey.(*rsa.PrivateKey)
+	return k.PublicKey.Size() * 8
 }
 
 // TestKeyCertBundleReloadInRootCertRotatorForSigningCitadel verifies that

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
@@ -143,11 +143,11 @@ func TestRootCertRotatorKeepCertFieldsUnchanged(t *testing.T) {
 	oldCertOrg := "old cert org"
 	oldCertRSAKeySize := 512
 	customCertOptions := util.CertOptions{
-		TTL:           rotator.config.caCertTTL,
-		Org:           oldCertOrg,
-		IsCA:          true,
-		IsSelfSigned:  true,
-		RSAKeySize:    oldCertRSAKeySize,
+		TTL:          rotator.config.caCertTTL,
+		Org:          oldCertOrg,
+		IsCA:         true,
+		IsSelfSigned: true,
+		RSAKeySize:   oldCertRSAKeySize,
 	}
 	updateRootCertWithCustomCertOptions(t, rotator, customCertOptions)
 
@@ -172,7 +172,7 @@ func TestRootCertRotatorKeepCertFieldsUnchanged(t *testing.T) {
 // updateRootCertWithCustomCertOptions generate root cert and private key with
 // custom cert options, and replaces root cert and key in CA secret.
 func updateRootCertWithCustomCertOptions(t *testing.T,
-		rotator *SelfSignedCARootCertRotator, options util.CertOptions) {
+	rotator *SelfSignedCARootCertRotator, options util.CertOptions) {
 	certItem := loadCert(rotator)
 
 	pemCert, pemKey, err := util.GenCertKeyFromOptions(options)

--- a/security/pkg/pki/util/generate_cert.go
+++ b/security/pkg/pki/util/generate_cert.go
@@ -154,6 +154,41 @@ func GenRootCertFromExistingKey(options CertOptions) (pemCert []byte, pemKey []b
 	return pemCert, options.SignerPrivPem, nil
 }
 
+// GetCertOptionsFromExistingCert parses cert and generates a CertOptions
+// that contains information about the cert. This is the reverse operation of
+// genCertTemplateFromOptions(), and only called by a self-signed Citadel.
+func GetCertOptionsFromExistingCert(certBytes []byte) (opts CertOptions, err error) {
+	cert, certErr := ParsePemEncodedCertificate(certBytes)
+	if certErr != nil {
+		return opts, certErr
+	}
+
+	orgs := cert.Subject.Organization
+	if len(orgs) > 0 {
+		opts.Org = orgs[0]
+	}
+	if len(cert.Subject.CommonName) > 0 {
+		opts.Host = cert.Subject.CommonName
+		opts.IsDualUse = true
+	}
+	return opts, nil
+}
+
+// MergeCertOptions merges deltaOpts into defaultOpts and returns the merged
+// CertOptions. Only called by a self-signed Citadel.
+func MergeCertOptions(defaultOpts, deltaOpts CertOptions) CertOptions {
+	if len(deltaOpts.Org) > 0 {
+		defaultOpts.Org = deltaOpts.Org
+	}
+	if len(deltaOpts.Host) > 0 {
+		defaultOpts.Host = deltaOpts.Host
+		if deltaOpts.IsDualUse {
+			defaultOpts.IsDualUse = true
+		}
+	}
+	return defaultOpts
+}
+
 // GenCertFromCSR generates a X.509 certificate with the given CSR.
 func GenCertFromCSR(csr *x509.CertificateRequest, signingCert *x509.Certificate, publicKey interface{},
 	signingKey crypto.PrivateKey, subjectIDs []string, ttl time.Duration, isCA bool) (cert []byte, err error) {

--- a/security/pkg/pki/util/generate_cert.go
+++ b/security/pkg/pki/util/generate_cert.go
@@ -167,10 +167,7 @@ func GetCertOptionsFromExistingCert(certBytes []byte) (opts CertOptions, err err
 	if len(orgs) > 0 {
 		opts.Org = orgs[0]
 	}
-	if len(cert.Subject.CommonName) > 0 {
-		opts.Host = cert.Subject.CommonName
-		opts.IsDualUse = true
-	}
+	// TODO(JimmyCYJ): parse other fields from certificate, e.g. CommonName.
 	return opts, nil
 }
 
@@ -180,12 +177,7 @@ func MergeCertOptions(defaultOpts, deltaOpts CertOptions) CertOptions {
 	if len(deltaOpts.Org) > 0 {
 		defaultOpts.Org = deltaOpts.Org
 	}
-	if len(deltaOpts.Host) > 0 {
-		defaultOpts.Host = deltaOpts.Host
-		if deltaOpts.IsDualUse {
-			defaultOpts.IsDualUse = true
-		}
-	}
+	// TODO(JimmyCYJ): merge other fields, e.g. Host, IsDualUse, etc.
 	return defaultOpts
 }
 

--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -609,6 +609,9 @@ func TestGenRootCertFromExistingKey(t *testing.T) {
 		t.Errorf("private key should not change")
 	}
 	keyLen, err := getPublicKeySizeInBits(newRootKeyPem)
+	if err != nil {
+		t.Errorf("failed to parse private key: %v", err)
+	}
 	if keyLen != caKeySize {
 		t.Errorf("Public key size should not change, (got %d) vs (expected %d)",
 			keyLen, caKeySize)

--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -614,7 +614,7 @@ func TestGetCertOptionsFromExistingCert(t *testing.T) {
 		t.Errorf("certificate IsCA does not match (old: %t) vs (new: %t)",
 			oldRootCert.IsCA, newRootCert.IsCA)
 	}
-  if oldRootCert.Version != newRootCert.Version {
+	if oldRootCert.Version != newRootCert.Version {
 		t.Errorf("certificate Version does not match (old: %d) vs (new: %d)",
 			oldRootCert.Version, newRootCert.Version)
 	}

--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -636,62 +636,62 @@ func TestGenRootCertFromExistingKey(t *testing.T) {
 		t.Errorf("public key algorithm does not match (old: %s) vs (new: %s)",
 			oldRootCert.PublicKeyAlgorithm.String(), newRootCert.PublicKeyAlgorithm.String())
 	}
- }
+}
 
- func getPublicKeySizeInBits(keyPem []byte) (int, error) {
- 	privateKey, err := ParsePemEncodedKey(keyPem)
- 	if err != nil {
- 		return 0, err
+func getPublicKeySizeInBits(keyPem []byte) (int, error) {
+	privateKey, err := ParsePemEncodedKey(keyPem)
+	if err != nil {
+		return 0, err
 	}
 	k := privateKey.(*rsa.PrivateKey)
-	return k.PublicKey.Size()*8, nil
- }
+	return k.PublicKey.Size() * 8, nil
+}
 
- // TestMergeCertOptions verifies that cert option fields are overwritten.
- func TestMergeCertOptions(t *testing.T) {
-	 certTTL := 240 * time.Hour
-	 org := "old org"
-	 keySize := 512
-	 defaultCertOptions := CertOptions{
-		 TTL:          certTTL,
-		 Org:          org,
-		 IsCA:         true,
-		 IsSelfSigned: true,
-		 RSAKeySize:   keySize,
-		 IsDualUse:    false,
-	 }
+// TestMergeCertOptions verifies that cert option fields are overwritten.
+func TestMergeCertOptions(t *testing.T) {
+	certTTL := 240 * time.Hour
+	org := "old org"
+	keySize := 512
+	defaultCertOptions := CertOptions{
+		TTL:          certTTL,
+		Org:          org,
+		IsCA:         true,
+		IsSelfSigned: true,
+		RSAKeySize:   keySize,
+		IsDualUse:    false,
+	}
 
-	 deltaCertTTL := 1 * time.Hour
-	 deltaOrg := "delta org"
-	 deltaKeySize := 1024
-	 deltaCertOptions := CertOptions{
-		 TTL:          deltaCertTTL,
-		 Org:          deltaOrg,
-		 IsCA:         true,
-		 IsSelfSigned: true,
-		 RSAKeySize:   deltaKeySize,
-		 IsDualUse:    true,
-	 }
+	deltaCertTTL := 1 * time.Hour
+	deltaOrg := "delta org"
+	deltaKeySize := 1024
+	deltaCertOptions := CertOptions{
+		TTL:          deltaCertTTL,
+		Org:          deltaOrg,
+		IsCA:         true,
+		IsSelfSigned: true,
+		RSAKeySize:   deltaKeySize,
+		IsDualUse:    true,
+	}
 
-	 mergedCertOptions := MergeCertOptions(defaultCertOptions, deltaCertOptions)
-	 if mergedCertOptions.Org != deltaCertOptions.Org {
-	 	t.Errorf("Org does not match, (get %s) vs (expected %s)",
-	 		mergedCertOptions.Org, deltaCertOptions.Org)
-	 }
-	 if mergedCertOptions.TTL != defaultCertOptions.TTL {
-		 t.Errorf("TTL does not match, (get %s) vs (expected %s)",
-			 mergedCertOptions.TTL.String(), deltaCertOptions.TTL.String())
-	 }
-	 if mergedCertOptions.IsCA != defaultCertOptions.IsCA {
-		 t.Errorf("IsCA does not match, (get %t) vs (expected %t)",
-			 mergedCertOptions.IsCA, deltaCertOptions.IsCA)
-	 }
-	 if mergedCertOptions.RSAKeySize != defaultCertOptions.RSAKeySize {
-		 t.Errorf("TTL does not match, (get %d) vs (expected %d)",
-			 mergedCertOptions.RSAKeySize, deltaCertOptions.RSAKeySize)
-	 }
-	 if mergedCertOptions.IsDualUse != defaultCertOptions.IsDualUse {
-		 t.Errorf("IsDualUse does not match, (get %t) vs (expected %t)",
-			 mergedCertOptions.IsDualUse, deltaCertOptions.IsDualUse)
-	 }
- }
+	mergedCertOptions := MergeCertOptions(defaultCertOptions, deltaCertOptions)
+	if mergedCertOptions.Org != deltaCertOptions.Org {
+		t.Errorf("Org does not match, (get %s) vs (expected %s)",
+			mergedCertOptions.Org, deltaCertOptions.Org)
+	}
+	if mergedCertOptions.TTL != defaultCertOptions.TTL {
+		t.Errorf("TTL does not match, (get %s) vs (expected %s)",
+			mergedCertOptions.TTL.String(), deltaCertOptions.TTL.String())
+	}
+	if mergedCertOptions.IsCA != defaultCertOptions.IsCA {
+		t.Errorf("IsCA does not match, (get %t) vs (expected %t)",
+			mergedCertOptions.IsCA, deltaCertOptions.IsCA)
+	}
+	if mergedCertOptions.RSAKeySize != defaultCertOptions.RSAKeySize {
+		t.Errorf("TTL does not match, (get %d) vs (expected %d)",
+			mergedCertOptions.RSAKeySize, deltaCertOptions.RSAKeySize)
+	}
+	if mergedCertOptions.IsDualUse != defaultCertOptions.IsDualUse {
+		t.Errorf("IsDualUse does not match, (get %t) vs (expected %t)",
+			mergedCertOptions.IsDualUse, deltaCertOptions.IsDualUse)
+	}
+}

--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -552,11 +552,14 @@ func TestAppendRootCerts(t *testing.T) {
 	}
 }
 
-func TestGetCertOptionsFromExistingCert(t *testing.T) {
+// TestGenRootCertFromExistingKey creates original root certificate and private key, and then
+// uses the private key to generate a new root certificate. Verifies that the new root certificate
+// matches old root certificate except lifetime changes.
+func TestGenRootCertFromExistingKey(t *testing.T) {
+	// Generate root certificate and private key
 	caCertTTL := 24 * time.Hour
 	oldOrg := "old org"
 	caKeySize := 512
-
 	caCertOptions := CertOptions{
 		TTL:          caCertTTL,
 		Org:          oldOrg,
@@ -565,18 +568,21 @@ func TestGetCertOptionsFromExistingCert(t *testing.T) {
 		RSAKeySize:   caKeySize,
 		IsDualUse:    false,
 	}
-
 	oldRootCertPem, oldRootKeyPem, err := GenCertKeyFromOptions(caCertOptions)
 	if err != nil {
 		t.Errorf("failed to generate root certificate from options: %v", err)
 	}
-	// Rotate root certificate
+
+	// Rotate root certificate using the old private key.
+	// 1. get cert option from old root certificate.
 	oldCertOptions, err := GetCertOptionsFromExistingCert(oldRootCertPem)
 	if err != nil {
 		t.Errorf("failed to generate cert options from existing root certificate: %v", err)
 	}
-
+	// 2. create cert option for new root certificate.
 	defaultOrg := "default org"
+	// Verify that changing RSA key size does not change private key, as the key is reused.
+	defaultRSAKeySize := 1024
 	// Create a default cert options
 	newCertOptions := CertOptions{
 		TTL:           caCertTTL,
@@ -584,20 +590,28 @@ func TestGetCertOptionsFromExistingCert(t *testing.T) {
 		Org:           defaultOrg,
 		IsCA:          true,
 		IsSelfSigned:  true,
-		RSAKeySize:    caKeySize,
+		RSAKeySize:    defaultRSAKeySize,
 		IsDualUse:     false,
 	}
-	// Merge cert options
+	// Merge cert options.
 	newCertOptions = MergeCertOptions(newCertOptions, oldCertOptions)
 	if newCertOptions.Org != oldOrg && newCertOptions.Org == defaultOrg {
 		t.Error("Org in cert options should be overwritten")
 	}
+	// 3. create new root certificate.
 	newRootCertPem, newRootKeyPem, err := GenRootCertFromExistingKey(newCertOptions)
 	if err != nil {
 		t.Errorf("failed to generate root certificate from existing key: %v", err)
 	}
+
+	// Verifies that private key does not change, and certificates match.
 	if !bytes.Equal(oldRootKeyPem, newRootKeyPem) {
 		t.Errorf("private key should not change")
+	}
+	keyLen, err := getPublicKeySizeInBits(newRootKeyPem)
+	if keyLen != caKeySize {
+		t.Errorf("Public key size should not change, (got %d) vs (expected %d)",
+			keyLen, caKeySize)
 	}
 
 	oldRootCert, _ := ParsePemEncodedCertificate(oldRootCertPem)
@@ -618,4 +632,66 @@ func TestGetCertOptionsFromExistingCert(t *testing.T) {
 		t.Errorf("certificate Version does not match (old: %d) vs (new: %d)",
 			oldRootCert.Version, newRootCert.Version)
 	}
-}
+	if oldRootCert.PublicKeyAlgorithm != newRootCert.PublicKeyAlgorithm {
+		t.Errorf("public key algorithm does not match (old: %s) vs (new: %s)",
+			oldRootCert.PublicKeyAlgorithm.String(), newRootCert.PublicKeyAlgorithm.String())
+	}
+ }
+
+ func getPublicKeySizeInBits(keyPem []byte) (int, error) {
+ 	privateKey, err := ParsePemEncodedKey(keyPem)
+ 	if err != nil {
+ 		return 0, err
+	}
+	k := privateKey.(*rsa.PrivateKey)
+	return k.PublicKey.Size()*8, nil
+ }
+
+ // TestMergeCertOptions verifies that cert option fields are overwritten.
+ func TestMergeCertOptions(t *testing.T) {
+	 certTTL := 240 * time.Hour
+	 org := "old org"
+	 keySize := 512
+	 defaultCertOptions := CertOptions{
+		 TTL:          certTTL,
+		 Org:          org,
+		 IsCA:         true,
+		 IsSelfSigned: true,
+		 RSAKeySize:   keySize,
+		 IsDualUse:    false,
+	 }
+
+	 deltaCertTTL := 1 * time.Hour
+	 deltaOrg := "delta org"
+	 deltaKeySize := 1024
+	 deltaCertOptions := CertOptions{
+		 TTL:          deltaCertTTL,
+		 Org:          deltaOrg,
+		 IsCA:         true,
+		 IsSelfSigned: true,
+		 RSAKeySize:   deltaKeySize,
+		 IsDualUse:    true,
+	 }
+
+	 mergedCertOptions := MergeCertOptions(defaultCertOptions, deltaCertOptions)
+	 if mergedCertOptions.Org != deltaCertOptions.Org {
+	 	t.Errorf("Org does not match, (get %s) vs (expected %s)",
+	 		mergedCertOptions.Org, deltaCertOptions.Org)
+	 }
+	 if mergedCertOptions.TTL != defaultCertOptions.TTL {
+		 t.Errorf("TTL does not match, (get %s) vs (expected %s)",
+			 mergedCertOptions.TTL.String(), deltaCertOptions.TTL.String())
+	 }
+	 if mergedCertOptions.IsCA != defaultCertOptions.IsCA {
+		 t.Errorf("IsCA does not match, (get %t) vs (expected %t)",
+			 mergedCertOptions.IsCA, deltaCertOptions.IsCA)
+	 }
+	 if mergedCertOptions.RSAKeySize != defaultCertOptions.RSAKeySize {
+		 t.Errorf("TTL does not match, (get %d) vs (expected %d)",
+			 mergedCertOptions.RSAKeySize, deltaCertOptions.RSAKeySize)
+	 }
+	 if mergedCertOptions.IsDualUse != defaultCertOptions.IsDualUse {
+		 t.Errorf("IsDualUse does not match, (get %t) vs (expected %t)",
+			 mergedCertOptions.IsDualUse, deltaCertOptions.IsDualUse)
+	 }
+ }


### PR DESCRIPTION

When rotating root certificate, Citadel should reuse fields from old root certificate to generate new root certificate, such as ```Subject``` and ```Issuer```.


https://github.com/istio/istio/issues/19644