### PR TITLE
istioctl: Add explicit namespace to SvcDescribeCmd test

### DIFF
--- a/istioctl/cmd/describe_test.go
+++ b/istioctl/cmd/describe_test.go
@@ -683,6 +683,7 @@ VirtualService: bookinfo
 			execClientConfig: canned14Config,
 			configs:          cannedIstioConfig,
 			k8sConfigs:       cannedK8sEnv,
+			namespace:        "default",
 			args:             strings.Split("x describe svc productpage", " "),
 			expectedOutput: `Service: productpage
    Port:  9080/auto-detect targets pod port 9080


### PR DESCRIPTION
I just spent 20 minutes figuring this out: if your `kubectl config current-context` points to a namespace other than `default`, this unit test will break if run locally. This is common when e.g. using `oc project` to switch between namespaces, as `oc` will create separate contexts for each namespace.