### PR TITLE
Splitting out SSE code into a separate package

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -41,6 +41,7 @@ import (
 	configmonitor "istio.io/istio/pilot/pkg/config/monitor"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
+	"istio.io/istio/pilot/pkg/serviceregistry/synthetic/serviceentry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schemas"
 	configz "istio.io/istio/pkg/mcp/configz/client"
@@ -319,17 +320,17 @@ func (s *Server) sseMCPController(args *PilotArgs,
 	clients *[]*sink.Client,
 	configStores *[]model.ConfigStoreCache) {
 	clientNodeID := "SSEMCP"
-	s.incrementalMcpOptions = &mcp.Options{
+	s.incrementalSSEDiscoveryOptions = &serviceentry.Options{
 		ClusterID:    s.clusterID,
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 		XDSUpdater:   s.EnvoyXdsServer,
 	}
-	ctl := mcp.NewSyntheticServiceEntryController(s.incrementalMcpOptions)
-	s.discoveryOptions = &mcp.DiscoveryOptions{
+	ctl := serviceentry.NewSyntheticServiceEntryController(s.incrementalSSEDiscoveryOptions)
+	s.sseDiscoveryOptions = &serviceentry.DiscoveryOptions{
 		ClusterID:    s.clusterID,
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 	}
-	s.mcpDiscovery = mcp.NewDiscovery(ctl, s.discoveryOptions)
+	s.sseDiscovery = serviceentry.NewDiscovery(ctl, s.sseDiscoveryOptions)
 	incrementalSinkOptions := &sink.Options{
 		CollectionOptions: []sink.CollectionOptions{
 			{

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -27,9 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"istio.io/istio/pilot/pkg/serviceregistry"
-	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
-
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	prom "github.com/prometheus/client_golang/prometheus"
@@ -41,8 +38,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	kubelib "istio.io/istio/pkg/kube"
-
 	"istio.io/pkg/ctrlz"
 	"istio.io/pkg/filewatcher"
 	"istio.io/pkg/log"
@@ -52,12 +47,16 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	envoyv2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/external"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
+	"istio.io/istio/pilot/pkg/serviceregistry/synthetic/serviceentry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schemas"
 	istiokeepalive "istio.io/istio/pkg/keepalive"
+	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/security/pkg/k8s/chiron"
 )
 
@@ -104,25 +103,25 @@ type Server struct {
 	// TODO(nmittler): Consider alternatives to exposing these directly
 	EnvoyXdsServer *envoyv2.DiscoveryServer
 
-	clusterID             string
-	environment           *model.Environment
-	configController      model.ConfigStoreCache
-	kubeClient            kubernetes.Interface
-	startFuncs            []startFunc
-	multicluster          *kubecontroller.Multicluster
-	httpServer            *http.Server
-	grpcServer            *grpc.Server
-	secureHTTPServer      *http.Server
-	secureGRPCServer      *grpc.Server
-	secureHTTPServerDNS   *http.Server
-	secureGRPCServerDNS   *grpc.Server
-	mux                   *http.ServeMux
-	kubeRegistry          *kubecontroller.Controller
-	mcpDiscovery          *mcp.Discovery
-	discoveryOptions      *mcp.DiscoveryOptions
-	incrementalMcpOptions *mcp.Options
-	mcpOptions            *mcp.Options
-	certController        *chiron.WebhookController
+	clusterID                      string
+	environment                    *model.Environment
+	configController               model.ConfigStoreCache
+	kubeClient                     kubernetes.Interface
+	startFuncs                     []startFunc
+	multicluster                   *kubecontroller.Multicluster
+	httpServer                     *http.Server
+	grpcServer                     *grpc.Server
+	secureHTTPServer               *http.Server
+	secureGRPCServer               *grpc.Server
+	secureHTTPServerDNS            *http.Server
+	secureGRPCServerDNS            *grpc.Server
+	mux                            *http.ServeMux
+	kubeRegistry                   *kubecontroller.Controller
+	sseDiscovery                   *serviceentry.Discovery
+	sseDiscoveryOptions            *serviceentry.DiscoveryOptions
+	incrementalSSEDiscoveryOptions *serviceentry.Options
+	mcpOptions                     *mcp.Options
+	certController                 *chiron.WebhookController
 
 	ConfigStores []model.ConfigStoreCache
 

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -17,9 +17,9 @@ package bootstrap
 import (
 	"fmt"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/pkg/log"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
@@ -52,8 +52,8 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 				return err
 			}
 		case serviceregistry.MCP:
-			if s.mcpDiscovery != nil {
-				serviceControllers.AddRegistry(s.mcpDiscovery)
+			if s.sseDiscovery != nil {
+				serviceControllers.AddRegistry(s.sseDiscovery)
 			}
 		case serviceregistry.Consul:
 			if err := s.initConsulRegistry(serviceControllers, args); err != nil {

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -21,14 +21,13 @@ import (
 	"sync"
 	"time"
 
-	"istio.io/istio/pilot/pkg/serviceregistry/kube"
-	"istio.io/pkg/ledger"
-
 	"github.com/gogo/protobuf/types"
 
+	"istio.io/pkg/ledger"
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schemas"
 	"istio.io/istio/pkg/mcp/sink"
@@ -261,30 +260,30 @@ func (c *controller) GetResourceAtVersion(version string, key string) (resourceV
 }
 
 // Run is not implemented
-func (c *controller) Run(stop <-chan struct{}) {
+func (c *controller) Run(<-chan struct{}) {
 	log.Warnf("Run: %s", errUnsupported)
 }
 
 // Get is not implemented
-func (c *controller) Get(typ, name, namespace string) *model.Config {
+func (c *controller) Get(_, _, _ string) *model.Config {
 	log.Warnf("get %s", errUnsupported)
 	return nil
 }
 
 // Update is not implemented
-func (c *controller) Update(config model.Config) (newRevision string, err error) {
+func (c *controller) Update(model.Config) (newRevision string, err error) {
 	log.Warnf("update %s", errUnsupported)
 	return "", errUnsupported
 }
 
 // Create is not implemented
-func (c *controller) Create(config model.Config) (revision string, err error) {
+func (c *controller) Create(model.Config) (revision string, err error) {
 	log.Warnf("create %s", errUnsupported)
 	return "", errUnsupported
 }
 
 // Delete is not implemented
-func (c *controller) Delete(typ, name, namespace string) error {
+func (c *controller) Delete(_, _, _ string) error {
 	return errUnsupported
 }
 

--- a/pilot/pkg/serviceregistry/synthetic/serviceentry/discovery.go
+++ b/pilot/pkg/serviceregistry/synthetic/serviceentry/discovery.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mcp
+package serviceentry
 
 import (
 	"net"
@@ -104,7 +104,7 @@ func (d *Discovery) HandleCacheEvents(config model.Config, event model.Event) {
 // basis to purge all caches, the purge maybe necessary since
 // controller's configStore only keeps track of one sink.Change
 // object at a time everytime apply is called.
-func (d *Discovery) Run(stop <-chan struct{}) {
+func (d *Discovery) Run(<-chan struct{}) {
 	if err := d.initializeCache(); err != nil {
 		log.Warnf("Run: %s", err)
 	}
@@ -482,25 +482,25 @@ func notReadyEndpoints(conf model.Config) map[string]int {
 }
 
 // GetService Not Supported
-func (d *Discovery) GetService(hostname host.Name) (*model.Service, error) {
+func (d *Discovery) GetService(host.Name) (*model.Service, error) {
 	log.Warnf("GetService %s", errUnsupported)
 	return nil, nil
 }
 
 // ManagementPorts Not Supported
-func (d *Discovery) ManagementPorts(addr string) model.PortList {
+func (d *Discovery) ManagementPorts(string) model.PortList {
 	log.Warnf("ManagementPorts %s", errUnsupported)
 	return nil
 }
 
 // WorkloadHealthCheckInfo Not Supported
-func (d *Discovery) WorkloadHealthCheckInfo(addr string) model.ProbeList {
+func (d *Discovery) WorkloadHealthCheckInfo(string) model.ProbeList {
 	log.Warnf("WorkloadHealthCheckInfo %s", errUnsupported)
 	return nil
 }
 
 // GetIstioServiceAccounts Not Supported
-func (d *Discovery) GetIstioServiceAccounts(svc *model.Service, ports []int) []string {
+func (d *Discovery) GetIstioServiceAccounts(*model.Service, []int) []string {
 	log.Warnf("GetIstioServiceAccounts %s", errUnsupported)
 	return nil
 }
@@ -514,13 +514,13 @@ func (d *Discovery) GetProxyWorkloadLabels(*model.Proxy) (labels.Collection, err
 // model controller
 
 // AppendServiceHandler Not Supported
-func (d *Discovery) AppendServiceHandler(f func(*model.Service, model.Event)) error {
+func (d *Discovery) AppendServiceHandler(func(*model.Service, model.Event)) error {
 	log.Warnf("AppendServiceHandler %s", errUnsupported)
 	return nil
 }
 
 // AppendInstanceHandler Not Supported
-func (d *Discovery) AppendInstanceHandler(f func(*model.ServiceInstance, model.Event)) error {
+func (d *Discovery) AppendInstanceHandler(func(*model.ServiceInstance, model.Event)) error {
 	log.Warnf("AppendInstanceHandler %s", errUnsupported)
 	return nil
 }

--- a/pilot/pkg/serviceregistry/synthetic/serviceentry/discovery_test.go
+++ b/pilot/pkg/serviceregistry/synthetic/serviceentry/discovery_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mcp_test
+package serviceentry_test
 
 import (
 	"fmt"
@@ -25,7 +25,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
+	"istio.io/istio/pilot/pkg/serviceregistry/synthetic/serviceentry"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	d          *mcp.Discovery
-	controller mcp.Controller
+	d          *serviceentry.Discovery
+	controller serviceentry.Controller
 	fx         *FakeXdsUpdater
 	namespace  = "random-namespace"
 	name       = "test-synthetic-se"
@@ -572,12 +572,12 @@ func initDiscovery() {
 	fx = NewFakeXDS()
 	fx.EDSErr <- nil
 	testControllerOptions.XDSUpdater = fx
-	controller = mcp.NewSyntheticServiceEntryController(testControllerOptions)
-	options := &mcp.DiscoveryOptions{
+	controller = serviceentry.NewSyntheticServiceEntryController(testControllerOptions)
+	options := &serviceentry.DiscoveryOptions{
 		ClusterID:    "test",
 		DomainSuffix: "cluster.local",
 	}
-	d = mcp.NewDiscovery(controller, options)
+	d = serviceentry.NewDiscovery(controller, options)
 }
 
 func testSetup(g *gomega.GomegaWithT) {


### PR DESCRIPTION
The synthetic service entry (SSE) code is currently in the same package as the mcp controller. This is going to make it difficult to refactor the mcp controller independent of the SSE controller.