### PR TITLE
helm: only add lightstepCacertpath if secure is true

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -127,8 +127,10 @@ spec:
           - --lightstepAccessToken
           - {{ $.Values.global.tracer.lightstep.accessToken }}
           - --lightstepSecure={{ $.Values.global.tracer.lightstep.secure }}
+          {{- if $.Values.global.tracer.lightstep.secure }}
           - --lightstepCacertPath
           - {{ $.Values.global.tracer.lightstep.cacertPath }}
+          {{- end }}
         {{- else if eq $.Values.global.proxy.tracer "zipkin" }}
           - --zipkinAddress
           {{- if $.Values.global.tracer.zipkin.address }}

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -108,8 +108,10 @@ containers:
   - --lightstepAccessToken
   - "{{ .ProxyConfig.GetTracing.GetLightstep.GetAccessToken }}"
   - --lightstepSecure={{ .ProxyConfig.GetTracing.GetLightstep.GetSecure }}
+{{- if .ProxyConfig.GetTracing.GetLightstep.GetSecure }}
   - --lightstepCacertPath
   - "{{ .ProxyConfig.GetTracing.GetLightstep.GetCacertPath }}"
+{{- end }}
 {{- else if eq .Values.global.proxy.tracer "zipkin" }}
   - --zipkinAddress
   - "{{ .ProxyConfig.GetTracing.GetZipkin.GetAddress }}"

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -247,8 +247,10 @@ data:
           accessToken: {{ .Values.global.tracer.lightstep.accessToken }}
           # Whether communication with the Satellite pool should be secure
           secure: {{ .Values.global.tracer.lightstep.secure }}
+          {{- if .Values.global.tracer.lightstep.secure }}
           # Path to the file containing the cacert to use when verifying TLS
           cacertPath: {{ .Values.global.tracer.lightstep.cacertPath }}
+          {{- end }}
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
       tracing:
         zipkin:


### PR DESCRIPTION
For the helm template value of `global.tracer.lightstep.cacertPath` it is only needed if secure is true. However, in the helm templates that value is used even if secure is false. This means that you get istio proxy args rendered like

```
- --lightstepSecure=false
- --lightstepCacertPath
- 
- --proxyAdminPort
- "15000"
```

which in turn causes the validation error of `error: error validating "deployment.istio-ingressgateway.yaml": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].args): unknown object type "nil" in Deployment.spec.template.spec.containers[0].args[19]; if you choose to ignore these errors, turn validation off with --validate=false` when applying the rendered file. 

This PR fixes the cause of that problem by changing the templating to only set up the cert path when secure is set to true.