### PR TITLE
Fix race condition in ADS

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/pkg/test/env"
@@ -263,9 +262,6 @@ func TestEnvoyRDSProtocolError(t *testing.T) {
 	}
 	defer cancel()
 
-	// wait for debounce
-	time.Sleep(3 * v2.DebounceAfter)
-
 	err = sendRDSReq(gatewayID(gatewayIP), []string{routeA, routeB}, "", edsstr)
 	if err != nil {
 		t.Fatal(err)
@@ -318,9 +314,6 @@ func TestEnvoyRDSUpdatedRouteRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cancel()
-
-	// wait for debounce
-	time.Sleep(3 * v2.DebounceAfter)
 
 	err = sendRDSReq(gatewayID(gatewayIP), []string{routeA}, "", edsstr)
 	if err != nil {

--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/pkg/test/env"


### PR DESCRIPTION
So basically these two tests are doing this 3 second sleep for a full push to be triggered. This is bad from a testing standpoint (because we never want to sleep if possible) and leads to flakes - this test has been super flaky. Additionally, this is not really testing what we want - Envoy has no such 3 second sleep.

When removing this sleep, the test fails pretty often. What is happening here is a race between connection being added and a full push being triggered.

Normally we expect:

1. We send RDS request
2. RDS request completes
3. We add the connection
4. We send a full push to 1 connections

But because of a race we get:

1. We send RDS request
2. RDS request completes
3. We add the connection
4. We send a full push to 0 connections

This can be fixed by adding the connection before we try to respond to xDS requests. The added connection is not used anywhere in that code, so doing it first or last is not important.

This makes the problem much rarer, but there is still another race. When we send a response, we set the nonce for the response. However, we return from the send() function BEFORE we set the nonce asynchronously. This introduces a race where the next request comes in before we finish setting the nonce, and it is rejected. To fix this, we simply return from send only after we have set the nonce.

Fixes: https://github.com/istio/istio/issues/14504
Fixes: https://github.com/istio/istio/issues/11022
Fixes: https://github.com/istio/istio/issues/15822
