### PR TITLE
Fix IstioSrc logic

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -113,7 +113,7 @@ func getDefaultIstioSrc() string {
 	}
 	idx := strings.Index(current, filepath.Join("/src", "istio.io", "istio"))
 	if idx > 0 {
-		return current[0:idx]
+		return filepath.Join(current[0:idx], "/src", "istio.io", "istio")
 	}
 	return current // launching from GOTOP (for example in goland)
 }


### PR DESCRIPTION
Currently this only works if run from a makefile, run `go test` or from
IDE fails since REPO_ROOT is not configured. This function was changed
from "IstioTop" to "IstioSrc" without changing the logic, so it returned
the wrong folder.

Ref #19322
