### PR TITLE
create a generic webhook controller

### DIFF
--- a/pkg/webhook/util.go
+++ b/pkg/webhook/util.go
@@ -1,0 +1,103 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"k8s.io/api/admissionregistration/v1beta1"
+	kubeApiAdmission "k8s.io/api/admissionregistration/v1beta1"
+	kubeApiCore "k8s.io/api/core/v1"
+	kubeApiRbac "k8s.io/api/rbac/v1"
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+// Return nil when the endpoint is ready. Otherwise, return an error.
+func endpointReady(endpoint *kubeApiCore.Endpoints) (ready bool, reason string) {
+	if len(endpoint.Subsets) == 0 {
+		return false, "no subsets"
+	}
+	for _, subset := range endpoint.Subsets {
+		if len(subset.Addresses) > 0 {
+			return true, ""
+		}
+	}
+	return false, "no subset addresses ready"
+}
+
+func verifyCABundle(caBundle []byte) error {
+	block, _ := pem.Decode(caBundle)
+	if block == nil {
+		return errors.New("could not decode pem")
+	}
+	if block.Type != "CERTIFICATE" {
+		return fmt.Errorf("cert contains wrong pem type: %q", block.Type)
+	}
+	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		return fmt.Errorf("cert contains invalid x509 certificate: %v", err)
+	}
+	return nil
+}
+
+func decodeValidatingConfig(encoded []byte) (*v1beta1.ValidatingWebhookConfiguration, error) {
+	var config kubeApiAdmission.ValidatingWebhookConfiguration
+	if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), encoded, &config); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func buildValidatingWebhookConfiguration(
+	caBundle, webhook []byte,
+	ownerRefs []kubeApiMeta.OwnerReference,
+) (*v1beta1.ValidatingWebhookConfiguration, error) {
+	config, err := decodeValidatingConfig(webhook)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyCABundle(caBundle); err != nil {
+		return nil, err
+	}
+	// update runtime fields
+	config.OwnerReferences = ownerRefs
+	for i := range config.Webhooks {
+		config.Webhooks[i].ClientConfig.CABundle = caBundle
+	}
+
+	return config, nil
+}
+
+func findClusterRoleOwnerRefs(client kubernetes.Interface, clusterRoleName string) []kubeApiMeta.OwnerReference {
+	clusterRole, err := client.RbacV1().ClusterRoles().Get(clusterRoleName, kubeApiMeta.GetOptions{})
+	if err != nil {
+		scope.Warnf("Could not find clusterrole: %s to set ownerRef. "+
+			"The webhook configuration must be deleted manually.",
+			clusterRoleName)
+		return nil
+	}
+
+	return []kubeApiMeta.OwnerReference{
+		*kubeApiMeta.NewControllerRef(
+			clusterRole,
+			kubeApiRbac.SchemeGroupVersion.WithKind("ClusterRole"),
+		),
+	}
+}

--- a/pkg/webhook/util_test.go
+++ b/pkg/webhook/util_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/pkg/mcp/testing/testcerts"
+)
+
+func TestLoadCaCertPem(t *testing.T) {
+	cases := []struct {
+		name      string
+		cert      []byte
+		wantError bool
+	}{
+		{
+			name:      "valid pem",
+			cert:      testcerts.CACert,
+			wantError: false,
+		},
+		{
+			name:      "pem decode error",
+			cert:      append([]byte("-----codec"), testcerts.CACert...),
+			wantError: true,
+		},
+		{
+			name:      "pem wrong type",
+			wantError: true,
+		},
+		{
+			name:      "invalid x509",
+			cert:      testcerts.BadCert,
+			wantError: true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%v] %s", i, c.name), func(tt *testing.T) {
+			err := verifyCABundle(c.cert)
+			if err != nil {
+				if !c.wantError {
+					tt.Fatalf("unexpected error: got error %q", err)
+				}
+			} else {
+				if c.wantError {
+					tt.Fatal("expected error")
+				}
+			}
+		})
+	}
+}

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -1,0 +1,333 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"time"
+
+	kubeApiAdmission "k8s.io/api/admissionregistration/v1beta1"
+	kubeApiApp "k8s.io/api/apps/v1"
+	kubeApiCore "k8s.io/api/core/v1"
+	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"istio.io/pkg/filewatcher"
+	"istio.io/pkg/log"
+)
+
+var scope = log.RegisterScope("webhook controller", "webhook controller", 0)
+
+type Options struct {
+	WatchedNamespace  string
+	ResyncPeriod      time.Duration
+	CAPath            string
+	ConfigPath        string
+	WebhookConfigName string
+	ServiceName       string
+	Client            kubernetes.Interface
+	GalleyDeployment  string
+	ClusterRoleName   string
+}
+
+type Controller struct {
+	o                 Options
+	ownerRefs         []kubeApiMeta.OwnerReference
+	queue             workqueue.RateLimitingInterface
+	sharedInformers   informers.SharedInformerFactory
+	caFileWatcher     filewatcher.FileWatcher
+	readFile          func(filename string) ([]byte, error) // test stub
+	reconcileDone     func()
+	endpointReadyOnce bool
+}
+
+type reconcileRequest struct {
+	description string
+}
+
+func (rr reconcileRequest) String() string {
+	return rr.description
+}
+
+func filter(in interface{}, wantName, wantNamespace string) (skip bool, key string) {
+	obj, err := meta.Accessor(in)
+	if err != nil {
+		skip = true
+		return
+	}
+	if wantNamespace != "" && obj.GetNamespace() != wantNamespace {
+		skip = true
+		return
+	}
+	if wantName != "" && obj.GetName() != wantName {
+		skip = true
+		return
+	}
+
+	// ignore the error because there's nothing to do if this fails.
+	key, _ = cache.DeletionHandlingMetaNamespaceKeyFunc(in)
+	return
+}
+
+func makeHandler(queue workqueue.Interface, gvk schema.GroupVersionKind, nameMatch, namespaceMatch string) *cache.ResourceEventHandlerFuncs {
+	return &cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			skip, key := filter(obj, nameMatch, namespaceMatch)
+			if skip {
+				return
+			}
+
+			req := &reconcileRequest{fmt.Sprintf("adding (%v, Kind=%v) %v", gvk.GroupVersion(), gvk.Kind, key)}
+			queue.Add(req)
+		},
+		UpdateFunc: func(prev, curr interface{}) {
+			skip, key := filter(curr, nameMatch, namespaceMatch)
+			if skip {
+				return
+			}
+			if !reflect.DeepEqual(prev, curr) {
+				req := &reconcileRequest{fmt.Sprintf("update (%v, Kind=%v) %v", gvk.GroupVersion(), gvk.Kind, key)}
+				queue.Add(req)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			if _, ok := obj.(kubeApiMeta.Object); !ok {
+				// If the object doesn't have Metadata, assume it is a tombstone object
+				// of type DeletedFinalStateUnknown
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					return
+				}
+				obj = tombstone.Obj
+			}
+			skip, key := filter(obj, nameMatch, namespaceMatch)
+			if skip {
+				return
+			}
+			req := &reconcileRequest{fmt.Sprintf("delete (%v, Kind=%v) %v", gvk.GroupVersion(), gvk.Kind, key)}
+			queue.Add(req)
+		},
+	}
+}
+
+func New(o Options) *Controller {
+	return newController(o, filewatcher.NewWatcher, ioutil.ReadFile, nil)
+}
+
+type readFileFunc func(filename string) ([]byte, error)
+
+// precompute GVK for known types for the purposes of logging.
+var (
+	configGVK     = kubeApiAdmission.SchemeGroupVersion.WithKind(reflect.TypeOf(kubeApiAdmission.ValidatingWebhookConfiguration{}).Name())
+	endpointGVK   = kubeApiCore.SchemeGroupVersion.WithKind(reflect.TypeOf(kubeApiCore.Endpoints{}).Name())
+	deploymentGVK = kubeApiApp.SchemeGroupVersion.WithKind(reflect.TypeOf(kubeApiApp.Deployment{}).Name())
+)
+
+func newController(
+	o Options,
+	newFileWatcher filewatcher.NewFileWatcherFunc,
+	readFile readFileFunc,
+	reconcileDone func(),
+) *Controller {
+	c := &Controller{
+		o:             o,
+		queue:         workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter()),
+		caFileWatcher: newFileWatcher(),
+		readFile:      readFile,
+		reconcileDone: reconcileDone,
+		ownerRefs:     findClusterRoleOwnerRefs(o.Client, o.ClusterRoleName),
+	}
+
+	c.sharedInformers = informers.NewSharedInformerFactoryWithOptions(o.Client, o.ResyncPeriod,
+		informers.WithNamespace(o.WatchedNamespace))
+
+	webhookInformer := c.sharedInformers.Admissionregistration().V1beta1().ValidatingWebhookConfigurations().Informer()
+	webhookInformer.AddEventHandler(makeHandler(c.queue, configGVK, o.WebhookConfigName, ""))
+
+	endpointInformer := c.sharedInformers.Core().V1().Endpoints().Informer()
+	endpointInformer.AddEventHandler(makeHandler(c.queue, endpointGVK, o.ServiceName, o.WatchedNamespace))
+
+	deploymentInformer := c.sharedInformers.Apps().V1().Deployments().Informer()
+	deploymentInformer.AddEventHandler(makeHandler(c.queue, deploymentGVK, o.GalleyDeployment, o.WatchedNamespace))
+
+	return c
+}
+
+func (c *Controller) Start(stop <-chan struct{}) {
+	go c.startFileWatcher(stop)
+	go c.sharedInformers.Start(stop)
+
+	for _, ready := range c.sharedInformers.WaitForCacheSync(stop) {
+		if !ready {
+			return
+		}
+	}
+
+	req := &reconcileRequest{"initial request to kickstart reconcilation"}
+	c.queue.Add(req)
+
+	go c.runWorker()
+}
+
+func (c *Controller) startFileWatcher(stop <-chan struct{}) {
+	for {
+		select {
+		case ev := <-c.caFileWatcher.Events(c.o.CAPath):
+			req := &reconcileRequest{fmt.Sprintf("CA file changed: %v", ev)}
+			c.queue.Add(req)
+		case <-c.caFileWatcher.Errors(c.o.CAPath):
+			// log only
+		case <-stop:
+			return
+		}
+	}
+}
+
+func (c *Controller) processDeployments() (stop bool, err error) {
+	galley, err := c.sharedInformers.Apps().V1().
+		Deployments().Lister().Deployments(c.o.WatchedNamespace).Get(c.o.GalleyDeployment)
+
+	// galley does/doesn't exist
+	if err != nil {
+		if kubeErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return true, err
+	}
+
+	// galley is scaled down to zero replicas. This is useful for debugging
+	// to force the istiod controller to run.
+	if galley.Spec.Replicas != nil && *galley.Spec.Replicas == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (c *Controller) processEndpoints() (stop bool, err error) {
+	if c.endpointReadyOnce {
+		return true, nil
+	}
+	endpoint, err := c.sharedInformers.Core().V1().
+		Endpoints().Lister().Endpoints(c.o.WatchedNamespace).Get(c.o.ServiceName)
+	if err != nil {
+		if kubeErrors.IsNotFound(err) {
+			return true, nil
+		}
+		return true, err
+	}
+	ready, _ := endpointReady(endpoint)
+	return !ready, nil
+}
+
+// reconcile the desired state with the kube-apiserver.
+func (c *Controller) reconcile(req *reconcileRequest) error {
+	defer func() {
+		if c.reconcileDone != nil {
+			c.reconcileDone()
+		}
+	}()
+
+	scope.Infof("Reconcile: %v", req)
+
+	// skip reconciliation if our endpoint isn't ready ...
+	if stop, err := c.processEndpoints(); stop || err != nil {
+		return err
+	}
+
+	// ... or another galley deployment is already managed the webhook.
+	if stop, err := c.processDeployments(); stop || err != nil {
+		return err
+	}
+
+	desired, err := c.buildValidatingWebhookConfiguration()
+	if err != nil {
+		// no point in retrying unless a local config or cert file changes.
+		return nil
+	}
+
+	current, err := c.sharedInformers.Admissionregistration().V1beta1().
+		ValidatingWebhookConfigurations().Lister().Get(c.o.WebhookConfigName)
+	if kubeErrors.IsNotFound(err) {
+		_, err := c.o.Client.AdmissionregistrationV1beta1().
+			ValidatingWebhookConfigurations().Create(desired)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	updated := current.DeepCopyObject().(*kubeApiAdmission.ValidatingWebhookConfiguration)
+	updated.Webhooks = desired.Webhooks
+	updated.OwnerReferences = desired.OwnerReferences
+
+	if !reflect.DeepEqual(updated, current) {
+		_, err := c.o.Client.AdmissionregistrationV1beta1().
+			ValidatingWebhookConfigurations().Update(updated)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) processNextWorkItem() (cont bool) {
+	obj, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(obj)
+
+	req, ok := obj.(*reconcileRequest)
+	if !ok {
+		// don't retry an invalid reconcileRequest item
+		c.queue.Forget(req)
+		return true
+	}
+
+	if err := c.reconcile(req); err != nil {
+		c.queue.AddRateLimited(obj)
+		utilruntime.HandleError(err)
+	} else {
+		c.queue.Forget(obj)
+	}
+	return true
+}
+
+func (c *Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Controller) buildValidatingWebhookConfiguration() (*kubeApiAdmission.ValidatingWebhookConfiguration, error) {
+	webhook, err := c.readFile(c.o.ConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	caBundle, err := c.readFile(c.o.CAPath)
+	if err != nil {
+		return nil, err
+	}
+	return buildValidatingWebhookConfiguration(caBundle, webhook, c.ownerRefs)
+}

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -1,0 +1,377 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	. "github.com/onsi/gomega"
+	kubeApiAdmission "k8s.io/api/admissionregistration/v1beta1"
+	kubeApiApp "k8s.io/api/apps/v1"
+	kubeApiCore "k8s.io/api/core/v1"
+	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
+	kubeApisMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	kubeTypedAdmission "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
+	kubeTypedApp "k8s.io/client-go/kubernetes/typed/apps/v1"
+	kubeTypedCore "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/kubectl/pkg/scheme"
+
+	"istio.io/pkg/filewatcher"
+)
+
+var (
+	istiodEndpoint = &kubeApiCore.Endpoints{
+		ObjectMeta: kubeApisMeta.ObjectMeta{
+			Name:      istiod,
+			Namespace: namespace,
+		},
+		Subsets: []kubeApiCore.EndpointSubset{{
+			Addresses: []kubeApiCore.EndpointAddress{{
+				IP: "192.168.1.1",
+			}},
+		}},
+	}
+
+	galleyDeployment = &kubeApiApp.Deployment{
+		ObjectMeta: kubeApisMeta.ObjectMeta{
+			Name:      galley,
+			Namespace: namespace,
+		},
+		Spec: kubeApiApp.DeploymentSpec{
+			Replicas: &[]int32{1}[0],
+		},
+	}
+
+	unpatchedIstiodWebhookConfig = &kubeApiAdmission.ValidatingWebhookConfiguration{
+		TypeMeta: kubeApisMeta.TypeMeta{
+			APIVersion: kubeApiAdmission.SchemeGroupVersion.String(),
+			Kind:       "ValidatingWebhookConfiguration",
+		},
+		ObjectMeta: kubeApisMeta.ObjectMeta{
+			Name: galleyWebhookName,
+		},
+		Webhooks: []kubeApiAdmission.ValidatingWebhook{{
+			Name: "hook0",
+			ClientConfig: kubeApiAdmission.WebhookClientConfig{Service: &kubeApiAdmission.ServiceReference{
+				Namespace: namespace,
+				Name:      istiod,
+				Path:      &[]string{"/hook0"}[0],
+			}},
+			Rules: []kubeApiAdmission.RuleWithOperations{{
+				Operations: []kubeApiAdmission.OperationType{kubeApiAdmission.Create, kubeApiAdmission.Update},
+				Rule: kubeApiAdmission.Rule{
+					APIGroups:   []string{"group0"},
+					APIVersions: []string{"*"},
+					Resources:   []string{"*"},
+				},
+			}},
+		}, {
+			Name: "hook1",
+			ClientConfig: kubeApiAdmission.WebhookClientConfig{Service: &kubeApiAdmission.ServiceReference{
+				Namespace: namespace,
+				Name:      istiod,
+				Path:      &[]string{"/hook1"}[0],
+			}},
+			Rules: []kubeApiAdmission.RuleWithOperations{{
+				Operations: []kubeApiAdmission.OperationType{kubeApiAdmission.Create, kubeApiAdmission.Update},
+				Rule: kubeApiAdmission.Rule{
+					APIGroups:   []string{"group1"},
+					APIVersions: []string{"*"},
+					Resources:   []string{"*"},
+				},
+			}},
+		}},
+	}
+	codec                      = scheme.Codecs.LegacyCodec(kubeApiAdmission.SchemeGroupVersion)
+	istiodWebhookConfigEncoded = runtime.EncodeOrDie(codec, unpatchedIstiodWebhookConfig)
+	finalIstiodWebhookConfig   *kubeApiAdmission.ValidatingWebhookConfiguration
+	galleyWebhookConfig        *kubeApiAdmission.ValidatingWebhookConfiguration
+
+	caBundle0 = []byte(`-----BEGIN CERTIFICATE-----
+MIIC9DCCAdygAwIBAgIJAIFe3lWPaalKMA0GCSqGSIb3DQEBCwUAMA4xDDAKBgNV
+BAMMA19jYTAgFw0xNzEyMjIxODA0MjRaGA8yMjkxMTAwNzE4MDQyNFowDjEMMAoG
+A1UEAwwDX2NhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuBdxj+Hi
+8h0TkId1f64TprLydwgzzLwXAs3wpmXz+BfnW1oMQPNyN7vojW6VzqJGGYLsc1OB
+MgwObU/VeFNc6YUCmu6mfFJwoPfXMPnhmGuSwf/kjXomlejAYjxClU3UFVWQht54
+xNLjTi2M1ZOnwNbECOhXC3Tw3G8mCtfanMAO0UXM5yObbPa8yauUpJKkpoxWA7Ed
+qiuUD9qRxluFPqqw/z86V8ikmvnyjQE9960j+8StlAbRs82ArtnrhRgkDO0Smtf7
+4QZsb/hA1KNMm73bOGS6+SVU+eH8FgVOzcTQYFRpRT3Mhi6dKZe9twIO8mpZK4wk
+uygRxBM32Ag9QQIDAQABo1MwUTAdBgNVHQ4EFgQUc8tvoNNBHyIkoVV8XCXy63Ya
+BEQwHwYDVR0jBBgwFoAUc8tvoNNBHyIkoVV8XCXy63YaBEQwDwYDVR0TAQH/BAUw
+AwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAVmaUkkYESfcfgnuPeZ4sTNs2nk2Y+Xpd
+lxkMJhChb8YQtlCe4uiLvVe7er1sXcBLNCm/+2K9AT71gnxBSeS5mEOzWmCPErhy
+RmYtSxeRyXAaUWVYLs/zMlBQ0Iz4dpY+FVVbMjIurelVwHF0NBk3VtU5U3lHyKdZ
+j4C2rMjvTxmkyIcR1uBEeVvuGU8R70nZ1yfo3vDwmNGMcLwW+4QK+WcfwfjLXhLs
+5550arfEYdTzYFMxY60HJT/LvbGrjxY0PQUWWDbPiRfsdRjOFduAbM0/EVRda/Oo
+Fg72WnHeojDUhqEz4UyFZbnRJ4x6leQhnrIcVjWX4FFFktiO9rqqfw==
+-----END CERTIFICATE-----`)
+
+	caBundle1 = []byte(`-----BEGIN CERTIFICATE-----
+MIIDCzCCAfOgAwIBAgIQbfOzhcKTldFipQ1X2WXpHDANBgkqhkiG9w0BAQsFADAv
+MS0wKwYDVQQDEyRhNzU5YzcyZC1lNjcyLTQwMzYtYWMzYy1kYzAxMDBmMTVkNWUw
+HhcNMTkwNTE2MjIxMTI2WhcNMjQwNTE0MjMxMTI2WjAvMS0wKwYDVQQDEyRhNzU5
+YzcyZC1lNjcyLTQwMzYtYWMzYy1kYzAxMDBmMTVkNWUwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQC6sSAN80Ci0DYFpNDumGYoejMQai42g6nSKYS+ekvs
+E7uT+eepO74wj8o6nFMNDu58+XgIsvPbWnn+3WtUjJfyiQXxmmTg8om4uY1C7R1H
+gMsrL26pUaXZ/lTE8ZV5CnQJ9XilagY4iZKeptuZkxrWgkFBD7tr652EA3hmj+3h
+4sTCQ+pBJKG8BJZDNRrCoiABYBMcFLJsaKuGZkJ6KtxhQEO9QxJVaDoSvlCRGa8R
+fcVyYQyXOZ+0VHZJQgaLtqGpiQmlFttpCwDiLfMkk3UAd79ovkhN1MCq+O5N7YVt
+eVQWaTUqUV2tKUFvVq21Zdl4dRaq+CF5U8uOqLY/4Kg9AgMBAAGjIzAhMA4GA1Ud
+DwEB/wQEAwICBDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCg
+oF71Ey2b1QY22C6BXcANF1+wPzxJovFeKYAnUqwh3rF7pIYCS/adZXOKlgDBsbcS
+MxAGnCRi1s+A7hMYj3sQAbBXttc31557lRoJrx58IeN5DyshT53t7q4VwCzuCXFT
+3zRHVRHQnO6LHgZx1FuKfwtkhfSXDyYU2fQYw2Hcb9krYU/alViVZdE0rENXCClq
+xO7AQk5MJcGg6cfE5wWAKU1ATjpK4CN+RTn8v8ODLoI2SW3pfsnXxm93O+pp9HN4
++O+1PQtNUWhCfh+g6BN2mYo2OEZ8qGSxDlMZej4YOdVkW8PHmFZTK0w9iJKqM5o1
+V6g5gZlqSoRhICK09tpc
+-----END CERTIFICATE-----`)
+
+	configNotFoundErr = kubeErrors.NewNotFound(kubeApiAdmission.Resource("validatingwebhookconfigurations"), galleyWebhookName)
+)
+
+// patch the caBundle into the final istiod and galley configs.
+func init() {
+	finalIstiodWebhookConfig = unpatchedIstiodWebhookConfig.DeepCopy()
+	finalIstiodWebhookConfig.Webhooks[0].ClientConfig.CABundle = caBundle0
+	finalIstiodWebhookConfig.Webhooks[1].ClientConfig.CABundle = caBundle0
+
+	galleyWebhookConfig = finalIstiodWebhookConfig.DeepCopy()
+	galleyWebhookConfig.Webhooks[0].ClientConfig.Service.Name = galley
+	galleyWebhookConfig.Webhooks[1].ClientConfig.Service.Name = galley
+	galleyWebhookConfig.Webhooks[0].ClientConfig.CABundle = caBundle1
+	galleyWebhookConfig.Webhooks[1].ClientConfig.CABundle = caBundle1
+}
+
+type fakeController struct {
+	*Controller
+
+	caChangedCh      chan bool
+	configChangedCh  chan bool
+	injectedCABundle []byte
+	injectedConfig   []byte
+	fakeWatcher      *filewatcher.FakeWatcher
+	fakeClient       *fake.Clientset
+	stop             chan struct{}
+	reconcileCounter int32 // atomic
+}
+
+const (
+	namespace            = "istio-system"
+	galley               = "istio-galley"
+	galleyDeploymentName = "istio-galley"
+	galleyWebhookName    = "istio-galley"
+	istiod               = "istiod"
+	caPath               = "fakeCAPath"
+	configPath           = "fakeConfigPath"
+	istiodClusterRole    = "istiod-istio-system"
+)
+
+func createTestController() *fakeController {
+	fakeClient := fake.NewSimpleClientset()
+	o := Options{
+		WatchedNamespace:  namespace,
+		ResyncPeriod:      time.Minute,
+		CAPath:            caPath,
+		ConfigPath:        configPath,
+		WebhookConfigName: galleyWebhookName,
+		ServiceName:       istiod,
+		Client:            fakeClient,
+		GalleyDeployment:  galleyDeploymentName,
+		ClusterRoleName:   istiodClusterRole,
+	}
+
+	caChanged := make(chan bool, 10)
+	configChanged := make(chan bool, 10)
+	changed := func(path string, added bool) {
+		switch path {
+		case o.CAPath:
+			caChanged <- added
+		case o.ConfigPath:
+			configChanged <- added
+		}
+	}
+
+	newFileWatcher, fakeWatcher := filewatcher.NewFakeWatcher(changed)
+
+	fc := &fakeController{
+		caChangedCh:      caChanged,
+		configChangedCh:  configChanged,
+		injectedCABundle: caBundle0,
+		injectedConfig:   []byte(istiodWebhookConfigEncoded),
+		fakeWatcher:      fakeWatcher,
+		fakeClient:       fakeClient,
+		stop:             make(chan struct{}),
+	}
+
+	readFile := func(filename string) ([]byte, error) {
+		switch filename {
+		case o.CAPath:
+			return fc.injectedCABundle, nil
+		case o.ConfigPath:
+			return fc.injectedConfig, nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	reconcileDone := func() {
+		atomic.AddInt32(&fc.reconcileCounter, 1)
+	}
+
+	fc.Controller = newController(o, newFileWatcher, readFile, reconcileDone)
+
+	return fc
+}
+
+func (fc *fakeController) reconcileAttempts() int {
+	return int(atomic.LoadInt32(&fc.reconcileCounter))
+}
+
+func (fc *fakeController) ValidatingWebhookConfigurations() kubeTypedAdmission.ValidatingWebhookConfigurationInterface {
+	return fc.o.Client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
+}
+
+func (fc *fakeController) Endpoints() kubeTypedCore.EndpointsInterface {
+	return fc.o.Client.CoreV1().Endpoints(fc.o.WatchedNamespace)
+}
+
+func (fc *fakeController) Deployments() kubeTypedApp.DeploymentInterface {
+	return fc.o.Client.AppsV1().Deployments(fc.o.WatchedNamespace)
+}
+
+// ensure that at least one reconcilation attempt has completed after the provided function is invoked.
+func (fc *fakeController) barrier(t *testing.T, fn func()) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	attempts := atomic.LoadInt32(&fc.reconcileCounter)
+	fn()
+	g.Eventually(fc.reconcileAttempts).Should(BeNumerically(">", attempts))
+}
+
+// gomega doesn't handle multi-value return functions well. Use helper functions to get
+// the first or second return value from k8s client REST calls.
+func first(ret, _ interface{}) interface{}  { return ret }
+func second(_, ret interface{}) interface{} { return ret }
+
+func TestController_Greenfield(t *testing.T) {
+	g := NewGomegaWithT(t)
+	c := createTestController()
+
+	stop := make(chan struct{})
+	defer func() { close(stop) }()
+	c.Start(stop)
+
+	g.Consistently(func() interface{} {
+		return second(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}).Should(MatchError(configNotFoundErr), "webhook should not exist before endpoint creation")
+
+	g.Expect(second(c.Endpoints().Create(istiodEndpoint))).Should(Succeed())
+
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}).Should(Equal(finalIstiodWebhookConfig), "webhook should exist after endpoint is ready")
+}
+
+func TestController_UpgradeDowngrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+	c := createTestController()
+
+	stop := make(chan struct{})
+	defer func() { close(stop) }()
+
+	c.Start(stop)
+
+	g.Expect(second(c.Deployments().Create(galleyDeployment))).Should(Succeed())
+	c.barrier(t, func() {
+		g.Expect(second(c.ValidatingWebhookConfigurations().Create(galleyWebhookConfig))).Should(Succeed())
+	})
+	// ensure galley exists before creating istiod
+	c.barrier(t, func() {
+		g.Expect(second(c.Endpoints().Create(istiodEndpoint))).Should(Succeed())
+	})
+	g.Consistently(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}).Should(Equal(galleyWebhookConfig),
+		"galley webhook should exist when istiod is deployed")
+
+	g.Expect(c.Deployments().Delete(galleyDeploymentName, &kubeApisMeta.DeleteOptions{})).Should(Succeed())
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}, 20*time.Second).Should(Equal(finalIstiodWebhookConfig),
+		"istiod webhook should exist when galley is removed")
+
+	g.Expect(second(c.Deployments().Create(galleyDeployment))).Should(Succeed())
+	c.barrier(t, func() {
+		g.Expect(second(c.ValidatingWebhookConfigurations().Update(galleyWebhookConfig))).Should(Succeed())
+	})
+	g.Consistently(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}).Should(Equal(galleyWebhookConfig),
+		"galley webhook should exist when galley is reployed")
+
+	galleyDeploymentWithZeroReplicas := galleyDeployment.DeepCopy()
+	galleyDeploymentWithZeroReplicas.Spec.Replicas = &[]int32{0}[0]
+	g.Expect(second(c.Deployments().Update(galleyDeploymentWithZeroReplicas))).Should(Succeed())
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}).Should(Equal(finalIstiodWebhookConfig),
+		"istio webhook should exist with zero galley replicas")
+
+	g.Expect(c.Deployments().Delete(galleyDeploymentName, &kubeApisMeta.DeleteOptions{})).Should(Succeed())
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}).Should(Equal(finalIstiodWebhookConfig),
+		"istio webhook should exist when zero-replica galley is removed")
+}
+
+func TestController_CertAndConfigFileChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+	c := createTestController()
+
+	stop := make(chan struct{})
+	defer func() { close(stop) }()
+	c.Start(stop)
+
+	g.Expect(second(c.Endpoints().Create(istiodEndpoint))).Should(Succeed())
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}).Should(Equal(finalIstiodWebhookConfig), "webhook should exist after endpoint is ready")
+
+	// verify the config updates after injecting a cafile change
+	c.injectedCABundle = caBundle1
+	c.fakeWatcher.InjectEvent(c.o.CAPath, fsnotify.Event{Name: c.o.CAPath, Op: fsnotify.Write})
+	updatedFinalConfig := finalIstiodWebhookConfig.DeepCopy()
+	updatedFinalConfig.Webhooks[0].ClientConfig.CABundle = caBundle0
+	updatedFinalConfig.Webhooks[1].ClientConfig.CABundle = caBundle1
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}).Should(Equal(finalIstiodWebhookConfig), "webhook should update after cert change")
+
+	// verify the config udpates after injecting a config file change.
+	updatedConfigFile := unpatchedIstiodWebhookConfig.DeepCopy()
+	se := kubeApiAdmission.SideEffectClassUnknown
+	updatedConfigFile.Webhooks[0].SideEffects = &se
+	c.injectedConfig = []byte(runtime.EncodeOrDie(codec, updatedConfigFile))
+	c.fakeWatcher.InjectEvent(c.o.ConfigPath, fsnotify.Event{Name: c.o.ConfigPath, Op: fsnotify.Write})
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}).Should(Equal(finalIstiodWebhookConfig), "webhook should update after config change")
+}


### PR DESCRIPTION
Galley, istioctl, operator, and istiod (soon) will all need to
optionally manage webhook lifecycle. Create a more generic webhook
controller package that can be shared.


