### PR TITLE
Fix flaky integration tests

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -22,6 +22,8 @@ import (
 	"path"
 	"path/filepath"
 
+	"istio.io/istio/pkg/test/util/retry"
+
 	"istio.io/istio/pkg/test/deployment"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
@@ -177,6 +179,12 @@ func deployOperator(ctx resource.Context, env *kube.Environment, cfg Config) (In
 			i.Dump()
 			return nil, err
 		}
+	}
+
+	// TODO(https://github.com/istio/istio/issues/19602) use --wait
+	if _, err := env.WaitUntilPodsAreReady(env.NewPodFetch(cfg.SystemNamespace), retry.Timeout(cfg.DeployTimeout)); err != nil {
+		scopes.CI.Errorf("Wait for Istio pods failed: %v", err)
+		return nil, err
 	}
 
 	return i, nil


### PR DESCRIPTION
* istioctl install method is not waiting for deployments to be ready
* We sleep needlessly. Instead, increase the max wait time a bit, and
retry at a faster rate.

For https://github.com/istio/istio/issues/19746
https://github.com/istio/istio/issues/19602 needs followup

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
