### PR TITLE
Kube controller simplify and improve

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -210,7 +210,6 @@ func NewController(client kubernetes.Interface, options Options) *Controller {
 	}
 
 	c.nodes = sharedInformers.Core().V1().Nodes().Informer()
-	registerHandlers(c.nodes, c.queue, "Nodes", c.onNodeEvent)
 
 	podInformer := sharedInformers.Core().V1().Pods().Informer()
 	c.pods = newPodCache(podInformer, c)
@@ -283,10 +282,6 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 		f(svcConv, event)
 	}
 
-	return nil
-}
-
-func (c *Controller) onNodeEvent(_ interface{}, _ model.Event) error {
 	return nil
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -256,7 +256,3 @@ func (e *endpointsController) onEvent(curr interface{}, event model.Event) error
 func (e *endpointsController) HasSynced() bool {
 	return e.informer.HasSynced()
 }
-
-func (e *endpointsController) Run(stopCh <-chan struct{}) {
-	e.informer.Run(stopCh)
-}

--- a/pilot/pkg/serviceregistry/kube/controller/endpointsdiscovery.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointsdiscovery.go
@@ -24,7 +24,6 @@ import (
 // both sources implement.
 type kubeEndpointsController interface {
 	HasSynced() bool
-	Run(stopCh <-chan struct{})
 	InstancesByPort(c *Controller, svc *model.Service, reqSvcPort int,
 		labelsList labels.Collection) ([]*model.ServiceInstance, error)
 	GetProxyServiceInstances(c *Controller, proxy *model.Proxy, proxyNamespace string) []*model.ServiceInstance

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -59,10 +59,6 @@ func (e *endpointSliceController) HasSynced() bool {
 	return e.informer.HasSynced()
 }
 
-func (e *endpointSliceController) Run(stopCh <-chan struct{}) {
-	e.informer.Run(stopCh)
-}
-
 func (e *endpointSliceController) updateEDSSlice(c *Controller, slice *discoveryv1alpha1.EndpointSlice, event model.Event) {
 	svcName := slice.Labels[discoveryv1alpha1.LabelServiceName]
 	hostname := kube.ServiceHostname(svcName, slice.Namespace, c.domainSuffix)


### PR DESCRIPTION
Please provide a description for what this PR is for.

The main changes:

1. Refine the controller `Run` with `SharedInformerFactory.Start` method
2. Record hasSynced flag to reduce calling of multi informers' HasSynced, and thus reducing race.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
