### PR TITLE
Replace flag --use-automatic-injection as --use_automatic_injection for naming consistent in e2e testing framework.

### DIFF
--- a/tests/e2e/framework/app_manager.go
+++ b/tests/e2e/framework/app_manager.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	useAutomaticInjection = flag.Bool("use-automatic-injection", false, "Use automatic injection instead of kube-inject for transparent proxy injection")
+	useAutomaticInjection = flag.Bool("use_automatic_injection", false, "Use automatic injection instead of kube-inject for transparent proxy injection")
 )
 
 const (


### PR DESCRIPTION
As the title.

The issue has been originally reported in https://github.com/istio/istio/issues/6921. I could not find any reference to --use-automatic-injection within github, thereby I fixed the flag name instead of changing README.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure