### PR TITLE
istio: add consecutive 5xx and gateway errors for outlier detection

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -981,10 +981,6 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6/go.mod h1:hhLFQmpHia8zgaM37vb2ml9iS5NfNfqZGRt1pS9aVEo=
-istio.io/api v0.0.0-20191120195622-f0abe0c81e59 h1:NlvDpTU4aQWcq9kOwq5BmG8dg+ZeSvAa25y9RwVO3do=
-istio.io/api v0.0.0-20191120195622-f0abe0c81e59/go.mod h1:+cyHH83OwC0rFpwk8eXctzPNpiCAbB+r6kmMiAxxBHw=
-istio.io/api v0.0.0-20191221190806-3dcc874c2838 h1:3uGASWmNZJcpb3Rj7LJoVrrptXoMD3ArEpwC3X82UJk=
-istio.io/api v0.0.0-20191221190806-3dcc874c2838/go.mod h1:jpzw4nhnN3hfvyICW6aVVPQOjR1VHXNSTxfl2W8uqik=
 istio.io/api v0.0.0-20191223205118-b8a70ca43b00 h1:DEhkvMj2DKCfe1kR0nAxI9u/AzPDy9qP8J5eh8pXzms=
 istio.io/api v0.0.0-20191223205118-b8a70ca43b00/go.mod h1:RXD9cVQsBOLpIb38NOMOa48DXvBtNdrA7bTHLMyuhvM=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a h1:w7zILua2dnYo9CxImhpNW4NE/8ZxEoc/wfBfHrhUhrE=

--- a/go.sum
+++ b/go.sum
@@ -981,6 +981,10 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6/go.mod h1:hhLFQmpHia8zgaM37vb2ml9iS5NfNfqZGRt1pS9aVEo=
+istio.io/api v0.0.0-20191120195622-f0abe0c81e59 h1:NlvDpTU4aQWcq9kOwq5BmG8dg+ZeSvAa25y9RwVO3do=
+istio.io/api v0.0.0-20191120195622-f0abe0c81e59/go.mod h1:+cyHH83OwC0rFpwk8eXctzPNpiCAbB+r6kmMiAxxBHw=
+istio.io/api v0.0.0-20191221190806-3dcc874c2838 h1:3uGASWmNZJcpb3Rj7LJoVrrptXoMD3ArEpwC3X82UJk=
+istio.io/api v0.0.0-20191221190806-3dcc874c2838/go.mod h1:jpzw4nhnN3hfvyICW6aVVPQOjR1VHXNSTxfl2W8uqik=
 istio.io/api v0.0.0-20191223205118-b8a70ca43b00 h1:DEhkvMj2DKCfe1kR0nAxI9u/AzPDy9qP8J5eh8pXzms=
 istio.io/api v0.0.0-20191223205118-b8a70ca43b00/go.mod h1:RXD9cVQsBOLpIb38NOMOa48DXvBtNdrA7bTHLMyuhvM=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a h1:w7zILua2dnYo9CxImhpNW4NE/8ZxEoc/wfBfHrhUhrE=

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -960,7 +960,7 @@ func applyOutlierDetection(cluster *apiv2.Cluster, outlier *networking.OutlierDe
 	}
 
 	setConsecErrs := func(errs, enforcing **wrappers.UInt32Value, v uint32) {
-		*errs =  &wrappers.UInt32Value{Value: v}
+		*errs = &wrappers.UInt32Value{Value: v}
 
 		if v > 0 {
 			v = 100

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -959,20 +959,25 @@ func applyOutlierDetection(cluster *apiv2.Cluster, outlier *networking.OutlierDe
 		out.ConsecutiveGatewayFailure = &wrappers.UInt32Value{Value: uint32(outlier.ConsecutiveErrors)}
 	}
 
-	setConsecErrs := func(errs, enforcing **wrappers.UInt32Value, v uint32) {
-		*errs = &wrappers.UInt32Value{Value: v}
+	if e := outlier.Consecutive_5XxErrors; e != nil {
+		v := e.GetValue()
+
+		out.Consecutive_5Xx = &wrappers.UInt32Value{Value: v}
 
 		if v > 0 {
 			v = 100
 		}
-		*enforcing = &wrappers.UInt32Value{Value: v}
+		out.EnforcingConsecutive_5Xx = &wrappers.UInt32Value{Value: v}
 	}
+	if e := outlier.ConsecutiveGatewayErrors; e != nil {
+		v := e.GetValue()
 
-	if c5xx := outlier.Consecutive_5XxErrors; c5xx != nil {
-		setConsecErrs(&out.Consecutive_5Xx, &out.EnforcingConsecutive_5Xx, c5xx.GetValue())
-	}
-	if cgateway := outlier.ConsecutiveGatewayErrors; cgateway != nil {
-		setConsecErrs(&out.ConsecutiveGatewayFailure, &out.EnforcingConsecutiveGatewayFailure, cgateway.GetValue())
+		out.ConsecutiveGatewayFailure = &wrappers.UInt32Value{Value: v}
+
+		if v > 0 {
+			v = 100
+		}
+		out.EnforcingConsecutiveGatewayFailure = &wrappers.UInt32Value{Value: v}
 	}
 
 	if outlier.Interval != nil {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -958,6 +958,23 @@ func applyOutlierDetection(cluster *apiv2.Cluster, outlier *networking.OutlierDe
 		out.EnforcingConsecutive_5Xx = &wrappers.UInt32Value{Value: uint32(0)}             // defaults to 100
 		out.ConsecutiveGatewayFailure = &wrappers.UInt32Value{Value: uint32(outlier.ConsecutiveErrors)}
 	}
+
+	setConsecErrs := func(errs, enforcing **wrappers.UInt32Value, v uint32) {
+		*errs =  &wrappers.UInt32Value{Value: v}
+
+		if v > 0 {
+			v = 100
+		}
+		*enforcing = &wrappers.UInt32Value{Value: v}
+	}
+
+	if c5xx := outlier.Consecutive_5XxErrors; c5xx != nil {
+		setConsecErrs(&out.Consecutive_5Xx, &out.EnforcingConsecutive_5Xx, c5xx.GetValue())
+	}
+	if cgateway := outlier.ConsecutiveGatewayErrors; cgateway != nil {
+		setConsecErrs(&out.ConsecutiveGatewayFailure, &out.EnforcingConsecutiveGatewayFailure, cgateway.GetValue())
+	}
+
 	if outlier.Interval != nil {
 		out.Interval = gogo.DurationToProtoDuration(outlier.Interval)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -25,8 +25,10 @@ import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
 
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	apiv2_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
@@ -42,6 +44,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/fakes"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
+	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
@@ -970,6 +973,101 @@ func TestDisablePanicThresholdAsDefault(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(clusters[0].CommonLbConfig.HealthyPanicThreshold).To(Not(BeNil()))
 		g.Expect(clusters[0].CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(0)))
+	}
+}
+
+func TestApplyOutlierDetection(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		name string
+		cfg  *networking.OutlierDetection
+		o    *apiv2_cluster.OutlierDetection
+	}{
+		{
+			"No outlier detection is set",
+			&networking.OutlierDetection{},
+			&apiv2_cluster.OutlierDetection{},
+		},
+		{
+			"Deprecated consecutive errors is set",
+			&networking.OutlierDetection{
+				ConsecutiveErrors: 3,
+			},
+			&apiv2_cluster.OutlierDetection{
+				EnforcingConsecutive_5Xx:           &wrappers.UInt32Value{Value: 0},
+				ConsecutiveGatewayFailure:          &wrappers.UInt32Value{Value: 3},
+				EnforcingConsecutiveGatewayFailure: &wrappers.UInt32Value{Value: 100},
+			},
+		},
+		{
+			"Consecutive gateway and 5xx errors are set",
+			&networking.OutlierDetection{
+				Consecutive_5XxErrors:    &types.UInt32Value{Value: 4},
+				ConsecutiveGatewayErrors: &types.UInt32Value{Value: 3},
+			},
+			&apiv2_cluster.OutlierDetection{
+				Consecutive_5Xx:                    &wrappers.UInt32Value{Value: 4},
+				EnforcingConsecutive_5Xx:           &wrappers.UInt32Value{Value: 100},
+				ConsecutiveGatewayFailure:          &wrappers.UInt32Value{Value: 3},
+				EnforcingConsecutiveGatewayFailure: &wrappers.UInt32Value{Value: 100},
+			},
+		},
+		{
+			"Only consecutive gateway is set",
+			&networking.OutlierDetection{
+				ConsecutiveGatewayErrors: &types.UInt32Value{Value: 3},
+			},
+			&apiv2_cluster.OutlierDetection{
+				ConsecutiveGatewayFailure:          &wrappers.UInt32Value{Value: 3},
+				EnforcingConsecutiveGatewayFailure: &wrappers.UInt32Value{Value: 100},
+			},
+		},
+		{
+			"Only consecutive 5xx is set",
+			&networking.OutlierDetection{
+				Consecutive_5XxErrors: &types.UInt32Value{Value: 3},
+			},
+			&apiv2_cluster.OutlierDetection{
+				Consecutive_5Xx:          &wrappers.UInt32Value{Value: 3},
+				EnforcingConsecutive_5Xx: &wrappers.UInt32Value{Value: 100},
+			},
+		},
+		{
+			"Consecutive gateway is set to 0",
+			&networking.OutlierDetection{
+				ConsecutiveGatewayErrors: &types.UInt32Value{Value: 0},
+			},
+			&apiv2_cluster.OutlierDetection{
+				ConsecutiveGatewayFailure:          &wrappers.UInt32Value{Value: 0},
+				EnforcingConsecutiveGatewayFailure: &wrappers.UInt32Value{Value: 0},
+			},
+		},
+		{
+			"Consecutive 5xx is set to 0",
+			&networking.OutlierDetection{
+				Consecutive_5XxErrors: &types.UInt32Value{Value: 0},
+			},
+			&apiv2_cluster.OutlierDetection{
+				Consecutive_5Xx:          &wrappers.UInt32Value{Value: 0},
+				EnforcingConsecutive_5Xx: &wrappers.UInt32Value{Value: 0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusters, err := buildTestClusters("*.example.org", model.DNSLB, model.SidecarProxy,
+				&core.Locality{}, testMesh,
+				&networking.DestinationRule{
+					Host: "*.example.org",
+					TrafficPolicy: &networking.TrafficPolicy{
+						OutlierDetection: tt.cfg,
+					},
+				})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(clusters[0].OutlierDetection).To(Equal(tt.o))
+		})
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -44,7 +44,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/fakes"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -851,6 +851,13 @@ func validateOutlierDetection(outlier *networking.OutlierDetection) (errs error)
 	if outlier.ConsecutiveErrors < 0 {
 		errs = appendErrors(errs, fmt.Errorf("outlier detection consecutive errors cannot be negative"))
 	}
+	if outlier.Consecutive_5XxErrors != nil || outlier.ConsecutiveGatewayErrors != nil {
+		// ConsecutiveErrors is deprecated for Consecutive_5XxErrors and
+		// ConsecutiveGatewayErrors; they should not be set at the same time.
+		if outlier.ConsecutiveErrors > 0 {
+			errs = appendErrors(errs, fmt.Errorf("consecutive_errors should not be set with consecutive_5xx_errors or consecutive_gateway_errors"))
+		}
+	}
 	if outlier.Interval != nil {
 		errs = appendErrors(errs, ValidateDurationGogo(outlier.Interval))
 	}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2679,7 +2679,7 @@ func TestValidateDestinationRule(t *testing.T) {
 			Host: "reviews",
 			TrafficPolicy: &networking.TrafficPolicy{
 				OutlierDetection: &networking.OutlierDetection{
-					ConsecutiveErrors: 3,
+					ConsecutiveErrors:     3,
 					Consecutive_5XxErrors: &types.UInt32Value{Value: 3},
 				},
 			},

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2661,6 +2661,33 @@ func TestValidateDestinationRule(t *testing.T) {
 				{Name: "v2", Labels: map[string]string{"version": "v2"}},
 			},
 		}, valid: true},
+
+		{name: "negative consecutive errors", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				OutlierDetection: &networking.OutlierDetection{
+					ConsecutiveErrors: -1,
+				},
+			},
+			Subsets: []*networking.Subset{
+				{Name: "v1", Labels: map[string]string{"version": "v1"}},
+				{Name: "v2", Labels: map[string]string{"version": "v2"}},
+			},
+		}, valid: false},
+
+		{name: "deprecated consecutive errors set together with consecutive 5xx errors", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				OutlierDetection: &networking.OutlierDetection{
+					ConsecutiveErrors: 3,
+					Consecutive_5XxErrors: &types.UInt32Value{Value: 3},
+				},
+			},
+			Subsets: []*networking.Subset{
+				{Name: "v1", Labels: map[string]string{"version": "v1"}},
+				{Name: "v2", Labels: map[string]string{"version": "v2"}},
+			},
+		}, valid: false},
 	}
 	for _, c := range cases {
 		if got := ValidateDestinationRule(someName, someNamespace, c.in); (got == nil) != c.valid {


### PR DESCRIPTION
This CL implements the consecutive 5xx and gateway errors for outlier detection. Corresponding API change: https://github.com/istio/api/pull/1189
Related to #909

@jhahn21 @brianwolfe @frankbu @rshriram 