### PR TITLE
Envoyfilter matching performance optimization

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -83,3 +83,27 @@ func convertToEnvoyFilterWrapper(local *Config) *EnvoyFilterWrapper {
 	}
 	return out
 }
+
+func proxyMatch(proxy *Proxy, cp *EnvoyFilterConfigPatchWrapper) bool {
+	if cp.Match.Proxy == nil {
+		return true
+	}
+
+	if cp.ProxyVersionRegex != nil {
+		ver := proxy.Metadata.IstioVersion
+		if ver == "" {
+			// we do not have a proxy version but the user has a regex. so this is a mismatch
+			return false
+		}
+		if !cp.ProxyVersionRegex.MatchString(ver) {
+			return false
+		}
+	}
+
+	for k, v := range cp.Match.Proxy.Metadata {
+		if proxy.Metadata.Raw[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1436,12 +1436,13 @@ func (ps *PushContext) initEnvoyFilters(env *Environment) error {
 	return nil
 }
 
-func (ps *PushContext) EnvoyFilters(proxy *Proxy) []*EnvoyFilterWrapper {
+// EnvoyFilters return the merged EnvoyFilterWrapper of a proxy
+func (ps *PushContext) EnvoyFilters(proxy *Proxy) *EnvoyFilterWrapper {
 	// this should never happen
 	if proxy == nil {
 		return nil
 	}
-	out := make([]*EnvoyFilterWrapper, 0)
+	matchedEnvoyFilters := make([]*EnvoyFilterWrapper, 0)
 	// EnvoyFilters supports inheritance (global ones plus namespace local ones).
 	// First get all the filter configs from the config root namespace
 	// and then add the ones from proxy's own namespace
@@ -1450,7 +1451,7 @@ func (ps *PushContext) EnvoyFilters(proxy *Proxy) []*EnvoyFilterWrapper {
 		// if there is a workload selector, check for matching workload labels
 		for _, efw := range ps.envoyFiltersByNamespace[ps.Mesh.RootNamespace] {
 			if efw.workloadSelector == nil || proxy.WorkloadLabels.IsSupersetOf(efw.workloadSelector) {
-				out = append(out, efw)
+				matchedEnvoyFilters = append(matchedEnvoyFilters, efw)
 			}
 		}
 	}
@@ -1459,7 +1460,28 @@ func (ps *PushContext) EnvoyFilters(proxy *Proxy) []*EnvoyFilterWrapper {
 	if proxy.ConfigNamespace != ps.Mesh.RootNamespace {
 		for _, efw := range ps.envoyFiltersByNamespace[proxy.ConfigNamespace] {
 			if efw.workloadSelector == nil || proxy.WorkloadLabels.IsSupersetOf(efw.workloadSelector) {
-				out = append(out, efw)
+				matchedEnvoyFilters = append(matchedEnvoyFilters, efw)
+			}
+		}
+	}
+
+	var out *EnvoyFilterWrapper
+	if len(matchedEnvoyFilters) > 0 {
+		out = &EnvoyFilterWrapper{
+			// no need populate workloadSelector, as it is not used later.
+			Patches: make(map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper),
+		}
+	}
+	// merge EnvoyFilterWrapper
+	for _, efw := range matchedEnvoyFilters {
+		for applyTo, cps := range efw.Patches {
+			if out.Patches[applyTo] == nil {
+				out.Patches[applyTo] = []*EnvoyFilterConfigPatchWrapper{}
+			}
+			for _, cp := range cps {
+				if proxyMatch(proxy, cp) {
+					out.Patches[applyTo] = append(out.Patches[applyTo], cp)
+				}
 			}
 		}
 	}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -17,6 +17,7 @@ package model
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 	"time"
 
@@ -433,10 +434,37 @@ func TestJwtAuthNPolicy(t *testing.T) {
 }
 
 func TestEnvoyFilters(t *testing.T) {
+	proxyVersionRegex, _ := regexp.Compile("1\\.4.*")
 	envoyFilters := []*EnvoyFilterWrapper{
 		{
 			workloadSelector: map[string]string{"app": "v1"},
-			Patches:          nil,
+			Patches: map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper{
+				networking.EnvoyFilter_LISTENER: []*EnvoyFilterConfigPatchWrapper{
+					{
+						Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+							Proxy: &networking.EnvoyFilter_ProxyMatch{
+								ProxyVersion: "1\\.4.*",
+							},
+						},
+						ProxyVersionRegex: proxyVersionRegex,
+					},
+				},
+			},
+		},
+		{
+			workloadSelector: map[string]string{"app": "v1"},
+			Patches: map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper{
+				networking.EnvoyFilter_CLUSTER: []*EnvoyFilterConfigPatchWrapper{
+					{
+						Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+							Proxy: &networking.EnvoyFilter_ProxyMatch{
+								ProxyVersion: "1\\.4.*",
+							},
+						},
+						ProxyVersionRegex: proxyVersionRegex,
+					},
+				},
+			},
 		},
 	}
 
@@ -451,43 +479,62 @@ func TestEnvoyFilters(t *testing.T) {
 	}
 
 	cases := []struct {
-		name     string
-		proxy    *Proxy
-		expected int
+		name                    string
+		proxy                   *Proxy
+		expectedListenerPatches int
+		expectedClusterPatches  int
 	}{
 		{
-			name:     "proxy matches two envoyfilters",
-			proxy:    &Proxy{ConfigNamespace: "test-ns", WorkloadLabels: labels.Collection{{"app": "v1"}}},
-			expected: 2,
+			name:                    "proxy matches two envoyfilters",
+			proxy:                   &Proxy{Metadata: &NodeMetadata{IstioVersion: "1.4.0"}, ConfigNamespace: "test-ns", WorkloadLabels: labels.Collection{{"app": "v1"}}},
+			expectedListenerPatches: 2,
+			expectedClusterPatches:  2,
 		},
 		{
-			name:     "proxy in root namespace matches an envoyfilter",
-			proxy:    &Proxy{ConfigNamespace: "istio-system", WorkloadLabels: labels.Collection{{"app": "v1"}}},
-			expected: 1,
-		},
-
-		{
-			name:     "proxy matches no envoyfilter",
-			proxy:    &Proxy{ConfigNamespace: "test-ns", WorkloadLabels: labels.Collection{{"app": "v2"}}},
-			expected: 0,
+			name:                    "proxy in root namespace matches an envoyfilter",
+			proxy:                   &Proxy{Metadata: &NodeMetadata{IstioVersion: "1.4.0"}, ConfigNamespace: "istio-system", WorkloadLabels: labels.Collection{{"app": "v1"}}},
+			expectedListenerPatches: 1,
+			expectedClusterPatches:  1,
 		},
 
 		{
-			name:     "proxy matches envoyfilter in root ns",
-			proxy:    &Proxy{ConfigNamespace: "test-n2", WorkloadLabels: labels.Collection{{"app": "v1"}}},
-			expected: 1,
+			name:                    "proxy matches no envoyfilter",
+			proxy:                   &Proxy{Metadata: &NodeMetadata{IstioVersion: "1.4.0"}, ConfigNamespace: "test-ns", WorkloadLabels: labels.Collection{{"app": "v2"}}},
+			expectedListenerPatches: 0,
+			expectedClusterPatches:  0,
+		},
+
+		{
+			name:                    "proxy matches envoyfilter in root ns",
+			proxy:                   &Proxy{Metadata: &NodeMetadata{IstioVersion: "1.4.0"}, ConfigNamespace: "test-n2", WorkloadLabels: labels.Collection{{"app": "v1"}}},
+			expectedListenerPatches: 1,
+			expectedClusterPatches:  1,
+		},
+		{
+			name:                    "proxy version matches no envoyfilters",
+			proxy:                   &Proxy{Metadata: &NodeMetadata{IstioVersion: "1.3.0"}, ConfigNamespace: "test-ns", WorkloadLabels: labels.Collection{{"app": "v1"}}},
+			expectedListenerPatches: 0,
+			expectedClusterPatches:  0,
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			filters := push.EnvoyFilters(tt.proxy)
-			if len(filters) != tt.expected {
-				t.Errorf("Expect %d envoy filters, but got %d", len(filters), tt.expected)
+			filter := push.EnvoyFilters(tt.proxy)
+			if filter == nil {
+				if tt.expectedClusterPatches != 0 || tt.expectedListenerPatches != 0 {
+					t.Errorf("Got no envoy filter")
+				}
+				return
+			}
+			if len(filter.Patches[networking.EnvoyFilter_CLUSTER]) != tt.expectedClusterPatches {
+				t.Errorf("Expect %d envoy filter cluster patches, but got %d", tt.expectedClusterPatches, len(filter.Patches[networking.EnvoyFilter_CLUSTER]))
+			}
+			if len(filter.Patches[networking.EnvoyFilter_LISTENER]) != tt.expectedListenerPatches {
+				t.Errorf("Expect %d envoy filter listener patches, but got %d", tt.expectedListenerPatches, len(filter.Patches[networking.EnvoyFilter_LISTENER]))
 			}
 		})
 	}
-
 }
 
 func TestSidecarScope(t *testing.T) {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -434,7 +434,7 @@ func TestJwtAuthNPolicy(t *testing.T) {
 }
 
 func TestEnvoyFilters(t *testing.T) {
-	proxyVersionRegex := regexp.MustCompile("1\\.4.*")
+	proxyVersionRegex := regexp.MustCompile(`1\.4.*`)
 	envoyFilters := []*EnvoyFilterWrapper{
 		{
 			workloadSelector: map[string]string{"app": "v1"},
@@ -458,7 +458,7 @@ func TestEnvoyFilters(t *testing.T) {
 					{
 						Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 							Proxy: &networking.EnvoyFilter_ProxyMatch{
-								ProxyVersion: "1\\.4.*",
+								ProxyVersion: `1\\.4.*`,
 							},
 						},
 						ProxyVersionRegex: proxyVersionRegex,

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -434,12 +434,12 @@ func TestJwtAuthNPolicy(t *testing.T) {
 }
 
 func TestEnvoyFilters(t *testing.T) {
-	proxyVersionRegex, _ := regexp.Compile("1\\.4.*")
+	proxyVersionRegex := regexp.MustCompile("1\\.4.*")
 	envoyFilters := []*EnvoyFilterWrapper{
 		{
 			workloadSelector: map[string]string{"app": "v1"},
 			Patches: map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper{
-				networking.EnvoyFilter_LISTENER: []*EnvoyFilterConfigPatchWrapper{
+				networking.EnvoyFilter_LISTENER: {
 					{
 						Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 							Proxy: &networking.EnvoyFilter_ProxyMatch{
@@ -454,7 +454,7 @@ func TestEnvoyFilters(t *testing.T) {
 		{
 			workloadSelector: map[string]string{"app": "v1"},
 			Patches: map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper{
-				networking.EnvoyFilter_CLUSTER: []*EnvoyFilterConfigPatchWrapper{
+				networking.EnvoyFilter_CLUSTER: {
 					{
 						Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 							Proxy: &networking.EnvoyFilter_ProxyMatch{
@@ -485,34 +485,54 @@ func TestEnvoyFilters(t *testing.T) {
 		expectedClusterPatches  int
 	}{
 		{
-			name:                    "proxy matches two envoyfilters",
-			proxy:                   &Proxy{Metadata: &NodeMetadata{IstioVersion: "1.4.0"}, ConfigNamespace: "test-ns", WorkloadLabels: labels.Collection{{"app": "v1"}}},
+			name: "proxy matches two envoyfilters",
+			proxy: &Proxy{
+				Metadata:        &NodeMetadata{IstioVersion: "1.4.0"},
+				ConfigNamespace: "test-ns",
+				WorkloadLabels:  labels.Collection{{"app": "v1"}},
+			},
 			expectedListenerPatches: 2,
 			expectedClusterPatches:  2,
 		},
 		{
-			name:                    "proxy in root namespace matches an envoyfilter",
-			proxy:                   &Proxy{Metadata: &NodeMetadata{IstioVersion: "1.4.0"}, ConfigNamespace: "istio-system", WorkloadLabels: labels.Collection{{"app": "v1"}}},
+			name: "proxy in root namespace matches an envoyfilter",
+			proxy: &Proxy{
+				Metadata:        &NodeMetadata{IstioVersion: "1.4.0"},
+				ConfigNamespace: "istio-system",
+				WorkloadLabels:  labels.Collection{{"app": "v1"}},
+			},
 			expectedListenerPatches: 1,
 			expectedClusterPatches:  1,
 		},
 
 		{
-			name:                    "proxy matches no envoyfilter",
-			proxy:                   &Proxy{Metadata: &NodeMetadata{IstioVersion: "1.4.0"}, ConfigNamespace: "test-ns", WorkloadLabels: labels.Collection{{"app": "v2"}}},
+			name: "proxy matches no envoyfilter",
+			proxy: &Proxy{
+				Metadata:        &NodeMetadata{IstioVersion: "1.4.0"},
+				ConfigNamespace: "test-ns",
+				WorkloadLabels:  labels.Collection{{"app": "v2"}},
+			},
 			expectedListenerPatches: 0,
 			expectedClusterPatches:  0,
 		},
 
 		{
-			name:                    "proxy matches envoyfilter in root ns",
-			proxy:                   &Proxy{Metadata: &NodeMetadata{IstioVersion: "1.4.0"}, ConfigNamespace: "test-n2", WorkloadLabels: labels.Collection{{"app": "v1"}}},
+			name: "proxy matches envoyfilter in root ns",
+			proxy: &Proxy{
+				Metadata:        &NodeMetadata{IstioVersion: "1.4.0"},
+				ConfigNamespace: "test-n2",
+				WorkloadLabels:  labels.Collection{{"app": "v1"}},
+			},
 			expectedListenerPatches: 1,
 			expectedClusterPatches:  1,
 		},
 		{
-			name:                    "proxy version matches no envoyfilters",
-			proxy:                   &Proxy{Metadata: &NodeMetadata{IstioVersion: "1.3.0"}, ConfigNamespace: "test-ns", WorkloadLabels: labels.Collection{{"app": "v1"}}},
+			name: "proxy version matches no envoyfilters",
+			proxy: &Proxy{
+				Metadata:        &NodeMetadata{IstioVersion: "1.3.0"},
+				ConfigNamespace: "test-ns",
+				WorkloadLabels:  labels.Collection{{"app": "v1"}},
+			},
 			expectedListenerPatches: 0,
 			expectedClusterPatches:  0,
 		},

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -38,37 +38,35 @@ func ApplyClusterPatches(
 	// In case the patches cause panic, use the clusters generated before to reduce the influence.
 	out = clusters
 
-	envoyFilterWrappers := push.EnvoyFilters(proxy)
+	efw := push.EnvoyFilters(proxy)
 	clustersRemoved := false
-	for _, efw := range envoyFilterWrappers {
-		for _, cp := range efw.Patches[networking.EnvoyFilter_CLUSTER] {
-			if cp.Operation != networking.EnvoyFilter_Patch_REMOVE &&
-				cp.Operation != networking.EnvoyFilter_Patch_MERGE {
+	for _, cp := range efw.Patches[networking.EnvoyFilter_CLUSTER] {
+		if cp.Operation != networking.EnvoyFilter_Patch_REMOVE &&
+			cp.Operation != networking.EnvoyFilter_Patch_MERGE {
+			continue
+		}
+		for i := range clusters {
+			if clusters[i] == nil {
+				// deleted by the remove operation
 				continue
 			}
-			for i := range clusters {
-				if clusters[i] == nil {
-					// deleted by the remove operation
-					continue
-				}
 
-				if commonConditionMatch(proxy, patchContext, cp) && clusterMatch(clusters[i], cp) {
-					if cp.Operation == networking.EnvoyFilter_Patch_REMOVE {
-						clusters[i] = nil
-						clustersRemoved = true
-					} else {
-						proto.Merge(clusters[i], cp.Value)
-					}
+			if commonConditionMatch(patchContext, cp) && clusterMatch(clusters[i], cp) {
+				if cp.Operation == networking.EnvoyFilter_Patch_REMOVE {
+					clusters[i] = nil
+					clustersRemoved = true
+				} else {
+					proto.Merge(clusters[i], cp.Value)
 				}
 			}
 		}
+	}
 
-		// Add cluster if the operation is add, and patch context matches
-		for _, cp := range efw.Patches[networking.EnvoyFilter_CLUSTER] {
-			if cp.Operation == networking.EnvoyFilter_Patch_ADD {
-				if commonConditionMatch(proxy, patchContext, cp) {
-					clusters = append(clusters, proto.Clone(cp.Value).(*xdsapi.Cluster))
-				}
+	// Add cluster if the operation is add, and patch context matches
+	for _, cp := range efw.Patches[networking.EnvoyFilter_CLUSTER] {
+		if cp.Operation == networking.EnvoyFilter_Patch_ADD {
+			if commonConditionMatch(patchContext, cp) {
+				clusters = append(clusters, proto.Clone(cp.Value).(*xdsapi.Cluster))
 			}
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -220,8 +220,8 @@ func TestApplyClusterPatches(t *testing.T) {
 				AllowMetadata: true,
 			}, LbPolicy: xdsapi.Cluster_RING_HASH, DnsLookupFamily: xdsapi.Cluster_V6_ONLY,
 		},
-		{Name: "new-cluster1", DnsLookupFamily: xdsapi.Cluster_V6_ONLY, LbPolicy: xdsapi.Cluster_RING_HASH},
-		{Name: "new-cluster2", DnsLookupFamily: xdsapi.Cluster_V6_ONLY, LbPolicy: xdsapi.Cluster_RING_HASH},
+		{Name: "new-cluster1"},
+		{Name: "new-cluster2"},
 	}
 
 	sidecarInboundIn := []*xdsapi.Cluster{
@@ -293,5 +293,6 @@ func TestApplyClusterPatches(t *testing.T) {
 				t.Errorf("ApplyClusterPatches(): %s mismatch (-want +got):\n%s", tc.name, diff)
 			}
 		})
+		return
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -293,6 +293,5 @@ func TestApplyClusterPatches(t *testing.T) {
 				t.Errorf("ApplyClusterPatches(): %s mismatch (-want +got):\n%s", tc.name, diff)
 			}
 		})
-		return
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/pkg/log"
 
 	networking "istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/util/runtime"

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -331,7 +331,7 @@ func doHTTPFilterListOperation(proxy *model.Proxy, patchContext networking.Envoy
 		if httpFilter.Name == "" {
 			continue
 		}
-		doHTTPFilterOperation(proxy, patchContext, patches, listener, fc, filter, httpFilter, &httpFiltersRemoved)
+		doHTTPFilterOperation(patchContext, patches, listener, fc, filter, httpFilter, &httpFiltersRemoved)
 	}
 	for _, cp := range patches[networking.EnvoyFilter_HTTP_FILTER] {
 		if !commonConditionMatch(patchContext, cp) ||
@@ -412,7 +412,7 @@ func doHTTPFilterListOperation(proxy *model.Proxy, patchContext networking.Envoy
 	}
 }
 
-func doHTTPFilterOperation(proxy *model.Proxy, patchContext networking.EnvoyFilter_PatchContext,
+func doHTTPFilterOperation(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
 	listener *xdsapi.Listener, fc *xdslistener.FilterChain, filter *xdslistener.Filter,
 	httpFilter *http_conn.HttpFilter, httpFilterRemoved *bool) {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -647,7 +647,18 @@ func TestApplyListenerPatches(t *testing.T) {
 			},
 		},
 	}
-	gatewayProxy := &model.Proxy{Type: model.Router, ConfigNamespace: "not-default"}
+
+	gatewayProxy := &model.Proxy{
+		Type:            model.Router,
+		ConfigNamespace: "not-default",
+		Metadata: &model.NodeMetadata{
+			IstioVersion: "1.2.2",
+			Raw: map[string]interface{}{
+				"foo": "sidecar",
+				"bar": "proxy",
+			},
+		},
+	}
 	serviceDiscovery := &fakes.ServiceDiscovery{}
 	e := newTestEnvironment(serviceDiscovery, testMesh, buildEnvoyFilterConfigStore(configPatches))
 	push := model.NewPushContext()

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -28,6 +28,7 @@ import (
 	fault "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/fault/v2"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -735,34 +736,32 @@ func TestApplyListenerPatches(t *testing.T) {
 // This benchmark measures the performance of Telemetry V2 EnvoyFilter patches. The intent here is to
 // measure overhead of using EnvoyFilters rather than native code.
 func BenchmarkTelemetryV2Filters(b *testing.B) {
-	l := []*xdsapi.Listener{
-		{
-			Name: "another-listener",
-			Address: &core.Address{
-				Address: &core.Address_SocketAddress{
-					SocketAddress: &core.SocketAddress{
-						PortSpecifier: &core.SocketAddress_PortValue{
-							PortValue: 80,
-						},
+	l := &xdsapi.Listener{
+		Name: "another-listener",
+		Address: &core.Address{
+			Address: &core.Address_SocketAddress{
+				SocketAddress: &core.SocketAddress{
+					PortSpecifier: &core.SocketAddress_PortValue{
+						PortValue: 80,
 					},
 				},
 			},
-			ListenerFilters: []*listener.ListenerFilter{{Name: "envoy.tls_inspector"}},
-			FilterChains: []*listener.FilterChain{
-				{
-					Filters: []*listener.Filter{
-						{
-							Name: xdsutil.HTTPConnectionManager,
-							ConfigType: &listener.Filter_TypedConfig{
-								TypedConfig: util.MessageToAny(&http_conn.HttpConnectionManager{
-									XffNumTrustedHops: 4,
-									HttpFilters: []*http_conn.HttpFilter{
-										{Name: "http-filter3"},
-										{Name: xdsutil.Router},
-										{Name: "http-filter2"},
-									},
-								}),
-							},
+		},
+		ListenerFilters: []*listener.ListenerFilter{{Name: "envoy.tls_inspector"}},
+		FilterChains: []*listener.FilterChain{
+			{
+				Filters: []*listener.Filter{
+					{
+						Name: xdsutil.HTTPConnectionManager,
+						ConfigType: &listener.Filter_TypedConfig{
+							TypedConfig: util.MessageToAny(&http_conn.HttpConnectionManager{
+								XffNumTrustedHops: 4,
+								HttpFilters: []*http_conn.HttpFilter{
+									{Name: "http-filter3"},
+									{Name: xdsutil.Router},
+									{Name: "http-filter2"},
+								},
+							}),
 						},
 					},
 				},
@@ -813,8 +812,9 @@ func BenchmarkTelemetryV2Filters(b *testing.B) {
 	var got interface{}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		copied := proto.Clone(l)
 		got = ApplyListenerPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, sidecarProxy, push,
-			l, false)
+			[]*xdsapi.Listener{copied.(*xdsapi.Listener)}, false)
 	}
 	_ = got
 }

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -52,19 +52,19 @@ func ApplyRouteConfigurationPatches(
 		}
 	}
 
-	doVirtualHostListOperation(proxy, patchContext, efw.Patches, routeConfiguration)
+	doVirtualHostListOperation(patchContext, efw.Patches, routeConfiguration)
 
 	return routeConfiguration
 }
 
-func doVirtualHostListOperation(proxy *model.Proxy, patchContext networking.EnvoyFilter_PatchContext,
+func doVirtualHostListOperation(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
 	routeConfiguration *xdsapi.RouteConfiguration) {
 
 	virtualHostsRemoved := false
 	// first do removes/merges
 	for _, vhost := range routeConfiguration.VirtualHosts {
-		doVirtualHostOperation(proxy, patchContext, patches, routeConfiguration, vhost, &virtualHostsRemoved)
+		doVirtualHostOperation(patchContext, patches, routeConfiguration, vhost, &virtualHostsRemoved)
 	}
 
 	// now for the adds
@@ -90,7 +90,7 @@ func doVirtualHostListOperation(proxy *model.Proxy, patchContext networking.Envo
 	}
 }
 
-func doVirtualHostOperation(proxy *model.Proxy, patchContext networking.EnvoyFilter_PatchContext,
+func doVirtualHostOperation(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
 	routeConfiguration *xdsapi.RouteConfiguration, virtualHost *route.VirtualHost, virtualHostRemoved *bool) {
 
@@ -109,17 +109,17 @@ func doVirtualHostOperation(proxy *model.Proxy, patchContext networking.EnvoyFil
 			}
 		}
 	}
-	doHTTPRouteListOperation(proxy, patchContext, patches, routeConfiguration, virtualHost)
+	doHTTPRouteListOperation(patchContext, patches, routeConfiguration, virtualHost)
 }
 
-func doHTTPRouteListOperation(proxy *model.Proxy, patchContext networking.EnvoyFilter_PatchContext,
+func doHTTPRouteListOperation(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
 	routeConfiguration *xdsapi.RouteConfiguration, virtualHost *route.VirtualHost) {
 
 	routesRemoved := false
 	// Apply the route level removes/merges if any.
 	for index := range virtualHost.Routes {
-		doHTTPRouteOperation(proxy, patchContext, patches, routeConfiguration, virtualHost, index, &routesRemoved)
+		doHTTPRouteOperation(patchContext, patches, routeConfiguration, virtualHost, index, &routesRemoved)
 	}
 
 	// now for the adds
@@ -146,7 +146,7 @@ func doHTTPRouteListOperation(proxy *model.Proxy, patchContext networking.EnvoyF
 	}
 }
 
-func doHTTPRouteOperation(proxy *model.Proxy, patchContext networking.EnvoyFilter_PatchContext,
+func doHTTPRouteOperation(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
 	routeConfiguration *xdsapi.RouteConfiguration, virtualHost *route.VirtualHost, routeIndex int, routesRemoved *bool) {
 	for _, cp := range patches[networking.EnvoyFilter_HTTP_ROUTE] {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
@@ -364,8 +364,7 @@ func TestApplyRouteConfigurationPatches(t *testing.T) {
 				},
 			},
 			{
-				Name:    "new-vhost",
-				Domains: []string{"domain:80"},
+				Name: "new-vhost",
 			},
 		},
 		RequestHeadersToRemove: []string{"h1", "h2", "h3", "h4"},
@@ -374,8 +373,7 @@ func TestApplyRouteConfigurationPatches(t *testing.T) {
 		Name: "inbound|http|80",
 		VirtualHosts: []*route.VirtualHost{
 			{
-				Name:    "vhost2",
-				Domains: []string{"domain"},
+				Name: "vhost2",
 			},
 		},
 	}
@@ -383,8 +381,7 @@ func TestApplyRouteConfigurationPatches(t *testing.T) {
 		Name: "inbound|http|80",
 		VirtualHosts: []*route.VirtualHost{
 			{
-				Name:    "new-vhost",
-				Domains: []string{"domain:80"},
+				Name: "new-vhost",
 			},
 		},
 	}
@@ -410,8 +407,7 @@ func TestApplyRouteConfigurationPatches(t *testing.T) {
 				Domains: []string{"gateway", "domain:80"},
 			},
 			{
-				Name:    "new-vhost",
-				Domains: []string{"domain:80"},
+				Name: "new-vhost",
 			},
 		},
 	}


### PR DESCRIPTION
1. move the config patch's proxy match to the top level , this is to reduce the calling of proxyMatch times,

2. merging envoyfilterWrappers in getting procedure from push context

3. The performance is improved.

Before: 

```
$ go test  -bench=. -benchtime 30s
goos: linux
goarch: amd64
pkg: istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter
BenchmarkTelemetryV2Filters-4   	  176700	    208609 ns/op
```

With this pr
```
$ go test  -bench=. -benchtime 30s
goos: linux
goarch: amd64
pkg: istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter
BenchmarkTelemetryV2Filters-4   	  415954	     87968 ns/op

```