### PR TITLE
Pilot unit test and integration test fixes

### DIFF
--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -57,7 +57,7 @@ func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {
 
 	server := createAndStartServer(liveServerStats)
 	defer server.Close()
-	probe := Probe{AdminPort: 1234}
+	probe := Probe{LocalHostAddr: "localhost", AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -70,7 +70,7 @@ func TestEnvoyStatsIncompleteCDS(t *testing.T) {
 
 	server := createAndStartServer(stats)
 	defer server.Close()
-	probe := Probe{AdminPort: 1234}
+	probe := Probe{LocalHostAddr: "localhost", AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -84,7 +84,7 @@ func TestEnvoyStatsIncompleteLDS(t *testing.T) {
 
 	server := createAndStartServer(stats)
 	defer server.Close()
-	probe := Probe{AdminPort: 1234}
+	probe := Probe{LocalHostAddr: "localhost", AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -98,7 +98,7 @@ func TestEnvoyStatsCompleteAndRejectedCDS(t *testing.T) {
 
 	server := createAndStartServer(stats)
 	defer server.Close()
-	probe := Probe{AdminPort: 1234}
+	probe := Probe{LocalHostAddr: "localhost", AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -111,7 +111,7 @@ func TestEnvoyCheckFailsIfStatsUnparsableNoSeparator(t *testing.T) {
 
 	server := createAndStartServer(stats)
 	defer server.Close()
-	probe := Probe{AdminPort: 1234}
+	probe := Probe{LocalHostAddr: "localhost", AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -125,7 +125,7 @@ func TestEnvoyCheckFailsIfStatsUnparsableNoNumber(t *testing.T) {
 
 	server := createAndStartServer(stats)
 	defer server.Close()
-	probe := Probe{AdminPort: 1234}
+	probe := Probe{LocalHostAddr: "localhost", AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -138,7 +138,7 @@ func TestEnvoyInitializing(t *testing.T) {
 
 	server := createAndStartServer(initServerStats)
 	defer server.Close()
-	probe := Probe{AdminPort: 1234}
+	probe := Probe{LocalHostAddr: "localhost", AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -150,7 +150,7 @@ func TestEnvoyNoClusterManagerStats(t *testing.T) {
 
 	server := createAndStartServer(onlyServerStats)
 	defer server.Close()
-	probe := Probe{AdminPort: 1234}
+	probe := Probe{LocalHostAddr: "localhost", AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -162,7 +162,7 @@ func TestEnvoyNoServerStats(t *testing.T) {
 
 	server := createAndStartServer(noServerStats)
 	defer server.Close()
-	probe := Probe{AdminPort: 1234}
+	probe := Probe{LocalHostAddr: "localhost", AdminPort: 1234}
 
 	err := probe.Check()
 
@@ -184,7 +184,7 @@ func TestEnvoyInitializingWithVirtualInboundListener(t *testing.T) {
 
 	server := createHTTPServer(funcMap)
 	defer server.Close()
-	probe := Probe{AdminPort: 1234, receivedFirstUpdate: true, NodeType: model.SidecarProxy}
+	probe := Probe{LocalHostAddr: "localhost", AdminPort: 1234, receivedFirstUpdate: true, NodeType: model.SidecarProxy}
 
 	err := probe.Check()
 


### PR DESCRIPTION
This PR resolves two issues in Pilot component:
✔ Fixed the corrupted docker building and unit testing process.
✔ Fixed some tests not fully applied to namespace isolation in integration tests.

I'll explain those in details:
📃First the docker building process was set the wrong working directory to "current directory" like "/mnt/mygo/src/istio.io/istio" and mapped it to "/work" in docker container. But the test get Istio src root by doing the following code in "pkg\test\env\istio.go"
```
func getDefaultIstioTop() string {
	// Assume it is run inside istio.io/istio
	current, err := os.Getwd()
	if err != nil {
		panic(err)
	}
	idx := strings.Index(current, filepath.Join("/src", "istio.io", "istio"))
	if idx > 0 {
		return current[0:idx]
	}
	return current // launching from GOTOP (for example in goland)
}
```

As there is no "src/istio.io/istio" any more, the GOTOP path will mapped to directory which the test resides. For example, if we run ./pilot/test/envoy, the GOTOP will become "/work/pilot/test/envoy". Because the IstioSrc depends on IstioTop, the IstioSrc will become weird like "/work/pilot/test/envoy/src/istio.io/istio" which leads to test failure in "envoy/v2" test.
```
// IstioTop has the top of the istio tree, matches the env variable from make.
IstioTop = TOP.ValueOrDefaultFunc(getDefaultIstioTop)

// IstioSrc is the location if istio source ($TOP/src/istio.io/istio
IstioSrc = path.Join(IstioTop, "src/istio.io/istio")
```

📃 Second the Istio integration test framework supports namespace customizing while deploying Istio despite the default "istio-system". But not all tests obeyed this principle and event some of the  configurations were hard coded in source. I fixed them up and tested. 

⚠ Other Istio components may also have the same issues and need fix up but I focused on Pilot only this time.