### PR TITLE
Correctly skip sds_egress test

### DIFF
--- a/tests/integration/security/sds_egress/main_test.go
+++ b/tests/integration/security/sds_egress/main_test.go
@@ -37,6 +37,7 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite("sds_egress_workload_mtls_istio_mutual_test", m).
+		Skip("https://github.com/istio/istio/issues/17933").
 		Label(label.CustomSetup).
 		RequireEnvironment(environment.Kube).
 		// SDS requires Kubernetes 1.13


### PR DESCRIPTION
This does NOT skip the test -- the test was already skipped, but was
done at the incorrect spot such that the test setup still occurs