### PR TITLE
Add support for pkcs8 private key

### DIFF
--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -67,7 +67,7 @@ var (
 	secretRotationIntervalEnv          = env.RegisterDurationVar(SecretRotationInterval, 10*time.Minute, "").Get()
 	staledConnectionRecycleIntervalEnv = env.RegisterDurationVar(staledConnectionRecycleInterval, 5*time.Minute, "").Get()
 	initialBackoffEnv                  = env.RegisterIntVar(InitialBackoff, 10, "").Get()
-
+	pkcs8KeysEnv                       = env.RegisterBoolVar(pkcs8Key, false, "Whether to generate PKCS#8 private keys").Get()
 	// Location of a custom-mounted root (for example using Secret)
 	mountedRoot = "/etc/certs/root-cert.pem"
 
@@ -114,6 +114,8 @@ const (
 	// The environmental variable name for the initial backoff in milliseconds.
 	// example value format like "10"
 	InitialBackoff = "INITIAL_BACKOFF_MSEC"
+
+	pkcs8Key = "PKCS8_KEY"
 )
 
 var (
@@ -389,6 +391,7 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache *cache.Secre
 	ret.CaClient = caClient
 
 	workloadSdsCacheOptions.TrustDomain = serverOptions.TrustDomain
+	workloadSdsCacheOptions.Pkcs8Keys = serverOptions.Pkcs8Keys
 	workloadSdsCacheOptions.Plugins = sds.NewPlugins(serverOptions.PluginNames)
 	workloadSecretCache = cache.NewSecretCache(ret, sds.NotifyProxy, workloadSdsCacheOptions)
 	return
@@ -425,6 +428,7 @@ func applyEnvVars() {
 	serverOptions.CAProviderName = caProviderEnv
 	serverOptions.CAEndpoint = caEndpointEnv
 	serverOptions.TrustDomain = trustDomainEnv
+	serverOptions.Pkcs8Keys = pkcs8KeysEnv
 	workloadSdsCacheOptions.SecretTTL = secretTTLEnv
 	workloadSdsCacheOptions.SecretRefreshGraceDuration = secretRefreshGraceDurationEnv
 	workloadSdsCacheOptions.RotationInterval = secretRotationIntervalEnv

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -125,7 +125,6 @@ const (
 	DebugPort       = "DEBUG_PORT"
 
 	pkcs8Key      = "PKCS8_KEY"
-	pkcs8KeysFlag = "pkcs8Key"
 )
 
 var (
@@ -290,10 +289,6 @@ func applyEnvVars(cmd *cobra.Command) {
 		serverOptions.TrustDomain = trustDomainEnv
 	}
 
-	if !cmd.Flag(pkcs8KeysFlag).Changed {
-		serverOptions.Pkcs8Keys = pkcs8KeyEnv
-	}
-
 	if !cmd.Flag(vaultAddressFlag).Changed {
 		serverOptions.VaultAddress = vaultAddressEnv
 	}
@@ -337,6 +332,7 @@ func applyEnvVars(cmd *cobra.Command) {
 	}
 
 	serverOptions.DebugPort = debugPortEnv
+	serverOptions.Pkcs8Keys = pkcs8KeyEnv
 }
 
 func validateOptions() error {
@@ -418,8 +414,6 @@ func main() {
 		"Vault sign CSR path")
 	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultTLSRootCert, vaultTLSRootCertFlag, "",
 		"Vault TLS root certificate")
-	rootCmd.PersistentFlags().BoolVar(&serverOptions.Pkcs8Keys, pkcs8KeysFlag,
-		false, "Whether to generate PKCS#8 private keys")
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -123,6 +123,9 @@ const (
 	MonitoringPort  = "MONITORING_PORT"
 	EnableProfiling = "ENABLE_PROFILING"
 	DebugPort       = "DEBUG_PORT"
+
+	pkcs8Key      = "PKCS8_KEY"
+	pkcs8KeysFlag = "pkcs8Key"
 )
 
 var (
@@ -208,6 +211,7 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache, gatewaySecr
 			os.Exit(1)
 		}
 		workloadSdsCacheOptions.TrustDomain = serverOptions.TrustDomain
+		workloadSdsCacheOptions.Pkcs8Keys = serverOptions.Pkcs8Keys
 		workloadSdsCacheOptions.Plugins = sds.NewPlugins(serverOptions.PluginNames)
 		workloadSecretCache = cache.NewSecretCache(wSecretFetcher, sds.NotifyProxy, workloadSdsCacheOptions)
 	} else {
@@ -254,6 +258,7 @@ var (
 		"Debug endpoints dump SDS configuration and connection data from this port").Get()
 	enableProfilingEnv = env.RegisterBoolVar(EnableProfiling, true,
 		"Enabling profiling when monitoring Citadel agent").Get()
+	pkcs8KeyEnv                        = env.RegisterBoolVar(pkcs8Key, false, "Whether to generate PKCS#8 private keys").Get()
 )
 
 func applyEnvVars(cmd *cobra.Command) {
@@ -283,6 +288,10 @@ func applyEnvVars(cmd *cobra.Command) {
 
 	if !cmd.Flag(trustDomainFlag).Changed {
 		serverOptions.TrustDomain = trustDomainEnv
+	}
+
+	if !cmd.Flag(pkcs8KeysFlag).Changed {
+		serverOptions.Pkcs8Keys = pkcs8KeyEnv
 	}
 
 	if !cmd.Flag(vaultAddressFlag).Changed {
@@ -409,6 +418,8 @@ func main() {
 		"Vault sign CSR path")
 	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultTLSRootCert, vaultTLSRootCertFlag, "",
 		"Vault TLS root certificate")
+	rootCmd.PersistentFlags().BoolVar(&serverOptions.Pkcs8Keys, pkcs8KeysFlag,
+		false, "Whether to generate PKCS#8 private keys")
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -124,7 +124,7 @@ const (
 	EnableProfiling = "ENABLE_PROFILING"
 	DebugPort       = "DEBUG_PORT"
 
-	pkcs8Key      = "PKCS8_KEY"
+	pkcs8Key = "PKCS8_KEY"
 )
 
 var (

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -258,7 +258,7 @@ var (
 		"Debug endpoints dump SDS configuration and connection data from this port").Get()
 	enableProfilingEnv = env.RegisterBoolVar(EnableProfiling, true,
 		"Enabling profiling when monitoring Citadel agent").Get()
-	pkcs8KeyEnv                        = env.RegisterBoolVar(pkcs8Key, false, "Whether to generate PKCS#8 private keys").Get()
+	pkcs8KeyEnv = env.RegisterBoolVar(pkcs8Key, false, "Whether to generate PKCS#8 private keys").Get()
 )
 
 func applyEnvVars(cmd *cobra.Command) {

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -115,6 +115,9 @@ type Options struct {
 
 	// set this flag to true if skip validate format for certificate chain returned from CA.
 	SkipValidateCert bool
+
+	// Whether to generate PKCS#8 private keys.
+	Pkcs8Keys bool
 }
 
 // SecretManager defines secrets management interface which is used by SDS.
@@ -718,6 +721,7 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token string, connKey
 	options := util.CertOptions{
 		Host:       csrHostName,
 		RSAKeySize: keySize,
+		PKCS8Key:   sc.configOptions.Pkcs8Keys,
 	}
 
 	// Generate the cert/key, send CSR to CA.

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -102,6 +102,9 @@ type Options struct {
 	// UseLocalJWT is set when the sds server should use its own local JWT, and not expect one
 	// from the UDS caller. Used when it runs in the same container with Envoy.
 	UseLocalJWT bool
+
+	// Whether to generate PKCS#8 private keys.
+	Pkcs8Keys bool
 }
 
 // Server is the gPRC server that exposes SDS through UDS.


### PR DESCRIPTION
Expose an env variable which allows Citadel agent to generate PKCS#8 private key. Currently the default private key type is PKCS#1.