### PR TITLE
Revert "Skip update when endpoints resource version equal"

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -57,10 +57,11 @@ func (e *endpointsController) registerEndpointsHandler() {
 				})
 			},
 			UpdateFunc: func(old, cur interface{}) {
+				// Avoid pushes if only resource version changed (kube-scheduller, cluster-autoscaller, etc)
 				oldE := old.(*v1.Endpoints)
 				curE := cur.(*v1.Endpoints)
 
-				if curE.ResourceVersion != oldE.ResourceVersion || !compareEndpoints(oldE, curE) {
+				if !compareEndpoints(oldE, curE) {
 					incrementEvent("Endpoints", "update")
 					e.c.queue.Push(func() error {
 						return e.onEvent(cur, model.EventUpdate)


### PR DESCRIPTION
Reverts istio/istio#19775

This change makes tons of endpoint updates per second when nothing is changing due to kube-system doing weird things with endpoints. This should not have been merged