### PR TITLE
cds: cache well known clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/d4l3k/messagediff v1.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dchest/siphash v1.1.0 // indirect
+	github.com/deepmind/objecthash-proto v0.0.0-20180608110149-5db4e5a3f4f4
 	github.com/denisenkom/go-mssqldb v0.0.0-20190423183735-731ef375ac02 // indirect
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0
@@ -87,6 +88,7 @@ require (
 	github.com/hashicorp/go-plugin v1.0.0 // indirect
 	github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/hashicorp/memberlist v0.1.3 // indirect
 	github.com/hashicorp/serf v0.8.1 // indirect
 	github.com/hashicorp/vault v0.10.0
@@ -99,6 +101,7 @@ require (
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
+	github.com/mitchellh/hashstructure v1.0.0
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/natefinch/lumberjack v2.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/d4l3k/messagediff v1.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dchest/siphash v1.1.0 // indirect
-	github.com/deepmind/objecthash-proto v0.0.0-20180608110149-5db4e5a3f4f4
 	github.com/denisenkom/go-mssqldb v0.0.0-20190423183735-731ef375ac02 // indirect
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0
@@ -101,7 +100,6 @@ require (
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/mitchellh/hashstructure v1.0.0
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/natefinch/lumberjack v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dchest/siphash v1.1.0 h1:1Rs9eTUlZLPBEvV+2sTaM8O0NWn0ppbgqS7p11aWawI=
 github.com/dchest/siphash v1.1.0/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
-github.com/deepmind/objecthash-proto v0.0.0-20180608110149-5db4e5a3f4f4 h1:Ix/TMsr31MKPRVZHDUl1NDSYKNPoNnTeXC89k+bz/0E=
-github.com/deepmind/objecthash-proto v0.0.0-20180608110149-5db4e5a3f4f4/go.mod h1:kRNxxawiNVpuep1mffLMOw0IjA6xYXy4rKZj6SDpBac=
 github.com/denisenkom/go-mssqldb v0.0.0-20190423183735-731ef375ac02 h1:PS3xfVPa8N84AzoWZHFCbA0+ikz4f4skktfjQoNMsgk=
 github.com/denisenkom/go-mssqldb v0.0.0-20190423183735-731ef375ac02/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
@@ -522,8 +520,6 @@ github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
-github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
-github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dchest/siphash v1.1.0 h1:1Rs9eTUlZLPBEvV+2sTaM8O0NWn0ppbgqS7p11aWawI=
 github.com/dchest/siphash v1.1.0/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
+github.com/deepmind/objecthash-proto v0.0.0-20180608110149-5db4e5a3f4f4 h1:Ix/TMsr31MKPRVZHDUl1NDSYKNPoNnTeXC89k+bz/0E=
+github.com/deepmind/objecthash-proto v0.0.0-20180608110149-5db4e5a3f4f4/go.mod h1:kRNxxawiNVpuep1mffLMOw0IjA6xYXy4rKZj6SDpBac=
 github.com/denisenkom/go-mssqldb v0.0.0-20190423183735-731ef375ac02 h1:PS3xfVPa8N84AzoWZHFCbA0+ikz4f4skktfjQoNMsgk=
 github.com/denisenkom/go-mssqldb v0.0.0-20190423183735-731ef375ac02/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
@@ -520,6 +522,8 @@ github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
+github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -94,9 +94,11 @@ var (
 		},
 	}
 
-	// Use pre-built clusters so that we do not rebuild them for every proxy.
-	blackholeCluster           *apiv2.Cluster
+	// Cache well known clusters, so that we do not build them for every proxy, every time.
+	blackholeCluster *apiv2.Cluster
+	// OutboundPassThroughCluster uses different LbPolicy based on proxy version. So cache them by LbPolicy.
 	outboundPassThroughCluster = make(map[apiv2.Cluster_LbPolicy]*apiv2.Cluster)
+	// InboundPassThroughCluster is built for IPv4 and IPv6 based on node metadata. index 0 contains IPv4 and 1 contains IPv6.
 	inboundPassThroughClusters = make([]*apiv2.Cluster, 2)
 )
 
@@ -1260,6 +1262,7 @@ func buildBlackHoleCluster(push *model.PushContext) *apiv2.Cluster {
 	return blackholeCluster
 }
 
+// defaultOutboundPassthroughCluster returns from cache if it exists, otherwise it is built.
 func defaultOutboundPassthroughCluster(push *model.PushContext, proxy *model.Proxy) *apiv2.Cluster {
 	if _, exists := outboundPassThroughCluster[lbPolicyClusterProvided(proxy)]; !exists {
 		outboundPassThroughCluster[lbPolicyClusterProvided(proxy)] = buildDefaultPassthroughCluster(push, proxy)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -581,6 +581,28 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 	g.Expect(actualOutboundClusterCount).To(Equal(expectedOutboundClusterCount))
 }
 
+func BenchmarkBuildClusters(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		buildTestClustersWithProxyMetadataWithIps("*.example.org", 0, false, model.SidecarProxy, nil, testMesh,
+			&networking.DestinationRule{
+				Host: "*.example.org",
+				TrafficPolicy: &networking.TrafficPolicy{
+					ConnectionPool: &networking.ConnectionPoolSettings{
+						Http: &networking.ConnectionPoolSettings_HTTPSettings{
+							Http1MaxPendingRequests: 1,
+							IdleTimeout:             &types.Duration{Seconds: 15},
+						},
+					},
+				},
+			},
+			nil, // authnPolicy
+			&model.NodeMetadata{},
+			model.MaxIstioVersion,
+			[]string{"6.6.6.6", "::1"},
+		)
+	}
+}
+
 func buildSniTestClustersForSidecar(sniValue string) ([]*apiv2.Cluster, error) {
 	return buildSniTestClustersWithMetadata(sniValue, model.SidecarProxy, &model.NodeMetadata{})
 }

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -513,39 +513,25 @@ func TestGetByAddress(t *testing.T) {
 	}
 }
 
-func TestMessageToAnyCache(t *testing.T) {
+func TestMessageToAnyCached(t *testing.T) {
 	// Call MessageToAny to populate the cache.
-	cluster := MessageToAny(buildFakeCluster())
+	cluster := buildFakeCluster()
+	ac := MessageToAnyCached(cluster)
 
-	if !MessageCache.Contains(buildFakeCluster().String()) {
+	if !messageCache.Contains(cluster) {
 		t.Fatal("Expected to be in cache, but not available")
 	}
 
-	if MessageToAny(buildFakeCluster()) != cluster {
+	if MessageToAnyCached(cluster) != ac {
 		t.Fatal("Cache is not returning the same any structure")
 	}
 
 }
 
-func BenchmarkMessageToAny(b *testing.B) {
-	// inHCM := &http_conn.HttpConnectionManager{
-	// 	CodecType:  http_conn.HttpConnectionManager_HTTP1,
-	// 	StatPrefix: "123",
-	// 	HttpFilters: []*http_conn.HttpFilter{
-	// 		{
-	// 			Name: "filter1",
-	// 			ConfigType: &http_conn.HttpFilter_TypedConfig{
-	// 				TypedConfig: &any.Any{},
-	// 			},
-	// 		},
-	// 	},
-	// 	ServerName:        "scooby",
-	// 	XffNumTrustedHops: 2,
-	// }
+func BenchmarkMessageToAnyCached(b *testing.B) {
 	c := buildFakeCluster()
 	for n := 0; n < b.N; n++ {
-	//	MessageToAny(inHCM)
-		MessageToAny(c)
+		MessageToAnyCached(c)
 	}
 }
 

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -513,6 +513,42 @@ func TestGetByAddress(t *testing.T) {
 	}
 }
 
+func TestMessageToAnyCache(t *testing.T) {
+	// Call MessageToAny to populate the cache.
+	cluster := MessageToAny(buildFakeCluster())
+
+	if !MessageCache.Contains(buildFakeCluster().String()) {
+		t.Fatal("Expected to be in cache, but not available")
+	}
+
+	if MessageToAny(buildFakeCluster()) != cluster {
+		t.Fatal("Cache is not returning the same any structure")
+	}
+
+}
+
+func BenchmarkMessageToAny(b *testing.B) {
+	// inHCM := &http_conn.HttpConnectionManager{
+	// 	CodecType:  http_conn.HttpConnectionManager_HTTP1,
+	// 	StatPrefix: "123",
+	// 	HttpFilters: []*http_conn.HttpFilter{
+	// 		{
+	// 			Name: "filter1",
+	// 			ConfigType: &http_conn.HttpFilter_TypedConfig{
+	// 				TypedConfig: &any.Any{},
+	// 			},
+	// 		},
+	// 	},
+	// 	ServerName:        "scooby",
+	// 	XffNumTrustedHops: 2,
+	// }
+	c := buildFakeCluster()
+	for n := 0; n < b.N; n++ {
+	//	MessageToAny(inHCM)
+		MessageToAny(c)
+	}
+}
+
 func TestMergeAnyWithStruct(t *testing.T) {
 	inHCM := &http_conn.HttpConnectionManager{
 		CodecType:  http_conn.HttpConnectionManager_HTTP1,

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -38,8 +38,7 @@ func (conn *XdsConnection) clusters(response []*xdsapi.Cluster, noncePrefix stri
 	}
 
 	for _, c := range response {
-		if c.Name == util.BlackHoleCluster || c.Name == util.PassthroughCluster ||
-			c.Name == util.InboundPassthroughClusterIpv4 || c.Name == util.InboundPassthroughClusterIpv6 {
+		if isCacheable(c) {
 			out.Resources = append(out.Resources, util.MessageToAnyCached(c))
 		} else {
 			out.Resources = append(out.Resources, util.MessageToAny(c))
@@ -47,6 +46,10 @@ func (conn *XdsConnection) clusters(response []*xdsapi.Cluster, noncePrefix stri
 	}
 
 	return out
+}
+
+func isCacheable(c *xdsapi.Cluster) bool {
+	return c.Name == util.BlackHoleCluster || c.Name == util.PassthroughCluster || c.Name == util.InboundPassthroughClusterIpv4 || c.Name == util.InboundPassthroughClusterIpv6
 }
 
 func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, version string) error {

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -48,8 +48,10 @@ func (conn *XdsConnection) clusters(response []*xdsapi.Cluster, noncePrefix stri
 	return out
 }
 
+// isCacheable returns true if a cluster's proto conversion to "any" can be cached, false otherwise.
 func isCacheable(c *xdsapi.Cluster) bool {
-	return c.Name == util.BlackHoleCluster || c.Name == util.PassthroughCluster || c.Name == util.InboundPassthroughClusterIpv4 || c.Name == util.InboundPassthroughClusterIpv6
+	return c.Name == util.BlackHoleCluster || c.Name == util.PassthroughCluster ||
+		c.Name == util.InboundPassthroughClusterIpv4 || c.Name == util.InboundPassthroughClusterIpv6
 }
 
 func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, version string) error {

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -38,8 +38,12 @@ func (conn *XdsConnection) clusters(response []*xdsapi.Cluster, noncePrefix stri
 	}
 
 	for _, c := range response {
-		cc := util.MessageToAny(c)
-		out.Resources = append(out.Resources, cc)
+		if c.Name == util.BlackHoleCluster || c.Name == util.PassthroughCluster ||
+			c.Name == util.InboundPassthroughClusterIpv4 || c.Name == util.InboundPassthroughClusterIpv6 {
+			out.Resources = append(out.Resources, util.MessageToAnyCached(c))
+		} else {
+			out.Resources = append(out.Resources, util.MessageToAny(c))
+		}
 	}
 
 	return out


### PR DESCRIPTION
Currently, we build standard well known clusters like Blackhole cluster and Passthrough clusters every time for every proxy. We can build them once, and reuse them whenever CDS is being built. This PR implements cache of these well known clusters.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
