### PR TITLE
only compareEndpoints when resource version updates

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/google/uuid"
 	coreV1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	discoveryv1alpha1 "k8s.io/api/discovery/v1alpha1"
@@ -1294,8 +1295,9 @@ func updateEndpoints(controller *Controller, name, namespace string, portNames, 
 
 	endpoint := &coreV1.Endpoints{
 		ObjectMeta: metaV1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:            name,
+			Namespace:       namespace,
+			ResourceVersion: uuid.New().String(), // update should set a new resource version
 		},
 		Subsets: []coreV1.EndpointSubset{{
 			Addresses: eas,

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -60,8 +60,7 @@ func (e *endpointsController) registerEndpointsHandler() {
 				// Avoid pushes if only resource version changed (kube-scheduller, cluster-autoscaller, etc)
 				oldE := old.(*v1.Endpoints)
 				curE := cur.(*v1.Endpoints)
-
-				if !compareEndpoints(oldE, curE) {
+				if oldE.ResourceVersion != curE.ResourceVersion && !compareEndpoints(oldE, curE) {
 					incrementEvent("Endpoints", "update")
 					e.c.queue.Push(func() error {
 						return e.onEvent(cur, model.EventUpdate)

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -15,6 +15,8 @@
 package controller
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
@@ -60,7 +62,10 @@ func (e *endpointsController) registerEndpointsHandler() {
 				// Avoid pushes if only resource version changed (kube-scheduller, cluster-autoscaller, etc)
 				oldE := old.(*v1.Endpoints)
 				curE := cur.(*v1.Endpoints)
+				fmt.Printf("rv %s %s\n", oldE.ResourceVersion, curE.ResourceVersion)
 				if oldE.ResourceVersion != curE.ResourceVersion && !compareEndpoints(oldE, curE) {
+					fmt.Printf("endpoint update\n")
+
 					incrementEvent("Endpoints", "update")
 					e.c.queue.Push(func() error {
 						return e.onEvent(cur, model.EventUpdate)

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -62,7 +62,6 @@ func (e *endpointsController) registerEndpointsHandler() {
 				// Avoid pushes if only resource version changed (kube-scheduller, cluster-autoscaller, etc)
 				oldE := old.(*v1.Endpoints)
 				curE := cur.(*v1.Endpoints)
-				fmt.Printf("rv %s %s\n", oldE.ResourceVersion, curE.ResourceVersion)
 				if oldE.ResourceVersion != curE.ResourceVersion && !compareEndpoints(oldE, curE) {
 					fmt.Printf("endpoint update\n")
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

This is to fix #19775 

There are many cases the resource object is unchanged when even client receives update event, like periodically resync,  kube-apiserver cache updates faster than the client, etc. 

With this, can prevent some unnecessary compare of endpoints. For other resources, we need do the same filter, but currently they use a common function `registerHandlers` to register resource event handler. If it make sense, i can change the function and improve the performance.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
