### PR TITLE
remove redundant field sseDiscoveryOptions incrementalSSEDiscoveryOpt…

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -126,7 +126,6 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 	var configStores []model.ConfigStoreCache
 
 	mcpOptions := &mcp.Options{
-		ClusterID:    s.clusterID,
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 		ConfigLedger: buildLedger(args.Config),
 		XDSUpdater:   s.EnvoyXdsServer,

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -119,8 +119,14 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 	return nil
 }
 
-func (s *Server) initMCPConfigController(args *PilotArgs) error {
+func (s *Server) initMCPConfigController(args *PilotArgs) (err error) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		if err != nil {
+			cancel()
+		}
+	}()
+
 	var clients []*sink.Client
 	var conns []*grpc.ClientConn
 	var configStores []model.ConfigStoreCache
@@ -136,12 +142,10 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 		if strings.Contains(configSource.Address, fsScheme+"://") {
 			srcAddress, err := url.Parse(configSource.Address)
 			if err != nil {
-				cancel()
 				return fmt.Errorf("invalid config URL %s %v", configSource.Address, err)
 			}
 			if srcAddress.Scheme == fsScheme {
 				if srcAddress.Path == "" {
-					cancel()
 					return fmt.Errorf("invalid fs config URL %s, contains no file path", configSource.Address)
 				}
 				store := memory.MakeWithLedger(schemas.Istio, buildLedger(args.Config))
@@ -149,7 +153,6 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 
 				err := s.makeFileMonitor(srcAddress.Path, configController)
 				if err != nil {
-					cancel()
 					return err
 				}
 				configStores = append(configStores, configController)
@@ -157,10 +160,9 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 			}
 		}
 
-		conn, err := grpcDial(ctx, cancel, configSource, args)
+		conn, err := grpcDial(ctx, configSource, args)
 		if err != nil {
 			log.Errorf("Unable to dial MCP Server %q: %v", configSource.Address, err)
-			cancel()
 			return err
 		}
 		conns = append(conns, conn)
@@ -168,10 +170,9 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 
 		// create MCP SyntheticServiceEntryController
 		if resourceContains(configSource.SubscribedResources, meshconfig.Resource_SERVICE_REGISTRY) {
-			conn, err := grpcDial(ctx, cancel, configSource, args)
+			conn, err := grpcDial(ctx, configSource, args)
 			if err != nil {
 				log.Errorf("Unable to dial MCP Server %q: %v", configSource.Address, err)
-				cancel()
 				return err
 			}
 			conns = append(conns, conn)
@@ -186,8 +187,8 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 			client := clients[i]
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				client.Run(ctx)
-				wg.Done()
 			}()
 		}
 
@@ -223,7 +224,7 @@ func resourceContains(resources []meshconfig.Resource, resource meshconfig.Resou
 	return false
 }
 
-func mcpSecurityOptions(ctx context.Context, cancel context.CancelFunc, configSource *meshconfig.ConfigSource) (grpc.DialOption, error) {
+func mcpSecurityOptions(ctx context.Context, configSource *meshconfig.ConfigSource) (grpc.DialOption, error) {
 	securityOption := grpc.WithInsecure()
 	if configSource.TlsSettings != nil &&
 		configSource.TlsSettings.Mode != networkingapi.TLSSettings_DISABLE {
@@ -261,7 +262,6 @@ func mcpSecurityOptions(ctx context.Context, cancel context.CancelFunc, configSo
 					log.Infof("%v not found. Checking again in %v", requiredFiles[0], requiredMCPCertCheckFreq)
 					select {
 					case <-ctx.Done():
-						cancel()
 						return nil, ctx.Err()
 					case <-time.After(requiredMCPCertCheckFreq):
 						// retry
@@ -274,7 +274,6 @@ func mcpSecurityOptions(ctx context.Context, cancel context.CancelFunc, configSo
 
 			watcher, err := creds.WatchFiles(ctx.Done(), credentialOption)
 			if err != nil {
-				cancel()
 				return nil, err
 			}
 			transportCreds := creds.CreateForClient(configSource.TlsSettings.Sni, watcher)
@@ -375,9 +374,9 @@ func (s *Server) makeFileMonitor(fileDir string, configController model.ConfigSt
 	return nil
 }
 
-func grpcDial(ctx context.Context, cancel context.CancelFunc,
-	configSource *meshconfig.ConfigSource, args *PilotArgs) (conn *grpc.ClientConn, err error) {
-	securityOption, err := mcpSecurityOptions(ctx, cancel, configSource)
+func grpcDial(ctx context.Context,
+	configSource *meshconfig.ConfigSource, args *PilotArgs) (*grpc.ClientConn, error) {
+	securityOption, err := mcpSecurityOptions(ctx, configSource)
 	if err != nil {
 		return nil, err
 	}

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -98,7 +98,7 @@ var (
 	k8sInCluster = env.RegisterStringVar("KUBERNETES_SERVICE_HOST", "",
 		"Kuberenetes service host, set automatically when running in-cluster")
 
-	// JWTPath is the well-knwon location of the projected K8S JWT. This is mounted on all workloads, as well as istiod.
+	// JWTPath is the well-known location of the projected K8S JWT. This is mounted on all workloads, as well as istiod.
 	// In a cluster that doesn't support projected JWTs we can't run the CA functionality of istiod - instead
 	// old-style Citadel must be run, with Secret created for each workload.
 	JWTPath = "./var/run/secrets/tokens/istio-token"

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -53,7 +53,6 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/external"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
-	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
 	"istio.io/istio/pilot/pkg/serviceregistry/synthetic/serviceentry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schemas"
@@ -105,25 +104,22 @@ type Server struct {
 	// TODO(nmittler): Consider alternatives to exposing these directly
 	EnvoyXdsServer *envoyv2.DiscoveryServer
 
-	clusterID                      string
-	environment                    *model.Environment
-	configController               model.ConfigStoreCache
-	kubeClient                     kubernetes.Interface
-	startFuncs                     []startFunc
-	multicluster                   *kubecontroller.Multicluster
-	httpServer                     *http.Server
-	grpcServer                     *grpc.Server
-	secureHTTPServer               *http.Server
-	secureGRPCServer               *grpc.Server
-	secureHTTPServerDNS            *http.Server
-	secureGRPCServerDNS            *grpc.Server
-	mux                            *http.ServeMux
-	kubeRegistry                   *kubecontroller.Controller
-	sseDiscovery                   *serviceentry.Discovery
-	sseDiscoveryOptions            *serviceentry.DiscoveryOptions
-	incrementalSSEDiscoveryOptions *serviceentry.Options
-	mcpOptions                     *mcp.Options
-	certController                 *chiron.WebhookController
+	clusterID           string
+	environment         *model.Environment
+	configController    model.ConfigStoreCache
+	kubeClient          kubernetes.Interface
+	startFuncs          []startFunc
+	multicluster        *kubecontroller.Multicluster
+	httpServer          *http.Server
+	grpcServer          *grpc.Server
+	secureHTTPServer    *http.Server
+	secureGRPCServer    *grpc.Server
+	secureHTTPServerDNS *http.Server
+	secureGRPCServerDNS *grpc.Server
+	mux                 *http.ServeMux
+	kubeRegistry        *kubecontroller.Controller
+	sseDiscovery        *serviceentry.Discovery
+	certController      *chiron.WebhookController
 
 	ConfigStores []model.ConfigStoreCache
 

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -76,10 +76,6 @@ func NewController(options *Options) Controller {
 	descriptorsByMessageName := make(map[string]schema.Instance, len(schemas.Istio))
 	synced := make(map[string]bool)
 	for _, descriptor := range schemas.Istio {
-		// do not register SSE as there is a dedicated controller
-		if descriptor.Collection == schemas.SyntheticServiceEntry.Collection {
-			continue
-		}
 		// don't register duplicate descriptors for the same collection
 		if _, ok := descriptorsByMessageName[descriptor.Collection]; !ok {
 			descriptorsByMessageName[descriptor.Collection] = descriptor

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -48,7 +48,6 @@ type Controller interface {
 
 // Options stores the configurable attributes of a Control
 type Options struct {
-	ClusterID    string
 	DomainSuffix string
 	XDSUpdater   model.XDSUpdater
 	ConfigLedger ledger.Ledger


### PR DESCRIPTION
…ions mcpOptions

1. The pilot` Server.{sseDiscoveryOptions,incrementalSSEDiscoveryOptions,mcpOptions}` are redundant, remove them

2. Simplify cleanup function calling