### PR TITLE
Fix API spelling

### DIFF
--- a/istioctl/pkg/multicluster/generate.go
+++ b/istioctl/pkg/multicluster/generate.go
@@ -52,7 +52,7 @@ func defaultControlPlane() (*operatorV1alpha2.IstioControlPlane, error) {
 
 	return &operatorV1alpha2.IstioControlPlane{
 		Kind:       "IstioControlPlane",
-		ApiVersion: "install.istio.io/v1alpah2",
+		ApiVersion: "install.istio.io/v1alpha2",
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
 		},
@@ -103,7 +103,7 @@ func overlayIstioControlPlane(mesh *Mesh, current *Cluster, meshNetworks *v1alph
 
 	return &operatorV1alpha2.IstioControlPlane{
 		Kind:       "IstioControlPlane",
-		ApiVersion: "install.istio.io/v1alpah2",
+		ApiVersion: "install.istio.io/v1alpha2",
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
 		},


### PR DESCRIPTION
This fixes a simple spelling mistake I noticed in the generated output.