### PR TITLE
Allow re-use of base.yaml

### DIFF
--- a/samples/multicluster/setup-mesh.sh
+++ b/samples/multicluster/setup-mesh.sh
@@ -116,6 +116,10 @@ create_offline_root_ca(){
 }
 
 create_base() {
+  if [ -f "${BASE_FILENAME}" ]; then
+    echo "${BASE_FILENAME} already exists."
+    return
+  fi
   cat << EOF > "${BASE_FILENAME}"
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane


### PR DESCRIPTION
Similar to the `topology.yaml`, it is convenient to not overwrite an existing `base.yaml`.

[X] Configuration Infrastructure

