### PR TITLE
make SSE controller share a connection with common mcp controller

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -170,12 +170,6 @@ func (s *Server) initMCPConfigController(args *PilotArgs) (err error) {
 
 		// create MCP SyntheticServiceEntryController
 		if resourceContains(configSource.SubscribedResources, meshconfig.Resource_SERVICE_REGISTRY) {
-			conn, err := grpcDial(ctx, configSource, args)
-			if err != nil {
-				log.Errorf("Unable to dial MCP Server %q: %v", configSource.Address, err)
-				return err
-			}
-			conns = append(conns, conn)
 			s.sseMCPController(args, conn, reporter, &clients, &configStores)
 		}
 	}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Make mcp controller and SSE controller share one underlying grpc connection

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
