### PR TITLE
Disable route timeout for passthrough cluster

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -18,9 +18,11 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/golang/protobuf/ptypes"
 
 	networking "istio.io/api/networking/v1alpha3"
 
@@ -193,6 +195,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(node *
 						Action: &route.Route_Route{
 							Route: &route.RouteAction{
 								ClusterSpecifier: &route.RouteAction_Cluster{Cluster: util.PassthroughCluster},
+								// Disable timeout instead of assuming some defaults.
+								Timeout: ptypes.DurationProto(0 * time.Millisecond),
 							},
 						},
 					},

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -662,7 +662,7 @@ func TestSidecarOutboundHTTPRouteConfigWithFallthroughRouteEnabled(t *testing.T)
 		proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
 		_ = os.Setenv(features.EnableFallthroughRoute.Name, "1")
 		vHostCache := make(map[int][]*route.VirtualHost)
-		config := configgen.buildSidecarOutboundHTTPRouteConfig(&env, &proxy, env.PushContext, routeName, vHostCache)
+		config := configgen.buildSidecarOutboundHTTPRouteConfig(&proxy, env.PushContext, routeName, vHostCache)
 
 		if config == nil {
 			t.Fatalf("got nil route for %s", routeName)


### PR DESCRIPTION
Disable timeout for passthrough cluster, which currently defaults to 15 seconds timeout ([see envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#route-routeaction))

see https://github.com/istio/istio/issues/6861