### PR TITLE
Add make target for pushing with buildkit

### DIFF
--- a/tools/buildx-gen.sh
+++ b/tools/buildx-gen.sh
@@ -43,12 +43,18 @@ for file in "$@"; do
   for variant in ${DOCKER_ALL_VARIANTS}; do
     image=${file#docker.}
     tag="${TAG}"
-    output="${image}"
     # The default variant has no suffix, others do
     if [[ "${variant}" != "default" ]]; then
       tag+="-${variant}"
-      output+="-${variant}"
     fi
+
+    # Output locally (like `docker build`) by default, or push
+    # Push requires using container driver. See https://github.com/docker/buildx#working-with-builder-instances
+    output='output = ["type=docker"]'
+    if [[ -n "${DOCKERX_PUSH:-}" ]]; then
+      output='output = ["type=registry"]'
+    fi
+
     cat <<EOF >> "${config}"
 target "$image-$variant" {
     context = "${out}/${file}"
@@ -60,6 +66,7 @@ target "$image-$variant" {
       proxy_version = "istio-proxy:${PROXY_REPO_SHA}"
       istio_version = "${VERSION}"
     }
+    ${output}
 }
 EOF
     # For the default variant, create an alias so we can do things like `build pilot` instead of `build pilot-default`

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -208,6 +208,7 @@ dockerx:
 		DOCKER_ALL_VARIANTS="$(DOCKER_ALL_VARIANTS)" \
 		ISTIO_DOCKER_TAR=$(ISTIO_DOCKER_TAR) \
 		BASE_VERSION=$(BASE_VERSION) \
+		DOCKERX_PUSH=$(DOCKERX_PUSH) \
 		./tools/buildx-gen.sh $(DOCKERX_BUILD_TOP) $(DOCKER_TARGETS)
 	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx bake -f $(DOCKERX_BUILD_TOP)/docker-bake.hcl $(DOCKER_BUILD_VARIANTS)
 
@@ -330,6 +331,13 @@ dockerx.push: dockerx
 	$(foreach TGT,$(DOCKER_TARGETS), time ( \
 		set -e && for distro in $(DOCKER_BUILD_VARIANTS); do tag=$(TAG)-$${distro}; docker push $(HUB)/$(subst docker.,,$(TGT)):$${tag%-$(DEFAULT_DISTRIBUTION)}; done); \
 	)
+
+# Build and push docker images using dockerx. Pushing is done inline as an optimization
+# This is not done in the dockerx.push target because it requires using the docker-container driver.
+# See https://github.com/docker/buildx#working-with-builder-instances for info to set this up
+dockerx.pushx: DOCKERX_PUSH=true
+dockerx.pushx: dockerx
+	@:
 
 # Scan images for security vulnerabilities using the ImageScanner tool
 docker.scan_images: $(DOCKER_PUSH_TARGETS)


### PR DESCRIPTION
Buildx has a option to push directly during the build (so its
parallelized). This is not enabled by default as there is some setup
needed (just `docker buildx create --use`, but it has some implications
so I don't really want to do this in the makefile for now).

Without this, `dockerx.push` takes 80s on my machine. With this, it is
14s.