### PR TITLE
Disable multiple metrics exporters with Istiod

### DIFF
--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -69,7 +69,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) error {
 			HealthCheckFile:     "",
 			HealthCheckInterval: 0,
 			// Disable monitoring. The injection metrics will be picked up by Pilots metrics exporter already
-			MonitoringPort: 0,
+			MonitoringPort: -1,
 		}
 
 		wh, err := inject.NewWebhook(parameters)

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -68,7 +68,8 @@ func (s *Server) initSidecarInjector(args *PilotArgs) error {
 			Port:                args.InjectionOptions.Port,
 			HealthCheckFile:     "",
 			HealthCheckInterval: 0,
-			MonitoringPort:      s.basePort + 16, // TODO: disable the second monitoring port
+			// Disable monitoring. The injection metrics will be picked up by Pilots metrics exporter already
+			MonitoringPort: 0,
 		}
 
 		wh, err := inject.NewWebhook(parameters)

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -142,6 +142,7 @@ type WebhookParameters struct {
 	Port int
 
 	// MonitoringPort is the webhook port, e.g. typically 15014.
+	// Set to -1 to disable monitoring
 	MonitoringPort int
 
 	// HealthCheckInterval configures how frequently the health check
@@ -217,7 +218,7 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 		})
 	}
 
-	if p.MonitoringPort != 0 {
+	if p.MonitoringPort >= 0 {
 		mon, err := startMonitor(h, p.MonitoringPort)
 		if err != nil {
 			return nil, fmt.Errorf("could not start monitoring server %v", err)


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/19826

Note that injection metrics are still served over Pilots metric port, so
we aren't losing anything here at all.