### PR TITLE
Don't use spew for pilot logs

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -54,7 +54,7 @@ func (s *Server) initCertController(args *PilotArgs) error {
 
 	meshConfig := s.environment.Mesh()
 	if meshConfig.GetCertificates() == nil || len(meshConfig.GetCertificates()) == 0 {
-		log.Info("nil certificate config")
+		log.Info("No certificates specified, skipping DNS certificate controller")
 		return nil
 	}
 

--- a/pilot/pkg/bootstrap/mesh.go
+++ b/pilot/pkg/bootstrap/mesh.go
@@ -15,9 +15,10 @@
 package bootstrap
 
 import (
+	"encoding/json"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/gogo/protobuf/jsonpb"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -40,9 +41,11 @@ const (
 func (s *Server) initMeshConfiguration(args *PilotArgs, fileWatcher filewatcher.FileWatcher) error {
 	defer func() {
 		if s.environment.Watcher != nil {
-			log.Infof("mesh configuration %s", spew.Sdump(s.environment.Mesh()))
-			log.Infof("version %s", version.Info.String())
-			log.Infof("flags %s", spew.Sdump(args))
+			meshJson, _ := (&jsonpb.Marshaler{}).MarshalToString(s.environment.Mesh())
+			log.Infof("mesh configuration: %s", meshJson)
+			log.Infof("version: %s", version.Info.String())
+			argsJson, _ := json.Marshal(args)
+			log.Infof("flags: %s", argsJson)
 		}
 	}()
 

--- a/pilot/pkg/bootstrap/mesh.go
+++ b/pilot/pkg/bootstrap/mesh.go
@@ -18,10 +18,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gogo/protobuf/jsonpb"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/pkg/filewatcher"
@@ -41,10 +42,10 @@ const (
 func (s *Server) initMeshConfiguration(args *PilotArgs, fileWatcher filewatcher.FileWatcher) error {
 	defer func() {
 		if s.environment.Watcher != nil {
-			meshdump, _ := (&jsonpb.Marshaler{}).MarshalToString(s.environment.Mesh())
+			meshdump, _ := gogoprotomarshal.ToJSONWithIndent(s.environment.Mesh(), "    ")
 			log.Infof("mesh configuration: %s", meshdump)
 			log.Infof("version: %s", version.Info.String())
-			argsdump, _ := json.Marshal(args)
+			argsdump, _ := json.MarshalIndent(args, "", "   ")
 			log.Infof("flags: %s", argsdump)
 		}
 	}()

--- a/pilot/pkg/bootstrap/mesh.go
+++ b/pilot/pkg/bootstrap/mesh.go
@@ -41,11 +41,11 @@ const (
 func (s *Server) initMeshConfiguration(args *PilotArgs, fileWatcher filewatcher.FileWatcher) error {
 	defer func() {
 		if s.environment.Watcher != nil {
-			meshJson, _ := (&jsonpb.Marshaler{}).MarshalToString(s.environment.Mesh())
-			log.Infof("mesh configuration: %s", meshJson)
+			meshdump, _ := (&jsonpb.Marshaler{}).MarshalToString(s.environment.Mesh())
+			log.Infof("mesh configuration: %s", meshdump)
 			log.Infof("version: %s", version.Info.String())
-			argsJson, _ := json.Marshal(args)
-			log.Infof("flags: %s", argsJson)
+			argsdump, _ := json.Marshal(args)
+			log.Infof("flags: %s", argsdump)
 		}
 	}()
 

--- a/pkg/config/mesh/networks_watcher.go
+++ b/pkg/config/mesh/networks_watcher.go
@@ -21,7 +21,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/gogo/protobuf/jsonpb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/pkg/filewatcher"
@@ -63,9 +63,9 @@ func NewNetworksWatcher(fileWatcher filewatcher.FileWatcher, filename string) (N
 		return nil, fmt.Errorf("failed to read mesh networks configuration from %q: %v", filename, err)
 	}
 
-	log.Infof("mesh networks configuration %s", spew.Sdump(meshNetworks))
 	ResolveHostsInNetworksConfig(meshNetworks)
-	log.Infof("mesh networks configuration post-resolution %s", spew.Sdump(meshNetworks))
+	networksJson, _ := (&jsonpb.Marshaler{}).MarshalToString(meshNetworks)
+	log.Infof("mesh networks configuration: %s", networksJson)
 
 	w := &networksWatcher{
 		networks: meshNetworks,
@@ -84,9 +84,9 @@ func NewNetworksWatcher(fileWatcher filewatcher.FileWatcher, filename string) (N
 
 		w.mutex.Lock()
 		if !reflect.DeepEqual(meshNetworks, w.networks) {
-			log.Infof("mesh networks configuration file updated to: %s", spew.Sdump(meshNetworks))
 			ResolveHostsInNetworksConfig(meshNetworks)
-			log.Infof("mesh networks configuration post-resolution %s", spew.Sdump(meshNetworks))
+			networksJson, _ := (&jsonpb.Marshaler{}).MarshalToString(meshNetworks)
+			log.Infof("mesh networks configuration updated to: %s", networksJson)
 
 			// Store the new config.
 			atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&w.networks)), unsafe.Pointer(meshNetworks))

--- a/pkg/config/mesh/networks_watcher.go
+++ b/pkg/config/mesh/networks_watcher.go
@@ -64,8 +64,8 @@ func NewNetworksWatcher(fileWatcher filewatcher.FileWatcher, filename string) (N
 	}
 
 	ResolveHostsInNetworksConfig(meshNetworks)
-	networksJson, _ := (&jsonpb.Marshaler{}).MarshalToString(meshNetworks)
-	log.Infof("mesh networks configuration: %s", networksJson)
+	networksdump, _ := (&jsonpb.Marshaler{}).MarshalToString(meshNetworks)
+	log.Infof("mesh networks configuration: %s", networksdump)
 
 	w := &networksWatcher{
 		networks: meshNetworks,
@@ -85,8 +85,8 @@ func NewNetworksWatcher(fileWatcher filewatcher.FileWatcher, filename string) (N
 		w.mutex.Lock()
 		if !reflect.DeepEqual(meshNetworks, w.networks) {
 			ResolveHostsInNetworksConfig(meshNetworks)
-			networksJson, _ := (&jsonpb.Marshaler{}).MarshalToString(meshNetworks)
-			log.Infof("mesh networks configuration updated to: %s", networksJson)
+			networksdump, _ := (&jsonpb.Marshaler{}).MarshalToString(meshNetworks)
+			log.Infof("mesh networks configuration updated to: %s", networksdump)
 
 			// Store the new config.
 			atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&w.networks)), unsafe.Pointer(meshNetworks))

--- a/pkg/config/mesh/networks_watcher.go
+++ b/pkg/config/mesh/networks_watcher.go
@@ -21,7 +21,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/pkg/filewatcher"
@@ -64,7 +64,7 @@ func NewNetworksWatcher(fileWatcher filewatcher.FileWatcher, filename string) (N
 	}
 
 	ResolveHostsInNetworksConfig(meshNetworks)
-	networksdump, _ := (&jsonpb.Marshaler{}).MarshalToString(meshNetworks)
+	networksdump, _ := gogoprotomarshal.ToJSONWithIndent(meshNetworks, "   ")
 	log.Infof("mesh networks configuration: %s", networksdump)
 
 	w := &networksWatcher{
@@ -85,7 +85,7 @@ func NewNetworksWatcher(fileWatcher filewatcher.FileWatcher, filename string) (N
 		w.mutex.Lock()
 		if !reflect.DeepEqual(meshNetworks, w.networks) {
 			ResolveHostsInNetworksConfig(meshNetworks)
-			networksdump, _ := (&jsonpb.Marshaler{}).MarshalToString(meshNetworks)
+			networksdump, _ := gogoprotomarshal.ToJSONWithIndent(meshNetworks, "    ")
 			log.Infof("mesh networks configuration updated to: %s", networksdump)
 
 			// Store the new config.


### PR DESCRIPTION
This is a bit of bikeshedding, but I don't think spew should be used in
logs. The output is pretty hard to read and looks like an error message
rather than a normal log. Json is pretty standard so using that instead.