### PR TITLE
Use consistent logging scope names

### DIFF
--- a/pkg/test/scopes/scopes.go
+++ b/pkg/test/scopes/scopes.go
@@ -21,5 +21,5 @@ var (
 	Framework = log.RegisterScope("tf", "General scope for the test framework", 0)
 
 	// CI system specific logging scope.
-	CI = log.RegisterScope("CI", "Scope for normal log reporting to be used in CI systems", 0)
+	CI = log.RegisterScope("ci", "Scope for normal log reporting to be used in CI systems", 0)
 )

--- a/security/pkg/k8s/configmap/configmap.go
+++ b/security/pkg/k8s/configmap/configmap.go
@@ -26,7 +26,7 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-var configMapLog = log.RegisterScope("configMapController", "ConfigMap controller log", 0)
+var configMapLog = log.RegisterScope("configmapcontroller", "ConfigMap controller log", 0)
 
 const (
 	IstioSecurityConfigMapName = "istio-security"

--- a/security/pkg/k8s/controller/casecret.go
+++ b/security/pkg/k8s/controller/casecret.go
@@ -20,12 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-
-	"istio.io/pkg/log"
 )
-
-var caSecretControllerLog = log.RegisterScope("caSecretController",
-	"Self-signed root cert secret controller log", 0)
 
 // CaSecretController manages the self-signed signing CA secret.
 type CaSecretController struct {
@@ -51,11 +46,11 @@ func (csc *CaSecretController) LoadCASecretWithRetry(secretName, namespace strin
 		if scrtErr == nil {
 			return caSecret, scrtErr
 		}
-		caSecretControllerLog.Errorf("Failed on loading CA secret %s:%s.",
+		k8sControllerLog.Errorf("Failed on loading CA secret %s:%s.",
 			namespace, secretName)
 
 		if time.Since(start) > timeout {
-			caSecretControllerLog.Errorf("Timeout on loading CA secret %s:%s.",
+			k8sControllerLog.Errorf("Timeout on loading CA secret %s:%s.",
 				namespace, secretName)
 			return caSecret, scrtErr
 		}
@@ -72,11 +67,11 @@ func (csc *CaSecretController) UpdateCASecretWithRetry(caSecret *v1.Secret,
 		if scrtErr == nil {
 			return nil
 		}
-		caSecretControllerLog.Errorf("Failed on updating CA secret %s:%s.",
+		k8sControllerLog.Errorf("Failed on updating CA secret %s:%s.",
 			caSecret.Namespace, caSecret.Name)
 
 		if time.Since(start) > timeout {
-			caSecretControllerLog.Errorf("Timeout on updating CA secret %s:%s.",
+			k8sControllerLog.Errorf("Timeout on updating CA secret %s:%s.",
 				caSecret.Namespace, caSecret.Name)
 			return scrtErr
 		}

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -82,7 +82,7 @@ const (
 	caPrivateKeyID = "ca-key.pem"
 )
 
-var k8sControllerLog = log.RegisterScope("k8sController", "Citadel kubernetes controller log", 0)
+var k8sControllerLog = log.RegisterScope("secretcontroller", "Citadel kubernetes controller log", 0)
 
 // DNSNameEntry stores the service name and namespace to construct the DNS id.
 // Service accounts matching the ServiceName and Namespace will have additional DNS SANs:

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	cacheLog = log.RegisterScope("cacheLog", "cache debugging", 0)
+	cacheLog = log.RegisterScope("cache", "cache debugging", 0)
 )
 
 const (

--- a/security/pkg/nodeagent/caclient/providers/citadel/client.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	citadelClientLog = log.RegisterScope("citadelClientLog", "citadel client debugging", 0)
+	citadelClientLog = log.RegisterScope("citadelclient", "citadel client debugging", 0)
 )
 
 type citadelClient struct {

--- a/security/pkg/nodeagent/caclient/providers/google/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client.go
@@ -35,7 +35,7 @@ import (
 const bearerTokenPrefix = "Bearer "
 
 var (
-	googleCAClientLog = log.RegisterScope("googleCAClientLog", "Google CA client debugging", 0)
+	googleCAClientLog = log.RegisterScope("googleca", "Google CA client debugging", 0)
 	gkeClusterURL     = env.RegisterStringVar("GKE_CLUSTER_URL", "", "The url of GKE cluster").Get()
 )
 

--- a/security/pkg/nodeagent/caclient/providers/vault/client.go
+++ b/security/pkg/nodeagent/caclient/providers/vault/client.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	vaultClientLog = log.RegisterScope("vaultClientLog", "Vault client debugging", 0)
+	vaultClientLog = log.RegisterScope("vault", "Vault client debugging", 0)
 )
 
 type vaultClient struct {

--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
@@ -37,7 +37,7 @@ var (
 	GKEClusterURL = env.RegisterStringVar("GKE_CLUSTER_URL", "", "The url of GKE cluster").Get()
 	// SecureTokenEndpoint is the Endpoint the STS client calls to.
 	SecureTokenEndpoint = "https://securetoken.googleapis.com/v1/identitybindingtoken"
-	stsClientLog        = log.RegisterScope("stsClientLog", "STS client debugging", 0)
+	stsClientLog        = log.RegisterScope("stsclient", "STS client debugging", 0)
 )
 
 const (

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher.go
@@ -75,7 +75,7 @@ var (
 	secretControllerResyncPeriod = env.RegisterStringVar("SECRET_WATCHER_RESYNC_PERIOD", "", "").Get()
 	// ingressFallbackSecret specifies the name of fallback secret for ingress gateway.
 	ingressFallbackSecret = env.RegisterStringVar("INGRESS_GATEWAY_FALLBACK_SECRET", "gateway-fallback", "").Get()
-	secretFetcherLog      = log.RegisterScope("secretFetcherLog", "secret fetcher debugging", 0)
+	secretFetcherLog      = log.RegisterScope("secretfetcher", "secret fetcher debugging", 0)
 )
 
 // SecretFetcher fetches secret via watching k8s secrets or sending CSR to CA.

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -60,7 +60,7 @@ const (
 	caKeySize = 2048
 )
 
-var pkiCaLog = log.RegisterScope("pkiCaLog", "Citadel CA log", 0)
+var pkiCaLog = log.RegisterScope("pkica", "Citadel CA log", 0)
 
 // caTypes is the enum for the CA type.
 type caTypes int

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -32,7 +32,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-var rootCertRotatorLog = log.RegisterScope("rootCertRotator", "Self-signed CA root cert rotator log", 0)
+var rootCertRotatorLog = log.RegisterScope("rootcertrotator", "Self-signed CA root cert rotator log", 0)
 
 type SelfSignedCARootCertRotatorConfig struct {
 	certInspector      certutil.CertUtil

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -45,7 +45,7 @@ const (
 	certExpirationBuffer = time.Minute
 )
 
-var serverCaLog = log.RegisterScope("serverCaLog", "Citadel server log", 0)
+var serverCaLog = log.RegisterScope("serverca", "Citadel server log", 0)
 
 type authenticator interface {
 	Authenticate(ctx context.Context) (*authenticate.Caller, error)

--- a/security/pkg/stsservice/server/server.go
+++ b/security/pkg/stsservice/server/server.go
@@ -39,7 +39,7 @@ const (
 	SubjectTokenType = "urn:ietf:params:oauth:token-type:jwt"
 )
 
-var stsServerLog = log.RegisterScope("stsServerLog", "STS service debugging", 0)
+var stsServerLog = log.RegisterScope("stsserver", "STS service debugging", 0)
 
 // error code sent in a STS error response. A full list of error code is
 // defined in https://tools.ietf.org/html/rfc6749#section-5.2.


### PR DESCRIPTION
With Istiod logging scope is pretty important, as it will help us
distinguish logs from XDS vs CA vs Injection, etc. This PR just renames
some of these scopes for consistency. Namely, use all lower case and
remove the Log suffix.

I am ok with removing the other changes if others don't agree, but
definitely should remove Log. It just adds noise - I have a small
screen.