### PR TITLE
Fix performance regression for EnvoyFilter w/o MCP

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -26,8 +26,9 @@ import (
 
 // EnvoyFilterWrapper is a wrapper for the EnvoyFilter api object with pre-processed data
 type EnvoyFilterWrapper struct {
-	workloadSelector labels.Instance
-	Patches          map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper
+	workloadSelector  labels.Instance
+	Patches           map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper
+	DeprecatedFilters []*networking.EnvoyFilter_Filter
 }
 
 // EnvoyFilterConfigPatchWrapper is a wrapper over the EnvoyFilter ConfigPatch api object
@@ -48,7 +49,10 @@ func convertToEnvoyFilterWrapper(local *Config) *EnvoyFilterWrapper {
 	out := &EnvoyFilterWrapper{}
 	if localEnvoyFilter.WorkloadSelector != nil {
 		out.workloadSelector = localEnvoyFilter.WorkloadSelector.Labels
+	} else {
+		out.workloadSelector = localEnvoyFilter.WorkloadLabels
 	}
+	out.DeprecatedFilters = localEnvoyFilter.Filters
 	out.Patches = make(map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper)
 	for _, cp := range localEnvoyFilter.ConfigPatches {
 		cpw := &EnvoyFilterConfigPatchWrapper{

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1484,6 +1484,7 @@ func (ps *PushContext) EnvoyFilters(proxy *Proxy) *EnvoyFilterWrapper {
 				}
 			}
 		}
+		out.DeprecatedFilters = append(out.DeprecatedFilters, efw.DeprecatedFilters...)
 	}
 
 	return out

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1731,27 +1731,25 @@ func buildListenerEnvWithVirtualServices(services []*model.Service, virtualServi
 	}
 	serviceDiscovery.GetProxyServiceInstancesReturns(instances, nil)
 
-	configStore := &fakes.IstioConfigStore{
-		EnvoyFilterStub: func(workloadLabels labels.Collection) *model.Config {
-			return &model.Config{
-				ConfigMeta: model.ConfigMeta{
-					Name:      "test-envoyfilter",
-					Namespace: "not-default",
-				},
-				Spec: &networking.EnvoyFilter{
-					Filters: []*networking.EnvoyFilter_Filter{
-						{
-							InsertPosition: &networking.EnvoyFilter_InsertPosition{
-								Index: networking.EnvoyFilter_InsertPosition_FIRST,
-							},
-							FilterType:   networking.EnvoyFilter_Filter_HTTP,
-							FilterName:   "envoy.lua",
-							FilterConfig: &types.Struct{},
-						},
-					},
-				},
-			}
+	envoyFilter := model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Name:      "test-envoyfilter",
+			Namespace: "not-default",
 		},
+		Spec: &networking.EnvoyFilter{
+			Filters: []*networking.EnvoyFilter_Filter{
+				{
+					InsertPosition: &networking.EnvoyFilter_InsertPosition{
+						Index: networking.EnvoyFilter_InsertPosition_FIRST,
+					},
+					FilterType:   networking.EnvoyFilter_Filter_HTTP,
+					FilterName:   "envoy.lua",
+					FilterConfig: &types.Struct{},
+				},
+			},
+		},
+	}
+	configStore := &fakes.IstioConfigStore{
 		ListStub: func(typ, namespace string) (configs []model.Config, e error) {
 			if typ == "virtual-service" {
 				result := make([]model.Config, len(virtualServices))
@@ -1759,6 +1757,9 @@ func buildListenerEnvWithVirtualServices(services []*model.Service, virtualServi
 					result[i] = *virtualServices[i]
 				}
 				return result, nil
+			}
+			if typ == "envoy-filter" {
+				return []model.Config{envoyFilter}, nil
 			}
 			return nil, nil
 

--- a/tests/testdata/networking/envoyfilter-without-service/configs.yaml
+++ b/tests/testdata/networking/envoyfilter-without-service/configs.yaml
@@ -89,7 +89,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: test-lua
-  #namespace: sr-test
+  namespace: istio-system
 spec:
   workloadLabels:
     app: envoyfilter-test-app


### PR DESCRIPTION

Right now having any EnvoyFilters and using non-MCP will cause a huge
performance regression. In my cluster, this was 20x more CPU usage. This
is due to the deprecated fields in EnvoyFilter, but it doesn't matter if
they are used or not, since we always do the lookup. Rather than calling
configStore.List() for every listener, instead cache in PushContext like
we do for everything else.


Graph shows using MCP, disabling MCP, then applying this patch
![2020-01-01_18-00-11](https://user-images.githubusercontent.com/623453/71649129-e2e19900-2cc0-11ea-9b4e-56e044dbb8a1.png)