### PR TITLE
Move dashboard test to integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,7 @@ require (
 	go.uber.org/zap v1.10.0
 	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0
 	golang.org/x/tools v0.0.0-20191216173652-a0e659d51361
 	google.golang.org/api v0.15.0

--- a/manifests/istio-telemetry/grafana/dashboards/istio-mesh-dashboard.json
+++ b/manifests/istio-telemetry/grafana/dashboards/istio-mesh-dashboard.json
@@ -420,7 +420,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(galley_istio_networking_virtualservices) / count(up{job=\"galley\"})",
+          "expr": "avg(galley_istio_networking_virtualservices)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -501,7 +501,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(galley_istio_networking_destinationrules) / count(up{job=\"galley\"})",
+          "expr": "avg(galley_istio_networking_destinationrules)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -582,7 +582,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(galley_istio_networking_gateways) / count(up{job=\"galley\"})",
+          "expr": "avg(galley_istio_networking_gateways)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -663,7 +663,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(galley_istio_authentication_meshpolicies) / count(up{job=\"galley\"})",
+          "expr": "avg(galley_istio_authentication_meshpolicies)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,

--- a/manifests/istio-telemetry/grafana/dashboards/istio-performance-dashboard.json
+++ b/manifests/istio-telemetry/grafana/dashboards/istio-performance-dashboard.json
@@ -976,7 +976,7 @@
           "step": 2
         },
         {
-          "expr": "sum(container_memory_usage_bytes{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istio-pilot-.*\"})",
+          "expr": "sum(container_memory_usage_bytes{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istiod-.*\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -985,7 +985,7 @@
           "step": 2
         },
         {
-          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1072,7 +1072,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istio-pilot-.*\"}[1m]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istiod-.*\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1081,7 +1081,7 @@
           "step": 2
         },
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istio-pilot-.*\"}[1m])) by (container)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istiod-.*\"}[1m])) by (container)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1187,7 +1187,7 @@
           "refId": "A"
         },
         {
-          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery|istio-proxy\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery|istio-proxy\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ container }}",

--- a/manifests/istio-telemetry/grafana/dashboards/pilot-dashboard.json
+++ b/manifests/istio-telemetry/grafana/dashboards/pilot-dashboard.json
@@ -224,7 +224,7 @@
           "step": 2
         },
         {
-          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery\", pod=~\"istiod-.*\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery\", pod=~\"istiod-.*|istio-pilot-.*\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -233,7 +233,7 @@
           "step": 2
         },
         {
-          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"istio-proxy\", pod=~\"istiod-.*\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"istio-proxy\", pod=~\"istiod-.*|istio-pilot-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sidecar (container)",
@@ -318,7 +318,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"discovery\", pod=~\"istiod-.*\"}[1m]))",
+          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"discovery\", pod=~\"istiod-.*|istio-pilot-.*\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Discovery (container)",
@@ -334,7 +334,7 @@
           "step": 2
         },
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"istio-proxy\", pod=~\"istiod-.*\"}[1m]))",
+          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"istio-proxy\", pod=~\"istiod-.*|istio-pilot-.*\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -421,7 +421,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"discovery\", pod=~\"istiod-.*\"}",
+          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"discovery\", pod=~\"istiod-.*|istio-pilot-.*\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Discovery",
@@ -429,7 +429,7 @@
           "step": 2
         },
         {
-          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"istio-proxy\", pod=~\"istiod-.*\"}",
+          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"istio-proxy\", pod=~\"istiod-.*|istio-pilot-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sidecar",

--- a/manifests/istio-telemetry/grafana/dashboards/pilot-dashboard.json
+++ b/manifests/istio-telemetry/grafana/dashboards/pilot-dashboard.json
@@ -224,7 +224,7 @@
           "step": 2
         },
         {
-          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -233,7 +233,7 @@
           "step": 2
         },
         {
-          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"istio-proxy\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"istio-proxy\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sidecar (container)",
@@ -318,7 +318,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"discovery\", pod=~\"istio-pilot-.*\"}[1m]))",
+          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"discovery\", pod=~\"istiod-.*\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Discovery (container)",
@@ -334,7 +334,7 @@
           "step": 2
         },
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"istio-proxy\", pod=~\"istio-pilot-.*\"}[1m]))",
+          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"istio-proxy\", pod=~\"istiod-.*\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -421,7 +421,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"discovery\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"discovery\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Discovery",
@@ -429,7 +429,7 @@
           "step": 2
         },
         {
-          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"istio-proxy\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"istio-proxy\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sidecar",

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -27650,7 +27650,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "step": 2
         },
         {
-          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery\", pod=~\"istiod-.*\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery\", pod=~\"istiod-.*|istio-pilot-.*\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -27659,7 +27659,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "step": 2
         },
         {
-          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"istio-proxy\", pod=~\"istiod-.*\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"istio-proxy\", pod=~\"istiod-.*|istio-pilot-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sidecar (container)",
@@ -27744,7 +27744,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"discovery\", pod=~\"istiod-.*\"}[1m]))",
+          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"discovery\", pod=~\"istiod-.*|istio-pilot-.*\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Discovery (container)",
@@ -27760,7 +27760,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "step": 2
         },
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"istio-proxy\", pod=~\"istiod-.*\"}[1m]))",
+          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"istio-proxy\", pod=~\"istiod-.*|istio-pilot-.*\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -27847,7 +27847,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"discovery\", pod=~\"istiod-.*\"}",
+          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"discovery\", pod=~\"istiod-.*|istio-pilot-.*\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Discovery",
@@ -27855,7 +27855,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "step": 2
         },
         {
-          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"istio-proxy\", pod=~\"istiod-.*\"}",
+          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"istio-proxy\", pod=~\"istiod-.*|istio-pilot-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sidecar",

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -18002,7 +18002,7 @@ var _chartsIstioTelemetryGrafanaDashboardsIstioMeshDashboardJson = []byte(`{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(galley_istio_networking_virtualservices) / count(up{job=\"galley\"})",
+          "expr": "avg(galley_istio_networking_virtualservices)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -18083,7 +18083,7 @@ var _chartsIstioTelemetryGrafanaDashboardsIstioMeshDashboardJson = []byte(`{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(galley_istio_networking_destinationrules) / count(up{job=\"galley\"})",
+          "expr": "avg(galley_istio_networking_destinationrules)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -18164,7 +18164,7 @@ var _chartsIstioTelemetryGrafanaDashboardsIstioMeshDashboardJson = []byte(`{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(galley_istio_networking_gateways) / count(up{job=\"galley\"})",
+          "expr": "avg(galley_istio_networking_gateways)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -18245,7 +18245,7 @@ var _chartsIstioTelemetryGrafanaDashboardsIstioMeshDashboardJson = []byte(`{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(galley_istio_authentication_meshpolicies) / count(up{job=\"galley\"})",
+          "expr": "avg(galley_istio_authentication_meshpolicies)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -19800,7 +19800,7 @@ var _chartsIstioTelemetryGrafanaDashboardsIstioPerformanceDashboardJson = []byte
           "step": 2
         },
         {
-          "expr": "sum(container_memory_usage_bytes{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istio-pilot-.*\"})",
+          "expr": "sum(container_memory_usage_bytes{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istiod-.*\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -19809,7 +19809,7 @@ var _chartsIstioTelemetryGrafanaDashboardsIstioPerformanceDashboardJson = []byte
           "step": 2
         },
         {
-          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -19896,7 +19896,7 @@ var _chartsIstioTelemetryGrafanaDashboardsIstioPerformanceDashboardJson = []byte
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istio-pilot-.*\"}[1m]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istiod-.*\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -19905,7 +19905,7 @@ var _chartsIstioTelemetryGrafanaDashboardsIstioPerformanceDashboardJson = []byte
           "step": 2
         },
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istio-pilot-.*\"}[1m])) by (container)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=~\"discovery|istio-proxy\", pod=~\"istiod-.*\"}[1m])) by (container)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -20011,7 +20011,7 @@ var _chartsIstioTelemetryGrafanaDashboardsIstioPerformanceDashboardJson = []byte
           "refId": "A"
         },
         {
-          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery|istio-proxy\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery|istio-proxy\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ container }}",
@@ -27650,7 +27650,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "step": 2
         },
         {
-          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"discovery\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -27659,7 +27659,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "step": 2
         },
         {
-          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"istio-proxy\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", container=~\"istio-proxy\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sidecar (container)",
@@ -27744,7 +27744,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"discovery\", pod=~\"istio-pilot-.*\"}[1m]))",
+          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"discovery\", pod=~\"istiod-.*\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Discovery (container)",
@@ -27760,7 +27760,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "step": 2
         },
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"istio-proxy\", pod=~\"istio-pilot-.*\"}[1m]))",
+          "expr": "sum(irate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\",container=\"istio-proxy\", pod=~\"istiod-.*\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -27847,7 +27847,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"discovery\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"discovery\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Discovery",
@@ -27855,7 +27855,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "step": 2
         },
         {
-          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"istio-proxy\", pod=~\"istio-pilot-.*\"}",
+          "expr": "container_fs_usage_bytes{job=\"kubernetes-cadvisor\", container=\"istio-proxy\", pod=~\"istiod-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sidecar",

--- a/pkg/test/framework/components/ingress/ingress.go
+++ b/pkg/test/framework/components/ingress/ingress.go
@@ -91,6 +91,9 @@ type Instance interface {
 	// HTTPSAddress returns the external HTTPS address of the ingress gateway (or the
 	// NodePort address, when running under Minikube).
 	HTTPSAddress() net.TCPAddr
+	// TCPAddress returns the external TCP address of the ingress gateway (or the NodePort address,
+	// when running under Minikube).
+	TCPAddress() net.TCPAddr
 
 	//  Call makes a call through ingress.
 	Call(options CallOptions) (CallResponse, error)

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -55,8 +55,8 @@ type kubeComponent struct {
 	env       *kube.Environment
 }
 
-// getHTTPAddressInner returns the ingress gateway address for plain text http requests.
-func getHTTPAddressInner(env *kube.Environment, ns string) (interface{}, bool, error) {
+// getAddressInner returns the ingress gateway address for plain text  requests.
+func getAddressInner(env *kube.Environment, ns string, port int) (interface{}, bool, error) {
 	// In Minikube, we don't have the ingress gateway. Instead we do a little bit of trickery to to get the Node
 	// port.
 	if env.Settings().Minikube {
@@ -88,13 +88,13 @@ func getHTTPAddressInner(env *kube.Environment, ns string) (interface{}, bool, e
 
 		var nodePort int32
 		for _, svcPort := range svc.Spec.Ports {
-			if svcPort.Protocol == "TCP" && svcPort.Port == 80 {
+			if svcPort.Protocol == "TCP" && svcPort.Port == int32(port) {
 				nodePort = svcPort.NodePort
 				break
 			}
 		}
 		if nodePort == 0 {
-			return nil, false, fmt.Errorf("no port 80 found in service: %s/%s", ns, "istio-ingressgateway")
+			return nil, false, fmt.Errorf("no port %d found in service: %s/%s", port, ns, "istio-ingressgateway")
 		}
 
 		return net.TCPAddr{IP: net.ParseIP(ip), Port: int(nodePort)}, true, nil
@@ -111,7 +111,7 @@ func getHTTPAddressInner(env *kube.Environment, ns string) (interface{}, bool, e
 	}
 
 	ip := svc.Status.LoadBalancer.Ingress[0].IP
-	return net.TCPAddr{IP: net.ParseIP(ip), Port: 80}, true, nil
+	return net.TCPAddr{IP: net.ParseIP(ip), Port: port}, true, nil
 }
 
 // getHTTPSAddressInner returns the ingress gateway address for https requests.
@@ -186,7 +186,18 @@ func (c *kubeComponent) ID() resource.ID {
 // HTTPAddress returns HTTP address of ingress gateway.
 func (c *kubeComponent) HTTPAddress() net.TCPAddr {
 	address, err := retry.Do(func() (interface{}, bool, error) {
-		return getHTTPAddressInner(c.env, c.namespace)
+		return getAddressInner(c.env, c.namespace, 80)
+	}, retryTimeout, retryDelay)
+	if err != nil {
+		return net.TCPAddr{}
+	}
+	return address.(net.TCPAddr)
+}
+
+// TCPAddress returns TCP address of ingress gateway.
+func (c *kubeComponent) TCPAddress() net.TCPAddr {
+	address, err := retry.Do(func() (interface{}, bool, error) {
+		return getAddressInner(c.env, c.namespace, 15029)
 	}, retryTimeout, retryDelay)
 	if err != nil {
 		return net.TCPAddr{}
@@ -276,7 +287,7 @@ func (c *kubeComponent) createRequest(options CallOptions) (*http.Request, error
 
 func (c *kubeComponent) Call(options CallOptions) (CallResponse, error) {
 	if err := options.sanitize(); err != nil {
-		scopes.Framework.Fatalf("CallOptions sanitization failure, error %v", err)
+		scopes.Framework.Fatalf("CallOptions sanitization failure. config: %+v, error:%v", options, err)
 	}
 	client, err := c.createClient(options)
 	if err != nil {

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -391,6 +391,11 @@ func (a *Accessor) GetSecret(ns string) kubeClientCore.SecretInterface {
 	return a.set.CoreV1().Secrets(ns)
 }
 
+// GetConfigMap returns the config resource with the given name and namespace.
+func (a *Accessor) GetConfigMap(name, ns string) (*kubeApiCore.ConfigMap, error) {
+	return a.set.CoreV1().ConfigMaps(ns).Get(name, kubeApiMeta.GetOptions{})
+}
+
 // CreateSecret takes the representation of a secret and creates it in the given namespace.
 // Returns an error if there is any.
 func (a *Accessor) CreateSecret(namespace string, secret *kubeApiCore.Secret) (err error) {

--- a/tests/integration/telemetry/dashboard_test.go
+++ b/tests/integration/telemetry/dashboard_test.go
@@ -66,25 +66,32 @@ var (
 		{
 			"istio-grafana-configuration-dashboards-istio-mesh-dashboard",
 			"istio-mesh-dashboard.json",
-			nil,
+			[]string{
+				"galley_",
+				"istio_tcp_",
+			},
 		},
 		{
 			"istio-grafana-configuration-dashboards-istio-service-dashboard",
 			"istio-service-dashboard.json",
-			nil,
+			[]string{
+				"istio_tcp_",
+			},
 		},
 		{
 			"istio-grafana-configuration-dashboards-istio-workload-dashboard",
 			"istio-workload-dashboard.json",
-			nil,
+			[]string{
+				"istio_tcp_",
+			},
 		},
 		{
 			"istio-grafana-configuration-dashboards-istio-performance-dashboard",
 			"istio-performance-dashboard.json",
 			[]string{
 				// TODO add these back: https://github.com/istio/istio/issues/20175
-				`destination_workload="istio-telemetry"`,
-				`destination_workload="istio-policy"`,
+				`istio-telemetry`,
+				`istio-policy`,
 				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
 				"container_fs_usage_bytes",
 			},
@@ -93,39 +100,24 @@ var (
 			"istio-grafana-configuration-dashboards-galley-dashboard",
 			"galley-dashboard.json",
 			[]string{
-				"validation_cert_key_update_errors",
-				"validation_failed",
-				"validation_http_error",
-				"event_error_total",
-				"converter_failure_total",
-				"request_nacks_total",
-				"runtime_strategy_timer",
-				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
-				"container_fs_usage_bytes",
+				// Exclude all metrics -- galley is disabled by default
+				"_",
 			},
 		},
 		{
 			"istio-grafana-configuration-dashboards-mixer-dashboard",
 			"mixer-dashboard.json",
 			[]string{
-				"grpc_code",
-				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
-				"container_fs_usage_bytes",
+				// Exclude all metrics -- mixer is disabled by default
+				"_",
 			},
 		},
 		{
 			"istio-grafana-configuration-dashboards-citadel-dashboard",
 			"citadel-dashboard.json",
 			[]string{
-				"citadel_server_csr_count",
-				"citadel_server_success_cert_issuance_count",
-				"citadel_secret_controller_csr_err_count",
-				"citadel_server_csr_parsing_err_count",
-				"citadel_server_authentication_failure_count",
-				"acc_deleted_cert_count",
-				"secret_deleted_cert_count",
-				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
-				"container_fs_usage_bytes",
+				// Exclude all metrics -- citadel is disabled by default
+				"_",
 			},
 		},
 	}
@@ -220,7 +212,7 @@ func checkMetric(p prometheus.Instance, query string, excluded []string) error {
 		}
 	} else {
 		if numSamples != 0 {
-			scopes.CI.Infof("Filtered out metric '%v', but got samples: %v", query, value)
+			scopes.CI.Debugf("Filtered out metric '%v', but got samples: %v", query, value)
 		}
 	}
 	return nil

--- a/tests/integration/telemetry/dashboard_test.go
+++ b/tests/integration/telemetry/dashboard_test.go
@@ -1,0 +1,415 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+
+	"github.com/prometheus/common/model"
+	"golang.org/x/sync/errgroup"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/components/ingress"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/prometheus"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+var (
+	dashboards = []struct {
+		configmap string
+		name      string
+		excluded  []string
+	}{
+		{
+			"istio-grafana-configuration-dashboards-pilot-dashboard",
+			"pilot-dashboard.json",
+			[]string{
+				"pilot_xds_push_errors",
+				"pilot_total_xds_internal_errors",
+				"pilot_xds_push_context_errors",
+				`pilot_xds_pushes{type!~"lds|cds|rds|eds"}`,
+				"pilot_xds_eds_instances",
+				"_timeout",
+				"_rejects",
+				// In default install, we have no proxy
+				"istio-proxy",
+				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
+				"container_fs_usage_bytes",
+			},
+		},
+		{
+			"istio-grafana-configuration-dashboards-istio-mesh-dashboard",
+			"istio-mesh-dashboard.json",
+			nil,
+		},
+		{
+			"istio-grafana-configuration-dashboards-istio-service-dashboard",
+			"istio-service-dashboard.json",
+			nil,
+		},
+		{
+			"istio-grafana-configuration-dashboards-istio-workload-dashboard",
+			"istio-workload-dashboard.json",
+			nil,
+		},
+		{
+			"istio-grafana-configuration-dashboards-istio-performance-dashboard",
+			"istio-performance-dashboard.json",
+			[]string{
+				// TODO add these back: https://github.com/istio/istio/issues/20175
+				`destination_workload="istio-telemetry"`,
+				`destination_workload="istio-policy"`,
+				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
+				"container_fs_usage_bytes",
+			},
+		},
+		{
+			"istio-grafana-configuration-dashboards-galley-dashboard",
+			"galley-dashboard.json",
+			[]string{
+				"validation_cert_key_update_errors",
+				"validation_failed",
+				"validation_http_error",
+				"event_error_total",
+				"converter_failure_total",
+				"request_nacks_total",
+				"runtime_strategy_timer",
+				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
+				"container_fs_usage_bytes",
+			},
+		},
+		{
+			"istio-grafana-configuration-dashboards-mixer-dashboard",
+			"mixer-dashboard.json",
+			[]string{
+				"grpc_code",
+				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
+				"container_fs_usage_bytes",
+			},
+		},
+		{
+			"istio-grafana-configuration-dashboards-citadel-dashboard",
+			"citadel-dashboard.json",
+			[]string{
+				"citadel_server_csr_count",
+				"citadel_server_success_cert_issuance_count",
+				"citadel_secret_controller_csr_err_count",
+				"citadel_server_csr_parsing_err_count",
+				"citadel_server_authentication_failure_count",
+				"acc_deleted_cert_count",
+				"secret_deleted_cert_count",
+				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
+				"container_fs_usage_bytes",
+			},
+		},
+	}
+)
+
+func TestDashboard(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+
+			p := prometheus.NewOrFail(ctx, ctx)
+			kenv := ctx.Environment().(*kube.Environment)
+			setupDashboardTest(ctx)
+			waitForMetrics(ctx, p)
+			for _, d := range dashboards {
+				d := d
+				ctx.NewSubTest(d.name).RunParallel(func(t framework.TestContext) {
+					cm, err := kenv.Accessor.GetConfigMap(d.configmap, i.Settings().TelemetryNamespace)
+					if err != nil {
+						t.Fatalf("Failed to find dashboard %v: %v", d.configmap, err)
+					}
+
+					config, f := cm.Data[d.name]
+					if !f {
+						t.Fatalf("Failed to find expected dashboard: %v", d.name)
+					}
+
+					queries, err := extractQueries(config)
+					if err != nil {
+						t.Fatalf("Failed to extract queries: %v", err)
+					}
+
+					for _, query := range queries {
+						if err := checkMetric(p, query, d.excluded); err != nil {
+							t.Errorf("Check query failed: %v", err)
+						}
+					}
+				})
+			}
+		})
+}
+
+var (
+	// Some templates use replacement variables. Instead, replace those with wildcard
+	replacer = strings.NewReplacer(
+		"$dstns", ".*",
+		"$dstwl", ".*",
+		"$service", ".*",
+		"$srcns", ".*",
+		"$srcwl", ".*",
+		"$namespace", ".*",
+		"$workload", ".*",
+		"$dstsvc", ".*",
+		"$adapter", ".*",
+		// Just allow all mTLS settings rather than trying to send mtls and plaintext
+		`connection_security_policy="unknown"`, `connection_security_policy=~".*"`,
+		`connection_security_policy="mutual_tls"`, `connection_security_policy=~".*"`,
+		`connection_security_policy!="mutual_tls"`, `connection_security_policy=~".*"`,
+		// Test runs in istio-system
+		`destination_workload_namespace!="istio-system"`, `destination_workload_namespace=~".*"`,
+		`source_workload_namespace!="istio-system"`, `source_workload_namespace=~".*"`,
+	)
+)
+
+func checkMetric(p prometheus.Instance, query string, excluded []string) error {
+	query = replacer.Replace(query)
+	value, _, err := p.API().QueryRange(context.Background(), query, promv1.Range{
+		Start: time.Now().Add(-time.Minute),
+		End:   time.Now(),
+		Step:  time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("failure executing query (%s): %v", query, err)
+	}
+	if value == nil {
+		return fmt.Errorf("returned value should not be nil for '%s'", query)
+	}
+	numSamples := 0
+	switch v := value.(type) {
+	case model.Vector:
+		numSamples = v.Len()
+	case model.Matrix:
+		numSamples = v.Len()
+	case *model.Scalar:
+		numSamples = 1
+	default:
+		return fmt.Errorf("unknown metric value type: %T", v)
+	}
+	if includeQuery(query, excluded) {
+		if numSamples == 0 {
+			return fmt.Errorf("expected a metric value for '%s', found no samples: %#v", query, value)
+		}
+	} else {
+		if numSamples != 0 {
+			scopes.CI.Infof("Filtered out metric '%v', but got samples: %v", query, value)
+		}
+	}
+	return nil
+}
+
+func waitForMetrics(t framework.TestContext, instance prometheus.Instance) {
+	// These are sentinel metrics that will be used to evaluate if prometheus
+	// scraping has occurred and data is available via promQL.
+	// We will retry these queries, but not future ones, otherwise failures will take too long
+	queries := []string{
+		`istio_requests_total`,
+		`istio_tcp_received_bytes_total`,
+		`mixer_runtime_dispatches_total`,
+	}
+
+	for _, query := range queries {
+		err := retry.UntilSuccess(func() error {
+			return checkMetric(instance, query, nil)
+		})
+		// Do not fail here - this is just to let the metrics sync. We will fail on the test if query fails
+		if err != nil {
+			t.Logf("Sentinel query %v failed: %v", query, err)
+		}
+	}
+}
+
+const gatewayConfig = `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: echo-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+  - port:
+      number: 15029
+      name: tcp
+      protocol: TCP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: echo
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - echo-gateway
+  http:
+  - match:
+    - uri:
+        exact: /echo-%s
+    route:
+    - destination:
+        host: server
+        port:
+          number: 80
+  tcp:
+  - match:
+    - port: 15029
+    route:
+    - destination:
+        host: server
+        port:
+          number: 7777
+`
+
+func setupDashboardTest(t framework.TestContext) {
+	ns := namespace.NewOrFail(t, t, namespace.Config{
+		Prefix: "dashboard",
+		Inject: true,
+	})
+	g.ApplyConfigOrFail(t, ns, fmt.Sprintf(gatewayConfig, ns.Name()))
+
+	var instance echo.Instance
+	echoboot.
+		NewBuilderOrFail(t, t).
+		With(&instance, echo.Config{
+			Service:   "server",
+			Pilot:     p,
+			Galley:    g,
+			Namespace: ns,
+			Ports: []echo.Port{
+				{
+					Name:     "http",
+					Protocol: protocol.HTTP,
+					// We use a port > 1024 to not require root
+					InstancePort: 8090,
+				},
+				{
+					Name:         "tcp",
+					Protocol:     protocol.TCP,
+					InstancePort: 7777,
+					ServicePort:  7777,
+				},
+			},
+		}).
+		BuildOrFail(t)
+
+	// Send 200 http requests, 20 tcp requests across goroutines, generating a variety of error codes.
+	// Spread out over 5s so rate() queries will behave correctly
+	g, _ := errgroup.WithContext(context.Background())
+	addr := ingr.HTTPAddress()
+	tcpAddr := ingr.TCPAddress()
+	ticker := time.NewTicker(time.Second * 5)
+	for t := 0; t < 20; t++ {
+		<-ticker.C
+		g.Go(func() error {
+			for i := 0; i < 10; i++ {
+				_, err := ingr.Call(ingress.CallOptions{
+					Host:     "server",
+					Path:     fmt.Sprintf("/echo-%s?codes=418:10,520:15,200:75", ns.Name()),
+					CallType: ingress.PlainText,
+					Address:  addr,
+				})
+				if err != nil {
+					return err
+				}
+			}
+			_, err := ingr.Call(ingress.CallOptions{
+				Host:     "server",
+				Path:     fmt.Sprintf("/echo-%s", ns.Name()),
+				CallType: ingress.PlainText,
+				Address:  tcpAddr,
+			})
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("ingress call failed: %v", err)
+	}
+}
+
+// extractQueries pulls all prometheus queries out of a grafana dashboard
+// Rather than importing the entire grafana API just for this test, do some shoddy json parsing
+// Equivalent to jq command: '.panels[].targets[]?.expr'
+func extractQueries(dash string) ([]string, error) {
+	var queries []string
+	js := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(dash), &js); err != nil {
+		return nil, err
+	}
+	panels, f := js["panels"]
+	if !f {
+		return nil, fmt.Errorf("failed to find panels in %v", dash)
+	}
+	panelsList, f := panels.([]interface{})
+	if !f {
+		return nil, fmt.Errorf("failed to find panelsList in type %T: %v", panels, panels)
+	}
+	for _, p := range panelsList {
+		pm := p.(map[string]interface{})
+		targets, f := pm["targets"]
+		if !f {
+			continue
+		}
+		targetsList, f := targets.([]interface{})
+		if !f {
+			return nil, fmt.Errorf("failed to find targetsList in type %T: %v", targets, targets)
+		}
+		for _, t := range targetsList {
+			tm := t.(map[string]interface{})
+			expr, f := tm["expr"]
+			if !f {
+				return nil, fmt.Errorf("failed to find expr in %v", t)
+			}
+			queries = append(queries, expr.(string))
+		}
+	}
+	return queries, nil
+}
+
+func includeQuery(query string, excluded []string) bool {
+	for _, f := range excluded {
+		if strings.Contains(query, f) {
+			return false
+		}
+	}
+	return true
+}

--- a/tests/integration/telemetry/dashboard_test.go
+++ b/tests/integration/telemetry/dashboard_test.go
@@ -225,7 +225,6 @@ func waitForMetrics(t framework.TestContext, instance prometheus.Instance) {
 	queries := []string{
 		`istio_requests_total`,
 		`istio_tcp_received_bytes_total`,
-		`mixer_runtime_dispatches_total`,
 	}
 
 	for _, query := range queries {

--- a/tests/integration/telemetry/main_test.go
+++ b/tests/integration/telemetry/main_test.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/ingress"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	i    istio.Instance
+	g    galley.Instance
+	p    pilot.Instance
+	ingr ingress.Instance
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("telemetry_test", m).
+		Label(label.CustomSetup).
+		SetupOnEnv(environment.Kube, istio.Setup(&i, func(cfg *istio.Config) {
+			cfg.Values["grafana.enabled"] = "true"
+			// TODO remove once https://github.com/istio/istio/issues/20137 is fixed
+			cfg.ControlPlaneValues = `
+addonComponents:
+  grafana:
+    enabled: true`
+		})).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			if ingr, err = ingress.New(ctx, ingress.Config{
+				Istio: i,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+}


### PR DESCRIPTION
This is not (just) because I am bored and love moving code around. The integration tests have more coverage, such as helm + operator, and multiple k8s versions. There are many bugs that would have been caught by this, such as k8s 1.16 metric changes, some old cadvisor changes, and https://github.com/istio/istio/issues/19826.

And it found a new bug, the galley dashboard is outdated.

This test passes with helm, but still some issues to work out when using operator. I think they will require changes to the installer