### PR TITLE
Don't validate credentialName in gateway secrets analyzer if it isn't specified

### DIFF
--- a/galley/pkg/config/analysis/analyzers/gateway/secret.go
+++ b/galley/pkg/config/analysis/analyzers/gateway/secret.go
@@ -66,6 +66,10 @@ func (a *SecretAnalyzer) Analyze(ctx analysis.Context) {
 			}
 
 			cn := tls.GetCredentialName()
+			if cn == "" {
+				continue
+			}
+
 			if !ctx.Exists(collections.K8SCoreV1Secrets.Name(), resource.NewShortOrFullName(gwNs, cn)) {
 				ctx.Report(collections.IstioNetworkingV1Alpha3Gateways.Name(), msg.NewReferencedResourceNotFound(r, "credentialName", cn))
 			}

--- a/galley/pkg/config/analysis/analyzers/testdata/gateway-secrets.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/gateway-secrets.yaml
@@ -86,3 +86,20 @@ spec:
       credentialName: "httpbin-credential"
     hosts:
     - "httpbin.example.com"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: defaultgateway-nocredential # No credentialName specified, we shouldn't generate any errors
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+    hosts:
+    - "httpbin.example.com"


### PR DESCRIPTION
Minor fix to gateway secrets analyzer to skip analyzing credentialName reference if it isn't specified