### PR TITLE
Update analyzer IsIstioControlPlane filter to also look for release=istio

### DIFF
--- a/galley/pkg/config/analysis/analyzers/testdata/service-no-port-name-system-namespace.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/service-no-port-name-system-namespace.yaml
@@ -45,8 +45,8 @@ spec:
       protocol: TCP
       port: 8080
       targetPort: 8080
-      apiVersion: v1
 ---
+apiVersion: v1
 kind: Service
 metadata:
   name: my-service4 # Skipped because of the release:istio label

--- a/galley/pkg/config/analysis/analyzers/testdata/service-no-port-name-system-namespace.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/service-no-port-name-system-namespace.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: my-service1
-  namespace: kube-system
+  namespace: kube-system  # Skipped because it's in a kube system namespace
 spec:
   selector:
     app: my-service1
@@ -19,7 +19,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: my-service2
+  name: my-service2 # Skipped because it has an istio: label
   namespace: istio-system
   labels:
     istio: xxx
@@ -35,13 +35,29 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: my-service3
+  name: my-service3 # Skipped because it's in a kube system namespace
   namespace: kube-public
 spec:
   selector:
     app: my-service3
   ports:
     - name: bar
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+      apiVersion: v1
+---
+kind: Service
+metadata:
+  name: my-service4 # Skipped because of the release:istio label
+  namespace: istio-system
+  labels:
+    release: istio
+spec:
+  selector:
+    app: my-service4
+  ports:
+    - name: foo
       protocol: TCP
       port: 8080
       targetPort: 8080

--- a/galley/pkg/config/analysis/analyzers/util/config.go
+++ b/galley/pkg/config/analysis/analyzers/util/config.go
@@ -36,11 +36,18 @@ func MeshConfig(ctx analysis.Context) *v1alpha1.MeshConfig {
 	return mc
 }
 
+// IsSystemNamespace returns true for system namespaces
 func IsSystemNamespace(ns resource.Namespace) bool {
 	return ns == "kube-system" || ns == "kube-public"
 }
 
+// IsIstioControlPlane returns true for resources that are part of the Istio control plane
 func IsIstioControlPlane(r *resource.Instance) bool {
-	_, ok := r.Metadata.Labels["istio"]
-	return ok
+	if _, ok := r.Metadata.Labels["istio"]; ok {
+		return true
+	}
+	if r.Metadata.Labels["release"] == "istio" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Followup on https://github.com/istio/istio/pull/19888 to better resolve https://github.com/istio/istio/issues/19688. Also adds some more comments. 

Updates the filter we use to detect the Istio control plane to include the "release=istio" label. 