### PR TITLE
Allow for specifying Prometheus remote_write configuration

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -12,6 +12,10 @@ data:
   prometheus.yml: |-
     global:
       scrape_interval: {{ .Values.scrapeInterval }}
+    {{ if .Values.remoteWrite }}
+    remote_write:
+      {{- toYaml .Values.remoteWrite | nindent 6 }}
+    {{- end }}
     scrape_configs:
 
     - job_name: 'istio-mesh'

--- a/install/kubernetes/helm/istio/charts/prometheus/values.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/values.yaml
@@ -34,6 +34,11 @@ podAntiAffinityTermLabelSelector: []
 # Controls the frequency of prometheus scraping
 scrapeInterval: 15s
 
+# Configures a remote endpoint to write metrics to. By default, this feature is
+# disabled. See the following for the configuration structure:
+# https://prometheus.io/docs/prometheus/2.12/configuration/configuration/#remote_write
+remoteWrite: {}
+
 contextPath: /prometheus
 
 ingress:


### PR DESCRIPTION
In certain deployments it is desirable to mirror metrics from Istio's
Prometheus cluster into a remote destination, such as another Prometheus
cluster or M3 cluster.

Allow the remote_write Prometheus configuration to be specified in the
Prometheus subchart. When specified, the YAML is inlined into the
Prometheus ConfigMap.

By default this feature is disabled.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>