### PR TITLE
[Galley] Add schemas to events and resource instances

### DIFF
--- a/galley/pkg/config/analysis/analyzer.go
+++ b/galley/pkg/config/analysis/analyzer.go
@@ -131,23 +131,23 @@ func getDisabledOutputs(disabledInputs collection.Names, xformProviders transfor
 	// 1. Count, for each output, how many xforms feed it
 	outputXformCount := make(map[collection.Name]int)
 	for _, p := range xformProviders {
-		for _, out := range p.Outputs() {
-			outputXformCount[out]++
+		for _, out := range p.Outputs().All() {
+			outputXformCount[out.Name()]++
 		}
 	}
 
 	// 2. For each xform, if inputs are disabled decrement each output counter for that xform
 	for _, p := range xformProviders {
 		hasDisabledInput := false
-		for _, in := range p.Inputs() {
-			if _, ok := disabledInputSet[in]; ok {
+		for _, in := range p.Inputs().All() {
+			if _, ok := disabledInputSet[in.Name()]; ok {
 				hasDisabledInput = true
 				break
 			}
 		}
 		if hasDisabledInput {
-			for _, out := range p.Outputs() {
-				outputXformCount[out]--
+			for _, out := range p.Outputs().All() {
+				outputXformCount[out.Name()]--
 			}
 		}
 	}

--- a/galley/pkg/config/analysis/analyzer_test.go
+++ b/galley/pkg/config/analysis/analyzer_test.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/galley/pkg/config/processing/transformer"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	resource2 "istio.io/istio/galley/pkg/config/schema/resource"
 )
 
 type analyzer struct {
@@ -57,28 +58,28 @@ func (ctx *context) Canceled() bool                                             
 func TestCombinedAnalyzer(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	col1 := collection.NewName("col1")
-	col2 := collection.NewName("col2")
-	col3 := collection.NewName("col3")
-	col4 := collection.NewName("col4")
+	col1 := newSchema("col1")
+	col2 := newSchema("col2")
+	col3 := newSchema("col3")
+	col4 := newSchema("col4")
 
-	a1 := &analyzer{name: "a1", inputs: collection.Names{col1}}
-	a2 := &analyzer{name: "a2", inputs: collection.Names{col2}}
-	a3 := &analyzer{name: "a3", inputs: collection.Names{col3}}
-	a4 := &analyzer{name: "a4", inputs: collection.Names{col4}}
+	a1 := &analyzer{name: "a1", inputs: collection.Names{col1.Name()}}
+	a2 := &analyzer{name: "a2", inputs: collection.Names{col2.Name()}}
+	a3 := &analyzer{name: "a3", inputs: collection.Names{col3.Name()}}
+	a4 := &analyzer{name: "a4", inputs: collection.Names{col4.Name()}}
 
 	xform := transformer.NewSimpleTransformerProvider(col3, col3, func(_ event.Event, _ event.Handler) {})
 
 	a := Combine("combined", a1, a2, a3, a4)
-	g.Expect(a.Metadata().Inputs).To(ConsistOf(col1, col2, col3, col4))
+	g.Expect(a.Metadata().Inputs).To(ConsistOf(col1.Name(), col2.Name(), col3.Name(), col4.Name()))
 
 	removed := a.RemoveSkipped(
-		collection.Names{col1, col2, col3},
-		collection.Names{col3},
+		collection.Names{col1.Name(), col2.Name(), col3.Name()},
+		collection.Names{col3.Name()},
 		transformer.Providers{xform})
 
 	g.Expect(removed).To(ConsistOf(a3.Metadata().Name, a4.Metadata().Name))
-	g.Expect(a.Metadata().Inputs).To(ConsistOf(col1, col2))
+	g.Expect(a.Metadata().Inputs).To(ConsistOf(col1.Name(), col2.Name()))
 
 	a.Analyze(&context{})
 
@@ -91,31 +92,31 @@ func TestCombinedAnalyzer(t *testing.T) {
 func TestGetDisabledOutputs(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	in1 := collection.NewName("in1")
-	in2 := collection.NewName("in2")
-	in3 := collection.NewName("in3")
-	in4 := collection.NewName("in4")
-	in5 := collection.NewName("in5")
-	out1 := collection.NewName("out1")
-	out2 := collection.NewName("out2")
-	out3 := collection.NewName("out3")
-	out4 := collection.NewName("out4")
+	in1 := newSchema("in1")
+	in2 := newSchema("in2")
+	in3 := newSchema("in3")
+	in4 := newSchema("in4")
+	in5 := newSchema("in5")
+	out1 := newSchema("out1")
+	out2 := newSchema("out2")
+	out3 := newSchema("out3")
+	out4 := newSchema("out4")
 
 	blankFn := func(_ processing.ProcessorOptions) event.Transformer {
-		return event.NewFnTransform(collection.Names{}, collection.Names{}, func() {}, func() {}, func(e event.Event, handler event.Handler) {})
+		return event.NewFnTransform(collection.SchemasFor(), collection.SchemasFor(), func() {}, func() {}, func(e event.Event, handler event.Handler) {})
 	}
 
 	xformProviders := transformer.Providers{
-		transformer.NewProvider(collection.Names{in1}, collection.Names{out1, out2}, blankFn),
-		transformer.NewProvider(collection.Names{in2}, collection.Names{out3}, blankFn),
-		transformer.NewProvider(collection.Names{in3}, collection.Names{out3}, blankFn),
-		transformer.NewProvider(collection.Names{in4, in5}, collection.Names{out4}, blankFn),
+		transformer.NewProvider(collection.SchemasFor(in1), collection.SchemasFor(out1, out2), blankFn),
+		transformer.NewProvider(collection.SchemasFor(in2), collection.SchemasFor(out3), blankFn),
+		transformer.NewProvider(collection.SchemasFor(in3), collection.SchemasFor(out3), blankFn),
+		transformer.NewProvider(collection.SchemasFor(in4, in5), collection.SchemasFor(out4), blankFn),
 	}
 
-	expectCollections(g, getDisabledOutputs(collection.Names{in1}, xformProviders), collection.Names{out1, out2})
-	expectCollections(g, getDisabledOutputs(collection.Names{in2}, xformProviders), collection.Names{})
-	expectCollections(g, getDisabledOutputs(collection.Names{in2, in3}, xformProviders), collection.Names{out3})
-	expectCollections(g, getDisabledOutputs(collection.Names{in4}, xformProviders), collection.Names{out4})
+	expectCollections(g, getDisabledOutputs(collection.Names{in1.Name()}, xformProviders), collection.Names{out1.Name(), out2.Name()})
+	expectCollections(g, getDisabledOutputs(collection.Names{in2.Name()}, xformProviders), collection.Names{})
+	expectCollections(g, getDisabledOutputs(collection.Names{in2.Name(), in3.Name()}, xformProviders), collection.Names{out3.Name()})
+	expectCollections(g, getDisabledOutputs(collection.Names{in4.Name()}, xformProviders), collection.Names{out4.Name()})
 }
 
 func expectCollections(g *GomegaWithT, actualSet map[collection.Name]struct{}, expectedCols collection.Names) {
@@ -123,4 +124,15 @@ func expectCollections(g *GomegaWithT, actualSet map[collection.Name]struct{}, e
 	for _, col := range expectedCols {
 		g.Expect(actualSet).To(HaveKey(col))
 	}
+}
+
+func newSchema(name string) collection.Schema {
+	return collection.Builder{
+		Name: name,
+		Schema: resource2.Builder{
+			Kind:         name,
+			ProtoPackage: "github.com/gogo/protobuf/types",
+			Proto:        "google.protobuf.Empty",
+		}.MustBuild(),
+	}.MustBuild()
 }

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/schema"
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/galley/pkg/config/schema/collections"
 	"istio.io/istio/galley/pkg/config/schema/snapshots"
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/source/kube"
@@ -131,7 +132,12 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (AnalysisResult, error) 
 	// Create a source representing mesh config. There should be exactly one of these.
 	meshsrc := meshcfg.NewInmemory()
 	meshsrc.Set(sa.meshCfg)
-	sa.sources = append(sa.sources, precedenceSourceInput{src: meshsrc, cols: collection.Names{meshcfg.IstioMeshconfig}})
+	sa.sources = append(sa.sources, precedenceSourceInput{
+		src: meshsrc,
+		cols: collection.Names{
+			collections.IstioMeshV1Alpha1MeshConfig.Name(),
+		},
+	})
 
 	var namespaces []resource.Namespace
 	if sa.namespace != "" {

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -84,8 +84,8 @@ func TestAnalyzersRun(t *testing.T) {
 	m := msg.NewInternalError(r, "msg")
 	a := &testAnalyzer{
 		fn: func(ctx analysis.Context) {
-			ctx.Exists(data.K8SCollection1, resource.NewFullName("", ""))
-			ctx.Report(data.K8SCollection1, m)
+			ctx.Exists(basicmeta.K8SCollection1.Name(), resource.NewFullName("", ""))
+			ctx.Report(basicmeta.K8SCollection1.Name(), m)
 		},
 	}
 
@@ -101,7 +101,7 @@ func TestAnalyzersRun(t *testing.T) {
 	result, err := sa.Analyze(cancel)
 	g.Expect(err).To(BeNil())
 	g.Expect(result.Messages).To(ConsistOf(m))
-	g.Expect(collectionAccessed).To(Equal(data.K8SCollection1))
+	g.Expect(collectionAccessed).To(Equal(basicmeta.K8SCollection1.Name()))
 	g.Expect(result.ExecutedAnalyzers).To(ConsistOf(a.Metadata().Name))
 }
 
@@ -116,8 +116,8 @@ func TestFilterOutputByNamespace(t *testing.T) {
 	msg2 := msg.NewInternalError(r2, "msg")
 	a := &testAnalyzer{
 		fn: func(ctx analysis.Context) {
-			ctx.Report(data.K8SCollection1, msg1)
-			ctx.Report(data.K8SCollection1, msg2)
+			ctx.Report(basicmeta.K8SCollection1.Name(), msg1)
+			ctx.Report(basicmeta.K8SCollection1.Name(), msg2)
 		},
 	}
 

--- a/galley/pkg/config/analysis/local/helpers_test.go
+++ b/galley/pkg/config/analysis/local/helpers_test.go
@@ -23,14 +23,14 @@ import (
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/source/kube/rt"
-	"istio.io/istio/galley/pkg/config/testing/data"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 )
 
 func createTestEvent(t *testing.T, k event.Kind, r *resource.Instance) event.Event {
 	t.Helper()
 	return event.Event{
 		Kind:     k,
-		Source:   data.K8SCollection1,
+		Source:   basicmeta.K8SCollection1,
 		Resource: r,
 	}
 }

--- a/galley/pkg/config/analysis/local/source.go
+++ b/galley/pkg/config/analysis/local/source.go
@@ -77,8 +77,9 @@ func (ph *precedenceHandler) Handle(e event.Event) {
 // handleFullSync handles FullSync events, which are a special case.
 // For each collection, we want to only send this once, after all upstream sources have sent theirs.
 func (ph *precedenceHandler) handleFullSync(e event.Event) {
-	ph.src.expectedCounts[e.Source]--
-	if ph.src.expectedCounts[e.Source] > 0 {
+	col := e.Source.Name()
+	ph.src.expectedCounts[col]--
+	if ph.src.expectedCounts[col] > 0 {
 		return
 	}
 	ph.src.handler.Handle(e)
@@ -88,7 +89,7 @@ func (ph *precedenceHandler) handleFullSync(e event.Event) {
 // For each event, only pass it along to the downstream handler if the source it came from
 // had equal or higher precedence on the current resource
 func (ph *precedenceHandler) handleEvent(e event.Event) {
-	key := fmt.Sprintf("%s/%s", e.Source, e.Resource.Metadata.FullName)
+	key := fmt.Sprintf("%s/%s", e.Source.Name(), e.Resource.Metadata.FullName)
 	curPrecedence, ok := ph.src.resourcePriority[key]
 	if ok && ph.precedence < curPrecedence {
 		return

--- a/galley/pkg/config/analysis/local/source_test.go
+++ b/galley/pkg/config/analysis/local/source_test.go
@@ -20,7 +20,7 @@ import (
 
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/schema/collection"
-	"istio.io/istio/galley/pkg/config/testing/data"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 )
 
@@ -29,7 +29,7 @@ func TestBasicSingleSource(t *testing.T) {
 
 	s1 := &fixtures.Source{}
 
-	psi := precedenceSourceInput{src: s1, cols: collection.Names{data.K8SCollection1}}
+	psi := precedenceSourceInput{src: s1, cols: collection.Names{basicmeta.K8SCollection1.Name()}}
 	ps := newPrecedenceSource([]precedenceSourceInput{psi})
 
 	h := &fixtures.Accumulator{}
@@ -52,8 +52,8 @@ func TestWaitAndCombineFullSync(t *testing.T) {
 	s1 := &fixtures.Source{}
 	s2 := &fixtures.Source{}
 
-	psi1 := precedenceSourceInput{src: s1, cols: collection.Names{data.K8SCollection1, data.Collection2}}
-	psi2 := precedenceSourceInput{src: s2, cols: collection.Names{data.K8SCollection1}}
+	psi1 := precedenceSourceInput{src: s1, cols: collection.Names{basicmeta.K8SCollection1.Name(), basicmeta.Collection2.Name()}}
+	psi2 := precedenceSourceInput{src: s2, cols: collection.Names{basicmeta.K8SCollection1.Name()}}
 
 	ps := newPrecedenceSource([]precedenceSourceInput{psi1, psi2})
 
@@ -74,7 +74,7 @@ func TestWaitAndCombineFullSync(t *testing.T) {
 
 	// Collection2 is only in one source, so we shouldn't wait for an event from both sources
 	e2 := createTestEvent(t, event.FullSync, nil)
-	e2.Source = data.Collection2
+	e2.Source = basicmeta.Collection2
 
 	s1.Handle(e2)
 	g.Expect(h.Events()).To(Equal([]event.Event{e1, e2}))
@@ -87,9 +87,9 @@ func TestPrecedence(t *testing.T) {
 	s2 := &fixtures.Source{}
 	s3 := &fixtures.Source{}
 
-	psi1 := precedenceSourceInput{src: s1, cols: collection.Names{data.K8SCollection1}}
-	psi2 := precedenceSourceInput{src: s2, cols: collection.Names{data.K8SCollection1}}
-	psi3 := precedenceSourceInput{src: s3, cols: collection.Names{data.K8SCollection1}}
+	psi1 := precedenceSourceInput{src: s1, cols: collection.Names{basicmeta.K8SCollection1.Name()}}
+	psi2 := precedenceSourceInput{src: s2, cols: collection.Names{basicmeta.K8SCollection1.Name()}}
+	psi3 := precedenceSourceInput{src: s3, cols: collection.Names{basicmeta.K8SCollection1.Name()}}
 
 	ps := newPrecedenceSource([]precedenceSourceInput{psi1, psi2, psi3})
 

--- a/galley/pkg/config/collection/instance.go
+++ b/galley/pkg/config/collection/instance.go
@@ -27,23 +27,28 @@ type ChangeNotifierFn func()
 // Instance is collection of resources, indexed by name.
 type Instance struct {
 	mu          sync.RWMutex // TODO: This lock will most likely cause contention. We should investigate whether removing it would help.
-	collection  collection.Name
+	schema      collection.Schema
 	generation  int64
 	resources   map[resource.FullName]*resource.Instance
 	copyOnWrite bool
 }
 
 // New returns a new collection.Instance
-func New(collection collection.Name) *Instance {
+func New(collection collection.Schema) *Instance {
 	return &Instance{
-		collection: collection,
-		resources:  make(map[resource.FullName]*resource.Instance),
+		schema:    collection,
+		resources: make(map[resource.FullName]*resource.Instance),
 	}
 }
 
 // Name of the collection
 func (c *Instance) Name() collection.Name {
-	return c.collection
+	return c.schema.Name()
+}
+
+// Schema for the collection.
+func (c *Instance) Schema() collection.Schema {
+	return c.schema
 }
 
 // Get the instance with the given name
@@ -124,7 +129,7 @@ func (c *Instance) Clone() *Instance {
 	defer c.mu.Unlock()
 	c.copyOnWrite = true
 	return &Instance{
-		collection:  c.collection,
+		schema:      c.schema,
 		generation:  c.generation,
 		resources:   c.resources,
 		copyOnWrite: true,

--- a/galley/pkg/config/collection/instance_test.go
+++ b/galley/pkg/config/collection/instance_test.go
@@ -21,13 +21,14 @@ import (
 
 	"istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 )
 
 func TestInstance_Basics(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	inst := collection.New(data.K8SCollection1)
+	inst := collection.New(basicmeta.K8SCollection1)
 
 	g.Expect(inst.Size()).To(Equal(0))
 
@@ -84,7 +85,7 @@ func TestInstance_Basics(t *testing.T) {
 func TestInstance_Clone(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	inst := collection.New(data.K8SCollection1)
+	inst := collection.New(basicmeta.K8SCollection1)
 	inst.Set(data.EntryN1I1V1)
 	inst.Set(data.EntryN2I2V2)
 
@@ -117,7 +118,7 @@ func TestInstance_Clone(t *testing.T) {
 func TestInstance_ForEach_False(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	inst := collection.New(data.K8SCollection1)
+	inst := collection.New(basicmeta.K8SCollection1)
 	inst.Set(data.EntryN1I1V2)
 	inst.Set(data.EntryN2I2V2)
 	inst.Set(data.EntryN3I3V1)
@@ -140,7 +141,7 @@ func TestInstance_ForEach_False(t *testing.T) {
 func TestInstance_Get(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	inst := collection.New(data.K8SCollection1)
+	inst := collection.New(basicmeta.K8SCollection1)
 	inst.Set(data.EntryN1I1V1)
 	inst.Set(data.EntryN3I3V1)
 

--- a/galley/pkg/config/collection/set.go
+++ b/galley/pkg/config/collection/set.go
@@ -26,11 +26,11 @@ type Set struct {
 	collections map[collection.Name]*Instance
 }
 
-// NewSet returns a new set of collections
-func NewSet(names []collection.Name) *Set {
+// NewSet returns a new set of collections for the given schemas.
+func NewSet(schemas collection.Schemas) *Set {
 	c := make(map[collection.Name]*Instance)
-	for _, n := range names {
-		c[n] = New(n)
+	for _, s := range schemas.All() {
+		c[s.Name()] = New(s)
 	}
 
 	return &Set{
@@ -42,7 +42,7 @@ func NewSet(names []collection.Name) *Set {
 func NewSetFromCollections(collections []*Instance) *Set {
 	c := make(map[collection.Name]*Instance, len(collections))
 	for _, col := range collections {
-		c[col.collection] = col
+		c[col.schema.Name()] = col
 	}
 
 	return &Set{

--- a/galley/pkg/config/collection/set_test.go
+++ b/galley/pkg/config/collection/set_test.go
@@ -21,17 +21,17 @@ import (
 
 	coll "istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/schema/collection"
-	"istio.io/istio/galley/pkg/config/testing/data"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 )
 
 func TestNewSet(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s := coll.NewSet([]collection.Name{data.K8SCollection1, data.Collection2})
+	s := coll.NewSet(collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).MustAdd(basicmeta.Collection2).Build())
 
-	s1 := s.Collection(data.K8SCollection1)
+	s1 := s.Collection(basicmeta.K8SCollection1.Name())
 	g.Expect(s1).NotTo(BeNil())
-	s2 := s.Collection(data.Collection2)
+	s2 := s.Collection(basicmeta.Collection2.Name())
 	g.Expect(s2).NotTo(BeNil())
 
 	s3 := s.Collection(collection.NewName("foobar"))
@@ -41,16 +41,16 @@ func TestNewSet(t *testing.T) {
 func TestNewSetFromCollections(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s1 := coll.New(data.K8SCollection1)
+	s1 := coll.New(basicmeta.K8SCollection1)
 	g.Expect(s1).NotTo(BeNil())
-	s2 := coll.New(data.Collection2)
+	s2 := coll.New(basicmeta.Collection2)
 	g.Expect(s2).NotTo(BeNil())
 
 	s := coll.NewSetFromCollections([]*coll.Instance{s1, s2})
 
-	c := s.Collection(data.K8SCollection1)
+	c := s.Collection(basicmeta.K8SCollection1.Name())
 	g.Expect(c).NotTo(BeNil())
-	c = s.Collection(data.Collection2)
+	c = s.Collection(basicmeta.Collection2.Name())
 	g.Expect(c).NotTo(BeNil())
 
 	c = s.Collection(collection.NewName("foobar"))
@@ -60,18 +60,18 @@ func TestNewSetFromCollections(t *testing.T) {
 func TestSet_Clone(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s1 := coll.New(data.K8SCollection1)
+	s1 := coll.New(basicmeta.K8SCollection1)
 	g.Expect(s1).NotTo(BeNil())
-	s2 := coll.New(data.Collection2)
+	s2 := coll.New(basicmeta.Collection2)
 	g.Expect(s2).NotTo(BeNil())
 
 	s := coll.NewSetFromCollections([]*coll.Instance{s1, s2})
 
 	s = s.Clone()
 
-	c := s.Collection(data.K8SCollection1)
+	c := s.Collection(basicmeta.K8SCollection1.Name())
 	g.Expect(c).NotTo(BeNil())
-	c = s.Collection(data.Collection2)
+	c = s.Collection(basicmeta.Collection2.Name())
 	g.Expect(c).NotTo(BeNil())
 
 	c = s.Collection(collection.NewName("foobar"))
@@ -81,12 +81,12 @@ func TestSet_Clone(t *testing.T) {
 func TestSet_Names(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s1 := coll.New(data.K8SCollection1)
-	s2 := coll.New(data.Collection2)
+	s1 := coll.New(basicmeta.K8SCollection1)
+	s2 := coll.New(basicmeta.Collection2)
 
 	s := coll.NewSetFromCollections([]*coll.Instance{s1, s2})
 	names := s.Names()
 	g.Expect(names).To(ConsistOf(
-		data.K8SCollection1,
-		data.Collection2))
+		basicmeta.K8SCollection1.Name(),
+		basicmeta.Collection2.Name()))
 }

--- a/galley/pkg/config/event/event.go
+++ b/galley/pkg/config/event/event.go
@@ -21,26 +21,37 @@ import (
 	"istio.io/istio/galley/pkg/config/schema/collection"
 )
 
+var _ fmt.Stringer = Event{}
+
 // Event represents a change that occurred against a resource in the source config system.
 type Event struct {
 	Kind Kind
 
-	// The collection that this event is emanating from.
-	Source collection.Name
+	// Source collection that this event is emanating from.
+	Source collection.Schema
 
 	// A single entry, in case the event is Added, Updated or Deleted.
 	Resource *resource.Instance
 }
 
+// SourceName is a utility method that returns the name of the source. If nil, returns "".
+func (e *Event) SourceName() collection.Name {
+	if e.Source != nil {
+		return e.Source.Name()
+	}
+	return ""
+}
+
 // IsSource checks whether the event has the appropriate source and returns false if it does not.
 func (e *Event) IsSource(s collection.Name) bool {
-	return e.Source == s
+	return e.SourceName() == s
 }
 
 // IsSourceAny checks whether the event has the appropriate source and returns false if it does not.
 func (e *Event) IsSourceAny(names ...collection.Name) bool {
+	name := e.SourceName()
 	for _, n := range names {
-		if n == e.Source {
+		if n == name {
 			return true
 		}
 	}
@@ -49,7 +60,7 @@ func (e *Event) IsSourceAny(names ...collection.Name) bool {
 }
 
 // WithSource returns a new event with the source changed to the given collection.Name, if the event.Kind != Reset.
-func (e *Event) WithSource(s collection.Name) Event {
+func (e *Event) WithSource(s collection.Schema) Event {
 	if e.Kind == Reset {
 		return *e
 	}
@@ -76,36 +87,36 @@ func (e *Event) Clone() Event {
 func (e Event) String() string {
 	switch e.Kind {
 	case Added, Updated, Deleted:
-		return fmt.Sprintf("[Event](%s: %v/%v)", e.Kind.String(), e.Source, e.Resource.Metadata.FullName)
+		return fmt.Sprintf("[Event](%s: %v/%v)", e.Kind.String(), e.SourceName(), e.Resource.Metadata.FullName)
 	case FullSync:
-		return fmt.Sprintf("[Event](%s: %v)", e.Kind.String(), e.Source)
+		return fmt.Sprintf("[Event](%s: %v)", e.Kind.String(), e.SourceName())
 	default:
 		return fmt.Sprintf("[Event](%s)", e.Kind.String())
 	}
 }
 
 // FullSyncFor creates a FullSync event for the given source.
-func FullSyncFor(source collection.Name) Event {
+func FullSyncFor(source collection.Schema) Event {
 	return Event{Kind: FullSync, Source: source}
 }
 
 // AddFor creates an Add event for the given source and entry.
-func AddFor(source collection.Name, r *resource.Instance) Event {
+func AddFor(source collection.Schema, r *resource.Instance) Event {
 	return Event{Kind: Added, Source: source, Resource: r}
 }
 
 // UpdateFor creates an Update event for the given source and entry.
-func UpdateFor(source collection.Name, r *resource.Instance) Event {
+func UpdateFor(source collection.Schema, r *resource.Instance) Event {
 	return Event{Kind: Updated, Source: source, Resource: r}
 }
 
 // DeleteForResource creates a Deleted event for the given source and entry.
-func DeleteForResource(source collection.Name, r *resource.Instance) Event {
+func DeleteForResource(source collection.Schema, r *resource.Instance) Event {
 	return Event{Kind: Deleted, Source: source, Resource: r}
 }
 
 // DeleteFor creates a Delete event for the given source and name.
-func DeleteFor(source collection.Name, name resource.FullName, v resource.Version) Event {
+func DeleteFor(source collection.Schema, name resource.FullName, v resource.Version) Event {
 	return DeleteForResource(source, &resource.Instance{
 		Metadata: resource.Metadata{
 			FullName: name,

--- a/galley/pkg/config/event/event_test.go
+++ b/galley/pkg/config/event/event_test.go
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package event
+package event_test
 
 import (
 	"strings"
 	"testing"
 
+	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/galley/pkg/config/testing/data"
 
 	. "github.com/onsi/gomega"
 
@@ -36,31 +38,31 @@ func TestEvent_String(t *testing.T) {
 	}
 
 	tests := []struct {
-		i   Event
+		i   event.Event
 		exp string
 	}{
 		{
-			i:   Event{},
+			i:   event.Event{},
 			exp: "[Event](None)",
 		},
 		{
-			i:   Event{Kind: Added, Resource: &e},
+			i:   event.Event{Kind: event.Added, Resource: &e},
 			exp: "[Event](Added: /ns1/rs1)",
 		},
 		{
-			i:   Event{Kind: Updated, Resource: &e},
+			i:   event.Event{Kind: event.Updated, Resource: &e},
 			exp: "[Event](Updated: /ns1/rs1)",
 		},
 		{
-			i:   Event{Kind: Deleted, Resource: &e},
+			i:   event.Event{Kind: event.Deleted, Resource: &e},
 			exp: "[Event](Deleted: /ns1/rs1)",
 		},
 		{
-			i:   Event{Kind: FullSync, Source: collection.NewName("foo")},
+			i:   event.Event{Kind: event.FullSync, Source: data.Foo},
 			exp: "[Event](FullSync: foo)",
 		},
 		{
-			i:   Event{Kind: Kind(99), Source: collection.NewName("foo")},
+			i:   event.Event{Kind: event.Kind(99), Source: data.Foo},
 			exp: "[Event](<<Unknown Kind 99>>)",
 		},
 	}
@@ -84,31 +86,31 @@ func TestEvent_DetailedString(t *testing.T) {
 	}
 
 	tests := []struct {
-		i      Event
+		i      event.Event
 		prefix string
 	}{
 		{
-			i:      Event{},
+			i:      event.Event{},
 			prefix: "[Event](None",
 		},
 		{
-			i:      Event{Kind: Added, Resource: &e},
+			i:      event.Event{Kind: event.Added, Resource: &e},
 			prefix: "[Event](Added: /ns1/rs1",
 		},
 		{
-			i:      Event{Kind: Updated, Resource: &e},
+			i:      event.Event{Kind: event.Updated, Resource: &e},
 			prefix: "[Event](Updated: /ns1/rs1",
 		},
 		{
-			i:      Event{Kind: Deleted, Resource: &e},
+			i:      event.Event{Kind: event.Deleted, Resource: &e},
 			prefix: "[Event](Deleted: /ns1/rs1",
 		},
 		{
-			i:      Event{Kind: FullSync, Source: collection.NewName("foo")},
+			i:      event.Event{Kind: event.FullSync, Source: data.Foo},
 			prefix: "[Event](FullSync: foo",
 		},
 		{
-			i:      Event{Kind: Kind(99), Source: collection.NewName("foo")},
+			i:      event.Event{Kind: event.Kind(99), Source: data.Foo},
 			prefix: "[Event](<<Unknown Kind 99>>",
 		},
 	}
@@ -138,7 +140,7 @@ func TestEvent_Clone(t *testing.T) {
 		Message: &types.Empty{},
 	}
 
-	e := Event{Kind: Added, Source: collection.NewName("boo"), Resource: &r}
+	e := event.Event{Kind: event.Added, Source: data.Boo, Resource: &r}
 
 	g.Expect(e.Clone()).To(Equal(e))
 }
@@ -146,11 +148,11 @@ func TestEvent_Clone(t *testing.T) {
 func TestEvent_FullSyncFor(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	e := FullSyncFor(collection.NewName("boo"))
+	e := event.FullSyncFor(data.Boo)
 
-	expected := Event{
-		Kind:   FullSync,
-		Source: collection.NewName("boo"),
+	expected := event.Event{
+		Kind:   event.FullSync,
+		Source: data.Boo,
 	}
 	g.Expect(e).To(Equal(expected))
 }
@@ -169,11 +171,11 @@ func TestEvent_AddFor(t *testing.T) {
 		Message: &types.Empty{},
 	}
 
-	e := AddFor(collection.NewName("boo"), &r)
+	e := event.AddFor(data.Boo, &r)
 
-	expected := Event{
-		Kind:     Added,
-		Source:   collection.NewName("boo"),
+	expected := event.Event{
+		Kind:     event.Added,
+		Source:   data.Boo,
 		Resource: &r,
 	}
 	g.Expect(e).To(Equal(expected))
@@ -193,11 +195,11 @@ func TestEvent_UpdateFor(t *testing.T) {
 		Message: &types.Empty{},
 	}
 
-	e := UpdateFor(collection.NewName("boo"), &r)
+	e := event.UpdateFor(data.Boo, &r)
 
-	expected := Event{
-		Kind:     Updated,
-		Source:   collection.NewName("boo"),
+	expected := event.Event{
+		Kind:     event.Updated,
+		Source:   data.Boo,
 		Resource: &r,
 	}
 	g.Expect(e).To(Equal(expected))
@@ -208,11 +210,11 @@ func TestEvent_DeleteFor(t *testing.T) {
 
 	n := resource.NewFullName("ns1", "rs1")
 	v := resource.Version("v1")
-	e := DeleteFor(collection.NewName("boo"), n, v)
+	e := event.DeleteFor(data.Boo, n, v)
 
-	expected := Event{
-		Kind:   Deleted,
-		Source: collection.NewName("boo"),
+	expected := event.Event{
+		Kind:   event.Deleted,
+		Source: data.Boo,
 		Resource: &resource.Instance{
 			Metadata: resource.Metadata{
 				FullName: n,
@@ -237,11 +239,11 @@ func TestEvent_UpdateForResource(t *testing.T) {
 		Message: &types.Empty{},
 	}
 
-	e := DeleteForResource(collection.NewName("boo"), &r)
+	e := event.DeleteForResource(data.Boo, &r)
 
-	expected := Event{
-		Kind:     Deleted,
-		Source:   collection.NewName("boo"),
+	expected := event.Event{
+		Kind:     event.Deleted,
+		Source:   data.Boo,
 		Resource: &r,
 	}
 	g.Expect(e).To(Equal(expected))
@@ -249,45 +251,45 @@ func TestEvent_UpdateForResource(t *testing.T) {
 
 func TestEvent_IsSource(t *testing.T) {
 	g := NewGomegaWithT(t)
-	e := Event{
-		Kind:   Deleted,
-		Source: collection.NewName("boo"),
+	e := event.Event{
+		Kind:   event.Deleted,
+		Source: data.Boo,
 	}
-	g.Expect(e.IsSource(collection.NewName("boo"))).To(BeTrue())
+	g.Expect(e.IsSource(data.Boo.Name())).To(BeTrue())
 	g.Expect(e.IsSource(collection.NewName("noo"))).To(BeFalse())
 }
 
 func TestEvent_IsSourceAny(t *testing.T) {
 	g := NewGomegaWithT(t)
-	e := Event{
-		Kind:   Deleted,
-		Source: collection.NewName("boo"),
+	e := event.Event{
+		Kind:   event.Deleted,
+		Source: data.Boo,
 	}
-	g.Expect(e.IsSourceAny(collection.NewName("foo"))).To(BeFalse())
-	g.Expect(e.IsSourceAny(collection.NewName("boo"))).To(BeTrue())
-	g.Expect(e.IsSourceAny(collection.NewName("boo"), collection.NewName("foo"))).To(BeTrue())
+	g.Expect(e.IsSourceAny(data.Foo.Name())).To(BeFalse())
+	g.Expect(e.IsSourceAny(data.Boo.Name())).To(BeTrue())
+	g.Expect(e.IsSourceAny(data.Boo.Name(), data.Foo.Name())).To(BeTrue())
 }
 
 func TestEvent_WithSource(t *testing.T) {
 	g := NewGomegaWithT(t)
-	oldCol := collection.NewName("boo")
-	e := Event{
-		Kind:   Deleted,
+	oldCol := data.Boo
+	e := event.Event{
+		Kind:   event.Deleted,
 		Source: oldCol,
 	}
-	newCol := collection.NewName("far")
+	newCol := data.Foo
 	a := e.WithSource(newCol)
-	g.Expect(a.Source).To(Equal(newCol))
-	g.Expect(e.Source).To(Equal(oldCol))
+	g.Expect(a.Source.Name()).To(Equal(newCol.Name()))
+	g.Expect(e.Source.Name()).To(Equal(oldCol.Name()))
 }
 
 func TestEvent_WithSource_Reset(t *testing.T) {
 	g := NewGomegaWithT(t)
-	e := Event{
-		Kind: Reset,
+	e := event.Event{
+		Kind: event.Reset,
 	}
-	newCol := collection.NewName("far")
+	newCol := data.Foo
 	a := e.WithSource(newCol)
-	g.Expect(a.Source).To(Equal(collection.EmptyName))
-	g.Expect(e.Source).To(Equal(collection.EmptyName))
+	g.Expect(a.Source).To(BeNil())
+	g.Expect(e.Source).To(BeNil())
 }

--- a/galley/pkg/config/event/handler_test.go
+++ b/galley/pkg/config/event/handler_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package event
+package event_test
 
 import (
 	"testing"
@@ -20,18 +20,19 @@ import (
 	"github.com/gogo/protobuf/types"
 	. "github.com/onsi/gomega"
 
+	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
 )
 
 func TestHandlerFromFn(t *testing.T) {
 	g := NewGomegaWithT(t)
-	var received Event
-	h := HandlerFromFn(func(e Event) {
+	var received event.Event
+	h := event.HandlerFromFn(func(e event.Event) {
 		received = e
 	})
 
-	sent := Event{
-		Kind: Added,
+	sent := event.Event{
+		Kind: event.Added,
 		Resource: &resource.Instance{
 			Message: &types.Empty{},
 		},
@@ -45,22 +46,22 @@ func TestHandlerFromFn(t *testing.T) {
 func TestHandlers(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	var received1 Event
-	h1 := HandlerFromFn(func(e Event) {
+	var received1 event.Event
+	h1 := event.HandlerFromFn(func(e event.Event) {
 		received1 = e
 	})
 
-	var received2 Event
-	h2 := HandlerFromFn(func(e Event) {
+	var received2 event.Event
+	h2 := event.HandlerFromFn(func(e event.Event) {
 		received2 = e
 	})
 
-	var hs Handlers
+	var hs event.Handlers
 	hs.Add(h1)
 	hs.Add(h2)
 
-	sent := Event{
-		Kind: Added,
+	sent := event.Event{
+		Kind: event.Added,
 		Resource: &resource.Instance{
 			Message: &types.Empty{},
 		},
@@ -75,20 +76,20 @@ func TestHandlers(t *testing.T) {
 func TestCombineHandlers(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	var received1 Event
-	h1 := HandlerFromFn(func(e Event) {
+	var received1 event.Event
+	h1 := event.HandlerFromFn(func(e event.Event) {
 		received1 = e
 	})
 
-	var received2 Event
-	h2 := HandlerFromFn(func(e Event) {
+	var received2 event.Event
+	h2 := event.HandlerFromFn(func(e event.Event) {
 		received2 = e
 	})
 
-	h3 := CombineHandlers(h1, h2)
+	h3 := event.CombineHandlers(h1, h2)
 
-	sent := Event{
-		Kind: Added,
+	sent := event.Event{
+		Kind: event.Added,
 		Resource: &resource.Instance{
 			Message: &types.Empty{},
 		},
@@ -103,15 +104,15 @@ func TestCombineHandlers(t *testing.T) {
 func TestCombineHandlers_Nil1(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	var received1 Event
-	h1 := HandlerFromFn(func(e Event) {
+	var received1 event.Event
+	h1 := event.HandlerFromFn(func(e event.Event) {
 		received1 = e
 	})
 
-	h3 := CombineHandlers(h1, nil)
+	h3 := event.CombineHandlers(h1, nil)
 
-	sent := Event{
-		Kind: Added,
+	sent := event.Event{
+		Kind: event.Added,
 		Resource: &resource.Instance{
 			Message: &types.Empty{},
 		},
@@ -125,15 +126,15 @@ func TestCombineHandlers_Nil1(t *testing.T) {
 func TestCombineHandlers_Nil2(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	var received1 Event
-	h1 := HandlerFromFn(func(e Event) {
+	var received1 event.Event
+	h1 := event.HandlerFromFn(func(e event.Event) {
 		received1 = e
 	})
 
-	h3 := CombineHandlers(nil, h1)
+	h3 := event.CombineHandlers(nil, h1)
 
-	sent := Event{
-		Kind: Added,
+	sent := event.Event{
+		Kind: event.Added,
 		Resource: &resource.Instance{
 			Message: &types.Empty{},
 		},
@@ -147,42 +148,42 @@ func TestCombineHandlers_Nil2(t *testing.T) {
 func TestCombineHandlers_MultipleHandlers(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	var received1 Event
-	h1 := HandlerFromFn(func(e Event) {
+	var received1 event.Event
+	h1 := event.HandlerFromFn(func(e event.Event) {
 		received1 = e
 	})
 
-	var received2 Event
-	h2 := HandlerFromFn(func(e Event) {
+	var received2 event.Event
+	h2 := event.HandlerFromFn(func(e event.Event) {
 		received2 = e
 	})
 
-	hs1 := &Handlers{}
+	hs1 := &event.Handlers{}
 	hs1.Add(h1)
 	hs1.Add(h2)
 
-	var received3 Event
-	h3 := HandlerFromFn(func(e Event) {
+	var received3 event.Event
+	h3 := event.HandlerFromFn(func(e event.Event) {
 		received3 = e
 	})
 
-	var received4 Event
-	h4 := HandlerFromFn(func(e Event) {
+	var received4 event.Event
+	h4 := event.HandlerFromFn(func(e event.Event) {
 		received4 = e
 	})
 
-	hs2 := &Handlers{}
+	hs2 := &event.Handlers{}
 	hs2.Add(h3)
 	hs2.Add(h4)
 
-	sent := Event{
-		Kind: Added,
+	sent := event.Event{
+		Kind: event.Added,
 		Resource: &resource.Instance{
 			Message: &types.Empty{},
 		},
 	}
 
-	hc := CombineHandlers(hs1, hs2)
+	hc := event.CombineHandlers(hs1, hs2)
 	hc.Handle(sent)
 
 	g.Expect(received1).To(Equal(sent))
@@ -192,9 +193,9 @@ func TestCombineHandlers_MultipleHandlers(t *testing.T) {
 }
 
 func TestSentinelHandler(t *testing.T) {
-	h := SentinelHandler()
-	e := Event{
-		Kind: Added,
+	h := event.SentinelHandler()
+	e := event.Event{
+		Kind: event.Added,
 		Resource: &resource.Instance{
 			Message: &types.Empty{},
 		},

--- a/galley/pkg/config/event/kind_test.go
+++ b/galley/pkg/config/event/kind_test.go
@@ -12,21 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package event
+package event_test
 
 import (
 	"testing"
+
+	"istio.io/istio/galley/pkg/config/event"
 )
 
 func TestEventKind_String(t *testing.T) {
-	tests := map[Kind]string{
-		None:     "None",
-		Added:    "Added",
-		Updated:  "Updated",
-		Deleted:  "Deleted",
-		FullSync: "FullSync",
-		Reset:    "Reset",
-		55:       "<<Unknown Kind 55>>",
+	tests := map[event.Kind]string{
+		event.None:     "None",
+		event.Added:    "Added",
+		event.Updated:  "Updated",
+		event.Deleted:  "Deleted",
+		event.FullSync: "FullSync",
+		event.Reset:    "Reset",
+		55:             "<<Unknown Kind 55>>",
 	}
 
 	for i, e := range tests {

--- a/galley/pkg/config/event/queue_test.go
+++ b/galley/pkg/config/event/queue_test.go
@@ -41,7 +41,7 @@ func TestQueueWrapEmpty(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		a := wrap(i, 0)
-		g.Expect(a).To((Equal(i)))
+		g.Expect(a).To(Equal(i))
 	}
 }
 

--- a/galley/pkg/config/event/router.go
+++ b/galley/pkg/config/event/router.go
@@ -40,7 +40,7 @@ func (r *emptyRouter) Handle(_ Event) {}
 func (r *emptyRouter) Broadcast(_ Event) {}
 
 type singleRouter struct {
-	source  collection.Name
+	source  collection.Schema
 	handler Handler
 }
 
@@ -48,7 +48,7 @@ var _ Router = &singleRouter{}
 
 // Handle implements Handler
 func (r *singleRouter) Handle(e Event) {
-	if e.Kind == Reset || e.IsSource(r.source) {
+	if e.Kind == Reset || e.IsSource(r.source.Name()) {
 		r.handler.Handle(e)
 	}
 }
@@ -61,16 +61,16 @@ func (r *singleRouter) Broadcast(e Event) {
 
 // Router distributes events to multiple different handlers, based on collection name.
 type router struct {
-	handlers map[collection.Name]Handler
+	routers map[collection.Name]*singleRouter
 }
 
 var _ Router = &router{}
 
 // Handle implements Handler
 func (r *router) Handle(e Event) {
-	h, found := r.handlers[e.Source]
+	h, found := r.routers[e.SourceName()]
 	if found {
-		h.Handle(e)
+		h.handler.Handle(e)
 	} else {
 		scope.Processing.Warna("Router.Handle: No handler for event, dropping: ", e)
 	}
@@ -78,9 +78,9 @@ func (r *router) Handle(e Event) {
 
 // Broadcast implements Router
 func (r *router) Broadcast(e Event) {
-	for d, h := range r.handlers {
-		e = e.WithSource(d)
-		h.Handle(e)
+	for _, h := range r.routers {
+		e = e.WithSource(h.source)
+		h.handler.Handle(e)
 	}
 }
 
@@ -90,7 +90,7 @@ func NewRouter() Router {
 }
 
 // AddToRouter adds the given handler for the given source collection.
-func AddToRouter(r Router, source collection.Name, handler Handler) Router {
+func AddToRouter(r Router, source collection.Schema, handler Handler) Router {
 	if r == nil {
 		return &singleRouter{
 			source:  source,
@@ -113,21 +113,33 @@ func AddToRouter(r Router, source collection.Name, handler Handler) Router {
 			}
 		}
 		s := &router{
-			handlers: make(map[collection.Name]Handler),
+			routers: make(map[collection.Name]*singleRouter),
 		}
-		s.handlers[v.source] = v.handler
-		s.handlers[source] = handler
+		s.routers[v.source.Name()] = &singleRouter{
+			source:  v.source,
+			handler: v.handler,
+		}
+		s.routers[source.Name()] = &singleRouter{
+			source:  source,
+			handler: handler,
+		}
 		return s
 
 	case *router:
 		s := &router{
-			handlers: make(map[collection.Name]Handler),
+			routers: make(map[collection.Name]*singleRouter),
 		}
-		for k, v := range v.handlers {
-			s.handlers[k] = v
+		for name, router := range v.routers {
+			s.routers[name] = router
 		}
-		old := s.handlers[source]
-		s.handlers[source] = CombineHandlers(old, handler)
+		var oldHandler Handler
+		if old := s.routers[source.Name()]; old != nil {
+			oldHandler = old.handler
+		}
+		s.routers[source.Name()] = &singleRouter{
+			source:  source,
+			handler: CombineHandlers(oldHandler, handler),
+		}
 		return s
 
 	default:

--- a/galley/pkg/config/event/router_test.go
+++ b/galley/pkg/config/event/router_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 )
@@ -36,7 +37,7 @@ func TestRouter_Single_Handle(t *testing.T) {
 
 	s := event.NewRouter()
 	acc := &fixtures.Accumulator{}
-	s = event.AddToRouter(s, data.K8SCollection1, acc)
+	s = event.AddToRouter(s, basicmeta.K8SCollection1, acc)
 	s.Handle(data.Event1Col1AddItem1)
 
 	g.Expect(acc.Events()).To(HaveLen(1))
@@ -47,7 +48,7 @@ func TestRouter_Single_Handle_AddToNil(t *testing.T) {
 
 	var s event.Router
 	acc := &fixtures.Accumulator{}
-	s = event.AddToRouter(s, data.K8SCollection1, acc)
+	s = event.AddToRouter(s, basicmeta.K8SCollection1, acc)
 	s.Handle(data.Event1Col1AddItem1)
 
 	g.Expect(acc.Events()).To(HaveLen(1))
@@ -58,7 +59,7 @@ func TestRouter_Single_Handle_NoMatch(t *testing.T) {
 
 	s := event.NewRouter()
 	acc := &fixtures.Accumulator{}
-	s = event.AddToRouter(s, data.Collection2, acc)
+	s = event.AddToRouter(s, basicmeta.Collection2, acc)
 	s.Handle(data.Event1Col1AddItem1)
 
 	g.Expect(acc.Events()).To(HaveLen(0))
@@ -70,8 +71,8 @@ func TestRouter_Single_MultiListener(t *testing.T) {
 	s := event.NewRouter()
 	acc1 := &fixtures.Accumulator{}
 	acc2 := &fixtures.Accumulator{}
-	s = event.AddToRouter(s, data.K8SCollection1, acc1)
-	s = event.AddToRouter(s, data.K8SCollection1, acc2)
+	s = event.AddToRouter(s, basicmeta.K8SCollection1, acc1)
+	s = event.AddToRouter(s, basicmeta.K8SCollection1, acc2)
 	s.Handle(data.Event1Col1AddItem1)
 
 	g.Expect(acc1.Events()).To(HaveLen(1))
@@ -83,7 +84,7 @@ func TestRouter_Single_Broadcast(t *testing.T) {
 
 	s := event.NewRouter()
 	acc := &fixtures.Accumulator{}
-	s = event.AddToRouter(s, data.K8SCollection1, acc)
+	s = event.AddToRouter(s, basicmeta.K8SCollection1, acc)
 	s.Broadcast(event.Event{Kind: event.Reset})
 
 	g.Expect(acc.Events()).To(HaveLen(1))
@@ -96,9 +97,9 @@ func TestRouter_Multi_Handle(t *testing.T) {
 	acc1 := &fixtures.Accumulator{}
 	acc2 := &fixtures.Accumulator{}
 	acc3 := &fixtures.Accumulator{}
-	s = event.AddToRouter(s, data.K8SCollection1, acc1)
-	s = event.AddToRouter(s, data.Collection2, acc2)
-	s = event.AddToRouter(s, data.Collection3, acc3)
+	s = event.AddToRouter(s, basicmeta.K8SCollection1, acc1)
+	s = event.AddToRouter(s, basicmeta.Collection2, acc2)
+	s = event.AddToRouter(s, data.Foo, acc3)
 	s.Handle(data.Event1Col1AddItem1)
 	s.Handle(data.Event3Col2AddItem1)
 
@@ -113,8 +114,8 @@ func TestRouter_Multi_NoTarget(t *testing.T) {
 	s := event.NewRouter()
 	acc1 := &fixtures.Accumulator{}
 	acc2 := &fixtures.Accumulator{}
-	s = event.AddToRouter(s, data.K8SCollection1, acc1)
-	s = event.AddToRouter(s, data.Collection3, acc2)
+	s = event.AddToRouter(s, basicmeta.K8SCollection1, acc1)
+	s = event.AddToRouter(s, data.Foo, acc2)
 	s.Handle(data.Event3Col2AddItem1)
 
 	g.Expect(acc1.Events()).To(HaveLen(0))
@@ -128,9 +129,9 @@ func TestRouter_Multi_Broadcast(t *testing.T) {
 	acc1 := &fixtures.Accumulator{}
 	acc2 := &fixtures.Accumulator{}
 	acc3 := &fixtures.Accumulator{}
-	s = event.AddToRouter(s, data.K8SCollection1, acc1)
-	s = event.AddToRouter(s, data.Collection2, acc2)
-	s = event.AddToRouter(s, data.Collection3, acc3)
+	s = event.AddToRouter(s, basicmeta.K8SCollection1, acc1)
+	s = event.AddToRouter(s, basicmeta.Collection2, acc2)
+	s = event.AddToRouter(s, data.Foo, acc3)
 	s.Broadcast(event.Event{Kind: event.Reset})
 
 	g.Expect(acc1.Events()).To(HaveLen(1))
@@ -145,12 +146,12 @@ func TestRouter_Multi_Unknown_Panic(t *testing.T) {
 		r := recover()
 		g.Expect(r).ToNot(BeNil())
 	}()
-	_ = event.AddToRouter(&unknownSelector{}, data.Collection3, &fixtures.Accumulator{})
+	_ = event.AddToRouter(&unknownSelector{}, data.Foo, &fixtures.Accumulator{})
 }
 
 type unknownSelector struct{}
 
 var _ event.Router = &unknownSelector{}
 
-func (u *unknownSelector) Handle(e event.Event)    {}
-func (u *unknownSelector) Broadcast(e event.Event) {}
+func (u *unknownSelector) Handle(event.Event)    {}
+func (u *unknownSelector) Broadcast(event.Event) {}

--- a/galley/pkg/config/event/transformer.go
+++ b/galley/pkg/config/event/transformer.go
@@ -33,19 +33,20 @@ type Transformer interface {
 	Processor
 
 	// DispatchFor registers the given handler for a particular output collection.
-	DispatchFor(c collection.Name, h Handler)
+	DispatchFor(c collection.Schema, h Handler)
 
 	// Inputs for this transformer
-	Inputs() collection.Names
+	Inputs() collection.Schemas
 
 	// Outputs for this transformer
-	Outputs() collection.Names
+	Outputs() collection.Schemas
 }
 
 // FnTransform is a base type for handling common Transformer operations.
 type FnTransform struct {
-	in       collection.Names
-	out      collection.Names
+	in       collection.Schemas
+	inNames  collection.Names
+	out      collection.Schemas
 	selector Router
 	startFn  func()
 	stopFn   func()
@@ -53,13 +54,15 @@ type FnTransform struct {
 	syncCtr  int32
 }
 
+var _ Transformer = &FnTransform{}
+
 // Inputs partially implements Transformer
-func (t *FnTransform) Inputs() collection.Names {
+func (t *FnTransform) Inputs() collection.Schemas {
 	return t.in
 }
 
 // Outputs partially implements Transformer
-func (t *FnTransform) Outputs() collection.Names {
+func (t *FnTransform) Outputs() collection.Schemas {
 	return t.out
 }
 
@@ -70,7 +73,7 @@ func (t *FnTransform) Start() {
 		t.selector = NewRouter()
 	}
 
-	atomic.StoreInt32(&t.syncCtr, int32(len(t.in)))
+	atomic.StoreInt32(&t.syncCtr, int32(len(t.inNames)))
 
 	if t.startFn != nil {
 		t.startFn()
@@ -86,7 +89,7 @@ func (t *FnTransform) Stop() {
 }
 
 // DispatchFor implements Transformer
-func (t *FnTransform) DispatchFor(c collection.Name, h Handler) {
+func (t *FnTransform) DispatchFor(c collection.Schema, h Handler) {
 	scope.Processing.Debugf("FnTransform.DispatchFor: %v => %T", c, h)
 	t.selector = AddToRouter(t.selector, c, h)
 }
@@ -98,7 +101,7 @@ func (t *FnTransform) Handle(e Event) {
 		return
 	}
 
-	if !e.IsSourceAny(t.in...) {
+	if !e.IsSourceAny(t.inNames...) {
 		scope.Processing.Warnf("Event with unexpected source received: %v", e)
 		return
 	}
@@ -122,9 +125,10 @@ func (t *FnTransform) Handle(e Event) {
 }
 
 // NewFnTransform returns a Transformer based on the given start, stop and input event handler functions.
-func NewFnTransform(inputs, outputs collection.Names, startFn, stopFn func(), fn func(e Event, handler Handler)) *FnTransform {
+func NewFnTransform(inputs, outputs collection.Schemas, startFn, stopFn func(), fn func(e Event, handler Handler)) *FnTransform {
 	return &FnTransform{
 		in:       inputs,
+		inNames:  inputs.CollectionNames(),
 		out:      outputs,
 		startFn:  startFn,
 		stopFn:   stopFn,

--- a/galley/pkg/config/event/transformer_test.go
+++ b/galley/pkg/config/event/transformer_test.go
@@ -28,8 +28,8 @@ import (
 func TestTransformer_Basics(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	inputs := collection.Names{collection.NewName("foo"), collection.NewName("bar")}
-	outputs := collection.Names{collection.NewName("boo"), collection.NewName("baz")}
+	inputs := collection.NewSchemasBuilder().MustAdd(data.Foo).MustAdd(data.Bar).Build()
+	outputs := collection.NewSchemasBuilder().MustAdd(data.Boo).MustAdd(data.Baz).Build()
 
 	var started, stopped bool
 	xform := event.NewFnTransform(
@@ -57,12 +57,8 @@ func TestTransformer_Basics(t *testing.T) {
 func TestTransformer_Selection(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	foo := collection.NewName("foo")
-	bar := collection.NewName("bar")
-	boo := collection.NewName("boo")
-	baz := collection.NewName("baz")
-	inputs := collection.Names{foo, bar}
-	outputs := collection.Names{boo, baz}
+	inputs := collection.NewSchemasBuilder().MustAdd(data.Foo).MustAdd(data.Bar).Build()
+	outputs := collection.NewSchemasBuilder().MustAdd(data.Boo).MustAdd(data.Baz).Build()
 
 	xform := event.NewFnTransform(
 		inputs,
@@ -71,40 +67,38 @@ func TestTransformer_Selection(t *testing.T) {
 		nil,
 		func(e event.Event, h event.Handler) {
 			// Simply translate events
-			if e.IsSource(foo) {
-				h.Handle(e.WithSource(boo))
+			if e.IsSource(data.Foo.Name()) {
+				h.Handle(e.WithSource(data.Boo))
 			}
-			if e.IsSource(bar) {
-				h.Handle(e.WithSource(baz))
+			if e.IsSource(data.Bar.Name()) {
+				h.Handle(e.WithSource(data.Baz))
 			}
 		},
 	)
 
 	accBoo := &fixtures.Accumulator{}
 	accBaz := &fixtures.Accumulator{}
-	xform.DispatchFor(boo, accBoo)
-	xform.DispatchFor(baz, accBaz)
+	xform.DispatchFor(data.Boo, accBoo)
+	xform.DispatchFor(data.Baz, accBaz)
 
 	xform.Start()
 
-	xform.Handle(data.Event1Col1AddItem1.WithSource(foo))
-	xform.Handle(data.Event1Col1AddItem1.WithSource(bar))
+	xform.Handle(data.Event1Col1AddItem1.WithSource(data.Foo))
+	xform.Handle(data.Event1Col1AddItem1.WithSource(data.Bar))
 
 	g.Expect(accBoo.Events()).To(ConsistOf(
-		data.Event1Col1AddItem1.WithSource(boo),
+		data.Event1Col1AddItem1.WithSource(data.Boo),
 	))
 	g.Expect(accBaz.Events()).To(ConsistOf(
-		data.Event1Col1AddItem1.WithSource(baz),
+		data.Event1Col1AddItem1.WithSource(data.Baz),
 	))
 }
 
 func TestTransformer_InvalidEvent(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	foo := collection.NewName("foo")
-	bar := collection.NewName("bar")
-	inputs := collection.Names{foo}
-	outputs := collection.Names{bar}
+	inputs := collection.NewSchemasBuilder().MustAdd(data.Foo).Build()
+	outputs := collection.NewSchemasBuilder().MustAdd(data.Bar).Build()
 
 	xform := event.NewFnTransform(
 		inputs,
@@ -113,18 +107,18 @@ func TestTransformer_InvalidEvent(t *testing.T) {
 		nil,
 		func(e event.Event, h event.Handler) {
 			// Simply translate events
-			if e.IsSource(foo) {
-				h.Handle(e.WithSource(bar))
+			if e.IsSource(data.Foo.Name()) {
+				h.Handle(e.WithSource(data.Bar))
 			}
 		},
 	)
 
 	acc := &fixtures.Accumulator{}
-	xform.DispatchFor(bar, acc)
+	xform.DispatchFor(data.Bar, acc)
 
 	xform.Start()
 
-	xform.Handle(data.Event1Col1AddItem1.WithSource(bar))
+	xform.Handle(data.Event1Col1AddItem1.WithSource(data.Bar))
 
 	g.Expect(acc.Events()).To(BeEmpty())
 }
@@ -132,11 +126,8 @@ func TestTransformer_InvalidEvent(t *testing.T) {
 func TestTransformer_Reset(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	foo := collection.NewName("foo")
-	bar := collection.NewName("bar")
-	baz := collection.NewName("baz")
-	inputs := collection.Names{foo}
-	outputs := collection.Names{bar, baz}
+	inputs := collection.NewSchemasBuilder().MustAdd(data.Foo).Build()
+	outputs := collection.NewSchemasBuilder().MustAdd(data.Bar).MustAdd(data.Baz).Build()
 
 	xform := event.NewFnTransform(
 		inputs,
@@ -145,16 +136,16 @@ func TestTransformer_Reset(t *testing.T) {
 		nil,
 		func(e event.Event, h event.Handler) {
 			// Simply translate events
-			if e.IsSource(foo) {
-				h.Handle(e.WithSource(bar))
+			if e.IsSource(data.Foo.Name()) {
+				h.Handle(e.WithSource(data.Bar))
 			}
 		},
 	)
 
 	accBar := &fixtures.Accumulator{} // it is a trap!
-	xform.DispatchFor(bar, accBar)
+	xform.DispatchFor(data.Bar, accBar)
 	accBaz := &fixtures.Accumulator{}
-	xform.DispatchFor(baz, accBaz)
+	xform.DispatchFor(data.Baz, accBaz)
 
 	xform.Start()
 
@@ -171,12 +162,8 @@ func TestTransformer_Reset(t *testing.T) {
 func TestTransformer_FullSync(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	foo := collection.NewName("foo")
-	bar := collection.NewName("bar")
-	boo := collection.NewName("boo")
-	baz := collection.NewName("baz")
-	inputs := collection.Names{foo, bar}
-	outputs := collection.Names{boo, baz}
+	inputs := collection.NewSchemasBuilder().MustAdd(data.Foo).MustAdd(data.Bar).Build()
+	outputs := collection.NewSchemasBuilder().MustAdd(data.Boo).MustAdd(data.Baz).Build()
 
 	xform := event.NewFnTransform(
 		inputs,
@@ -185,29 +172,29 @@ func TestTransformer_FullSync(t *testing.T) {
 		nil,
 		func(e event.Event, h event.Handler) {
 			// Simply translate events
-			if e.IsSource(foo) {
-				h.Handle(e.WithSource(boo))
+			if e.IsSource(data.Foo.Name()) {
+				h.Handle(e.WithSource(data.Boo))
 			}
-			if e.IsSource(bar) {
-				h.Handle(e.WithSource(baz))
+			if e.IsSource(data.Bar.Name()) {
+				h.Handle(e.WithSource(data.Baz))
 			}
 		},
 	)
 
 	accBoo := &fixtures.Accumulator{}
 	accBaz := &fixtures.Accumulator{}
-	xform.DispatchFor(boo, accBoo)
-	xform.DispatchFor(baz, accBaz)
+	xform.DispatchFor(data.Boo, accBoo)
+	xform.DispatchFor(data.Baz, accBaz)
 
 	xform.Start()
 
-	xform.Handle(event.FullSyncFor(foo))
+	xform.Handle(event.FullSyncFor(data.Foo))
 	g.Expect(accBoo.Events()).To(BeEmpty())
 	g.Expect(accBaz.Events()).To(BeEmpty())
 
-	xform.Handle(event.FullSyncFor(bar))
-	g.Expect(accBoo.Events()).To(ConsistOf(event.FullSyncFor(boo)))
-	g.Expect(accBaz.Events()).To(ConsistOf(event.FullSyncFor(baz)))
+	xform.Handle(event.FullSyncFor(data.Bar))
+	g.Expect(accBoo.Events()).To(ConsistOf(event.FullSyncFor(data.Boo)))
+	g.Expect(accBaz.Events()).To(ConsistOf(event.FullSyncFor(data.Baz)))
 
 	// redo
 	accBoo.Clear()
@@ -215,11 +202,11 @@ func TestTransformer_FullSync(t *testing.T) {
 	xform.Stop()
 	xform.Start()
 
-	xform.Handle(event.FullSyncFor(bar))
+	xform.Handle(event.FullSyncFor(data.Bar))
 	g.Expect(accBoo.Events()).To(BeEmpty())
 	g.Expect(accBaz.Events()).To(BeEmpty())
 
-	xform.Handle(event.FullSyncFor(foo))
-	g.Expect(accBoo.Events()).To(ConsistOf(event.FullSyncFor(boo)))
-	g.Expect(accBaz.Events()).To(ConsistOf(event.FullSyncFor(baz)))
+	xform.Handle(event.FullSyncFor(data.Foo))
+	g.Expect(accBoo.Events()).To(ConsistOf(event.FullSyncFor(data.Boo)))
+	g.Expect(accBaz.Events()).To(ConsistOf(event.FullSyncFor(data.Baz)))
 }

--- a/galley/pkg/config/meshcfg/const.go
+++ b/galley/pkg/config/meshcfg/const.go
@@ -16,12 +16,7 @@ package meshcfg
 
 import (
 	"istio.io/istio/galley/pkg/config/resource"
-	"istio.io/istio/galley/pkg/config/schema/collection"
 )
-
-// IstioMeshconfig is the name of collection istio/meshconfig
-// It is captured here explicitly, as some of the core pieces of code need to reference this.
-var IstioMeshconfig = collection.NewName("istio/mesh/v1alpha1/MeshConfig")
 
 // ResourceName for the Istio Mesh Config resource
 var ResourceName = resource.NewFullName("istio-system", "meshconfig")

--- a/galley/pkg/config/meshcfg/fs_test.go
+++ b/galley/pkg/config/meshcfg/fs_test.go
@@ -29,6 +29,7 @@ import (
 
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/schema/collections"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 )
 
@@ -51,20 +52,21 @@ func TestFsSource_NoInitialFile(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: Default(),
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 }
 
 func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
@@ -86,20 +88,21 @@ func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: Default(),
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 
 	acc.Clear()
 	mcfg := Default()
@@ -109,10 +112,10 @@ func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
 	expected = []event.Event{
 		{
 			Kind:   event.Reset,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(ContainElement(expected[0]))
+	fixtures.ExpectEventsEventually(t, acc, expected[0])
 }
 
 func TestFsSource_InitialFile_UpdateAfterStart(t *testing.T) {
@@ -136,20 +139,21 @@ func TestFsSource_InitialFile_UpdateAfterStart(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: mcfg,
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 
 	acc.Clear()
 	mcfg2 := Default()
@@ -159,10 +163,10 @@ func TestFsSource_InitialFile_UpdateAfterStart(t *testing.T) {
 	expected = []event.Event{
 		{
 			Kind:   event.Reset,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(ContainElement(expected[0]))
+	fixtures.ExpectEventsEventually(t, acc, expected[0])
 }
 
 func TestFsSource_InitialFile(t *testing.T) {
@@ -186,20 +190,21 @@ func TestFsSource_InitialFile(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: mcfg,
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 }
 
 func TestFsSource_StartStopStart(t *testing.T) {
@@ -222,27 +227,28 @@ func TestFsSource_StartStopStart(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: mcfg,
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 
 	acc.Clear()
 	fs.Stop()
 	g.Consistently(acc.Events()).Should(HaveLen(0))
 
 	fs.Start()
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 }
 
 func TestFsSource_FileRemoved_NoChange(t *testing.T) {
@@ -265,20 +271,21 @@ func TestFsSource_FileRemoved_NoChange(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: mcfg,
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 	acc.Clear()
 
 	err = os.Remove(file)
@@ -308,20 +315,21 @@ func TestFsSource_BogusFile_NoChange(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: mcfg,
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 	acc.Clear()
 
 	err = ioutil.WriteFile(file, []byte(":@#Hallo!"), os.ModePerm)
@@ -388,18 +396,19 @@ func TestFsSource_YamlToJSONError(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: Default(),
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 }

--- a/galley/pkg/config/meshcfg/inmemory.go
+++ b/galley/pkg/config/meshcfg/inmemory.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/schema/collections"
 )
 
 // InMemorySource is an event.InMemorySource implementation for meshconfig. When the mesh config is first set, add & fullsync events
@@ -107,7 +108,7 @@ func (s *InMemorySource) send(k event.Kind) {
 	// must be called under lock
 	e := event.Event{
 		Kind:   k,
-		Source: IstioMeshconfig,
+		Source: collections.IstioMeshV1Alpha1MeshConfig,
 	}
 
 	switch k {
@@ -115,6 +116,7 @@ func (s *InMemorySource) send(k event.Kind) {
 		e.Resource = &resource.Instance{
 			Metadata: resource.Metadata{
 				FullName: ResourceName,
+				Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 			},
 			Message: proto.Clone(s.current),
 		}

--- a/galley/pkg/config/meshcfg/inmemory_test.go
+++ b/galley/pkg/config/meshcfg/inmemory_test.go
@@ -21,6 +21,7 @@ import (
 
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/schema/collections"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 )
 
@@ -55,20 +56,21 @@ func TestInMemorySource_SetBeforeStart(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: ResourceName,
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: Default(),
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 }
 
 func TestInMemorySource_SetAfterStart(t *testing.T) {
@@ -86,20 +88,21 @@ func TestInMemorySource_SetAfterStart(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: ResourceName,
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: Default(),
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 }
 
 func TestInMemorySource_DoubleStart(t *testing.T) {
@@ -118,20 +121,21 @@ func TestInMemorySource_DoubleStart(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: ResourceName,
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: Default(),
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 }
 
 func TestInMemorySource_StartStop(t *testing.T) {
@@ -153,25 +157,24 @@ func TestInMemorySource_StartStop(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: ResourceName,
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: Default(),
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 }
 
 func TestInMemorySource_ResetOnUpdate(t *testing.T) {
-	g := NewGomegaWithT(t)
-
 	s := NewInmemory()
 
 	acc := &fixtures.Accumulator{}
@@ -186,22 +189,23 @@ func TestInMemorySource_ResetOnUpdate(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.Added,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: ResourceName,
+					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: Default(),
 			},
 		},
 		{
 			Kind:   event.FullSync,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 		{
 			Kind:   event.Reset,
-			Source: IstioMeshconfig,
+			Source: collections.IstioMeshV1Alpha1MeshConfig,
 		},
 	}
-	g.Eventually(acc.Events).Should(Equal(expected))
+	fixtures.ExpectEventsEventually(t, acc, expected...)
 }

--- a/galley/pkg/config/meshcfg/metadata_test.go
+++ b/galley/pkg/config/meshcfg/metadata_test.go
@@ -18,11 +18,12 @@ import (
 	"testing"
 
 	"istio.io/istio/galley/pkg/config/schema"
+	"istio.io/istio/galley/pkg/config/schema/collections"
 )
 
 func TestMeshConfigNameValidity(t *testing.T) {
 	m := schema.MustGet()
-	_, found := m.AllCollections().Find(IstioMeshconfig.String())
+	_, found := m.AllCollections().Find(collections.IstioMeshV1Alpha1MeshConfig.Name().String())
 	if !found {
 		t.Fatalf("Mesh config collection not found in metadata.")
 	}

--- a/galley/pkg/config/processing/session.go
+++ b/galley/pkg/config/processing/session.go
@@ -24,6 +24,7 @@ import (
 
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/meshcfg"
+	"istio.io/istio/galley/pkg/config/schema/collections"
 	"istio.io/istio/galley/pkg/config/scope"
 )
 
@@ -221,7 +222,7 @@ func (s *session) handle(e event.Event) {
 	if e.Kind != event.Reset {
 		s.buffer.Handle(e)
 
-		if e.Source == meshcfg.IstioMeshconfig {
+		if e.SourceName() == collections.IstioMeshV1Alpha1MeshConfig.Name() {
 			s.handleMeshEvent(e)
 		}
 		return

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -25,9 +25,10 @@ import (
 	coll "istio.io/istio/galley/pkg/config/collection"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	resource2 "istio.io/istio/galley/pkg/config/schema/resource"
 	"istio.io/istio/galley/pkg/config/schema/snapshots"
 	"istio.io/istio/galley/pkg/config/source/kube/rt"
-	"istio.io/istio/galley/pkg/config/testing/data"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/pkg/mcp/snapshot"
 )
 
@@ -72,17 +73,17 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 
 	u := &updaterMock{}
 	a := &analyzerMock{
-		collectionToAccess: data.K8SCollection1,
+		collectionToAccess: basicmeta.K8SCollection1.Name(),
 		resourcesToReport: []*resource.Instance{
 			{
 				Origin: &rt.Origin{
-					Collection: data.K8SCollection1,
+					Collection: basicmeta.K8SCollection1.Name(),
 					FullName:   resource.NewFullName("includedNamespace", "r1"),
 				},
 			},
 			{
 				Origin: &rt.Origin{
-					Collection: data.K8SCollection1,
+					Collection: basicmeta.K8SCollection1.Name(),
 					FullName:   resource.NewFullName("excludedNamespace", "r2"),
 				},
 			},
@@ -106,9 +107,14 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 	}
 	ad := NewAnalyzingDistributor(settings)
 
-	sDefault := getTestSnapshot("a", "b")
-	sSynthetic := getTestSnapshot("c")
-	sOther := getTestSnapshot("a", "d")
+	schemaA := newSchema("a")
+	schemaB := newSchema("b")
+	schemaC := newSchema("c")
+	schemaD := newSchema("d")
+
+	sDefault := getTestSnapshot(schemaA, schemaB)
+	sSynthetic := getTestSnapshot(schemaC)
+	sOther := getTestSnapshot(schemaA, schemaD)
 
 	ad.Distribute(snapshots.SyntheticServiceEntry, sSynthetic)
 	ad.Distribute(snapshots.Default, sDefault)
@@ -120,7 +126,7 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 	g.Eventually(func() snapshot.Snapshot { return d.GetSnapshot("other") }).Should(Equal(sOther))
 
 	// Assert we triggered analysis only once, with the expected combination of snapshots
-	sCombined := getTestSnapshot("a", "b", "c")
+	sCombined := getTestSnapshot(schemaA, schemaB, schemaC)
 	g.Eventually(func() []*Snapshot { return a.analyzeCalls }).Should(ConsistOf(sCombined))
 
 	// Verify the collection reporter hook was called
@@ -138,7 +144,7 @@ func TestAnalyzeNamespaceMessageHasNoOrigin(t *testing.T) {
 
 	u := &updaterMock{}
 	a := &analyzerMock{
-		collectionToAccess: data.K8SCollection1,
+		collectionToAccess: basicmeta.K8SCollection1.Name(),
 		resourcesToReport: []*resource.Instance{
 			{},
 		},
@@ -168,7 +174,7 @@ func TestAnalyzeNamespaceMessageHasOriginWithNoNamespace(t *testing.T) {
 
 	u := &updaterMock{}
 	a := &analyzerMock{
-		collectionToAccess: data.K8SCollection1,
+		collectionToAccess: basicmeta.K8SCollection1.Name(),
 		resourcesToReport: []*resource.Instance{
 			{
 				Origin: fakeOrigin{
@@ -204,15 +210,15 @@ func TestAnalyzeSortsMessages(t *testing.T) {
 
 	u := &updaterMock{}
 	o1 := &rt.Origin{
-		Collection: data.K8SCollection1,
+		Collection: basicmeta.K8SCollection1.Name(),
 		FullName:   resource.NewFullName("includedNamespace", "r2"),
 	}
 	o2 := &rt.Origin{
-		Collection: data.K8SCollection1,
+		Collection: basicmeta.K8SCollection1.Name(),
 		FullName:   resource.NewFullName("includedNamespace", "r1"),
 	}
 	a := &analyzerMock{
-		collectionToAccess: data.K8SCollection1,
+		collectionToAccess: basicmeta.K8SCollection1.Name(),
 		resourcesToReport: []*resource.Instance{
 			{Origin: o1},
 			{Origin: o2},
@@ -241,14 +247,25 @@ func TestAnalyzeSortsMessages(t *testing.T) {
 	g.Expect(u.messages[1].Origin).To(Equal(o1))
 }
 
-func getTestSnapshot(names ...string) *Snapshot {
+func getTestSnapshot(schemas ...collection.Schema) *Snapshot {
 	c := make([]*coll.Instance, 0)
-	for _, name := range names {
-		c = append(c, coll.New(collection.NewName(name)))
+	for _, s := range schemas {
+		c = append(c, coll.New(s))
 	}
 	return &Snapshot{
 		set: coll.NewSetFromCollections(c),
 	}
+}
+
+func newSchema(name string) collection.Schema {
+	return collection.Builder{
+		Name: name,
+		Schema: resource2.Builder{
+			Kind:         name,
+			ProtoPackage: "github.com/gogo/protobuf/types",
+			Proto:        "google.protobuf.Empty",
+		}.MustBuild(),
+	}.MustBuild()
 }
 
 var _ resource.Origin = fakeOrigin{}

--- a/galley/pkg/config/processing/snapshotter/distributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/distributor_test.go
@@ -18,13 +18,14 @@ import (
 	"testing"
 
 	"istio.io/istio/galley/pkg/config/collection"
+	collection2 "istio.io/istio/galley/pkg/config/schema/collection"
 )
 
 func TestDistributor_Distribute(t *testing.T) {
 	d := NewInMemoryDistributor()
 
 	s := &Snapshot{
-		set: collection.NewSet(nil),
+		set: collection.NewSet(collection2.NewSchemasBuilder().Build()),
 	}
 	d.Distribute("foo", s)
 	if _, ok := d.snapshots["foo"]; !ok {
@@ -36,7 +37,7 @@ func TestDistributor_GetSnapshot(t *testing.T) {
 	d := NewInMemoryDistributor()
 
 	s := &Snapshot{
-		set: collection.NewSet(nil),
+		set: collection.NewSet(collection2.NewSchemasBuilder().Build()),
 	}
 	d.Distribute("foo", s)
 
@@ -50,7 +51,7 @@ func TestDistributor_GetSnapshot_Unknown(t *testing.T) {
 	d := NewInMemoryDistributor()
 
 	s := &Snapshot{
-		set: collection.NewSet(nil),
+		set: collection.NewSet(collection2.NewSchemasBuilder().Build()),
 	}
 	d.Distribute("foo", s)
 
@@ -64,7 +65,7 @@ func TestDistributor_NumSnapshots(t *testing.T) {
 	d := NewInMemoryDistributor()
 
 	s := &Snapshot{
-		set: collection.NewSet(nil),
+		set: collection.NewSet(collection2.NewSchemasBuilder().Build()),
 	}
 	d.Distribute("foo", s)
 

--- a/galley/pkg/config/processing/snapshotter/snapshotter_test.go
+++ b/galley/pkg/config/processing/snapshotter/snapshotter_test.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/processing/snapshotter/strategy"
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 )
@@ -30,15 +31,15 @@ func TestSnapshotter_Basic(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	tr := fixtures.NewTransformer(
-		[]collection.Name{data.K8SCollection1},
-		[]collection.Name{data.Collection2},
+		collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).Build(),
+		collection.NewSchemasBuilder().MustAdd(basicmeta.Collection2).Build(),
 		func(tr *fixtures.Transformer, e event.Event) {
 			switch e.Kind {
 			case event.Reset:
-				tr.Publish(data.Collection2, e)
+				tr.Publish(basicmeta.Collection2.Name(), e)
 			default:
-				e.Source = data.Collection2
-				tr.Publish(data.Collection2, e)
+				e.Source = basicmeta.Collection2
+				tr.Publish(basicmeta.Collection2.Name(), e)
 			}
 		})
 
@@ -46,7 +47,7 @@ func TestSnapshotter_Basic(t *testing.T) {
 
 	options := []SnapshotOptions{
 		{
-			Collections: []collection.Name{data.Collection2},
+			Collections: []collection.Name{basicmeta.Collection2.Name()},
 			Strategy:    strategy.NewImmediate(),
 			Group:       "default",
 			Distributor: d,
@@ -72,8 +73,8 @@ func TestSnapshotter_Basic(t *testing.T) {
 
 	sn = d.GetSnapshot("default")
 	g.Expect(sn).NotTo(BeNil())
-	g.Expect(sn.Version(data.Collection2.String())).To(Equal("collection2/2"))
-	g.Expect(sn.Resources(data.Collection2.String())).To(HaveLen(1))
+	g.Expect(sn.Version(basicmeta.Collection2.Name().String())).To(Equal("collection2/2"))
+	g.Expect(sn.Resources(basicmeta.Collection2.Name().String())).To(HaveLen(1))
 
 	s.Handle(data.Event1Col1UpdateItem1)
 	s.Handle(data.Event1Col1DeleteItem1)
@@ -81,23 +82,23 @@ func TestSnapshotter_Basic(t *testing.T) {
 
 	sn = d.GetSnapshot("default")
 	g.Expect(sn).NotTo(BeNil())
-	g.Expect(sn.Version(data.Collection2.String())).To(Equal("collection2/4"))
-	g.Expect(sn.Resources(data.Collection2.String())).To(HaveLen(0))
+	g.Expect(sn.Version(basicmeta.Collection2.Name().String())).To(Equal("collection2/4"))
+	g.Expect(sn.Resources(basicmeta.Collection2.Name().String())).To(HaveLen(0))
 }
 
 func TestSnapshotter_SnapshotMismatch(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	tr := fixtures.NewTransformer(
-		[]collection.Name{data.K8SCollection1},
-		[]collection.Name{data.Collection2},
+		collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).Build(),
+		collection.NewSchemasBuilder().MustAdd(basicmeta.Collection2).Build(),
 		func(tr *fixtures.Transformer, e event.Event) {
 			switch e.Kind {
 			case event.Reset:
-				tr.Publish(data.Collection2, e)
+				tr.Publish(basicmeta.Collection2.Name(), e)
 			default:
-				e.Source = data.Collection2
-				tr.Publish(data.Collection2, e)
+				e.Source = basicmeta.Collection2
+				tr.Publish(basicmeta.Collection2.Name(), e)
 			}
 		})
 
@@ -105,7 +106,7 @@ func TestSnapshotter_SnapshotMismatch(t *testing.T) {
 
 	options := []SnapshotOptions{
 		{
-			Collections: []collection.Name{data.Collection3},
+			Collections: []collection.Name{data.Foo.Name()},
 			Strategy:    strategy.NewImmediate(),
 			Group:       "default",
 			Distributor: d,
@@ -121,17 +122,17 @@ func TestSnapshotterWaitForAllSync(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	tr := fixtures.NewTransformer(
-		[]collection.Name{data.K8SCollection1, data.Collection2},
-		[]collection.Name{data.K8SCollection1, data.Collection2},
+		collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).MustAdd(basicmeta.Collection2).Build(),
+		collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).MustAdd(basicmeta.Collection2).Build(),
 		func(tr *fixtures.Transformer, e event.Event) {
-			tr.Publish(e.Source, e)
+			tr.Publish(e.Source.Name(), e)
 		})
 
 	d := NewInMemoryDistributor()
 
 	options := []SnapshotOptions{
 		{
-			Collections: []collection.Name{data.K8SCollection1, data.Collection2},
+			Collections: []collection.Name{basicmeta.K8SCollection1.Name(), basicmeta.Collection2.Name()},
 			Strategy:    strategy.NewImmediate(),
 			Group:       "default",
 			Distributor: d,

--- a/galley/pkg/config/processing/transformer/provider.go
+++ b/galley/pkg/config/processing/transformer/provider.go
@@ -28,13 +28,13 @@ import (
 // that aren't available until after processing has started, but we need to know about inputs/outputs
 // before that happens.
 type Provider struct {
-	inputs   collection.Names
-	outputs  collection.Names
+	inputs   collection.Schemas
+	outputs  collection.Schemas
 	createFn func(processing.ProcessorOptions) event.Transformer
 }
 
 // NewProvider creates a new transformer Provider
-func NewProvider(inputs, outputs collection.Names, createFn func(processing.ProcessorOptions) event.Transformer) Provider {
+func NewProvider(inputs, outputs collection.Schemas, createFn func(processing.ProcessorOptions) event.Transformer) Provider {
 	return Provider{
 		inputs:   inputs,
 		outputs:  outputs,
@@ -43,12 +43,12 @@ func NewProvider(inputs, outputs collection.Names, createFn func(processing.Proc
 }
 
 // Inputs returns the input collections for this provider
-func (p *Provider) Inputs() collection.Names {
+func (p *Provider) Inputs() collection.Schemas {
 	return p.inputs
 }
 
 // Outputs returns the output collections for this provider
-func (p *Provider) Outputs() collection.Names {
+func (p *Provider) Outputs() collection.Schemas {
 	return p.outputs
 }
 
@@ -75,12 +75,12 @@ func (t Providers) RequiredInputsFor(outputs collection.Names) map[collection.Na
 	// For each transform, map output to inputs
 	outToIn := make(map[collection.Name]map[collection.Name]struct{})
 	for _, xfp := range t {
-		for _, out := range xfp.Outputs() {
-			if _, ok := outToIn[out]; !ok {
-				outToIn[out] = make(map[collection.Name]struct{})
+		for _, out := range xfp.Outputs().All() {
+			if _, ok := outToIn[out.Name()]; !ok {
+				outToIn[out.Name()] = make(map[collection.Name]struct{})
 			}
-			for _, in := range xfp.Inputs() {
-				outToIn[out][in] = struct{}{}
+			for _, in := range xfp.Inputs().All() {
+				outToIn[out.Name()][in.Name()] = struct{}{}
 			}
 		}
 	}
@@ -97,9 +97,9 @@ func (t Providers) RequiredInputsFor(outputs collection.Names) map[collection.Na
 }
 
 // NewSimpleTransformerProvider creates a basic transformer provider for a basic transformer
-func NewSimpleTransformerProvider(input, output collection.Name, handleFn func(e event.Event, h event.Handler)) Provider {
-	inputs := collection.Names{input}
-	outputs := collection.Names{output}
+func NewSimpleTransformerProvider(input, output collection.Schema, handleFn func(e event.Event, h event.Handler)) Provider {
+	inputs := collection.NewSchemasBuilder().MustAdd(input).Build()
+	outputs := collection.NewSchemasBuilder().MustAdd(output).Build()
 
 	createFn := func(processing.ProcessorOptions) event.Transformer {
 		return event.NewFnTransform(inputs, outputs, nil, nil, handleFn)

--- a/galley/pkg/config/processing/transformer/provider_test.go
+++ b/galley/pkg/config/processing/transformer/provider_test.go
@@ -21,26 +21,28 @@ import (
 
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/processing"
-	"istio.io/istio/galley/pkg/config/testing/data"
+	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
+	"istio.io/istio/galley/pkg/config/testing/fixtures"
 )
 
 func TestSimpleTransformerProvider(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	input := data.K8SCollection1
-	output := data.Collection2
+	input := basicmeta.K8SCollection1
+	output := basicmeta.Collection2
 	handleFn := func(e event.Event, h event.Handler) {}
 	opts := processing.ProcessorOptions{}
 
 	providers := Providers{
 		NewSimpleTransformerProvider(input, output, handleFn),
 	}
-	g.Expect(providers[0].Inputs()).To(ConsistOf(input))
-	g.Expect(providers[0].Outputs()).To(ConsistOf(output))
+	fixtures.ExpectEqual(t, providers[0].Inputs(), collection.SchemasFor(input))
+	fixtures.ExpectEqual(t, providers[0].Outputs(), collection.SchemasFor(output))
 
 	transformers := providers.Create(opts)
 	g.Expect(transformers).To(HaveLen(len(providers)))
 
-	g.Expect(transformers[0].Inputs()).To(ConsistOf(input))
-	g.Expect(transformers[0].Outputs()).To(ConsistOf(output))
+	fixtures.ExpectEqual(t, transformers[0].Inputs(), collection.SchemasFor(input))
+	fixtures.ExpectEqual(t, transformers[0].Outputs(), collection.SchemasFor(output))
 }

--- a/galley/pkg/config/processor/transforms/authpolicy/create.go
+++ b/galley/pkg/config/processor/transforms/authpolicy/create.go
@@ -30,19 +30,19 @@ import (
 func GetProviders() transformer.Providers {
 	return []transformer.Provider{
 		transformer.NewSimpleTransformerProvider(
-			collections.K8SAuthenticationIstioIoV1Alpha1Policies.Name(),
-			collections.IstioAuthenticationV1Alpha1Policies.Name(),
-			handler(collections.IstioAuthenticationV1Alpha1Policies.Name()),
+			collections.K8SAuthenticationIstioIoV1Alpha1Policies,
+			collections.IstioAuthenticationV1Alpha1Policies,
+			handler(collections.IstioAuthenticationV1Alpha1Policies),
 		),
 		transformer.NewSimpleTransformerProvider(
-			collections.K8SAuthenticationIstioIoV1Alpha1Meshpolicies.Name(),
-			collections.IstioAuthenticationV1Alpha1Meshpolicies.Name(),
-			handler(collections.IstioAuthenticationV1Alpha1Meshpolicies.Name()),
+			collections.K8SAuthenticationIstioIoV1Alpha1Meshpolicies,
+			collections.IstioAuthenticationV1Alpha1Meshpolicies,
+			handler(collections.IstioAuthenticationV1Alpha1Meshpolicies),
 		),
 	}
 }
 
-func handler(destination collection.Name) func(e event.Event, h event.Handler) {
+func handler(destination collection.Schema) func(e event.Event, h event.Handler) {
 	return func(e event.Event, h event.Handler) {
 		e = e.WithSource(destination)
 

--- a/galley/pkg/config/processor/transforms/authpolicy/create_test.go
+++ b/galley/pkg/config/processor/transforms/authpolicy/create_test.go
@@ -35,21 +35,17 @@ func TestAuthPolicy_Input_Output(t *testing.T) {
 
 	xform, _, _ := setup(g, 0)
 
-	g.Expect(xform.Inputs()).To(Equal(collection.Names{
-		collections.K8SAuthenticationIstioIoV1Alpha1Policies.Name(),
-	}))
-	g.Expect(xform.Outputs()).To(Equal(collection.Names{
-		collections.IstioAuthenticationV1Alpha1Policies.Name(),
-	}))
+	fixtures.ExpectEqual(t, xform.Inputs(), collection.NewSchemasBuilder().MustAdd(
+		collections.K8SAuthenticationIstioIoV1Alpha1Policies).Build())
+	fixtures.ExpectEqual(t, xform.Outputs(), collection.NewSchemasBuilder().MustAdd(
+		collections.IstioAuthenticationV1Alpha1Policies).Build())
 
 	xform, _, _ = setup(g, 1)
 
-	g.Expect(xform.Inputs()).To(Equal(collection.Names{
-		collections.K8SAuthenticationIstioIoV1Alpha1Meshpolicies.Name(),
-	}))
-	g.Expect(xform.Outputs()).To(Equal(collection.Names{
-		collections.IstioAuthenticationV1Alpha1Meshpolicies.Name(),
-	}))
+	fixtures.ExpectEqual(t, xform.Inputs(), collection.NewSchemasBuilder().MustAdd(
+		collections.K8SAuthenticationIstioIoV1Alpha1Meshpolicies).Build())
+	fixtures.ExpectEqual(t, xform.Outputs(), collection.NewSchemasBuilder().MustAdd(
+		collections.IstioAuthenticationV1Alpha1Meshpolicies).Build())
 }
 
 func TestAuthPolicy_AddSync(t *testing.T) {
@@ -61,12 +57,12 @@ func TestAuthPolicy_AddSync(t *testing.T) {
 		acc.Clear()
 		xform.Start()
 
-		src.Handlers.Handle(event.AddFor(xform.Inputs()[0], input()))
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
+		src.Handlers.Handle(event.AddFor(xform.Inputs().All()[0], input()))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
 
 		g.Eventually(acc.Events).Should(ConsistOf(
-			event.AddFor(xform.Outputs()[0], output()),
-			event.FullSyncFor(xform.Outputs()[0]),
+			event.AddFor(xform.Outputs().All()[0], output()),
+			event.FullSyncFor(xform.Outputs().All()[0]),
 		))
 		xform.Stop()
 	}
@@ -79,12 +75,12 @@ func TestAuthPolicy_SyncAdd(t *testing.T) {
 		xform, src, acc := setup(g, i)
 		xform.Start()
 
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
-		src.Handlers.Handle(event.AddFor(xform.Inputs()[0], input()))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
+		src.Handlers.Handle(event.AddFor(xform.Inputs().All()[0], input()))
 
 		g.Eventually(acc.Events).Should(ConsistOf(
-			event.FullSyncFor(xform.Outputs()[0]),
-			event.AddFor(xform.Outputs()[0], output()),
+			event.FullSyncFor(xform.Outputs().All()[0]),
+			event.AddFor(xform.Outputs().All()[0], output()),
 		))
 
 		xform.Stop()
@@ -102,16 +98,16 @@ func TestAuthPolicy_AddUpdateDelete(t *testing.T) {
 
 		xform.Start()
 
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
-		src.Handlers.Handle(event.AddFor(xform.Inputs()[0], input()))
-		src.Handlers.Handle(event.UpdateFor(xform.Inputs()[0], r2))
-		src.Handlers.Handle(event.DeleteForResource(xform.Inputs()[0], r2))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
+		src.Handlers.Handle(event.AddFor(xform.Inputs().All()[0], input()))
+		src.Handlers.Handle(event.UpdateFor(xform.Inputs().All()[0], r2))
+		src.Handlers.Handle(event.DeleteForResource(xform.Inputs().All()[0], r2))
 
 		g.Eventually(acc.Events).Should(ConsistOf(
-			event.FullSyncFor(xform.Outputs()[0]),
-			event.AddFor(xform.Outputs()[0], output()),
-			event.UpdateFor(xform.Outputs()[0], r2),
-			event.DeleteForResource(xform.Outputs()[0], r2),
+			event.FullSyncFor(xform.Outputs().All()[0]),
+			event.AddFor(xform.Outputs().All()[0], output()),
+			event.UpdateFor(xform.Outputs().All()[0], r2),
+			event.DeleteForResource(xform.Outputs().All()[0], r2),
 		))
 		xform.Stop()
 	}
@@ -125,11 +121,11 @@ func TestAuthPolicy_SyncReset(t *testing.T) {
 
 		xform.Start()
 
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
 		src.Handlers.Handle(event.Event{Kind: event.Reset})
 
 		g.Eventually(acc.Events).Should(ConsistOf(
-			event.FullSyncFor(xform.Outputs()[0]),
+			event.FullSyncFor(xform.Outputs().All()[0]),
 			event.Event{Kind: event.Reset},
 		))
 
@@ -145,11 +141,11 @@ func TestAuthPolicy_InvalidEventKind(t *testing.T) {
 
 		xform.Start()
 
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
 		src.Handlers.Handle(event.Event{Kind: 55})
 
 		g.Eventually(acc.Events).Should(ConsistOf(
-			event.FullSyncFor(xform.Outputs()[0]),
+			event.FullSyncFor(xform.Outputs().All()[0]),
 		))
 
 		xform.Stop()
@@ -169,9 +165,9 @@ func TestAuthPolicy_NoListeners(t *testing.T) {
 
 		xform.Start()
 
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
 		src.Handlers.Handle(event.Event{Kind: event.Reset})
-		src.Handlers.Handle(event.AddFor(xform.Inputs()[0], input()))
+		src.Handlers.Handle(event.AddFor(xform.Inputs().All()[0], input()))
 
 		// No crash
 		xform.Stop()
@@ -187,12 +183,12 @@ func TestAuthPolicy_DoubleStart(t *testing.T) {
 		xform.Start()
 		xform.Start()
 
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
-		src.Handlers.Handle(event.AddFor(xform.Inputs()[0], input()))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
+		src.Handlers.Handle(event.AddFor(xform.Inputs().All()[0], input()))
 
 		g.Eventually(acc.Events).Should(ConsistOf(
-			event.AddFor(xform.Outputs()[0], output()),
-			event.FullSyncFor(xform.Outputs()[0]),
+			event.AddFor(xform.Outputs().All()[0], output()),
+			event.FullSyncFor(xform.Outputs().All()[0]),
 		))
 		xform.Stop()
 	}
@@ -206,12 +202,12 @@ func TestAuthPolicy_DoubleStop(t *testing.T) {
 
 		xform.Start()
 
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
-		src.Handlers.Handle(event.AddFor(xform.Inputs()[0], input()))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
+		src.Handlers.Handle(event.AddFor(xform.Inputs().All()[0], input()))
 
 		g.Eventually(acc.Events).Should(ConsistOf(
-			event.AddFor(xform.Outputs()[0], output()),
-			event.FullSyncFor(xform.Outputs()[0]),
+			event.AddFor(xform.Outputs().All()[0], output()),
+			event.FullSyncFor(xform.Outputs().All()[0]),
 		))
 
 		acc.Clear()
@@ -231,12 +227,12 @@ func TestAuthPolicy_StartStopStartStop(t *testing.T) {
 
 		xform.Start()
 
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
-		src.Handlers.Handle(event.AddFor(xform.Inputs()[0], input()))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
+		src.Handlers.Handle(event.AddFor(xform.Inputs().All()[0], input()))
 
 		g.Eventually(acc.Events).Should(ConsistOf(
-			event.AddFor(xform.Outputs()[0], output()),
-			event.FullSyncFor(xform.Outputs()[0]),
+			event.AddFor(xform.Outputs().All()[0], output()),
+			event.FullSyncFor(xform.Outputs().All()[0]),
 		))
 
 		acc.Clear()
@@ -244,12 +240,12 @@ func TestAuthPolicy_StartStopStartStop(t *testing.T) {
 		g.Consistently(acc.Events).Should(BeEmpty())
 
 		xform.Start()
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
-		src.Handlers.Handle(event.AddFor(xform.Inputs()[0], input()))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
+		src.Handlers.Handle(event.AddFor(xform.Inputs().All()[0], input()))
 
 		g.Eventually(acc.Events).Should(ConsistOf(
-			event.AddFor(xform.Outputs()[0], output()),
-			event.FullSyncFor(xform.Outputs()[0]),
+			event.AddFor(xform.Outputs().All()[0], output()),
+			event.FullSyncFor(xform.Outputs().All()[0]),
 		))
 
 		acc.Clear()
@@ -266,8 +262,8 @@ func TestAuthPolicy_InvalidEvent(t *testing.T) {
 
 		xform.Start()
 
-		src.Handlers.Handle(event.FullSyncFor(xform.Outputs()[0])) // Send output events
-		src.Handlers.Handle(event.AddFor(xform.Outputs()[0], input()))
+		src.Handlers.Handle(event.FullSyncFor(xform.Outputs().All()[0])) // Send output events
+		src.Handlers.Handle(event.AddFor(xform.Outputs().All()[0], input()))
 
 		g.Consistently(acc.Events).Should(BeEmpty())
 		xform.Stop()
@@ -286,11 +282,11 @@ func TestAuthPolicy_InvalidProto(t *testing.T) {
 		acc.Clear()
 		xform.Start()
 
-		src.Handlers.Handle(event.AddFor(xform.Inputs()[0], r))
-		src.Handlers.Handle(event.FullSyncFor(xform.Inputs()[0]))
+		src.Handlers.Handle(event.AddFor(xform.Inputs().All()[0], r))
+		src.Handlers.Handle(event.FullSyncFor(xform.Inputs().All()[0]))
 
 		g.Eventually(acc.Events).Should(ConsistOf( // No add event
-			event.FullSyncFor(xform.Outputs()[0]),
+			event.FullSyncFor(xform.Outputs().All()[0]),
 		))
 		xform.Stop()
 	}
@@ -303,7 +299,7 @@ func setup(g *GomegaWithT, i int) (event.Transformer, *fixtures.Source, *fixture
 	src := &fixtures.Source{}
 	acc := &fixtures.Accumulator{}
 	src.Dispatch(xforms[i])
-	xforms[i].DispatchFor(xforms[i].Outputs()[0], acc)
+	xforms[i].DispatchFor(xforms[i].Outputs().All()[0], acc)
 
 	return xforms[i], src, acc
 }

--- a/galley/pkg/config/processor/transforms/direct/create.go
+++ b/galley/pkg/config/processor/transforms/direct/create.go
@@ -24,9 +24,11 @@ import (
 func GetProviders(m *schema.Metadata) transformer.Providers {
 	var result []transformer.Provider
 
+	cols := m.AllCollections()
+
 	for k, v := range m.DirectTransformSettings().Mapping() {
-		from := k
-		to := v
+		from := cols.MustFind(k.String())
+		to := cols.MustFind(v.String())
 
 		handleFn := func(e event.Event, h event.Handler) {
 			e = e.WithSource(to)

--- a/galley/pkg/config/processor/transforms/direct/create_test.go
+++ b/galley/pkg/config/processor/transforms/direct/create_test.go
@@ -32,8 +32,8 @@ func TestDirect_Input_Output(t *testing.T) {
 
 	xform, _, _ := setup(g)
 
-	g.Expect(xform.Inputs()).To(Equal(collection.Names{basicmeta.K8SCollection1.Name()}))
-	g.Expect(xform.Outputs()).To(Equal(collection.Names{basicmeta.Collection2.Name()}))
+	fixtures.ExpectEqual(t, xform.Inputs(), collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).Build())
+	fixtures.ExpectEqual(t, xform.Outputs(), collection.NewSchemasBuilder().MustAdd(basicmeta.Collection2).Build())
 }
 
 func TestDirect_AddSync(t *testing.T) {
@@ -44,13 +44,12 @@ func TestDirect_AddSync(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1))
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1.Name()))
+	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1))
 
-	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(basicmeta.Collection2.Name(), data.EntryN1I1V1), // XForm to Collection2
-		event.FullSyncFor(basicmeta.Collection2.Name()),
-	))
+	fixtures.ExpectEventsEventually(t, acc,
+		event.AddFor(basicmeta.Collection2, data.EntryN1I1V1), // XForm to Collection2
+		event.FullSyncFor(basicmeta.Collection2))
 }
 
 func TestDirect_SyncAdd(t *testing.T) {
@@ -61,13 +60,12 @@ func TestDirect_SyncAdd(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1.Name()))
-	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1))
+	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
-	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(basicmeta.Collection2.Name(), data.EntryN1I1V1), // XForm to Collection2
-		event.FullSyncFor(basicmeta.Collection2.Name()),
-	))
+	fixtures.ExpectEventsEventually(t, acc,
+		event.FullSyncFor(basicmeta.Collection2),
+		event.AddFor(basicmeta.Collection2, data.EntryN1I1V1)) // XForm to Collection2
 }
 
 func TestDirect_AddUpdateDelete(t *testing.T) {
@@ -78,17 +76,17 @@ func TestDirect_AddUpdateDelete(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1.Name()))
-	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1))
-	src.Handlers.Handle(event.UpdateFor(basicmeta.K8SCollection1.Name(), data.EntryN1I1V2))
-	src.Handlers.Handle(event.DeleteForResource(basicmeta.K8SCollection1.Name(), data.EntryN1I1V2))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1))
+	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
+	src.Handlers.Handle(event.UpdateFor(basicmeta.K8SCollection1, data.EntryN1I1V2))
+	src.Handlers.Handle(event.DeleteForResource(basicmeta.K8SCollection1, data.EntryN1I1V2))
 
-	g.Eventually(acc.Events).Should(ConsistOf(
-		event.FullSyncFor(basicmeta.Collection2.Name()),
-		event.AddFor(basicmeta.Collection2.Name(), data.EntryN1I1V1),
-		event.UpdateFor(basicmeta.Collection2.Name(), data.EntryN1I1V2),
-		event.DeleteForResource(basicmeta.Collection2.Name(), data.EntryN1I1V2),
-	))
+	fixtures.ExpectEventsEventually(t, acc,
+		event.FullSyncFor(basicmeta.Collection2),
+		event.AddFor(basicmeta.Collection2, data.EntryN1I1V1),
+		event.UpdateFor(basicmeta.Collection2, data.EntryN1I1V2),
+		event.DeleteForResource(basicmeta.Collection2, data.EntryN1I1V2),
+	)
 }
 
 func TestDirect_SyncReset(t *testing.T) {
@@ -99,13 +97,13 @@ func TestDirect_SyncReset(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1.Name()))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1))
 	src.Handlers.Handle(event.Event{Kind: event.Reset})
 
-	g.Eventually(acc.Events).Should(ConsistOf(
-		event.FullSyncFor(basicmeta.Collection2.Name()),
+	fixtures.ExpectEventsEventually(t, acc,
+		event.FullSyncFor(basicmeta.Collection2),
 		event.Event{Kind: event.Reset},
-	))
+	)
 }
 
 func TestDirect_InvalidEventKind(t *testing.T) {
@@ -116,12 +114,12 @@ func TestDirect_InvalidEventKind(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1.Name()))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1))
 	src.Handlers.Handle(event.Event{Kind: 55})
 
-	g.Eventually(acc.Events).Should(ConsistOf(
-		event.FullSyncFor(basicmeta.Collection2.Name()),
-	))
+	fixtures.ExpectEventsEventually(t, acc,
+		event.FullSyncFor(basicmeta.Collection2),
+	)
 }
 
 func TestDirect_NoListeners(t *testing.T) {
@@ -137,9 +135,9 @@ func TestDirect_NoListeners(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1.Name()))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1))
 	src.Handlers.Handle(event.Event{Kind: event.Reset})
-	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1))
+	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
 	// No crash
 }
@@ -153,13 +151,13 @@ func TestDirect_DoubleStart(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1.Name()))
-	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1))
+	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
-	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(basicmeta.Collection2.Name(), data.EntryN1I1V1), // XForm to Collection2
-		event.FullSyncFor(basicmeta.Collection2.Name()),
-	))
+	fixtures.ExpectEventsEventually(t, acc,
+		event.FullSyncFor(basicmeta.Collection2),
+		event.AddFor(basicmeta.Collection2, data.EntryN1I1V1), // XForm to Collection2
+	)
 }
 
 func TestDirect_DoubleStop(t *testing.T) {
@@ -169,13 +167,13 @@ func TestDirect_DoubleStop(t *testing.T) {
 
 	xform.Start()
 
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1.Name()))
-	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1))
+	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
-	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(basicmeta.Collection2.Name(), data.EntryN1I1V1), // XForm to Collection2
-		event.FullSyncFor(basicmeta.Collection2.Name()),
-	))
+	fixtures.ExpectEventsEventually(t, acc,
+		event.FullSyncFor(basicmeta.Collection2),
+		event.AddFor(basicmeta.Collection2, data.EntryN1I1V1), // XForm to Collection2
+	)
 
 	acc.Clear()
 
@@ -193,26 +191,26 @@ func TestDirect_StartStopStartStop(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1.Name()))
-	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1))
+	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
-	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(basicmeta.Collection2.Name(), data.EntryN1I1V1), // XForm to Collection2
-		event.FullSyncFor(basicmeta.Collection2.Name()),
-	))
+	fixtures.ExpectEventsEventually(t, acc,
+		event.FullSyncFor(basicmeta.Collection2),
+		event.AddFor(basicmeta.Collection2, data.EntryN1I1V1), // XForm to Collection2
+	)
 
 	acc.Clear()
 	xform.Stop()
 	g.Consistently(acc.Events).Should(BeEmpty())
 
 	xform.Start()
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1.Name()))
-	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.K8SCollection1))
+	src.Handlers.Handle(event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
-	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(basicmeta.Collection2.Name(), data.EntryN1I1V1), // XForm to Collection2
-		event.FullSyncFor(basicmeta.Collection2.Name()),
-	))
+	fixtures.ExpectEventsEventually(t, acc,
+		event.FullSyncFor(basicmeta.Collection2),
+		event.AddFor(basicmeta.Collection2, data.EntryN1I1V1), // XForm to Collection2
+	)
 
 	acc.Clear()
 	xform.Stop()
@@ -227,8 +225,8 @@ func TestDirect_InvalidEvent(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(basicmeta.Collection2.Name())) // Collection2
-	src.Handlers.Handle(event.AddFor(basicmeta.Collection2.Name(), data.EntryN1I1V1))
+	src.Handlers.Handle(event.FullSyncFor(basicmeta.Collection2)) // Collection2
+	src.Handlers.Handle(event.AddFor(basicmeta.Collection2, data.EntryN1I1V1))
 
 	g.Consistently(acc.Events).Should(BeEmpty())
 }
@@ -241,7 +239,7 @@ func setup(g *GomegaWithT) (event.Transformer, *fixtures.Source, *fixtures.Accum
 	acc := &fixtures.Accumulator{}
 	xform := xforms[0]
 	src.Dispatch(xform)
-	xform.DispatchFor(xform.Outputs()[0], acc)
+	xform.DispatchFor(xform.Outputs().All()[0], acc)
 
 	return xform, src, acc
 }

--- a/galley/pkg/config/processor/transforms/ingress/gateway.go
+++ b/galley/pkg/config/processor/transforms/ingress/gateway.go
@@ -42,8 +42,8 @@ type gatewayXform struct {
 var _ event.Transformer = &gatewayXform{}
 
 func getGatewayXformProvider() transformer.Provider {
-	inputs := collection.Names{collections.K8SExtensionsV1Beta1Ingresses.Name()}
-	outputs := collection.Names{collections.IstioNetworkingV1Alpha3Gateways.Name()}
+	inputs := collection.NewSchemasBuilder().MustAdd(collections.K8SExtensionsV1Beta1Ingresses).Build()
+	outputs := collection.NewSchemasBuilder().MustAdd(collections.IstioNetworkingV1Alpha3Gateways).Build()
 
 	createFn := func(o processing.ProcessorOptions) event.Transformer {
 		xform := &gatewayXform{}
@@ -75,7 +75,7 @@ func (g *gatewayXform) handle(e event.Event, h event.Handler) {
 		gw := g.convertIngressToGateway(e.Resource)
 		evt := event.Event{
 			Kind:     e.Kind,
-			Source:   collections.IstioNetworkingV1Alpha3Gateways.Name(),
+			Source:   collections.IstioNetworkingV1Alpha3Gateways,
 			Resource: gw,
 		}
 		h.Handle(evt)
@@ -84,7 +84,7 @@ func (g *gatewayXform) handle(e event.Event, h event.Handler) {
 		gw := g.convertIngressToGateway(e.Resource)
 		evt := event.Event{
 			Kind:     e.Kind,
-			Source:   collections.IstioNetworkingV1Alpha3Gateways.Name(),
+			Source:   collections.IstioNetworkingV1Alpha3Gateways,
 			Resource: gw,
 		}
 		evt.Resource.Metadata.FullName = generateSyntheticGatewayName(e.Resource.Metadata.FullName)

--- a/galley/pkg/config/processor/transforms/ingress/virtualService.go
+++ b/galley/pkg/config/processor/transforms/ingress/virtualService.go
@@ -47,8 +47,8 @@ type virtualServiceXform struct {
 }
 
 func getVirtualServiceXformProvider() transformer.Provider {
-	inputs := collection.Names{collections.K8SExtensionsV1Beta1Ingresses.Name()}
-	outputs := collection.Names{collections.IstioNetworkingV1Alpha3Virtualservices.Name()}
+	inputs := collection.NewSchemasBuilder().MustAdd(collections.K8SExtensionsV1Beta1Ingresses).Build()
+	outputs := collection.NewSchemasBuilder().MustAdd(collections.IstioNetworkingV1Alpha3Virtualservices).Build()
 
 	createFn := func(o processing.ProcessorOptions) event.Transformer {
 		xform := &virtualServiceXform{
@@ -219,7 +219,7 @@ loop:
 func (g *virtualServiceXform) notifyUpdate(h event.Handler, k event.Kind, svs *syntheticVirtualService) {
 	e := event.Event{
 		Kind:     k,
-		Source:   collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+		Source:   collections.IstioNetworkingV1Alpha3Virtualservices,
 		Resource: svs.generateEntry(g.options.DomainSuffix),
 	}
 	h.Handle(e)
@@ -228,7 +228,7 @@ func (g *virtualServiceXform) notifyUpdate(h event.Handler, k event.Kind, svs *s
 func (g *virtualServiceXform) notifyDelete(h event.Handler, name resource.FullName, v resource.Version) {
 	e := event.Event{
 		Kind:   event.Deleted,
-		Source: collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+		Source: collections.IstioNetworkingV1Alpha3Virtualservices,
 		Resource: &resource.Instance{
 			Metadata: resource.Metadata{
 				FullName: name,

--- a/galley/pkg/config/processor/transforms/ingress/virtualService_test.go
+++ b/galley/pkg/config/processor/transforms/ingress/virtualService_test.go
@@ -32,8 +32,8 @@ func TestVirtualService_Input_Output(t *testing.T) {
 
 	xform, _, _ := setupVS(g, processing.ProcessorOptions{})
 
-	g.Expect(xform.Inputs()).To(Equal(collection.Names{collections.K8SExtensionsV1Beta1Ingresses.Name()}))
-	g.Expect(xform.Outputs()).To(Equal(collection.Names{collections.IstioNetworkingV1Alpha3Virtualservices.Name()}))
+	g.Expect(xform.Inputs()).To(Equal(collection.NewSchemasBuilder().MustAdd(collections.K8SExtensionsV1Beta1Ingresses).Build()))
+	g.Expect(xform.Outputs()).To(Equal(collection.NewSchemasBuilder().MustAdd(collections.IstioNetworkingV1Alpha3Virtualservices).Build()))
 }
 
 func TestVirtualService_AddSync(t *testing.T) {
@@ -49,12 +49,12 @@ func TestVirtualService_AddSync(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses.Name(), ingress1()))
-	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses.Name()))
+	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses, ingress1()))
+	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses))
 
 	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), vs1()),
-		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name())))
+		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices, vs1()),
+		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices)))
 }
 
 func TestVirtualService_SyncAdd(t *testing.T) {
@@ -70,12 +70,12 @@ func TestVirtualService_SyncAdd(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses.Name(), ingress1()))
-	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses.Name()))
+	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses, ingress1()))
+	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses))
 
 	g.Eventually(acc.Events).Should(ConsistOf(
-		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name()),
-		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), vs1()),
+		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices),
+		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices, vs1()),
 	))
 }
 
@@ -92,16 +92,16 @@ func TestVirtualService_AddUpdateDelete(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses.Name()))
-	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses.Name(), ingress1()))
-	src.Handlers.Handle(event.UpdateFor(collections.K8SExtensionsV1Beta1Ingresses.Name(), ingress1v2()))
-	src.Handlers.Handle(event.DeleteForResource(collections.K8SExtensionsV1Beta1Ingresses.Name(), ingress1v2()))
+	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses))
+	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses, ingress1()))
+	src.Handlers.Handle(event.UpdateFor(collections.K8SExtensionsV1Beta1Ingresses, ingress1v2()))
+	src.Handlers.Handle(event.DeleteForResource(collections.K8SExtensionsV1Beta1Ingresses, ingress1v2()))
 
 	g.Eventually(acc.Events).Should(ConsistOf(
-		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name()),
-		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), vs1()),
-		event.UpdateFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), vs1v2()),
-		event.DeleteFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), vs1v2().Metadata.FullName, vs1v2().Metadata.Version),
+		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices),
+		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices, vs1()),
+		event.UpdateFor(collections.IstioNetworkingV1Alpha3Virtualservices, vs1v2()),
+		event.DeleteFor(collections.IstioNetworkingV1Alpha3Virtualservices, vs1v2().Metadata.FullName, vs1v2().Metadata.Version),
 	))
 }
 
@@ -118,11 +118,11 @@ func TestVirtualService_SyncReset(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses.Name()))
+	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses))
 	src.Handlers.Handle(event.Event{Kind: event.Reset})
 
 	g.Eventually(acc.Events).Should(ConsistOf(
-		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name()),
+		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices),
 		event.Event{Kind: event.Reset},
 	))
 }
@@ -140,11 +140,11 @@ func TestVirtualService_InvalidEventKind(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses.Name()))
+	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses))
 	src.Handlers.Handle(event.Event{Kind: 55})
 
 	g.Eventually(acc.Events).Should(ConsistOf(
-		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name()),
+		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices),
 	))
 }
 
@@ -166,9 +166,9 @@ func TestVirtualService_NoListeners(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses.Name()))
+	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses))
 	src.Handlers.Handle(event.Event{Kind: event.Reset})
-	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses.Name(), ingress1()))
+	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses, ingress1()))
 
 	// No crash
 }
@@ -187,12 +187,12 @@ func TestVirtualService_DoubleStart(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses.Name()))
-	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses.Name(), ingress1()))
+	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses))
+	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses, ingress1()))
 
 	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), vs1()),
-		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name()),
+		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices, vs1()),
+		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices),
 	))
 }
 
@@ -208,12 +208,12 @@ func TestVirtualService_DoubleStop(t *testing.T) {
 
 	xform.Start()
 
-	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses.Name()))
-	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses.Name(), ingress1()))
+	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses))
+	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses, ingress1()))
 
 	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), vs1()),
-		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name()),
+		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices, vs1()),
+		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices),
 	))
 
 	acc.Clear()
@@ -236,12 +236,12 @@ func TestVirtualService_StartStopStartStop(t *testing.T) {
 
 	xform.Start()
 
-	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses.Name()))
-	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses.Name(), ingress1()))
+	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses))
+	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses, ingress1()))
 
 	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), vs1()),
-		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name()),
+		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices, vs1()),
+		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices),
 	))
 
 	acc.Clear()
@@ -249,12 +249,12 @@ func TestVirtualService_StartStopStartStop(t *testing.T) {
 	g.Consistently(acc.Events).Should(BeEmpty())
 
 	xform.Start()
-	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses.Name()))
-	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses.Name(), ingress1()))
+	src.Handlers.Handle(event.FullSyncFor(collections.K8SExtensionsV1Beta1Ingresses))
+	src.Handlers.Handle(event.AddFor(collections.K8SExtensionsV1Beta1Ingresses, ingress1()))
 
 	g.Eventually(acc.Events).Should(ConsistOf(
-		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), vs1()),
-		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name()),
+		event.AddFor(collections.IstioNetworkingV1Alpha3Virtualservices, vs1()),
+		event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices),
 	))
 
 	acc.Clear()
@@ -275,7 +275,7 @@ func TestVirtualService_InvalidEvent(t *testing.T) {
 	xform.Start()
 	defer xform.Stop()
 
-	src.Handlers.Handle(event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name()))
+	src.Handlers.Handle(event.FullSyncFor(collections.IstioNetworkingV1Alpha3Virtualservices))
 
 	g.Consistently(acc.Events).Should(BeEmpty())
 }
@@ -288,7 +288,7 @@ func setupVS(g *GomegaWithT, o processing.ProcessorOptions) (event.Transformer, 
 	acc := &fixtures.Accumulator{}
 	xform := xforms[1]
 	src.Dispatch(xform)
-	xform.DispatchFor(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), acc)
+	xform.DispatchFor(collections.IstioNetworkingV1Alpha3Virtualservices, acc)
 
 	return xform, src, acc
 }

--- a/galley/pkg/config/processor/transforms/serviceentry/create.go
+++ b/galley/pkg/config/processor/transforms/serviceentry/create.go
@@ -24,15 +24,16 @@ import (
 
 // GetProviders creates transformer providers for Synthetic Service entries
 func GetProviders() xformer.Providers {
-	inputs := collection.Names{
-		collections.K8SCoreV1Endpoints.Name(),
-		collections.K8SCoreV1Nodes.Name(),
-		collections.K8SCoreV1Pods.Name(),
-		collections.K8SCoreV1Services.Name(),
-	}
-	outputs := collection.Names{
-		collections.IstioNetworkingV1Alpha3SyntheticServiceentries.Name(),
-	}
+	inputs := collection.NewSchemasBuilder().
+		MustAdd(collections.K8SCoreV1Endpoints).
+		MustAdd(collections.K8SCoreV1Nodes).
+		MustAdd(collections.K8SCoreV1Pods).
+		MustAdd(collections.K8SCoreV1Services).
+		Build()
+
+	outputs := collection.NewSchemasBuilder().
+		MustAdd(collections.IstioNetworkingV1Alpha3SyntheticServiceentries).
+		Build()
 
 	createFn := func(o processing.ProcessorOptions) event.Transformer {
 		return &serviceEntryTransformer{

--- a/galley/pkg/config/processor/transforms/serviceentry/create_test.go
+++ b/galley/pkg/config/processor/transforms/serviceentry/create_test.go
@@ -63,11 +63,11 @@ var (
 	serviceName = resource.NewFullName(namespace, "svc1")
 	createTime  = time.Now()
 
-	nodeCollection         = collections.K8SCoreV1Nodes.Name()
-	podCollection          = collections.K8SCoreV1Pods.Name()
-	serviceCollection      = collections.K8SCoreV1Services.Name()
-	endpointsCollection    = collections.K8SCoreV1Endpoints.Name()
-	serviceEntryCollection = collections.IstioNetworkingV1Alpha3SyntheticServiceentries.Name()
+	nodeCollection         = collections.K8SCoreV1Nodes
+	podCollection          = collections.K8SCoreV1Pods
+	serviceCollection      = collections.K8SCoreV1Services
+	endpointsCollection    = collections.K8SCoreV1Endpoints
+	serviceEntryCollection = collections.IstioNetworkingV1Alpha3SyntheticServiceentries
 	serviceAnnotations     = resource.StringMap{
 		"ak1": "av1",
 	}
@@ -84,7 +84,7 @@ func TestInvalidCollectionShouldNotPanic(t *testing.T) {
 	defer rt.Stop()
 	src.Handlers.Handle(event.Event{
 		Kind:   event.Added,
-		Source: collections.IstioNetworkingV1Alpha3Gateways.Name(),
+		Source: collections.IstioNetworkingV1Alpha3Gateways,
 		Resource: &resource.Instance{
 			Metadata: resource.Metadata{
 				FullName: resource.NewFullName("ns", "svc1"),
@@ -102,19 +102,19 @@ func TestLifecycle(t *testing.T) {
 	stages := []stage{
 		{
 			name:  "NodeSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Nodes.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Nodes),
 		},
 		{
 			name:  "PodSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Pods.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Pods),
 		},
 		{
 			name:  "ServiceSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Services.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Services),
 		},
 		{
 			name:  "EndpointSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Endpoints.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Endpoints),
 			validator: func(ctx pipelineContext) {
 				expectNotifications(ctx.t, ctx.acc, 1)
 			},
@@ -382,19 +382,19 @@ func TestAddOrder(t *testing.T) {
 	initialStages := []stage{
 		{
 			name:  "NodeSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Nodes.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Nodes),
 		},
 		{
 			name:  "PodSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Pods.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Pods),
 		},
 		{
 			name:  "ServiceSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Services.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Services),
 		},
 		{
 			name:  "EndpointSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Endpoints.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Endpoints),
 		},
 	}
 
@@ -557,19 +557,19 @@ func TestDeleteOrder(t *testing.T) {
 	syncStages := []stage{
 		{
 			name:  "NodeSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Nodes.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Nodes),
 		},
 		{
 			name:  "PodSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Pods.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Pods),
 		},
 		{
 			name:  "ServiceSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Services.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Services),
 		},
 		{
 			name:  "EndpointSync",
-			event: event.FullSyncFor(collections.K8SCoreV1Endpoints.Name()),
+			event: event.FullSyncFor(collections.K8SCoreV1Endpoints),
 			validator: func(ctx pipelineContext) {
 				expectNotifications(ctx.t, ctx.acc, 1)
 			},
@@ -678,10 +678,10 @@ func TestReceiveEndpointsBeforeService(t *testing.T) {
 	defer rt.Stop()
 
 	syncEvents := []event.Event{
-		event.FullSyncFor(collections.K8SCoreV1Nodes.Name()),
-		event.FullSyncFor(collections.K8SCoreV1Pods.Name()),
-		event.FullSyncFor(collections.K8SCoreV1Services.Name()),
-		event.FullSyncFor(collections.K8SCoreV1Endpoints.Name()),
+		event.FullSyncFor(collections.K8SCoreV1Nodes),
+		event.FullSyncFor(collections.K8SCoreV1Pods),
+		event.FullSyncFor(collections.K8SCoreV1Services),
+		event.FullSyncFor(collections.K8SCoreV1Endpoints),
 	}
 
 	for _, e := range syncEvents {
@@ -781,7 +781,7 @@ func newHandler() (*processing.Runtime, *fixtures.Source, *snapshotter.InMemoryD
 		Source:       event.CombineSources(src, meshSrc),
 		ProcessorProvider: func(o processing.ProcessorOptions) event.Processor {
 			xforms := serviceentry.GetProviders().Create(o)
-			xforms[0].DispatchFor(collections.IstioNetworkingV1Alpha3SyntheticServiceentries.Name(), a)
+			xforms[0].DispatchFor(collections.IstioNetworkingV1Alpha3SyntheticServiceentries, a)
 			settings := []snapshotter.SnapshotOptions{
 				{
 					Group:       "syntheticServiceEntry",
@@ -1256,12 +1256,12 @@ func expectResource(
 	expectedVersionStr := fmt.Sprintf("istio/networking/v1alpha3/synthetic/serviceentries/%d", expectedVersion)
 	g.Eventually(func() string {
 		sn := dst.GetSnapshot("syntheticServiceEntry")
-		return sn.Version(serviceEntryCollection.String())
+		return sn.Version(serviceEntryCollection.Name().String())
 	}).Should(Equal(expectedVersionStr))
 
 	sn := dst.GetSnapshot("syntheticServiceEntry")
 	// Extract out the resource.
-	rs := sn.Resources(serviceEntryCollection.String())
+	rs := sn.Resources(serviceEntryCollection.Name().String())
 	if len(rs) != 1 {
 		t.Fatalf("expected snapshot resource count %d to equal %d", len(rs), 1)
 	}
@@ -1289,13 +1289,13 @@ func expectEmptySnapshot(t *testing.T, dst *snapshotter.InMemoryDistributor, exp
 	expectedVersionStr := fmt.Sprintf("istio/networking/v1alpha3/synthetic/serviceentries/%d", expectedVersion)
 	g.Eventually(func() string {
 		sn := dst.GetSnapshot("syntheticServiceEntry")
-		return sn.Version(serviceEntryCollection.String())
+		return sn.Version(serviceEntryCollection.Name().String())
 	}).Should(Equal(expectedVersionStr))
 
 	sn := dst.GetSnapshot("syntheticServiceEntry")
 
 	// Verify there are no resources in the snapshot.
-	rs := sn.Resources(serviceEntryCollection.String())
+	rs := sn.Resources(serviceEntryCollection.Name().String())
 	if len(rs) != 0 {
 		t.Fatalf("expected snapshot resource count %d to equal %d", len(rs), 0)
 	}

--- a/galley/pkg/config/processor/transforms/serviceentry/handler_bench_test.go
+++ b/galley/pkg/config/processor/transforms/serviceentry/handler_bench_test.go
@@ -173,7 +173,7 @@ func loadNodesAndPods(handler event.Handler) {
 		nodeName := "node" + strconv.Itoa(i)
 		handler.Handle(event.Event{
 			Kind:   event.Added,
-			Source: collections.K8SCoreV1Nodes.Name(),
+			Source: collections.K8SCoreV1Nodes,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName:   resource.NewFullName("", resource.LocalName(nodeName)),
@@ -194,7 +194,7 @@ func loadNodesAndPods(handler event.Handler) {
 		saIndex = (saIndex + 1) % len(serviceAccounts)
 		handler.Handle(event.Event{
 			Kind:   event.Added,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName:   resource.NewFullName(namespace, resource.LocalName(podName)),

--- a/galley/pkg/config/processor/transforms/serviceentry/pod/cache.go
+++ b/galley/pkg/config/processor/transforms/serviceentry/pod/cache.go
@@ -84,7 +84,7 @@ func (pc *cacheImpl) GetPodByIP(ip string) (Info, bool) {
 
 // Handle implements event.Handler
 func (pc *cacheImpl) Handle(e event.Event) {
-	switch e.Source {
+	switch e.Source.Name() {
 	case collections.K8SCoreV1Nodes.Name():
 		pc.handleNode(e)
 	case collections.K8SCoreV1Pods.Name():

--- a/galley/pkg/config/processor/transforms/serviceentry/pod/cache_test.go
+++ b/galley/pkg/config/processor/transforms/serviceentry/pod/cache_test.go
@@ -61,7 +61,7 @@ func TestPodLifecycle(t *testing.T) {
 	// Add the node.
 	h.Handle(event.Event{
 		Kind:     event.Added,
-		Source:   collections.K8SCoreV1Nodes.Name(),
+		Source:   collections.K8SCoreV1Nodes,
 		Resource: nodeEntry(region, zone),
 	})
 
@@ -69,7 +69,7 @@ func TestPodLifecycle(t *testing.T) {
 		g := NewGomegaWithT(t)
 		h.Handle(event.Event{
 			Kind:   event.Added,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Labels(labels).
@@ -96,7 +96,7 @@ func TestPodLifecycle(t *testing.T) {
 		g := NewGomegaWithT(t)
 		h.Handle(event.Event{
 			Kind:   event.Updated,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Labels(labels).
@@ -128,7 +128,7 @@ func TestPodLifecycle(t *testing.T) {
 		}
 		h.Handle(event.Event{
 			Kind:   event.Updated,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Labels(labels).
@@ -155,7 +155,7 @@ func TestPodLifecycle(t *testing.T) {
 		g := NewGomegaWithT(t)
 		h.Handle(event.Event{
 			Kind:   event.Deleted,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Labels(labels).
@@ -185,12 +185,12 @@ func TestNodeLifecycle(t *testing.T) {
 	applyEvents(l, h, []event.Event{
 		{
 			Kind:     event.Added,
-			Source:   collections.K8SCoreV1Nodes.Name(),
+			Source:   collections.K8SCoreV1Nodes,
 			Resource: nodeEntry(region, zone),
 		},
 		{
 			Kind:   event.Added,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Labels(labels).
@@ -200,7 +200,7 @@ func TestNodeLifecycle(t *testing.T) {
 		},
 		{
 			Kind:     event.Deleted,
-			Source:   collections.K8SCoreV1Nodes.Name(),
+			Source:   collections.K8SCoreV1Nodes,
 			Resource: nodeEntry(region, zone),
 		},
 	})
@@ -227,7 +227,7 @@ func TestNodeAddedAfterPod(t *testing.T) {
 	applyEvents(l, h, []event.Event{
 		{
 			Kind:   event.Added,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Labels(labels).
@@ -237,7 +237,7 @@ func TestNodeAddedAfterPod(t *testing.T) {
 		},
 		{
 			Kind:     event.Added,
-			Source:   collections.K8SCoreV1Nodes.Name(),
+			Source:   collections.K8SCoreV1Nodes,
 			Resource: nodeEntry(region, zone),
 		},
 	})
@@ -264,12 +264,12 @@ func TestNodeWithOnlyRegion(t *testing.T) {
 	applyEvents(l, h, []event.Event{
 		{
 			Kind:     event.Added,
-			Source:   collections.K8SCoreV1Nodes.Name(),
+			Source:   collections.K8SCoreV1Nodes,
 			Resource: nodeEntry(region, ""),
 		},
 		{
 			Kind:   event.Added,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Phase(coreV1.PodPending).
@@ -299,12 +299,12 @@ func TestNodeWithNoLocality(t *testing.T) {
 	applyEvents(l, h, []event.Event{
 		{
 			Kind:     event.Added,
-			Source:   collections.K8SCoreV1Nodes.Name(),
+			Source:   collections.K8SCoreV1Nodes,
 			Resource: nodeEntry("", ""),
 		},
 		{
 			Kind:   event.Added,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Phase(coreV1.PodPending).
@@ -332,7 +332,7 @@ func TestNoNamespaceAndNoServiceAccount(t *testing.T) {
 	g := NewGomegaWithT(t)
 	h.Handle(event.Event{
 		Kind:   event.Added,
-		Source: collections.K8SCoreV1Pods.Name(),
+		Source: collections.K8SCoreV1Pods,
 		Resource: &resource.Instance{
 			Metadata: resource.Metadata{
 				FullName: fullName,
@@ -371,7 +371,7 @@ func TestWrongCollectionShouldNotPanic(t *testing.T) {
 
 	h.Handle(event.Event{
 		Kind:   event.Added,
-		Source: collections.K8SCoreV1Services.Name(),
+		Source: collections.K8SCoreV1Services,
 		Resource: &resource.Instance{
 			Metadata: resource.Metadata{
 				FullName: resource.NewFullName("ns", "myservice"),
@@ -392,7 +392,7 @@ func TestInvalidPodPhase(t *testing.T) {
 			g := NewGomegaWithT(t)
 			h.Handle(event.Event{
 				Kind:   event.Added,
-				Source: collections.K8SCoreV1Services.Name(),
+				Source: collections.K8SCoreV1Services,
 				Resource: newPodEntryBuilder().
 					IP(ip).
 					Labels(labels).
@@ -415,7 +415,7 @@ func TestUpdateWithInvalidPhaseShouldDelete(t *testing.T) {
 	applyEvents(l, h, []event.Event{
 		{
 			Kind:   event.Added,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Labels(labels).
@@ -425,7 +425,7 @@ func TestUpdateWithInvalidPhaseShouldDelete(t *testing.T) {
 		},
 		{
 			Kind:   event.Updated,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Labels(labels).
@@ -455,7 +455,7 @@ func TestDeleteWithNoItemShouldUseFullName(t *testing.T) {
 	applyEvents(l, h, []event.Event{
 		{
 			Kind:   event.Added,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: newPodEntryBuilder().
 				IP(ip).
 				Labels(labels).
@@ -465,7 +465,7 @@ func TestDeleteWithNoItemShouldUseFullName(t *testing.T) {
 		},
 		{
 			Kind:   event.Deleted,
-			Source: collections.K8SCoreV1Pods.Name(),
+			Source: collections.K8SCoreV1Pods,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
 					FullName: fullName,
@@ -486,7 +486,7 @@ func TestDeleteNotFoundShouldNotPanic(t *testing.T) {
 	// Delete it, but with a nil Message to force a lookup by fullName.
 	h.Handle(event.Event{
 		Kind:   event.Deleted,
-		Source: collections.K8SCoreV1Services.Name(),
+		Source: collections.K8SCoreV1Services,
 		Resource: newPodEntryBuilder().
 			IP(ip).
 			Labels(labels).
@@ -503,7 +503,7 @@ func TestDeleteNotFoundWithMissingItemShouldNotPanic(t *testing.T) {
 	// Delete it, but with a nil Message to force a lookup by fullName.
 	h.Handle(event.Event{
 		Kind:   event.Deleted,
-		Source: collections.K8SCoreV1Pods.Name(),
+		Source: collections.K8SCoreV1Pods,
 		Resource: &resource.Instance{
 			Metadata: resource.Metadata{
 				FullName: fullName,
@@ -518,7 +518,7 @@ func TestPodWithNoIPShouldBeIgnored(t *testing.T) {
 
 	h.Handle(event.Event{
 		Kind:   event.Added,
-		Source: collections.K8SCoreV1Pods.Name(),
+		Source: collections.K8SCoreV1Pods,
 		Resource: newPodEntryBuilder().
 			Phase(coreV1.PodPending).Build(),
 	})

--- a/galley/pkg/config/resource/metadata.go
+++ b/galley/pkg/config/resource/metadata.go
@@ -16,10 +16,13 @@ package resource
 
 import (
 	"time"
+
+	"istio.io/istio/galley/pkg/config/schema/resource"
 )
 
 // Metadata about a resource.
 type Metadata struct {
+	Schema      resource.Schema
 	FullName    FullName
 	CreateTime  time.Time
 	Version     Version

--- a/galley/pkg/config/resource/serialization_test.go
+++ b/galley/pkg/config/resource/serialization_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package resource
+package resource_test
 
 import (
 	"bytes"
@@ -26,19 +26,28 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
+
+	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/schema/collections"
+	"istio.io/istio/galley/pkg/config/testing/fixtures"
+)
+
+var (
+	testSchema = collections.IstioMeshV1Alpha1MeshConfig.Resource()
 )
 
 func TestSerialization_Basic(t *testing.T) {
-	e := Instance{
-		Metadata: Metadata{
-			FullName:   NewFullName("ns1", "res1"),
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			Schema:     testSchema,
+			FullName:   resource.NewFullName("ns1", "res1"),
 			CreateTime: time.Unix(1, 1).UTC(),
 			Version:    "v1",
 		},
 		Message: parseStruct(`{ "foo": "bar" }`),
 	}
 
-	env, err := Serialize(&e)
+	env, err := resource.Serialize(&e)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -60,27 +69,25 @@ func TestSerialization_Basic(t *testing.T) {
 		t.Fatalf("Resources are not equal %v != %v", env.Body, expected)
 	}
 
-	ext, err := Deserialize(env)
+	ext, err := resource.Deserialize(env, testSchema)
 	if err != nil {
 		t.Fatalf("Unexpected error when extracting: %v", err)
 	}
 
-	if !reflect.DeepEqual(ext.Metadata, e.Metadata) {
-		t.Fatalf("mismatch: got:%v, wanted: %v", ext, e)
-	}
+	fixtures.ExpectEqual(t, ext.Metadata, e.Metadata)
 }
 
 func TestSerialize_Error(t *testing.T) {
-	e := Instance{
-		Metadata: Metadata{
-			FullName:   NewFullName("ns1", "res1"),
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			FullName:   resource.NewFullName("ns1", "res1"),
 			CreateTime: time.Unix(1, 1).UTC(),
 			Version:    "v1",
 		},
 		Message: &invalidProto{},
 	}
 
-	_, err := Serialize(&e)
+	_, err := resource.Serialize(&e)
 	if err == nil {
 		t.Fatal("expected error not found")
 	}
@@ -93,16 +100,16 @@ func TestMustSerialize(t *testing.T) {
 		}
 	}()
 
-	e := Instance{
-		Metadata: Metadata{
-			FullName:   NewFullName("ns1", "res1"),
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			FullName:   resource.NewFullName("ns1", "res1"),
 			CreateTime: time.Unix(1, 1).UTC(),
 			Version:    "v1",
 		},
 		Message: &types.Empty{},
 	}
 
-	_ = MustSerialize(&e)
+	_ = resource.MustSerialize(&e)
 }
 
 func TestMustSerialize_Panic(t *testing.T) {
@@ -112,88 +119,108 @@ func TestMustSerialize_Panic(t *testing.T) {
 		}
 	}()
 
-	e := Instance{
-		Metadata: Metadata{
-			FullName:   NewFullName("ns1", "res1"),
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			FullName:   resource.NewFullName("ns1", "res1"),
 			CreateTime: time.Unix(1, 1).UTC(),
 			Version:    "v1",
 		},
 		Message: &invalidProto{},
 	}
 
-	_ = MustSerialize(&e)
+	_ = resource.MustSerialize(&e)
 }
 
 func TestSerialize_InvalidTimestamp_Error(t *testing.T) {
-	e := Instance{
-		Metadata: Metadata{
-			FullName:   NewFullName("ns1", "res1"),
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			FullName:   resource.NewFullName("ns1", "res1"),
 			CreateTime: time.Unix(math.MinInt64, math.MinInt64).UTC(),
 			Version:    "v1",
 		},
 		Message: &types.Empty{},
 	}
-	_, err := Serialize(&e)
+	_, err := resource.Serialize(&e)
 	if err == nil {
 		t.Fatal("expected error not found")
 	}
 }
 
 func TestDeserialize_Error(t *testing.T) {
-	e := Instance{
-		Metadata: Metadata{
-			FullName:   NewFullName("ns1", "res1"),
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			FullName:   resource.NewFullName("ns1", "res1"),
 			CreateTime: time.Unix(1, 1).UTC(),
 			Version:    "v1",
 		},
 		Message: &types.Empty{},
 	}
 
-	env, err := Serialize(&e)
+	env, err := resource.Serialize(&e)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	env.Body.TypeUrl += ".foo"
 
-	if _, err = Deserialize(env); err == nil {
+	if _, err = resource.Deserialize(env, testSchema); err == nil {
 		t.Fatalf("expected error not found")
 	}
 }
 
-func TestDeserialize_InvalidTimestamp_Error(t *testing.T) {
-	e := Instance{
-		Metadata: Metadata{
-			FullName:   NewFullName("ns1", "res1"),
+func TestDeserialize_InvalidSchema(t *testing.T) {
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			FullName:   resource.NewFullName("ns1", "res1"),
 			CreateTime: time.Unix(1, 1).UTC(),
 			Version:    "v1",
 		},
 		Message: &types.Empty{},
 	}
 
-	env, err := Serialize(&e)
+	env, err := resource.Serialize(&e)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if _, err = resource.Deserialize(env, nil); err == nil {
+		t.Fatalf("expected error not found")
+	}
+}
+
+func TestDeserialize_InvalidTimestamp_Error(t *testing.T) {
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			FullName:   resource.NewFullName("ns1", "res1"),
+			CreateTime: time.Unix(1, 1).UTC(),
+			Version:    "v1",
+		},
+		Message: &types.Empty{},
+	}
+
+	env, err := resource.Serialize(&e)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	env.Metadata.CreateTime.Seconds = 253402300800 + 1
 
-	if _, err = Deserialize(env); err == nil {
+	if _, err = resource.Deserialize(env, testSchema); err == nil {
 		t.Fatalf("expected error not found")
 	}
 }
 
 func TestDeserialize_Any_Error(t *testing.T) {
-	e := Instance{
-		Metadata: Metadata{
-			FullName:   NewFullName("ns1", "res1"),
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			FullName:   resource.NewFullName("ns1", "res1"),
 			CreateTime: time.Unix(1, 1).UTC(),
 			Version:    "v1",
 		},
 		Message: &types.Empty{},
 	}
 
-	env, err := Serialize(&e)
+	env, err := resource.Serialize(&e)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -203,22 +230,22 @@ func TestDeserialize_Any_Error(t *testing.T) {
 	copy(b[1:], env.Body.Value)
 	env.Body.Value = b
 
-	if _, err = Deserialize(env); err == nil {
+	if _, err = resource.Deserialize(env, testSchema); err == nil {
 		t.Fatalf("expected error not found")
 	}
 }
 
 func TestMustDeserialize(t *testing.T) {
-	e := Instance{
-		Metadata: Metadata{
-			FullName:   NewFullName("ns1", "res1"),
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			FullName:   resource.NewFullName("ns1", "res1"),
 			CreateTime: time.Unix(1, 1).UTC(),
 			Version:    "v1",
 		},
 		Message: &types.Empty{},
 	}
 
-	s := MustSerialize(&e)
+	s := resource.MustSerialize(&e)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -226,20 +253,20 @@ func TestMustDeserialize(t *testing.T) {
 		}
 	}()
 
-	_ = MustDeserialize(s)
+	_ = resource.MustDeserialize(s, testSchema)
 }
 
 func TestMustDeserialize_Panic(t *testing.T) {
-	e := Instance{
-		Metadata: Metadata{
-			FullName:   NewFullName("ns1", "res1"),
+	e := resource.Instance{
+		Metadata: resource.Metadata{
+			FullName:   resource.NewFullName("ns1", "res1"),
 			CreateTime: time.Unix(1, 1).UTC(),
 			Version:    "v1",
 		},
 		Message: &types.Empty{},
 	}
 
-	s := MustSerialize(&e)
+	s := resource.MustSerialize(&e)
 
 	defer func() {
 		if r := recover(); r == nil {
@@ -249,57 +276,57 @@ func TestMustDeserialize_Panic(t *testing.T) {
 
 	s.Metadata.CreateTime.Seconds = 253402300800 + 1
 
-	_ = MustDeserialize(s)
+	_ = resource.MustDeserialize(s, testSchema)
 }
 
 func TestDeserializeAll(t *testing.T) {
-	entries := []*Instance{
+	entries := []*resource.Instance{
 		{
-			Metadata: Metadata{
-				FullName:   NewFullName("ns1", "res1"),
+			Metadata: resource.Metadata{
+				FullName:   resource.NewFullName("ns1", "res1"),
 				CreateTime: time.Unix(1, 1).UTC(),
 				Version:    "v1",
+				Schema:     testSchema,
 			},
 			Message: parseStruct(`{"foo": "bar"}`),
 		},
 		{
-			Metadata: Metadata{
-				FullName:   NewFullName("ns2", "res2"),
+			Metadata: resource.Metadata{
+				FullName:   resource.NewFullName("ns2", "res2"),
 				CreateTime: time.Unix(1, 1).UTC(),
 				Version:    "v2",
+				Schema:     testSchema,
 			},
 			Message: parseStruct(`{"bar": "foo"}`),
 		},
 	}
 
-	envs, err := SerializeAll(entries)
+	envs, err := resource.SerializeAll(entries)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	actual, err := DeserializeAll(envs)
+	actual, err := resource.DeserializeAll(envs, testSchema)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !reflect.DeepEqual(entries, actual) {
-		t.Fatalf("mismatch: got:%+v, wanted:%+v", actual, entries)
-	}
+	fixtures.ExpectEqual(t, entries, actual)
 }
 
 func TestSerializeAll_Error(t *testing.T) {
-	entries := []*Instance{
+	entries := []*resource.Instance{
 		{
-			Metadata: Metadata{
-				FullName:   NewFullName("ns1", "res1"),
+			Metadata: resource.Metadata{
+				FullName:   resource.NewFullName("ns1", "res1"),
 				CreateTime: time.Unix(1, 1).UTC(),
 				Version:    "v1",
 			},
 			Message: &invalidProto{},
 		},
 		{
-			Metadata: Metadata{
-				FullName:   NewFullName("ns2", "res2"),
+			Metadata: resource.Metadata{
+				FullName:   resource.NewFullName("ns2", "res2"),
 				CreateTime: time.Unix(1, 1).UTC(),
 				Version:    "v2",
 			},
@@ -307,24 +334,24 @@ func TestSerializeAll_Error(t *testing.T) {
 		},
 	}
 
-	if _, err := SerializeAll(entries); err == nil {
+	if _, err := resource.SerializeAll(entries); err == nil {
 		t.Fatal("expected error not found")
 	}
 }
 
 func TestDeserializeAll_Error(t *testing.T) {
-	entries := []*Instance{
+	entries := []*resource.Instance{
 		{
-			Metadata: Metadata{
-				FullName:   NewFullName("ns1", "res1"),
+			Metadata: resource.Metadata{
+				FullName:   resource.NewFullName("ns1", "res1"),
 				CreateTime: time.Unix(1, 1).UTC(),
 				Version:    "v1",
 			},
 			Message: &types.Empty{},
 		},
 		{
-			Metadata: Metadata{
-				FullName:   NewFullName("ns2", "res2"),
+			Metadata: resource.Metadata{
+				FullName:   resource.NewFullName("ns2", "res2"),
 				CreateTime: time.Unix(2, 2).UTC(),
 				Version:    "v2",
 			},
@@ -332,14 +359,14 @@ func TestDeserializeAll_Error(t *testing.T) {
 		},
 	}
 
-	env, err := SerializeAll(entries)
+	env, err := resource.SerializeAll(entries)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	env[1].Metadata.CreateTime.Seconds = 253402300800 + 1
 
-	if _, err = DeserializeAll(env); err == nil {
+	if _, err = resource.DeserializeAll(env, testSchema); err == nil {
 		t.Fatal("expected error not found")
 	}
 }

--- a/galley/pkg/config/schema/codegen/collections.go
+++ b/galley/pkg/config/schema/codegen/collections.go
@@ -49,7 +49,7 @@ var (
 			ProtoPackage: "{{ .Resource.ProtoPackage }}",
 			ClusterScoped: {{ .Resource.ClusterScoped }},
 			ValidateProto: validation.{{ .Resource.Validate }},
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 {{ end }}
 

--- a/galley/pkg/config/schema/codegen/collections_test.go
+++ b/galley/pkg/config/schema/codegen/collections_test.go
@@ -101,7 +101,7 @@ var (
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// Foo describes a really cool foo thing
@@ -117,7 +117,7 @@ var (
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			ClusterScoped: true,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 

--- a/galley/pkg/config/schema/collection/names_test.go
+++ b/galley/pkg/config/schema/collection/names_test.go
@@ -20,13 +20,14 @@ import (
 	. "github.com/onsi/gomega"
 
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 )
 
 func TestNames_Clone(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	n := collection.Names{data.K8SCollection1, data.Collection2}
+	n := collection.Names{basicmeta.K8SCollection1.Name(), basicmeta.Collection2.Name()}
 
 	n2 := n.Clone()
 	g.Expect(n2).To(Equal(n))
@@ -35,8 +36,8 @@ func TestNames_Clone(t *testing.T) {
 func TestNames_Sort(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	n := collection.Names{data.Collection2, data.Collection3, data.K8SCollection1}
-	expected := collection.Names{data.Collection2, data.Collection3, data.K8SCollection1}
+	n := collection.Names{data.Foo.Name(), data.Baz.Name(), data.Bar.Name()}
+	expected := collection.Names{data.Bar.Name(), data.Baz.Name(), data.Foo.Name()}
 
 	n.Sort()
 	g.Expect(n).To(Equal(expected))

--- a/galley/pkg/config/schema/collection/schema.go
+++ b/galley/pkg/config/schema/collection/schema.go
@@ -22,10 +22,13 @@ import (
 
 // Schema for a collection.
 type Schema interface {
-	resource.Schema
+	fmt.Stringer
 
 	// Name of the collection.
 	Name() Name
+
+	// Resource is the schema for resources contained in this collection.
+	Resource() resource.Schema
 
 	// IsDisabled indicates whether or not this collection is disabled.
 	IsDisabled() bool
@@ -65,7 +68,7 @@ func (b Builder) Build() (Schema, error) {
 func (b Builder) MustBuild() Schema {
 	s, err := b.Build()
 	if err != nil {
-		panic(fmt.Sprintf("MustNewSchema: %v", err))
+		panic(fmt.Sprintf("MustBuild: %v", err))
 	}
 
 	return s
@@ -86,6 +89,10 @@ func (s *immutableSchema) Name() Name {
 	return s.name
 }
 
+func (s *immutableSchema) Resource() resource.Schema {
+	return s.Schema
+}
+
 func (s *immutableSchema) IsDisabled() bool {
 	return s.disabled
 }
@@ -103,11 +110,5 @@ func (s *immutableSchema) Disable() Schema {
 func (s *immutableSchema) Equal(o Schema) bool {
 	return s.name == o.Name() &&
 		s.disabled == o.IsDisabled() &&
-		s.IsClusterScoped() == o.IsClusterScoped() &&
-		s.Kind() == o.Kind() &&
-		s.Plural() == o.Plural() &&
-		s.Group() == o.Group() &&
-		s.Version() == o.Version() &&
-		s.Proto() == o.Proto() &&
-		s.ProtoPackage() == o.ProtoPackage()
+		s.Resource().Equal(o.Resource())
 }

--- a/galley/pkg/config/schema/collection/schema_test.go
+++ b/galley/pkg/config/schema/collection/schema_test.go
@@ -17,7 +17,6 @@ package collection
 import (
 	"testing"
 
-	"github.com/gogo/protobuf/types"
 	. "github.com/onsi/gomega"
 
 	"istio.io/istio/galley/pkg/config/schema/resource"
@@ -29,14 +28,15 @@ func TestSchema_NewSchema(t *testing.T) {
 	s, err := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.Build()
 	g.Expect(err).To(BeNil())
 	g.Expect(s.Name()).To(Equal(NewName("foo")))
-	g.Expect(s.ProtoPackage()).To(Equal("github.com/gogo/protobuf/types"))
-	g.Expect(s.Proto()).To(Equal("google.protobuf.Empty"))
+	g.Expect(s.Resource().ProtoPackage()).To(Equal("github.com/gogo/protobuf/types"))
+	g.Expect(s.Resource().Proto()).To(Equal("google.protobuf.Empty"))
 }
 
 func TestSchema_NewSchema_Error(t *testing.T) {
@@ -45,9 +45,10 @@ func TestSchema_NewSchema_Error(t *testing.T) {
 	_, err := Builder{
 		Name: "$",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.Build()
 	g.Expect(err).NotTo(BeNil())
 }
@@ -62,13 +63,14 @@ func TestSchema_MustNewSchema(t *testing.T) {
 	s := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 	g.Expect(s.Name()).To(Equal(NewName("foo")))
-	g.Expect(s.ProtoPackage()).To(Equal("github.com/gogo/protobuf/types"))
-	g.Expect(s.Proto()).To(Equal("google.protobuf.Empty"))
+	g.Expect(s.Resource().ProtoPackage()).To(Equal("github.com/gogo/protobuf/types"))
+	g.Expect(s.Resource().Proto()).To(Equal("google.protobuf.Empty"))
 }
 
 func TestSchema_MustNewSchema_Error(t *testing.T) {
@@ -82,32 +84,20 @@ func TestSchema_MustNewSchema_Error(t *testing.T) {
 		Schema: resource.Builder{
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
-}
-
-func TestSchema_NewProtoInstance(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	s, err := Builder{
-		Name: "foo",
-		Schema: resource.Builder{
-			ProtoPackage: "github.com/gogo/protobuf/types",
-			Proto:        "google.protobuf.Empty",
-		}.Build()}.Build()
-	g.Expect(err).To(BeNil())
-
-	p := s.NewProtoInstance()
-	g.Expect(p).To(Equal(&types.Empty{}))
 }
 
 func TestSchema_String(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s := Builder{Name: "foo", Schema: resource.Builder{
-		ProtoPackage: "github.com/gogo/protobuf/types",
-		Proto:        "google.protobuf.Empty",
-	}.Build(),
+	s := Builder{
+		Name: "foo",
+		Schema: resource.Builder{
+			Kind:         "Empty",
+			ProtoPackage: "github.com/gogo/protobuf/types",
+			Proto:        "google.protobuf.Empty",
+		}.MustBuild(),
 	}.MustBuild()
 
 	g.Expect(s.String()).To(Equal(`[Schema](foo, "github.com/gogo/protobuf/types", google.protobuf.Empty)`))

--- a/galley/pkg/config/schema/collection/schemas.go
+++ b/galley/pkg/config/schema/collection/schemas.go
@@ -27,6 +27,15 @@ type Schemas struct {
 	byCollection map[string]Schema
 }
 
+// SchemasFor is a shortcut for creating Schemas. It uses MustAdd for each element.
+func SchemasFor(schemas ...Schema) Schemas {
+	b := NewSchemasBuilder()
+	for _, s := range schemas {
+		b.MustAdd(s)
+	}
+	return b.Build()
+}
+
 // SchemasBuilder is a builder for the schemas type.
 type SchemasBuilder struct {
 	schemas Schemas
@@ -102,7 +111,7 @@ func (s Schemas) MustFind(collection string) Schema {
 // FindByGroupAndKind searches and returns the resource spec with the given group/kind
 func (s Schemas) FindByGroupAndKind(group, kind string) (Schema, bool) {
 	for _, rs := range s.byCollection {
-		if rs.Group() == group && rs.Kind() == kind {
+		if rs.Resource().Group() == group && rs.Resource().Kind() == kind {
 			return rs, true
 		}
 	}
@@ -159,7 +168,7 @@ func (s Schemas) DisabledCollectionNames() Names {
 // Validate the schemas. Returns error if there is a problem.
 func (s Schemas) Validate() error {
 	for _, c := range s.All() {
-		if err := c.Validate(); err != nil {
+		if err := c.Resource().Validate(); err != nil {
 			return err
 		}
 	}

--- a/galley/pkg/config/schema/collection/schemas_test.go
+++ b/galley/pkg/config/schema/collection/schemas_test.go
@@ -30,9 +30,10 @@ func TestSchemas_Basic(t *testing.T) {
 	s := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 	err := b.Add(s)
 	g.Expect(err).To(BeNil())
@@ -53,9 +54,10 @@ func TestSchemas_MustAdd(t *testing.T) {
 	s := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 	b.MustAdd(s)
 }
@@ -71,9 +73,10 @@ func TestSchemas_MustRegister_Panic(t *testing.T) {
 	s := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 	b.MustAdd(s)
 	b.MustAdd(s)
@@ -86,9 +89,10 @@ func TestSchemasBuilder_Remove(t *testing.T) {
 	s := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 	b.MustAdd(s)
 
@@ -104,9 +108,10 @@ func TestSchemasBuilder_RemoveSpecs(t *testing.T) {
 	s := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	b1 := NewSchemasBuilder()
@@ -128,9 +133,10 @@ func TestSchemas_Find(t *testing.T) {
 	s := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	b.MustAdd(s)
@@ -156,9 +162,10 @@ func TestSchemas_MustFind(t *testing.T) {
 	s := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	b.MustAdd(s)
@@ -180,9 +187,10 @@ func TestSchemas_MustFind_Panic(t *testing.T) {
 	s := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	b.MustAdd(s)
@@ -202,7 +210,7 @@ func TestSchema_FindByGroupAndKind(t *testing.T) {
 			Proto:        "google.protobuf.Empty",
 			Group:        "mygroup",
 			Kind:         "Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	b.MustAdd(s)
@@ -227,7 +235,7 @@ func TestSchema_MustFind(t *testing.T) {
 			Proto:        "google.protobuf.Empty",
 			Group:        "mygroup",
 			Kind:         "Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	b.MustAdd(s)
@@ -256,16 +264,18 @@ func TestSchemas_CollectionNames(t *testing.T) {
 	s1 := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 	s2 := Builder{
 		Name: "bar",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 	b.MustAdd(s1)
 	b.MustAdd(s2)
@@ -282,16 +292,18 @@ func TestSchemas_Validate(t *testing.T) {
 	s1 := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 	s2 := Builder{
 		Name: "bar",
 		Schema: resource.Builder{
+			Kind:         "Empty",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "google.protobuf.Empty",
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 	b.MustAdd(s1)
 	b.MustAdd(s2)
@@ -307,9 +319,10 @@ func TestSchemas_Validate_Error(t *testing.T) {
 	s1 := Builder{
 		Name: "foo",
 		Schema: resource.Builder{
+			Kind:         "Zoo",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			Proto:        "zoo",
-		}.Build(),
+		}.BuildNoValidate(),
 	}.MustBuild()
 	b.MustAdd(s1)
 

--- a/galley/pkg/config/schema/collections/collections.gen.go
+++ b/galley/pkg/config/schema/collections/collections.gen.go
@@ -25,7 +25,7 @@ var (
 			ProtoPackage:  "istio.io/api/authentication/v1alpha1",
 			ClusterScoped: true,
 			ValidateProto: validation.ValidateAuthenticationPolicy,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioAuthenticationV1Alpha1Policies describes the collection
@@ -42,7 +42,7 @@ var (
 			ProtoPackage:  "istio.io/api/authentication/v1alpha1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateAuthenticationPolicy,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioConfigV1Alpha2Adapters describes the collection
@@ -59,7 +59,7 @@ var (
 			ProtoPackage:  "github.com/gogo/protobuf/types",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioConfigV1Alpha2Httpapispecbindings describes the collection
@@ -76,7 +76,7 @@ var (
 			ProtoPackage:  "istio.io/api/mixer/v1/config/client",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateHTTPAPISpecBinding,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioConfigV1Alpha2Httpapispecs describes the collection
@@ -93,7 +93,7 @@ var (
 			ProtoPackage:  "istio.io/api/mixer/v1/config/client",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateHTTPAPISpec,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioConfigV1Alpha2Templates describes the collection
@@ -110,7 +110,7 @@ var (
 			ProtoPackage:  "github.com/gogo/protobuf/types",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioMeshV1Alpha1MeshConfig describes the collection
@@ -127,7 +127,7 @@ var (
 			ProtoPackage:  "istio.io/api/mesh/v1alpha1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioMixerV1ConfigClientQuotaspecbindings describes the collection
@@ -144,7 +144,7 @@ var (
 			ProtoPackage:  "istio.io/api/mixer/v1/config/client",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateQuotaSpecBinding,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioMixerV1ConfigClientQuotaspecs describes the collection
@@ -161,7 +161,7 @@ var (
 			ProtoPackage:  "istio.io/api/mixer/v1/config/client",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateQuotaSpec,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioNetworkingV1Alpha3Destinationrules describes the collection
@@ -178,7 +178,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateDestinationRule,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioNetworkingV1Alpha3Envoyfilters describes the collection
@@ -195,7 +195,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateEnvoyFilter,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioNetworkingV1Alpha3Gateways describes the collection
@@ -212,7 +212,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateGateway,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioNetworkingV1Alpha3Serviceentries describes the collection
@@ -229,7 +229,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateServiceEntry,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioNetworkingV1Alpha3Sidecars describes the collection
@@ -246,7 +246,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateSidecar,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioNetworkingV1Alpha3SyntheticServiceentries describes the collection
@@ -263,7 +263,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateServiceEntry,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioNetworkingV1Alpha3Virtualservices describes the collection
@@ -280,7 +280,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateVirtualService,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioPolicyV1Beta1Attributemanifests describes the collection
@@ -297,7 +297,7 @@ var (
 			ProtoPackage:  "istio.io/api/policy/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioPolicyV1Beta1Handlers describes the collection
@@ -314,7 +314,7 @@ var (
 			ProtoPackage:  "istio.io/api/policy/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioPolicyV1Beta1Instances describes the collection
@@ -331,7 +331,7 @@ var (
 			ProtoPackage:  "istio.io/api/policy/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioPolicyV1Beta1Rules describes the collection
@@ -348,7 +348,7 @@ var (
 			ProtoPackage:  "istio.io/api/policy/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioRbacV1Alpha1Clusterrbacconfigs describes the collection
@@ -365,7 +365,7 @@ var (
 			ProtoPackage:  "istio.io/api/rbac/v1alpha1",
 			ClusterScoped: true,
 			ValidateProto: validation.ValidateClusterRbacConfig,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioRbacV1Alpha1Rbacconfigs describes the collection
@@ -382,7 +382,7 @@ var (
 			ProtoPackage:  "istio.io/api/rbac/v1alpha1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateRbacConfig,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioRbacV1Alpha1Servicerolebindings describes the collection
@@ -399,7 +399,7 @@ var (
 			ProtoPackage:  "istio.io/api/rbac/v1alpha1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateServiceRoleBinding,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioRbacV1Alpha1Serviceroles describes the collection
@@ -416,7 +416,7 @@ var (
 			ProtoPackage:  "istio.io/api/rbac/v1alpha1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateServiceRole,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioSecurityV1Beta1Authorizationpolicies describes the collection
@@ -433,7 +433,7 @@ var (
 			ProtoPackage:  "istio.io/api/security/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateAuthorizationPolicy,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// IstioSecurityV1Beta1Requestauthentications describes the collection
@@ -450,7 +450,7 @@ var (
 			ProtoPackage:  "istio.io/api/security/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateRequestAuthentication,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SAppsV1Deployments describes the collection k8s/apps/v1/deployments
@@ -466,7 +466,7 @@ var (
 			ProtoPackage:  "k8s.io/api/apps/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SAuthenticationIstioIoV1Alpha1Meshpolicies describes the collection
@@ -483,7 +483,7 @@ var (
 			ProtoPackage:  "istio.io/api/authentication/v1alpha1",
 			ClusterScoped: true,
 			ValidateProto: validation.ValidateAuthenticationPolicy,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SAuthenticationIstioIoV1Alpha1Policies describes the collection
@@ -500,7 +500,7 @@ var (
 			ProtoPackage:  "istio.io/api/authentication/v1alpha1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateAuthenticationPolicy,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SConfigIstioIoV1Alpha2Adapters describes the collection
@@ -517,7 +517,7 @@ var (
 			ProtoPackage:  "github.com/gogo/protobuf/types",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SConfigIstioIoV1Alpha2Attributemanifests describes the collection
@@ -534,7 +534,7 @@ var (
 			ProtoPackage:  "istio.io/api/policy/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SConfigIstioIoV1Alpha2Handlers describes the collection
@@ -551,7 +551,7 @@ var (
 			ProtoPackage:  "istio.io/api/policy/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SConfigIstioIoV1Alpha2Httpapispecbindings describes the collection
@@ -568,7 +568,7 @@ var (
 			ProtoPackage:  "istio.io/api/mixer/v1/config/client",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateHTTPAPISpecBinding,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SConfigIstioIoV1Alpha2Httpapispecs describes the collection
@@ -585,7 +585,7 @@ var (
 			ProtoPackage:  "istio.io/api/mixer/v1/config/client",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateHTTPAPISpec,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SConfigIstioIoV1Alpha2Instances describes the collection
@@ -602,7 +602,7 @@ var (
 			ProtoPackage:  "istio.io/api/policy/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SConfigIstioIoV1Alpha2Quotaspecbindings describes the collection
@@ -619,7 +619,7 @@ var (
 			ProtoPackage:  "istio.io/api/mixer/v1/config/client",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateQuotaSpecBinding,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SConfigIstioIoV1Alpha2Quotaspecs describes the collection
@@ -636,7 +636,7 @@ var (
 			ProtoPackage:  "istio.io/api/mixer/v1/config/client",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateQuotaSpec,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SConfigIstioIoV1Alpha2Rules describes the collection
@@ -653,7 +653,7 @@ var (
 			ProtoPackage:  "istio.io/api/policy/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SConfigIstioIoV1Alpha2Templates describes the collection
@@ -670,7 +670,7 @@ var (
 			ProtoPackage:  "github.com/gogo/protobuf/types",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Endpoints describes the collection k8s/core/v1/endpoints
@@ -686,7 +686,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Namespaces describes the collection k8s/core/v1/namespaces
@@ -702,7 +702,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: true,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Nodes describes the collection k8s/core/v1/nodes
@@ -718,7 +718,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: true,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Pods describes the collection k8s/core/v1/pods
@@ -734,7 +734,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Secrets describes the collection k8s/core/v1/secrets
@@ -750,7 +750,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Services describes the collection k8s/core/v1/services
@@ -766,7 +766,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SExtensionsV1Beta1Ingresses describes the collection
@@ -783,7 +783,7 @@ var (
 			ProtoPackage:  "k8s.io/api/extensions/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SNetworkingIstioIoV1Alpha3Destinationrules describes the collection
@@ -800,7 +800,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateDestinationRule,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SNetworkingIstioIoV1Alpha3Envoyfilters describes the collection
@@ -817,7 +817,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateEnvoyFilter,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SNetworkingIstioIoV1Alpha3Gateways describes the collection
@@ -834,7 +834,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateGateway,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SNetworkingIstioIoV1Alpha3Serviceentries describes the collection
@@ -851,7 +851,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateServiceEntry,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SNetworkingIstioIoV1Alpha3Sidecars describes the collection
@@ -868,7 +868,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateSidecar,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SNetworkingIstioIoV1Alpha3Virtualservices describes the collection
@@ -885,7 +885,7 @@ var (
 			ProtoPackage:  "istio.io/api/networking/v1alpha3",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateVirtualService,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SRbacIstioIoV1Alpha1Clusterrbacconfigs describes the collection
@@ -902,7 +902,7 @@ var (
 			ProtoPackage:  "istio.io/api/rbac/v1alpha1",
 			ClusterScoped: true,
 			ValidateProto: validation.ValidateClusterRbacConfig,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SRbacIstioIoV1Alpha1Policy describes the collection
@@ -919,7 +919,7 @@ var (
 			ProtoPackage:  "istio.io/api/rbac/v1alpha1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateServiceRoleBinding,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SRbacIstioIoV1Alpha1Rbacconfigs describes the collection
@@ -936,7 +936,7 @@ var (
 			ProtoPackage:  "istio.io/api/rbac/v1alpha1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateRbacConfig,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SRbacIstioIoV1Alpha1Serviceroles describes the collection
@@ -953,7 +953,7 @@ var (
 			ProtoPackage:  "istio.io/api/rbac/v1alpha1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateServiceRole,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SSecurityIstioIoV1Beta1Authorizationpolicies describes the collection
@@ -970,7 +970,7 @@ var (
 			ProtoPackage:  "istio.io/api/security/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateAuthorizationPolicy,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SSecurityIstioIoV1Beta1Requestauthentications describes the
@@ -987,7 +987,7 @@ var (
 			ProtoPackage:  "istio.io/api/security/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateRequestAuthentication,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// All contains all collections in the system.

--- a/galley/pkg/config/schema/kindmapping.go
+++ b/galley/pkg/config/schema/kindmapping.go
@@ -41,11 +41,12 @@ func ConstructKindMapping(allKinds []string, metadata *Metadata) (*Mapping, erro
 	kindToCollection := make(map[string]string)
 	collectionToKind := make(map[string]string)
 	for _, r := range metadata.KubeCollections().All() {
-		if _, ok := mixerKindMap[r.Kind()]; ok {
+		kind := r.Resource().Kind()
+		if _, ok := mixerKindMap[kind]; ok {
 			source := r.Name()
 			target := metadata.DirectTransformSettings().Mapping()[source]
-			kindToCollection[r.Kind()] = target.String()
-			collectionToKind[target.String()] = r.Kind()
+			kindToCollection[kind] = target.String()
+			collectionToKind[target.String()] = kind
 		}
 	}
 

--- a/galley/pkg/config/schema/schema.go
+++ b/galley/pkg/config/schema/schema.go
@@ -192,7 +192,7 @@ func Build(astm *ast.Metadata) (*Metadata, error) {
 			return nil, fmt.Errorf("failed locating proto validation function %s", ar.Validate)
 		}
 
-		r := resource.Builder{
+		r, err := resource.Builder{
 			ClusterScoped: ar.ClusterScoped,
 			Kind:          ar.Kind,
 			Plural:        ar.Plural,
@@ -202,8 +202,11 @@ func Build(astm *ast.Metadata) (*Metadata, error) {
 			ProtoPackage:  ar.ProtoPackage,
 			ValidateProto: validateFn,
 		}.Build()
+		if err != nil {
+			return nil, err
+		}
 
-		key := resourceKey(r.Group(), r.Kind())
+		key := resourceKey(ar.Group, ar.Kind)
 		if _, ok := resources[key]; ok {
 			return nil, fmt.Errorf("found duplicate resource for resource (%s)", key)
 		}

--- a/galley/pkg/config/schema/schema_test.go
+++ b/galley/pkg/config/schema/schema_test.go
@@ -21,21 +21,12 @@ import (
 
 	"istio.io/istio/galley/pkg/config/schema/ast"
 	"istio.io/istio/galley/pkg/config/schema/collection"
-	"istio.io/istio/galley/pkg/config/schema/resource"
+	"istio.io/istio/galley/pkg/config/schema/collections"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
-	"istio.io/istio/pkg/config/validation"
 )
 
 var (
-	virtualServiceResource = resource.Builder{
-		ProtoPackage:  "istio.io/api/networking/v1alpha3",
-		Proto:         "istio.networking.v1alpha3.VirtualService",
-		Version:       "v1alpha3",
-		Kind:          "VirtualService",
-		Plural:        "VirtualServices",
-		Group:         "networking.istio.io",
-		ValidateProto: validation.ValidateVirtualService,
-	}.Build()
+	virtualServiceResource = collections.IstioNetworkingV1Alpha3Virtualservices.Resource()
 )
 
 func TestSchema_ParseAndBuild(t *testing.T) {
@@ -70,7 +61,7 @@ snapshots:
 
 resources:
   - kind:         "VirtualService"
-    plural:       "VirtualServices"
+    plural:       "virtualservices"
     group:        "networking.istio.io"
     version:      "v1alpha3"
     proto:        "istio.networking.v1alpha3.VirtualService"
@@ -163,7 +154,7 @@ collections:
     group:        "networking.istio.io"
 resources:
   - kind:         "VirtualService"
-    plural:       "VirtualServices"
+    plural:       "virtualservices"
     group:        "networking.istio.io"
     version:      "v1alpha3"
     proto:        "istio.networking.v1alpha3.VirtualService"
@@ -183,7 +174,7 @@ collections:
     group:        "networking.istio.io"
 resources:
   - kind:         "VirtualService"
-    plural:       "VirtualServices"
+    plural:       "virtualservices"
     group:        "networking.istio.io"
     version:      "v1alpha3"
     proto:        "istio.networking.v1alpha3.VirtualService"
@@ -200,7 +191,7 @@ collections:
     group:        "networking.istio.io"
 resources:
   - kind:         "VirtualService"
-    plural:       "VirtualServices"
+    plural:       "virtualservices"
     group:        "networking.istio.io"
     version:      "v1alpha3"
     proto:        "istio.networking.v1alpha3.VirtualService"
@@ -232,7 +223,7 @@ collections:
     group:        "networking.istio.io"
 resources:
   - kind:         "VirtualService"
-    plural:       "VirtualServices"
+    plural:       "virtualservices"
     group:        "networking.istio.io"
     version:      "v1alpha3"
     proto:        "istio.networking.v1alpha3.VirtualService"
@@ -253,7 +244,7 @@ collections:
     group:        "networking.istio.io"
 resources:
   - kind:         "VirtualService"
-    plural:       "VirtualServices"
+    plural:       "virtualservices"
     group:        "networking.istio.io"
     version:      "v1alpha3"
     proto:        "istio.networking.v1alpha3.VirtualService"
@@ -295,7 +286,7 @@ snapshots:
 
 resources:
   - kind:         "VirtualService"
-    plural:       "VirtualServices"
+    plural:       "virtualservices"
     group:        "networking.istio.io"
     version:      "v1alpha3"
     proto:        "istio.networking.v1alpha3.VirtualService"
@@ -363,7 +354,7 @@ func TestSchemaBasic(t *testing.T) {
 		collection.NewName("k8s/networking.istio.io/v1alpha3/virtualservices"),
 	})
 
-	g.Expect(s.KubeCollections().All()[0].CanonicalResourceName()).To(Equal("networking.istio.io/v1alpha3/VirtualService"))
+	g.Expect(s.KubeCollections().All()[0].Resource().CanonicalName()).To(Equal("networking.istio.io/v1alpha3/VirtualService"))
 }
 
 func TestSchema_DirectTransform_Panic(t *testing.T) {

--- a/galley/pkg/config/source/inmemory/collection_test.go
+++ b/galley/pkg/config/source/inmemory/collection_test.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/scope"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 )
@@ -31,13 +32,13 @@ import (
 func TestCollection_Start_Empty(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	col := NewCollection(data.K8SCollection1)
+	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
 	col.Dispatch(acc)
 
 	col.Start()
 
-	expected := []event.Event{event.FullSyncFor(data.K8SCollection1)}
+	expected := []event.Event{event.FullSyncFor(basicmeta.K8SCollection1)}
 	actual := acc.Events()
 	g.Expect(actual).To(Equal(expected))
 }
@@ -51,14 +52,14 @@ func TestCollection_Start_Element(t *testing.T) {
 	}()
 	scope.Source.SetOutputLevel(log.DebugLevel)
 
-	col := NewCollection(data.K8SCollection1)
+	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
 	col.Dispatch(acc)
 
 	col.Set(data.Event1Col1AddItem1.Resource)
 	col.Start()
 
-	expected := []event.Event{data.Event1Col1AddItem1, event.FullSyncFor(data.K8SCollection1)}
+	expected := []event.Event{data.Event1Col1AddItem1, event.FullSyncFor(basicmeta.K8SCollection1)}
 	actual := acc.Events()
 	g.Expect(actual).To(Equal(expected))
 }
@@ -66,7 +67,7 @@ func TestCollection_Start_Element(t *testing.T) {
 func TestCollection_Update(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	col := NewCollection(data.K8SCollection1)
+	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
 	col.Dispatch(acc)
 
@@ -77,7 +78,7 @@ func TestCollection_Update(t *testing.T) {
 
 	expected := []event.Event{
 		data.Event1Col1AddItem1,
-		event.FullSyncFor(data.K8SCollection1),
+		event.FullSyncFor(basicmeta.K8SCollection1),
 		data.Event1Col1UpdateItem1}
 
 	actual := acc.Events()
@@ -87,7 +88,7 @@ func TestCollection_Update(t *testing.T) {
 func TestCollection_Delete(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	col := NewCollection(data.K8SCollection1)
+	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
 	col.Dispatch(acc)
 
@@ -98,7 +99,7 @@ func TestCollection_Delete(t *testing.T) {
 
 	expected := []event.Event{
 		data.Event1Col1AddItem1,
-		event.FullSyncFor(data.K8SCollection1),
+		event.FullSyncFor(basicmeta.K8SCollection1),
 		data.Event1Col1DeleteItem1}
 
 	actual := acc.Events()
@@ -108,7 +109,7 @@ func TestCollection_Delete(t *testing.T) {
 func TestCollection_Delete_NoItem(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	col := NewCollection(data.K8SCollection1)
+	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
 	col.Dispatch(acc)
 
@@ -119,7 +120,7 @@ func TestCollection_Delete_NoItem(t *testing.T) {
 
 	expected := []event.Event{
 		data.Event1Col1AddItem1,
-		event.FullSyncFor(data.K8SCollection1)}
+		event.FullSyncFor(basicmeta.K8SCollection1)}
 
 	actual := acc.Events()
 	g.Expect(actual).To(Equal(expected))
@@ -128,7 +129,7 @@ func TestCollection_Delete_NoItem(t *testing.T) {
 func TestCollection_Clear_BeforeStart(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	col := NewCollection(data.K8SCollection1)
+	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
 	col.Dispatch(acc)
 
@@ -138,7 +139,7 @@ func TestCollection_Clear_BeforeStart(t *testing.T) {
 
 	col.Start()
 
-	expected := []event.Event{event.FullSyncFor(data.K8SCollection1)}
+	expected := []event.Event{event.FullSyncFor(basicmeta.K8SCollection1)}
 	actual := acc.Events()
 	g.Expect(actual).To(Equal(expected))
 }
@@ -146,7 +147,7 @@ func TestCollection_Clear_BeforeStart(t *testing.T) {
 func TestCollection_Clear_AfterStart(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	col := NewCollection(data.K8SCollection1)
+	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
 	col.Dispatch(acc)
 
@@ -158,7 +159,7 @@ func TestCollection_Clear_AfterStart(t *testing.T) {
 	expected := []interface{}{
 		data.Event1Col1AddItem1,
 		data.Event2Col1AddItem2,
-		event.FullSyncFor(data.K8SCollection1),
+		event.FullSyncFor(basicmeta.K8SCollection1),
 		data.Event1Col1DeleteItem1,
 		data.Event1Col1DeleteItem2,
 	}
@@ -170,7 +171,7 @@ func TestCollection_Clear_AfterStart(t *testing.T) {
 func TestCollection_StopStart(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	col := NewCollection(data.K8SCollection1)
+	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
 	col.Dispatch(acc)
 
@@ -179,7 +180,7 @@ func TestCollection_StopStart(t *testing.T) {
 
 	expected := []event.Event{
 		data.Event1Col1AddItem1,
-		event.FullSyncFor(data.K8SCollection1)}
+		event.FullSyncFor(basicmeta.K8SCollection1)}
 
 	g.Eventually(acc.Events).Should(Equal(expected))
 
@@ -193,7 +194,7 @@ func TestCollection_StopStart(t *testing.T) {
 func TestCollection_AllSorted(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	col := NewCollection(data.K8SCollection1)
+	col := NewCollection(basicmeta.K8SCollection1)
 
 	col.Set(data.EntryN1I1V1)
 	col.Set(data.EntryN2I2V2)

--- a/galley/pkg/config/source/inmemory/source.go
+++ b/galley/pkg/config/source/inmemory/source.go
@@ -37,19 +37,20 @@ type Source struct {
 var _ event.Source = &Source{}
 
 // New returns a new in-memory source, based on given collections.
-func New(collections collection.Names) *Source {
+func New(collections collection.Schemas) *Source {
 	name := fmt.Sprintf("inmemory-%d", inMemoryNameDiscriminator)
 	inMemoryNameDiscriminator++
 
-	scope.Source.Debugf("Creating new in-memory source (collections: %d)", len(collections))
+	all := collections.All()
+	scope.Source.Debugf("Creating new in-memory source (collections: %d)", len(all))
 
 	s := &Source{
 		collections: make(map[collection.Name]*Collection),
 		name:        name,
 	}
 
-	for _, c := range collections {
-		s.collections[c] = NewCollection(c)
+	for _, c := range all {
+		s.collections[c.Name()] = NewCollection(c)
 	}
 
 	return s

--- a/galley/pkg/config/source/inmemory/source_test.go
+++ b/galley/pkg/config/source/inmemory/source_test.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 
@@ -29,13 +30,13 @@ import (
 )
 
 var (
-	collectionNames = collection.Names{data.K8SCollection1}
+	cols = collection.SchemasFor(basicmeta.K8SCollection1)
 )
 
 func TestInMemory_Register_Empty(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	i := New(collectionNames)
+	i := New(cols)
 	h := &fixtures.Accumulator{}
 	i.Dispatch(h)
 	i.Start()
@@ -44,7 +45,7 @@ func TestInMemory_Register_Empty(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.FullSync,
-			Source: data.K8SCollection1,
+			Source: basicmeta.K8SCollection1,
 		},
 	}
 
@@ -62,8 +63,8 @@ func TestInMemory_Set_BeforeSync(t *testing.T) {
 		Message: &types.Empty{},
 	}
 
-	i := New(collectionNames)
-	i.Get(data.K8SCollection1).Set(r)
+	i := New(cols)
+	i.Get(basicmeta.K8SCollection1.Name()).Set(r)
 
 	h := &fixtures.Accumulator{}
 	i.Dispatch(h)
@@ -73,12 +74,12 @@ func TestInMemory_Set_BeforeSync(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:     event.Added,
-			Source:   data.K8SCollection1,
+			Source:   basicmeta.K8SCollection1,
 			Resource: r,
 		},
 		{
 			Kind:   event.FullSync,
-			Source: data.K8SCollection1,
+			Source: basicmeta.K8SCollection1,
 		},
 	}
 
@@ -96,7 +97,7 @@ func TestInMemory_Set_Add(t *testing.T) {
 		Message: &types.Empty{},
 	}
 
-	i := New(collectionNames)
+	i := New(cols)
 
 	h := &fixtures.Accumulator{}
 	i.Dispatch(h)
@@ -106,22 +107,22 @@ func TestInMemory_Set_Add(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.FullSync,
-			Source: data.K8SCollection1,
+			Source: basicmeta.K8SCollection1,
 		},
 	}
 
 	g.Expect(h.Events()).To(Equal(expected))
 
-	i.Get(data.K8SCollection1).Set(r)
+	i.Get(basicmeta.K8SCollection1.Name()).Set(r)
 
 	expected = []event.Event{
 		{
 			Kind:   event.FullSync,
-			Source: data.K8SCollection1,
+			Source: basicmeta.K8SCollection1,
 		},
 		{
 			Kind:     event.Added,
-			Source:   data.K8SCollection1,
+			Source:   basicmeta.K8SCollection1,
 			Resource: r,
 		},
 	}
@@ -147,7 +148,7 @@ func TestInMemory_Set_Update(t *testing.T) {
 		Message: &types.Empty{},
 	}
 
-	i := New(collectionNames)
+	i := New(cols)
 
 	h := &fixtures.Accumulator{}
 	i.Dispatch(h)
@@ -157,28 +158,28 @@ func TestInMemory_Set_Update(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.FullSync,
-			Source: data.K8SCollection1,
+			Source: basicmeta.K8SCollection1,
 		},
 	}
 
 	g.Expect(h.Events()).To(Equal(expected))
 
-	i.Get(data.K8SCollection1).Set(r1)
-	i.Get(data.K8SCollection1).Set(r2)
+	i.Get(basicmeta.K8SCollection1.Name()).Set(r1)
+	i.Get(basicmeta.K8SCollection1.Name()).Set(r2)
 
 	expected = []event.Event{
 		{
 			Kind:   event.FullSync,
-			Source: data.K8SCollection1,
+			Source: basicmeta.K8SCollection1,
 		},
 		{
 			Kind:     event.Added,
-			Source:   data.K8SCollection1,
+			Source:   basicmeta.K8SCollection1,
 			Resource: r1,
 		},
 		{
 			Kind:     event.Updated,
-			Source:   data.K8SCollection1,
+			Source:   basicmeta.K8SCollection1,
 			Resource: r2,
 		},
 	}
@@ -189,8 +190,8 @@ func TestInMemory_Set_Update(t *testing.T) {
 func TestInMemory_Clear_BeforeSync(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	i := New(collectionNames)
-	i.Get(data.K8SCollection1).Set(data.EntryN1I1V1)
+	i := New(cols)
+	i.Get(basicmeta.K8SCollection1.Name()).Set(data.EntryN1I1V1)
 
 	h := &fixtures.Accumulator{}
 	i.Dispatch(h)
@@ -203,7 +204,7 @@ func TestInMemory_Clear_BeforeSync(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.FullSync,
-			Source: data.K8SCollection1,
+			Source: basicmeta.K8SCollection1,
 		},
 	}
 
@@ -213,8 +214,8 @@ func TestInMemory_Clear_BeforeSync(t *testing.T) {
 func TestInMemory_Clear_AfterSync(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	i := New(collectionNames)
-	i.Get(data.K8SCollection1).Set(data.EntryN1I1V1)
+	i := New(cols)
+	i.Get(basicmeta.K8SCollection1.Name()).Set(data.EntryN1I1V1)
 
 	h := &fixtures.Accumulator{}
 	i.Dispatch(h)
@@ -228,7 +229,7 @@ func TestInMemory_Clear_AfterSync(t *testing.T) {
 		data.Event1Col1AddItem1,
 		{
 			Kind:   event.FullSync,
-			Source: data.K8SCollection1,
+			Source: basicmeta.K8SCollection1,
 		},
 		data.Event1Col1DeleteItem1,
 	}
@@ -239,7 +240,7 @@ func TestInMemory_Clear_AfterSync(t *testing.T) {
 func TestInMemory_DoubleStart(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	i := New(collectionNames)
+	i := New(cols)
 	h := &fixtures.Accumulator{}
 	i.Dispatch(h)
 	i.Start()
@@ -249,7 +250,7 @@ func TestInMemory_DoubleStart(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.FullSync,
-			Source: data.K8SCollection1,
+			Source: basicmeta.K8SCollection1,
 		},
 	}
 
@@ -259,7 +260,7 @@ func TestInMemory_DoubleStart(t *testing.T) {
 func TestInMemory_DoubleStop(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	i := New(collectionNames)
+	i := New(cols)
 	h := &fixtures.Accumulator{}
 	i.Dispatch(h)
 	i.Start()
@@ -267,7 +268,7 @@ func TestInMemory_DoubleStop(t *testing.T) {
 	expected := []event.Event{
 		{
 			Kind:   event.FullSync,
-			Source: data.K8SCollection1,
+			Source: basicmeta.K8SCollection1,
 		},
 	}
 

--- a/galley/pkg/config/source/kube/apiserver/source_builtin_test.go
+++ b/galley/pkg/config/source/kube/apiserver/source_builtin_test.go
@@ -26,7 +26,9 @@ import (
 
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
+	resource2 "istio.io/istio/galley/pkg/config/schema/resource"
 	"istio.io/istio/galley/pkg/config/scope"
+	"istio.io/istio/galley/pkg/config/testing/fixtures"
 	"istio.io/istio/galley/pkg/config/testing/k8smeta"
 	"istio.io/istio/galley/pkg/testing/mock"
 )
@@ -52,6 +54,8 @@ var (
 		},
 		ResourceVersion: "rv1",
 	}
+
+	metadata = k8smeta.MustGet().KubeCollections()
 )
 
 func TestBasic(t *testing.T) {
@@ -90,8 +94,9 @@ func TestBasic(t *testing.T) {
 		t.Fatalf("failed creating node: %v", err)
 	}
 
-	expected := event.AddFor(k8smeta.K8SCoreV1Nodes.Name(), toResource(node, &node.Spec))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected := event.AddFor(k8smeta.K8SCoreV1Nodes, toResource(node, &node.Spec, k8smeta.K8SCoreV1Nodes.Resource()))
+
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 }
 
 func TestNodes(t *testing.T) {
@@ -106,7 +111,7 @@ func TestNodes(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Start the source.
-	s := newOrFail(t, k, k8smeta.MustGet().KubeCollections(), nil)
+	s := newOrFail(t, k, metadata, nil)
 	acc := start(s)
 	defer s.Stop()
 
@@ -129,8 +134,8 @@ func TestNodes(t *testing.T) {
 		t.Fatalf("failed creating node: %v", err)
 	}
 
-	expected := event.AddFor(k8smeta.K8SCoreV1Nodes.Name(), toResource(node, &node.Spec))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected := event.AddFor(k8smeta.K8SCoreV1Nodes, toResource(node, &node.Spec, k8smeta.K8SCoreV1Nodes.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 
 	acc.Clear()
 
@@ -142,8 +147,8 @@ func TestNodes(t *testing.T) {
 		t.Fatalf("failed updating node: %v", err)
 	}
 
-	expected = event.UpdateFor(k8smeta.K8SCoreV1Nodes.Name(), toResource(node, &node.Spec))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected = event.UpdateFor(k8smeta.K8SCoreV1Nodes, toResource(node, &node.Spec, k8smeta.K8SCoreV1Nodes.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 
 	acc.Clear()
 
@@ -158,8 +163,8 @@ func TestNodes(t *testing.T) {
 	if err = client.CoreV1().Nodes().Delete(node.Name, nil); err != nil {
 		t.Fatalf("failed deleting node: %v", err)
 	}
-	expected = event.DeleteForResource(k8smeta.K8SCoreV1Nodes.Name(), toResource(node, &node.Spec))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected = event.DeleteForResource(k8smeta.K8SCoreV1Nodes, toResource(node, &node.Spec, k8smeta.K8SCoreV1Nodes.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 }
 
 func TestPods(t *testing.T) {
@@ -174,7 +179,7 @@ func TestPods(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Start the source.
-	s := newOrFail(t, k, k8smeta.MustGet().KubeCollections(), nil)
+	s := newOrFail(t, k, metadata, nil)
 	acc := start(s)
 	defer s.Stop()
 
@@ -207,8 +212,8 @@ func TestPods(t *testing.T) {
 	if pod, err = client.CoreV1().Pods(namespace).Create(pod); err != nil {
 		t.Fatalf("failed creating pod: %v", err)
 	}
-	expected := event.AddFor(k8smeta.K8SCoreV1Pods.Name(), toResource(pod, pod))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected := event.AddFor(k8smeta.K8SCoreV1Pods, toResource(pod, pod, k8smeta.K8SCoreV1Pods.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 
 	acc.Clear()
 
@@ -219,8 +224,8 @@ func TestPods(t *testing.T) {
 	if _, err = client.CoreV1().Pods(namespace).Update(pod); err != nil {
 		t.Fatalf("failed updating pod: %v", err)
 	}
-	expected = event.UpdateFor(k8smeta.K8SCoreV1Pods.Name(), toResource(pod, pod))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected = event.UpdateFor(k8smeta.K8SCoreV1Pods, toResource(pod, pod, k8smeta.K8SCoreV1Pods.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 
 	acc.Clear()
 
@@ -236,8 +241,8 @@ func TestPods(t *testing.T) {
 	if err = client.CoreV1().Pods(namespace).Delete(pod.Name, nil); err != nil {
 		t.Fatalf("failed deleting pod: %v", err)
 	}
-	expected = event.DeleteForResource(k8smeta.K8SCoreV1Pods.Name(), toResource(pod, pod))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected = event.DeleteForResource(k8smeta.K8SCoreV1Pods, toResource(pod, pod, k8smeta.K8SCoreV1Pods.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 }
 
 func TestServices(t *testing.T) {
@@ -252,7 +257,7 @@ func TestServices(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Start the source.
-	s := newOrFail(t, k, k8smeta.MustGet().KubeCollections(), nil)
+	s := newOrFail(t, k, metadata, nil)
 	acc := start(s)
 	defer s.Stop()
 
@@ -280,8 +285,8 @@ func TestServices(t *testing.T) {
 	if svc, err = client.CoreV1().Services(namespace).Create(svc); err != nil {
 		t.Fatalf("failed creating service: %v", err)
 	}
-	expected := event.AddFor(k8smeta.K8SCoreV1Services.Name(), toResource(svc, &svc.Spec))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected := event.AddFor(k8smeta.K8SCoreV1Services, toResource(svc, &svc.Spec, k8smeta.K8SCoreV1Services.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 
 	acc.Clear()
 
@@ -292,8 +297,8 @@ func TestServices(t *testing.T) {
 	if _, err = client.CoreV1().Services(namespace).Update(svc); err != nil {
 		t.Fatalf("failed updating service: %v", err)
 	}
-	expected = event.UpdateFor(k8smeta.K8SCoreV1Services.Name(), toResource(svc, &svc.Spec))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected = event.UpdateFor(k8smeta.K8SCoreV1Services, toResource(svc, &svc.Spec, k8smeta.K8SCoreV1Services.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 
 	acc.Clear()
 
@@ -309,8 +314,8 @@ func TestServices(t *testing.T) {
 	if err = client.CoreV1().Services(namespace).Delete(svc.Name, nil); err != nil {
 		t.Fatalf("failed deleting service: %v", err)
 	}
-	expected = event.DeleteForResource(k8smeta.K8SCoreV1Services.Name(), toResource(svc, &svc.Spec))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected = event.DeleteForResource(k8smeta.K8SCoreV1Services, toResource(svc, &svc.Spec, k8smeta.K8SCoreV1Services.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 }
 
 func TestEndpoints(t *testing.T) {
@@ -325,7 +330,7 @@ func TestEndpoints(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Start the source.
-	s := newOrFail(t, k, k8smeta.MustGet().KubeCollections(), nil)
+	s := newOrFail(t, k, metadata, nil)
 	acc := start(s)
 	defer s.Stop()
 
@@ -360,8 +365,8 @@ func TestEndpoints(t *testing.T) {
 	if eps, err = client.CoreV1().Endpoints(namespace).Create(eps); err != nil {
 		t.Fatalf("failed creating endpoints: %v", err)
 	}
-	expected := event.AddFor(k8smeta.K8SCoreV1Endpoints.Name(), toResource(eps, eps))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected := event.AddFor(k8smeta.K8SCoreV1Endpoints, toResource(eps, eps, k8smeta.K8SCoreV1Endpoints.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 
 	acc.Clear()
 
@@ -372,8 +377,8 @@ func TestEndpoints(t *testing.T) {
 	if _, err = client.CoreV1().Endpoints(namespace).Update(eps); err != nil {
 		t.Fatalf("failed updating endpoints: %v", err)
 	}
-	expected = event.UpdateFor(k8smeta.K8SCoreV1Endpoints.Name(), toResource(eps, eps))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected = event.UpdateFor(k8smeta.K8SCoreV1Endpoints, toResource(eps, eps, k8smeta.K8SCoreV1Endpoints.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 
 	acc.Clear()
 
@@ -390,11 +395,11 @@ func TestEndpoints(t *testing.T) {
 	if err = client.CoreV1().Endpoints(namespace).Delete(eps.Name, nil); err != nil {
 		t.Fatalf("failed deleting endpoints: %v", err)
 	}
-	expected = event.DeleteForResource(k8smeta.K8SCoreV1Endpoints.Name(), toResource(eps, eps))
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(expected))
+	expected = event.DeleteForResource(k8smeta.K8SCoreV1Endpoints, toResource(eps, eps, k8smeta.K8SCoreV1Endpoints.Resource()))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc, expected)
 }
 
-func toResource(objectMeta metav1.Object, item proto.Message) *resource.Instance {
+func toResource(objectMeta metav1.Object, item proto.Message, schema resource2.Schema) *resource.Instance {
 	return &resource.Instance{
 		Metadata: resource.Metadata{
 			FullName:    resource.NewFullName(resource.Namespace(objectMeta.GetNamespace()), resource.LocalName(objectMeta.GetName())),
@@ -402,6 +407,7 @@ func toResource(objectMeta metav1.Object, item proto.Message) *resource.Instance
 			CreateTime:  fakeCreateTime,
 			Labels:      objectMeta.GetLabels(),
 			Annotations: objectMeta.GetAnnotations(),
+			Schema:      schema,
 		},
 		Message: item,
 	}

--- a/galley/pkg/config/source/kube/apiserver/status/controller.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller.go
@@ -76,9 +76,9 @@ func (c *ControllerImpl) Start(p *rt.Provider, resources []collection.Schema) {
 			continue
 		}
 
-		iface, err := p.GetDynamicResourceInterface(r)
+		iface, err := p.GetDynamicResourceInterface(r.Resource())
 		if err != nil {
-			scope.Source.Errorf("Unable to create a dynamic resource interface for resource %v", r.CanonicalResourceName())
+			scope.Source.Errorf("Unable to create a dynamic resource interface for resource %v", r.Resource().CanonicalName())
 		}
 		ifaces[r.Name()] = iface
 	}

--- a/galley/pkg/config/source/kube/apiserver/status/state_test.go
+++ b/galley/pkg/config/source/kube/apiserver/status/state_test.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/source/kube/rt"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 )
 
@@ -33,13 +34,13 @@ func TestState_SetLastKnown_NoEntry(t *testing.T) {
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
 
 	g.Expect(s.hasWork()).To(BeTrue())
 
 	st, ok := s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
-	g.Expect(st.key.col).To(Equal(data.K8SCollection1))
+	g.Expect(st.key.col).To(Equal(basicmeta.K8SCollection1.Name()))
 	g.Expect(st.key.res).To(Equal(data.EntryN1I1V1.Metadata.FullName))
 	g.Expect(st.observedStatus).To(Equal("foo"))
 	g.Expect(st.observedVersion).To(Equal(data.EntryN1I1V1.Metadata.Version))
@@ -53,7 +54,7 @@ func TestState_SetLastKnown_NoReconciliation(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	s := newState()
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
 
 	g.Expect(s.hasWork()).To(BeFalse())
 }
@@ -63,13 +64,13 @@ func TestState_SetLastKnown_TwoEntries(t *testing.T) {
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
-	s.setObserved(data.Collection2, data.EntryN2I2V1.Metadata.FullName, data.EntryN2I2V1.Metadata.Version, "bar")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
+	s.setObserved(basicmeta.Collection2.Name(), data.EntryN2I2V1.Metadata.FullName, data.EntryN2I2V1.Metadata.Version, "bar")
 
 	g.Expect(s.hasWork()).To(BeTrue())
 	st, ok := s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
-	g.Expect(st.key.col).To(Equal(data.K8SCollection1))
+	g.Expect(st.key.col).To(Equal(basicmeta.K8SCollection1.Name()))
 	g.Expect(st.key.res).To(Equal(data.EntryN1I1V1.Metadata.FullName))
 	g.Expect(st.observedStatus).To(Equal("foo"))
 	g.Expect(st.observedVersion).To(Equal(data.EntryN1I1V1.Metadata.Version))
@@ -79,7 +80,7 @@ func TestState_SetLastKnown_TwoEntries(t *testing.T) {
 	g.Expect(s.hasWork()).To(BeTrue())
 	st, ok = s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
-	g.Expect(st.key.col).To(Equal(data.Collection2))
+	g.Expect(st.key.col).To(Equal(basicmeta.Collection2.Name()))
 	g.Expect(st.key.res).To(Equal(data.EntryN2I2V1.Metadata.FullName))
 	g.Expect(st.observedStatus).To(Equal("bar"))
 	g.Expect(st.observedVersion).To(Equal(data.EntryN2I2V1.Metadata.Version))
@@ -94,14 +95,14 @@ func TestState_SetLastKnown_ExistingEntry(t *testing.T) {
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V2.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, "bar")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V2.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, "bar")
 
 	g.Expect(s.hasWork()).To(BeTrue())
 
 	st, ok := s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
-	g.Expect(st.key.col).To(Equal(data.K8SCollection1))
+	g.Expect(st.key.col).To(Equal(basicmeta.K8SCollection1.Name()))
 	g.Expect(st.key.res).To(Equal(data.EntryN1I1V2.Metadata.FullName))
 	g.Expect(st.observedStatus).To(Equal("bar"))
 	g.Expect(st.observedVersion).To(Equal(data.EntryN1I1V2.Metadata.Version))
@@ -119,7 +120,7 @@ func TestState_ClearLastKnown_NoEntry(t *testing.T) {
 
 	g.Expect(s.hasWork()).To(BeFalse())
 
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V2.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, nil)
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V2.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, nil)
 
 	g.Expect(s.hasWork()).To(BeFalse())
 }
@@ -129,21 +130,21 @@ func TestState_ClearLastKnown_ExistingEntry(t *testing.T) {
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V2.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, nil)
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V2.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, nil)
 
 	// Even though we reverted to the original state before dequeueing, it is still in the queue. Let the dequeueWork()
 	// call deal with this.
 	g.Expect(s.hasWork()).To(BeTrue())
 
 	// Add work for another collection, so that dequeueWork would complete.
-	s.setObserved(data.Collection2, data.EntryN1I1V2.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, "zzz")
+	s.setObserved(basicmeta.Collection2.Name(), data.EntryN1I1V2.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, "zzz")
 
 	// Simulate removal of work.
 	_, ok := s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
 
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, nil)
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, nil)
 
 	g.Expect(s.hasWork()).To(BeFalse())
 }
@@ -153,8 +154,8 @@ func TestState_Quiesce_PendingWork(t *testing.T) {
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V2.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, "bar")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V2.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, "bar")
 
 	s.quiesceWork()
 
@@ -192,7 +193,7 @@ func TestState_ApplyMessages_New(t *testing.T) {
 
 	res := *data.EntryN1I1V1
 	res.Origin = &rt.Origin{
-		Collection: data.K8SCollection1,
+		Collection: basicmeta.K8SCollection1.Name(),
 		Kind:       "k1",
 		FullName:   res.Metadata.FullName,
 		Version:    res.Metadata.Version,
@@ -206,7 +207,7 @@ func TestState_ApplyMessages_New(t *testing.T) {
 	g.Expect(s.hasWork()).To(BeTrue())
 	st, ok := s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
-	g.Expect(st.key.col).To(Equal(data.K8SCollection1))
+	g.Expect(st.key.col).To(Equal(basicmeta.K8SCollection1.Name()))
 	g.Expect(st.key.res).To(Equal(res.Metadata.FullName))
 	g.Expect(st.observedStatus).To(BeNil())
 	g.Expect(st.observedVersion).To(Equal(resource.Version("")))
@@ -219,14 +220,14 @@ func TestState_ApplyMessages_AgainstExistingUnappliedState(t *testing.T) {
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, "foo")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V2.Metadata.Version, "foo")
 
 	_, ok := s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
 
 	res := *data.EntryN1I1V1
 	res.Origin = &rt.Origin{
-		Collection: data.K8SCollection1,
+		Collection: basicmeta.K8SCollection1.Name(),
 		Kind:       "k1",
 		FullName:   res.Metadata.FullName,
 		Version:    res.Metadata.Version,
@@ -241,7 +242,7 @@ func TestState_ApplyMessages_AgainstExistingUnappliedState(t *testing.T) {
 	g.Expect(s.hasWork()).To(BeTrue())
 	st, ok := s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
-	g.Expect(st.key.col).To(Equal(data.K8SCollection1))
+	g.Expect(st.key.col).To(Equal(basicmeta.K8SCollection1.Name()))
 	g.Expect(st.key.res).To(Equal(res.Metadata.FullName))
 	g.Expect(st.observedStatus).To(Equal("foo"))
 	g.Expect(st.observedVersion).To(Equal(data.EntryN1I1V2.Metadata.Version))
@@ -254,7 +255,7 @@ func TestState_ClearMessages_AgainstAppliedState(t *testing.T) {
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
 
 	_, ok := s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
@@ -264,7 +265,7 @@ func TestState_ClearMessages_AgainstAppliedState(t *testing.T) {
 	g.Expect(s.hasWork()).To(BeTrue())
 	st, ok := s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
-	g.Expect(st.key.col).To(Equal(data.K8SCollection1))
+	g.Expect(st.key.col).To(Equal(basicmeta.K8SCollection1.Name()))
 	g.Expect(st.key.res).To(Equal(data.EntryN1I1V1.Metadata.FullName))
 	g.Expect(st.observedStatus).To(Equal("foo"))
 	g.Expect(st.observedVersion).To(Equal(data.EntryN1I1V1.Metadata.Version))
@@ -277,12 +278,12 @@ func TestState_ClearMessages_AgainstAppliedEmptyState(t *testing.T) {
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
 
 	_, ok := s.dequeueWork()
 	g.Expect(ok).To(BeTrue())
 
-	s.setObserved(data.K8SCollection1, data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, nil)
+	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, nil)
 
 	s.applyMessages(NewMessageSet())
 

--- a/galley/pkg/config/source/kube/fs/source_test.go
+++ b/galley/pkg/config/source/kube/fs/source_test.go
@@ -52,8 +52,6 @@ func TestInvalidDirShouldSucceed(t *testing.T) {
 }
 
 func TestInitialFile(t *testing.T) {
-	g := NewGomegaWithT(t)
-
 	dir := createTempDir(t)
 	defer deleteTempDir(t, dir)
 
@@ -64,22 +62,20 @@ func TestInitialFile(t *testing.T) {
 	acc := startOrFail(t, s)
 	defer s.Stop()
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.FullSyncFor(basicmeta.K8SCollection1.Name()),
-		event.AddFor(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1)))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.FullSyncFor(basicmeta.K8SCollection1),
+		event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
 	acc.Clear()
 
 	deleteFiles(t, dir, "foo.yaml")
 	appsignals.Notify("test", syscall.SIGUSR1)
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.DeleteForResource(data.K8SCollection1, data.EntryN1I1V1)))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.DeleteForResource(basicmeta.K8SCollection1, data.EntryN1I1V1))
 }
 
 func TestInitialFileWatcherEnabled(t *testing.T) {
-	g := NewGomegaWithT(t)
-
 	dir := createTempDir(t)
 	defer deleteTempDir(t, dir)
 
@@ -90,21 +86,19 @@ func TestInitialFileWatcherEnabled(t *testing.T) {
 	acc := startOrFail(t, s)
 	defer s.Stop()
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.FullSyncFor(basicmeta.K8SCollection1.Name()),
-		event.AddFor(data.K8SCollection1, data.EntryN1I1V1)))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.FullSyncFor(basicmeta.K8SCollection1),
+		event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
 	acc.Clear()
 
 	deleteFiles(t, dir, "foo.yaml")
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.DeleteForResource(data.K8SCollection1, data.EntryN1I1V1)))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.DeleteForResource(basicmeta.K8SCollection1, data.EntryN1I1V1))
 }
 
 func TestAddDeleteMultipleTimes(t *testing.T) {
-	g := NewGomegaWithT(t)
-
 	dir := createTempDir(t)
 	defer deleteTempDir(t, dir)
 
@@ -114,32 +108,30 @@ func TestAddDeleteMultipleTimes(t *testing.T) {
 
 	copyFile(t, dir, "foo.yaml", data.YamlN1I1V1)
 	appsignals.Notify("test", syscall.SIGUSR1)
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.FullSyncFor(basicmeta.K8SCollection1.Name()),
-		event.AddFor(data.K8SCollection1, data.EntryN1I1V1)))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.FullSyncFor(basicmeta.K8SCollection1),
+		event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
 	acc.Clear()
 	deleteFiles(t, dir, "foo.yaml")
 	appsignals.Notify("test", syscall.SIGUSR1)
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.DeleteForResource(data.K8SCollection1, data.EntryN1I1V1)))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.DeleteForResource(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
 	acc.Clear()
 	copyFile(t, dir, "foo.yaml", data.YamlN1I1V1)
 	appsignals.Notify("test", syscall.SIGUSR1)
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.AddFor(data.K8SCollection1, withVersion(data.EntryN1I1V1, "v2"))))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.AddFor(basicmeta.K8SCollection1, withVersion(data.EntryN1I1V1, "v2")))
 
 	acc.Clear()
 	deleteFiles(t, dir, "foo.yaml")
 	appsignals.Notify("test", syscall.SIGUSR1)
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.DeleteForResource(data.K8SCollection1, withVersion(data.EntryN1I1V1, "v2"))))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.DeleteForResource(basicmeta.K8SCollection1, withVersion(data.EntryN1I1V1, "v2")))
 }
 
 func TestAddDeleteMultipleTimes1(t *testing.T) {
-	g := NewGomegaWithT(t)
-
 	dir := createTempDir(t)
 	defer deleteTempDir(t, dir)
 
@@ -150,21 +142,19 @@ func TestAddDeleteMultipleTimes1(t *testing.T) {
 	copyFile(t, dir, "foo.yaml", data.YamlN1I1V1)
 	appsignals.Notify("test", syscall.SIGUSR1)
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.FullSyncFor(basicmeta.K8SCollection1.Name()),
-		event.AddFor(data.K8SCollection1, data.EntryN1I1V1)))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.FullSyncFor(basicmeta.K8SCollection1),
+		event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
 	acc.Clear()
 	deleteFiles(t, dir, "foo.yaml")
 	appsignals.Notify("test", syscall.SIGUSR1)
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.DeleteForResource(data.K8SCollection1, data.EntryN1I1V1)))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.DeleteForResource(basicmeta.K8SCollection1, data.EntryN1I1V1))
 }
 
 func TestAddUpdateDelete(t *testing.T) {
-	g := NewGomegaWithT(t)
-
 	dir := createTempDir(t)
 	defer deleteTempDir(t, dir)
 
@@ -175,23 +165,23 @@ func TestAddUpdateDelete(t *testing.T) {
 	copyFile(t, dir, "foo.yaml", data.YamlN1I1V1)
 	appsignals.Notify("test", syscall.SIGUSR1)
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.FullSyncFor(basicmeta.K8SCollection1.Name()),
-		event.AddFor(data.K8SCollection1, data.EntryN1I1V1)))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.FullSyncFor(basicmeta.K8SCollection1),
+		event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1))
 
 	acc.Clear()
 	copyFile(t, dir, "foo.yaml", data.YamlN1I1V2)
 	appsignals.Notify("test", syscall.SIGUSR1)
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.UpdateFor(data.K8SCollection1, withVersion(data.EntryN1I1V2, "v2"))))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.UpdateFor(basicmeta.K8SCollection1, withVersion(data.EntryN1I1V2, "v2")))
 
 	acc.Clear()
 	copyFile(t, dir, "foo.yaml", "")
 	appsignals.Notify("test", syscall.SIGUSR1)
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.DeleteForResource(data.K8SCollection1, withVersion(data.EntryN1I1V2, "v2"))))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.DeleteForResource(basicmeta.K8SCollection1, withVersion(data.EntryN1I1V2, "v2")))
 }
 
 func TestAddUpdateDeleteWithWatcherEnabled(t *testing.T) {
@@ -208,20 +198,20 @@ func TestAddUpdateDeleteWithWatcherEnabled(t *testing.T) {
 	copyFile(t, dir, "foo.yaml", data.YamlN1I1V1)
 
 	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.FullSyncFor(basicmeta.K8SCollection1.Name()),
-		event.AddFor(data.K8SCollection1, data.EntryN1I1V1)))
+		event.FullSyncFor(basicmeta.K8SCollection1),
+		event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1)))
 
 	acc.Clear()
 	copyFile(t, dir, "foo.yaml", data.YamlN1I1V2)
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.UpdateFor(data.K8SCollection1, withVersion(data.EntryN1I1V2, "v2"))))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.UpdateFor(basicmeta.K8SCollection1, withVersion(data.EntryN1I1V2, "v2")))
 
 	acc.Clear()
 	copyFile(t, dir, "foo.yaml", "")
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.DeleteForResource(data.K8SCollection1, withVersion(data.EntryN1I1V2, "v2"))))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.DeleteForResource(basicmeta.K8SCollection1, withVersion(data.EntryN1I1V2, "v2")))
 }
 
 func TestAddUpdateDelete_K8sResources(t *testing.T) {
@@ -234,21 +224,21 @@ func TestAddUpdateDelete_K8sResources(t *testing.T) {
 	acc := startOrFail(t, s)
 	defer s.Stop()
 
-	g.Eventually(acc.EventsWithoutOrigins).Should(ConsistOf(
-		event.FullSyncFor(k8smeta.K8SCoreV1Endpoints.Name()),
-		event.FullSyncFor(k8smeta.K8SExtensionsV1Beta1Ingresses.Name()),
-		event.FullSyncFor(k8smeta.K8SCoreV1Namespaces.Name()),
-		event.FullSyncFor(k8smeta.K8SCoreV1Nodes.Name()),
-		event.FullSyncFor(k8smeta.K8SCoreV1Pods.Name()),
-		event.FullSyncFor(k8smeta.K8SAppsV1Deployments.Name()),
-		event.FullSyncFor(k8smeta.K8SCoreV1Services.Name())))
+	fixtures.ExpectEventsWithoutOriginsEventually(t, acc,
+		event.FullSyncFor(k8smeta.K8SCoreV1Endpoints),
+		event.FullSyncFor(k8smeta.K8SExtensionsV1Beta1Ingresses),
+		event.FullSyncFor(k8smeta.K8SCoreV1Namespaces),
+		event.FullSyncFor(k8smeta.K8SCoreV1Nodes),
+		event.FullSyncFor(k8smeta.K8SCoreV1Pods),
+		event.FullSyncFor(k8smeta.K8SAppsV1Deployments),
+		event.FullSyncFor(k8smeta.K8SCoreV1Services))
 
 	acc.Clear()
 	copyFile(t, dir, "bar.yaml", data.GetService())
 	appsignals.Notify("test", syscall.SIGUSR1)
 
 	g.Eventually(acc.EventsWithoutOrigins).Should(HaveLen(1))
-	g.Expect(acc.EventsWithoutOrigins()[0].Source).To(Equal(k8smeta.K8SCoreV1Services.Name()))
+	g.Expect(acc.EventsWithoutOrigins()[0].Source.Name()).To(Equal(k8smeta.K8SCoreV1Services.Name()))
 	g.Expect(acc.EventsWithoutOrigins()[0].Kind).To(Equal(event.Added))
 	g.Expect(acc.EventsWithoutOrigins()[0].Resource.Metadata.FullName).To(Equal(resource.NewFullName("kube-system", "kube-dns")))
 
@@ -257,7 +247,7 @@ func TestAddUpdateDelete_K8sResources(t *testing.T) {
 	appsignals.Notify("test", syscall.SIGUSR1)
 
 	g.Eventually(acc.EventsWithoutOrigins).Should(HaveLen(1))
-	g.Expect(acc.EventsWithoutOrigins()[0].Source).To(Equal(k8smeta.K8SCoreV1Services.Name()))
+	g.Expect(acc.EventsWithoutOrigins()[0].Source.Name()).To(Equal(k8smeta.K8SCoreV1Services.Name()))
 	g.Expect(acc.EventsWithoutOrigins()[0].Kind).To(Equal(event.Deleted))
 	g.Expect(acc.EventsWithoutOrigins()[0].Resource.Metadata.FullName).To(Equal(resource.NewFullName("kube-system", "kube-dns")))
 }

--- a/galley/pkg/config/source/kube/inmemory/kubesource_test.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource_test.go
@@ -40,7 +40,7 @@ func TestKubeSource_ApplyContent(t *testing.T) {
 
 	g.Expect(s.ContentNames()).To(Equal(map[string]struct{}{"foo": {}}))
 
-	actual := s.Get(data.K8SCollection1).AllSorted()
+	actual := s.Get(basicmeta.K8SCollection1.Name()).AllSorted()
 	g.Expect(actual).To(HaveLen(1))
 
 	g.Expect(actual[0].Metadata.FullName).To(Equal(data.EntryN1I1V1.Metadata.FullName))
@@ -63,7 +63,7 @@ func TestKubeSource_ApplyContent_BeforeStart(t *testing.T) {
 
 	g.Expect(s.ContentNames()).To(Equal(map[string]struct{}{"foo": {}}))
 
-	actual := s.Get(data.K8SCollection1).AllSorted()
+	actual := s.Get(basicmeta.K8SCollection1.Name()).AllSorted()
 	g.Expect(actual).To(HaveLen(1))
 
 	g.Expect(actual[0].Metadata.FullName).To(Equal(data.EntryN1I1V1.Metadata.FullName))
@@ -84,7 +84,7 @@ func TestKubeSource_ApplyContent_Unchanged0Add1(t *testing.T) {
 	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, data.YamlN2I2V1))
 	g.Expect(err).To(BeNil())
 
-	actual := s.Get(data.K8SCollection1).AllSorted()
+	actual := s.Get(basicmeta.K8SCollection1.Name()).AllSorted()
 	g.Expect(actual).To(HaveLen(2))
 	g.Expect(actual[0].Metadata.FullName).To(Equal(data.EntryN1I1V1.Metadata.FullName))
 	g.Expect(actual[1].Metadata.FullName).To(Equal(data.EntryN2I2V1.Metadata.FullName))
@@ -94,7 +94,7 @@ func TestKubeSource_ApplyContent_Unchanged0Add1(t *testing.T) {
 
 	g.Expect(s.ContentNames()).To(Equal(map[string]struct{}{"foo": {}}))
 
-	actual = s.Get(data.K8SCollection1).AllSorted()
+	actual = s.Get(basicmeta.K8SCollection1.Name()).AllSorted()
 	g.Expect(actual).To(HaveLen(2))
 	g.Expect(actual[0].Metadata.FullName).To(Equal(data.EntryN2I2V2.Metadata.FullName))
 	g.Expect(actual[1].Metadata.FullName).To(Equal(data.EntryN3I3V1.Metadata.FullName))
@@ -103,13 +103,13 @@ func TestKubeSource_ApplyContent_Unchanged0Add1(t *testing.T) {
 	g.Expect(events).To(HaveLen(6))
 	g.Expect(events[0].Kind).To(Equal(event.FullSync))
 	g.Expect(events[1].Kind).To(Equal(event.Added))
-	g.Expect(events[1].Resource).To(Equal(data.EntryN1I1V1))
+	fixtures.ExpectEqual(t, events[1].Resource, data.EntryN1I1V1)
 	g.Expect(events[2].Kind).To(Equal(event.Added))
-	g.Expect(events[2].Resource).To(Equal(withVersion(data.EntryN2I2V1, "v2")))
+	fixtures.ExpectEqual(t, events[2].Resource, withVersion(data.EntryN2I2V1, "v2"))
 	g.Expect(events[3].Kind).To(Equal(event.Updated))
-	g.Expect(events[3].Resource).To(Equal(withVersion(data.EntryN2I2V2, "v3")))
+	fixtures.ExpectEqual(t, events[3].Resource, withVersion(data.EntryN2I2V2, "v3"))
 	g.Expect(events[4].Kind).To(Equal(event.Added))
-	g.Expect(events[4].Resource).To(Equal(withVersion(data.EntryN3I3V1, "v4")))
+	fixtures.ExpectEqual(t, events[4].Resource, withVersion(data.EntryN3I3V1, "v4"))
 	g.Expect(events[5].Kind).To(Equal(event.Deleted))
 	g.Expect(events[5].Resource.Metadata.FullName).To(Equal(data.EntryN1I1V1.Metadata.FullName))
 }
@@ -131,29 +131,29 @@ func TestKubeSource_RemoveContent(t *testing.T) {
 	s.RemoveContent("foo")
 	g.Expect(s.ContentNames()).To(Equal(map[string]struct{}{"bar": {}}))
 
-	actual := s.Get(data.K8SCollection1).AllSorted()
+	actual := s.Get(basicmeta.K8SCollection1.Name()).AllSorted()
 	g.Expect(actual).To(HaveLen(1))
 
 	events := acc.EventsWithoutOrigins()
 	g.Expect(events).To(HaveLen(6))
-	g.Expect(events[0:4]).To(ConsistOf(
-		event.FullSyncFor(data.K8SCollection1),
-		event.AddFor(data.K8SCollection1, data.EntryN1I1V1),
-		event.AddFor(data.K8SCollection1, withVersion(data.EntryN2I2V1, "v2")),
-		event.AddFor(data.K8SCollection1, withVersion(data.EntryN3I3V1, "v3"))))
+	fixtures.ExpectContainEvents(t, events[0:4],
+		event.FullSyncFor(basicmeta.K8SCollection1),
+		event.AddFor(basicmeta.K8SCollection1, data.EntryN1I1V1),
+		event.AddFor(basicmeta.K8SCollection1, withVersion(data.EntryN2I2V1, "v2")),
+		event.AddFor(basicmeta.K8SCollection1, withVersion(data.EntryN3I3V1, "v3")))
 
 	//  Delete events can appear out of order.
 	g.Expect(events[4].Kind).To(Equal(event.Deleted))
 	g.Expect(events[5].Kind).To(Equal(event.Deleted))
 
 	if events[4].Resource.Metadata.FullName == data.EntryN1I1V1.Metadata.FullName {
-		g.Expect(events[4:]).To(ConsistOf(
-			event.DeleteForResource(data.K8SCollection1, data.EntryN1I1V1),
-			event.DeleteForResource(data.K8SCollection1, withVersion(data.EntryN2I2V1, "v2"))))
+		fixtures.ExpectContainEvents(t, events[4:],
+			event.DeleteForResource(basicmeta.K8SCollection1, data.EntryN1I1V1),
+			event.DeleteForResource(basicmeta.K8SCollection1, withVersion(data.EntryN2I2V1, "v2")))
 	} else {
-		g.Expect(events[4:]).To(ConsistOf(
-			event.DeleteForResource(data.K8SCollection1, withVersion(data.EntryN2I2V1, "v2")),
-			event.DeleteForResource(data.K8SCollection1, data.EntryN1I1V1)))
+		fixtures.ExpectContainEvents(t, events[4:],
+			event.DeleteForResource(basicmeta.K8SCollection1, withVersion(data.EntryN2I2V1, "v2")),
+			event.DeleteForResource(basicmeta.K8SCollection1, data.EntryN1I1V1))
 	}
 }
 
@@ -169,16 +169,16 @@ func TestKubeSource_Clear(t *testing.T) {
 
 	s.Clear()
 
-	actual := s.Get(data.K8SCollection1).AllSorted()
+	actual := s.Get(basicmeta.K8SCollection1.Name()).AllSorted()
 	g.Expect(actual).To(HaveLen(0))
 
 	events := acc.EventsWithoutOrigins()
 	g.Expect(events).To(HaveLen(5))
 	g.Expect(events[0].Kind).To(Equal(event.FullSync))
 	g.Expect(events[1].Kind).To(Equal(event.Added))
-	g.Expect(events[1].Resource).To(Equal(data.EntryN1I1V1))
+	fixtures.ExpectEqual(t, events[1].Resource, data.EntryN1I1V1)
 	g.Expect(events[2].Kind).To(Equal(event.Added))
-	g.Expect(events[2].Resource).To(Equal(withVersion(data.EntryN2I2V1, "v2")))
+	fixtures.ExpectEqual(t, events[2].Resource, withVersion(data.EntryN2I2V1, "v2"))
 
 	g.Expect(events[3].Kind).To(Equal(event.Deleted))
 	g.Expect(events[4].Kind).To(Equal(event.Deleted))
@@ -202,10 +202,10 @@ func TestKubeSource_UnparseableSegment(t *testing.T) {
 	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, "	\n", data.YamlN2I2V1))
 	g.Expect(err).To(Not(BeNil()))
 
-	actual := removeEntryOrigins(s.Get(data.K8SCollection1).AllSorted())
+	actual := removeEntryOrigins(s.Get(basicmeta.K8SCollection1.Name()).AllSorted())
 	g.Expect(actual).To(HaveLen(2))
-	g.Expect(actual[0]).To(Equal(data.EntryN1I1V1))
-	g.Expect(actual[1]).To(Equal(withVersion(data.EntryN2I2V1, "v2")))
+	fixtures.ExpectEqual(t, actual[0], data.EntryN1I1V1)
+	fixtures.ExpectEqual(t, actual[1], withVersion(data.EntryN2I2V1, "v2"))
 }
 
 func TestKubeSource_Unrecognized(t *testing.T) {
@@ -218,9 +218,9 @@ func TestKubeSource_Unrecognized(t *testing.T) {
 	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, data.YamlUnrecognized))
 	g.Expect(err).To(Not(BeNil()))
 
-	actual := removeEntryOrigins(s.Get(data.K8SCollection1).AllSorted())
+	actual := removeEntryOrigins(s.Get(basicmeta.K8SCollection1.Name()).AllSorted())
 	g.Expect(actual).To(HaveLen(1))
-	g.Expect(actual[0]).To(Equal(data.EntryN1I1V1))
+	fixtures.ExpectEqual(t, actual[0], data.EntryN1I1V1)
 }
 
 func TestKubeSource_UnparseableResource(t *testing.T) {
@@ -233,9 +233,9 @@ func TestKubeSource_UnparseableResource(t *testing.T) {
 	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, data.YamlUnparseableResource))
 	g.Expect(err).To(Not(BeNil()))
 
-	actual := removeEntryOrigins(s.Get(data.K8SCollection1).AllSorted())
+	actual := removeEntryOrigins(s.Get(basicmeta.K8SCollection1.Name()).AllSorted())
 	g.Expect(actual).To(HaveLen(1))
-	g.Expect(actual[0]).To(Equal(data.EntryN1I1V1))
+	fixtures.ExpectEqual(t, actual[0], data.EntryN1I1V1)
 }
 
 func TestKubeSource_NonStringKey(t *testing.T) {
@@ -248,9 +248,9 @@ func TestKubeSource_NonStringKey(t *testing.T) {
 	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, data.YamlNonStringKey))
 	g.Expect(err).To(Not(BeNil()))
 
-	actual := removeEntryOrigins(s.Get(data.K8SCollection1).AllSorted())
+	actual := removeEntryOrigins(s.Get(basicmeta.K8SCollection1.Name()).AllSorted())
 	g.Expect(actual).To(HaveLen(1))
-	g.Expect(actual[0]).To(Equal(data.EntryN1I1V1))
+	fixtures.ExpectEqual(t, actual[0], data.EntryN1I1V1)
 }
 
 func TestKubeSource_Service(t *testing.T) {
@@ -271,7 +271,10 @@ func TestKubeSource_Service(t *testing.T) {
 func TestSameNameDifferentKind(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s := NewKubeSource(basicmeta.MustGet2().KubeCollections())
+	meta := basicmeta.MustGet2().KubeCollections()
+	col1 := meta.MustFind(basicmeta.K8SCollection1.Name().String())
+
+	s := NewKubeSource(meta)
 	acc := &fixtures.Accumulator{}
 	s.Dispatch(acc)
 	s.Start()
@@ -282,11 +285,11 @@ func TestSameNameDifferentKind(t *testing.T) {
 
 	events := acc.EventsWithoutOrigins()
 	g.Expect(events).To(HaveLen(4))
-	g.Expect(events).To(ConsistOf(
-		event.FullSyncFor(data.K8SCollection1),
+	fixtures.ExpectContainEvents(t, events,
+		event.FullSyncFor(col1),
 		event.FullSyncFor(data.K8SCollection2),
-		event.AddFor(data.K8SCollection1, data.EntryN1I1V1),
-		event.AddFor(data.K8SCollection2, withVersion(data.EntryN1I1V1ClusterScoped, "v2"))))
+		event.AddFor(col1, data.EntryN1I1V1),
+		event.AddFor(data.K8SCollection2, withVersion(data.EntryN1I1V1ClusterScoped, "v2")))
 }
 
 func TestKubeSource_DefaultNamespace(t *testing.T) {
@@ -304,7 +307,7 @@ func TestKubeSource_DefaultNamespace(t *testing.T) {
 
 	expectedName := data.EntryI1V1NoNamespace.Metadata.FullName.Name
 
-	actual := s.Get(data.K8SCollection1).AllSorted()
+	actual := s.Get(basicmeta.K8SCollection1.Name()).AllSorted()
 	g.Expect(actual).To(HaveLen(1))
 	g.Expect(actual[0].Metadata.FullName).To(Equal(resource.NewFullName(defaultNs, expectedName)))
 }
@@ -324,7 +327,7 @@ func TestKubeSource_DefaultNamespaceSkipClusterScoped(t *testing.T) {
 	err := s.ApplyContent("foo", data.YamlI1V1NoNamespaceKind2)
 	g.Expect(err).To(BeNil())
 
-	actual := s.Get(data.K8SCollection2).AllSorted()
+	actual := s.Get(data.K8SCollection2.Name()).AllSorted()
 	g.Expect(actual).To(HaveLen(1))
 	g.Expect(actual[0].Metadata.FullName).To(Equal(data.EntryI1V1NoNamespace.Metadata.FullName))
 }

--- a/galley/pkg/config/source/kube/rt/dynamic.go
+++ b/galley/pkg/config/source/kube/rt/dynamic.go
@@ -29,7 +29,7 @@ import (
 	"istio.io/istio/galley/pkg/config/util/pb"
 )
 
-func (p *Provider) getDynamicAdapter(c resource.Schema) *Adapter {
+func (p *Provider) getDynamicAdapter(r resource.Schema) *Adapter {
 	return &Adapter{
 		extractObject: func(o interface{}) metav1.Object {
 			res, ok := o.(*unstructured.Unstructured)
@@ -45,7 +45,7 @@ func (p *Provider) getDynamicAdapter(c resource.Schema) *Adapter {
 				return nil, fmt.Errorf("extractResource: not unstructured: %v", o)
 			}
 
-			pr := c.NewProtoInstance()
+			pr := r.NewProtoInstance()
 			if err := pb.UnmarshalData(pr, u.Object["spec"]); err != nil {
 				return nil, err
 			}
@@ -54,7 +54,7 @@ func (p *Provider) getDynamicAdapter(c resource.Schema) *Adapter {
 		},
 
 		newInformer: func() (cache.SharedIndexInformer, error) {
-			d, err := p.GetDynamicResourceInterface(c)
+			d, err := p.GetDynamicResourceInterface(r)
 			if err != nil {
 				return nil, err
 			}

--- a/galley/pkg/config/source/kube/rt/dynamic_test.go
+++ b/galley/pkg/config/source/kube/rt/dynamic_test.go
@@ -46,9 +46,9 @@ func TestParseDynamic(t *testing.T) {
 
 func TestExtractObjectDynamic(t *testing.T) {
 	for _, r := range basicmeta.MustGet().KubeCollections().All() {
-		a := rt.DefaultProvider().GetAdapter(r)
+		a := rt.DefaultProvider().GetAdapter(r.Resource())
 
-		t.Run(r.Kind(), func(t *testing.T) {
+		t.Run(r.Resource().Kind(), func(t *testing.T) {
 			t.Run("WrongTypeShouldReturnNil", func(t *testing.T) {
 				out := a.ExtractObject(struct{}{})
 				g := NewGomegaWithT(t)
@@ -66,9 +66,9 @@ func TestExtractObjectDynamic(t *testing.T) {
 
 func TestExtractResourceDynamic(t *testing.T) {
 	for _, r := range basicmeta.MustGet().KubeCollections().All() {
-		a := rt.DefaultProvider().GetAdapter(r)
+		a := rt.DefaultProvider().GetAdapter(r.Resource())
 
-		t.Run(r.Kind(), func(t *testing.T) {
+		t.Run(r.Resource().Kind(), func(t *testing.T) {
 			t.Run("WrongTypeShouldReturnNil", func(t *testing.T) {
 				_, err := a.ExtractResource(struct{}{})
 				g := NewGomegaWithT(t)
@@ -90,7 +90,7 @@ func parseDynamic(t *testing.T, input []byte, kind string) (metaV1.Object, proto
 	g := NewGomegaWithT(t)
 
 	pr := rt.DefaultProvider()
-	a := pr.GetAdapter(basicmeta.MustGet().KubeCollections().MustFindByGroupAndKind("testdata.istio.io", kind))
+	a := pr.GetAdapter(basicmeta.MustGet().KubeCollections().MustFindByGroupAndKind("testdata.istio.io", kind).Resource())
 
 	obj, err := a.ParseJSON(input)
 	g.Expect(err).To(BeNil())

--- a/galley/pkg/config/source/kube/rt/extract.go
+++ b/galley/pkg/config/source/kube/rt/extract.go
@@ -21,26 +21,30 @@ import (
 
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	resource2 "istio.io/istio/galley/pkg/config/schema/resource"
 )
 
 // ToResource converts the given object and proto to a resource.Instance
-func ToResource(object metav1.Object, r collection.Schema, item proto.Message) *resource.Instance {
+func ToResource(object metav1.Object, schema collection.Schema, item proto.Message) *resource.Instance {
 	var o *Origin
 
 	name := resource.NewFullName(resource.Namespace(object.GetNamespace()), resource.LocalName(object.GetName()))
 	version := resource.Version(object.GetResourceVersion())
 
-	if r != nil {
+	var resourceSchema resource2.Schema
+	if schema != nil {
+		resourceSchema = schema.Resource()
 		o = &Origin{
 			FullName:   name,
-			Collection: r.Name(),
-			Kind:       r.Kind(),
+			Collection: schema.Name(),
+			Kind:       schema.Resource().Kind(),
 			Version:    version,
 		}
 	}
 
 	return &resource.Instance{
 		Metadata: resource.Metadata{
+			Schema:      resourceSchema,
 			FullName:    name,
 			Version:     version,
 			Annotations: object.GetAnnotations(),

--- a/galley/pkg/config/source/kube/rt/known_test.go
+++ b/galley/pkg/config/source/kube/rt/known_test.go
@@ -134,9 +134,9 @@ func TestParse(t *testing.T) {
 
 func TestExtractObject(t *testing.T) {
 	for _, r := range k8smeta.MustGet().KubeCollections().All() {
-		a := rt.DefaultProvider().GetAdapter(r)
+		a := rt.DefaultProvider().GetAdapter(r.Resource())
 
-		t.Run(r.Kind(), func(t *testing.T) {
+		t.Run(r.Resource().Kind(), func(t *testing.T) {
 			t.Run("WrongTypeShouldReturnNil", func(t *testing.T) {
 				out := a.ExtractObject(struct{}{})
 				g := NewGomegaWithT(t)
@@ -144,7 +144,7 @@ func TestExtractObject(t *testing.T) {
 			})
 
 			t.Run("Success", func(t *testing.T) {
-				out := a.ExtractObject(empty(r.Kind()))
+				out := a.ExtractObject(empty(r.Resource().Kind()))
 				g := NewGomegaWithT(t)
 				g.Expect(out).ToNot(BeNil())
 			})
@@ -154,9 +154,9 @@ func TestExtractObject(t *testing.T) {
 
 func TestExtractResource(t *testing.T) {
 	for _, r := range k8smeta.MustGet().KubeCollections().All() {
-		a := rt.DefaultProvider().GetAdapter(r)
+		a := rt.DefaultProvider().GetAdapter(r.Resource())
 
-		t.Run(r.Kind(), func(t *testing.T) {
+		t.Run(r.Resource().Kind(), func(t *testing.T) {
 			t.Run("WrongTypeShouldReturnNil", func(t *testing.T) {
 				_, err := a.ExtractResource(struct{}{})
 				g := NewGomegaWithT(t)
@@ -164,7 +164,7 @@ func TestExtractResource(t *testing.T) {
 			})
 
 			t.Run("Success", func(t *testing.T) {
-				out, err := a.ExtractResource(empty(r.Kind()))
+				out, err := a.ExtractResource(empty(r.Resource().Kind()))
 				g := NewGomegaWithT(t)
 				g.Expect(err).To(BeNil())
 				g.Expect(out).ToNot(BeNil())
@@ -178,7 +178,7 @@ func parse(t *testing.T, input []byte, group, kind string) (metaV1.Object, proto
 	g := NewGomegaWithT(t)
 
 	pr := rt.DefaultProvider()
-	a := pr.GetAdapter(k8smeta.MustGet().KubeCollections().MustFindByGroupAndKind(group, kind))
+	a := pr.GetAdapter(k8smeta.MustGet().KubeCollections().MustFindByGroupAndKind(group, kind).Resource())
 	obj, err := a.ParseJSON(input)
 	g.Expect(err).To(BeNil())
 

--- a/galley/pkg/config/source/kube/rt/provider.go
+++ b/galley/pkg/config/source/kube/rt/provider.go
@@ -62,12 +62,12 @@ func NewProvider(interfaces kube.Interfaces, resyncPeriod time.Duration) *Provid
 
 // GetAdapter returns a type for the group/kind. If the type is a well-known type, then the returned type will have
 // a specialized implementation. Otherwise, it will be using the dynamic conversion logic.
-func (p *Provider) GetAdapter(c resource.Schema) *Adapter {
-	if t, found := p.known[asTypesKey(c.Group(), c.Kind())]; found {
+func (p *Provider) GetAdapter(r resource.Schema) *Adapter {
+	if t, found := p.known[asTypesKey(r.Group(), r.Kind())]; found {
 		return t
 	}
 
-	return p.getDynamicAdapter(c)
+	return p.getDynamicAdapter(r)
 }
 
 func (p *Provider) sharedInformerFactory() (informers.SharedInformerFactory, error) {
@@ -89,7 +89,7 @@ func (p *Provider) sharedInformerFactory() (informers.SharedInformerFactory, err
 }
 
 // GetDynamicResourceInterface returns a dynamic.NamespaceableResourceInterface for the given resource.
-func (p *Provider) GetDynamicResourceInterface(c resource.Schema) (dynamic.NamespaceableResourceInterface, error) {
+func (p *Provider) GetDynamicResourceInterface(r resource.Schema) (dynamic.NamespaceableResourceInterface, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -105,8 +105,8 @@ func (p *Provider) GetDynamicResourceInterface(c resource.Schema) (dynamic.Names
 	}
 
 	return p.dynamicInterface.Resource(kubeSchema.GroupVersionResource{
-		Group:    c.Group(),
-		Version:  c.Version(),
-		Resource: c.Plural(),
+		Group:    r.Group(),
+		Version:  r.Version(),
+		Resource: r.Plural(),
 	}), nil
 }

--- a/galley/pkg/config/source/mcp/cache.go
+++ b/galley/pkg/config/source/mcp/cache.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	resource2 "istio.io/istio/galley/pkg/config/schema/resource"
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/pkg/mcp/sink"
 )
@@ -30,7 +31,7 @@ var _ event.Source = &cache{}
 // cache is an in-memory cache for a single collection.
 type cache struct {
 	mu                 sync.RWMutex
-	collection         collection.Name
+	schema             collection.Schema
 	handler            event.Handler
 	resources          map[resource.FullName]*resource.Instance
 	synced             bool
@@ -38,12 +39,12 @@ type cache struct {
 	fullUpdateReceived bool
 }
 
-func newCache(c collection.Name) *cache {
+func newCache(c collection.Schema) *cache {
 	scope.Source.Debuga("  Creating mcp cache for collection: ", c)
 
 	return &cache{
-		collection: c,
-		resources:  make(map[resource.FullName]*resource.Instance),
+		schema:    c,
+		resources: make(map[resource.FullName]*resource.Instance),
 	}
 }
 
@@ -52,7 +53,7 @@ func (c *cache) apply(change *sink.Change) error {
 	defer c.mu.Unlock()
 
 	// Make sure the event is for this collection. This will always be the case in practice.
-	if c.collection.String() != change.Collection {
+	if c.schema.Name().String() != change.Collection {
 		return fmt.Errorf("failed applying change for unexpected collection (%v)", change.Collection)
 	}
 
@@ -70,9 +71,9 @@ func (c *cache) applyFull(change *sink.Change) error {
 
 	// Add/update resources.
 	for _, obj := range change.Objects {
-		e, err := deserializeEntry(obj)
+		e, err := deserializeEntry(obj, c.schema.Resource())
 		if err != nil {
-			return fmt.Errorf("failed parsing entry for collection (%v): %v", c.collection, err)
+			return fmt.Errorf("failed parsing entry for collection (%v): %v", c.schema.Name(), err)
 		}
 
 		// Notify the handler if we've already synced.
@@ -108,9 +109,9 @@ func (c *cache) applyIncremental(change *sink.Change) error {
 
 	// Add/update resources.
 	for _, obj := range change.Objects {
-		e, err := deserializeEntry(obj)
+		e, err := deserializeEntry(obj, c.schema.Resource())
 		if err != nil {
-			return fmt.Errorf("failed parsing entry for collection (%v): %v", c.collection, err)
+			return fmt.Errorf("failed parsing entry for collection (%v): %v", c.schema.Name(), err)
 		}
 
 		// Notify the handler if we've already synced.
@@ -167,7 +168,7 @@ func (c *cache) Stop() {
 // Dispatch an event handler to receive resource events.
 func (c *cache) Dispatch(handler event.Handler) {
 	if scope.Source.DebugEnabled() {
-		scope.Source.Debugf("cache.Dispatch: (collection: %-50v, handler: %T)", c.collection, handler)
+		scope.Source.Debugf("cache.Dispatch: (collection: %-50v, handler: %T)", c.schema.Name(), handler)
 	}
 
 	c.handler = event.CombineHandlers(c.handler, handler)
@@ -183,12 +184,12 @@ func (c *cache) sync() {
 		c.dispatchFor(e, event.Added)
 	}
 
-	c.dispatchEvent(event.FullSyncFor(c.collection))
+	c.dispatchEvent(event.FullSyncFor(c.schema))
 }
 
 func (c *cache) dispatchEvent(e event.Event) {
 	if scope.Source.DebugEnabled() {
-		scope.Source.Debugf(">>> cache.dispatchEvent: (col: %-50s): %v", c.collection, e)
+		scope.Source.Debugf(">>> cache.dispatchEvent: (col: %-50s): %v", c.schema.Name(), e)
 	}
 	if c.handler != nil {
 		c.handler.Handle(e)
@@ -197,15 +198,15 @@ func (c *cache) dispatchEvent(e event.Event) {
 
 func (c *cache) dispatchFor(entry *resource.Instance, kind event.Kind) {
 	e := event.Event{
-		Source:   c.collection,
+		Source:   c.schema,
 		Resource: entry,
 		Kind:     kind,
 	}
 	c.dispatchEvent(e)
 }
 
-func deserializeEntry(obj *sink.Object) (*resource.Instance, error) {
-	metadata, err := resource.DeserializeMetadata(obj.Metadata)
+func deserializeEntry(obj *sink.Object, s resource2.Schema) (*resource.Instance, error) {
+	metadata, err := resource.DeserializeMetadata(obj.Metadata, s)
 	if err != nil {
 		return nil, err
 	}

--- a/galley/pkg/config/source/mcp/cache_test.go
+++ b/galley/pkg/config/source/mcp/cache_test.go
@@ -15,7 +15,6 @@
 package mcp
 
 import (
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -30,11 +29,21 @@ import (
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/resource"
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	resource2 "istio.io/istio/galley/pkg/config/schema/resource"
+	"istio.io/istio/galley/pkg/config/testing/fixtures"
 	"istio.io/istio/pkg/mcp/sink"
 )
 
 var (
-	colName   = name("ns/mycol")
+	testCollection = collection.Builder{
+		Name: "ns/mycol",
+		Schema: resource2.Builder{
+			Kind:         "Empty",
+			ProtoPackage: "github.com/gogo/protobuf/types",
+			Proto:        "google.protobuf.Empty",
+		}.MustBuild(),
+	}.MustBuild()
+
 	eventTime = time.Now().UTC()
 	fullSync  = output{
 		kind: event.FullSync,
@@ -270,10 +279,6 @@ func TestFullUpdate(t *testing.T) {
 		})
 }
 
-func name(n string) collection.Name {
-	return collection.NewName(n)
-}
-
 type cacheHelper struct {
 	*cache
 
@@ -282,7 +287,7 @@ type cacheHelper struct {
 
 func newCacheHelper() *cacheHelper {
 	c := &cacheHelper{
-		cache: newCache(colName),
+		cache: newCache(testCollection),
 	}
 	c.Dispatch(event.HandlerFromFn(func(e event.Event) {
 		c.events = append(c.events, e)
@@ -326,9 +331,7 @@ func (c *cacheHelper) expect(t *testing.T, expectedOutput ...output) {
 
 	for i, actual := range c.events {
 		expected := expectedEvents[i]
-		if !reflect.DeepEqual(actual, expected) {
-			t.Fatalf("expected:\n%v\nto equal:\n%v", actual, expected)
-		}
+		fixtures.ExpectEqual(t, actual, expected)
 	}
 }
 
@@ -369,7 +372,7 @@ type change struct {
 func (c change) toMCP() *sink.Change {
 	col := c.collection
 	if col == "" {
-		col = colName.String()
+		col = testCollection.Name().String()
 	}
 	return &sink.Change{
 		Incremental: c.incremental,
@@ -423,18 +426,19 @@ type output struct {
 
 func (e output) toEvent() event.Event {
 	if e.kind == event.FullSync {
-		return event.FullSyncFor(colName)
+		return event.FullSyncFor(testCollection)
 	}
 
 	fullName, _ := resource.ParseFullName(e.name)
 	return event.Event{
 		Kind:   e.kind,
-		Source: colName,
+		Source: testCollection,
 		Resource: &resource.Instance{
 			Metadata: resource.Metadata{
 				FullName:   fullName,
 				CreateTime: eventTime,
 				Version:    "v1",
+				Schema:     testCollection.Resource(),
 			},
 			Message: e.body,
 			Origin:  defaultOrigin,

--- a/galley/pkg/config/source/mcp/source.go
+++ b/galley/pkg/config/source/mcp/source.go
@@ -31,10 +31,11 @@ type Source struct {
 }
 
 // NewSource creates a new MCP event Source.
-func NewSource(collections collection.Names) *Source {
-	caches := make(map[string]*cache, len(collections))
-	for _, c := range collections {
-		caches[c.String()] = newCache(c)
+func NewSource(schemas collection.Schemas) *Source {
+	all := schemas.All()
+	caches := make(map[string]*cache, len(all))
+	for _, c := range all {
+		caches[c.Name().String()] = newCache(c)
 	}
 
 	return &Source{

--- a/galley/pkg/config/source/mcp/source_test.go
+++ b/galley/pkg/config/source/mcp/source_test.go
@@ -27,7 +27,7 @@ import (
 func TestApplyUnknownCollection(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s := NewSource(collection.Names{})
+	s := NewSource(collection.SchemasFor())
 	s.Start()
 	defer s.Stop()
 
@@ -40,7 +40,7 @@ func TestApplyUnknownCollection(t *testing.T) {
 func TestApply(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s := NewSource(collection.Names{colName})
+	s := NewSource(collection.SchemasFor(testCollection))
 	s.Start()
 	defer s.Stop()
 
@@ -50,9 +50,9 @@ func TestApply(t *testing.T) {
 	}))
 
 	err := s.Apply(&sink.Change{
-		Collection: colName.String(),
+		Collection: testCollection.Name().String(),
 	})
 	g.Expect(err).To(BeNil())
 	g.Expect(len(events)).To(Equal(1))
-	g.Expect(events[0]).To(Equal(event.FullSyncFor(colName)))
+	g.Expect(events[0]).To(Equal(event.FullSyncFor(testCollection)))
 }

--- a/galley/pkg/config/testing/basicmeta/collections.gen.go
+++ b/galley/pkg/config/testing/basicmeta/collections.gen.go
@@ -24,7 +24,7 @@ var (
 			ProtoPackage:  "github.com/gogo/protobuf/types",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCollection1 describes the collection k8s/collection1
@@ -40,7 +40,7 @@ var (
 			ProtoPackage:  "github.com/gogo/protobuf/types",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// All contains all collections in the system.

--- a/galley/pkg/config/testing/data/collections.go
+++ b/galley/pkg/config/testing/data/collections.go
@@ -16,18 +16,47 @@ package data
 
 import (
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/galley/pkg/config/schema/resource"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 )
 
 var (
-	// K8SCollection1 is a testing collection
-	K8SCollection1 = collection.NewName("k8s/collection1")
-
-	// Collection2 is a testing collection
-	Collection2 = collection.NewName("collection2")
-
 	// K8SCollection2 is a testing collection
-	K8SCollection2 = collection.NewName("k8s/collection2")
+	K8SCollection2 = basicmeta.MustGet2().KubeCollections().MustFind("k8s/collection2")
 
-	// Collection3 is a testing collection
-	Collection3 = collection.NewName("collection3")
+	Foo = collection.Builder{
+		Name: "foo",
+		Schema: resource.Builder{
+			Kind:         "Foo",
+			ProtoPackage: "github.com/gogo/protobuf/types",
+			Proto:        "google.protobuf.Empty",
+		}.MustBuild(),
+	}.MustBuild()
+
+	Bar = collection.Builder{
+		Name: "bar",
+		Schema: resource.Builder{
+			Kind:         "Bar",
+			ProtoPackage: "github.com/gogo/protobuf/types",
+			Proto:        "google.protobuf.Empty",
+		}.MustBuild(),
+	}.MustBuild()
+
+	Boo = collection.Builder{
+		Name: "boo",
+		Schema: resource.Builder{
+			Kind:         "Boo",
+			ProtoPackage: "github.com/gogo/protobuf/types",
+			Proto:        "google.protobuf.Empty",
+		}.MustBuild(),
+	}.MustBuild()
+
+	Baz = collection.Builder{
+		Name: "baz",
+		Schema: resource.Builder{
+			Kind:         "Baz",
+			ProtoPackage: "github.com/gogo/protobuf/types",
+			Proto:        "google.protobuf.Empty",
+		}.MustBuild(),
+	}.MustBuild()
 )

--- a/galley/pkg/config/testing/data/events.go
+++ b/galley/pkg/config/testing/data/events.go
@@ -16,67 +16,68 @@ package data
 
 import (
 	"istio.io/istio/galley/pkg/config/event"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 )
 
 var (
 	// Event1Col1AddItem1 is a testing event
 	Event1Col1AddItem1 = event.Event{
 		Kind:     event.Added,
-		Source:   K8SCollection1,
+		Source:   basicmeta.K8SCollection1,
 		Resource: EntryN1I1V1,
 	}
 
 	// Event1Col1AddItem1Broken is a testing event
 	Event1Col1AddItem1Broken = event.Event{
 		Kind:     event.Added,
-		Source:   K8SCollection1,
+		Source:   basicmeta.K8SCollection1,
 		Resource: EntryN1I1V1Broken,
 	}
 
 	// Event1Col1UpdateItem1 is a testing event
 	Event1Col1UpdateItem1 = event.Event{
 		Kind:     event.Updated,
-		Source:   K8SCollection1,
+		Source:   basicmeta.K8SCollection1,
 		Resource: EntryN1I1V2,
 	}
 
 	// Event1Col1DeleteItem1 is a testing event
 	Event1Col1DeleteItem1 = event.Event{
 		Kind:     event.Deleted,
-		Source:   K8SCollection1,
+		Source:   basicmeta.K8SCollection1,
 		Resource: EntryN1I1V1,
 	}
 
 	// Event1Col1DeleteItem2 is a testing event
 	Event1Col1DeleteItem2 = event.Event{
 		Kind:     event.Deleted,
-		Source:   K8SCollection1,
+		Source:   basicmeta.K8SCollection1,
 		Resource: EntryN2I2V2,
 	}
 
 	// Event1Col1Synced is a testing event
 	Event1Col1Synced = event.Event{
 		Kind:   event.FullSync,
-		Source: K8SCollection1,
+		Source: basicmeta.K8SCollection1,
 	}
 
 	// Event1Col2Synced is a testing event
 	Event1Col2Synced = event.Event{
 		Kind:   event.FullSync,
-		Source: Collection2,
+		Source: basicmeta.Collection2,
 	}
 
 	// Event2Col1AddItem2 is a testing event
 	Event2Col1AddItem2 = event.Event{
 		Kind:     event.Added,
-		Source:   K8SCollection1,
+		Source:   basicmeta.K8SCollection1,
 		Resource: EntryN2I2V2,
 	}
 
 	// Event3Col2AddItem1 is a testing event
 	Event3Col2AddItem1 = event.Event{
 		Kind:     event.Added,
-		Source:   Collection2,
+		Source:   basicmeta.Collection2,
 		Resource: EntryN1I1V1,
 	}
 )

--- a/galley/pkg/config/testing/data/resources.go
+++ b/galley/pkg/config/testing/data/resources.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 		Metadata: resource.Metadata{
 			FullName: resource.NewFullName("n1", "i1"),
 			Version:  "v1",
+			Schema:   basicmeta.K8SCollection1.Resource(),
 		},
 		Message: parseStruct(`
 {
@@ -41,6 +43,7 @@ var (
 		Metadata: resource.Metadata{
 			FullName: resource.NewFullName("", "i1"),
 			Version:  "v1",
+			Schema:   K8SCollection2.Resource(),
 		},
 		Message: parseStruct(`
 {
@@ -53,6 +56,7 @@ var (
 		Metadata: resource.Metadata{
 			FullName: resource.NewFullName("n1", "i1"),
 			Version:  "v1",
+			Schema:   basicmeta.K8SCollection1.Resource(),
 		},
 		Message: nil,
 	}
@@ -62,6 +66,7 @@ var (
 		Metadata: resource.Metadata{
 			FullName: resource.NewFullName("n1", "i1"),
 			Version:  "v2",
+			Schema:   basicmeta.K8SCollection1.Resource(),
 		},
 		Message: parseStruct(`
 {
@@ -74,6 +79,7 @@ var (
 		Metadata: resource.Metadata{
 			FullName: resource.NewFullName("n2", "i2"),
 			Version:  "v1",
+			Schema:   basicmeta.K8SCollection1.Resource(),
 		},
 		Message: parseStruct(`
 {
@@ -86,6 +92,7 @@ var (
 		Metadata: resource.Metadata{
 			FullName: resource.NewFullName("n2", "i2"),
 			Version:  "v2",
+			Schema:   basicmeta.K8SCollection1.Resource(),
 		},
 		Message: parseStruct(`{
 	"n2_i2": "v2"
@@ -97,6 +104,7 @@ var (
 		Metadata: resource.Metadata{
 			FullName: resource.NewFullName("n3", "i3"),
 			Version:  "v1",
+			Schema:   basicmeta.K8SCollection1.Resource(),
 		},
 		Message: parseStruct(`{
 	"n3_i3": "v1"
@@ -108,6 +116,7 @@ var (
 		Metadata: resource.Metadata{
 			FullName: resource.NewFullName("", "i1"),
 			Version:  "v1",
+			Schema:   basicmeta.K8SCollection1.Resource(),
 		},
 		Message: parseStruct(`{
 		"n1_i1": "v1"

--- a/galley/pkg/config/testing/fixtures/expect.go
+++ b/galley/pkg/config/testing/fixtures/expect.go
@@ -15,6 +15,9 @@
 package fixtures
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,14 +26,76 @@ import (
 
 	"istio.io/istio/galley/pkg/config/event"
 	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
-// ExpectEqual expects that o1 and o2 are equal. If not, fails with the diff.
+// ExpectEventsEventually waits for the Accumulator.Events() to contain the expected events.
+func ExpectEventsEventually(t *testing.T, acc *Accumulator, expected ...event.Event) {
+	t.Helper()
+	expectEventsEventually(t, acc.Events, expected...)
+}
+
+// ExpectEventsWithoutOriginsEventually waits for the Accumulator.EventsWithoutOrigins() to contain the expected events.
+func ExpectEventsWithoutOriginsEventually(t *testing.T, acc *Accumulator, expected ...event.Event) {
+	t.Helper()
+	expectEventsEventually(t, acc.EventsWithoutOrigins, expected...)
+}
+
+func expectEventsEventually(t *testing.T, getActuals func() []event.Event, expected ...event.Event) {
+	t.Helper()
+	retry.UntilSuccessOrFail(t, func() error {
+		return CheckContainEvents(getActuals(), expected...)
+	}, retry.Delay(time.Millisecond*100), retry.Timeout(time.Second*2))
+}
+
+// ExpectContainEvents calls CheckContainEvents and fails the test if an error is returned.
+func ExpectContainEvents(t *testing.T, actuals []event.Event, expected ...event.Event) {
+	t.Helper()
+	if err := CheckContainEvents(actuals, expected...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// CheckContainEvents checks that the expected elements are all contained within the actual events list (order independent).
+func CheckContainEvents(actuals []event.Event, expected ...event.Event) error {
+	sort.SliceStable(expected, func(i, j int) bool {
+		return strings.Compare(expected[i].String(), expected[j].String()) < 0
+	})
+
+	sort.SliceStable(actuals, func(i, j int) bool {
+		return strings.Compare(actuals[i].String(), actuals[j].String()) < 0
+	})
+
+	for _, e := range expected {
+		found := false
+		for _, a := range actuals {
+			if cmp.Equal(a, e) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("element %s not found. Diff:\n%s", e, cmp.Diff(actuals, expected))
+		}
+	}
+	return nil
+}
+
+// ExpectEqual calls CheckEqual and fails the test if it returns an error.
 func ExpectEqual(t *testing.T, o1 interface{}, o2 interface{}) {
 	t.Helper()
-	if diff := cmp.Diff(o1, o2); diff != "" {
-		t.Fatal(diff)
+	if err := CheckEqual(o1, o2); err != nil {
+		t.Fatal(err)
 	}
+}
+
+// CheckEqual checks that o1 and o2 are equal. If not, returns an error with the diff.
+func CheckEqual(o1 interface{}, o2 interface{}) error {
+	if diff := cmp.Diff(o1, o2); diff != "" {
+		return fmt.Errorf(diff)
+	}
+	return nil
 }
 
 // Expect calls gomega.Eventually to wait until the accumulator accumulated specified events.
@@ -39,7 +104,7 @@ func Expect(t *testing.T, acc *Accumulator, expected ...event.Event) {
 }
 
 // ExpectFullSync expects the given full sync event.
-func ExpectFullSync(t *testing.T, acc *Accumulator, c collection.Name) {
+func ExpectFullSync(t *testing.T, acc *Accumulator, c collection.Schema) {
 	e := event.FullSyncFor(c)
 	Expect(t, acc, e)
 }

--- a/galley/pkg/config/testing/fixtures/expect_test.go
+++ b/galley/pkg/config/testing/fixtures/expect_test.go
@@ -17,6 +17,7 @@ package fixtures_test
 import (
 	"testing"
 
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 )
@@ -33,7 +34,7 @@ func TestExpect_FullSync(t *testing.T) {
 	acc := &fixtures.Accumulator{}
 	acc.Handle(data.Event1Col1Synced)
 
-	fixtures.ExpectFullSync(t, acc, data.K8SCollection1)
+	fixtures.ExpectFullSync(t, acc, basicmeta.K8SCollection1)
 }
 
 func TestExpect_None(t *testing.T) {

--- a/galley/pkg/config/testing/fixtures/source_test.go
+++ b/galley/pkg/config/testing/fixtures/source_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/onsi/gomega"
 
 	"istio.io/istio/galley/pkg/config/event"
-	"istio.io/istio/galley/pkg/config/testing/data"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 )
 
 func TestSource(t *testing.T) {
@@ -59,7 +59,7 @@ func TestSource_Handle(t *testing.T) {
 
 	e := event.Event{
 		Kind:     event.Added,
-		Source:   data.K8SCollection1,
+		Source:   basicmeta.K8SCollection1,
 		Resource: nil,
 	}
 	s.Handle(e)

--- a/galley/pkg/config/testing/fixtures/transformer.go
+++ b/galley/pkg/config/testing/fixtures/transformer.go
@@ -21,10 +21,10 @@ import (
 
 // Transformer implements event.Transformer for testing purposes.
 type Transformer struct {
-	Handlers          map[collection.Name]event.Handler
+	Handlers          map[collection.Name]*sourceAndHandler
 	Started           bool
-	InputCollections  collection.Names
-	OutputCollections collection.Names
+	InputCollections  collection.Schemas
+	OutputCollections collection.Schemas
 
 	fn func(tr *Transformer, e event.Event)
 }
@@ -32,11 +32,11 @@ type Transformer struct {
 var _ event.Transformer = &Transformer{}
 
 // NewTransformer returns a new fixture.Transformer.
-func NewTransformer(inputs, outputs collection.Names, handlerFn func(tr *Transformer, e event.Event)) *Transformer {
+func NewTransformer(inputs, outputs collection.Schemas, handlerFn func(tr *Transformer, e event.Event)) *Transformer {
 	return &Transformer{
 		InputCollections:  inputs,
 		OutputCollections: outputs,
-		Handlers:          make(map[collection.Name]event.Handler),
+		Handlers:          make(map[collection.Name]*sourceAndHandler),
 		fn:                handlerFn,
 	}
 }
@@ -57,19 +57,26 @@ func (t *Transformer) Handle(e event.Event) {
 }
 
 // DispatchFor implements event.Transformer
-func (t *Transformer) DispatchFor(c collection.Name, h event.Handler) {
-	handlers := t.Handlers[c]
-	handlers = event.CombineHandlers(handlers, h)
-	t.Handlers[c] = handlers
+func (t *Transformer) DispatchFor(c collection.Schema, h event.Handler) {
+	entry := t.Handlers[c.Name()]
+	if entry == nil {
+		t.Handlers[c.Name()] = &sourceAndHandler{
+			source:  c,
+			handler: h,
+		}
+		return
+	}
+
+	entry.handler = event.CombineHandlers(entry.handler, h)
 }
 
 // Inputs implements event.Transformer
-func (t *Transformer) Inputs() collection.Names {
+func (t *Transformer) Inputs() collection.Schemas {
 	return t.InputCollections
 }
 
 // Outputs implements event.Transformer
-func (t *Transformer) Outputs() collection.Names {
+func (t *Transformer) Outputs() collection.Schemas {
 	return t.OutputCollections
 }
 
@@ -77,6 +84,11 @@ func (t *Transformer) Outputs() collection.Names {
 func (t *Transformer) Publish(c collection.Name, e event.Event) {
 	h := t.Handlers[c]
 	if h != nil {
-		h.Handle(e)
+		h.handler.Handle(e)
 	}
+}
+
+type sourceAndHandler struct {
+	source  collection.Schema
+	handler event.Handler
 }

--- a/galley/pkg/config/testing/k8smeta/collections.gen.go
+++ b/galley/pkg/config/testing/k8smeta/collections.gen.go
@@ -24,7 +24,7 @@ var (
 			ProtoPackage:  "k8s.io/api/apps/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Endpoints describes the collection k8s/core/v1/endpoints
@@ -40,7 +40,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Namespaces describes the collection k8s/core/v1/namespaces
@@ -56,7 +56,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Nodes describes the collection k8s/core/v1/nodes
@@ -72,7 +72,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Pods describes the collection k8s/core/v1/pods
@@ -88,7 +88,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SCoreV1Services describes the collection k8s/core/v1/services
@@ -104,7 +104,7 @@ var (
 			ProtoPackage:  "k8s.io/api/core/v1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// K8SExtensionsV1Beta1Ingresses describes the collection
@@ -121,7 +121,7 @@ var (
 			ProtoPackage:  "k8s.io/api/extensions/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
-		}.Build(),
+		}.MustBuild(),
 	}.MustBuild()
 
 	// All contains all collections in the system.

--- a/galley/pkg/config/util/kuberesource/resources.go
+++ b/galley/pkg/config/util/kuberesource/resources.go
@@ -36,13 +36,13 @@ func DisableExcludedCollections(in collection.Schemas, providers transformer.Pro
 	resultBuilder := collection.NewSchemasBuilder()
 	for _, s := range in.All() {
 		disabled := false
-		if isKindExcluded(excludedResourceKinds, s.Kind()) {
+		if isKindExcluded(excludedResourceKinds, s.Resource().Kind()) {
 			// Found a matching exclude directive for this KubeResource. Disable the resource.
 			disabled = true
 
 			// Check and see if this is needed for Service Discovery. If needed, we will need to re-enable.
 			if enableServiceDiscovery {
-				a := rt.DefaultProvider().GetAdapter(s)
+				a := rt.DefaultProvider().GetAdapter(s.Resource())
 				if a.IsRequiredForServiceDiscovery() {
 					// This is needed for service discovery. Re-enable.
 					disabled = false
@@ -69,9 +69,9 @@ func DisableExcludedCollections(in collection.Schemas, providers transformer.Pro
 func DefaultExcludedResourceKinds() []string {
 	resources := make([]string, 0)
 	for _, r := range schema.MustGet().KubeCollections().All() {
-		a := rt.DefaultProvider().GetAdapter(r)
+		a := rt.DefaultProvider().GetAdapter(r.Resource())
 		if a.IsDefaultExcluded() {
-			resources = append(resources, r.Kind())
+			resources = append(resources, r.Resource().Kind())
 		}
 	}
 	return resources

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -262,9 +262,9 @@ func getDeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.Depl
 }
 
 func findResourceInSpec(kind string) string {
-	for _, r := range schema.MustGet().KubeCollections().All() {
-		if r.Kind() == kind {
-			return r.Plural()
+	for _, c := range schema.MustGet().KubeCollections().All() {
+		if c.Resource().Kind() == kind {
+			return c.Resource().Plural()
 		}
 	}
 	return ""

--- a/mixer/pkg/config/mcp/backend_test.go
+++ b/mixer/pkg/config/mcp/backend_test.go
@@ -74,7 +74,7 @@ func init() {
 
 func collectionOf(nonLegacyKind string) string { // nolint: unparam
 	for _, r := range schema.MustGet().KubeCollections().All() {
-		if r.Kind() == nonLegacyKind {
+		if r.Resource().Kind() == nonLegacyKind {
 			return schema.MustGet().DirectTransformSettings().Mapping()[r.Name()].String()
 		}
 	}

--- a/tests/integration/galley/conversion_test.go
+++ b/tests/integration/galley/conversion_test.go
@@ -137,7 +137,7 @@ func syntheticServiceEntryValidator(ns string) galley.SnapshotValidatorFunc {
 	return galley.NewSingleObjectSnapshotValidator(ns, func(ns string, actual *galley.SnapshotObject) error {
 		v := structpath.ForProto(actual)
 		sp := schema.MustGet().AllCollections().MustFind(collections.IstioNetworkingV1Alpha3SyntheticServiceentries.Name().String())
-		typeURL := "type.googleapis.com/" + sp.Proto()
+		typeURL := "type.googleapis.com/" + sp.Resource().Proto()
 		if err := v.Equals(typeURL, "{.TypeURL}").
 			Equals(fmt.Sprintf("%s/kube-dns", ns), "{.Metadata.name}").
 			Check(); err != nil {

--- a/tests/integration/galley/validation_test.go
+++ b/tests/integration/galley/validation_test.go
@@ -166,7 +166,7 @@ func TestEnsureNoMissingCRDs(t *testing.T) {
 			recognized := make(map[string]struct{})
 
 			for _, r := range schema.MustGet().KubeCollections().All() {
-				s := strings.Join([]string{r.Group(), r.Version(), r.Kind()}, "/")
+				s := strings.Join([]string{r.Resource().Group(), r.Resource().Version(), r.Resource().Kind()}, "/")
 				recognized[s] = struct{}{}
 			}
 

--- a/tests/integration/pilot/mcp/synthetic_serviceentry_test.go
+++ b/tests/integration/pilot/mcp/synthetic_serviceentry_test.go
@@ -295,7 +295,7 @@ func validateSse(response *structpath.Instance, params testParam) error {
 func syntheticServiceEntryValidator(params testParam) galley.SnapshotValidatorFunc {
 	return galley.NewSingleObjectSnapshotValidator(params.namespace.Name(), func(ns string, actual *galley.SnapshotObject) error {
 		sp := schema.MustGet().AllCollections().MustFind(collections.IstioNetworkingV1Alpha3SyntheticServiceentries.Name().String())
-		typeURL := "type.googleapis.com/" + sp.Proto()
+		typeURL := "type.googleapis.com/" + sp.Resource().Proto()
 		v := structpath.ForProto(actual)
 		if err := v.Equals(typeURL, "{.TypeURL}").
 			Equals(fmt.Sprintf("%s/%s", params.namespace.Name(), params.svcName), "{.Metadata.name}").


### PR DESCRIPTION
This is the next step toward merging the galley and pilot processing pipelines.  This PR does the following:

1. Adds a `collection.Schema` to `event.Event`. This replaces the old `Source` collection string.
2. Adds a `resource.Schema` to `resource.Metadata`. Pilot's `ConfigMeta` has Kind, Group, and Version which was previously unavailable in `resource.Metadata`. By adding the schema to `resource.Metadata` we can eventually eliminate `ConfigMeta` altogether.

We need both 1 and 2 since the `Resource` field in `event.Event` is optional.

Schemas are references, so there will not be much additional copying involved. This change should therefore not affect performance or memory usage.