### PR TITLE
Add support for building arm64 images using local envoy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,11 @@ else
 endif
 
 export TARGET_OUT ?= $(shell pwd)/out/$(TARGET_OS)_$(TARGET_ARCH)
-export TARGET_OUT_LINUX ?= $(shell pwd)/out/linux_amd64
+export TARGET_OUT_LINUX ?= $(shell pwd)/out/linux_$(TARGET_ARCH)
 
 ifeq ($(BUILD_WITH_CONTAINER),1)
 export TARGET_OUT = /work/out/$(TARGET_OS)_$(TARGET_ARCH)
-export TARGET_OUT_LINUX = /work/out/linux_amd64
+export TARGET_OUT_LINUX = /work/out/linux_$(TARGET_ARCH)
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
 IMG ?= gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -283,7 +283,7 @@ build: depend $(BUILD_DEPS)
 # various platform images.
 .PHONY: build-linux
 build-linux: depend
-	STATIC=0 GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh $(ISTIO_OUT_LINUX)/ $(BINARIES)
+	STATIC=0 GOOS=linux GOARCH=$(GOARCH_LOCAL) LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh $(ISTIO_OUT_LINUX)/ $(BINARIES)
 
 # Create targets for ISTIO_OUT_LINUX/binary
 # There are two use cases here:
@@ -296,7 +296,7 @@ ifeq ($(BUILD_ALL),true)
 $(ISTIO_OUT_LINUX)/$(shell basename $(1)): build-linux
 else
 $(ISTIO_OUT_LINUX)/$(shell basename $(1)): $(ISTIO_OUT_LINUX)
-	STATIC=0 GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh $(ISTIO_OUT_LINUX)/ $(1)
+	STATIC=0 GOOS=linux GOARCH=$(GOARCH_LOCAL) LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh $(ISTIO_OUT_LINUX)/ $(1)
 endif
 endef
 

--- a/docker/Dockerfile.istiod
+++ b/docker/Dockerfile.istiod
@@ -11,7 +11,7 @@ USER 1337:1337
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:nonroot as distroless
+FROM discolix/static:nonroot as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/docker/Dockerfile.kubectl
+++ b/docker/Dockerfile.kubectl
@@ -6,7 +6,8 @@ ARG BASE_VERSION=latest
 FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # This container should only contain kubectl.  Hard-coding to use Linux K8s 1.13.10 version.
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.13.10/bin/linux/amd64/kubectl /usr/bin/kubectl
+ARG TARGET_ARCH=amd64
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.13.10/bin/linux/${TARGET_ARCH}/kubectl /usr/bin/kubectl
 RUN chmod +x /usr/bin/kubectl
 
 # Ensure a kubectl compatible with the container OS was used.  This is a safety

--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -3,6 +3,7 @@ ARG BASE_DISTRIBUTION=default
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
@@ -11,7 +12,7 @@ USER 1337:1337
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:nonroot as distroless
+FROM ${DISTROLESS_IMAGE}/static:nonroot as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/mixer/docker/Dockerfile.mixer
+++ b/mixer/docker/Dockerfile.mixer
@@ -3,6 +3,7 @@ ARG BASE_DISTRIBUTION=default
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
@@ -11,7 +12,7 @@ USER 1337:1337
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:nonroot as distroless
+FROM ${DISTROLESS_IMAGE}/static:nonroot as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/mixer/docker/Dockerfile.mixer_codegen
+++ b/mixer/docker/Dockerfile.mixer_codegen
@@ -3,6 +3,7 @@ ARG BASE_DISTRIBUTION=default
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
@@ -11,7 +12,7 @@ USER 1337:1337
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:nonroot as distroless
+FROM ${DISTROLESS_IMAGE}/static:nonroot as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/mixer/docker/Dockerfile.test_policybackend
+++ b/mixer/docker/Dockerfile.test_policybackend
@@ -3,13 +3,14 @@ ARG BASE_DISTRIBUTION=default
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:latest as distroless
+FROM ${DISTROLESS_IMAGE}/static:latest as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/mixer/test/listbackend/cmd/Dockerfile
+++ b/mixer/test/listbackend/cmd/Dockerfile
@@ -14,6 +14,7 @@
 
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 # No tag available https://hub.docker.com/_/scratch?tab=description
@@ -22,7 +23,7 @@ FROM scratch as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:latest as distroless
+FROM ${DISTROLESS_IMAGE}/static:latest as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/mixer/test/prometheus/cmd/Dockerfile
+++ b/mixer/test/prometheus/cmd/Dockerfile
@@ -14,6 +14,7 @@
 
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 # No tag available https://hub.docker.com/_/scratch?tab=description
@@ -22,7 +23,7 @@ FROM scratch as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:latest as distroless
+FROM ${DISTROLESS_IMAGE}/static:latest as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -3,6 +3,7 @@ ARG BASE_DISTRIBUTION=default
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
@@ -11,7 +12,7 @@ USER 1337:1337
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:nonroot as distroless
+FROM ${DISTROLESS_IMAGE}/static:nonroot as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -3,6 +3,7 @@ ARG BASE_DISTRIBUTION=default
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
@@ -17,12 +18,13 @@ COPY istio-iptables /usr/local/bin/istio-iptables
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/cc:latest as distroless
+FROM ${DISTROLESS_IMAGE}/cc:latest as distroless
 
 # TODO(https://github.com/istio/istio/issues/17656) clean up this hack
+ARG ARCH=x86_64
 COPY --from=default /sbin/xtables-multi /sbin/iptables* /sbin/ip6tables* /sbin/ip /sbin/
-COPY --from=default /usr/lib/x86_64-linux-gnu/xtables/ /usr/lib/x86_64-linux-gnu/xtables
-COPY --from=default /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu
+COPY --from=default /usr/lib/${ARCH}-linux-gnu/xtables/ /usr/lib/${ARCH}-linux-gnu/xtables
+COPY --from=default /usr/lib/${ARCH}-linux-gnu/ /usr/lib/${ARCH}-linux-gnu
 COPY --from=default /etc/iproute2 /etc/iproute2
 
 COPY istio-iptables /usr/local/bin/istio-iptables

--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -21,6 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go
 
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
 ARG BASE_DISTRIBUTION=default
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 # No tag available https://hub.docker.com/_/scratch?tab=description
@@ -29,7 +30,7 @@ FROM scratch as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:latest as distroless
+FROM ${DISTROLESS_IMAGE}/static:latest as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/security/docker/Dockerfile.citadel
+++ b/security/docker/Dockerfile.citadel
@@ -3,6 +3,7 @@ ARG BASE_DISTRIBUTION=default
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
@@ -11,7 +12,7 @@ USER 1337:1337
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:nonroot as distroless
+FROM ${DISTROLESS_IMAGE}/static:nonroot as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/security/docker/Dockerfile.node-agent
+++ b/security/docker/Dockerfile.node-agent
@@ -3,13 +3,14 @@ ARG BASE_DISTRIBUTION=default
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:latest as distroless
+FROM ${DISTROLESS_IMAGE}/static:latest as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/security/docker/Dockerfile.node-agent-k8s
+++ b/security/docker/Dockerfile.node-agent-k8s
@@ -3,13 +3,14 @@ ARG BASE_DISTRIBUTION=default
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:latest as distroless
+FROM ${DISTROLESS_IMAGE}/static:latest as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/sidecar-injector/docker/Dockerfile.sidecar_injector
+++ b/sidecar-injector/docker/Dockerfile.sidecar_injector
@@ -3,6 +3,7 @@ ARG BASE_DISTRIBUTION=default
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG DISTROLESS_IMAGE=gcr.io/distroless
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM docker.io/istio/base:${BASE_VERSION} as default
@@ -11,7 +12,7 @@ USER 1337:1337
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:nonroot as distroless
+FROM ${DISTROLESS_IMAGE}/static:nonroot as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006


### PR DESCRIPTION
We sucessfully build with this command:
USE_LOCAL_PROXY=1 make docker.base BAZEL_BUILD_ARGS="--cpu aarch64"
docker tag istio/base:${TAG} istio/base:${BASE_VERSION}
USE_LOCAL_PROXY=1 make docker BAZEL_BUILD_ARGS="--cpu aarch64"