### PR TITLE
handle http proxy while generating routes

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -271,10 +271,10 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(node *mod
 	// this listener and not all virtual services accessible to this proxy.
 	virtualServices = egressListener.VirtualServices()
 
-	// When generating RDS for ports created via the SidecarScope, we treat
-	// these ports as HTTP proxy style ports. All services attached to this listener
-	// must feature in this RDS route irrespective of the service port.
-	if egressListener.IstioListener != nil && egressListener.IstioListener.Port != nil {
+	// When generating RDS for ports created via the SidecarScope, we treat ports as HTTP proxy style ports
+	// if ports protocol is HTTP_PROXY.
+	if egressListener.IstioListener != nil && egressListener.IstioListener.Port != nil &&
+		protocol.Parse(egressListener.IstioListener.Port.Protocol) == protocol.HTTP_PROXY {
 		listenerPort = 0
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -435,14 +435,14 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 	// With the config above, RDS should return a valid route for the following route names
 	// port 9000 - [bookinfo.com:9999, *.bookinfo.com:9990], [bookinfo.com:70, *.bookinfo.com:70] but no bookinfo.com
 	// unix://foo/bar/baz - [bookinfo.com:9999, *.bookinfo.com:9999], [bookinfo.com:70, *.bookinfo.com:70] but no bookinfo.com
-	// port 8080 - [test.com:8080, 8.8.8.8:8080], but no bookinfo.com or test.com
+	// port 8080 - [test.com, test.com:8080, 8.8.8.8, 8.8.8.8:8080], but no bookinfo.com or test.com
 	// port 9999 - [bookinfo.com, bookinfo.com:9999, *.bookinfo.com, *.bookinfo.com:9999]
 	// port 80 - [test-private.com, test-private.com:80, 9.9.9.9:80, 9.9.9.9]
 	// port 70 - [test-private.com, test-private.com:70, 9.9.9.9, 9.9.9.9:70], [bookinfo.com, bookinfo.com:70]
 
 	// Without sidecar config [same as wildcard egress listener], expect routes
 	// 9999 - [bookinfo.com, bookinfo.com:9999, *.bookinfo.com, *.bookinfo.com:9999],
-	// 8080 - [test.com, test.com:8080, 8.8.8.8:8080, 8.8.8.8]
+	// 8080 - [test.com, test.com:8080, 8.8.8.8, 8.8.8.8:8080]
 	// 80 - [test-private.com, test-private.com:80, 9.9.9.9:80, 9.9.9.9]
 	// 70 - [bookinfo.com, bookinfo.com:70, *.bookinfo.com:70],[test-private.com, test-private.com:70, 9.9.9.9:70, 9.9.9.9]
 	cases := []struct {

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -176,7 +176,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			},
 		},
 	}
-	sidecarConfigWitHttpProxy := &model.Config{
+	sidecarConfigWitHTTPProxy := &model.Config{
 		ConfigMeta: model.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
@@ -710,7 +710,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		{
 			name:                  "http proxy sidecar config, with non matching virtual service",
 			routeName:             "7443",
-			sidecarConfig:         sidecarConfigWitHttpProxy,
+			sidecarConfig:         sidecarConfigWitHTTPProxy,
 			virtualServiceConfigs: []*model.Config{&virtualService5},
 			expectedHosts: map[string]map[string]bool{
 				"bookinfo.com:9999":      {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},


### PR DESCRIPTION
PR https://github.com/istio/istio/pull/19160 added support for http_proxy protocol in side car config. That needs to be handled in routes. With out this, routes with invalid cluster like `outbound|0` are generated if a virtual service exists for a service and service does not have the port specified in the egress listener. See the new test cases added that explains the behaviour.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
