### PR TITLE
Fix TestConformance

### DIFF
--- a/tests/integration/conformance/testdata/policy/instance/basic/input.yaml
+++ b/tests/integration/conformance/testdata/policy/instance/basic/input.yaml
@@ -4,4 +4,3 @@ metadata:
   name: idynlistentry1
 spec:
   template: listentry
-  params:


### PR DESCRIPTION
Recently after #8df0cb5e5, TestConformance always failed