### PR TITLE
service entry: recompute indexes only when services have changed

### DIFF
--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -137,26 +137,15 @@ func TestServiceDiscoveryGetProxyServiceInstances(t *testing.T) {
 		makeInstance(tcpStatic, "2.2.2.2", 444, tcpStatic.Spec.(*networking.ServiceEntry).Ports[0], nil, true),
 	}
 
-	done := make(chan bool)
-	for i := 0; i < 25; i++ {
-		go func() {
-			instances, err := sd.GetProxyServiceInstances(&model.Proxy{IPAddresses: []string{"2.2.2.2"}})
-			if err != nil {
-				t.Errorf("GetProxyServiceInstances() encountered unexpected error: %v", err)
-			}
-			sortServiceInstances(instances)
-			sortServiceInstances(expectedInstances)
-			if err := compare(t, instances, expectedInstances); err != nil {
-				t.Error(err)
-			}
-			done <- true
-		}()
+	instances, err := sd.GetProxyServiceInstances(&model.Proxy{IPAddresses: []string{"2.2.2.2"}})
+	if err != nil {
+		t.Errorf("GetProxyServiceInstances() encountered unexpected error: %v", err)
 	}
-
-	for i := 0; i < 25; i++ {
-		<-done
+	sortServiceInstances(instances)
+	sortServiceInstances(expectedInstances)
+	if err := compare(t, instances, expectedInstances); err != nil {
+		t.Error(err)
 	}
-
 }
 
 // Keeping this test for legacy - but it never happens in real life.


### PR DESCRIPTION
Currently we recompute the internal indexes (maps) for every change in Service Entry on next access to `GetProxyServiceInstances` etc. This PR changes it and computes the indexes only when services changed and updates instance inline when only instances have changed.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
