### PR TITLE
Add msg.All() which returns all analyzer message types

### DIFF
--- a/galley/pkg/config/analysis/msg/generate.main.go
+++ b/galley/pkg/config/analysis/msg/generate.main.go
@@ -133,6 +133,15 @@ var (
 	{{end}}
 )
 
+// All returns a list of all known message types.
+func All() []*diag.MessageType {
+	return []*diag.MessageType{
+		{{- range .Messages}}
+			{{.Name}},
+		{{- end}}
+	}
+}
+
 {{range .Messages}}
 // New{{.Name}} returns a new diag.Message based on {{.Name}}.
 func New{{.Name}}(r *resource.Instance{{range .Args}}, {{.Name}} {{.Type}}{{end}}) diag.Message {

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -90,6 +90,32 @@ var (
 	PortNameIsNotUnderNamingConvention = diag.NewMessageType(diag.Info, "IST0118", "Port name %s (port: %d, targetPort: %s) doesn't follow the naming convention of Istio port.")
 )
 
+// All returns a list of all known message types.
+func All() []*diag.MessageType {
+	return []*diag.MessageType{
+		InternalError,
+		Deprecated,
+		ReferencedResourceNotFound,
+		NamespaceNotInjected,
+		PodMissingProxy,
+		GatewayPortNotOnWorkload,
+		IstioProxyVersionMismatch,
+		SchemaValidationError,
+		MisplacedAnnotation,
+		UnknownAnnotation,
+		ConflictingMeshGatewayVirtualServiceHosts,
+		ConflictingSidecarWorkloadSelectors,
+		MultipleSidecarsWithoutWorkloadSelectors,
+		VirtualServiceDestinationPortSelectorRequired,
+		MTLSPolicyConflict,
+		PolicySpecifiesPortNameThatDoesntExist,
+		DestinationRuleUsesMTLSForWorkloadWithoutSidecar,
+		DeploymentAssociatedToMultipleServices,
+		DeploymentRequiresServiceAssociated,
+		PortNameIsNotUnderNamingConvention,
+	}
+}
+
 // NewInternalError returns a new diag.Message based on InternalError.
 func NewInternalError(r *resource.Instance, detail string) diag.Message {
 	return diag.NewMessage(


### PR DESCRIPTION
This allows callers to iterate over all known message types to collect, say, all the known message codes.

I was going to add some additional tests using this as well (e.g. all analyzer message types must have unique codes) but it turns out these invariants are actually enforced at code generation.

This change is followup to #19673 