### PR TITLE
correctly pass service host name in eds update for service entries

### DIFF
--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -93,10 +93,10 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 				instances := convertInstances(curr, cs)
 				// If only instances have changed, just update the indexes for the changed instances.
 				c.updateExistingInstances(instances)
-				hosteps := make(map[string][]*model.IstioEndpoint)
+				endpointsByHostName := make(map[string][]*model.IstioEndpoint)
 				for _, instance := range instances {
 					for _, port := range instance.Service.Ports {
-						hosteps[string(instance.Service.Hostname)] = append(hosteps[string(instance.Service.Hostname)],
+						endpointsByHostName[string(instance.Service.Hostname)] = append(endpointsByHostName[string(instance.Service.Hostname)],
 							&model.IstioEndpoint{
 								Address:         instance.Endpoint.Address,
 								EndpointPort:    uint32(port.Port),
@@ -115,7 +115,7 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 					}
 				}
 
-				for host, eps := range hosteps {
+				for host, eps := range endpointsByHostName {
 					_ = c.XdsUpdater.EDSUpdate(c.Cluster(), host, curr.Namespace, eps)
 				}
 

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -93,27 +93,32 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 				instances := convertInstances(curr, cs)
 				// If only instances have changed, just update the indexes for the changed instances.
 				c.updateExistingInstances(instances)
+				hosteps := make(map[string][]*model.IstioEndpoint)
 				for _, instance := range instances {
-					endpoints := make([]*model.IstioEndpoint, 0)
 					for _, port := range instance.Service.Ports {
-						endpoints = append(endpoints, &model.IstioEndpoint{
-							Address:         instance.Endpoint.Address,
-							EndpointPort:    uint32(port.Port),
-							ServicePortName: port.Name,
-							Labels:          instance.Endpoint.Labels,
-							UID:             instance.Endpoint.UID,
-							ServiceAccount:  instance.Endpoint.ServiceAccount,
-							Network:         instance.Endpoint.Network,
-							Locality:        instance.Endpoint.Locality,
-							Attributes: model.ServiceAttributes{
-								Name:      instance.Service.Attributes.Name,
-								Namespace: instance.Service.Attributes.Namespace,
-							},
-							TLSMode: instance.Endpoint.TLSMode,
-						})
+						hosteps[string(instance.Service.Hostname)] = append(hosteps[string(instance.Service.Hostname)],
+							&model.IstioEndpoint{
+								Address:         instance.Endpoint.Address,
+								EndpointPort:    uint32(port.Port),
+								ServicePortName: port.Name,
+								Labels:          instance.Endpoint.Labels,
+								UID:             instance.Endpoint.UID,
+								ServiceAccount:  instance.Endpoint.ServiceAccount,
+								Network:         instance.Endpoint.Network,
+								Locality:        instance.Endpoint.Locality,
+								Attributes: model.ServiceAttributes{
+									Name:      instance.Service.Attributes.Name,
+									Namespace: instance.Service.Attributes.Namespace,
+								},
+								TLSMode: instance.Endpoint.TLSMode,
+							})
 					}
-					_ = c.XdsUpdater.EDSUpdate(c.Cluster(), string(instance.Service.Hostname), curr.Namespace, endpoints)
 				}
+
+				for host, eps := range hosteps {
+					_ = c.XdsUpdater.EDSUpdate(c.Cluster(), host, curr.Namespace, eps)
+				}
+
 			}
 		})
 	}

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -93,8 +93,8 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 				instances := convertInstances(curr, cs)
 				// If only instances have changed, just update the indexes for the changed instances.
 				c.updateExistingInstances(instances)
-				endpoints := make([]*model.IstioEndpoint, 0)
 				for _, instance := range instances {
+					endpoints := make([]*model.IstioEndpoint, 0)
 					for _, port := range instance.Service.Ports {
 						endpoints = append(endpoints, &model.IstioEndpoint{
 							Address:         instance.Endpoint.Address,
@@ -112,8 +112,8 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 							TLSMode: instance.Endpoint.TLSMode,
 						})
 					}
+					_ = c.XdsUpdater.EDSUpdate(c.Cluster(), string(instance.Service.Hostname), curr.Namespace, endpoints)
 				}
-				_ = c.XdsUpdater.EDSUpdate(c.Cluster(), curr.Name, curr.Namespace, endpoints)
 			}
 		})
 	}

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -93,10 +93,10 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 				instances := convertInstances(curr, cs)
 				// If only instances have changed, just update the indexes for the changed instances.
 				c.updateExistingInstances(instances)
-				endpointsByHostName := make(map[string][]*model.IstioEndpoint)
+				endpointsByHostname := make(map[string][]*model.IstioEndpoint)
 				for _, instance := range instances {
 					for _, port := range instance.Service.Ports {
-						endpointsByHostName[string(instance.Service.Hostname)] = append(endpointsByHostName[string(instance.Service.Hostname)],
+						endpointsByHostname[string(instance.Service.Hostname)] = append(endpointsByHostname[string(instance.Service.Hostname)],
 							&model.IstioEndpoint{
 								Address:         instance.Endpoint.Address,
 								EndpointPort:    uint32(port.Port),
@@ -115,7 +115,7 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 					}
 				}
 
-				for host, eps := range endpointsByHostName {
+				for host, eps := range endpointsByHostname {
 					_ = c.XdsUpdater.EDSUpdate(c.Cluster(), host, curr.Namespace, eps)
 				}
 


### PR DESCRIPTION
Pass service.host.Name of instance while triggering eds updates for service entries
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
