### PR TITLE
fix(bootstrap): add time-bounded platform detection logic with fail-fast

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -101,13 +101,7 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 		cfg.PilotSubjectAltName = defaultPilotSAN()
 	}
 	if cfg.PlatEnv == nil {
-		if platform.IsGCP() {
-			cfg.PlatEnv = platform.NewGCP()
-		} else if platform.IsAWS() {
-			cfg.PlatEnv = platform.NewAWS()
-		} else {
-			cfg.PlatEnv = &platform.Unknown{}
-		}
+		cfg.PlatEnv = platform.Discover()
 	}
 
 	// Remove duplicates from the node IPs.

--- a/pkg/bootstrap/platform/discovery.go
+++ b/pkg/bootstrap/platform/discovery.go
@@ -52,7 +52,7 @@ func DiscoverWithTimeout(timeout time.Duration) Environment {
 
 	go func() {
 		wg.Wait()
-		done <- true
+		close(done)
 	}()
 
 	timer := time.NewTimer(timeout)
@@ -61,7 +61,12 @@ func DiscoverWithTimeout(timeout time.Duration) Environment {
 	case p := <-plat:
 		return p
 	case <-done:
-		return &Unknown{}
+		select {
+		case p := <-plat:
+			return p
+		default:
+			return &Unknown{}
+		}
 	case <-timer.C:
 		return &Unknown{}
 	}

--- a/pkg/bootstrap/platform/discovery.go
+++ b/pkg/bootstrap/platform/discovery.go
@@ -1,0 +1,68 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"sync"
+	"time"
+)
+
+const defaultTimeout = 5 * time.Second
+
+// Discover attempts to discover the host platform, defaulting to
+// `Unknown` if a platform cannot be discovered.
+func Discover() Environment {
+	return DiscoverWithTimeout(defaultTimeout)
+}
+
+// DiscoverWithTimeout attempts to discover the host platform, defaulting to
+// `Unknown` after the provided timeout.
+func DiscoverWithTimeout(timeout time.Duration) Environment {
+	plat := make(chan Environment, 2) // sized to match number of platform goroutines
+	done := make(chan bool)
+
+	var wg sync.WaitGroup
+	wg.Add(2) // check GCP and AWS
+
+	go func() {
+		if IsGCP() {
+			plat <- NewGCP()
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		if IsAWS() {
+			plat <- NewAWS()
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		wg.Wait()
+		done <- true
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case p := <-plat:
+		return p
+	case <-done:
+		return &Unknown{}
+	case <-timer.C:
+		return &Unknown{}
+	}
+}


### PR DESCRIPTION
This PR attempts to update the platform-detection logic in the bootstrap in a way that should avoid serialized long waits on platforms other than GCP and AWS.

The AWS platform detection logic that was added had the unintended side effect of causing a `20s` delay in sidecar start for non-AWS and non-GCP platforms (local with [kind](https://github.com/kubernetes-sigs/kind), for instance).

This PR does a number of things towards that end:
- parallelizes the platform discovery with goroutines
- allows for a hard upper-limit to be spent on platform discovery (`5s`, but configurable)
- adds some quick fail logic to AWS platform discovery, based on a rubric from AWS docs and otehr implementations.

With this PR, I observed a delay in Envoy startup of ~`5ms` (or less) in local testing and on a GKE cluster, with the correct platform behavior observed in both environments. I, unfortunately, don't have a good way to verify in AWS.

Example proxy logs:

```
2020-01-07T18:51:36.488124Z	info	Epoch 0 starting
...
2020-01-07T18:51:36.494013Z	info	Envoy command:
```

Fixes https://github.com/istio/istio/issues/19868

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
