### PR TITLE
Fix bug(#18283) add fault injection integration test for istio.io

### DIFF
--- a/tests/integration/istioio/trafficmanagement/faultinjection/fault_injection_test.go
+++ b/tests/integration/istioio/trafficmanagement/faultinjection/fault_injection_test.go
@@ -1,0 +1,96 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package faultinjection
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/istioio"
+)
+
+//https://istio.io/docs/tasks/traffic-management/fault-injection/
+//https://github.com/istio/istio.io/blob/release-1.2/content/docs/tasks/traffic-management/fault-injection/index.md
+func TestFaultInjection(t *testing.T) {
+
+	framework.
+		NewTest(t).
+		Run(istioio.NewBuilder("tasks__trafic__management_fault_injection").
+			Add(istioio.Script{
+				WorkDir: env.IstioSrc,
+				Input: istioio.Inline{
+					FileName: "create_request_routing_virtual_services.sh",
+					Value: `
+set -e
+set -u
+set -o pipefail
+# $snippet create_request_routing_virtual_services.sh syntax="bash"
+$ kubectl apply -f samples/bookinfo/networking/virtual-service-all-v1.yaml
+$ kubectl apply -f samples/bookinfo/networking/virtual-service-reviews-test-v2.yaml
+# $endsnippet`,
+				},
+			}).
+            //crete Vs for rating test delay
+			Add(istioio.Script{
+				WorkDir: env.IstioSrc,
+				Input: istioio.Inline{
+					FileName: "create_virtual_service_delay_test.sh",
+					Value: `
+set -e
+set -u
+set -o pipefail
+# $snippet create_virtual_service_delay_test.sh syntax="bash"
+$ kubectl apply -f @samples/bookinfo/networking/virtual-service-ratings-test-delay.yaml@
+# $endsnippet`,
+				},
+			}).
+			// check if VS delay was created`.
+			Add(istioio.Script{
+				Input:   istioio.Path("scripts/virtual_service_delay_creation.txt"),
+				WorkDir: env.IstioSrc,
+			}).
+            //crete Vs for rating test abort
+			Add(istioio.Script{
+				WorkDir: env.IstioSrc,
+				Input: istioio.Inline{
+					FileName: "create_virtual_service_rating_test.sh",
+					Value: `
+set -e
+set -u
+set -o pipefail
+# $snippet create_virtual_service_rating_test.sh syntax="bash"
+$ kubectl apply -f @samples/bookinfo/networking/virtual-service-ratings-test-abort.yaml@
+# $endsnippet`,
+				},
+			}).
+
+			// check if VS abort was created`.
+			Add(istioio.Script{
+				Input:   istioio.Path("scripts/virtual_service_abort_creation.txt"),
+				WorkDir: env.IstioSrc,
+			}).
+			// Cleanup.
+			Defer(istioio.Script{
+				Input: istioio.Inline{
+					FileName: "cleanup.sh",
+					Value: `
+# $snippet cleanup.sh syntax="bash" outputis="text"
+$ kubectl delete VirtualService ratings
+# $endsnippet`,
+				},
+			}).
+			Build())
+}

--- a/tests/integration/istioio/trafficmanagement/faultinjection/main_test.go
+++ b/tests/integration/istioio/trafficmanagement/faultinjection/main_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package faultinjection
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
+)
+
+var (
+	ist istio.Instance
+)
+
+func TestMain(m *testing.M) {
+	framework.NewSuite("faultinjection", m).
+		Label(label.CustomSetup).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
+		RequireEnvironment(environment.Kube).
+		Run()
+}
+
+//grafana is disabled in the default test framework config. Enable it.
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+
+	cfg.Values["grafana.enabled"] = "true"
+}

--- a/tests/integration/istioio/trafficmanagement/faultinjection/scripts/virtual_service_abort_creation.txt
+++ b/tests/integration/istioio/trafficmanagement/faultinjection/scripts/virtual_service_abort_creation.txt
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+
+# $snippet get_abort_ratings_virtual_service_yaml syntax="bash" outputis="text"
+#nolint
+$ kubectl get virtualservice ratings -o yaml
+# $verify verifier="contains"
+spec:
+  hosts:
+  - ratings
+  http:
+  - fault:
+      abort:
+        httpStatus: 500
+        percentage:
+          value: 100
+    match:
+    - headers:
+        end-user:
+          exact: jason
+    route:
+    - destination:
+        host: ratings
+        subset: v1
+  - route:
+    - destination:
+        host: ratings
+        subset: v1
+# $snippetoutput
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings
+  ...
+spec:
+  hosts:
+  - ratings
+  http:
+  - fault:
+      abort:
+        httpStatus: 500
+        percentage:
+          value: 100
+    match:
+    - headers:
+        end-user:
+          exact: jason
+    route:
+    - destination:
+        host: ratings
+        subset: v1
+  - route:
+    - destination:
+        host: ratings
+        subset: v1
+# $endsnippet
+
+# Restore error handling
+set -e
+set -o pipefail
+
+
+

--- a/tests/integration/istioio/trafficmanagement/faultinjection/scripts/virtual_service_delay_creation.txt
+++ b/tests/integration/istioio/trafficmanagement/faultinjection/scripts/virtual_service_delay_creation.txt
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+
+# $snippet get_delay_ratings_virtual_service_yaml syntax="bash" outputis="text"
+#nolint
+$ kubectl get virtualservice ratings -o yaml
+# $verify verifier="contains"
+spec:
+  hosts:
+  - ratings
+  http:
+  - fault:
+      delay:
+        fixedDelay: 7s
+        percentage:
+          value: 100
+    match:
+    - headers:
+        end-user:
+          exact: jason
+    route:
+    - destination:
+        host: ratings
+        subset: v1
+  - route:
+    - destination:
+        host: ratings
+        subset: v1
+# $snippetoutput
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings
+  ...
+spec:
+  hosts:
+  - ratings
+  http:
+  - fault:
+      delay:
+        fixedDelay: 7s
+        percentage:
+          value: 100
+    match:
+    - headers:
+        end-user:
+          exact: jason
+    route:
+    - destination:
+        host: ratings
+        subset: v1
+  - route:
+    - destination:
+        host: ratings
+        subset: v1
+# $endsnippet
+
+# Restore error handling
+set -e
+set -o pipefail
+
+
+


### PR DESCRIPTION


[ ] Configuration Infrastructure
[x ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ x] User Experience
[ ] Developer Infrastructure

this is a integration test for fault injection task in istio.io [here](https://preliminary.istio.io/docs/tasks/traffic-management/fault-injection/)