### PR TITLE
Update CRD names for operator test

### DIFF
--- a/istioctl/pkg/multicluster/generate.go
+++ b/istioctl/pkg/multicluster/generate.go
@@ -51,7 +51,7 @@ func defaultControlPlane() (*operatorV1alpha2.IstioControlPlane, error) {
 	}
 
 	return &operatorV1alpha2.IstioControlPlane{
-		Kind:       "IstioControlPlane",
+		Kind:       "IstioOperator",
 		ApiVersion: "install.istio.io/v1alpha2",
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
@@ -102,7 +102,7 @@ func overlayIstioControlPlane(mesh *Mesh, current *Cluster, meshNetworks *v1alph
 	}
 
 	return &operatorV1alpha2.IstioControlPlane{
-		Kind:       "IstioControlPlane",
+		Kind:       "IstioOperator",
 		ApiVersion: "install.istio.io/v1alpha2",
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -170,7 +170,7 @@ func (c *Config) IsMtlsEnabled() bool {
 	return true
 }
 
-func (c *Config) IstioControlPlane() string {
+func (c *Config) IstioOperator() string {
 	data := c.ControlPlaneValues
 	if data == "" && c.ValuesFile != "" {
 		var err error
@@ -185,8 +185,8 @@ func (c *Config) IstioControlPlane() string {
 	}
 
 	return fmt.Sprintf(`
-apiVersion: install.istio.io/v1alpha2
-kind: IstioControlPlane
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
 spec:
   hub: %s
   tag: %s

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -133,9 +133,9 @@ func deployOperator(ctx resource.Context, env *kube.Environment, cfg Config) (In
 		return nil, err
 	}
 
-	icpFile := filepath.Join(workDir, "icp.yaml")
-	if err := ioutil.WriteFile(icpFile, []byte(cfg.IstioControlPlane()), os.ModePerm); err != nil {
-		return nil, fmt.Errorf("failed to write icp: %v", err)
+	iopFile := filepath.Join(workDir, "iop.yaml")
+	if err := ioutil.WriteFile(iopFile, []byte(cfg.IstioOperator()), os.ModePerm); err != nil {
+		return nil, fmt.Errorf("failed to write iop: %v", err)
 	}
 	s, err := image.SettingsFromCommandLine()
 	if err != nil {
@@ -145,7 +145,7 @@ func deployOperator(ctx resource.Context, env *kube.Environment, cfg Config) (In
 		"manifest", "apply",
 		"--skip-confirmation",
 		"--logtostderr",
-		"-f", icpFile,
+		"-f", iopFile,
 		"--force", // Blocked by https://github.com/istio/istio/issues/19009
 		"--set", "values.global.controlPlaneSecurityEnabled=false",
 		"--set", "values.global.imagePullPolicy=" + s.PullPolicy,

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -575,7 +575,7 @@ func (k *KubeInfo) Teardown() error {
 				log.Errorf("Failed to save operator logs: %v", err)
 			}
 			// Need an operator unique delete procedure
-			if _, err := util.Shell("kubectl -n istio-operator delete IstioControlPlane example-istiocontrolplane"); err != nil {
+			if _, err := util.Shell("kubectl -n istio-operator delete IstioOperator example-istiocontrolplane"); err != nil {
 				log.Errorf("Failed to delete the Istio CR.")
 				return err
 			}
@@ -1038,7 +1038,7 @@ EOF`, k.KubeConfig, dummyValidationRule)
 
 func (k *KubeInfo) waitForIstioOperator() error {
 
-	get := fmt.Sprintf(`kubectl --kubeconfig=%s get icp example-istiocontrolplane -n istio-operator -o yaml`, k.KubeConfig)
+	get := fmt.Sprintf(`kubectl --kubeconfig=%s get iop example-istiocontrolplane -n istio-operator -o yaml`, k.KubeConfig)
 	timeout := time.Now().Add(istioOperatorTimeout)
 	for {
 		if time.Now().After(timeout) {
@@ -1234,7 +1234,7 @@ func replacePattern(content []byte, src, dest string) []byte {
 
 // This code is in need of a reimplementation and some rethinking. An in-place
 // modification on the raw manifest is the wrong approach. This model is also
-// not portable to our future around IstioControlPlane where we don't necessarily
+// not portable to our future around IstioOperator where we don't necessarily
 // have a manifest to in place modify...
 func (k *KubeInfo) generateIstio(src, dst string) error {
 	content, err := ioutil.ReadFile(src)


### PR DESCRIPTION
Due to API changes, v1alpha2/IstioControlPlane is now v1alpha1/IstioOperator.