### PR TITLE
add standalone webhook validation controller and server packages (1 of 3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -161,6 +161,7 @@ require (
 	k8s.io/cli-runtime v0.17.0
 	k8s.io/client-go v0.17.0
 	k8s.io/helm v2.14.3+incompatible
+	k8s.io/kubectl v0.17.0
 	sigs.k8s.io/yaml v1.1.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -161,7 +161,6 @@ require (
 	k8s.io/cli-runtime v0.17.0
 	k8s.io/client-go v0.17.0
 	k8s.io/helm v2.14.3+incompatible
-	k8s.io/kubectl v0.17.0
 	sigs.k8s.io/yaml v1.1.0
 )
 

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -368,7 +368,6 @@ func (c *Controller) reconcileRequest(req *reconcileRequest) error {
 	}
 
 	return c.updateValidatingWebhookConfiguration(desired)
-
 }
 
 func (c *Controller) isEndpointReady() (ready bool, err error) {

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -1,0 +1,532 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package controller implements a k8s controller for managing the lifecycle of a validating webhook.
+package controller
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	kubeApiAdmission "k8s.io/api/admissionregistration/v1beta1"
+	kubeApiApp "k8s.io/api/apps/v1"
+	kubeApiCore "k8s.io/api/core/v1"
+	kubeApiRbac "k8s.io/api/rbac/v1"
+	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/kubectl/pkg/scheme"
+
+	"istio.io/pkg/filewatcher"
+	"istio.io/pkg/log"
+
+	"istio.io/istio/pkg/config/labels"
+)
+
+var scope = log.RegisterScope("webhook controller", "webhook controller", 0)
+
+type Options struct {
+	Client kubernetes.Interface
+
+	// Istio system namespace in which galley and istiod reside.
+	WatchedNamespace string
+
+	// Periodically resync with the kube-apiserver. Set to zero to disable.
+	ResyncPeriod time.Duration
+
+	// File path to the x509 certificate bundle used by the webhook server
+	// and patched into the webhook config.
+	CAPath string
+
+	// Name of the k8s validatingwebhookconfiguration resource. This should
+	// match the name in the config template.
+	WebhookConfigName string
+
+	// File path to the validatingwebhookconfiguration template
+	WebhookConfigPath string
+
+	// Name of the service running the webhook server.
+	ServiceName string
+
+	// name of the galley deployment in the watched namespace.
+	// When non-empty the controller will defer reconciling config
+	// until the named deployment no longer exists.
+	GalleyDeploymentName string
+
+	// Name of the ClusterRole that the controller should assign
+	// cluster-scoped ownership to. The webhook config will be GC'c
+	// when this ClusterRole is deleted.
+	ClusterRoleName string
+
+	// Enable galley validation controller.
+	Enabled bool
+
+	// If true, the controller will run but actively try to remove the
+	// validatingwebhookconfiguration instead of creating it. This is
+	// useful in cases where validation was previously enabled and
+	// subsequently disabled. The controller can clean up after itself
+	// without relying on the user to manually delete configs.
+	UnregisterValidationWebhook bool
+}
+
+// Validate the options that exposed to end users
+func (o Options) Validate() error {
+	var errs *multierror.Error
+	if o.WebhookConfigName == "" || !labels.IsDNS1123Label(o.WebhookConfigName) {
+		errs = multierror.Append(errs, fmt.Errorf("invalid webhook name: %q", o.WebhookConfigName)) // nolint: lll
+	}
+	if o.WatchedNamespace == "" || !labels.IsDNS1123Label(o.WatchedNamespace) {
+		errs = multierror.Append(errs, fmt.Errorf("invalid namespace: %q", o.WatchedNamespace)) // nolint: lll
+	}
+	if o.GalleyDeploymentName != "" && !labels.IsDNS1123Label(o.GalleyDeploymentName) {
+		errs = multierror.Append(errs, fmt.Errorf("invalid deployment name: %q", o.GalleyDeploymentName))
+	}
+	if o.ServiceName == "" || !labels.IsDNS1123Label(o.ServiceName) {
+		errs = multierror.Append(errs, fmt.Errorf("invalid service name: %q", o.ServiceName))
+	}
+	if len(o.CAPath) == 0 {
+		errs = multierror.Append(errs, errors.New("CA cert file not specified"))
+	}
+	if len(o.WebhookConfigPath) == 0 {
+		errs = multierror.Append(errs, errors.New("webhook config file not specified"))
+	}
+	return errs
+}
+
+type readFileFunc func(filename string) ([]byte, error)
+
+type Controller struct {
+	o                 Options
+	ownerRefs         []kubeApiMeta.OwnerReference
+	queue             workqueue.RateLimitingInterface
+	sharedInformers   informers.SharedInformerFactory
+	endpointReadyOnce bool
+
+	// unittest hooks
+	caFileWatcher filewatcher.FileWatcher
+	readFile      readFileFunc
+	reconcileDone func()
+}
+
+type reconcileRequest struct {
+	description string
+}
+
+func (rr reconcileRequest) String() string {
+	return rr.description
+}
+
+func filterWatchedObject(in interface{}, name string) (skip bool, key string) {
+	obj, err := meta.Accessor(in)
+	if err != nil {
+		return true, ""
+	}
+	if obj.GetName() != name {
+		return true, ""
+	}
+	key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(in)
+	if err != nil {
+		return true, ""
+	}
+	return false, key
+}
+
+func makeHandler(queue workqueue.Interface, gvk schema.GroupVersionKind, name string) *cache.ResourceEventHandlerFuncs {
+	return &cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			skip, key := filterWatchedObject(obj, name)
+			scope.Debugf("HandlerAdd: key=%v skip=%v", key, skip)
+			if skip {
+				return
+			}
+			req := &reconcileRequest{fmt.Sprintf("adding (%v, Kind=%v) %v", gvk.GroupVersion(), gvk.Kind, key)}
+			queue.Add(req)
+		},
+		UpdateFunc: func(prev, curr interface{}) {
+			skip, key := filterWatchedObject(curr, name)
+			scope.Debugf("HandlerUpdate: key=%v skip=%v", key, skip)
+			if skip {
+				return
+			}
+			if !reflect.DeepEqual(prev, curr) {
+				req := &reconcileRequest{fmt.Sprintf("update (%v, Kind=%v) %v", gvk.GroupVersion(), gvk.Kind, key)}
+				queue.Add(req)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			if _, ok := obj.(kubeApiMeta.Object); !ok {
+				// If the object doesn't have Metadata, assume it is a tombstone object
+				// of type DeletedFinalStateUnknown
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					return
+				}
+				obj = tombstone.Obj
+			}
+			skip, key := filterWatchedObject(obj, name)
+			scope.Debugf("HandlerDelete: key=%v skip=%v", key, skip)
+			if skip {
+				return
+			}
+			req := &reconcileRequest{fmt.Sprintf("delete (%v, Kind=%v) %v", gvk.GroupVersion(), gvk.Kind, key)}
+			queue.Add(req)
+		},
+	}
+}
+
+// precompute GVK for known types.
+var (
+	configGVK     = kubeApiAdmission.SchemeGroupVersion.WithKind(reflect.TypeOf(kubeApiAdmission.ValidatingWebhookConfiguration{}).Name())
+	endpointGVK   = kubeApiCore.SchemeGroupVersion.WithKind(reflect.TypeOf(kubeApiCore.Endpoints{}).Name())
+	deploymentGVK = kubeApiApp.SchemeGroupVersion.WithKind(reflect.TypeOf(kubeApiApp.Deployment{}).Name())
+)
+
+func findClusterRoleOwnerRefs(client kubernetes.Interface, clusterRoleName string) []kubeApiMeta.OwnerReference {
+	clusterRole, err := client.RbacV1().ClusterRoles().Get(clusterRoleName, kubeApiMeta.GetOptions{})
+	if err != nil {
+		scope.Warnf("Could not find clusterrole: %s to set ownerRef. "+
+			"The webhook configuration must be deleted manually.",
+			clusterRoleName)
+		return nil
+	}
+
+	return []kubeApiMeta.OwnerReference{
+		*kubeApiMeta.NewControllerRef(
+			clusterRole,
+			kubeApiRbac.SchemeGroupVersion.WithKind("ClusterRole"),
+		),
+	}
+}
+
+func New(o Options) (*Controller, error) {
+	return newController(o, filewatcher.NewWatcher, ioutil.ReadFile, nil)
+}
+
+func newController(
+	o Options,
+	newFileWatcher filewatcher.NewFileWatcherFunc,
+	readFile readFileFunc,
+	reconcileDone func(),
+) (*Controller, error) {
+	caFileWatcher := newFileWatcher()
+	if err := caFileWatcher.Add(o.WebhookConfigPath); err != nil {
+		return nil, err
+	}
+	if err := caFileWatcher.Add(o.CAPath); err != nil {
+		return nil, err
+	}
+
+	c := &Controller{
+		o:             o,
+		queue:         workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter()),
+		caFileWatcher: caFileWatcher,
+		readFile:      readFile,
+		reconcileDone: reconcileDone,
+		ownerRefs:     findClusterRoleOwnerRefs(o.Client, o.ClusterRoleName),
+	}
+
+	c.sharedInformers = informers.NewSharedInformerFactoryWithOptions(o.Client, o.ResyncPeriod,
+		informers.WithNamespace(o.WatchedNamespace))
+
+	webhookInformer := c.sharedInformers.Admissionregistration().V1beta1().ValidatingWebhookConfigurations().Informer()
+	webhookInformer.AddEventHandler(makeHandler(c.queue, configGVK, o.WebhookConfigName))
+
+	endpointInformer := c.sharedInformers.Core().V1().Endpoints().Informer()
+	endpointInformer.AddEventHandler(makeHandler(c.queue, endpointGVK, o.ServiceName))
+
+	deploymentInformer := c.sharedInformers.Apps().V1().Deployments().Informer()
+	deploymentInformer.AddEventHandler(makeHandler(c.queue, deploymentGVK, o.GalleyDeploymentName))
+
+	return c, nil
+}
+
+func (c *Controller) Start(stop <-chan struct{}) {
+	go c.startFileWatcher(stop)
+	go c.sharedInformers.Start(stop)
+
+	for _, ready := range c.sharedInformers.WaitForCacheSync(stop) {
+		if !ready {
+			return
+		}
+	}
+
+	req := &reconcileRequest{"initial request to kickstart reconcilation"}
+	c.queue.Add(req)
+
+	go c.runWorker()
+}
+
+func (c *Controller) startFileWatcher(stop <-chan struct{}) {
+	for {
+		select {
+		case ev := <-c.caFileWatcher.Events(c.o.WebhookConfigPath):
+			req := &reconcileRequest{fmt.Sprintf("Webhook configuration changed: %v", ev)}
+			c.queue.Add(req)
+		case ev := <-c.caFileWatcher.Events(c.o.CAPath):
+			req := &reconcileRequest{fmt.Sprintf("CA file changed: %v", ev)}
+			c.queue.Add(req)
+		case err := <-c.caFileWatcher.Errors(c.o.WebhookConfigPath):
+			scope.Warnf("error watching local webhook configuration: %v", err)
+		case err := <-c.caFileWatcher.Errors(c.o.CAPath):
+			scope.Warnf("error watching local CA bundle: %v", err)
+		case <-stop:
+			return
+		}
+	}
+}
+
+func (c *Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Controller) processNextWorkItem() (cont bool) {
+	obj, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(obj)
+
+	req, ok := obj.(*reconcileRequest)
+	if !ok {
+		// don't retry an invalid reconcileRequest item
+		c.queue.Forget(req)
+		return true
+	}
+
+	if err := c.reconcileRequest(req); err != nil {
+		c.queue.AddRateLimited(obj)
+		utilruntime.HandleError(err)
+	} else {
+		c.queue.Forget(obj)
+	}
+	return true
+}
+
+// reconcileRequest the desired state with the kube-apiserver.
+func (c *Controller) reconcileRequest(req *reconcileRequest) error {
+	defer func() {
+		if c.reconcileDone != nil {
+			c.reconcileDone()
+		}
+	}()
+
+	scope.Infof("Reconcile: %v", req)
+
+	// don't create the webhook config before the endpoint is ready
+	if !c.endpointReadyOnce {
+		if ready, err := c.isEndpointReady(); !ready || err != nil {
+			scope.Infof("Endpoint not ready: ready=%v err=%v", ready, err)
+			return err
+		}
+		c.endpointReadyOnce = true
+	}
+
+	// don't update the webhook config if its already managed by an existing galley deployment.
+	if c.o.GalleyDeploymentName != "" {
+		if running, err := c.isGalleyDeploymentRunning(); running || err != nil {
+			scope.Infof("Galley deployment detected: running=%v err=%v", running, err)
+			return err
+		}
+	}
+
+	// actively remove the webhook configuration if the controller is running but the webhook
+	if c.o.UnregisterValidationWebhook {
+		return c.deleteValidatingWebhookConfiguration()
+	}
+
+	desired, err := c.buildValidatingWebhookConfiguration()
+	if err != nil {
+		scope.Errorf("Failed to build validatingwebhookconfiguration: %v", err)
+		reportValidationConfigLoadError(err.(*configError).Reason())
+		// no point in retrying unless a local config or cert file changes.
+		return nil
+	}
+
+	return c.updateValidatingWebhookConfiguration(desired)
+
+}
+
+func (c *Controller) isEndpointReady() (ready bool, err error) {
+	endpoint, err := c.sharedInformers.Core().V1().
+		Endpoints().Lister().Endpoints(c.o.WatchedNamespace).Get(c.o.ServiceName)
+	if err != nil {
+		if kubeErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	ready, _ = isEndpointReady(endpoint)
+	return ready, nil
+}
+
+func isEndpointReady(endpoint *kubeApiCore.Endpoints) (ready bool, reason string) {
+	if len(endpoint.Subsets) == 0 {
+		return false, "no subsets"
+	}
+	for _, subset := range endpoint.Subsets {
+		if len(subset.Addresses) > 0 {
+			return true, ""
+		}
+	}
+	return false, "no subset addresses ready"
+}
+
+func (c *Controller) isGalleyDeploymentRunning() (running bool, err error) {
+	galley, err := c.sharedInformers.Apps().V1().
+		Deployments().Lister().Deployments(c.o.WatchedNamespace).Get(c.o.GalleyDeploymentName)
+
+	// galley does/doesn't exist
+	if err != nil {
+		if kubeErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	// galley is scaled down to zero replicas. This is useful for debugging
+	// to force the istiod controller to run.
+	if galley.Spec.Replicas == nil || *galley.Spec.Replicas == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (c *Controller) deleteValidatingWebhookConfiguration() error {
+	err := c.o.Client.AdmissionregistrationV1beta1().
+		ValidatingWebhookConfigurations().Delete(c.o.WebhookConfigName, &kubeApiMeta.DeleteOptions{})
+	if err != nil {
+		scope.Errorf("Failed to delete validatingwebhookconfiguration: %v", err)
+		reportValidationConfigDeleteError(kubeErrors.ReasonForError(err))
+		return err
+	}
+	scope.Info("Successfully deleted validatingwebhookconfiguration")
+	return nil
+}
+
+func (c *Controller) updateValidatingWebhookConfiguration(desired *kubeApiAdmission.ValidatingWebhookConfiguration) error {
+	current, err := c.sharedInformers.Admissionregistration().V1beta1().
+		ValidatingWebhookConfigurations().Lister().Get(c.o.WebhookConfigName)
+
+	if kubeErrors.IsNotFound(err) {
+		_, err := c.o.Client.AdmissionregistrationV1beta1().
+			ValidatingWebhookConfigurations().Create(desired)
+		if err != nil {
+			scope.Errorf("Failed to create webhook config: %v", err)
+			reportValidationConfigUpdateError(kubeErrors.ReasonForError(err))
+			return err
+		}
+		scope.Info("Successfully created webhook config")
+		reportValidationConfigUpdate()
+		return nil
+	}
+
+	updated := current.DeepCopyObject().(*kubeApiAdmission.ValidatingWebhookConfiguration)
+	updated.Webhooks = desired.Webhooks
+	updated.OwnerReferences = desired.OwnerReferences
+
+	if !reflect.DeepEqual(updated, current) {
+		_, err := c.o.Client.AdmissionregistrationV1beta1().
+			ValidatingWebhookConfigurations().Update(updated)
+		if err != nil {
+			scope.Errorf("Failed to update webhook config: %v", err)
+			reportValidationConfigUpdateError(kubeErrors.ReasonForError(err))
+			return err
+		}
+	}
+	scope.Info("Successfully created webhook config")
+	reportValidationConfigUpdate()
+	return nil
+}
+
+type configError struct {
+	err    error
+	reason string
+}
+
+func (e configError) Error() string {
+	return e.err.Error()
+}
+
+func (e configError) Reason() string {
+	return e.reason
+}
+
+func (c *Controller) buildValidatingWebhookConfiguration() (*kubeApiAdmission.ValidatingWebhookConfiguration, error) {
+	webhook, err := c.readFile(c.o.WebhookConfigPath)
+	if err != nil {
+		return nil, &configError{err, "could not read configuration file"}
+	}
+	caBundle, err := c.readFile(c.o.CAPath)
+	if err != nil {
+		return nil, &configError{err, "could not read caBundle file"}
+	}
+	return buildValidatingWebhookConfiguration(caBundle, webhook, c.ownerRefs)
+}
+
+func buildValidatingWebhookConfiguration(
+	caBundle, webhook []byte,
+	ownerRefs []kubeApiMeta.OwnerReference,
+) (*kubeApiAdmission.ValidatingWebhookConfiguration, error) {
+	config, err := decodeValidatingConfig(webhook)
+	if err != nil {
+		return nil, &configError{err, "could not decode webhook configurationd"}
+	}
+	if err := verifyCABundle(caBundle); err != nil {
+		return nil, &configError{err, "could not verify caBundle"}
+	}
+	// update runtime fields
+	config.OwnerReferences = ownerRefs
+	for i := range config.Webhooks {
+		config.Webhooks[i].ClientConfig.CABundle = caBundle
+	}
+
+	return config, nil
+}
+
+func decodeValidatingConfig(encoded []byte) (*kubeApiAdmission.ValidatingWebhookConfiguration, error) {
+	var config kubeApiAdmission.ValidatingWebhookConfiguration
+	if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), encoded, &config); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func verifyCABundle(caBundle []byte) error {
+	block, _ := pem.Decode(caBundle)
+	if block == nil {
+		return errors.New("could not decode pem")
+	}
+	if block.Type != "CERTIFICATE" {
+		return fmt.Errorf("cert contains wrong pem type: %q", block.Type)
+	}
+	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		return fmt.Errorf("cert contains invalid x509 certificate: %v", err)
+	}
+	return nil
+}

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -274,7 +274,7 @@ func (c *Controller) Start(stop <-chan struct{}) {
 		}
 	}
 
-	req := &reconcileRequest{"initial request to kickstart reconcilation"}
+	req := &reconcileRequest{"initial request to kickstart reconciliation"}
 	c.queue.Add(req)
 
 	go c.runWorker()

--- a/pkg/webhooks/validation/controller/controller_test.go
+++ b/pkg/webhooks/validation/controller/controller_test.go
@@ -274,7 +274,7 @@ func (fc *fakeController) Deployments() kubeTypedApp.DeploymentInterface {
 	return fc.o.Client.AppsV1().Deployments(fc.o.WatchedNamespace)
 }
 
-// ensure that at least one reconcilation attempt has completed after the provided function is invoked.
+// ensure that at least one reconciliation attempt has completed after the provided function is invoked.
 func (fc *fakeController) barrier(t *testing.T, fn func()) {
 	t.Helper()
 	g := NewGomegaWithT(t)

--- a/pkg/webhooks/validation/controller/controller_test.go
+++ b/pkg/webhooks/validation/controller/controller_test.go
@@ -1,0 +1,434 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	. "github.com/onsi/gomega"
+	kubeApiAdmission "k8s.io/api/admissionregistration/v1beta1"
+	kubeApiApp "k8s.io/api/apps/v1"
+	kubeApiCore "k8s.io/api/core/v1"
+	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
+	kubeApisMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	kubeTypedAdmission "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
+	kubeTypedApp "k8s.io/client-go/kubernetes/typed/apps/v1"
+	kubeTypedCore "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/kubectl/pkg/scheme"
+
+	"istio.io/istio/pkg/mcp/testing/testcerts"
+	"istio.io/pkg/filewatcher"
+)
+
+const (
+	eventuallyTimeout   = 10 * time.Second
+	consistentlyTimeout = time.Second
+)
+
+var (
+	istiodEndpoint = &kubeApiCore.Endpoints{
+		ObjectMeta: kubeApisMeta.ObjectMeta{
+			Name:      istiod,
+			Namespace: namespace,
+		},
+		Subsets: []kubeApiCore.EndpointSubset{{
+			Addresses: []kubeApiCore.EndpointAddress{{
+				IP: "192.168.1.1",
+			}},
+		}},
+	}
+
+	galleyDeployment = &kubeApiApp.Deployment{
+		ObjectMeta: kubeApisMeta.ObjectMeta{
+			Name:      galley,
+			Namespace: namespace,
+		},
+		Spec: kubeApiApp.DeploymentSpec{
+			Replicas: &[]int32{1}[0],
+		},
+	}
+
+	unpatchedIstiodWebhookConfig = &kubeApiAdmission.ValidatingWebhookConfiguration{
+		TypeMeta: kubeApisMeta.TypeMeta{
+			APIVersion: kubeApiAdmission.SchemeGroupVersion.String(),
+			Kind:       "ValidatingWebhookConfiguration",
+		},
+		ObjectMeta: kubeApisMeta.ObjectMeta{
+			Name: galleyWebhookName,
+		},
+		Webhooks: []kubeApiAdmission.ValidatingWebhook{{
+			Name: "hook0",
+			ClientConfig: kubeApiAdmission.WebhookClientConfig{Service: &kubeApiAdmission.ServiceReference{
+				Namespace: namespace,
+				Name:      istiod,
+				Path:      &[]string{"/hook0"}[0],
+			}},
+			Rules: []kubeApiAdmission.RuleWithOperations{{
+				Operations: []kubeApiAdmission.OperationType{kubeApiAdmission.Create, kubeApiAdmission.Update},
+				Rule: kubeApiAdmission.Rule{
+					APIGroups:   []string{"group0"},
+					APIVersions: []string{"*"},
+					Resources:   []string{"*"},
+				},
+			}},
+		}, {
+			Name: "hook1",
+			ClientConfig: kubeApiAdmission.WebhookClientConfig{Service: &kubeApiAdmission.ServiceReference{
+				Namespace: namespace,
+				Name:      istiod,
+				Path:      &[]string{"/hook1"}[0],
+			}},
+			Rules: []kubeApiAdmission.RuleWithOperations{{
+				Operations: []kubeApiAdmission.OperationType{kubeApiAdmission.Create, kubeApiAdmission.Update},
+				Rule: kubeApiAdmission.Rule{
+					APIGroups:   []string{"group1"},
+					APIVersions: []string{"*"},
+					Resources:   []string{"*"},
+				},
+			}},
+		}},
+	}
+	codec                            = scheme.Codecs.LegacyCodec(kubeApiAdmission.SchemeGroupVersion)
+	istiodWebhookConfigEncoded       = runtime.EncodeOrDie(codec, unpatchedIstiodWebhookConfig)
+	webhookConfigWithCABundle0       *kubeApiAdmission.ValidatingWebhookConfiguration
+	galleyWebhookConfigWithCABundle1 *kubeApiAdmission.ValidatingWebhookConfiguration
+
+	caBundle0 = []byte(`-----BEGIN CERTIFICATE-----
+MIIC9DCCAdygAwIBAgIJAIFe3lWPaalKMA0GCSqGSIb3DQEBCwUAMA4xDDAKBgNV
+BAMMA19jYTAgFw0xNzEyMjIxODA0MjRaGA8yMjkxMTAwNzE4MDQyNFowDjEMMAoG
+A1UEAwwDX2NhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuBdxj+Hi
+8h0TkId1f64TprLydwgzzLwXAs3wpmXz+BfnW1oMQPNyN7vojW6VzqJGGYLsc1OB
+MgwObU/VeFNc6YUCmu6mfFJwoPfXMPnhmGuSwf/kjXomlejAYjxClU3UFVWQht54
+xNLjTi2M1ZOnwNbECOhXC3Tw3G8mCtfanMAO0UXM5yObbPa8yauUpJKkpoxWA7Ed
+qiuUD9qRxluFPqqw/z86V8ikmvnyjQE9960j+8StlAbRs82ArtnrhRgkDO0Smtf7
+4QZsb/hA1KNMm73bOGS6+SVU+eH8FgVOzcTQYFRpRT3Mhi6dKZe9twIO8mpZK4wk
+uygRxBM32Ag9QQIDAQABo1MwUTAdBgNVHQ4EFgQUc8tvoNNBHyIkoVV8XCXy63Ya
+BEQwHwYDVR0jBBgwFoAUc8tvoNNBHyIkoVV8XCXy63YaBEQwDwYDVR0TAQH/BAUw
+AwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAVmaUkkYESfcfgnuPeZ4sTNs2nk2Y+Xpd
+lxkMJhChb8YQtlCe4uiLvVe7er1sXcBLNCm/+2K9AT71gnxBSeS5mEOzWmCPErhy
+RmYtSxeRyXAaUWVYLs/zMlBQ0Iz4dpY+FVVbMjIurelVwHF0NBk3VtU5U3lHyKdZ
+j4C2rMjvTxmkyIcR1uBEeVvuGU8R70nZ1yfo3vDwmNGMcLwW+4QK+WcfwfjLXhLs
+5550arfEYdTzYFMxY60HJT/LvbGrjxY0PQUWWDbPiRfsdRjOFduAbM0/EVRda/Oo
+Fg72WnHeojDUhqEz4UyFZbnRJ4x6leQhnrIcVjWX4FFFktiO9rqqfw==
+-----END CERTIFICATE-----`)
+
+	caBundle1 = []byte(`-----BEGIN CERTIFICATE-----
+MIIDCzCCAfOgAwIBAgIQbfOzhcKTldFipQ1X2WXpHDANBgkqhkiG9w0BAQsFADAv
+MS0wKwYDVQQDEyRhNzU5YzcyZC1lNjcyLTQwMzYtYWMzYy1kYzAxMDBmMTVkNWUw
+HhcNMTkwNTE2MjIxMTI2WhcNMjQwNTE0MjMxMTI2WjAvMS0wKwYDVQQDEyRhNzU5
+YzcyZC1lNjcyLTQwMzYtYWMzYy1kYzAxMDBmMTVkNWUwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQC6sSAN80Ci0DYFpNDumGYoejMQai42g6nSKYS+ekvs
+E7uT+eepO74wj8o6nFMNDu58+XgIsvPbWnn+3WtUjJfyiQXxmmTg8om4uY1C7R1H
+gMsrL26pUaXZ/lTE8ZV5CnQJ9XilagY4iZKeptuZkxrWgkFBD7tr652EA3hmj+3h
+4sTCQ+pBJKG8BJZDNRrCoiABYBMcFLJsaKuGZkJ6KtxhQEO9QxJVaDoSvlCRGa8R
+fcVyYQyXOZ+0VHZJQgaLtqGpiQmlFttpCwDiLfMkk3UAd79ovkhN1MCq+O5N7YVt
+eVQWaTUqUV2tKUFvVq21Zdl4dRaq+CF5U8uOqLY/4Kg9AgMBAAGjIzAhMA4GA1Ud
+DwEB/wQEAwICBDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCg
+oF71Ey2b1QY22C6BXcANF1+wPzxJovFeKYAnUqwh3rF7pIYCS/adZXOKlgDBsbcS
+MxAGnCRi1s+A7hMYj3sQAbBXttc31557lRoJrx58IeN5DyshT53t7q4VwCzuCXFT
+3zRHVRHQnO6LHgZx1FuKfwtkhfSXDyYU2fQYw2Hcb9krYU/alViVZdE0rENXCClq
+xO7AQk5MJcGg6cfE5wWAKU1ATjpK4CN+RTn8v8ODLoI2SW3pfsnXxm93O+pp9HN4
++O+1PQtNUWhCfh+g6BN2mYo2OEZ8qGSxDlMZej4YOdVkW8PHmFZTK0w9iJKqM5o1
+V6g5gZlqSoRhICK09tpc
+-----END CERTIFICATE-----`)
+
+	configNotFoundErr = kubeErrors.NewNotFound(kubeApiAdmission.Resource("validatingwebhookconfigurations"), galleyWebhookName)
+)
+
+// patch the caBundle into the final istiod and galley configs.
+func init() {
+	webhookConfigWithCABundle0 = unpatchedIstiodWebhookConfig.DeepCopyObject().(*kubeApiAdmission.ValidatingWebhookConfiguration)
+	webhookConfigWithCABundle0.Webhooks[0].ClientConfig.CABundle = caBundle0
+	webhookConfigWithCABundle0.Webhooks[1].ClientConfig.CABundle = caBundle0
+
+	galleyWebhookConfigWithCABundle1 = webhookConfigWithCABundle0.DeepCopyObject().(*kubeApiAdmission.ValidatingWebhookConfiguration)
+	galleyWebhookConfigWithCABundle1.Webhooks[0].ClientConfig.Service.Name = galley
+	galleyWebhookConfigWithCABundle1.Webhooks[1].ClientConfig.Service.Name = galley
+	galleyWebhookConfigWithCABundle1.Webhooks[0].ClientConfig.CABundle = caBundle1
+	galleyWebhookConfigWithCABundle1.Webhooks[1].ClientConfig.CABundle = caBundle1
+}
+
+type fakeController struct {
+	*Controller
+
+	caChangedCh      chan bool
+	configChangedCh  chan bool
+	injectedCABundle []byte
+	injectedConfig   []byte
+	fakeWatcher      *filewatcher.FakeWatcher
+	fakeClient       *fake.Clientset
+	stop             chan struct{}
+	reconcileCounter int32 // atomic
+}
+
+const (
+	namespace            = "istio-system"
+	galley               = "istio-galley"
+	galleyDeploymentName = "istio-galley"
+	galleyWebhookName    = "istio-galley"
+	istiod               = "istiod"
+	caPath               = "fakeCAPath"
+	configPath           = "fakeConfigPath"
+	istiodClusterRole    = "istiod-istio-system"
+)
+
+func createTestController() *fakeController {
+	fakeClient := fake.NewSimpleClientset()
+	o := Options{
+		WatchedNamespace:     namespace,
+		ResyncPeriod:         time.Minute,
+		CAPath:               caPath,
+		WebhookConfigName:    galleyWebhookName,
+		WebhookConfigPath:    configPath,
+		ServiceName:          istiod,
+		Client:               fakeClient,
+		GalleyDeploymentName: galleyDeploymentName,
+		ClusterRoleName:      istiodClusterRole,
+	}
+
+	caChanged := make(chan bool, 10)
+	configChanged := make(chan bool, 10)
+	changed := func(path string, added bool) {
+		switch path {
+		case o.CAPath:
+			caChanged <- added
+		case o.WebhookConfigPath:
+			configChanged <- added
+		}
+	}
+
+	newFileWatcher, fakeWatcher := filewatcher.NewFakeWatcher(changed)
+
+	fc := &fakeController{
+		caChangedCh:      caChanged,
+		configChangedCh:  configChanged,
+		injectedCABundle: caBundle0,
+		injectedConfig:   []byte(istiodWebhookConfigEncoded),
+		fakeWatcher:      fakeWatcher,
+		fakeClient:       fakeClient,
+		stop:             make(chan struct{}),
+	}
+
+	readFile := func(filename string) ([]byte, error) {
+		switch filename {
+		case o.CAPath:
+			return fc.injectedCABundle, nil
+		case o.WebhookConfigPath:
+			return fc.injectedConfig, nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	reconcileDone := func() {
+		atomic.AddInt32(&fc.reconcileCounter, 1)
+	}
+
+	var err error
+	fc.Controller, err = newController(o, newFileWatcher, readFile, reconcileDone)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create test controller: %v", err))
+	}
+
+	return fc
+}
+
+func (fc *fakeController) reconcileAttempts() int {
+	return int(atomic.LoadInt32(&fc.reconcileCounter))
+}
+
+func (fc *fakeController) ValidatingWebhookConfigurations() kubeTypedAdmission.ValidatingWebhookConfigurationInterface {
+	return fc.o.Client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
+}
+
+func (fc *fakeController) Endpoints() kubeTypedCore.EndpointsInterface {
+	return fc.o.Client.CoreV1().Endpoints(fc.o.WatchedNamespace)
+}
+
+func (fc *fakeController) Deployments() kubeTypedApp.DeploymentInterface {
+	return fc.o.Client.AppsV1().Deployments(fc.o.WatchedNamespace)
+}
+
+// ensure that at least one reconcilation attempt has completed after the provided function is invoked.
+func (fc *fakeController) barrier(t *testing.T, fn func()) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	attempts := atomic.LoadInt32(&fc.reconcileCounter)
+	fn()
+	g.Eventually(fc.reconcileAttempts, eventuallyTimeout).Should(BeNumerically(">", attempts))
+}
+
+// gomega doesn't handle multi-value return functions well. Use helper functions to get
+// the first or second return value from k8s client REST calls.
+func first(ret, _ interface{}) interface{}  { return ret }
+func second(_, ret interface{}) interface{} { return ret }
+
+func TestController_Greenfield(t *testing.T) {
+	g := NewGomegaWithT(t)
+	c := createTestController()
+
+	stop := make(chan struct{})
+	defer func() { close(stop) }()
+	c.Start(stop)
+
+	g.Consistently(func() interface{} {
+		return second(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}, consistentlyTimeout).Should(MatchError(configNotFoundErr), "webhook should not exist before endpoint creation")
+
+	g.Expect(second(c.Endpoints().Create(istiodEndpoint))).Should(Succeed())
+
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}, eventuallyTimeout).Should(Equal(webhookConfigWithCABundle0), "webhook should exist after endpoint is ready")
+}
+
+func TestController_UpgradeDowngrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+	c := createTestController()
+
+	stop := make(chan struct{})
+	defer func() { close(stop) }()
+
+	c.Start(stop)
+
+	g.Expect(second(c.Deployments().Create(galleyDeployment))).Should(Succeed())
+	c.barrier(t, func() {
+		g.Expect(second(c.ValidatingWebhookConfigurations().Create(galleyWebhookConfigWithCABundle1))).Should(Succeed())
+	})
+	// ensure galley exists before creating istiod
+	c.barrier(t, func() {
+		g.Expect(second(c.Endpoints().Create(istiodEndpoint))).Should(Succeed())
+	})
+	g.Consistently(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}, consistentlyTimeout).Should(Equal(galleyWebhookConfigWithCABundle1),
+		"galley webhook should exist when istiod is deployed")
+
+	g.Expect(c.Deployments().Delete(galleyDeploymentName, &kubeApisMeta.DeleteOptions{})).Should(Succeed())
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}, eventuallyTimeout).Should(Equal(webhookConfigWithCABundle0),
+		"istiod webhook should exist when galley is removed")
+
+	g.Expect(second(c.Deployments().Create(galleyDeployment))).Should(Succeed())
+	c.barrier(t, func() {
+		g.Expect(second(c.ValidatingWebhookConfigurations().Update(galleyWebhookConfigWithCABundle1))).Should(Succeed())
+	})
+	g.Consistently(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}, consistentlyTimeout).Should(Equal(galleyWebhookConfigWithCABundle1),
+		"galley webhook should exist when galley is reployed")
+
+	galleyDeploymentWithZeroReplicas := galleyDeployment.DeepCopyObject().(*kubeApiApp.Deployment)
+	galleyDeploymentWithZeroReplicas.Spec.Replicas = &[]int32{0}[0]
+	g.Expect(second(c.Deployments().Update(galleyDeploymentWithZeroReplicas))).Should(Succeed())
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}, eventuallyTimeout).Should(Equal(webhookConfigWithCABundle0),
+		"istio webhook should exist with zero galley replicas")
+
+	g.Expect(c.Deployments().Delete(galleyDeploymentName, &kubeApisMeta.DeleteOptions{})).Should(Succeed())
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}, eventuallyTimeout).Should(Equal(webhookConfigWithCABundle0),
+		"istio webhook should exist when zero-replica galley is removed")
+}
+
+func TestController_CertAndConfigFileChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+	c := createTestController()
+
+	stop := make(chan struct{})
+	defer func() { close(stop) }()
+	c.Start(stop)
+
+	g.Expect(second(c.Endpoints().Create(istiodEndpoint))).Should(Succeed())
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}, eventuallyTimeout).Should(Equal(webhookConfigWithCABundle0), "webhook should exist after endpoint is ready")
+
+	// verify the config updates after injecting a cafile change
+	c.injectedCABundle = caBundle1
+	c.fakeWatcher.InjectEvent(c.o.CAPath, fsnotify.Event{Name: c.o.CAPath, Op: fsnotify.Write})
+	webconfigAfterCAUpdate := webhookConfigWithCABundle0.DeepCopyObject().(*kubeApiAdmission.ValidatingWebhookConfiguration)
+	webconfigAfterCAUpdate.Webhooks[0].ClientConfig.CABundle = caBundle1
+	webconfigAfterCAUpdate.Webhooks[1].ClientConfig.CABundle = caBundle1
+	var last interface{}
+	g.Eventually(func() interface{} {
+		last = first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+		return last
+	}, eventuallyTimeout).ShouldNot(Equal(webconfigAfterCAUpdate), "webhook should update after cert change")
+
+	// verify the config updates after injecting a config file change.
+	webconfigAfterConfigUpdate := webconfigAfterCAUpdate.DeepCopyObject().(*kubeApiAdmission.ValidatingWebhookConfiguration)
+	se := kubeApiAdmission.SideEffectClassUnknown
+	webconfigAfterConfigUpdate.Webhooks[0].SideEffects = &se
+	c.injectedConfig = []byte(runtime.EncodeOrDie(codec, webconfigAfterConfigUpdate))
+	c.fakeWatcher.InjectEvent(c.o.WebhookConfigPath, fsnotify.Event{Name: c.o.WebhookConfigPath, Op: fsnotify.Write})
+
+	g.Eventually(func() interface{} {
+		return first(c.ValidatingWebhookConfigurations().Get(galleyWebhookName, kubeApisMeta.GetOptions{}))
+	}, eventuallyTimeout).Should(Equal(webconfigAfterConfigUpdate), "webhook should update after config change")
+}
+
+func TestLoadCaCertPem(t *testing.T) {
+	cases := []struct {
+		name      string
+		cert      []byte
+		wantError bool
+	}{
+		{
+			name:      "valid pem",
+			cert:      testcerts.CACert,
+			wantError: false,
+		},
+		{
+			name:      "pem decode error",
+			cert:      append([]byte("-----codec"), testcerts.CACert...),
+			wantError: true,
+		},
+		{
+			name:      "pem wrong type",
+			wantError: true,
+		},
+		{
+			name:      "invalid x509",
+			cert:      testcerts.BadCert,
+			wantError: true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%v] %s", i, c.name), func(tt *testing.T) {
+			err := verifyCABundle(c.cert)
+			if err != nil {
+				if !c.wantError {
+					tt.Fatalf("unexpected error: got error %q", err)
+				}
+			} else {
+				if c.wantError {
+					tt.Fatal("expected error")
+				}
+			}
+		})
+	}
+}

--- a/pkg/webhooks/validation/controller/monitoring.go
+++ b/pkg/webhooks/validation/controller/monitoring.go
@@ -29,7 +29,6 @@ const (
 )
 
 var (
-
 	// reasonTag holds the error reason for the context.
 	reasonTag tag.Key
 )

--- a/pkg/webhooks/validation/controller/monitoring.go
+++ b/pkg/webhooks/validation/controller/monitoring.go
@@ -1,0 +1,121 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+
+	kubeMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	reason = "reason"
+)
+
+var (
+
+	// reasonTag holds the error reason for the context.
+	reasonTag tag.Key
+)
+
+var (
+	metricWebhookConfigurationUpdateError = stats.Int64(
+		"galley/validation/config_update_error",
+		"k8s webhook configuration update error",
+		stats.UnitDimensionless)
+	metricWebhookConfigurationUpdates = stats.Int64(
+		"galley/validation_config_updates",
+		"k8s webhook configuration updates",
+		stats.UnitDimensionless)
+	metricWebhookConfigurationDeleteError = stats.Int64(
+		"galley/validation/config_delete_error",
+		"k8s webhook configuration delete error",
+		stats.UnitDimensionless)
+	metricWebhookConfigurationLoadError = stats.Int64(
+		"galley/validation/config_load_error",
+		"k8s webhook configuration (re)load error",
+		stats.UnitDimensionless)
+	metricWebhookConfigurationLoad = stats.Int64(
+		"galley/validation/config_load",
+		"k8s webhook configuration (re)loads",
+		stats.UnitDimensionless)
+)
+
+func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
+	return &view.View{
+		Name:        measure.Name(),
+		Description: measure.Description(),
+		Measure:     measure,
+		TagKeys:     keys,
+		Aggregation: aggregation,
+	}
+}
+
+func init() {
+	var err error
+	if reasonTag, err = tag.NewKey(reason); err != nil {
+		panic(err)
+	}
+
+	var noKeys []tag.Key
+	reasonKey := []tag.Key{reasonTag}
+
+	err = view.Register(
+		newView(metricWebhookConfigurationUpdateError, reasonKey, view.Count()),
+		newView(metricWebhookConfigurationUpdates, noKeys, view.Count()),
+		newView(metricWebhookConfigurationDeleteError, reasonKey, view.Count()),
+		newView(metricWebhookConfigurationLoadError, reasonKey, view.Count()),
+		newView(metricWebhookConfigurationLoad, noKeys, view.Count()),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+func reportValidationConfigUpdateError(reason kubeMeta.StatusReason) {
+	ctx, err := tag.New(context.Background(), tag.Insert(reasonTag, string(reason)))
+	if err != nil {
+		scope.Errorf("Error creating monitoring context for reportValidationConfigUpdateError: %v", err)
+	} else {
+		stats.Record(ctx, metricWebhookConfigurationUpdateError.M(1))
+	}
+}
+
+func reportValidationConfigDeleteError(reason kubeMeta.StatusReason) {
+	ctx, err := tag.New(context.Background(), tag.Insert(reasonTag, string(reason)))
+	if err != nil {
+		scope.Errorf("Error creating monitoring context for reportValidationConfigDeleteError: %v", err)
+	} else {
+		stats.Record(ctx, metricWebhookConfigurationDeleteError.M(1))
+	}
+}
+
+func reportValidationConfigLoadError(reason string) {
+	ctx, err := tag.New(context.Background(), tag.Insert(reasonTag, reason))
+	if err != nil {
+		scope.Errorf("Error creating monitoring context for reportValidationConfigLoadError: %v", err)
+	} else {
+		stats.Record(ctx, metricWebhookConfigurationLoadError.M(1))
+	}
+}
+
+func reportValidationConfigUpdate() {
+	stats.Record(context.Background(), metricWebhookConfigurationUpdates.M(1))
+}

--- a/pkg/webhooks/validation/server/monitoring.go
+++ b/pkg/webhooks/validation/server/monitoring.go
@@ -1,0 +1,183 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"strconv"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+
+	kubeApiAdmission "k8s.io/api/admission/v1beta1"
+)
+
+const (
+	errorStr = "error"
+	group    = "group"
+	version  = "version"
+	resource = "resource"
+	reason   = "reason"
+	status   = "status"
+)
+
+var (
+	// ErrorTag holds the error for the context.
+	ErrorTag tag.Key
+
+	// GroupTag holds the resource group for the context.
+	GroupTag tag.Key
+
+	// VersionTag holds the resource version for the context.
+	VersionTag tag.Key
+
+	// ResourceTag holds the resource name for the context.
+	ResourceTag tag.Key
+
+	// ReasonTag holds the error reason for the context.
+	ReasonTag tag.Key
+
+	// StatusTag holds the error code for the context.
+	StatusTag tag.Key
+)
+
+var (
+	metricCertKeyUpdate = stats.Int64(
+		"galley/validation/cert_key_updates",
+		"Galley validation webhook certificate updates",
+		stats.UnitDimensionless)
+	metricCertKeyUpdateError = stats.Int64(
+		"galley/validation/cert_key_update_errors",
+		"Galley validation webhook certificate updates errors",
+		stats.UnitDimensionless)
+	metricValidationPassed = stats.Int64(
+		"galley/validation/passed",
+		"Resource is valid",
+		stats.UnitDimensionless)
+	metricValidationFailed = stats.Int64(
+		"galley/validation/failed",
+		"Resource validation failed",
+		stats.UnitDimensionless)
+	metricValidationHTTPError = stats.Int64(
+		"galley/validation/http_error",
+		"Resource validation http serve errors",
+		stats.UnitDimensionless)
+)
+
+func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
+	return &view.View{
+		Name:        measure.Name(),
+		Description: measure.Description(),
+		Measure:     measure,
+		TagKeys:     keys,
+		Aggregation: aggregation,
+	}
+}
+
+func init() {
+	var err error
+	if ErrorTag, err = tag.NewKey(errorStr); err != nil {
+		panic(err)
+	}
+	if GroupTag, err = tag.NewKey(group); err != nil {
+		panic(err)
+	}
+	if VersionTag, err = tag.NewKey(version); err != nil {
+		panic(err)
+	}
+	if ResourceTag, err = tag.NewKey(resource); err != nil {
+		panic(err)
+	}
+	if ReasonTag, err = tag.NewKey(reason); err != nil {
+		panic(err)
+	}
+	if StatusTag, err = tag.NewKey(status); err != nil {
+		panic(err)
+	}
+
+	var noKeys []tag.Key
+	errorKey := []tag.Key{ErrorTag}
+	resourceKeys := []tag.Key{GroupTag, VersionTag, ResourceTag}
+	resourceErrorKeys := []tag.Key{GroupTag, VersionTag, ResourceTag, ReasonTag}
+	statusKey := []tag.Key{StatusTag}
+
+	err = view.Register(
+		newView(metricCertKeyUpdate, noKeys, view.Count()),
+		newView(metricCertKeyUpdateError, errorKey, view.Count()),
+		newView(metricValidationPassed, resourceKeys, view.Count()),
+		newView(metricValidationFailed, resourceErrorKeys, view.Count()),
+		newView(metricValidationHTTPError, statusKey, view.Count()),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+func reportValidationFailed(request *kubeApiAdmission.AdmissionRequest, reason string) {
+	ctx, err := tag.New(context.Background(),
+		tag.Insert(GroupTag, request.Resource.Group),
+		tag.Insert(VersionTag, request.Resource.Version),
+		tag.Insert(ResourceTag, request.Resource.Resource),
+		tag.Insert(ReasonTag, reason))
+	if err != nil {
+		scope.Errorf("Error creating monitoring context for reportValidationFailed: %v", err)
+	} else {
+		stats.Record(ctx, metricValidationFailed.M(1))
+	}
+}
+
+func reportValidationPass(request *kubeApiAdmission.AdmissionRequest) {
+	ctx, err := tag.New(context.Background(),
+		tag.Insert(GroupTag, request.Resource.Group),
+		tag.Insert(VersionTag, request.Resource.Version),
+		tag.Insert(ResourceTag, request.Resource.Resource))
+	if err != nil {
+		scope.Errorf("Error creating monitoring context for reportValidationPass: %v", err)
+	} else {
+		stats.Record(ctx, metricValidationPassed.M(1))
+	}
+}
+
+func reportValidationHTTPError(status int) {
+	ctx, err := tag.New(context.Background(), tag.Insert(StatusTag, strconv.Itoa(status)))
+	if err != nil {
+		scope.Errorf("Error creating monitoring context for reportValidationHTTPError: %v", err)
+	} else {
+		stats.Record(ctx, metricValidationHTTPError.M(1))
+	}
+}
+
+func reportValidationCertKeyUpdate() {
+	stats.Record(context.Background(), metricCertKeyUpdate.M(1))
+}
+
+func reportValidationCertKeyUpdateError(err error) {
+	ctx, err := tag.New(context.Background(), tag.Insert(ErrorTag, err.Error()))
+	if err != nil {
+		scope.Errorf("Error creating monitoring context for reportValidationCertKeyUpdateError: %v", err)
+	} else {
+		stats.Record(ctx, metricCertKeyUpdateError.M(1))
+	}
+}
+
+const (
+	reasonUnsupportedOperation = "unsupported_operation"
+	reasonYamlDecodeError      = "yaml_decode_error"
+	reasonUnknownType          = "unknown_type"
+	reasonCRDConversionError   = "crd_conversion_error"
+	reasonInvalidConfig        = "invalid_resource"
+)

--- a/pkg/webhooks/validation/server/server.go
+++ b/pkg/webhooks/validation/server/server.go
@@ -1,0 +1,500 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/hashicorp/go-multierror"
+	"github.com/howeyc/fsnotify"
+	kubeApiAdmission "k8s.io/api/admission/v1beta1"
+	kubeApiApps "k8s.io/api/apps/v1beta1"
+	kubeApisMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	mixerCrd "istio.io/istio/mixer/pkg/config/crd"
+	"istio.io/istio/mixer/pkg/config/store"
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/schema"
+	"istio.io/pkg/log"
+)
+
+var scope = log.RegisterScope("validation", "CRD validation debugging", 0)
+
+var (
+	runtimeScheme = runtime.NewScheme()
+	codecs        = serializer.NewCodecFactory(runtimeScheme)
+	deserializer  = codecs.UniversalDeserializer()
+
+	// Expect AdmissionRequest to only include these top-level field names
+	validFields = map[string]bool{
+		"apiVersion": true,
+		"kind":       true,
+		"metadata":   true,
+		"spec":       true,
+		"status":     true,
+	}
+)
+
+func init() {
+	_ = kubeApiApps.AddToScheme(runtimeScheme)
+}
+
+const HTTPSHandlerReadyPath = "/ready"
+
+const (
+	watchDebounceDelay = 100 * time.Millisecond
+)
+
+// Options contains the configuration for the Istio Pilot validation
+// admission controller.
+type Options struct {
+	// MixerValidator implements the backend validator functions for mixer configuration.
+	MixerValidator store.BackendValidator
+
+	// PilotDescriptor provides a description of all pilot configuration resources.
+	PilotDescriptor schema.Set
+
+	// DomainSuffix is the DNS domain suffix for Pilot CRD resources,
+	// e.g. cluster.local.
+	DomainSuffix string
+
+	// Port where the webhook is served. the number should be greater than 1024 for non-root
+	// user, because non-root user cannot bind port number less than 1024
+	Port uint
+
+	// CertFile is the path to the x509 certificate for https.
+	CertFile string
+
+	// KeyFile is the path to the x509 private key matching `CertFile`.
+	KeyFile string
+
+	// Enable galley validation mode
+	Enabled bool
+
+	// Mux of an existing HTTP server, Galley will not manage its own
+	Mux *http.ServeMux
+}
+
+// String produces a stringified version of the arguments for debugging.
+func (p *Options) String() string {
+	buf := &bytes.Buffer{}
+
+	fmt.Fprintf(buf, "DomainSuffix: %s\n", p.DomainSuffix)
+	fmt.Fprintf(buf, "Port: %d\n", p.Port)
+	fmt.Fprintf(buf, "CertFile: %s\n", p.CertFile)
+	fmt.Fprintf(buf, "KeyFile: %s\n", p.KeyFile)
+
+	return buf.String()
+}
+
+// DefaultArgs allocates an Options struct initialized with Webhook's default configuration.
+func DefaultArgs() Options {
+	return Options{
+		Port:     9443,
+		CertFile: constants.DefaultCertChain,
+		KeyFile:  constants.DefaultKey,
+		Enabled:  true,
+	}
+}
+
+// Webhook implements the validating admission webhook for validating Istio configuration.
+type Webhook struct {
+	keyCertWatcher *fsnotify.Watcher
+
+	mu   sync.RWMutex
+	cert *tls.Certificate
+
+	// pilot
+	descriptor   schema.Set
+	domainSuffix string
+
+	// mixer
+	validator store.BackendValidator
+
+	server   *http.Server
+	keyFile  string
+	certFile string
+}
+
+// Reload the server's cert/key for TLS from file and save it for later use by the https server.
+func (wh *Webhook) reloadKeyCert() {
+	pair, err := reloadKeyCert(wh.certFile, wh.keyFile)
+	if err != nil {
+		return
+	}
+
+	wh.mu.Lock()
+	wh.cert = pair
+	wh.mu.Unlock()
+}
+
+// Reload the server's cert/key for TLS from file.
+func reloadKeyCert(certFile, keyFile string) (*tls.Certificate, error) {
+	pair, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		reportValidationCertKeyUpdateError(err)
+		scope.Warnf("Cert/Key reload error: %v", err)
+		return nil, err
+	}
+
+	reportValidationCertKeyUpdate()
+	scope.Info("Cert and Key reloaded")
+
+	var row int
+	for _, cert := range pair.Certificate {
+		if x509Cert, err := x509.ParseCertificates(cert); err != nil {
+			scope.Infof("x509 cert [%v] - ParseCertificates() error: %v\n", row, err)
+			row++
+		} else {
+			for _, c := range x509Cert {
+				scope.Infof("x509 cert [%v] - Issuer: %q, Subject: %q, SN: %x, NotBefore: %q, NotAfter: %q\n",
+					row, c.Issuer, c.Subject, c.SerialNumber,
+					c.NotBefore.Format(time.RFC3339), c.NotAfter.Format(time.RFC3339))
+				row++
+			}
+		}
+	}
+	return &pair, nil
+}
+
+// New creates a new instance of the admission webhook server.
+func New(p Options) (*Webhook, error) {
+	if p.Mux != nil {
+		wh := &Webhook{
+			descriptor: p.PilotDescriptor,
+			validator:  p.MixerValidator,
+		}
+
+		p.Mux.HandleFunc("/admitpilot", wh.serveAdmitPilot)
+		p.Mux.HandleFunc("/admitmixer", wh.serveAdmitMixer)
+		return wh, nil
+	}
+	pair, err := reloadKeyCert(p.CertFile, p.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configuration must be updated whenever the caBundle changes. Watch the parent directory of
+	// the target files so we can catch symlink updates of k8s secrets.
+	keyCertWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range []string{p.CertFile, p.KeyFile} {
+		watchDir, _ := filepath.Split(file)
+		if err := keyCertWatcher.Watch(watchDir); err != nil {
+			return nil, fmt.Errorf("could not watch %v: %v", file, err)
+		}
+	}
+
+	wh := &Webhook{
+		server: &http.Server{
+			Addr: fmt.Sprintf(":%v", p.Port),
+		},
+		keyFile:        p.KeyFile,
+		certFile:       p.CertFile,
+		keyCertWatcher: keyCertWatcher,
+		cert:           pair,
+		descriptor:     p.PilotDescriptor,
+		validator:      p.MixerValidator,
+	}
+
+	// mtls disabled because apiserver webhook cert usage is still TBD.
+	wh.server.TLSConfig = &tls.Config{GetCertificate: wh.getCert}
+	h := http.NewServeMux()
+	h.HandleFunc("/admitpilot", wh.serveAdmitPilot)
+	h.HandleFunc("/admitmixer", wh.serveAdmitMixer)
+	h.HandleFunc(HTTPSHandlerReadyPath, wh.serveReady)
+	wh.server.Handler = h
+
+	return wh, nil
+}
+
+//Stop the server
+func (wh *Webhook) Stop() {
+	wh.server.Close() // nolint: errcheck
+}
+
+var readyHook = func() {}
+
+// Run implements the webhook server
+func (wh *Webhook) Run(stopCh <-chan struct{}) {
+	if wh.server == nil {
+		// Externally managed
+		return
+	}
+	go func() {
+		if err := wh.server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+			scope.Fatalf("admission webhook ListenAndServeTLS failed: %v", err)
+		}
+	}()
+	defer func() {
+		wh.Stop()
+	}()
+
+	if readyHook != nil {
+		readyHook()
+	}
+
+	// use a timer to debounce key/cert updates
+	var keyCertTimerC <-chan time.Time
+
+	for {
+		select {
+		case <-keyCertTimerC:
+			keyCertTimerC = nil
+			wh.reloadKeyCert()
+		case event, more := <-wh.keyCertWatcher.Event:
+			if more && (event.IsModify() || event.IsCreate()) && keyCertTimerC == nil {
+				keyCertTimerC = time.After(watchDebounceDelay)
+			}
+		case err := <-wh.keyCertWatcher.Error:
+			scope.Errorf("configWatcher error: %v", err)
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+func (wh *Webhook) getCert(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	wh.mu.Lock()
+	defer wh.mu.Unlock()
+	return wh.cert, nil
+}
+
+func toAdmissionResponse(err error) *kubeApiAdmission.AdmissionResponse {
+	return &kubeApiAdmission.AdmissionResponse{Result: &kubeApisMeta.Status{Message: err.Error()}}
+}
+
+type admitFunc func(*kubeApiAdmission.AdmissionRequest) *kubeApiAdmission.AdmissionResponse
+
+func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
+	var body []byte
+	if r.Body != nil {
+		if data, err := ioutil.ReadAll(r.Body); err == nil {
+			body = data
+		}
+	}
+	if len(body) == 0 {
+		reportValidationHTTPError(http.StatusBadRequest)
+		http.Error(w, "no body found", http.StatusBadRequest)
+		return
+	}
+
+	// verify the content type is accurate
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		reportValidationHTTPError(http.StatusUnsupportedMediaType)
+		http.Error(w, "invalid Content-Type, want `application/json`", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	var reviewResponse *kubeApiAdmission.AdmissionResponse
+	ar := kubeApiAdmission.AdmissionReview{}
+	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
+		reviewResponse = toAdmissionResponse(fmt.Errorf("could not decode body: %v", err))
+	} else {
+		reviewResponse = admit(ar.Request)
+	}
+
+	response := kubeApiAdmission.AdmissionReview{}
+	if reviewResponse != nil {
+		response.Response = reviewResponse
+		if ar.Request != nil {
+			response.Response.UID = ar.Request.UID
+		}
+	}
+
+	resp, err := json.Marshal(response)
+	if err != nil {
+		reportValidationHTTPError(http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("could encode response: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if _, err := w.Write(resp); err != nil {
+		reportValidationHTTPError(http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("could write response: %v", err), http.StatusInternalServerError)
+	}
+}
+
+func (wh *Webhook) serveReady(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func (wh *Webhook) serveAdmitPilot(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, wh.admitPilot)
+}
+
+func (wh *Webhook) serveAdmitMixer(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, wh.admitMixer)
+}
+
+func (wh *Webhook) admitPilot(request *kubeApiAdmission.AdmissionRequest) *kubeApiAdmission.AdmissionResponse {
+	switch request.Operation {
+	case kubeApiAdmission.Create, kubeApiAdmission.Update:
+	default:
+		scope.Warnf("Unsupported webhook operation %v", request.Operation)
+		reportValidationFailed(request, reasonUnsupportedOperation)
+		return &kubeApiAdmission.AdmissionResponse{Allowed: true}
+	}
+
+	var obj crd.IstioKind
+	if err := yaml.Unmarshal(request.Object.Raw, &obj); err != nil {
+		scope.Infof("cannot decode configuration: %v", err)
+		reportValidationFailed(request, reasonYamlDecodeError)
+		return toAdmissionResponse(fmt.Errorf("cannot decode configuration: %v", err))
+	}
+
+	s, exists := wh.descriptor.GetByType(crd.CamelCaseToKebabCase(obj.Kind))
+	if !exists {
+		scope.Infof("unrecognized type %v", obj.Kind)
+		reportValidationFailed(request, reasonUnknownType)
+		return toAdmissionResponse(fmt.Errorf("unrecognized type %v", obj.Kind))
+	}
+
+	out, err := crd.ConvertObject(s, &obj, wh.domainSuffix)
+	if err != nil {
+		scope.Infof("error decoding configuration: %v", err)
+		reportValidationFailed(request, reasonCRDConversionError)
+		return toAdmissionResponse(fmt.Errorf("error decoding configuration: %v", err))
+	}
+
+	if err := s.Validate(out.Name, out.Namespace, out.Spec); err != nil {
+		scope.Infof("configuration is invalid: %v", err)
+		reportValidationFailed(request, reasonInvalidConfig)
+		return toAdmissionResponse(fmt.Errorf("configuration is invalid: %v", err))
+	}
+
+	if reason, err := checkFields(request.Object.Raw, request.Kind.Kind, request.Namespace, obj.Name); err != nil {
+		reportValidationFailed(request, reason)
+		return toAdmissionResponse(err)
+	}
+
+	reportValidationPass(request)
+	return &kubeApiAdmission.AdmissionResponse{Allowed: true}
+}
+
+func (wh *Webhook) admitMixer(request *kubeApiAdmission.AdmissionRequest) *kubeApiAdmission.AdmissionResponse {
+	ev := &store.BackendEvent{
+		Key: store.Key{
+			Namespace: request.Namespace,
+			Kind:      request.Kind.Kind,
+		},
+	}
+	switch request.Operation {
+	case kubeApiAdmission.Create, kubeApiAdmission.Update:
+		ev.Type = store.Update
+		var obj unstructured.Unstructured
+		if err := yaml.Unmarshal(request.Object.Raw, &obj); err != nil {
+			reportValidationFailed(request, reasonYamlDecodeError)
+			return toAdmissionResponse(fmt.Errorf("cannot decode configuration: %v", err))
+		}
+
+		ev.Value = mixerCrd.ToBackEndResource(&obj)
+		ev.Key.Name = ev.Value.Metadata.Name
+
+		if reason, err := checkFields(request.Object.Raw, request.Kind.Kind, request.Namespace, ev.Key.Name); err != nil {
+			reportValidationFailed(request, reason)
+			return toAdmissionResponse(err)
+		}
+
+	case kubeApiAdmission.Delete:
+		if request.Name == "" {
+			reportValidationFailed(request, reasonUnknownType)
+			return toAdmissionResponse(fmt.Errorf("illformed request: name not found on delete request"))
+		}
+		ev.Type = store.Delete
+		ev.Key.Name = request.Name
+	default:
+		scope.Warnf("Unsupported webhook operation %v", request.Operation)
+		reportValidationFailed(request, reasonUnsupportedOperation)
+		return &kubeApiAdmission.AdmissionResponse{Allowed: true}
+	}
+
+	// webhook skips deletions
+	if ev.Type == store.Update {
+		if err := wh.validator.Validate(ev); err != nil {
+			reportValidationFailed(request, reasonInvalidConfig)
+			return toAdmissionResponse(err)
+		}
+	}
+
+	reportValidationPass(request)
+	return &kubeApiAdmission.AdmissionResponse{Allowed: true}
+}
+
+func checkFields(raw []byte, kind string, namespace string, name string) (string, error) {
+	trial := make(map[string]json.RawMessage)
+	if err := yaml.Unmarshal(raw, &trial); err != nil {
+		scope.Infof("cannot decode configuration fields: %v", err)
+		return reasonYamlDecodeError, fmt.Errorf("cannot decode configuration fields: %v", err)
+	}
+
+	for key := range trial {
+		if _, ok := validFields[key]; !ok {
+			scope.Infof("unknown field %q on %s resource %s/%s",
+				key, kind, namespace, name)
+			return reasonInvalidConfig, fmt.Errorf("unknown field %q on %s resource %s/%s",
+				key, kind, namespace, name)
+		}
+	}
+
+	return "", nil
+}
+
+// validatePort checks that the network port is in range
+func validatePort(port int) error {
+	if 1 <= port && port <= 65535 {
+		return nil
+	}
+	return fmt.Errorf("port number %d must be in the range 1..65535", port)
+}
+
+// Validate tests if the Options has valid params.
+func (p *Options) Validate() error {
+	if p == nil {
+		return errors.New("nil Options")
+	}
+
+	var errs *multierror.Error
+	if p.Enabled {
+		if len(p.CertFile) == 0 {
+			errs = multierror.Append(errs, errors.New("cert file not specified"))
+		}
+		if len(p.KeyFile) == 0 {
+			errs = multierror.Append(errs, errors.New("key file not specified"))
+		}
+		if err := validatePort(int(p.Port)); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+
+	return errs.ErrorOrNil()
+}

--- a/pkg/webhooks/validation/server/server.go
+++ b/pkg/webhooks/validation/server/server.go
@@ -45,7 +45,7 @@ import (
 	"istio.io/pkg/log"
 )
 
-var scope = log.RegisterScope("validation", "CRD validation debugging", 0)
+var scope = log.RegisterScope("validationServer", "validation webhook server", 0)
 
 var (
 	runtimeScheme = runtime.NewScheme()

--- a/pkg/webhooks/validation/server/server_test.go
+++ b/pkg/webhooks/validation/server/server_test.go
@@ -540,7 +540,7 @@ func TestServe(t *testing.T) {
 
 func checkCert(t *testing.T, whc *Webhook, cert, key []byte) bool {
 	t.Helper()
-	actual := whc.cert
+	actual, _ := whc.getCert(nil)
 	expected, err := tls.X509KeyPair(cert, key)
 	if err != nil {
 		t.Fatalf("fail to load test certs.")

--- a/pkg/webhooks/validation/server/server_test.go
+++ b/pkg/webhooks/validation/server/server_test.go
@@ -1,0 +1,631 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	kubeApiAdmission "k8s.io/api/admission/v1beta1"
+	kubeApisMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"istio.io/istio/mixer/pkg/config/store"
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/test/mock"
+	"istio.io/istio/pkg/config/schemas"
+	"istio.io/istio/pkg/mcp/testing/testcerts"
+	"istio.io/istio/pkg/test/config"
+)
+
+const (
+	// testDomainSuffix is the default DNS domain suffix for Istio
+	// CRD resources.
+	testDomainSuffix = "local.cluster"
+)
+
+type fakeValidator struct{ err error }
+
+func (fv *fakeValidator) Validate(*store.BackendEvent) error {
+	return fv.err
+}
+
+func (fv *fakeValidator) SupportsKind(string) bool {
+	return true
+}
+
+func TestArgs_String(t *testing.T) {
+	p := DefaultArgs()
+	// Should not crash
+	_ = p.String()
+}
+
+func createTestWebhook(t testing.TB) (*Webhook, func()) {
+
+	t.Helper()
+	dir, err := ioutil.TempDir("", "galley_validation_webhook")
+	if err != nil {
+		t.Fatalf("TempDir() failed: %v", err)
+	}
+	cleanup := func() {
+		_ = os.RemoveAll(dir) // nolint: errcheck
+	}
+
+	var (
+		certFile = filepath.Join(dir, "cert-file.yaml")
+		keyFile  = filepath.Join(dir, "key-file.yaml")
+		port     = uint(0)
+	)
+
+	// cert
+	if err := ioutil.WriteFile(certFile, testcerts.ServerCert, 0644); err != nil { // nolint: vetshadow
+		cleanup()
+		t.Fatalf("WriteFile(%v) failed: %v", certFile, err)
+	}
+	// key
+	if err := ioutil.WriteFile(keyFile, testcerts.ServerKey, 0644); err != nil { // nolint: vetshadow
+		cleanup()
+		t.Fatalf("WriteFile(%v) failed: %v", keyFile, err)
+	}
+
+	options := Options{
+		CertFile:        certFile,
+		KeyFile:         keyFile,
+		Port:            port,
+		DomainSuffix:    testDomainSuffix,
+		PilotDescriptor: mock.Types,
+		MixerValidator:  &fakeValidator{},
+	}
+	wh, err := New(options)
+	if err != nil {
+		cleanup()
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	return wh, func() {
+		cleanup()
+		wh.Stop()
+	}
+}
+
+func makePilotConfig(t *testing.T, i int, validConfig bool, includeBogusKey bool) []byte { // nolint: unparam
+	t.Helper()
+
+	var key string
+	if validConfig {
+		key = "key"
+	}
+
+	name := fmt.Sprintf("%s%d", "mock-config", i)
+	config := model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Type: schemas.MockConfig.Type,
+			Name: name,
+			Labels: map[string]string{
+				"key": name,
+			},
+			Annotations: map[string]string{
+				"annotationkey": name,
+			},
+		},
+		Spec: &config.MockConfig{
+			Key: key,
+			Pairs: []*config.ConfigPair{{
+				Key:   key,
+				Value: strconv.Itoa(i),
+			}},
+		},
+	}
+	obj, err := crd.ConvertConfig(schemas.MockConfig, config)
+	if err != nil {
+		t.Fatalf("ConvertConfig(%v) failed: %v", config.Name, err)
+	}
+	raw, err := json.Marshal(&obj)
+	if err != nil {
+		t.Fatalf("Marshal(%v) failed: %v", config.Name, err)
+	}
+	if includeBogusKey {
+		trial := make(map[string]interface{})
+		if err := json.Unmarshal(raw, &trial); err != nil {
+			t.Fatalf("Unmarshal(%v) failed: %v", config.Name, err)
+		}
+		trial["unexpected_key"] = "any value"
+		if raw, err = json.Marshal(&trial); err != nil {
+			t.Fatalf("re-Marshal(%v) failed: %v", config.Name, err)
+		}
+	}
+	return raw
+}
+
+func TestAdmitPilot(t *testing.T) {
+	valid := makePilotConfig(t, 0, true, false)
+	invalidConfig := makePilotConfig(t, 0, false, false)
+	extraKeyConfig := makePilotConfig(t, 0, true, true)
+
+	wh, cancel := createTestWebhook(t)
+	defer cancel()
+
+	cases := []struct {
+		name    string
+		admit   admitFunc
+		in      *kubeApiAdmission.AdmissionRequest
+		allowed bool
+	}{
+		{
+			name:  "valid create",
+			admit: wh.admitPilot,
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Object:    runtime.RawExtension{Raw: valid},
+				Operation: kubeApiAdmission.Create,
+			},
+			allowed: true,
+		},
+		{
+			name:  "valid update",
+			admit: wh.admitPilot,
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Object:    runtime.RawExtension{Raw: valid},
+				Operation: kubeApiAdmission.Update,
+			},
+			allowed: true,
+		},
+		{
+			name:  "unsupported operation",
+			admit: wh.admitPilot,
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Object:    runtime.RawExtension{Raw: valid},
+				Operation: kubeApiAdmission.Delete,
+			},
+			allowed: true,
+		},
+		{
+			name:  "invalid spec",
+			admit: wh.admitPilot,
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Object:    runtime.RawExtension{Raw: invalidConfig},
+				Operation: kubeApiAdmission.Create,
+			},
+			allowed: false,
+		},
+		{
+			name:  "corrupt object",
+			admit: wh.admitPilot,
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Object:    runtime.RawExtension{Raw: append([]byte("---"), valid...)},
+				Operation: kubeApiAdmission.Create,
+			},
+			allowed: false,
+		},
+		{
+			name:  "invalid extra key create",
+			admit: wh.admitPilot,
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Object:    runtime.RawExtension{Raw: extraKeyConfig},
+				Operation: kubeApiAdmission.Create,
+			},
+			allowed: false,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] %s", i, c.name), func(t *testing.T) {
+			got := wh.admitPilot(c.in)
+			if got.Allowed != c.allowed {
+				t.Fatalf("got %v want %v", got.Allowed, c.allowed)
+			}
+		})
+	}
+}
+
+func makeMixerConfig(t *testing.T, i int, includeBogusKey bool) []byte {
+	t.Helper()
+	uns := &unstructured.Unstructured{}
+	name := fmt.Sprintf("%s%d", "mock-config", i)
+	uns.SetName(name)
+	uns.SetKind("mock")
+	uns.Object["spec"] = map[string]interface{}{"foo": 1}
+	if includeBogusKey {
+		uns.Object["unexpected_key"] = "any value"
+	}
+	raw, err := json.Marshal(uns)
+	if err != nil {
+		t.Fatalf("Marshal(%v) failed: %v", uns, err)
+	}
+	return raw
+}
+
+func TestAdmitMixer(t *testing.T) {
+	rawConfig := makeMixerConfig(t, 0, false)
+	extraKeyConfig := makeMixerConfig(t, 0, true)
+	wh, cancel := createTestWebhook(t)
+	defer cancel()
+
+	cases := []struct {
+		name      string
+		in        *kubeApiAdmission.AdmissionRequest
+		allowed   bool
+		validator store.BackendValidator
+	}{
+		{
+			name: "valid create",
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Name:      "valid-create",
+				Object:    runtime.RawExtension{Raw: rawConfig},
+				Operation: kubeApiAdmission.Create,
+			},
+			validator: &fakeValidator{},
+			allowed:   true,
+		},
+		{
+			name: "valid update",
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Name:      "valid-update",
+				Object:    runtime.RawExtension{Raw: rawConfig},
+				Operation: kubeApiAdmission.Update,
+			},
+			validator: &fakeValidator{},
+			allowed:   true,
+		},
+		{
+			name: "valid delete",
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Name:      "valid-delete",
+				Object:    runtime.RawExtension{Raw: rawConfig},
+				Operation: kubeApiAdmission.Delete,
+			},
+			validator: &fakeValidator{},
+			allowed:   true,
+		},
+		{
+			name: "invalid update",
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Name:      "invalid-update",
+				Object:    runtime.RawExtension{Raw: rawConfig},
+				Operation: kubeApiAdmission.Update,
+			},
+			validator: &fakeValidator{errors.New("fail")},
+			allowed:   false,
+		},
+		{
+			name: "invalid delete",
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Name:      "to-be-deleted",
+				Object:    runtime.RawExtension{Raw: rawConfig},
+				Operation: kubeApiAdmission.Delete,
+			},
+			validator: &fakeValidator{errors.New("fail")},
+			allowed:   true,
+		},
+		{
+			name: "invalid delete (missing name)",
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Object:    runtime.RawExtension{Raw: rawConfig},
+				Operation: kubeApiAdmission.Delete,
+			},
+			validator: &fakeValidator{errors.New("fail")},
+			allowed:   false,
+		},
+		{
+			name: "invalid create",
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Name:      "invalid create",
+				Object:    runtime.RawExtension{Raw: rawConfig},
+				Operation: kubeApiAdmission.Create,
+			},
+			validator: &fakeValidator{errors.New("fail")},
+			allowed:   false,
+		},
+		{
+			name: "invalid operation",
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Name:      "invalid operation",
+				Object:    runtime.RawExtension{Raw: rawConfig},
+				Operation: kubeApiAdmission.Connect,
+			},
+			validator: &fakeValidator{},
+			allowed:   true,
+		},
+		{
+			name: "invalid object",
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Name:      "invalid object",
+				Object:    runtime.RawExtension{Raw: append([]byte("---"), rawConfig...)},
+				Operation: kubeApiAdmission.Create,
+			},
+			validator: &fakeValidator{},
+			allowed:   false,
+		},
+		{
+			name: "invalid extra key create",
+			in: &kubeApiAdmission.AdmissionRequest{
+				Kind:      kubeApisMeta.GroupVersionKind{Kind: "mock"},
+				Name:      "invalid extra key create",
+				Object:    runtime.RawExtension{Raw: extraKeyConfig},
+				Operation: kubeApiAdmission.Create,
+			},
+			validator: &fakeValidator{},
+			allowed:   false,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] %s", i, c.name), func(t *testing.T) {
+			wh.validator = c.validator // override mixer backend validator
+			got := wh.admitMixer(c.in)
+			if c.allowed != got.Allowed {
+				t.Fatalf("got %v want %v", got, c.allowed)
+			}
+		})
+	}
+}
+
+func makeTestReview(t *testing.T, valid bool) []byte {
+	t.Helper()
+	review := kubeApiAdmission.AdmissionReview{
+		Request: &kubeApiAdmission.AdmissionRequest{
+			Kind: kubeApisMeta.GroupVersionKind{},
+			Object: runtime.RawExtension{
+				Raw: makePilotConfig(t, 0, valid, false),
+			},
+			Operation: kubeApiAdmission.Create,
+		},
+	}
+	reviewJSON, err := json.Marshal(review)
+	if err != nil {
+		t.Fatalf("Failed to create AdmissionReview: %v", err)
+	}
+	return reviewJSON
+}
+
+func TestServe_Basic(t *testing.T) {
+	ready := make(chan struct{})
+	readyHook = func() {
+		ready <- struct{}{}
+	}
+	defer func() { readyHook = func() {} }()
+
+	wh, cleanup := createTestWebhook(t)
+	defer cleanup()
+
+	stop := make(chan struct{})
+	defer func() {
+		close(stop)
+	}()
+
+	go wh.Run(stop)
+
+	select {
+	case <-ready:
+		wh.Stop()
+	case <-time.After(10 * time.Second):
+		t.Fatal("The webhook serve cannot be started in 10 seconds")
+	}
+}
+
+func TestServe(t *testing.T) {
+	wh, cleanup := createTestWebhook(t)
+	defer cleanup()
+	stop := make(chan struct{})
+	defer func() {
+		close(stop)
+	}()
+	go wh.Run(stop)
+
+	validReview := makeTestReview(t, true)
+	invalidReview := makeTestReview(t, false)
+
+	cases := []struct {
+		name            string
+		body            []byte
+		contentType     string
+		wantStatusCode  int
+		wantAllowed     bool
+		allowedResponse bool
+	}{
+		{
+			name:            "valid",
+			body:            validReview,
+			contentType:     "application/json",
+			wantAllowed:     true,
+			wantStatusCode:  http.StatusOK,
+			allowedResponse: true,
+		},
+		{
+			name:           "invalid",
+			body:           invalidReview,
+			contentType:    "application/json",
+			wantAllowed:    false,
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:           "wrong content-type",
+			body:           validReview,
+			contentType:    "application/yaml",
+			wantAllowed:    false,
+			wantStatusCode: http.StatusUnsupportedMediaType,
+		},
+		{
+			name:           "bad content",
+			body:           []byte{0, 1, 2, 3, 4, 5}, // random data
+			contentType:    "application/json",
+			wantAllowed:    false,
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:           "no content",
+			body:           []byte{},
+			contentType:    "application/json",
+			wantAllowed:    false,
+			wantStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] %s", i, c.name), func(t *testing.T) {
+			req := httptest.NewRequest("POST", "http://validator", bytes.NewReader(c.body))
+			req.Header.Add("Content-Type", c.contentType)
+			w := httptest.NewRecorder()
+
+			serve(w, req, func(*kubeApiAdmission.AdmissionRequest) *kubeApiAdmission.AdmissionResponse {
+				return &kubeApiAdmission.AdmissionResponse{Allowed: c.allowedResponse}
+			})
+
+			res := w.Result()
+
+			if res.StatusCode != c.wantStatusCode {
+				t.Fatalf("%v: wrong status code: \ngot %v \nwant %v", c.name, res.StatusCode, c.wantStatusCode)
+			}
+
+			if res.StatusCode != http.StatusOK {
+				return
+			}
+
+			gotBody, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				t.Fatalf("%v: could not read body: %v", c.name, err)
+			}
+			var gotReview kubeApiAdmission.AdmissionReview
+			if err := json.Unmarshal(gotBody, &gotReview); err != nil {
+				t.Fatalf("%v: could not decode response body: %v", c.name, err)
+			}
+			if gotReview.Response.Allowed != c.wantAllowed {
+				t.Fatalf("%v: AdmissionReview.Response.Allowed is wrong : got %v want %v",
+					c.name, gotReview.Response.Allowed, c.wantAllowed)
+			}
+		})
+	}
+}
+
+func checkCert(t *testing.T, whc *Webhook, cert, key []byte) bool {
+	t.Helper()
+	actual := whc.cert
+	expected, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		t.Fatalf("fail to load test certs.")
+	}
+	return bytes.Equal(actual.Certificate[0], expected.Certificate[0])
+}
+
+func TestReloadCert(t *testing.T) {
+	wh, cleanup := createTestWebhook(t)
+	defer cleanup()
+	stop := make(chan struct{})
+	defer func() {
+		close(stop)
+	}()
+	go wh.Run(stop)
+
+	checkCert(t, wh, testcerts.ServerCert, testcerts.ServerKey)
+	// Update cert/key files.
+	if err := ioutil.WriteFile(wh.certFile, testcerts.RotatedCert, 0644); err != nil { // nolint: vetshadow
+		cleanup()
+		t.Fatalf("WriteFile(%v) failed: %v", wh.certFile, err)
+	}
+	if err := ioutil.WriteFile(wh.keyFile, testcerts.RotatedKey, 0644); err != nil { // nolint: vetshadow
+		cleanup()
+		t.Fatalf("WriteFile(%v) failed: %v", wh.keyFile, err)
+	}
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		return checkCert(t, wh, testcerts.RotatedCert, testcerts.RotatedKey)
+	}, "10s", "100ms").Should(gomega.BeTrue())
+}
+
+// scenario is a common struct used by many tests in this context.
+type scenario struct {
+	wrapFunc      func(*Options)
+	expectedError string
+}
+
+func TestValidate(t *testing.T) {
+	scenarios := map[string]scenario{
+		"valid": {
+			wrapFunc:      func(args *Options) {},
+			expectedError: "",
+		},
+		"cert unset": {
+			wrapFunc:      func(args *Options) { args.CertFile = "" },
+			expectedError: "cert file not specified",
+		},
+		"key unset": {
+			wrapFunc:      func(args *Options) { args.KeyFile = "" },
+			expectedError: "key file not specified",
+		},
+		"invalid port": {
+			wrapFunc:      func(args *Options) { args.Port = 100000 },
+			expectedError: "port number 100000 must be in the range 1..65535",
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(tt *testing.T) {
+			runTestCode(name, tt, scenario)
+		})
+	}
+}
+
+func runTestCode(name string, t *testing.T, test scenario) {
+	args := DefaultArgs()
+
+	test.wrapFunc(&args)
+	err := args.Validate()
+	if err == nil && test.expectedError != "" {
+		t.Errorf("Test %q failed: expected error: %q, got nil", name, test.expectedError)
+	}
+	if err != nil {
+		if test.expectedError == "" {
+			t.Errorf("Test %q failed: expected nil error, got %v", name, err)
+		}
+		if !strings.Contains(err.Error(), test.expectedError) {
+			t.Errorf("Test %q failed: expected error: %q, got %q", name, test.expectedError, err.Error())
+		}
+	}
+
+	// Should not return error if validation disabled
+	args.Enabled = false
+	if err := args.Validate(); err != nil {
+		t.Errorf("Test %q failed with validation disabled, expected nil error, but got: %v", name, err)
+	}
+}

--- a/pkg/webhooks/validation/server/server_test.go
+++ b/pkg/webhooks/validation/server/server_test.go
@@ -622,10 +622,4 @@ func runTestCode(name string, t *testing.T, test scenario) {
 			t.Errorf("Test %q failed: expected error: %q, got %q", name, test.expectedError, err.Error())
 		}
 	}
-
-	// Should not return error if validation disabled
-	args.Enabled = false
-	if err := args.Validate(); err != nil {
-		t.Errorf("Test %q failed with validation disabled, expected nil error, but got: %v", name, err)
-	}
 }


### PR DESCRIPTION
Part 1 of 3 in a set of changes to unify webhook validation.

This PR introduces standalone server and controller packages for serving webhook requests and managing the webhook config lifecycle. This will be used by Galley, Pilot (istiod), and eventually the operator and istioctl. 

These new packages address several problems:

* The server and controller no longer share common code, making them easier to integrate across components, e.g. controller-only in operator, server-only in galley.

* The controller has been rewritten to be easier to understand and extend. The existing code was difficult to understand and modify.

* The controller supports a mode where Galley and Pilot-based validation webhooks can safely coexist in the same cluster during migration. Pilot's defer to Galley's when Galley is present. Pilot's  only starts managing the webhook configuration when Galley is uninstalled.

Additional notes to reviewers:

* The server is a copy of `galley/pkg/crd/validation/webhook.go` with the unused intermixed controller code removed. The existing server code will be removed once galley switches to the new server package.

* The existing metrics have been retained across the two packages. The `monitoring.go` files in each package are a copy of `galley/pkg/crd/validation/monitoring.go` with the non-relevant metrics removed respectively. 

TODO
* deflake unit tests prior to merge

