### PR TITLE
Improve proto.Buffer pool performance

### DIFF
--- a/mixer/pkg/protobuf/yaml/pool.go
+++ b/mixer/pkg/protobuf/yaml/pool.go
@@ -12,23 +12,162 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Copyright (c) 2016 Aliaksandr Valialkin, VertaMedia, Refactor by Andy Pan. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be found
+// at https://github.com/valyala/bytebufferpool/blob/master/LICENSE.
+
 package yaml
 
 import (
+	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/gogo/protobuf/proto"
 )
 
-var bufferPool = sync.Pool{New: func() interface{} { return proto.NewBuffer(make([]byte, 0, 256)) }}
+const (
+	minBitSize = 6 // 2**6=64 is a CPU cache line size
+	steps      = 20
 
-// GetBuffer returns a new buffer from the pool
-func GetBuffer() *proto.Buffer {
-	return bufferPool.Get().(*proto.Buffer)
+	minSize = 1 << minBitSize
+	maxSize = 1 << (minBitSize + steps - 1)
+
+	calibrateCallsThreshold = 42000
+	maxPercentile           = 0.95
+)
+
+// protoBufferPool represents proto.Buffer pool.
+//
+// Distinct pools may be used for distinct types of byte buffers.
+// Properly determined proto.Buffer types with their own pools may help reducing
+// memory waste.
+type protoBufferPool struct {
+	calls       [steps]uint64
+	calibrating uint64
+
+	defaultSize uint64
+	maxSize     uint64
+
+	pool sync.Pool
 }
 
-// PutBuffer returns the buffer back to the pool
-func PutBuffer(b *proto.Buffer) {
-	b.Reset()
-	bufferPool.Put(b)
+var defaultPool protoBufferPool
+
+func init() {
+	defaultPool.defaultSize = 256
+}
+
+// GetBuffer returns an empty proto.Buffer from the pool.
+//
+// Got proto.Buffer may be returned to the pool via Put call.
+// This reduces the number of memory allocations required for proto.Buffer
+// management.
+func GetBuffer() *proto.Buffer { return defaultPool.Get() }
+
+// Get returns new proto.Buffer with zero length.
+//
+// The proto.Buffer may be returned to the pool via Put after the use
+// in order to minimize GC overhead.
+func (p *protoBufferPool) Get() *proto.Buffer {
+	v := p.pool.Get()
+	if v != nil {
+		return v.(*proto.Buffer)
+	}
+	return proto.NewBuffer(make([]byte, 0, atomic.LoadUint64(&p.defaultSize)))
+}
+
+// PutBuffer returns proto.Buffer to the pool.
+//
+// ByteBuffer.B mustn't be touched after returning it to the pool.
+// Otherwise data races will occur.
+func PutBuffer(b *proto.Buffer) { defaultPool.Put(b) }
+
+// Put releases proto.Buffer obtained via Get to the pool.
+//
+// The buffer mustn't be accessed after returning to the pool.
+func (p *protoBufferPool) Put(b *proto.Buffer) {
+	idx := index(len(b.Bytes()))
+
+	if atomic.AddUint64(&p.calls[idx], 1) > calibrateCallsThreshold {
+		p.calibrate()
+	}
+
+	maxSize := int(atomic.LoadUint64(&p.maxSize))
+	if maxSize == 0 || cap(b.Bytes()) <= maxSize {
+		b.Reset()
+		p.pool.Put(b)
+	}
+}
+
+func (p *protoBufferPool) calibrate() {
+	if !atomic.CompareAndSwapUint64(&p.calibrating, 0, 1) {
+		return
+	}
+
+	a := make(callSizes, 0, steps)
+	var callsSum uint64
+	for i := uint64(0); i < steps; i++ {
+		calls := atomic.SwapUint64(&p.calls[i], 0)
+		callsSum += calls
+		a = append(a, callSize{
+			calls: calls,
+			size:  minSize << i,
+		})
+	}
+	sort.Sort(a)
+
+	defaultSize := a[0].size
+	maxSize := defaultSize
+
+	maxSum := uint64(float64(callsSum) * maxPercentile)
+	callsSum = 0
+	for i := 0; i < steps; i++ {
+		if callsSum > maxSum {
+			break
+		}
+		callsSum += a[i].calls
+		size := a[i].size
+		if size > maxSize {
+			maxSize = size
+		}
+	}
+
+	atomic.StoreUint64(&p.defaultSize, defaultSize)
+	atomic.StoreUint64(&p.maxSize, maxSize)
+
+	atomic.StoreUint64(&p.calibrating, 0)
+}
+
+type callSize struct {
+	calls uint64
+	size  uint64
+}
+
+type callSizes []callSize
+
+func (ci callSizes) Len() int {
+	return len(ci)
+}
+
+func (ci callSizes) Less(i, j int) bool {
+	return ci[i].calls > ci[j].calls
+}
+
+func (ci callSizes) Swap(i, j int) {
+	ci[i], ci[j] = ci[j], ci[i]
+}
+
+func index(n int) int {
+	n--
+	n >>= minBitSize
+	idx := 0
+	for n > 0 {
+		n >>= 1
+		idx++
+	}
+	if idx >= steps {
+		idx = steps - 1
+	}
+	return idx
 }

--- a/mixer/pkg/protobuf/yaml/pool.go
+++ b/mixer/pkg/protobuf/yaml/pool.go
@@ -31,7 +31,6 @@ const (
 	steps      = 20
 
 	minSize = 1 << minBitSize
-	maxSize = 1 << (minBitSize + steps - 1)
 
 	calibrateCallsThreshold = 42000
 	maxPercentile           = 0.95


### PR DESCRIPTION
Improve proto.Buffer pool performance by introducing and refactoring [bytebufferpool](https://github.com/valyala/bytebufferpool).
Benchmark between bytebufferpool and other buffer pool is shown as below:
```
BenchmarkGenericBuf-4                       	 1724506	       743 ns/op	    2576 B/op	       4 allocs/op
BenchmarkGenericStackBuf-4                  	 1721428	      1450 ns/op	    2576 B/op	       4 allocs/op
BenchmarkAllocBuf-4                         	  817185	      1466 ns/op	    2576 B/op	       4 allocs/op
BenchmarkSyncPoolBuf-4                      	14212396	       108 ns/op	       0 B/op	       0 allocs/op
BenchmarkBpoolPoolBuf-4                     	 4306632	       272 ns/op	       0 B/op	       0 allocs/op
BenchmarkByteBufferPoolBuf-4                	14618955	        73.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkEasyJsonBuffer-4                   	 3852164	       296 ns/op	     608 B/op	       4 allocs/op
BenchmarkEasyJsonBuffer_OptimizedConfig-4   	 9305934	       118 ns/op	      32 B/op	       1 allocs/op
```
Find more details [here](https://omgnull.github.io/go-benchmark/buffer/).

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure