### PR TITLE
Fix names of istio-iptables scripts called in Debian package

### DIFF
--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -69,21 +69,21 @@ if [ "${ISTIO_CUSTOM_IP_TABLES}" != "true" ] ; then
     if [[ ${1-} == "init" || ${1-} == "-p" ]] ; then
       # clean the previous Istio iptables chains. This part is different from the init image mode,
       # where the init container runs in a fresh environment and there cannot be previous Istio chains
-      "${ISTIO_BIN_BASE}/istio-clean-iptables"
+      "${ISTIO_BIN_BASE}/istio-clean-iptables.sh"
 
       # Update iptables, based on current config. This is for backward compatibility with the init image mode.
       # The sidecar image can replace the k8s init image, to avoid downloading 2 different images.
-      "${ISTIO_BIN_BASE}/istio-iptables" "${@}"
+      "${ISTIO_BIN_BASE}/istio-iptables.sh" "${@}"
       exit 0
     fi
 
     if [[ ${1-} != "run" ]] ; then
       # clean the previous Istio iptables chains. This part is different from the init image mode,
       # where the init container runs in a fresh environment and there cannot be previous Istio chains
-      "${ISTIO_BIN_BASE}/istio-clean-iptables"
+      "${ISTIO_BIN_BASE}/istio-clean-iptables.sh"
 
       # Update iptables, based on config file
-      "${ISTIO_BIN_BASE}/istio-iptables"
+      "${ISTIO_BIN_BASE}/istio-iptables.sh"
     fi
 fi
 


### PR DESCRIPTION
In 1.4 only, we still use the shell script versions of the `istio-iptables` scripts, but the Debian package's `istio-start.sh` script was calling the commands without the `.sh` suffix like in master.

Fixes #17989
Fixes #17615