### PR TITLE
Refactor messages to track resource rather than origin

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -516,9 +516,10 @@ func extractFields(msgs diag.Messages) []message {
 		expMsg := message{
 			messageType: m.Type,
 		}
-		if m.Origin != nil {
-			expMsg.origin = m.Origin.FriendlyName()
+		if m.Resource != nil {
+			expMsg.origin = m.Resource.Origin.FriendlyName()
 		}
+
 		result = append(result, expMsg)
 	}
 	return result

--- a/galley/pkg/config/analysis/analyzers/schema/validation_test.go
+++ b/galley/pkg/config/analysis/analyzers/schema/validation_test.go
@@ -50,6 +50,7 @@ func TestCorrectArgs(t *testing.T) {
 				Metadata: resource.Metadata{
 					FullName: resource.NewFullName("ns", "name"),
 				},
+				Origin: fakeOrigin{},
 			},
 		},
 	}
@@ -104,6 +105,7 @@ func TestSchemaValidationWrapper(t *testing.T) {
 			Resources: []*resource.Instance{
 				{
 					Message: m2,
+					Origin:  fakeOrigin{},
 				},
 			},
 		}
@@ -118,6 +120,7 @@ func TestSchemaValidationWrapper(t *testing.T) {
 			Resources: []*resource.Instance{
 				{
 					Message: m3,
+					Origin:  fakeOrigin{},
 				},
 			},
 		}
@@ -144,3 +147,8 @@ func schemaWithValidateFn(validateFn func(string, string, proto.Message) error) 
 		}.MustBuild(),
 	}.MustBuild()
 }
+
+type fakeOrigin struct{}
+
+func (fakeOrigin) FriendlyName() string          { return "myFriendlyName" }
+func (fakeOrigin) Namespace() resource.Namespace { return "myNamespace" }

--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -52,8 +52,9 @@ type Message struct {
 	// The Parameters to the message
 	Parameters []interface{}
 
-	// Origin of the message
-	Origin resource.Origin
+	// Resource is the underlying resource instance associated with the
+	// message, or nil if no resource is associated with it.
+	Resource *resource.Instance
 
 	// DocRef is an optional reference tracker for the documentation URL
 	DocRef string
@@ -65,8 +66,8 @@ func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 
 	result["code"] = m.Type.Code()
 	result["level"] = m.Type.Level().String()
-	if includeOrigin && m.Origin != nil {
-		result["origin"] = m.Origin.FriendlyName()
+	if includeOrigin && m.Resource != nil {
+		result["origin"] = m.Resource.Origin.FriendlyName()
 	}
 	result["message"] = fmt.Sprintf(m.Type.Template(), m.Parameters...)
 
@@ -82,8 +83,8 @@ func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 // String implements io.Stringer
 func (m *Message) String() string {
 	origin := ""
-	if m.Origin != nil {
-		origin = "(" + m.Origin.FriendlyName() + ")"
+	if m.Resource != nil {
+		origin = "(" + m.Resource.Origin.FriendlyName() + ")"
 	}
 	return fmt.Sprintf(
 		"%v [%v]%s %s", m.Type.Level(), m.Type.Code(), origin, fmt.Sprintf(m.Type.Template(), m.Parameters...))
@@ -104,10 +105,10 @@ func NewMessageType(level Level, code, template string) *MessageType {
 }
 
 // NewMessage returns a new Message instance from an existing type.
-func NewMessage(mt *MessageType, o resource.Origin, p ...interface{}) Message {
+func NewMessage(mt *MessageType, r *resource.Instance, p ...interface{}) Message {
 	return Message{
 		Type:       mt,
-		Origin:     o,
+		Resource:   r,
 		Parameters: p,
 	}
 }

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"istio.io/istio/galley/pkg/config/resource"
+
 	. "github.com/onsi/gomega"
 )
 
@@ -29,11 +31,10 @@ func TestMessage_String(t *testing.T) {
 	g.Expect(m.String()).To(Equal(`Error [IST-0042] Cheese type not found: "Feta"`))
 }
 
-func TestMessageWithOrigin_String(t *testing.T) {
+func TestMessageWithResource_String(t *testing.T) {
 	g := NewGomegaWithT(t)
-	o := testOrigin("toppings/cheese")
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
-	m := NewMessage(mt, o, "Feta")
+	m := NewMessage(mt, &resource.Instance{Origin: testOrigin("toppings/cheese")}, "Feta")
 
 	g.Expect(m.String()).To(Equal(`Error [IST-0042](toppings/cheese) Cheese type not found: "Feta"`))
 }
@@ -46,7 +47,7 @@ func TestMessage_Unstructured(t *testing.T) {
 	g.Expect(m.Unstructured(true)).To(Not(HaveKey("origin")))
 	g.Expect(m.Unstructured(false)).To(Not(HaveKey("origin")))
 
-	m = NewMessage(mt, testOrigin("toppings/cheese"), "Feta")
+	m = NewMessage(mt, &resource.Instance{Origin: testOrigin("toppings/cheese")}, "Feta")
 
 	g.Expect(m.Unstructured(true)).To((HaveKey("origin")))
 	g.Expect(m.Unstructured(false)).To(Not(HaveKey("origin")))
@@ -62,9 +63,8 @@ func TestMessageWithDocRef(t *testing.T) {
 
 func TestMessage_JSON(t *testing.T) {
 	g := NewGomegaWithT(t)
-	o := testOrigin("toppings/cheese")
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
-	m := NewMessage(mt, o, "Feta")
+	m := NewMessage(mt, &resource.Instance{Origin: testOrigin("toppings/cheese")}, "Feta")
 
 	j, _ := json.Marshal(&m)
 	g.Expect(string(j)).To(Equal(`{"code":"IST-0042","documentation_url":"https://istio.io/docs/reference/config/analysis/IST-0042"` +

--- a/galley/pkg/config/analysis/diag/messages.go
+++ b/galley/pkg/config/analysis/diag/messages.go
@@ -24,7 +24,7 @@ func (ms *Messages) Add(m Message) {
 	*ms = append(*ms, m)
 }
 
-// Sort the message lexicographically by level, code, origin, then string.
+// Sort the message lexicographically by level, code, resource origin name, then string.
 func (ms *Messages) Sort() {
 	sort.Slice(*ms, func(i, j int) bool {
 		a, b := (*ms)[i], (*ms)[j]
@@ -33,12 +33,12 @@ func (ms *Messages) Sort() {
 			return a.Type.Level().sortOrder < b.Type.Level().sortOrder
 		case a.Type.Code() != b.Type.Code():
 			return a.Type.Code() < b.Type.Code()
-		case a.Origin == nil && b.Origin != nil:
+		case a.Resource == nil && b.Resource != nil:
 			return true
-		case a.Origin != nil && b.Origin == nil:
+		case a.Resource != nil && b.Resource == nil:
 			return false
-		case a.Origin != nil && b.Origin != nil && a.Origin.FriendlyName() != b.Origin.FriendlyName():
-			return a.Origin.FriendlyName() < b.Origin.FriendlyName()
+		case a.Resource != nil && b.Resource != nil && a.Resource.Origin.FriendlyName() != b.Resource.Origin.FriendlyName():
+			return a.Resource.Origin.FriendlyName() < b.Resource.Origin.FriendlyName()
 		default:
 			return a.String() < b.String()
 		}

--- a/galley/pkg/config/analysis/diag/messages_test.go
+++ b/galley/pkg/config/analysis/diag/messages_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
 	"istio.io/istio/galley/pkg/config/resource"
 )
 

--- a/galley/pkg/config/analysis/diag/messages_test.go
+++ b/galley/pkg/config/analysis/diag/messages_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"istio.io/istio/galley/pkg/config/resource"
 )
 
 func TestMessages_Sort(t *testing.T) {
@@ -25,27 +26,27 @@ func TestMessages_Sort(t *testing.T) {
 
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
-		testOrigin("B"),
+		testResource("B"),
 		"B",
 	)
 	secondMsg := NewMessage(
 		NewMessageType(Warning, "A1", "Template: %q"),
-		testOrigin("B"),
+		testResource("B"),
 		"B",
 	)
 	thirdMsg := NewMessage(
 		NewMessageType(Warning, "B1", "Template: %q"),
-		testOrigin("A"),
+		testResource("A"),
 		"B",
 	)
 	fourthMsg := NewMessage(
 		NewMessageType(Warning, "B1", "Template: %q"),
-		testOrigin("B"),
+		testResource("B"),
 		"A",
 	)
 	fifthMsg := NewMessage(
 		NewMessageType(Warning, "B1", "Template: %q"),
-		testOrigin("B"),
+		testResource("B"),
 		"B",
 	)
 
@@ -72,7 +73,7 @@ func TestMessages_SortWithNilOrigin(t *testing.T) {
 	)
 	thirdMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
-		testOrigin("B"),
+		testResource("B"),
 		"B",
 	)
 
@@ -89,18 +90,18 @@ func TestMessages_SortedCopy(t *testing.T) {
 
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
-		testOrigin("B"),
+		testResource("B"),
 		"B",
 	)
 	secondMsg := NewMessage(
 		NewMessageType(Warning, "A1", "Template: %q"),
-		testOrigin("B"),
+		testResource("B"),
 		"B",
 	)
 	// Oops, we have a duplicate (identical to firstMsg) - it should be removed.
 	thirdMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
-		testOrigin("B"),
+		testResource("B"),
 		"B",
 	)
 
@@ -110,4 +111,13 @@ func TestMessages_SortedCopy(t *testing.T) {
 	newMsgs := msgs.SortedDedupedCopy()
 
 	g.Expect(newMsgs).To(Equal(expectedMsgs))
+}
+
+func testResource(name string) *resource.Instance {
+	return &resource.Instance{
+		Metadata: resource.Metadata{
+			FullName: resource.NewShortOrFullName("default", name),
+		},
+		Origin: testOrigin(name),
+	}
 }

--- a/galley/pkg/config/analysis/msg/generate.main.go
+++ b/galley/pkg/config/analysis/msg/generate.main.go
@@ -147,21 +147,13 @@ func All() []*diag.MessageType {
 func New{{.Name}}(r *resource.Instance{{range .Args}}, {{.Name}} {{.Type}}{{end}}) diag.Message {
 	return diag.NewMessage(
 		{{.Name}},
-		originOrNil(r),
+		r,
 		{{- range .Args}}
 			{{.Name}},
 		{{- end}}
 	)
 }
 {{end}}
-
-func originOrNil(r *resource.Instance) resource.Origin {
-	var o resource.Origin
-	if r != nil {
-		o = r.Origin
-	}
-	return o
-}
 `
 
 func generate(m *messages) (string, error) {

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -120,7 +120,7 @@ func All() []*diag.MessageType {
 func NewInternalError(r *resource.Instance, detail string) diag.Message {
 	return diag.NewMessage(
 		InternalError,
-		originOrNil(r),
+		r,
 		detail,
 	)
 }
@@ -129,7 +129,7 @@ func NewInternalError(r *resource.Instance, detail string) diag.Message {
 func NewDeprecated(r *resource.Instance, detail string) diag.Message {
 	return diag.NewMessage(
 		Deprecated,
-		originOrNil(r),
+		r,
 		detail,
 	)
 }
@@ -138,7 +138,7 @@ func NewDeprecated(r *resource.Instance, detail string) diag.Message {
 func NewReferencedResourceNotFound(r *resource.Instance, reftype string, refval string) diag.Message {
 	return diag.NewMessage(
 		ReferencedResourceNotFound,
-		originOrNil(r),
+		r,
 		reftype,
 		refval,
 	)
@@ -148,7 +148,7 @@ func NewReferencedResourceNotFound(r *resource.Instance, reftype string, refval 
 func NewNamespaceNotInjected(r *resource.Instance, namespace string, namespace2 string) diag.Message {
 	return diag.NewMessage(
 		NamespaceNotInjected,
-		originOrNil(r),
+		r,
 		namespace,
 		namespace2,
 	)
@@ -158,7 +158,7 @@ func NewNamespaceNotInjected(r *resource.Instance, namespace string, namespace2 
 func NewPodMissingProxy(r *resource.Instance) diag.Message {
 	return diag.NewMessage(
 		PodMissingProxy,
-		originOrNil(r),
+		r,
 	)
 }
 
@@ -166,7 +166,7 @@ func NewPodMissingProxy(r *resource.Instance) diag.Message {
 func NewGatewayPortNotOnWorkload(r *resource.Instance, selector string, port int) diag.Message {
 	return diag.NewMessage(
 		GatewayPortNotOnWorkload,
-		originOrNil(r),
+		r,
 		selector,
 		port,
 	)
@@ -176,7 +176,7 @@ func NewGatewayPortNotOnWorkload(r *resource.Instance, selector string, port int
 func NewIstioProxyVersionMismatch(r *resource.Instance, proxyVersion string, injectionVersion string) diag.Message {
 	return diag.NewMessage(
 		IstioProxyVersionMismatch,
-		originOrNil(r),
+		r,
 		proxyVersion,
 		injectionVersion,
 	)
@@ -186,7 +186,7 @@ func NewIstioProxyVersionMismatch(r *resource.Instance, proxyVersion string, inj
 func NewSchemaValidationError(r *resource.Instance, err error) diag.Message {
 	return diag.NewMessage(
 		SchemaValidationError,
-		originOrNil(r),
+		r,
 		err,
 	)
 }
@@ -195,7 +195,7 @@ func NewSchemaValidationError(r *resource.Instance, err error) diag.Message {
 func NewMisplacedAnnotation(r *resource.Instance, annotation string, kind string) diag.Message {
 	return diag.NewMessage(
 		MisplacedAnnotation,
-		originOrNil(r),
+		r,
 		annotation,
 		kind,
 	)
@@ -205,7 +205,7 @@ func NewMisplacedAnnotation(r *resource.Instance, annotation string, kind string
 func NewUnknownAnnotation(r *resource.Instance, annotation string) diag.Message {
 	return diag.NewMessage(
 		UnknownAnnotation,
-		originOrNil(r),
+		r,
 		annotation,
 	)
 }
@@ -214,7 +214,7 @@ func NewUnknownAnnotation(r *resource.Instance, annotation string) diag.Message 
 func NewConflictingMeshGatewayVirtualServiceHosts(r *resource.Instance, virtualServices string, host string) diag.Message {
 	return diag.NewMessage(
 		ConflictingMeshGatewayVirtualServiceHosts,
-		originOrNil(r),
+		r,
 		virtualServices,
 		host,
 	)
@@ -224,7 +224,7 @@ func NewConflictingMeshGatewayVirtualServiceHosts(r *resource.Instance, virtualS
 func NewConflictingSidecarWorkloadSelectors(r *resource.Instance, conflictingSidecars []string, namespace string, workloadPod string) diag.Message {
 	return diag.NewMessage(
 		ConflictingSidecarWorkloadSelectors,
-		originOrNil(r),
+		r,
 		conflictingSidecars,
 		namespace,
 		workloadPod,
@@ -235,7 +235,7 @@ func NewConflictingSidecarWorkloadSelectors(r *resource.Instance, conflictingSid
 func NewMultipleSidecarsWithoutWorkloadSelectors(r *resource.Instance, conflictingSidecars []string, namespace string) diag.Message {
 	return diag.NewMessage(
 		MultipleSidecarsWithoutWorkloadSelectors,
-		originOrNil(r),
+		r,
 		conflictingSidecars,
 		namespace,
 	)
@@ -245,7 +245,7 @@ func NewMultipleSidecarsWithoutWorkloadSelectors(r *resource.Instance, conflicti
 func NewVirtualServiceDestinationPortSelectorRequired(r *resource.Instance, destHost string, destPorts []int) diag.Message {
 	return diag.NewMessage(
 		VirtualServiceDestinationPortSelectorRequired,
-		originOrNil(r),
+		r,
 		destHost,
 		destPorts,
 	)
@@ -255,7 +255,7 @@ func NewVirtualServiceDestinationPortSelectorRequired(r *resource.Instance, dest
 func NewMTLSPolicyConflict(r *resource.Instance, host string, destinationRuleName string, destinationRuleMTLSMode bool, policyName string, policyMTLSMode string) diag.Message {
 	return diag.NewMessage(
 		MTLSPolicyConflict,
-		originOrNil(r),
+		r,
 		host,
 		destinationRuleName,
 		destinationRuleMTLSMode,
@@ -268,7 +268,7 @@ func NewMTLSPolicyConflict(r *resource.Instance, host string, destinationRuleNam
 func NewPolicySpecifiesPortNameThatDoesntExist(r *resource.Instance, portName string, host string) diag.Message {
 	return diag.NewMessage(
 		PolicySpecifiesPortNameThatDoesntExist,
-		originOrNil(r),
+		r,
 		portName,
 		host,
 	)
@@ -278,7 +278,7 @@ func NewPolicySpecifiesPortNameThatDoesntExist(r *resource.Instance, portName st
 func NewDestinationRuleUsesMTLSForWorkloadWithoutSidecar(r *resource.Instance, destinationRuleName string, host string) diag.Message {
 	return diag.NewMessage(
 		DestinationRuleUsesMTLSForWorkloadWithoutSidecar,
-		originOrNil(r),
+		r,
 		destinationRuleName,
 		host,
 	)
@@ -288,7 +288,7 @@ func NewDestinationRuleUsesMTLSForWorkloadWithoutSidecar(r *resource.Instance, d
 func NewDeploymentAssociatedToMultipleServices(r *resource.Instance, deployment string, port int32, services []string) diag.Message {
 	return diag.NewMessage(
 		DeploymentAssociatedToMultipleServices,
-		originOrNil(r),
+		r,
 		deployment,
 		port,
 		services,
@@ -299,7 +299,7 @@ func NewDeploymentAssociatedToMultipleServices(r *resource.Instance, deployment 
 func NewDeploymentRequiresServiceAssociated(r *resource.Instance, deployment string) diag.Message {
 	return diag.NewMessage(
 		DeploymentRequiresServiceAssociated,
-		originOrNil(r),
+		r,
 		deployment,
 	)
 }
@@ -308,17 +308,9 @@ func NewDeploymentRequiresServiceAssociated(r *resource.Instance, deployment str
 func NewPortNameIsNotUnderNamingConvention(r *resource.Instance, portName string, port int, targetPort string) diag.Message {
 	return diag.NewMessage(
 		PortNameIsNotUnderNamingConvention,
-		originOrNil(r),
+		r,
 		portName,
 		port,
 		targetPort,
 	)
-}
-
-func originOrNil(r *resource.Instance) resource.Origin {
-	var o resource.Origin
-	if r != nil {
-		o = r.Origin
-	}
-	return o
 }

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -149,11 +149,12 @@ func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name
 		msgs = ctx.messages
 	} else {
 		for _, m := range ctx.messages {
-			if m.Origin != nil && m.Origin.Namespace() != "" {
-				if _, ok := namespaces[m.Origin.Namespace()]; !ok {
+			if m.Resource != nil && m.Resource.Origin.Namespace() != "" {
+				if _, ok := namespaces[m.Resource.Origin.Namespace()]; !ok {
 					continue
 				}
 			}
+
 			msgs = append(msgs, m)
 		}
 	}

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -135,18 +135,18 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 	// Verify we only reported messages in the AnalysisNamespaces
 	g.Expect(u.messages).To(HaveLen(1))
 	for _, m := range u.messages {
-		g.Expect(m.Origin.Namespace()).To(Equal(resource.Namespace("includedNamespace")))
+		g.Expect(m.Resource.Origin.Namespace()).To(Equal(resource.Namespace("includedNamespace")))
 	}
 }
 
-func TestAnalyzeNamespaceMessageHasNoOrigin(t *testing.T) {
+func TestAnalyzeNamespaceMessageHasNoResource(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	u := &updaterMock{}
 	a := &analyzerMock{
 		collectionToAccess: basicmeta.K8SCollection1.Name(),
 		resourcesToReport: []*resource.Instance{
-			{},
+			nil,
 		},
 	}
 	d := NewInMemoryDistributor()
@@ -209,20 +209,22 @@ func TestAnalyzeSortsMessages(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	u := &updaterMock{}
-	o1 := &rt.Origin{
-		Collection: basicmeta.K8SCollection1.Name(),
-		FullName:   resource.NewFullName("includedNamespace", "r2"),
+	r1 := &resource.Instance{
+		Origin: &rt.Origin{
+			Collection: basicmeta.K8SCollection1.Name(),
+			FullName:   resource.NewFullName("includedNamespace", "r2"),
+		},
 	}
-	o2 := &rt.Origin{
-		Collection: basicmeta.K8SCollection1.Name(),
-		FullName:   resource.NewFullName("includedNamespace", "r1"),
+	r2 := &resource.Instance{
+		Origin: &rt.Origin{
+			Collection: basicmeta.K8SCollection1.Name(),
+			FullName:   resource.NewFullName("includedNamespace", "r1"),
+		},
 	}
+
 	a := &analyzerMock{
 		collectionToAccess: basicmeta.K8SCollection1.Name(),
-		resourcesToReport: []*resource.Instance{
-			{Origin: o1},
-			{Origin: o2},
-		},
+		resourcesToReport:  []*resource.Instance{r1, r2},
 	}
 	d := NewInMemoryDistributor()
 
@@ -243,8 +245,8 @@ func TestAnalyzeSortsMessages(t *testing.T) {
 
 	g.Eventually(func() []*Snapshot { return a.analyzeCalls }).Should(ConsistOf(sDefault))
 	g.Expect(u.messages).To(HaveLen(2))
-	g.Expect(u.messages[0].Origin).To(Equal(o2))
-	g.Expect(u.messages[1].Origin).To(Equal(o1))
+	g.Expect(u.messages[0].Resource).To(Equal(r2))
+	g.Expect(u.messages[1].Resource).To(Equal(r1))
 }
 
 func getTestSnapshot(schemas ...collection.Schema) *Snapshot {

--- a/galley/pkg/config/source/kube/apiserver/status/controller.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller.go
@@ -118,13 +118,19 @@ func (c *ControllerImpl) Report(messages diag.Messages) {
 
 	for _, m := range messages {
 
-		if m.Origin == nil {
+		if m.Resource == nil {
+			// This should not happen. All messages should be reported against at least one resource.
+			scope.Source.Errorf("Encountered a diagnostic message without a resource: %v", m)
+			continue
+		}
+
+		if m.Resource.Origin == nil {
 			// This should not happen. All messages should be reported against at least one origin.
 			scope.Source.Errorf("Encountered a diagnostic message without an origin: %v", m)
 			continue
 		}
 
-		origin, ok := m.Origin.(*rt.Origin)
+		origin, ok := m.Resource.Origin.(*rt.Origin)
 		if !ok {
 			// This should not happen. All messages should be routed back to the appropriate source.
 			scope.Source.Errorf("Encountered a diagnostic message with unrecognized origin: %v", m)

--- a/galley/pkg/config/source/kube/apiserver/status/controller_test.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller_test.go
@@ -391,7 +391,7 @@ func expectedMessage(m diag.Message) *diag.Message {
 	return &diag.Message{
 		Type:       m.Type,
 		Parameters: m.Parameters,
-		Origin:     m.Origin,
+		Resource:   m.Resource,
 		DocRef:     DocRef,
 	}
 }

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -329,8 +329,8 @@ func colorSuffix() string {
 
 func renderMessage(m diag.Message) string {
 	origin := ""
-	if m.Origin != nil {
-		origin = " (" + m.Origin.FriendlyName() + ")"
+	if m.Resource != nil {
+		origin = " (" + m.Resource.Origin.FriendlyName() + ")"
 	}
 	return fmt.Sprintf(
 		"%s%v%s [%v]%s %s", colorPrefix(m), m.Type.Level(), colorSuffix(), m.Type.Code(), origin, fmt.Sprintf(m.Type.Template(), m.Parameters...))


### PR DESCRIPTION
Including resource in each message allows for aggregation/filtering based on
metadata associated on the resource. For example, this enables
skipping/ignoring validation messages based on resource metadata.

This change is purely a refactor and does not introduce any new functionality.

NOTE: Previously, Origin was an optional field on message. Now, Resource is optional, but if resource is present, we assume Origin exists (which makes sense - if we have a concrete resource, it should have an origin, right?). I didn't find anywhere where this constraint is violated, but let me know if you think this assumption is dangerous.