### PR TITLE
Add permissions check for `istioctl analyze`

### DIFF
--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -55,7 +55,7 @@ const (
 	meshConfigMapName = "istio"
 )
 
-// Psuedo-constants, since golang doesn't support a true const slice/array
+// Pseudo-constants, since golang doesn't support a true const slice/array
 var (
 	requiredPerms = []string{"list", "watch"}
 )

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -55,6 +55,11 @@ const (
 	meshConfigMapName = "istio"
 )
 
+// Psuedo-constants, since golang doesn't support a true const slice/array
+var (
+	requiredPerms = []string{"list", "watch"}
+)
+
 // Patch table
 var (
 	apiserverNew = apiserver.New
@@ -310,8 +315,9 @@ func (sa *SourceAnalyzer) disableKubeResourcesWithoutPermissions(client kubernet
 	resultBuilder := collection.NewSchemasBuilder()
 
 	for _, s := range sa.kubeResources.All() {
-		if !s.IsDisabled() && !hasPermissionsOnCollection(client, s, []string{"list", "watch"}) {
-			scope.Analysis.Infof("Skipping resource %q since the user doesn't have required permissions", s.Resource().CanonicalName())
+		if !s.IsDisabled() && !hasPermissionsOnCollection(client, s, requiredPerms) {
+			scope.Analysis.Errorf("Skipping resource %q since the current user doesn't have required permissions %v",
+				s.Resource().CanonicalName(), requiredPerms)
 			s = s.Disable()
 		}
 

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
+	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"istio.io/api/mesh/v1alpha1"
 
@@ -225,16 +227,24 @@ func (sa *SourceAnalyzer) AddReaderKubeSource(readers []io.Reader) error {
 // AddRunningKubeSource adds a source based on a running k8s cluster to the current SourceAnalyzer
 // Also tries to get mesh config from the running cluster, if it can
 func (sa *SourceAnalyzer) AddRunningKubeSource(k kube.Interfaces) {
-	o := apiserver.Options{
-		Client:  k,
-		Schemas: sa.kubeResources,
+	client, err := k.KubeClient()
+	if err != nil {
+		scope.Analysis.Errorf("error getting KubeClient: %v", err)
+		return
 	}
 
-	if err := sa.addRunningKubeMeshConfigSource(k); err != nil {
+	// Since we're using a running k8s source, do a permissions pre-check and disable any resources the current user doesn't have permissions for
+	sa.disableKubeResourcesWithoutPermissions(client)
+
+	// Since we're using a running k8s source, try to get mesh config from the configmap
+	if err := sa.addRunningKubeMeshConfigSource(client); err != nil {
 		scope.Analysis.Errorf("error getting mesh config from running kube source: %v", err)
 	}
 
-	src := apiserverNew(o)
+	src := apiserverNew(apiserver.Options{
+		Client:  k,
+		Schemas: sa.kubeResources,
+	})
 	sa.sources = append(sa.sources, precedenceSourceInput{src: src, cols: sa.kubeResources.CollectionNames()})
 }
 
@@ -276,12 +286,7 @@ func (sa *SourceAnalyzer) AddDefaultResources() error {
 	return sa.AddReaderKubeSource(readers)
 }
 
-func (sa *SourceAnalyzer) addRunningKubeMeshConfigSource(k kube.Interfaces) error {
-	client, err := k.KubeClient()
-	if err != nil {
-		return fmt.Errorf("error getting KubeClient: %v", err)
-	}
-
+func (sa *SourceAnalyzer) addRunningKubeMeshConfigSource(client kubernetes.Interface) error {
 	meshConfigMap, err := client.CoreV1().ConfigMaps(string(sa.istioNamespace)).Get(meshConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("could not read configmap %q from namespace %q: %v", meshConfigMapName, sa.istioNamespace, err)
@@ -299,4 +304,47 @@ func (sa *SourceAnalyzer) addRunningKubeMeshConfigSource(k kube.Interfaces) erro
 
 	sa.meshCfg = cfg
 	return nil
+}
+
+func (sa *SourceAnalyzer) disableKubeResourcesWithoutPermissions(client kubernetes.Interface) {
+	resultBuilder := collection.NewSchemasBuilder()
+
+	for _, s := range sa.kubeResources.All() {
+		if !hasPermissionsOnCollection(client, s, []string{"list", "watch"}) {
+			scope.Analysis.Infof("Skipping resource %q since the user doesn't have required permissions", s.Resource().CanonicalName())
+			s = s.Disable()
+		}
+
+		// The possible error here is if the collection is already in the list.
+		// Since we are making a clone of the list with modified elements,
+		// we can be sure this won't happen and safely ignore the returned error.
+		_ = resultBuilder.Add(s)
+	}
+
+	sa.kubeResources = resultBuilder.Build()
+}
+
+func hasPermissionsOnCollection(client kubernetes.Interface, s collection.Schema, verbs []string) bool {
+	for _, verb := range verbs {
+		sar := &v1.SelfSubjectAccessReview{
+			Spec: v1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &v1.ResourceAttributes{
+					Verb:     verb,
+					Group:    s.Resource().Group(),
+					Resource: s.Resource().CanonicalName(),
+				},
+			},
+		}
+
+		response, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(sar)
+		if err != nil {
+			scope.Analysis.Errorf("error creating SelfSubjectAccessReview for %q: %v", s.Resource().CanonicalName(), err)
+			return false
+		}
+
+		if !response.Status.Allowed {
+			return false
+		}
+	}
+	return true
 }

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
-	v1 "k8s.io/api/authorization/v1"
+	authorizationapi "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -326,9 +326,9 @@ func (sa *SourceAnalyzer) disableKubeResourcesWithoutPermissions(client kubernet
 
 func hasPermissionsOnCollection(client kubernetes.Interface, s collection.Schema, verbs []string) bool {
 	for _, verb := range verbs {
-		sar := &v1.SelfSubjectAccessReview{
-			Spec: v1.SelfSubjectAccessReviewSpec{
-				ResourceAttributes: &v1.ResourceAttributes{
+		sar := &authorizationapi.SelfSubjectAccessReview{
+			Spec: authorizationapi.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationapi.ResourceAttributes{
 					Verb:     verb,
 					Group:    s.Resource().Group(),
 					Resource: s.Resource().CanonicalName(),

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -310,7 +310,7 @@ func (sa *SourceAnalyzer) disableKubeResourcesWithoutPermissions(client kubernet
 	resultBuilder := collection.NewSchemasBuilder()
 
 	for _, s := range sa.kubeResources.All() {
-		if !hasPermissionsOnCollection(client, s, []string{"list", "watch"}) {
+		if !s.IsDisabled() && !hasPermissionsOnCollection(client, s, []string{"list", "watch"}) {
 			scope.Analysis.Infof("Skipping resource %q since the user doesn't have required permissions", s.Resource().CanonicalName())
 			s = s.Disable()
 		}

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	authorizationapi "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -271,6 +272,35 @@ func TestResourceFiltering(t *testing.T) {
 			g.Expect(r.IsDisabled()).To(BeTrue(), fmt.Sprintf("%s should be disabled", r.Name()))
 		}
 	}
+}
+
+func TestRemoveResourcesWithoutPermission(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	usedCollection := k8smeta.K8SCoreV1Services
+	a := &testAnalyzer{
+		fn:     func(_ analysis.Context) {},
+		inputs: []collection.Name{usedCollection.Name()},
+	}
+
+	// Set up the mock so that when we query if the user has permission to list the collection, the answer is no.
+	mk := mock.NewKube()
+	mkClient, _ := mk.KubeClient()
+	mkSelfSubjectAccessReviews, _ := mkClient.AuthorizationV1().SelfSubjectAccessReviews().(*mock.SelfSubjectAccessReviewImpl)
+	mkSelfSubjectAccessReviews.DisallowResourceAttributes(&authorizationapi.ResourceAttributes{
+		Verb:     "list",
+		Group:    usedCollection.Resource().Group(),
+		Resource: usedCollection.Resource().CanonicalName(),
+	})
+
+	sa := NewSourceAnalyzer(schema.MustGet(), analysis.Combine("a", a), "", "", nil, true, timeout)
+	sa.AddRunningKubeSource(mk)
+
+	// Since this collection is used by an analyzer and service discovery is on, it would normally not be disabled...
+	// but since we fail the permissions pre-check, it should be disabled anyway.
+	actualCollection, found := sa.kubeResources.Find(usedCollection.Name().String())
+	g.Expect(found).To(BeTrue())
+	g.Expect(actualCollection.IsDisabled()).To(BeTrue(), fmt.Sprintf("%s should be disabled", actualCollection.Name()))
 }
 
 func tempFileFromString(t *testing.T, content string) *os.File {

--- a/galley/pkg/testing/mock/authorizationv1.go
+++ b/galley/pkg/testing/mock/authorizationv1.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	"k8s.io/client-go/rest"
+)
+
+type authorizationv1Impl struct {
+	selfSubjectAccessReviews authorizationv1.SelfSubjectAccessReviewInterface
+}
+
+var _ authorizationv1.AuthorizationV1Interface = &authorizationv1Impl{}
+
+func (a *authorizationv1Impl) RESTClient() rest.Interface {
+	panic("not implemented")
+}
+
+func (a *authorizationv1Impl) LocalSubjectAccessReviews(namespace string) authorizationv1.LocalSubjectAccessReviewInterface {
+	panic("not implemented")
+}
+
+func (a *authorizationv1Impl) SelfSubjectAccessReviews() authorizationv1.SelfSubjectAccessReviewInterface {
+	return a.selfSubjectAccessReviews
+}
+
+func (a *authorizationv1Impl) SelfSubjectRulesReviews() authorizationv1.SelfSubjectRulesReviewInterface {
+	panic("not implemented")
+}
+
+func (a *authorizationv1Impl) SubjectAccessReviews() authorizationv1.SubjectAccessReviewInterface {
+	panic("not implemented")
+}

--- a/galley/pkg/testing/mock/kube_interface.go
+++ b/galley/pkg/testing/mock/kube_interface.go
@@ -62,9 +62,10 @@ import (
 var _ kubernetes.Interface = &kubeInterface{}
 
 type kubeInterface struct {
-	core       corev1.CoreV1Interface
-	extensions extensionsv1beta1.ExtensionsV1beta1Interface
-	appsv1     appsv1.AppsV1Interface
+	core            corev1.CoreV1Interface
+	extensions      extensionsv1beta1.ExtensionsV1beta1Interface
+	appsv1          appsv1.AppsV1Interface
+	authorizationv1 authorizationv1.AuthorizationV1Interface
 }
 
 // newKubeInterface returns a lightweight fake that implements kubernetes.Interface. Only implements a portion of the
@@ -88,6 +89,10 @@ func newKubeInterface() kubernetes.Interface {
 
 		appsv1: &appsv1Impl{
 			apps: newAppsInterface(),
+		},
+
+		authorizationv1: &authorizationv1Impl{
+			selfSubjectAccessReviews: newSelfSubjectAccessReviewInterface(),
 		},
 	}
 }
@@ -149,7 +154,7 @@ func (c *kubeInterface) AuthenticationV1beta1() authenticationv1beta1.Authentica
 }
 
 func (c *kubeInterface) AuthorizationV1() authorizationv1.AuthorizationV1Interface {
-	panic("not implemented")
+	return c.authorizationv1
 }
 
 func (c *kubeInterface) AuthorizationV1beta1() authorizationv1beta1.AuthorizationV1beta1Interface {

--- a/galley/pkg/testing/mock/selfsubjectaccessreviews.go
+++ b/galley/pkg/testing/mock/selfsubjectaccessreviews.go
@@ -1,0 +1,75 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+
+	authorizationapi "k8s.io/api/authorization/v1"
+	v1 "k8s.io/api/authorization/v1"
+	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+)
+
+var _ authorizationv1.SelfSubjectAccessReviewInterface = &SelfSubjectAccessReviewImpl{}
+
+// SelfSubjectAccessReviewImpl is a mock implementation of SelfSubjectAccessReviewInterface
+// Exported so that helpers can be used to set expected mock behavior
+type SelfSubjectAccessReviewImpl struct {
+	disallowed map[disallowKey]bool
+}
+
+// The subset of SelfSubjectAccessReview.Spec.ResourceAttributes we want to match on for controlling mock allow/disallow behavior
+type disallowKey struct {
+	verb     string
+	group    string
+	resource string
+}
+
+func newSelfSubjectAccessReviewInterface() authorizationv1.SelfSubjectAccessReviewInterface {
+	return &SelfSubjectAccessReviewImpl{
+		disallowed: make(map[disallowKey]bool),
+	}
+}
+
+// Create implements authorizationv1.SelfSubjectAccessReviewInterface
+func (i *SelfSubjectAccessReviewImpl) Create(sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
+	allowed := true
+	if i.disallowed[newDisallowKey(sar.Spec.ResourceAttributes)] {
+		allowed = false
+	}
+
+	result = sar.DeepCopy()
+	result.Status = authorizationapi.SubjectAccessReviewStatus{Allowed: allowed}
+	return result, nil
+}
+
+// CreateContext implements authorizationv1.SelfSubjectAccessReviewInterface
+func (i *SelfSubjectAccessReviewImpl) CreateContext(ctx context.Context, sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
+	panic("not implemented")
+
+}
+
+// DisallowResourceAttributes is a helper for testing that marks particular resource attributes as not allowed in the mock.
+func (i *SelfSubjectAccessReviewImpl) DisallowResourceAttributes(r *v1.ResourceAttributes) {
+	i.disallowed[newDisallowKey(r)] = true
+}
+
+func newDisallowKey(r *v1.ResourceAttributes) disallowKey {
+	return disallowKey{
+		verb:     r.Verb,
+		group:    r.Group,
+		resource: r.Resource,
+	}
+}

--- a/galley/pkg/testing/mock/selfsubjectaccessreviews.go
+++ b/galley/pkg/testing/mock/selfsubjectaccessreviews.go
@@ -56,9 +56,10 @@ func (i *SelfSubjectAccessReviewImpl) Create(sar *authorizationapi.SelfSubjectAc
 }
 
 // CreateContext implements authorizationv1.SelfSubjectAccessReviewInterface
-func (i *SelfSubjectAccessReviewImpl) CreateContext(ctx context.Context, sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
-	panic("not implemented")
+func (i *SelfSubjectAccessReviewImpl) CreateContext(ctx context.Context,
+	sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
 
+	panic("not implemented")
 }
 
 // DisallowResourceAttributes is a helper for testing that marks particular resource attributes as not allowed in the mock.


### PR DESCRIPTION
Adds a permissions pre-check to `istioctl analyze`. If the user doesn't have permissions on any resource, it will be treated as disabled and any analyzers that depend on it will be skipped over. An error-level log message is also printed. 

See https://github.com/istio/istio/issues/18177 and https://github.com/istio/istio/pull/19890 for further context.