### PR TITLE
Remove legacy searching endpoints in other namesapces

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -532,7 +532,6 @@ func (c *Controller) InstancesByPort(svc *model.Service, reqSvcPort int,
 // GetProxyServiceInstances returns service instances co-located with a given proxy
 func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.ServiceInstance, error) {
 	out := make([]*model.ServiceInstance, 0)
-	proxyNamespace := ""
 	if len(proxy.IPAddresses) > 0 {
 		// only need to fetch the corresponding pod through the first IP, although there are multiple IP scenarios,
 		// because multiple ips belong to the same pod
@@ -546,10 +545,8 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.Serv
 			if proxy.Metadata.Network != c.endpointNetwork(proxyIP) {
 				return out, nil
 			}
-
-			proxyNamespace = pod.Namespace
-			// 1. find proxy service by label selector, if not any, there may exist headless service
-			// failover to 3
+			// 1. find proxy service by label selector, if not any, there may exist headless service without selector
+			// failover to 1.1
 			svcLister := listerv1.NewServiceLister(c.services.GetIndexer())
 			if services, err := svcLister.GetPodServices(pod); err == nil && len(services) > 0 {
 				for _, svc := range services {
@@ -558,6 +555,8 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.Serv
 				return out, nil
 			}
 
+			// 1.1. Headless service without selector
+			out = c.endpoints.GetProxyServiceInstances(c, proxy)
 		}
 
 		// 2. The pod is not present when this is called
@@ -569,9 +568,6 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.Serv
 		if err == nil {
 			return instances, nil
 		}
-
-		// 3. Headless service
-		out = c.endpoints.GetProxyServiceInstances(c, proxy, proxyNamespace)
 	}
 
 	if len(out) == 0 {

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -483,13 +483,13 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			svcNode.IPAddresses = []string{"128.0.0.1"}
 			svcNode.ID = "pod1.nsa"
 			svcNode.DNSDomain = "nsa.svc.cluster.local"
-			svcNode.Metadata = &model.NodeMetadata{}
+			svcNode.Metadata = &model.NodeMetadata{Namespace: "nsa"}
 			services, err := controller.GetProxyServiceInstances(&svcNode)
 			if err != nil {
 				t.Fatalf("client encountered error during GetProxyServiceInstances(): %v", err)
 			}
 
-			if len(services) != fakeSvcCounts+1 {
+			if len(services) != 1 {
 				t.Fatalf("GetProxyServiceInstances() returned wrong # of endpoints => %d, want %d", len(services), fakeSvcCounts+1)
 			}
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -20,7 +20,6 @@ import (
 	discoveryv1alpha1 "k8s.io/api/discovery/v1alpha1"
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
-	listerv1 "k8s.io/client-go/listers/core/v1"
 	discoverylister "k8s.io/client-go/listers/discovery/v1alpha1"
 	"k8s.io/client-go/tools/cache"
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

Cleanup the legacy endpoints in other namespaces, which is impossible. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
