### PR TITLE
Stop using deprecated fields in virtualservice

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -750,7 +750,6 @@ func convertTLSMatchToL4Match(tlsMatch *networking.TLSMatchAttributes) *networki
 	return &networking.L4MatchAttributes{
 		DestinationSubnets: tlsMatch.DestinationSubnets,
 		Port:               tlsMatch.Port,
-		SourceSubnet:       tlsMatch.SourceSubnet,
 		SourceLabels:       tlsMatch.SourceLabels,
 		Gateways:           tlsMatch.Gateways,
 	}

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -414,20 +414,15 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 
 		requestHeadersToAdd := translateAppendHeaders(in.Headers.GetRequest().GetSet(), false)
 		requestHeadersToAdd = append(requestHeadersToAdd, translateAppendHeaders(in.Headers.GetRequest().GetAdd(), true)...)
-		requestHeadersToAdd = append(requestHeadersToAdd, translateAppendHeaders(in.AppendRequestHeaders, true)...)
-		requestHeadersToAdd = append(requestHeadersToAdd, translateAppendHeaders(in.AppendHeaders, true)...)
 		out.RequestHeadersToAdd = requestHeadersToAdd
 		responseHeadersToAdd := translateAppendHeaders(in.Headers.GetResponse().GetSet(), false)
 		responseHeadersToAdd = append(responseHeadersToAdd, translateAppendHeaders(in.Headers.GetResponse().GetAdd(), true)...)
-		responseHeadersToAdd = append(responseHeadersToAdd, translateAppendHeaders(in.AppendResponseHeaders, true)...)
 		out.ResponseHeadersToAdd = responseHeadersToAdd
 		requestHeadersToRemove := make([]string, 0)
 		requestHeadersToRemove = append(requestHeadersToRemove, in.Headers.GetRequest().GetRemove()...)
-		requestHeadersToRemove = append(requestHeadersToRemove, in.RemoveRequestHeaders...)
 		out.RequestHeadersToRemove = requestHeadersToRemove
 		responseHeadersToRemove := make([]string, 0)
 		responseHeadersToRemove = append(responseHeadersToRemove, in.Headers.GetResponse().GetRemove()...)
-		responseHeadersToRemove = append(responseHeadersToRemove, in.RemoveResponseHeaders...)
 		out.ResponseHeadersToRemove = responseHeadersToRemove
 
 		if in.Mirror != nil {
@@ -823,8 +818,6 @@ func translateFault(in *networking.HTTPFaultInjection) *xdshttpfault.HTTPFault {
 		out.Abort = &xdshttpfault.FaultAbort{}
 		if in.Abort.Percentage != nil {
 			out.Abort.Percentage = translatePercentToFractionalPercent(in.Abort.Percentage)
-		} else {
-			out.Abort.Percentage = translateIntegerToFractionalPercent(in.Abort.Percent)
 		}
 		switch a := in.Abort.ErrorType.(type) {
 		case *networking.HTTPFaultInjection_Abort_HttpStatus:

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2107,24 +2107,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 			Route: []*networking.HTTPRouteDestination{{
 				Destination: &networking.Destination{Host: "foo.baz"},
 			}},
-			AppendRequestHeaders: map[string]string{
-				"name": "",
-			},
-			AppendResponseHeaders: map[string]string{
-				"name": "",
-			},
 		}, valid: true},
-		{name: "empty request response headers", route: &networking.HTTPRoute{
-			Route: []*networking.HTTPRouteDestination{{
-				Destination: &networking.Destination{Host: "foo.baz"},
-			}},
-			AppendRequestHeaders: map[string]string{
-				"": "value",
-			},
-			AppendResponseHeaders: map[string]string{
-				"": "value",
-			},
-		}, valid: false},
 		{name: "valid headers", route: &networking.HTTPRoute{
 			Route: []*networking.HTTPRouteDestination{{
 				Destination: &networking.Destination{Host: "foo.baz"},
@@ -2472,7 +2455,6 @@ func TestValidateVirtualService(t *testing.T) {
 				Route: []*networking.HTTPRouteDestination{{
 					Destination: &networking.Destination{Host: "foo.baz"},
 				}},
-				RemoveResponseHeaders: []string{"unwantedHeader", "secretStuff"},
 			}},
 		}, valid: true},
 		{name: "missing tcp route", in: &networking.VirtualService{

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1656,7 +1656,9 @@ func TestValidateHTTPFaultInjectionAbort(t *testing.T) {
 	}{
 		{name: "nil", in: nil, valid: true},
 		{name: "valid", in: &networking.HTTPFaultInjection_Abort{
-			Percent: 20,
+			Percentage: &networking.Percent{
+				Value: 20,
+			},
 			ErrorType: &networking.HTTPFaultInjection_Abort_HttpStatus{
 				HttpStatus: 200,
 			},
@@ -1666,20 +1668,18 @@ func TestValidateHTTPFaultInjectionAbort(t *testing.T) {
 				HttpStatus: 200,
 			},
 		}, valid: true},
-		{name: "invalid percent", in: &networking.HTTPFaultInjection_Abort{
-			Percent: -1,
-			ErrorType: &networking.HTTPFaultInjection_Abort_HttpStatus{
-				HttpStatus: 200,
-			},
-		}, valid: false},
 		{name: "invalid http status", in: &networking.HTTPFaultInjection_Abort{
-			Percent: 20,
+			Percentage: &networking.Percent{
+				Value: 20,
+			},
 			ErrorType: &networking.HTTPFaultInjection_Abort_HttpStatus{
 				HttpStatus: 9000,
 			},
 		}, valid: false},
 		{name: "invalid low http status", in: &networking.HTTPFaultInjection_Abort{
-			Percent: 20,
+			Percentage: &networking.Percent{
+				Value: 20,
+			},
 			ErrorType: &networking.HTTPFaultInjection_Abort_HttpStatus{
 				HttpStatus: 100,
 			},
@@ -1720,7 +1720,9 @@ func TestValidateHTTPFaultInjectionDelay(t *testing.T) {
 	}{
 		{name: "nil", in: nil, valid: true},
 		{name: "valid fixed", in: &networking.HTTPFaultInjection_Delay{
-			Percent: 20,
+			Percentage: &networking.Percent{
+				Value: 20,
+			},
 			HttpDelayType: &networking.HTTPFaultInjection_Delay_FixedDelay{
 				FixedDelay: &types.Duration{Seconds: 3},
 			},
@@ -1731,13 +1733,17 @@ func TestValidateHTTPFaultInjectionDelay(t *testing.T) {
 			},
 		}, valid: true},
 		{name: "invalid percent", in: &networking.HTTPFaultInjection_Delay{
-			Percent: 101,
+			Percentage: &networking.Percent{
+				Value: 101,
+			},
 			HttpDelayType: &networking.HTTPFaultInjection_Delay_FixedDelay{
 				FixedDelay: &types.Duration{Seconds: 3},
 			},
 		}, valid: false},
 		{name: "invalid delay", in: &networking.HTTPFaultInjection_Delay{
-			Percent: 20,
+			Percentage: &networking.Percent{
+				Value: 20,
+			},
 			HttpDelayType: &networking.HTTPFaultInjection_Delay_FixedDelay{
 				FixedDelay: &types.Duration{Seconds: 3, Nanos: 42},
 			},

--- a/samples/bookinfo/networking/fault-injection-details-v1.yaml
+++ b/samples/bookinfo/networking/fault-injection-details-v1.yaml
@@ -9,7 +9,8 @@ spec:
   - fault:
       abort:
         httpStatus: 555
-        percent: 100
+        percentage:
+          value: 100
     route:
     - destination:
         host: details

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-default-route-append-headers.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-default-route-append-headers.yaml
@@ -38,28 +38,23 @@ spec:
           host: c
           subset: v2
         weight: 25
-      appendHeaders: #deprecated
-        istio-custom-header: user-defined-value
-      appendRequestHeaders: #deprecated
-        istio-custom-req-header: user-defined-value
-      removeRequestHeaders: #deprecated
-      - istio-custom-req-header-remove
-      appendResponseHeaders: #deprecated
-        istio-custom-resp-header: user-defined-value
-      removeResponseHeaders: #deprecated
-      - istio-custom-resp-header-remove
       headers:
         request:
-          add: 
+          add:
             req-append: added-in-request
+            istio-custom-header: user-defined-value
+            istio-custom-req-header: user-defined-value
           set: 
             req-replace: new-value
           remove: 
             - req-remove
+            - istio-custom-req-header-remove
         response:
           add:
             res-append: added-in-response
+            istio-custom-resp-header: user-defined-value
           set:
             res-replace: new-value
           remove:
             - res-remove
+            - istio-custom-resp-header-remove

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-route-via-egressgateway.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-route-via-egressgateway.yaml
@@ -35,8 +35,10 @@ spec:
           port:
             number: 80
         weight: 100
-      appendHeaders:
-        handled-by-egress-gateway: "true"
+      headers:
+        request:
+          add:
+            handled-by-egress-gateway: "true"
   tls:
     - match:
       - gateways:

--- a/tests/e2e/tests/pilot/testdata/rbac/v1alpha1/istio-egressgateway.yaml
+++ b/tests/e2e/tests/pilot/testdata/rbac/v1alpha1/istio-egressgateway.yaml
@@ -58,8 +58,10 @@ spec:
             port:
               number: 80
           weight: 100
-      appendHeaders:
-        handled-by-egress-gateway: "true"
+      headers:
+        request:
+          add:
+            handled-by-egress-gateway: "true"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry

--- a/tests/testdata/config/rule-default-route-append-headers.yaml
+++ b/tests/testdata/config/rule-default-route-append-headers.yaml
@@ -28,5 +28,7 @@ spec:
     - route:
       - destination:
           host: appendh.test.istio.io
-      appendHeaders:
-        istio-custom-header: user-defined-value
+      headers:
+        request:
+          add:
+            istio-custom-header: user-defined-value


### PR DESCRIPTION
I do not remove it from analysis, maybe keep it until they are removed from api.
