### PR TITLE
Fix a group of mixer attributes generated from k8s when pod name contains dot

### DIFF
--- a/mixer/adapter/kubernetesenv/kubernetesenv.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv.go
@@ -266,16 +266,15 @@ func (h *handler) findPod(uid string) (cacheController, *v1.Pod, bool) {
 	return c, pod, found
 }
 
+//The name of workload may contain '.'
 func keyFromUID(uid string) string {
 	if ip := net.ParseIP(uid); ip != nil {
 		return uid
 	}
 	fullname := strings.TrimPrefix(uid, kubePrefix)
-	if strings.Contains(fullname, ".") {
-		parts := strings.Split(fullname, ".")
-		if len(parts) == 2 {
-			return key(parts[1], parts[0])
-		}
+	dotPos := strings.LastIndex(fullname, ".")
+	if dotPos != -1 {
+		return key(fullname[dotPos+1:], fullname[:dotPos])
 	}
 	return fullname
 }

--- a/mixer/adapter/kubernetesenv/kubernetesenv_test.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv_test.go
@@ -419,6 +419,27 @@ func TestKubegen_Generate(t *testing.T) {
 	ipToDeploymentConfigOut.SetDestinationWorkloadNamespace("testns")
 	ipToDeploymentConfigOut.SetDestinationWorkloadUid("istio://testns/workloads/test-deploymentconfig")
 
+	podNameWithDotIn := &kubernetes_apa_tmpl.Instance{
+		SourceUid:      "pod-with-dot.in-name.testns",
+		DestinationUid: "alt-pod-with-dot.in-name.testns",
+	}
+
+	podNameWithDotOut := kubernetes_apa_tmpl.NewOutput()
+	podNameWithDotOut.SetSourcePodName("pod-with-dot.in-name")
+	podNameWithDotOut.SetSourceNamespace("testns")
+	podNameWithDotOut.SetSourcePodUid("kubernetes://pod-with-dot.in-name.testns")
+	podNameWithDotOut.SetSourceLabels(map[string]string{"app": "some-app"})
+	podNameWithDotOut.SetSourceWorkloadName("pod-with-dot.in-name")
+	podNameWithDotOut.SetSourceWorkloadNamespace("testns")
+	podNameWithDotOut.SetSourceWorkloadUid("istio://testns/workloads/pod-with-dot.in-name")
+	podNameWithDotOut.SetDestinationPodName("alt-pod-with-dot.in-name")
+	podNameWithDotOut.SetDestinationNamespace("testns")
+	podNameWithDotOut.SetDestinationPodUid("kubernetes://alt-pod-with-dot.in-name.testns")
+	podNameWithDotOut.SetDestinationLabels(map[string]string{"app": "some-app"})
+	podNameWithDotOut.SetDestinationWorkloadName("alt-pod-with-dot.in-name")
+	podNameWithDotOut.SetDestinationWorkloadNamespace("testns")
+	podNameWithDotOut.SetDestinationWorkloadUid("istio://testns/workloads/alt-pod-with-dot.in-name")
+
 	tests := []struct {
 		name   string
 		inputs *kubernetes_apa_tmpl.Instance
@@ -435,6 +456,7 @@ func TestKubegen_Generate(t *testing.T) {
 		{"not-k8s", notKubernetesIn, kubernetes_apa_tmpl.NewOutput(), conf},
 		{"ip-svc-pod to pod-with-container", containerNameIn, containerNameOut, conf},
 		{"ip-svc-pod to deploymentconfig", ipToDeploymentConfigIn, ipToDeploymentConfigOut, conf},
+		{"pod-with-dot.in-name to alt-pod-with-dot.in-name", podNameWithDotIn, podNameWithDotOut, conf},
 	}
 
 	for _, v := range tests {
@@ -740,6 +762,20 @@ var k8sobjs = []runtime.Object{
 	&v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "no-controller-pod",
+			Namespace: "testns",
+			Labels:    map[string]string{"app": "some-app"},
+		},
+	},
+	&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-with-dot.in-name",
+			Namespace: "testns",
+			Labels:    map[string]string{"app": "some-app"},
+		},
+	},
+	&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alt-pod-with-dot.in-name",
 			Namespace: "testns",
 			Labels:    map[string]string{"app": "some-app"},
 		},


### PR DESCRIPTION
Fix a group of mixer attributes generated from k8s env such as source/destination's name, owner, namespace when dot in pod name