### PR TITLE
istio.io test framework: set default Script.WorkDir to env.IstioSrc

### DIFF
--- a/pkg/test/istioio/script.go
+++ b/pkg/test/istioio/script.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 
+	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/scopes"
 )
@@ -447,7 +448,7 @@ func (s Script) getWorkDir(ctx Context) string {
 		// User-specified work dir for the script.
 		return s.WorkDir
 	}
-	return ctx.WorkDir()
+	return env.IstioSrc
 }
 
 func (s Script) getEnv(ctx Context) []string {

--- a/tests/integration/istioio/examples/bookinfo_test.go
+++ b/tests/integration/istioio/examples/bookinfo_test.go
@@ -17,7 +17,6 @@ package security
 import (
 	"testing"
 
-	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/istioio"
 )
@@ -29,8 +28,7 @@ func TestBookinfo(t *testing.T) {
 		NewTest(t).
 		Run(istioio.NewBuilder("examples__bookinfo").
 			Add(istioio.Script{
-				Input:   istioio.Path("scripts/bookinfo.txt"),
-				WorkDir: env.IstioSrc,
+				Input: istioio.Path("scripts/bookinfo.txt"),
 			}).
 			Defer(istioio.Script{
 				Input: istioio.Inline{
@@ -38,7 +36,6 @@ func TestBookinfo(t *testing.T) {
 					Value: `
 kubectl delete -n default -f samples/bookinfo/platform/kube/bookinfo.yaml || true`,
 				},
-				WorkDir: env.IstioSrc,
 			}).
 			Build())
 }

--- a/tests/integration/istioio/security/authz_http_test.go
+++ b/tests/integration/istioio/security/authz_http_test.go
@@ -17,7 +17,6 @@ package security
 import (
 	"testing"
 
-	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/istioio"
 )
@@ -29,8 +28,7 @@ func TestAuthorizationForHTTPServices(t *testing.T) {
 		NewTest(t).
 		Run(istioio.NewBuilder("tasks__security__authorization_for_http_services").
 			Add(istioio.Script{
-				Input:   istioio.Path("scripts/authz_http.txt"),
-				WorkDir: env.IstioSrc,
+				Input: istioio.Path("scripts/authz_http.txt"),
 			}, istioio.YamlResources{
 				BaseName:      "enforcing_namespace_level_access_control",
 				Input:         istioio.BookInfo("rbac/namespace-policy.yaml"),
@@ -63,6 +61,5 @@ kubectl delete -f samples/bookinfo/platform/kube/bookinfo.yaml || true
 kubectl delete -f samples/bookinfo/networking/bookinfo-gateway.yaml || true
 kubectl delete -f samples/sleep/sleep.yaml || true`,
 				},
-				WorkDir: env.IstioSrc,
 			}).Build())
 }

--- a/tests/integration/istioio/security/mtls_migration_test.go
+++ b/tests/integration/istioio/security/mtls_migration_test.go
@@ -55,8 +55,7 @@ $ kubectl apply -f samples/sleep/sleep.yaml -n legacy
 				istioio.MultiPodWait("bar"),
 				istioio.MultiPodWait("legacy")).
 			Add(istioio.Script{
-				Input:   istioio.Path("scripts/mtls_migration.txt"),
-				WorkDir: env.IstioSrc,
+				Input: istioio.Path("scripts/mtls_migration.txt"),
 			}).
 			// Cleanup.
 			Defer(istioio.Script{


### PR DESCRIPTION
I think this will eliminate a potential source of errors when writing tests. Most istio.io test scripts will want to use files from the `samples/` directory, which is only accessible when you set the `WorkDir` correctly.