### PR TITLE
Allow setting the template file for pilot-agent

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -219,6 +219,7 @@ var (
 
 			// set all flags
 			proxyConfig.CustomConfigFile = customConfigFile
+			proxyConfig.ProxyBootstrapTemplatePath = templateFile
 			proxyConfig.ConfigPath = configPath
 			proxyConfig.BinaryPath = binaryPath
 			proxyConfig.ServiceCluster = serviceCluster


### PR DESCRIPTION
This change is just to allow overriding the bootstrap template file in
pilot-agent.

This will NOT impact existing code paths, this is only to support
running pilot-agent in local environment