### PR TITLE
Switch JWT validation to allow_missing instead of allow_missing_or_failed

### DIFF
--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -161,13 +161,25 @@ func NewPolicyApplier(jwtPolicies []*model.Config, policy *authn_alpha_api.Polic
 	}
 }
 
+// convertToEnvoyJwtConfig converts a list of JWT rules into Envoy JWT filter config to enforce it.
+// Each rule is expected corresponding to one JWT issuer (provider).
+// The behavior of the filter should reject all requests with invalid token. On the other hand,
+// if no token provided, the request is allowed.
 func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule) *envoy_jwt.JwtAuthentication {
 	if len(jwtRules) == 0 {
 		return nil
 	}
 
 	providers := map[string]*envoy_jwt.JwtProvider{}
-	requirementAndList := []*envoy_jwt.JwtRequirement{}
+	// Each element of innerAndList is the requirement for each provider, in the form of
+	// {provider OR `allow_missing`}
+	// This list will be ANDed (if have more than one provider) for the final requirment.
+	innerAndList := []*envoy_jwt.JwtRequirement{}
+
+	// This is an (or) list for all providers. This will be OR with the innerAndList above so
+	// it can pass the requirement in the case that providers share the same location.
+	outterOrList := []*envoy_jwt.JwtRequirement{}
+
 	for i, jwtRule := range jwtRules {
 		provider := &envoy_jwt.JwtProvider{
 			Issuer:               jwtRule.Issuer,
@@ -203,7 +215,7 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule) *envoy_jwt.JwtAuthenti
 
 		name := fmt.Sprintf("origins-%d", i)
 		providers[name] = provider
-		requirementAndList = append(requirementAndList, &envoy_jwt.JwtRequirement{
+		innerAndList = append(innerAndList, &envoy_jwt.JwtRequirement{
 			RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
 				RequiresAny: &envoy_jwt.JwtRequirementOrList{
 					Requirements: []*envoy_jwt.JwtRequirement{
@@ -221,9 +233,15 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule) *envoy_jwt.JwtAuthenti
 				},
 			},
 		})
+		outterOrList = append(outterOrList, &envoy_jwt.JwtRequirement{
+			RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+				ProviderName: name,
+			},
+		})
 	}
 
-	if len(requirementAndList) == 1 {
+	// If there is only one provider, simply use an OR of {provider, `allow_missing`}.
+	if len(innerAndList) == 1 {
 		return &envoy_jwt.JwtAuthentication{
 			Rules: []*envoy_jwt.RequirementRule{
 				{
@@ -232,12 +250,25 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule) *envoy_jwt.JwtAuthenti
 							Prefix: "/",
 						},
 					},
-					Requires: requirementAndList[0],
+					Requires: innerAndList[0],
 				},
 			},
 			Providers: providers,
 		}
 	}
+
+	// If there are more than one provider, filter should OR of
+	// {P1, P2 .., AND of {OR{P1, allow_missing}, OR{P2, allow_missing} ...}}
+	// where the innerAnd enforce a token, if provided, must be valid, and the
+	// outter OR aids the case where providers share the same location (as
+	// it will always fail with the innerAND).
+	outterOrList = append(outterOrList, &envoy_jwt.JwtRequirement{
+		RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+			RequiresAll: &envoy_jwt.JwtRequirementAndList{
+				Requirements: innerAndList,
+			},
+		},
+	})
 
 	return &envoy_jwt.JwtAuthentication{
 		Rules: []*envoy_jwt.RequirementRule{
@@ -248,9 +279,9 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule) *envoy_jwt.JwtAuthenti
 					},
 				},
 				Requires: &envoy_jwt.JwtRequirement{
-					RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
-						RequiresAll: &envoy_jwt.JwtRequirementAndList{
-							Requirements: requirementAndList,
+					RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+						RequiresAny: &envoy_jwt.JwtRequirementOrList{
+							Requirements: outterOrList,
 						},
 					},
 				},

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -173,7 +173,7 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule) *envoy_jwt.JwtAuthenti
 	providers := map[string]*envoy_jwt.JwtProvider{}
 	// Each element of innerAndList is the requirement for each provider, in the form of
 	// {provider OR `allow_missing`}
-	// This list will be ANDed (if have more than one provider) for the final requirment.
+	// This list will be ANDed (if have more than one provider) for the final requirement.
 	innerAndList := []*envoy_jwt.JwtRequirement{}
 
 	// This is an (or) list for all providers. This will be OR with the innerAndList above so

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -183,8 +183,8 @@ func TestJwtFilter(t *testing.T) {
 														},
 													},
 													{
-														RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-															AllowMissingOrFailed: &empty.Empty{},
+														RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+															AllowMissing: &empty.Empty{},
 														},
 													},
 												},
@@ -251,22 +251,43 @@ func TestJwtFilter(t *testing.T) {
 										},
 									},
 									Requires: &envoy_jwt.JwtRequirement{
-										RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-											RequiresAny: &envoy_jwt.JwtRequirementOrList{
+										RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+											RequiresAll: &envoy_jwt.JwtRequirementAndList{
 												Requirements: []*envoy_jwt.JwtRequirement{
 													{
-														RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-															ProviderName: "origins-0",
+														RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+															RequiresAny: &envoy_jwt.JwtRequirementOrList{
+																Requirements: []*envoy_jwt.JwtRequirement{
+																	{
+																		RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																			ProviderName: "origins-0",
+																		},
+																	},
+																	{
+																		RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																			AllowMissing: &empty.Empty{},
+																		},
+																	},
+																},
+															},
 														},
 													},
 													{
-														RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-															ProviderName: "origins-1",
-														},
-													},
-													{
-														RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-															AllowMissingOrFailed: &empty.Empty{},
+														RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+															RequiresAny: &envoy_jwt.JwtRequirementOrList{
+																Requirements: []*envoy_jwt.JwtRequirement{
+																	{
+																		RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																			ProviderName: "origins-1",
+																		},
+																	},
+																	{
+																		RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																			AllowMissing: &empty.Empty{},
+																		},
+																	},
+																},
+															},
 														},
 													},
 												},
@@ -341,8 +362,8 @@ func TestJwtFilter(t *testing.T) {
 														},
 													},
 													{
-														RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-															AllowMissingOrFailed: &empty.Empty{},
+														RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+															AllowMissing: &empty.Empty{},
 														},
 													},
 												},
@@ -405,8 +426,8 @@ func TestJwtFilter(t *testing.T) {
 														},
 													},
 													{
-														RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-															AllowMissingOrFailed: &empty.Empty{},
+														RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+															AllowMissing: &empty.Empty{},
 														},
 													},
 												},
@@ -470,8 +491,8 @@ func TestJwtFilter(t *testing.T) {
 														},
 													},
 													{
-														RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-															AllowMissingOrFailed: &empty.Empty{},
+														RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+															AllowMissing: &empty.Empty{},
 														},
 													},
 												},
@@ -536,8 +557,8 @@ func TestJwtFilter(t *testing.T) {
 														},
 													},
 													{
-														RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-															AllowMissingOrFailed: &empty.Empty{},
+														RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+															AllowMissing: &empty.Empty{},
 														},
 													},
 												},
@@ -620,8 +641,8 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 											},
 										},
 										{
-											RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-												AllowMissingOrFailed: &empty.Empty{},
+											RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+												AllowMissing: &empty.Empty{},
 											},
 										},
 									},
@@ -667,22 +688,43 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 							},
 						},
 						Requires: &envoy_jwt.JwtRequirement{
-							RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-								RequiresAny: &envoy_jwt.JwtRequirementOrList{
+							RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+								RequiresAll: &envoy_jwt.JwtRequirementAndList{
 									Requirements: []*envoy_jwt.JwtRequirement{
 										{
-											RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-												ProviderName: "origins-0",
+											RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+												RequiresAny: &envoy_jwt.JwtRequirementOrList{
+													Requirements: []*envoy_jwt.JwtRequirement{
+														{
+															RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																ProviderName: "origins-0",
+															},
+														},
+														{
+															RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																AllowMissing: &empty.Empty{},
+															},
+														},
+													},
+												},
 											},
 										},
 										{
-											RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-												ProviderName: "origins-1",
-											},
-										},
-										{
-											RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-												AllowMissingOrFailed: &empty.Empty{},
+											RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+												RequiresAny: &envoy_jwt.JwtRequirementOrList{
+													Requirements: []*envoy_jwt.JwtRequirement{
+														{
+															RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																ProviderName: "origins-1",
+															},
+														},
+														{
+															RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																AllowMissing: &empty.Empty{},
+															},
+														},
+													},
+												},
 											},
 										},
 									},
@@ -744,8 +786,8 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 											},
 										},
 										{
-											RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-												AllowMissingOrFailed: &empty.Empty{},
+											RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+												AllowMissing: &empty.Empty{},
 											},
 										},
 									},
@@ -796,8 +838,8 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 											},
 										},
 										{
-											RequiresType: &envoy_jwt.JwtRequirement_AllowMissingOrFailed{
-												AllowMissingOrFailed: &empty.Empty{},
+											RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+												AllowMissing: &empty.Empty{},
 											},
 										},
 									},

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -251,39 +251,57 @@ func TestJwtFilter(t *testing.T) {
 										},
 									},
 									Requires: &envoy_jwt.JwtRequirement{
-										RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
-											RequiresAll: &envoy_jwt.JwtRequirementAndList{
+										RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+											RequiresAny: &envoy_jwt.JwtRequirementOrList{
 												Requirements: []*envoy_jwt.JwtRequirement{
 													{
-														RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-															RequiresAny: &envoy_jwt.JwtRequirementOrList{
-																Requirements: []*envoy_jwt.JwtRequirement{
-																	{
-																		RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-																			ProviderName: "origins-0",
-																		},
-																	},
-																	{
-																		RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
-																			AllowMissing: &empty.Empty{},
-																		},
-																	},
-																},
-															},
+														RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+															ProviderName: "origins-0",
 														},
 													},
 													{
-														RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-															RequiresAny: &envoy_jwt.JwtRequirementOrList{
+														RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+															ProviderName: "origins-1",
+														},
+													},
+													{
+														RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+															RequiresAll: &envoy_jwt.JwtRequirementAndList{
 																Requirements: []*envoy_jwt.JwtRequirement{
 																	{
-																		RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-																			ProviderName: "origins-1",
+																		RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+																			RequiresAny: &envoy_jwt.JwtRequirementOrList{
+																				Requirements: []*envoy_jwt.JwtRequirement{
+																					{
+																						RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																							ProviderName: "origins-0",
+																						},
+																					},
+																					{
+																						RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																							AllowMissing: &empty.Empty{},
+																						},
+																					},
+																				},
+																			},
 																		},
 																	},
 																	{
-																		RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
-																			AllowMissing: &empty.Empty{},
+																		RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+																			RequiresAny: &envoy_jwt.JwtRequirementOrList{
+																				Requirements: []*envoy_jwt.JwtRequirement{
+																					{
+																						RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																							ProviderName: "origins-1",
+																						},
+																					},
+																					{
+																						RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																							AllowMissing: &empty.Empty{},
+																						},
+																					},
+																				},
+																			},
 																		},
 																	},
 																},
@@ -688,39 +706,57 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 							},
 						},
 						Requires: &envoy_jwt.JwtRequirement{
-							RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
-								RequiresAll: &envoy_jwt.JwtRequirementAndList{
+							RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+								RequiresAny: &envoy_jwt.JwtRequirementOrList{
 									Requirements: []*envoy_jwt.JwtRequirement{
 										{
-											RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-												RequiresAny: &envoy_jwt.JwtRequirementOrList{
-													Requirements: []*envoy_jwt.JwtRequirement{
-														{
-															RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-																ProviderName: "origins-0",
-															},
-														},
-														{
-															RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
-																AllowMissing: &empty.Empty{},
-															},
-														},
-													},
-												},
+											RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+												ProviderName: "origins-0",
 											},
 										},
 										{
-											RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-												RequiresAny: &envoy_jwt.JwtRequirementOrList{
+											RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+												ProviderName: "origins-1",
+											},
+										},
+										{
+											RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+												RequiresAll: &envoy_jwt.JwtRequirementAndList{
 													Requirements: []*envoy_jwt.JwtRequirement{
 														{
-															RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-																ProviderName: "origins-1",
+															RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+																RequiresAny: &envoy_jwt.JwtRequirementOrList{
+																	Requirements: []*envoy_jwt.JwtRequirement{
+																		{
+																			RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																				ProviderName: "origins-0",
+																			},
+																		},
+																		{
+																			RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																				AllowMissing: &empty.Empty{},
+																			},
+																		},
+																	},
+																},
 															},
 														},
 														{
-															RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
-																AllowMissing: &empty.Empty{},
+															RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+																RequiresAny: &envoy_jwt.JwtRequirementOrList{
+																	Requirements: []*envoy_jwt.JwtRequirement{
+																		{
+																			RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																				ProviderName: "origins-1",
+																			},
+																		},
+																		{
+																			RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																				AllowMissing: &empty.Empty{},
+																			},
+																		},
+																	},
+																},
 															},
 														},
 													},

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -380,8 +380,8 @@ func TestRequestAuthentication(t *testing.T) {
 					},
 					ExpectResponseCode: response.StatusCodeOK,
 					ExpectHeaders: map[string]string{
-						authHeaderKey: "",
-						"X-Test-Payload-1": payload1,
+						authHeaderKey:      "",
+						"X-Test-Payload": payload1,
 					},
 				},
 				{
@@ -399,8 +399,8 @@ func TestRequestAuthentication(t *testing.T) {
 					},
 					ExpectResponseCode: response.StatusCodeOK,
 					ExpectHeaders: map[string]string{
-						authHeaderKey: "",
-						"X-Test-Payload-2": payload2,
+						authHeaderKey:      "",
+						"X-Test-Payload": payload2,
 					},
 				},
 				{

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -380,7 +380,7 @@ func TestRequestAuthentication(t *testing.T) {
 					},
 					ExpectResponseCode: response.StatusCodeOK,
 					ExpectHeaders: map[string]string{
-						authHeaderKey:      "",
+						authHeaderKey:    "",
 						"X-Test-Payload": payload1,
 					},
 				},
@@ -399,7 +399,7 @@ func TestRequestAuthentication(t *testing.T) {
 					},
 					ExpectResponseCode: response.StatusCodeOK,
 					ExpectHeaders: map[string]string{
-						authHeaderKey:      "",
+						authHeaderKey:    "",
 						"X-Test-Payload": payload2,
 					},
 				},

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -395,7 +395,7 @@ func TestRequestAuthentication(t *testing.T) {
 							},
 						},
 					},
-					ExpectResponseCode: response.StatusCodeOK,
+					ExpectResponseCode: response.StatusUnauthorized,
 					ExpectHeaders: map[string]string{
 						authHeaderKey: "Bearer " + jwt.TokenExpired,
 					},
@@ -444,7 +444,7 @@ func TestRequestAuthentication(t *testing.T) {
 							},
 						},
 					},
-					ExpectResponseCode: response.StatusCodeForbidden,
+					ExpectResponseCode: response.StatusUnauthorized,
 				},
 				{
 					Name: "no-token",
@@ -557,7 +557,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 							},
 						},
 					},
-					ExpectResponseCode: response.StatusCodeOK,
+					ExpectResponseCode: response.StatusUnauthorized,
 				},
 				{
 					Name: "in-mesh-without-token",
@@ -605,14 +605,14 @@ func TestIngressRequestAuthentication(t *testing.T) {
 					Host:               "example.com",
 					Path:               "/",
 					Token:              jwt.TokenIssuer2,
-					ExpectResponseCode: 403,
+					ExpectResponseCode: 401,
 				},
 				{
 					Name:               "deny with expired token",
 					Host:               "example.com",
 					Path:               "/",
 					Token:              jwt.TokenExpired,
-					ExpectResponseCode: 403,
+					ExpectResponseCode: 401,
 				},
 				{
 					Name:               "allow with sub-1 token on any.com",
@@ -622,11 +622,11 @@ func TestIngressRequestAuthentication(t *testing.T) {
 					ExpectResponseCode: 200,
 				},
 				{
-					Name:               "allow with sub-2 token on any.com",
+					Name:               "deny with sub-2 token (bad issuer) on any.com",
 					Host:               "any-request-principlal-ok.com",
 					Path:               "/",
 					Token:              jwt.TokenIssuer2,
-					ExpectResponseCode: 200,
+					ExpectResponseCode: 401,
 				},
 				{
 					Name:               "deny without token on any.com",

--- a/tests/integration/security/testdata/requestauthn/c-authn.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/c-authn.yaml.tmpl
@@ -11,8 +11,8 @@ spec:
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
     jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
-    outputPayloadToHeader: "x-test-payload-1"
+    outputPayloadToHeader: "x-test-payload"
   - issuer: "test-issuer-2@istio.io"
     jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
-    outputPayloadToHeader: "x-test-payload-2"
+    outputPayloadToHeader: "x-test-payload"
 ---

--- a/tests/integration/security/testdata/requestauthn/c-authn.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/c-authn.yaml.tmpl
@@ -11,6 +11,8 @@ spec:
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
     jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    outputPayloadToHeader: "x-test-payload-1"
   - issuer: "test-issuer-2@istio.io"
     jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    outputPayloadToHeader: "x-test-payload-2"
 ---

--- a/tests/integration/security/testdata/requestauthn/c-authn.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/c-authn.yaml.tmpl
@@ -11,4 +11,6 @@ spec:
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
     jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+  - issuer: "test-issuer-2@istio.io"
+    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
 ---


### PR DESCRIPTION
This will make invalid JWT token return 401 right away.

Issue: https://github.com/istio/istio/issues/19084

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
