### PR TITLE
Update envoyproxy api to 0.9.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible
-	github.com/cncf/udpa/go v0.0.0-20191127193423-5f054cc4b1a0
+	github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/containerd/containerd v1.3.0 // indirect
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
@@ -50,7 +50,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20190630181448-f1e96bc0f4c5 // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20190630181448-f1e96bc0f4c5 // indirect
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
-	github.com/envoyproxy/go-control-plane v0.9.1
+	github.com/envoyproxy/go-control-plane v0.9.2
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fluent/fluent-logger-golang v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,6 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cncf/udpa/go v0.0.0-20191127193423-5f054cc4b1a0 h1:JDgYvo/W+p3kUtiLXK+zh9o+pXYNLLzsl0d6cqwGelw=
-github.com/cncf/udpa/go v0.0.0-20191127193423-5f054cc4b1a0/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f h1:WBZRG4aNOuI15bLRrCgN8fCq8E5Xuty6jGbmSNEvSsU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
@@ -192,8 +190,6 @@ github.com/emicklei/go-restful v2.9.6+incompatible h1:tfrHha8zJ01ywiOEC1miGY8st1
 github.com/emicklei/go-restful v2.9.6+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
-github.com/envoyproxy/go-control-plane v0.9.1 h1:+8frETDtT11P1dMCWySse/d0jMPOKYYF7OZjl7cZLvQ=
-github.com/envoyproxy/go-control-plane v0.9.1/go.mod h1:G1fbsNGAFpC1aaERrShZQVdUV2ZuZuv6FCl2v9JNSxQ=
 github.com/envoyproxy/go-control-plane v0.9.2 h1:GJ5MKABRjz+QuET1GHm0KD9HC/mAzb3g2FznLQ0aThc=
 github.com/envoyproxy/go-control-plane v0.9.2/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191127193423-5f054cc4b1a0 h1:JDgYvo/W+p3kUtiLXK+zh9o+pXYNLLzsl0d6cqwGelw=
 github.com/cncf/udpa/go v0.0.0-20191127193423-5f054cc4b1a0/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f h1:WBZRG4aNOuI15bLRrCgN8fCq8E5Xuty6jGbmSNEvSsU=
+github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
@@ -192,6 +194,8 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1 h1:+8frETDtT11P1dMCWySse/d0jMPOKYYF7OZjl7cZLvQ=
 github.com/envoyproxy/go-control-plane v0.9.1/go.mod h1:G1fbsNGAFpC1aaERrShZQVdUV2ZuZuv6FCl2v9JNSxQ=
+github.com/envoyproxy/go-control-plane v0.9.2 h1:GJ5MKABRjz+QuET1GHm0KD9HC/mAzb3g2FznLQ0aThc=
+github.com/envoyproxy/go-control-plane v0.9.2/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/mixer/test/client/dynamic_attribute/dynamic_attribute_test.go
+++ b/mixer/test/client/dynamic_attribute/dynamic_attribute_test.go
@@ -187,33 +187,33 @@ func TestDynamicAttribute(t *testing.T) {
 	snapshots := cache.NewSnapshotCache(false, hasher{}, nil)
 	snapshot := cache.Snapshot{}
 	snapshot.Resources[cache.Endpoint] = cache.Resources{Version: "1", Items: map[string]cache.Resource{
-			"backend": &v2.ClusterLoadAssignment{
-				ClusterName: "backend",
-				Endpoints: []*endpoint.LocalityLbEndpoints{{
-					LbEndpoints: []*endpoint.LbEndpoint{{
-						Metadata: &core.Metadata{
-							FilterMetadata: map[string]*structpb.Struct{
-								"istio": {
-									Fields: map[string]*structpb.Value{
-										"uid": {Kind: &structpb.Value_StringValue{StringValue: "pod1.ns2"}},
-									},
+		"backend": &v2.ClusterLoadAssignment{
+			ClusterName: "backend",
+			Endpoints: []*endpoint.LocalityLbEndpoints{{
+				LbEndpoints: []*endpoint.LbEndpoint{{
+					Metadata: &core.Metadata{
+						FilterMetadata: map[string]*structpb.Struct{
+							"istio": {
+								Fields: map[string]*structpb.Value{
+									"uid": {Kind: &structpb.Value_StringValue{StringValue: "pod1.ns2"}},
 								},
 							},
 						},
-						HostIdentifier: &endpoint.LbEndpoint_Endpoint{
-							Endpoint: &endpoint.Endpoint{
-								Address: &core.Address{Address: &core.Address_SocketAddress{
-									SocketAddress: &core.SocketAddress{
-										Address:       "127.0.0.1",
-										PortSpecifier: &core.SocketAddress_PortValue{PortValue: uint32(s.Ports().BackendPort)},
-									},
-								}},
-							},
+					},
+					HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+						Endpoint: &endpoint.Endpoint{
+							Address: &core.Address{Address: &core.Address_SocketAddress{
+								SocketAddress: &core.SocketAddress{
+									Address:       "127.0.0.1",
+									PortSpecifier: &core.SocketAddress_PortValue{PortValue: uint32(s.Ports().BackendPort)},
+								},
+							}},
 						},
-					}},
+					},
 				}},
-			},
-		}}
+			}},
+		},
+	}}
 	snapshots.SetSnapshot("", snapshot)
 	server := xds.NewServer(context.Background(), snapshots, nil)
 	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)

--- a/mixer/test/client/dynamic_attribute/dynamic_attribute_test.go
+++ b/mixer/test/client/dynamic_attribute/dynamic_attribute_test.go
@@ -185,8 +185,8 @@ func TestDynamicAttribute(t *testing.T) {
 	}
 
 	snapshots := cache.NewSnapshotCache(false, hasher{}, nil)
-	snapshots.SetSnapshot("", cache.Snapshot{
-		Endpoints: cache.Resources{Version: "1", Items: map[string]cache.Resource{
+	snapshot := cache.Snapshot{}
+	snapshot.Resources[cache.Endpoint] = cache.Resources{Version: "1", Items: map[string]cache.Resource{
 			"backend": &v2.ClusterLoadAssignment{
 				ClusterName: "backend",
 				Endpoints: []*endpoint.LocalityLbEndpoints{{
@@ -213,8 +213,8 @@ func TestDynamicAttribute(t *testing.T) {
 					}},
 				}},
 			},
-		}},
-	})
+		}}
+	snapshots.SetSnapshot("", snapshot)
 	server := xds.NewServer(context.Background(), snapshots, nil)
 	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
 

--- a/mixer/test/client/dynamic_listener/dynamic_listener_test.go
+++ b/mixer/test/client/dynamic_listener/dynamic_listener_test.go
@@ -194,9 +194,10 @@ func TestDynamicListener(t *testing.T) {
 	count := 0
 	server := xds.NewServer(context.Background(), snapshots, nil)
 	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
-	snapshots.SetSnapshot("", cache.Snapshot{
-		Listeners: cache.Resources{Version: strconv.Itoa(count), Items: map[string]cache.Resource{
-			"backend": makeListener(s, fmt.Sprintf("count%d", count))}}})
+	snapshot := cache.Snapshot{}
+	snapshot.Resources[cache.Listener] = cache.Resources{Version: strconv.Itoa(count), Items: map[string]cache.Resource{
+		"backend": makeListener(s, fmt.Sprintf("count%d", count))}}
+	snapshots.SetSnapshot("", snapshot)
 
 	go func() {
 		_ = grpcServer.Serve(lis)
@@ -210,9 +211,10 @@ func TestDynamicListener(t *testing.T) {
 
 	for ; count < 2; count++ {
 		log.Printf("iteration %d", count)
-		snapshots.SetSnapshot("", cache.Snapshot{
-			Listeners: cache.Resources{Version: strconv.Itoa(count), Items: map[string]cache.Resource{
-				"backend": makeListener(s, fmt.Sprintf("count%d", count))}}})
+		snapshot := cache.Snapshot{}
+		snapshot.Resources[cache.Listener] = cache.Resources{Version: strconv.Itoa(count), Items: map[string]cache.Resource{
+			"backend": makeListener(s, fmt.Sprintf("count%d", count))}}
+		snapshots.SetSnapshot("", snapshot)
 
 		// wait a bit for config to propagate and old listener to drain
 		time.Sleep(2 * time.Second)

--- a/mixer/test/client/gateway/gateway_test.go
+++ b/mixer/test/client/gateway/gateway_test.go
@@ -337,8 +337,8 @@ func makeSnapshot(s *env.TestSetup, t *testing.T) cache.Snapshot {
 
 	p.OnOutboundRouteConfiguration(&clientParams, clientRoute)
 
-	return cache.Snapshot{
-		Routes:    cache.NewResources("http", []cache.Resource{clientRoute}),
-		Listeners: cache.NewResources("http", []cache.Resource{clientListener}),
-	}
+	snapshot := cache.Snapshot{}
+	snapshot.Resources[cache.Route] = cache.NewResources("http", []cache.Resource{clientRoute})
+	snapshot.Resources[cache.Listener] = cache.NewResources("http", []cache.Resource{clientListener})
+	return snapshot
 }

--- a/mixer/test/client/pilotplugin/pilotplugin_test.go
+++ b/mixer/test/client/pilotplugin/pilotplugin_test.go
@@ -435,8 +435,8 @@ func makeSnapshot(s *env.TestSetup, t *testing.T) cache.Snapshot {
 	p.OnInboundRouteConfiguration(&serverParams, serverRoute)
 	p.OnOutboundRouteConfiguration(&clientParams, clientRoute)
 
-	return cache.Snapshot{
-		Routes:    cache.NewResources("http", []cache.Resource{clientRoute, serverRoute}),
-		Listeners: cache.NewResources("http", []cache.Resource{clientListener, serverListener}),
-	}
+	snapshot := cache.Snapshot{}
+	snapshot.Resources[cache.Route] = cache.NewResources("http", []cache.Resource{clientRoute, serverRoute})
+	snapshot.Resources[cache.Listener] = cache.NewResources("http", []cache.Resource{clientListener, serverListener})
+	return snapshot
 }

--- a/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
+++ b/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
@@ -462,8 +462,8 @@ func makeSnapshot(s *env.TestSetup, t *testing.T) cache.Snapshot {
 	p.OnInboundRouteConfiguration(&serverParams, serverRoute)
 	p.OnOutboundRouteConfiguration(&clientParams, clientRoute)
 
-	return cache.Snapshot{
-		Routes:    cache.NewResources("http", []cache.Resource{clientRoute, serverRoute}),
-		Listeners: cache.NewResources("http", []cache.Resource{clientListener, serverListener}),
-	}
+	snapshot := cache.Snapshot{}
+	snapshot.Resources[cache.Route] = cache.NewResources("http", []cache.Resource{clientRoute, serverRoute})
+	snapshot.Resources[cache.Listener] = cache.NewResources("http", []cache.Resource{clientListener, serverListener})
+	return snapshot
 }

--- a/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
+++ b/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
@@ -285,7 +285,7 @@ func makeSnapshot(s *env.TestSetup, t *testing.T, node model.NodeType) cache.Sna
 	}
 	clientListener.FilterChains[0].Filters = append(clientMutable.FilterChains[0].TCP, clientListener.FilterChains[0].Filters...)
 
-	return cache.Snapshot{
-		Listeners: cache.NewResources(string(node), []cache.Resource{clientListener, serverListener}),
-	}
+	snapshot := cache.Snapshot{}
+	snapshot.Resources[cache.Listener] = cache.NewResources(string(node), []cache.Resource{clientListener, serverListener})
+	return snapshot
 }


### PR DESCRIPTION
Update envoyproxy API to https://github.com/envoyproxy/go-control-plane/releases/tag/v0.9.2