### PR TITLE
Improve Helm charts by adding some missing configuration possibilities

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
@@ -29,8 +29,10 @@ data:
     external_services:
       tracing:
         url: {{ .Values.dashboard.jaegerURL }}
+        in_cluster_url: {{ .Values.dashboard.inclusterjaegerURL }}
       grafana:
         url: {{ .Values.dashboard.grafanaURL }}
+        in_cluster_url: {{ .Values.dashboard.inclustergrafanaURL }}
       prometheus:
         url: {{ .Values.prometheusAddr }}
 {{- if .Values.security.enabled }}

--- a/install/kubernetes/helm/istio/charts/kiali/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/service.yaml
@@ -3,12 +3,19 @@ kind: Service
 metadata:
   name: kiali
   namespace: {{ .Release.Namespace }}
+{{- if .Values.service.annotations }}
+  annotations:
+    {{- range $key, $val := .Values.service.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+{{- end }}
   labels:
     app: {{ template "kiali.name" . }}
     chart: {{ template "kiali.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  type: {{ .Values.service.type }}
   ports:
   - name: http-kiali
     protocol: TCP

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -46,6 +46,9 @@ ingress:
     #   hosts:
     #     - kiali.local
 
+service:
+  type: ClusterIP
+
 dashboard:
   auth:
     strategy: login # Can be anonymous, login, openshift, or ldap
@@ -66,7 +69,9 @@ dashboard:
   secretName: kiali # You must create a secret with this name - one is not provided out-of-box.
   viewOnlyMode: false # Bind the service account to a role with only read access
   grafanaURL:  # If you have Grafana installed and it is accessible to client browsers, then set this to its external URL. Kiali will redirect users to this URL when Grafana metrics are to be shown.
+  inclustergrafanaURL: # same as above, but URL should be Kubernetes internal URL
   jaegerURL:  # If you have Jaeger installed and it is accessible to client browsers, then set this property to its external URL. Kiali will redirect users to this URL when Jaeger tracing is to be shown.
+  inclusterjaegerURL: # same as above, but URL should be Kubernetes internal URL
 prometheusAddr: http://prometheus:9090
 
 # When true, a secret will be created with a default username and password. Useful for demos.

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/service.yaml
@@ -29,6 +29,10 @@ kind: Service
 metadata:
   name: prometheus-nodeport
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $val := .Values.service.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   labels:
     app: prometheus
     chart: {{ template "prometheus.chart" . }}


### PR DESCRIPTION

It adds some missing configuration options in Helm charts. It also makes Kiali chart more alike to the rest of charts, so it would be possible also for Kiali provide service type and annotation, like with other charts.


[ x ] Configuration Infrastructure
[ ] Docs
[ x ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure