### PR TITLE
Actually test the duplicate CSR case

### DIFF
--- a/security/pkg/k8s/chiron/utils_test.go
+++ b/security/pkg/k8s/chiron/utils_test.go
@@ -96,7 +96,7 @@ func TestGenKeyCertK8sCA(t *testing.T) {
 		dnsNames          []string
 		secretNames       []string
 		serviceNamespaces []string
-		expectFaill       bool
+		expectFail        bool
 	}{
 		"gen cert should succeed": {
 			gracePeriodRatio:  0.6,
@@ -104,7 +104,7 @@ func TestGenKeyCertK8sCA(t *testing.T) {
 			dnsNames:          []string{"foo"},
 			secretNames:       []string{"istio.webhook.foo"},
 			serviceNamespaces: []string{"foo.ns"},
-			expectFaill:       false,
+			expectFail:        false,
 		},
 	}
 
@@ -130,7 +130,7 @@ func TestGenKeyCertK8sCA(t *testing.T) {
 
 		_, _, _, err = GenKeyCertK8sCA(wc.certClient.CertificateSigningRequests(), tc.dnsNames[0], tc.secretNames[0],
 			tc.serviceNamespaces[0], wc.k8sCaCertFile)
-		if tc.expectFaill {
+		if tc.expectFail {
 			if err == nil {
 				t.Errorf("should have failed")
 			}
@@ -217,7 +217,7 @@ func TestReloadCACert(t *testing.T) {
 		secretNames       []string
 		serviceNamespaces []string
 
-		expectFaill   bool
+		expectFail    bool
 		expectChanged bool
 	}{
 		"reload from valid CA cert path": {
@@ -226,7 +226,7 @@ func TestReloadCACert(t *testing.T) {
 			secretNames:       []string{"istio.webhook.foo"},
 			serviceNamespaces: []string{"foo.ns"},
 			k8sCaCertFile:     "./test-data/example-ca-cert.pem",
-			expectFaill:       false,
+			expectFail:        false,
 			expectChanged:     false,
 		},
 	}
@@ -241,7 +241,7 @@ func TestReloadCACert(t *testing.T) {
 			continue
 		}
 		changed, err := reloadCACert(wc)
-		if tc.expectFaill {
+		if tc.expectFail {
 			if err == nil {
 				t.Errorf("should have failed at reloading CA cert")
 			}
@@ -275,9 +275,9 @@ func TestSubmitCSR(t *testing.T) {
 		secretNameSpace string
 
 		createDuplicate bool
-		expectFaill     bool
+		expectFail      bool
 	}{
-		"submit a CSR without duplicate should succeed": {
+		"submitting a CSR without duplicate should succeed": {
 			gracePeriodRatio:  0.6,
 			k8sCaCertFile:     "./test-data/example-ca-cert.pem",
 			dnsNames:          []string{"foo"},
@@ -286,18 +286,18 @@ func TestSubmitCSR(t *testing.T) {
 			secretName:        "mock-secret",
 			secretNameSpace:   "mock-secret-namespace",
 			createDuplicate:   false,
-			expectFaill:       false,
+			expectFail:        false,
 		},
-		"submit a CSR with duplicate should succeed": {
+		"submitting a CSR with duplicate should succeed": {
 			gracePeriodRatio:  0.6,
+			k8sCaCertFile:     "./test-data/example-ca-cert.pem",
 			dnsNames:          []string{"foo"},
 			secretNames:       []string{"istio.webhook.foo"},
 			serviceNamespaces: []string{"foo.ns"},
-			k8sCaCertFile:     "./test-data/example-ca-cert.pem",
 			secretName:        "mock-secret",
 			secretNameSpace:   "mock-secret-namespace",
-			createDuplicate:   false,
-			expectFaill:       false,
+			createDuplicate:   true,
+			expectFail:        false,
 		},
 	}
 
@@ -347,14 +347,14 @@ func TestSubmitCSR(t *testing.T) {
 				},
 			}
 			reqRet, errRet := wc.certClient.CertificateSigningRequests().Create(k8sCSR)
-			if errRet == nil && reqRet != nil {
+			if errRet != nil && reqRet == nil {
 				t.Errorf("failed to create a CSR, return is nil or error (%v)", errRet)
 				continue
 			}
 		}
 
 		r, err := submitCSR(wc.certClient.CertificateSigningRequests(), csrName, []byte(csrPEM), numRetries)
-		if tc.expectFaill {
+		if tc.expectFail {
 			if err == nil {
 				t.Errorf("should have failed")
 			}
@@ -377,7 +377,7 @@ func TestReadSignedCertificate(t *testing.T) {
 		secretNameSpace string
 
 		invalidCert bool
-		expectFaill bool
+		expectFail  bool
 	}{
 		"read signed cert should succeed": {
 			gracePeriodRatio:  0.6,
@@ -388,7 +388,7 @@ func TestReadSignedCertificate(t *testing.T) {
 			secretName:        "mock-secret",
 			secretNameSpace:   "mock-secret-namespace",
 			invalidCert:       false,
-			expectFaill:       false,
+			expectFail:        false,
 		},
 		"read invalid signed cert should fail": {
 			gracePeriodRatio:  0.6,
@@ -399,7 +399,7 @@ func TestReadSignedCertificate(t *testing.T) {
 			secretName:        "mock-secret",
 			secretNameSpace:   "mock-secret-namespace",
 			invalidCert:       true,
-			expectFaill:       true,
+			expectFail:        true,
 		},
 	}
 
@@ -440,7 +440,7 @@ func TestReadSignedCertificate(t *testing.T) {
 		csrName := fmt.Sprintf("domain-%s-ns-%s-secret-%s", spiffe.GetTrustDomain(), tc.secretNameSpace, tc.secretName)
 		_, _, err = readSignedCertificate(wc.certClient.CertificateSigningRequests(), csrName, certReadInterval, maxNumCertRead, wc.k8sCaCertFile)
 
-		if tc.expectFaill {
+		if tc.expectFail {
 			if err == nil {
 				t.Errorf("should have failed at updateMutatingWebhookConfig")
 			}


### PR DESCRIPTION
We weren't actually testing the duplicate CSR case, but running the same test twice. Apart from that, the expectFailure case did not work because the if statement was the wrong way around

I also fixed some typos

[x] Security

