### PR TITLE
Fix locality load balancing

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1013,11 +1013,8 @@ func applyLoadBalancer(cluster *apiv2.Cluster, lb *networking.LoadBalancerSettin
 	}
 
 	// Use locality lb settings from load balancer settings if present, else use mesh wide locality lb settings
-	var localityLbSettings = meshConfig.LocalityLbSetting
-	if lb != nil && lb.LocalityLbSetting != nil {
-		localityLbSettings = lb.LocalityLbSetting
-	}
-	applyLocalityLBSetting(proxy.Locality, cluster, localityLbSettings)
+	lbSetting := loadbalancer.GetLocalityLbSetting(meshConfig.GetLocalityLbSetting(), lb.GetLocalityLbSetting())
+	applyLocalityLBSetting(proxy.Locality, cluster, lbSetting)
 
 	// The following order is important. If cluster type has been identified as Original DST since Resolution is PassThrough,
 	// and port is named as redis-xxx we end up creating a cluster with type Original DST and LbPolicy as MAGLEV which would be

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -23,8 +23,6 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
-	"istio.io/pkg/log"
-
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/util"
 )
@@ -40,16 +38,13 @@ func GetLocalityLbSetting(
 		enabled = destrule.Enabled.GetValue()
 	}
 	if !enabled {
-		log.Errorf("howardjohn: not enabled! return false %v %v", mesh, destrule)
 		return nil
 	}
 
 	// Destination Rule overrides mesh config. If its defined, use that
 	if destrule != nil {
-		log.Errorf("howardjohn: override %v %v", mesh, destrule)
 		return destrule
 	}
-	log.Errorf("howardjohn: mesh %v %v", mesh, destrule)
 	// Otherwise fall back to mesh default
 	return mesh
 }

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -158,6 +158,51 @@ func TestApplyLocalitySetting(t *testing.T) {
 	})
 }
 
+func TestGetLocalityLbSetting(t *testing.T) {
+	// dummy config for test
+	failover := []*networking.LocalityLoadBalancerSetting_Failover{nil}
+	cases := []struct {
+		name     string
+		mesh     *networking.LocalityLoadBalancerSetting
+		dr       *networking.LocalityLoadBalancerSetting
+		expected *networking.LocalityLoadBalancerSetting
+	}{
+		{"all disabled",
+			nil,
+			nil,
+			nil,
+		},
+		{"mesh only",
+			&networking.LocalityLoadBalancerSetting{},
+			nil,
+			&networking.LocalityLoadBalancerSetting{},
+		},
+		{"dr only",
+			nil,
+			&networking.LocalityLoadBalancerSetting{},
+			nil,
+		},
+		{"dr only override",
+			nil,
+			&networking.LocalityLoadBalancerSetting{Enabled: &types.BoolValue{Value: true}},
+			&networking.LocalityLoadBalancerSetting{Enabled: &types.BoolValue{Value: true}},
+		},
+		{"both",
+			&networking.LocalityLoadBalancerSetting{},
+			&networking.LocalityLoadBalancerSetting{Failover: failover},
+			&networking.LocalityLoadBalancerSetting{Failover: failover},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetLocalityLbSetting(tt.mesh, tt.dr)
+			if !reflect.DeepEqual(tt.expected, got) {
+				t.Fatalf("Expected: %v, got: %v", tt.expected, got)
+			}
+		})
+	}
+}
+
 func buildEnvForClustersWithDistribute(distribute []*networking.LocalityLoadBalancerSetting_Distribute) *model.Environment {
 	serviceDiscovery := &fakes.ServiceDiscovery{}
 

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -292,7 +292,7 @@ func IsProtocolSniffingEnabledForOutboundPort(node *model.Proxy, port *model.Por
 // ConvertLocality converts '/' separated locality string to Locality struct.
 func ConvertLocality(locality string) *core.Locality {
 	if locality == "" {
-		return nil
+		return &core.Locality{}
 	}
 
 	region, zone, subzone := SplitLocality(locality)

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -141,7 +141,7 @@ func TestConvertLocality(t *testing.T) {
 		{
 			name:     "nil locality",
 			locality: "",
-			want:     nil,
+			want:     &core.Locality{},
 		},
 		{
 			name:     "locality with only region",

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -690,7 +690,6 @@ func (s *DiscoveryServer) generateEndpoints(
 	// Failover should only be enabled when there is an outlier detection, otherwise Envoy
 	// will never detect the hosts are unhealthy and redirect traffic.
 	enableFailover, lb := getOutlierDetectionAndLoadBalancerSettings(push, proxy, clusterName)
-	adsLog.Errorf("howardjohn: lb: %v", lb)
 	lbSetting := loadbalancer.GetLocalityLbSetting(push.Mesh.GetLocalityLbSetting(), lb.GetLocalityLbSetting())
 	if lbSetting != nil {
 		loadbalancer.ApplyLocalityLBSetting(proxy.Locality, l, lbSetting, enableFailover)
@@ -749,7 +748,6 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 // which is needed to access the traffic policy from the destination rule.
 func getDestinationRule(push *model.PushContext, proxy *model.Proxy, hostname host.Name, clusterPort int) (*networkingapi.DestinationRule, *model.Port) {
 	for _, service := range push.Services(proxy) {
-		adsLog.Errorf("howardjohn: check svc %v == %v", service.Hostname, hostname)
 		if service.Hostname == hostname {
 			cfg := push.DestinationRule(proxy, service)
 			if cfg == nil {
@@ -770,7 +768,6 @@ func getOutlierDetectionAndLoadBalancerSettings(push *model.PushContext, proxy *
 	var outlierDetectionEnabled = false
 	var lbSettings *networkingapi.LoadBalancerSettings
 	destinationRule, port := getDestinationRule(push, proxy, hostname, portNumber)
-	adsLog.Errorf("howardjohn: dest rule for %v %v %v", proxy.ID, clusterName, destinationRule)
 	if destinationRule == nil || port == nil {
 		return false, nil
 	}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -692,6 +692,9 @@ func (s *DiscoveryServer) generateEndpoints(
 	enableFailover, lb := getOutlierDetectionAndLoadBalancerSettings(push, proxy, clusterName)
 	lbSetting := loadbalancer.GetLocalityLbSetting(push.Mesh.GetLocalityLbSetting(), lb.GetLocalityLbSetting())
 	if lbSetting != nil {
+		// Make a shallow copy of the cla as we are mutating the endpoints with priorities/weights relative to the calling proxy
+		clonedCLA := util.CloneClusterLoadAssignment(l)
+		l = &clonedCLA
 		loadbalancer.ApplyLocalityLBSetting(proxy.Locality, l, lbSetting, enableFailover)
 	}
 	return l

--- a/tests/integration/pilot/locality/distribute_test.go
+++ b/tests/integration/pilot/locality/distribute_test.go
@@ -1,0 +1,126 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package locality
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/pkg/log"
+)
+
+// This test allows for Locality Distribution Load Balancing testing without needing Kube nodes in multiple regions.
+// We do this by overriding the calling service's locality with the istio-locality label and the serving
+// service's locality with a service entry.
+//
+// The created Service Entry for fake-(cds|eds)-external-service-12345.com points the domain at services
+// that exist internally in the mesh. In the Service Entry we set service B to be in the same locality
+// as the caller (A) and service C to be in a different locality. We then verify that all request go to
+// service B. For details check the Service Entry configuration at the bottom of the page.
+//
+//                                                                 +-> 10.28.1.138 (b -> region.zone.subzone)
+//                                                                 |
+//                                                            20% |
+//                                                                 |
+// A (region.zone.subzone) -> fake-eds-external-service-12345.com -|
+//                                                                 |
+//                                                              80% |
+//                                                                 |
+//                                                                 +-> 10.28.1.139 (c -> notregion.notzone.notsubzone)
+
+func TestDistribute(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(ctx, ctx, namespace.Config{
+				Prefix: "locality-distribute-eds",
+				Inject: true,
+			})
+
+			var a, b, c echo.Instance
+			echoboot.NewBuilderOrFail(ctx, ctx).
+				With(&a, echoConfig(ns, "a")).
+				With(&b, echoConfig(ns, "b")).
+				With(&c, echoConfig(ns, "c")).
+				BuildOrFail(ctx)
+
+			fakeHostname := fmt.Sprintf("fake-eds-external-service-%v.com", r.Int())
+
+			// First, deploy across multiple zones
+			deploy(ctx, ns, serviceConfig{
+				Name:       "distribute-eds",
+				Host:       fakeHostname,
+				Namespace:  ns.Name(),
+				Resolution: "STATIC",
+				// Add a fake service with no locality to ensure we don't route there
+				NonExistantService:         "1.1.1.1",
+				NonExistantServiceLocality: "",
+				ServiceBAddress:            b.Address(),
+				ServiceBLocality:           "region/zone/subzone",
+				ServiceCAddress:            c.Address(),
+				ServiceCLocality:           "notregion/notzone/notsubzone",
+			}, a, distributeTemplate)
+
+			log.Infof("Sending traffic to local service (EDS) via %v", fakeHostname)
+
+			if err := retry.UntilSuccess(func() error {
+				e := sendTraffic(a, fakeHostname, map[string]int{
+					"b": 20,
+					"c": 80,
+				})
+				scopes.CI.Errorf("%v: ", e)
+				return e
+			}, retry.Timeout(time.Second*5)); err != nil {
+				ctx.Fatal(err)
+			}
+
+			// Set a to no locality, b to matching locality, and c to non-matching.
+			// Expect all to get even traffic after disabling locality lb.
+			deploy(ctx, ns, serviceConfig{
+				Name:                       "distribute-eds",
+				Host:                       fakeHostname,
+				Namespace:                  ns.Name(),
+				Resolution:                 "STATIC",
+				NonExistantService:         a.Address(),
+				NonExistantServiceLocality: "",
+				ServiceBAddress:            b.Address(),
+				ServiceBLocality:           "region/zone/subzone",
+				ServiceCAddress:            c.Address(),
+				ServiceCLocality:           "notregion/notzone/notsubzone",
+			}, a, disabledTemplate)
+
+			log.Infof("Sending without locality enabled traffic to local service (EDS) via %v", fakeHostname)
+
+			if err := retry.UntilSuccess(func() error {
+				e := sendTraffic(a, fakeHostname, map[string]int{
+					"a": 33,
+					"b": 33,
+					"c": 33,
+				})
+				scopes.CI.Errorf("%v: ", e)
+				return e
+			}, retry.Delay(time.Second*5)); err != nil {
+				ctx.Fatal(err)
+			}
+		})
+}

--- a/tests/integration/pilot/locality/failover_test.go
+++ b/tests/integration/pilot/locality/failover_test.go
@@ -17,6 +17,7 @@ package locality
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -101,13 +102,13 @@ func TestFailover(t *testing.T) {
 						ServiceCLocality:           "notcloseregion/zone/subzone",
 						NonExistantService:         "nonexistantservice",
 						NonExistantServiceLocality: "region/zone/subzone",
-					}, a)
+					}, a, failoverTemplate)
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (CDS) via %v", fakeHostname)
 					if err := retry.UntilSuccess(func() error {
-						return sendTraffic(a, fakeHostname)
-					}); err != nil {
+						return sendTraffic(a, fakeHostname, expectAllTrafficToB)
+					}, retry.Delay(time.Second*5)); err != nil {
 						ctx.Fatal(err)
 					}
 				})
@@ -139,13 +140,13 @@ func TestFailover(t *testing.T) {
 						ServiceCLocality:           "notcloseregion/zone/subzone",
 						NonExistantService:         "10.10.10.10",
 						NonExistantServiceLocality: "region/zone/subzone",
-					}, a)
+					}, a, failoverTemplate)
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (EDS) via %v", fakeHostname)
 					if err := retry.UntilSuccess(func() error {
-						return sendTraffic(a, fakeHostname)
-					}); err != nil {
+						return sendTraffic(a, fakeHostname, expectAllTrafficToB)
+					}, retry.Delay(time.Second*5)); err != nil {
 						ctx.Fatal(err)
 					}
 				})

--- a/tests/integration/pilot/locality/main_test.go
+++ b/tests/integration/pilot/locality/main_test.go
@@ -143,7 +143,9 @@ spec:
   host: {{.Host}}
   trafficPolicy:
     loadBalancer:
-      enabled: false
+      simple: ROUND_ROBIN
+      localityLbSetting:
+        enabled: false
     outlierDetection:
       consecutiveErrors: 100
       interval: 1s

--- a/tests/integration/pilot/locality/main_test.go
+++ b/tests/integration/pilot/locality/main_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"regexp"
+	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -64,7 +64,7 @@ spec:
   endpoints:
   {{ if ne .NonExistantService "" }}
   - address: {{.NonExistantService}}
-    locality: {{.NonExistantServiceLocality}}
+    locality: "{{.NonExistantServiceLocality}}"
   {{ end }}
   - address: {{.ServiceBAddress}}
     locality: {{.ServiceBLocality}}
@@ -87,7 +87,9 @@ spec:
       attempts: 3
       perTryTimeout: 1s
       retryOn: gateway-error,connect-failure,refused-stream
----
+`
+
+	failoverYaml = `
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -108,11 +110,55 @@ spec:
       baseEjectionTime: 3m
       maxEjectionPercent: 100
 `
+	distributeYaml = `
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: {{.Name}}-destination
+  namespace: {{.Namespace}}
+spec:
+  host: {{.Host}}
+  trafficPolicy:
+    loadBalancer:
+      simple: ROUND_ROBIN
+      localityLbSetting:
+        distribute:
+        - from: region
+          to:
+            notregion: 80
+            region: 20
+    outlierDetection:
+      consecutiveErrors: 100
+      interval: 1s
+      baseEjectionTime: 3m
+      maxEjectionPercent: 100
+`
+	disabledYaml = `
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: {{.Name}}-destination
+  namespace: {{.Namespace}}
+spec:
+  host: {{.Host}}
+  trafficPolicy:
+    loadBalancer:
+      enabled: false
+    outlierDetection:
+      consecutiveErrors: 100
+      interval: 1s
+      baseEjectionTime: 3m
+      maxEjectionPercent: 100
+`
 )
 
 var (
-	bHostnameMatcher   = regexp.MustCompile("^b-.*$")
 	deploymentTemplate *template.Template
+	failoverTemplate   *template.Template
+	distributeTemplate *template.Template
+	disabledTemplate   *template.Template
+
+	expectAllTrafficToB = map[string]int{"b": sendCount}
 
 	ist istio.Instance
 	p   pilot.Instance
@@ -123,6 +169,18 @@ var (
 func init() {
 	var err error
 	deploymentTemplate, err = template.New("localityTemplate").Parse(deploymentYAML)
+	if err != nil {
+		panic(err)
+	}
+	failoverTemplate, err = template.New("localityTemplate").Parse(failoverYaml)
+	if err != nil {
+		panic(err)
+	}
+	distributeTemplate, err = template.New("localityTemplate").Parse(distributeYaml)
+	if err != nil {
+		panic(err)
+	}
+	disabledTemplate, err = template.New("localityTemplate").Parse(disabledYaml)
 	if err != nil {
 		panic(err)
 	}
@@ -177,10 +235,15 @@ type serviceConfig struct {
 	NonExistantServiceLocality string
 }
 
-func deploy(t test.Failer, ns namespace.Instance, se serviceConfig, from echo.Instance) {
+func deploy(t test.Failer, ns namespace.Instance, se serviceConfig, from echo.Instance, tmpl *template.Template) {
 	t.Helper()
 	var buf bytes.Buffer
 	if err := deploymentTemplate.Execute(&buf, se); err != nil {
+		t.Fatal(err)
+	}
+	g.ApplyConfigOrFail(t, ns, buf.String())
+	buf.Reset()
+	if err := tmpl.Execute(&buf, se); err != nil {
 		t.Fatal(err)
 	}
 	g.ApplyConfigOrFail(t, ns, buf.String())
@@ -222,7 +285,7 @@ func WaitUntilRoute(c echo.Instance, dest string) error {
 	return nil
 }
 
-func sendTraffic(from echo.Instance, host string) error {
+func sendTraffic(from echo.Instance, host string, expected map[string]int) error {
 	headers := http.Header{}
 	headers.Add("Host", host)
 	// This is a hack to remain infrastructure agnostic when running these tests
@@ -239,10 +302,30 @@ func sendTraffic(from echo.Instance, host string) error {
 	if len(resp) != sendCount {
 		return fmt.Errorf("%s->%s expected %d responses, received %d", from.Config().Service, host, sendCount, len(resp))
 	}
-	for i, r := range resp {
-		if match := bHostnameMatcher.FindString(r.Hostname); len(match) == 0 {
-			return fmt.Errorf("%s->%s request[%d] made to unexpected service: %s", from.Config().Service, host, i, r.Hostname)
+	got := map[string]int{}
+	for _, r := range resp {
+		// Hostname will take form of svc-v1-random. We want to extract just 'svc'
+		parts := strings.SplitN(r.Hostname, "-", 2)
+		if len(parts) < 2 {
+			return fmt.Errorf("unexpected hostname: %v", r)
+		}
+		gotHost := parts[0]
+		got[gotHost]++
+	}
+	for svc, reqs := range got {
+		expect := expected[svc]
+		if !almostEquals(reqs, expect, 5) {
+			return fmt.Errorf("unexpected request distribution. Expected: %+v, got: %+v", expected, got)
 		}
 	}
 	return nil
+}
+
+func almostEquals(a, b, precision int) bool {
+	upper := a + precision
+	lower := a - precision
+	if b < lower || b > upper {
+		return false
+	}
+	return true
 }

--- a/tests/integration/pilot/locality/prioritized_test.go
+++ b/tests/integration/pilot/locality/prioritized_test.go
@@ -17,6 +17,7 @@ package locality
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -90,13 +91,13 @@ func TestPrioritized(t *testing.T) {
 						ServiceBLocality: "region/zone/subzone",
 						ServiceCAddress:  "c",
 						ServiceCLocality: "notregion/notzone/notsubzone",
-					}, a)
+					}, a, failoverTemplate)
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (CDS) via %v", fakeHostname)
 					if err := retry.UntilSuccess(func() error {
-						return sendTraffic(a, fakeHostname)
-					}); err != nil {
+						return sendTraffic(a, fakeHostname, expectAllTrafficToB)
+					}, retry.Delay(time.Second*5)); err != nil {
 						ctx.Fatal(err)
 					}
 				})
@@ -128,13 +129,13 @@ func TestPrioritized(t *testing.T) {
 						ServiceBLocality: "region/zone/subzone",
 						ServiceCAddress:  c.Address(),
 						ServiceCLocality: "notregion/notzone/notsubzone",
-					}, a)
+					}, a, failoverTemplate)
 
 					// Send traffic to service B via a service entry.
 					log.Infof("Sending traffic to local service (EDS) via %v", fakeHostname)
 					if err := retry.UntilSuccess(func() error {
-						return sendTraffic(a, fakeHostname)
-					}); err != nil {
+						return sendTraffic(a, fakeHostname, expectAllTrafficToB)
+					}, retry.Delay(time.Second*5)); err != nil {
 						ctx.Fatal(err)
 					}
 				})


### PR DESCRIPTION
This PR includes 3 things:
* Fix for https://github.com/istio/istio/issues/20077. When there is no
locality, traffic will never be sent to the pod, even with locality lb
disabled. The fix here is setting locality to {} instead of nil
* Destinationrule cannot override mesh config to disable locality lb
* Fix https://github.com/istio/istio/issues/13317 by adding the test

The test added also tests the first two cases

Test is still failing locally so need to make a few more changes, WIP at the moment