### PR TITLE
eds: remove sleep in initLocalPilotTestEnv

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -66,6 +66,9 @@ func TestEds(t *testing.T) {
 	// Add the test ads clients to list of service instances in order to test the context dependent locality coloring.
 	addTestClientEndpoints(server)
 
+	// Trigger a push to update the contents of the registry to push context and push to connected clients.
+	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
+
 	adscConn := adsConnectAndWait(t, 0x0a0a0a0a)
 	defer adscConn.Close()
 	adscConn2 := adsConnectAndWait(t, 0x0a0a0a0b)
@@ -324,7 +327,6 @@ func addTestClientEndpoints(server *bootstrap.Server) {
 			Protocol: protocol.HTTP,
 		},
 	})
-	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
 }
 
 // Verify server sends the endpoint. This check for a single endpoint with the given
@@ -702,8 +704,6 @@ func addUdsEndpoint(server *bootstrap.Server) {
 			Protocol: protocol.GRPC,
 		},
 	})
-
-	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
 }
 
 func addLocalityEndpoints(server *bootstrap.Server, hostname host.Name) {
@@ -741,7 +741,6 @@ func addLocalityEndpoints(server *bootstrap.Server, hostname host.Name) {
 			},
 		})
 	}
-	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
 }
 
 func addEdsCluster(server *bootstrap.Server, hostName string, portName string, address string, port int) {
@@ -768,6 +767,7 @@ func addEdsCluster(server *bootstrap.Server, hostName string, portName string, a
 			Protocol: protocol.HTTP,
 		},
 	})
+
 	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
 }
 

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -767,7 +767,6 @@ func addEdsCluster(server *bootstrap.Server, hostName string, portName string, a
 			Protocol: protocol.HTTP,
 		},
 	})
-
 	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
 }
 

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 	"sync"
 	"testing"
-	"time"
 
 	testenv "istio.io/istio/mixer/test/client/env"
 	"istio.io/istio/pilot/pkg/bootstrap"
@@ -298,11 +297,12 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc, "",
 		newEndpointWithAccount("127.0.0.1", "hello-sa", "v1"))
 
-	// Update cache
+	// Trigger a push, to initiate push context with contents of registry.
 	server.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{Full: true})
-	// TODO: channel to notify when the push is finished and to notify individual updates, for
-	// debug and for the canary.
-	time.Sleep(2 * time.Second)
+
+	// Add a dummy client connection to validate that push is triggered.
+	dummyClient := adsConnectAndWait(t, 0x0a0a0a0a)
+	defer dummyClient.Close()
 
 	return server, tearDown
 }


### PR DESCRIPTION
Removes Sleep during initLocalPilotTestEnv

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
