### PR TITLE
istio.io tests: don't set WorkDir to env.IstioSrc

### DIFF
--- a/tests/integration/istioio/README.md
+++ b/tests/integration/istioio/README.md
@@ -75,12 +75,10 @@ func TestCombinedMethods(t *testing.T) {
         Run(istioio.NewBuilder("tasks__security__my_task").
             Add(istioio.Script{
                 Input:         istioio.Path("myscript.sh"),
-                WorkDir:       env.IstioSrc,
             },
             istioio.MultiPodWait("foo"),
             istioio.Script{
                 Input:         istioio.Path("myotherscript.sh"),
-                WorkDir:       env.IstioSrc,
             }).Build())
 }
 ```
@@ -148,7 +146,6 @@ snippets with `istioio.Script`:
 ```golang
 istioio.Script{
     Input:   istioio.Path("myscript.sh"),
-    WorkDir: env.IstioSrc,
 }
 ```
 

--- a/tests/integration/istioio/examples/bookinfo_test.go
+++ b/tests/integration/istioio/examples/bookinfo_test.go
@@ -17,7 +17,6 @@ package security
 import (
 	"testing"
 
-	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/istioio"
 )
@@ -29,8 +28,7 @@ func TestBookinfo(t *testing.T) {
 		NewTest(t).
 		Run(istioio.NewBuilder("examples__bookinfo").
 			Add(istioio.Script{
-				Input:   istioio.Path("scripts/bookinfo.txt"),
-				WorkDir: env.IstioSrc,
+				Input: istioio.Path("scripts/bookinfo.txt"),
 			}).
 			Defer(istioio.Script{
 				Input: istioio.Inline{
@@ -38,7 +36,6 @@ func TestBookinfo(t *testing.T) {
 					Value: `
 kubectl delete -n default -f samples/bookinfo/platform/kube/bookinfo.yaml || true`,
 				},
-				WorkDir: env.IstioSrc,
 			}).
 			Build())
 }

--- a/tests/integration/istioio/security/authz_http_test.go
+++ b/tests/integration/istioio/security/authz_http_test.go
@@ -17,7 +17,6 @@ package security
 import (
 	"testing"
 
-	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/istioio"
 )
@@ -29,8 +28,7 @@ func TestAuthorizationForHTTPServices(t *testing.T) {
 		NewTest(t).
 		Run(istioio.NewBuilder("tasks__security__authorization_for_http_services").
 			Add(istioio.Script{
-				Input:   istioio.Path("scripts/authz_http.txt"),
-				WorkDir: env.IstioSrc,
+				Input: istioio.Path("scripts/authz_http.txt"),
 			}, istioio.YamlResources{
 				BaseName:      "enforcing_namespace_level_access_control",
 				Input:         istioio.BookInfo("rbac/namespace-policy.yaml"),
@@ -63,6 +61,5 @@ kubectl delete -f samples/bookinfo/platform/kube/bookinfo.yaml || true
 kubectl delete -f samples/bookinfo/networking/bookinfo-gateway.yaml || true
 kubectl delete -f samples/sleep/sleep.yaml || true`,
 				},
-				WorkDir: env.IstioSrc,
 			}).Build())
 }

--- a/tests/integration/istioio/security/mtls_migration_test.go
+++ b/tests/integration/istioio/security/mtls_migration_test.go
@@ -17,7 +17,6 @@ package security
 import (
 	"testing"
 
-	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/istioio"
 )
@@ -30,7 +29,6 @@ func TestMutualTLSMigration(t *testing.T) {
 		NewTest(t).
 		Run(istioio.NewBuilder("tasks__security__mututal_tls_migration").
 			Add(istioio.Script{
-				WorkDir: env.IstioSrc,
 				Input: istioio.Inline{
 					FileName: "create_ns_foo_bar_legacy.sh",
 					Value: `
@@ -55,8 +53,7 @@ $ kubectl apply -f samples/sleep/sleep.yaml -n legacy
 				istioio.MultiPodWait("bar"),
 				istioio.MultiPodWait("legacy")).
 			Add(istioio.Script{
-				Input:   istioio.Path("scripts/mtls_migration.txt"),
-				WorkDir: env.IstioSrc,
+				Input: istioio.Path("scripts/mtls_migration.txt"),
 			}).
 			// Cleanup.
 			Defer(istioio.Script{

--- a/tests/integration/istioio/trafficmanagement/traffic_shifting_test.go
+++ b/tests/integration/istioio/trafficmanagement/traffic_shifting_test.go
@@ -17,7 +17,6 @@ package trafficmanagement
 import (
 	"testing"
 
-	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/istioio"
 )
@@ -27,8 +26,7 @@ func TestTrafficShifting(t *testing.T) {
 		NewTest(t).
 		Run(istioio.NewBuilder("tasks__traffic_management__traffic_shifting").
 			Add(istioio.Script{
-				Input:   istioio.Path("scripts/traffic_shifting.txt"),
-				WorkDir: env.IstioSrc,
+				Input: istioio.Path("scripts/traffic_shifting.txt"),
 			}).
 			Defer(istioio.Script{
 				Input: istioio.Inline{
@@ -41,7 +39,6 @@ kubectl delete -f samples/bookinfo/networking/virtual-service-all-v1.yaml || tru
 kubectl delete -f samples/bookinfo/networking/bookinfo-gateway.yaml || true
 kubectl delete -f samples/sleep/sleep.yaml || true`,
 				},
-				WorkDir: env.IstioSrc,
 			}).
 			Build())
 }


### PR DESCRIPTION
This is not required anymore as we're symlinking the samples/
directory into the test's WorkDir.

[x] Test and Release