### PR TITLE
Add basic bench testing for analyzers

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_bench_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_bench_test.go
@@ -1,0 +1,130 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/diag"
+	coll "istio.io/istio/galley/pkg/config/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/schema"
+	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/galley/pkg/config/schema/collections"
+	"istio.io/istio/galley/pkg/config/schema/snapshots"
+)
+
+type context struct {
+	set      *coll.Set
+	messages diag.Messages
+}
+
+var _ analysis.Context = &context{}
+
+// Report implements analysis.Context
+func (ctx *context) Report(_ collection.Name, m diag.Message) {
+	ctx.messages.Add(m)
+}
+
+// Find implements analysis.Context
+func (ctx *context) Find(col collection.Name, name resource.FullName) *resource.Instance {
+	c := ctx.set.Collection(col)
+	if c == nil {
+		return nil
+	}
+	return c.Get(name)
+}
+
+// Exists implements analysis.Context
+func (ctx *context) Exists(col collection.Name, name resource.FullName) bool {
+	return ctx.Find(col, name) != nil
+}
+
+// ForEach implements analysis.Context
+func (ctx *context) ForEach(col collection.Name, fn analysis.IteratorFn) {
+	c := ctx.set.Collection(col)
+	if c == nil {
+		return
+	}
+	c.ForEach(fn)
+}
+
+// Canceled implements analysis.Context
+func (ctx *context) Canceled() bool {
+	return false
+}
+
+type origin struct {
+	friendlyName string
+}
+
+func (o origin) Namespace() resource.Namespace { return "" }
+func (o origin) FriendlyName() string          { return o.friendlyName }
+
+// Note that what gets measured here is both the input pipeline (reading in YAML files, turning it into a snapshot) and the analysis.
+// This also doesn't tell us anything about how an analyzer performs at scale, since we're just looking at unit test data.
+func BenchmarkAnalyzers(b *testing.B) {
+	for _, tc := range testGrid {
+		tc := tc // Capture range variable so subtests work correctly
+		b.Run(tc.name+"-bench", func(b *testing.B) {
+			_, err := setupAndRunCase(tc, nil)
+			if err != nil {
+				b.Fatalf("Error running benchmark on testcase %s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// Benchmark analyzers against an artificial set of blank data.
+// This does not cover all scaling factors, and it's not representative of a realistic snapshot, but it does cover some things.
+func BenchmarkAnalyzersArtificialBlankData(b *testing.B) {
+	// TODO: Fix log spam
+
+	// Get the set of collections that could actually get used
+	m := schema.MustGet()
+	isUsedCollection := make(map[string]bool)
+	for _, col := range m.AllCollectionsInSnapshots(snapshots.SnapshotNames()) {
+		isUsedCollection[col] = true
+	}
+
+	set := coll.NewSet(collections.All)
+	collections.All.ForEach(func(s collection.Schema) bool {
+		// Skip over collections that the Galley pipeline would always ignore
+		if !isUsedCollection[s.Name().String()] {
+			return false
+		}
+
+		for i := 0; i < 100; i++ { // TODO: Configurable scaling factor
+			name := resource.NewFullName("default", resource.LocalName(fmt.Sprintf("%s-%d", s.Name(), i)))
+			r := &resource.Instance{
+				Metadata: resource.Metadata{
+					Schema:   s.Resource(),
+					FullName: name,
+				},
+				Message: s.Resource().MustNewProtoInstance(),
+				Origin:  &origin{friendlyName: name.String()},
+			}
+			set.Collection(s.Name()).Set(r)
+		}
+
+		return false
+	})
+	ctx := &context{set: set}
+
+	b.ResetTimer()
+	AllCombined().Analyze(ctx)
+}

--- a/galley/pkg/config/analysis/analyzers/analyzers_bench_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_bench_test.go
@@ -123,6 +123,7 @@ func benchmarkAnalyzersArtificialBlankData(count int, b *testing.B) {
 		isUsedCollection[col] = true
 	}
 
+	// Generate blank test data
 	set := coll.NewSet(collections.All)
 	collections.All.ForEach(func(s collection.Schema) bool {
 		// Skip over collections that the Galley pipeline would always ignore
@@ -148,5 +149,9 @@ func benchmarkAnalyzersArtificialBlankData(count int, b *testing.B) {
 	ctx := &context{set: set}
 
 	b.ResetTimer()
-	AllCombined().Analyze(ctx)
+	for _, a := range All() {
+		b.Run(a.Metadata().Name+"-bench", func(b *testing.B) {
+			a.Analyze(ctx)
+		})
+	}
 }

--- a/galley/pkg/config/analysis/analyzers/analyzers_bench_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_bench_test.go
@@ -77,15 +77,22 @@ type origin struct {
 func (o origin) Namespace() resource.Namespace { return "" }
 func (o origin) FriendlyName() string          { return o.friendlyName }
 
-// Note that what gets measured here is both the input pipeline (reading in YAML files, turning it into a snapshot) and the analysis.
-// This also doesn't tell us anything about how an analyzer performs at scale, since we're just looking at unit test data.
+// This is a very basic benchmark on unit test data, so it doesn't tell us anything about how an analyzer performs at scale
 func BenchmarkAnalyzers(b *testing.B) {
 	for _, tc := range testGrid {
 		tc := tc // Capture range variable so subtests work correctly
 		b.Run(tc.name+"-bench", func(b *testing.B) {
-			_, err := setupAndRunCase(tc, nil)
+			sa, err := setupAnalyzerForCase(tc, nil)
 			if err != nil {
-				b.Fatalf("Error running benchmark on testcase %s: %v", tc.name, err)
+				b.Fatalf("Error setting up analysis for benchmark on testcase %s: %v", tc.name, err)
+			}
+
+			b.ResetTimer()
+
+			// Run the analysis
+			_, err = runAnalyzer(sa)
+			if err != nil {
+				b.Fatalf("Error running analysis for benchmark on testcase %s: %v", tc.name, err)
 			}
 		})
 	}

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -475,21 +475,6 @@ func TestAnalyzersHaveDescription(t *testing.T) {
 	}
 }
 
-// Note that what gets measured here is both the input pipeline (reading in YAML files, turning it into a snapshot) and the analysis.
-// TODO: Can I separate those, so I can measure only the latter?
-// TODO: Can I adapt this for scale? Or separate scaling-sensitive tests?
-func BenchmarkAnalyzers(b *testing.B) {
-	for _, tc := range testGrid {
-		tc := tc // Capture range variable so subtests work correctly
-		b.Run(tc.name+"-bench", func(b *testing.B) {
-			_, err := setupAndRunCase(tc, nil)
-			if err != nil {
-				b.Fatalf("Error running benchmark on testcase %s: %v", tc.name, err)
-			}
-		})
-	}
-}
-
 func setupAndRunCase(tc testCase, cr snapshotter.CollectionReporterFn) (local.AnalysisResult, error) {
 	// Default processing log level is too chatty for these tests
 	prevLogLevel := scope.Processing.GetOutputLevel()

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -57,10 +57,8 @@ const (
 
 // Pseudo-constants, since golang doesn't support a true const slice/array
 var (
-	requiredPerms = []string{"list", "watch"}
-
-	// AnalysisSnapshots are the snapshots used for local analysis
-	AnalysisSnapshots = []string{snapshots.LocalAnalysis, snapshots.SyntheticServiceEntry}
+	requiredPerms     = []string{"list", "watch"}
+	analysisSnapshots = []string{snapshots.LocalAnalysis, snapshots.SyntheticServiceEntry}
 )
 
 // Patch table
@@ -158,7 +156,7 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (AnalysisResult, error) 
 	}
 
 	var colsInSnapshots collection.Names
-	for _, c := range sa.m.AllCollectionsInSnapshots(AnalysisSnapshots) {
+	for _, c := range sa.m.AllCollectionsInSnapshots(analysisSnapshots) {
 		colsInSnapshots = append(colsInSnapshots, collection.NewName(c))
 	}
 
@@ -171,7 +169,7 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (AnalysisResult, error) 
 		StatusUpdater:      updater,
 		Analyzer:           sa.analyzer,
 		Distributor:        snapshotter.NewInMemoryDistributor(),
-		AnalysisSnapshots:  AnalysisSnapshots,
+		AnalysisSnapshots:  analysisSnapshots,
 		TriggerSnapshot:    snapshots.LocalAnalysis,
 		CollectionReporter: sa.collectionReporter,
 		AnalysisNamespaces: namespaces,
@@ -185,7 +183,7 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (AnalysisResult, error) 
 		Source:             newPrecedenceSource(sa.sources),
 		TransformProviders: sa.transformerProviders,
 		Distributor:        distributor,
-		EnabledSnapshots:   AnalysisSnapshots,
+		EnabledSnapshots:   analysisSnapshots,
 	}
 	rt, err := processor.Initialize(processorSettings)
 	if err != nil {

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -58,6 +58,9 @@ const (
 // Pseudo-constants, since golang doesn't support a true const slice/array
 var (
 	requiredPerms = []string{"list", "watch"}
+
+	// AnalysisSnapshots are the snapshots used for local analysis
+	AnalysisSnapshots = []string{snapshots.LocalAnalysis, snapshots.SyntheticServiceEntry}
 )
 
 // Patch table
@@ -155,7 +158,7 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (AnalysisResult, error) 
 	}
 
 	var colsInSnapshots collection.Names
-	for _, c := range sa.m.AllCollectionsInSnapshots([]string{snapshots.LocalAnalysis, snapshots.SyntheticServiceEntry}) {
+	for _, c := range sa.m.AllCollectionsInSnapshots(AnalysisSnapshots) {
 		colsInSnapshots = append(colsInSnapshots, collection.NewName(c))
 	}
 
@@ -168,7 +171,7 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (AnalysisResult, error) 
 		StatusUpdater:      updater,
 		Analyzer:           sa.analyzer,
 		Distributor:        snapshotter.NewInMemoryDistributor(),
-		AnalysisSnapshots:  []string{snapshots.LocalAnalysis, snapshots.SyntheticServiceEntry},
+		AnalysisSnapshots:  AnalysisSnapshots,
 		TriggerSnapshot:    snapshots.LocalAnalysis,
 		CollectionReporter: sa.collectionReporter,
 		AnalysisNamespaces: namespaces,
@@ -182,7 +185,7 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (AnalysisResult, error) 
 		Source:             newPrecedenceSource(sa.sources),
 		TransformProviders: sa.transformerProviders,
 		Distributor:        distributor,
-		EnabledSnapshots:   []string{snapshots.LocalAnalysis, snapshots.SyntheticServiceEntry},
+		EnabledSnapshots:   AnalysisSnapshots,
 	}
 	rt, err := processor.Initialize(processorSettings)
 	if err != nil {


### PR DESCRIPTION
Add basic performance bench tests for analyzers. For https://github.com/istio/istio/issues/18008. 

These come in two forms:

* A simple bench test using our unit test case data (minimal input sizes). This is simply a benchmarked version of the required analyzer unit tests.  
* A bench test using artificially constructed test data, with N of every possible resource (and each resource being entirely blank). 

This doesn't give anywhere near perfect coverage and neither scenario is really "realistic", but it is enough to highlight some analyzers as being outliers in terms of how long they take to run, and that's something we can take action on. 

Example output (filtering out results with < 0.01 ns/op):
```
 crwilson@crwilson:~/go/src/istio.io/istio$ go test -bench=. -run=XXX ./galley/pkg/config/analysis/analyzers -v | grep -v "0\.00"
goos: linux
goarch: amd64
pkg: istio.io/istio/galley/pkg/config/analysis/analyzers
BenchmarkAnalyzers/virtualServiceDestinationHosts-bench-8                        	1000000000	         0.0115 ns/op
BenchmarkAnalyzersArtificialBlankData100/gateway.IngressGatewayPortAnalyzer-bench-8       	1000000000	         0.0231 ns/op
BenchmarkAnalyzersArtificialBlankData200/gateway.IngressGatewayPortAnalyzer-bench-8                         	1000000000	         0.181 ns/op
BenchmarkAnalyzersArtificialBlankData400/gateway.IngressGatewayPortAnalyzer-bench-8                         	       1	1436830870 ns/op
BenchmarkAnalyzersArtificialBlankData800/auth.MTLSAnalyzer-bench-8                                          	1000000000	         0.0216 ns/op
BenchmarkAnalyzersArtificialBlankData800/gateway.IngressGatewayPortAnalyzer-bench-8                         	       1	11516476224 ns/op
PASS
ok  	istio.io/istio/galley/pkg/config/analysis/analyzers	22.562s
```
Note that bench results can be further profiled, see https://medium.com/@felipedutratine/profile-your-benchmark-with-pprof-fb7070ee1a94 for one article about how. 