### PR TITLE
Enable k8s CA signing through an environmental variable

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -367,7 +367,7 @@ var (
 			if !nodeAgentSDSEnabled { // Not using citadel agent - this is either Pilot or Istiod.
 
 				// Istiod and new SDS-only mode doesn't use sdsUdsPathVar - sdsEnabled will be false.
-				sa := istio_agent.NewSDSAgent(discoveryAddress, controlPlaneAuthEnabled)
+				sa := istio_agent.NewSDSAgent(discoveryAddress, controlPlaneAuthEnabled, pilotCertProvider)
 
 				if sa.JWTPath != "" {
 					// If user injected a JWT token for SDS - use SDS.

--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -351,7 +352,7 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache *cache.Secre
 
 			if serverOptions.PilotCertProvider == "citadel" {
 				log.Info("istiod uses self-issued certificate")
-				if rootCert, err = ioutil.ReadFile(CitadelCACertPath + "/" + bootstrap.CACertNamespaceConfigMapDataName); err != nil {
+				if rootCert, err = ioutil.ReadFile(path.Join(CitadelCACertPath, bootstrap.CACertNamespaceConfigMapDataName)); err != nil {
 					certReadErr = true
 				}
 			} else if serverOptions.PilotCertProvider == "kubernetes" {
@@ -380,11 +381,10 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache *cache.Secre
 			if strings.HasSuffix(serverOptions.CAEndpoint, ":15010") {
 				log.Warna("Debug mode or IP-secure network")
 				tls = false
-			}
-			if strings.HasSuffix(serverOptions.CAEndpoint, ":15012") {
+			} else if strings.HasSuffix(serverOptions.CAEndpoint, ":15012") {
 				if serverOptions.PilotCertProvider == "citadel" {
 					log.Info("istiod uses self-issued certificate")
-					if rootCert, err = ioutil.ReadFile(CitadelCACertPath + "/" + bootstrap.CACertNamespaceConfigMapDataName); err != nil {
+					if rootCert, err = ioutil.ReadFile(path.Join(CitadelCACertPath, bootstrap.CACertNamespaceConfigMapDataName)); err != nil {
 						certReadErr = true
 					}
 				} else if serverOptions.PilotCertProvider == "kubernetes" {
@@ -405,6 +405,8 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache *cache.Secre
 					rootCert = nil
 					log.Fatal("invalid config - port 15012 missing a root certificate")
 				}
+			} else {
+				log.Fatal("invalid config - the port is not 15010 or 15012")
 			}
 		}
 

--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -124,7 +124,7 @@ const (
 	pkcs8Key = "PKCS8_KEY"
 
 	// The environmental variable name for whether enabling k8s CA signing
-	enableKubernetesCaKey = "ENABLE_KUBERNETES_CA"
+	enableKubernetesCaKey = "SIGN_CERT_AT_KUBERNETES_CA"
 )
 
 var (
@@ -357,6 +357,7 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache *cache.Secre
 				log.Infof("istiod uses the root certificate mounted in a well known location %v",
 					cache.ExistingRootCertFile)
 			} else {
+				rootCert = nil
 				// for debugging only
 				log.Warnf("Failed to load root cert, assume IP secure network: %v", err)
 				serverOptions.CAEndpoint = "istio-pilot.istio-system.svc:15010"
@@ -377,6 +378,7 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache *cache.Secre
 					log.Infof("istiod uses the root certificate mounted in a well known location %v",
 						cache.ExistingRootCertFile)
 				} else {
+					rootCert = nil
 					log.Fatal("invalid config - port 15012 missing a root certificate")
 				}
 			}

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -106,8 +106,8 @@ type Options struct {
 	// Whether to generate PKCS#8 private keys.
 	Pkcs8Keys bool
 
-	// Whether enable Kubernetes CA signing.
-	EnableKubernetesCa bool
+	// PilotCertProvider is the provider of the Pilot certificate.
+	PilotCertProvider string
 }
 
 // Server is the gPRC server that exposes SDS through UDS.

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -105,6 +105,9 @@ type Options struct {
 
 	// Whether to generate PKCS#8 private keys.
 	Pkcs8Keys bool
+
+	// Whether enable Kubernetes CA signing.
+	EnableKubernetesCa bool
 }
 
 // Server is the gPRC server that exposes SDS through UDS.


### PR DESCRIPTION
Please provide a description for what this PR is for: 
Enable k8s CA signing through an environmental variable since the existence of "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" does not necessarily mean using k8s CA signing. This PR is related to the issue https://github.com/istio/istio/issues/19950.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure