### PR TITLE
support deny action in authorization policy

### DIFF
--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -29,7 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
-	authz_builder "istio.io/istio/pilot/pkg/security/authz/builder"
+	authzBuilder "istio.io/istio/pilot/pkg/security/authz/builder"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
 	"istio.io/istio/pkg/spiffe"
 )
@@ -80,7 +80,7 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 	// TODO: Get trust domain from MeshConfig instead.
 	// https://github.com/istio/istio/issues/17873
 	trustDomainBundle := trustdomain.NewTrustDomainBundle(spiffe.GetTrustDomain(), in.Push.Mesh.TrustDomainAliases)
-	builder := authz_builder.NewBuilder(trustDomainBundle, in.ServiceInstance,
+	builder := authzBuilder.NewBuilder(trustDomainBundle, in.ServiceInstance,
 		in.Node.WorkloadLabels, in.Node.ConfigNamespace, in.Push.AuthzPolicies, util.IsXDSMarshalingToAnyEnabled(in.Node))
 	if builder == nil {
 		return

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -89,35 +89,37 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 	switch in.ListenerProtocol {
 	case plugin.ListenerProtocolTCP:
 		rbacLog.Debugf("building filter for TCP listener protocol")
-		tcpFilter := builder.BuildTCPFilter()
+		tcpFilters := builder.BuildTCPFilters()
 		if in.Node.Type == model.Router {
 			// For gateways, due to TLS termination, a listener marked as TCP could very well
 			// be using a HTTP connection manager. So check the filterChain.listenerProtocol
 			// to decide the type of filter to attach
-			httpFilter := builder.BuildHTTPFilter()
+			httpFilters := builder.BuildHTTPFilters()
 			for cnum := range mutable.FilterChains {
 				if mutable.FilterChains[cnum].ListenerProtocol == plugin.ListenerProtocolHTTP {
-					if httpFilter != nil {
+					for _, httpFilter := range httpFilters {
 						rbacLog.Debugf("added HTTP filter to gateway filter chain %d", cnum)
 						mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, httpFilter)
 					}
 				} else {
-					if tcpFilter != nil {
+					for _, tcpFilter := range tcpFilters {
 						rbacLog.Debugf("added TCP filter to gateway filter chain %d", cnum)
 						mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, tcpFilter)
 					}
 				}
 			}
 		} else {
-			for cnum := range mutable.FilterChains {
-				rbacLog.Debugf("added TCP filter to filter chain %d", cnum)
-				mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, tcpFilter)
+			for _, tcpFilter := range tcpFilters {
+				for cnum := range mutable.FilterChains {
+					rbacLog.Debugf("added TCP filter to filter chain %d", cnum)
+					mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, tcpFilter)
+				}
 			}
 		}
 	case plugin.ListenerProtocolHTTP:
 		rbacLog.Debugf("building filter for HTTP listener protocol")
-		filter := builder.BuildHTTPFilter()
-		if filter != nil {
+		filters := builder.BuildHTTPFilters()
+		for _, filter := range filters {
 			for cnum := range mutable.FilterChains {
 				rbacLog.Debugf("added HTTP filter to filter chain %d", cnum)
 				mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, filter)
@@ -125,18 +127,18 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) {
 		}
 	case plugin.ListenerProtocolAuto:
 		rbacLog.Debugf("building filter for AUTO listener protocol")
-		httpFilter := builder.BuildHTTPFilter()
-		tcpFilter := builder.BuildTCPFilter()
+		httpFilters := builder.BuildHTTPFilters()
+		tcpFilters := builder.BuildTCPFilters()
 
 		for cnum := range mutable.FilterChains {
 			switch mutable.FilterChains[cnum].ListenerProtocol {
 			case plugin.ListenerProtocolTCP:
-				if tcpFilter != nil {
+				for _, tcpFilter := range tcpFilters {
 					rbacLog.Debugf("added TCP filter to filter chain %d", cnum)
 					mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, tcpFilter)
 				}
 			case plugin.ListenerProtocolHTTP:
-				if httpFilter != nil {
+				for _, httpFilter := range httpFilters {
 					rbacLog.Debugf("added HTTP filter to filter chain %d", cnum)
 					mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, httpFilter)
 				}

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -126,7 +126,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 		p := policy.NewAuthzPolicies(tc.policies, t)
 		b := NewBuilder(trustdomain.NewTrustDomainBundle("", nil), service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
 
-		got := b.BuildHTTPFilter()
+		_, got := b.BuildHTTPFilter()
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.wantPolicies == nil {
 				if got != nil {
@@ -219,7 +219,7 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 		b := NewBuilder(trustdomain.NewTrustDomainBundle("", nil), service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
 
 		t.Run(tc.name, func(t *testing.T) {
-			got := b.BuildTCPFilter()
+			_, got := b.BuildTCPFilter()
 			if got.Name != authz_model.RBACTCPFilterName {
 				t.Errorf("got filter name %q but want %q", got.Name, authz_model.RBACTCPFilterName)
 			}

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -18,15 +18,15 @@ import (
 	"strings"
 	"testing"
 
-	http_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
-	tcp_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rbac/v2"
+	envoyRbacHttpPb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
+	envoyRbacTcpPb "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rbac/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 
-	istio_rbac "istio.io/api/rbac/v1alpha1"
+	istioRbacPb "istio.io/api/rbac/v1alpha1"
 
 	"istio.io/istio/galley/pkg/config/schema/collections"
 	"istio.io/istio/pilot/pkg/model"
-	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
+	authzModel "istio.io/istio/pilot/pkg/security/authz/model"
 	"istio.io/istio/pilot/pkg/security/authz/policy"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
 	"istio.io/istio/pkg/config/host"
@@ -61,9 +61,9 @@ func simpleGlobalPermissiveMode() *model.Config {
 			Name:      "default",
 			Namespace: "default",
 		},
-		Spec: &istio_rbac.RbacConfig{
-			Mode:            istio_rbac.RbacConfig_ON,
-			EnforcementMode: istio_rbac.EnforcementMode_PERMISSIVE,
+		Spec: &istioRbacPb.RbacConfig{
+			Mode:            istioRbacPb.RbacConfig_ON,
+			EnforcementMode: istioRbacPb.EnforcementMode_PERMISSIVE,
 		},
 	}
 	return cfg
@@ -76,7 +76,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 		name                        string
 		policies                    []*model.Config
 		isXDSMarshalingToAnyEnabled bool
-		wantPolicies                []string
+		wantPolicies                [][]string
 	}{
 		{
 			name: "XDSMarshalingToAnyEnabled",
@@ -84,7 +84,7 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 				policy.SimpleClusterRbacConfig(),
 			},
 			isXDSMarshalingToAnyEnabled: true,
-			wantPolicies:                []string{},
+			wantPolicies:                [][]string{},
 		},
 		{
 			name: "v1alpha1 only",
@@ -93,7 +93,9 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 				policy.SimpleRole("role-1", "a", "bar"),
 				policy.SimpleBinding("binding-1", "a", "role-1"),
 			},
-			wantPolicies: []string{"role-1"},
+			wantPolicies: [][]string{
+				{"role-1"},
+			},
 		},
 		{
 			name: "v1alpha1 without ClusterRbacConfig",
@@ -103,12 +105,23 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "v1beta1 only",
+			name: "v1beta1 allow policies",
 			policies: []*model.Config{
-				policy.SimpleAuthorizationPolicy("authz-bar", "a"),
-				policy.SimpleAuthorizationPolicy("authz-foo", "a"),
+				policy.SimpleAllowPolicy("authz-bar", "a"),
+				policy.SimpleAllowPolicy("authz-foo", "a"),
 			},
-			wantPolicies: []string{"ns[a]-policy[authz-bar]-rule[0]", "ns[a]-policy[authz-foo]-rule[0]"},
+			wantPolicies: [][]string{
+				{"ns[a]-policy[authz-bar]-rule[0]", "ns[a]-policy[authz-foo]-rule[0]"}},
+		},
+		{
+			name: "v1beta1 deny policies",
+			policies: []*model.Config{
+				policy.SimpleDenyPolicy("authz-bar", "a"),
+				policy.SimpleDenyPolicy("authz-foo", "a"),
+			},
+			wantPolicies: [][]string{
+				{"ns[a]-policy[authz-bar]-rule[0]", "ns[a]-policy[authz-foo]-rule[0]"},
+			},
 		},
 		{
 			name: "v1alpha1 and v1beta1",
@@ -116,9 +129,13 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 				policy.SimpleClusterRbacConfig(),
 				policy.SimpleRole("role-1", "a", "bar"),
 				policy.SimpleBinding("binding-1", "a", "role-1"),
-				policy.SimpleAuthorizationPolicy("authz-bar", "a"),
+				policy.SimpleAllowPolicy("authz-allow-bar", "a"),
+				policy.SimpleDenyPolicy("authz-deny-bar", "a"),
 			},
-			wantPolicies: []string{"ns[a]-policy[authz-bar]-rule[0]"},
+			wantPolicies: [][]string{
+				{"ns[a]-policy[authz-deny-bar]-rule[0]"},
+				{"ns[a]-policy[authz-allow-bar]-rule[0]"},
+			},
 		},
 	}
 
@@ -126,41 +143,46 @@ func TestBuilder_BuildHTTPFilter(t *testing.T) {
 		p := policy.NewAuthzPolicies(tc.policies, t)
 		b := NewBuilder(trustdomain.NewTrustDomainBundle("", nil), service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
 
-		_, got := b.BuildHTTPFilter()
+		filters := b.BuildHTTPFilters()
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.wantPolicies == nil {
-				if got != nil {
-					t.Errorf("want empty config but got: %v", got)
+				if len(filters) != 0 {
+					t.Errorf("want empty config but got: %v", filters)
 				}
 			} else {
-				if got.Name != authz_model.RBACHTTPFilterName {
-					t.Errorf("got filter name %q but want %q", got.Name, authz_model.RBACHTTPFilterName)
-				}
-				if tc.isXDSMarshalingToAnyEnabled {
-					if got.GetTypedConfig() == nil {
-						t.Errorf("want typed config when isXDSMarshalingToAnyEnabled is true")
+				for i, got := range filters {
+					if got.Name != authzModel.RBACHTTPFilterName {
+						t.Errorf("got filter name %q but want %q", got.Name, authzModel.RBACHTTPFilterName)
 					}
-				} else {
-					rbacConfig := &http_config.RBAC{}
-
-					// nolint: staticcheck
-					if got.GetConfig() == nil {
-						t.Errorf("want struct config when isXDSMarshalingToAnyEnabled is false")
-					} else if err := conversion.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
-						t.Errorf("failed to convert struct to message: %s", err)
+					if tc.isXDSMarshalingToAnyEnabled {
+						if got.GetTypedConfig() == nil {
+							t.Errorf("want typed config when isXDSMarshalingToAnyEnabled is true")
+						}
 					} else {
-						if len(tc.wantPolicies) == 0 {
-							if len(rbacConfig.GetRules().GetPolicies()) > 0 {
-								t.Errorf("got rules with policies %v but want no policies", rbacConfig.GetRules().GetPolicies())
-							}
+						if len(tc.wantPolicies) != len(filters) {
+							t.Fatalf("want %d filters but found %d", len(tc.wantPolicies), len(filters))
+						}
+						rbacConfig := &envoyRbacHttpPb.RBAC{}
+
+						// nolint: staticcheck
+						if got.GetConfig() == nil {
+							t.Errorf("want struct config when isXDSMarshalingToAnyEnabled is false")
+						} else if err := conversion.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
+							t.Errorf("failed to convert struct to message: %s", err)
 						} else {
-							for _, want := range tc.wantPolicies {
-								if _, found := rbacConfig.GetRules().GetPolicies()[want]; !found {
-									t.Errorf("got rules with policies %v but want %v", rbacConfig.GetRules().GetPolicies(), want)
+							if len(tc.wantPolicies[i]) == 0 {
+								if len(rbacConfig.GetRules().GetPolicies()) > 0 {
+									t.Errorf("got rules with policies %v but want no policies", rbacConfig.GetRules().GetPolicies())
 								}
-							}
-							if len(tc.wantPolicies) != len(rbacConfig.GetRules().GetPolicies()) {
-								t.Errorf("got %d policies but want %d", len(rbacConfig.GetRules().GetPolicies()), len(tc.wantPolicies))
+							} else {
+								for _, want := range tc.wantPolicies[i] {
+									if _, found := rbacConfig.GetRules().GetPolicies()[want]; !found {
+										t.Errorf("got rules with policies %v but want %v", rbacConfig.GetRules().GetPolicies(), want)
+									}
+								}
+								if len(tc.wantPolicies[i]) != len(rbacConfig.GetRules().GetPolicies()) {
+									t.Errorf("got %d policies but want %d", len(rbacConfig.GetRules().GetPolicies()), len(tc.wantPolicies[i]))
+								}
 							}
 						}
 					}
@@ -219,9 +241,13 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 		b := NewBuilder(trustdomain.NewTrustDomainBundle("", nil), service, nil, "a", p, tc.isXDSMarshalingToAnyEnabled)
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, got := b.BuildTCPFilter()
-			if got.Name != authz_model.RBACTCPFilterName {
-				t.Errorf("got filter name %q but want %q", got.Name, authz_model.RBACTCPFilterName)
+			filters := b.BuildTCPFilters()
+			if len(filters) != 1 {
+				t.Fatalf("want 1 filter but got %d", len(filters))
+			}
+			got := filters[0]
+			if got.Name != authzModel.RBACTCPFilterName {
+				t.Errorf("got filter name %q but want %q", got.Name, authzModel.RBACTCPFilterName)
 			}
 
 			if tc.isXDSMarshalingToAnyEnabled {
@@ -229,16 +255,16 @@ func TestBuilder_BuildTCPFilter(t *testing.T) {
 					t.Errorf("want typed config when isXDSMarshalingToAnyEnabled is true")
 				}
 			} else {
-				rbacConfig := &tcp_config.RBAC{}
+				rbacConfig := &envoyRbacTcpPb.RBAC{}
 				// nolint: staticcheck
 				if got.GetConfig() == nil {
 					t.Errorf("want struct config when isXDSMarshalingToAnyEnabled is false")
 				} else if err := conversion.StructToMessage(got.GetConfig(), rbacConfig); err != nil {
 					t.Errorf("failed to convert struct to message: %s", err)
 				} else {
-					if rbacConfig.StatPrefix != authz_model.RBACTCPFilterStatPrefix {
+					if rbacConfig.StatPrefix != authzModel.RBACTCPFilterStatPrefix {
 						t.Errorf("got filter stat prefix %q but want %q",
-							rbacConfig.StatPrefix, authz_model.RBACTCPFilterStatPrefix)
+							rbacConfig.StatPrefix, authzModel.RBACTCPFilterStatPrefix)
 					}
 
 					if len(rbacConfig.GetRules().GetPolicies()) > 0 != tc.wantRuleWithPolicies {

--- a/pilot/pkg/security/authz/builder/integration_test.go
+++ b/pilot/pkg/security/authz/builder/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	http_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
+	"github.com/gogo/protobuf/proto"
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/model"
@@ -34,89 +35,96 @@ func TestBuildHTTPFilter(t *testing.T) {
 		name              string
 		trustDomainBundle trustdomain.Bundle
 		policies          *model.AuthorizationPolicies
-		want              *http_config.RBAC
+		wantDeny          *http_config.RBAC
+		wantAllow         *http_config.RBAC
 	}{
 		{
-			name:     "v1beta1 all fields",
-			policies: getPolicies("testdata/v1beta1/all-fields-in.yaml", t),
-			want:     getProto("testdata/v1beta1/all-fields-out.yaml", t),
+			name:      "v1beta1 action",
+			policies:  getPolicies("testdata/v1beta1/action-in.yaml", t),
+			wantDeny:  getProto("testdata/v1beta1/action-deny-out.yaml", t),
+			wantAllow: getProto("testdata/v1beta1/action-allow-out.yaml", t),
 		},
 		{
-			name:     "v1beta1 allow all",
-			policies: getPolicies("testdata/v1beta1/allow-all-in.yaml", t),
-			want:     getProto("testdata/v1beta1/allow-all-out.yaml", t),
+			name:      "v1beta1 all fields",
+			policies:  getPolicies("testdata/v1beta1/all-fields-in.yaml", t),
+			wantAllow: getProto("testdata/v1beta1/all-fields-out.yaml", t),
 		},
 		{
-			name:     "v1beta1 deny all",
-			policies: getPolicies("testdata/v1beta1/deny-all-in.yaml", t),
-			want:     getProto("testdata/v1beta1/deny-all-out.yaml", t),
+			name:      "v1beta1 allow all",
+			policies:  getPolicies("testdata/v1beta1/allow-all-in.yaml", t),
+			wantAllow: getProto("testdata/v1beta1/allow-all-out.yaml", t),
 		},
 		{
-			name:     "v1beta1 multiple policies",
-			policies: getPolicies("testdata/v1beta1/multiple-policies-in.yaml", t),
-			want:     getProto("testdata/v1beta1/multiple-policies-out.yaml", t),
+			name:      "v1beta1 deny all",
+			policies:  getPolicies("testdata/v1beta1/deny-all-in.yaml", t),
+			wantAllow: getProto("testdata/v1beta1/deny-all-out.yaml", t),
 		},
 		{
-			name:     "v1beta1 not override v1alpha1",
-			policies: getPolicies("testdata/v1beta1/not-override-v1alpha1-in.yaml", t),
-			want:     getProto("testdata/v1beta1/not-override-v1alpha1-out.yaml", t),
+			name:      "v1beta1 multiple policies",
+			policies:  getPolicies("testdata/v1beta1/multiple-policies-in.yaml", t),
+			wantAllow: getProto("testdata/v1beta1/multiple-policies-out.yaml", t),
 		},
 		{
-			name:     "v1beta1 override v1alpha1",
-			policies: getPolicies("testdata/v1beta1/override-v1alpha1-in.yaml", t),
-			want:     getProto("testdata/v1beta1/override-v1alpha1-out.yaml", t),
+			name:      "v1beta1 not override v1alpha1",
+			policies:  getPolicies("testdata/v1beta1/not-override-v1alpha1-in.yaml", t),
+			wantAllow: getProto("testdata/v1beta1/not-override-v1alpha1-out.yaml", t),
 		},
 		{
-			name:     "v1beta1 single policy",
-			policies: getPolicies("testdata/v1beta1/single-policy-in.yaml", t),
-			want:     getProto("testdata/v1beta1/single-policy-out.yaml", t),
+			name:      "v1beta1 override v1alpha1",
+			policies:  getPolicies("testdata/v1beta1/override-v1alpha1-in.yaml", t),
+			wantAllow: getProto("testdata/v1beta1/override-v1alpha1-out.yaml", t),
 		},
 		{
-			name:     "v1alpha1 all fields",
-			policies: getPolicies("testdata/v1alpha1/all-fields-in.yaml", t),
-			want:     getProto("testdata/v1alpha1/all-fields-out.yaml", t),
+			name:      "v1beta1 single policy",
+			policies:  getPolicies("testdata/v1beta1/single-policy-in.yaml", t),
+			wantAllow: getProto("testdata/v1beta1/single-policy-out.yaml", t),
+		},
+		{
+			name:      "v1alpha1 all fields",
+			policies:  getPolicies("testdata/v1alpha1/all-fields-in.yaml", t),
+			wantAllow: getProto("testdata/v1alpha1/all-fields-out.yaml", t),
 		},
 		{
 			name:              "v1beta1 one trust domain alias",
 			trustDomainBundle: trustdomain.NewTrustDomainBundle("td1", []string{"cluster.local"}),
 			policies:          getPolicies("testdata/v1beta1/simple-policy-td-aliases-in.yaml", t),
-			want:              getProto("testdata/v1beta1/simple-policy-td-aliases-out.yaml", t),
+			wantAllow:         getProto("testdata/v1beta1/simple-policy-td-aliases-out.yaml", t),
 		},
 		{
 			name:              "v1beta1 multiple trust domain aliases",
 			trustDomainBundle: trustdomain.NewTrustDomainBundle("td1", []string{"cluster.local", "some-td"}),
 			policies:          getPolicies("testdata/v1beta1/simple-policy-multiple-td-aliases-in.yaml", t),
-			want:              getProto("testdata/v1beta1/simple-policy-multiple-td-aliases-out.yaml", t),
+			wantAllow:         getProto("testdata/v1beta1/simple-policy-multiple-td-aliases-out.yaml", t),
 		},
 		{
 			name:              "v1alpha1 one trust domain alias",
 			trustDomainBundle: trustdomain.NewTrustDomainBundle("td1", []string{"cluster.local"}),
 			policies:          getPolicies("testdata/v1alpha1/simple-policy-td-aliases-in.yaml", t),
-			want:              getProto("testdata/v1alpha1/simple-policy-td-aliases-out.yaml", t),
+			wantAllow:         getProto("testdata/v1alpha1/simple-policy-td-aliases-out.yaml", t),
 		},
 		{
 			name:              "v1alpha1 trust domain with * in principal",
 			trustDomainBundle: trustdomain.NewTrustDomainBundle("td1", []string{"foobar"}),
 			policies:          getPolicies("testdata/v1alpha1/simple-policy-user-with-wildcard-in.yaml", t),
-			want:              getProto("testdata/v1alpha1/simple-policy-user-with-wildcard-out.yaml", t),
+			wantAllow:         getProto("testdata/v1alpha1/simple-policy-user-with-wildcard-out.yaml", t),
 		},
 		{
 			name:              "v1beta1 trust domain with * in principal",
 			trustDomainBundle: trustdomain.NewTrustDomainBundle("td1", []string{"foobar"}),
 			policies:          getPolicies("testdata/v1beta1/simple-policy-principal-with-wildcard-in.yaml", t),
-			want:              getProto("testdata/v1beta1/simple-policy-principal-with-wildcard-out.yaml", t),
+			wantAllow:         getProto("testdata/v1beta1/simple-policy-principal-with-wildcard-out.yaml", t),
 		},
 		{
 			name:              "v1alpha1 trust domain aliases with source.principal",
 			trustDomainBundle: trustdomain.NewTrustDomainBundle("new-td", []string{"old-td", "some-trustdomain"}),
 			policies:          getPolicies("testdata/v1alpha1/td-aliases-source-principal-in.yaml", t),
-			want:              getProto("testdata/v1alpha1/td-aliases-source-principal-out.yaml", t),
+			wantAllow:         getProto("testdata/v1alpha1/td-aliases-source-principal-out.yaml", t),
 		},
 		{
 			name:              "v1beta1 trust domain aliases with source.principal",
 			trustDomainBundle: trustdomain.NewTrustDomainBundle("new-td", []string{"old-td", "some-trustdomain"}),
 			policies:          getPolicies("testdata/v1beta1/td-aliases-source-principal-in.yaml", t),
-			want:              getProto("testdata/v1beta1/td-aliases-source-principal-out.yaml", t),
+			wantAllow:         getProto("testdata/v1beta1/td-aliases-source-principal-out.yaml", t),
 		},
 	}
 
@@ -131,18 +139,12 @@ func TestBuildHTTPFilter(t *testing.T) {
 			if b == nil {
 				t.Fatalf("failed to create builder")
 			}
-			_, got := b.generator.Generate(false)
-
-			if !reflect.DeepEqual(got, tc.want) {
-				gotYaml, err := protomarshal.ToYAML(got)
-				if err != nil {
-					t.Fatalf("failed to convert to YAML: %v", err)
-				}
-				wantYaml, err := protomarshal.ToYAML(tc.want)
-				if err != nil {
-					t.Fatalf("failed to convert to YAML: %v", err)
-				}
-				t.Errorf("got:\n%s\nwant:\n%s\n", gotYaml, wantYaml)
+			gotDeny, gotAllow := b.generator.Generate(false)
+			if tc.wantDeny != nil {
+				verify(t, gotDeny, tc.wantDeny)
+			}
+			if tc.wantAllow != nil {
+				verify(t, gotAllow, tc.wantAllow)
 			}
 		})
 	}
@@ -177,4 +179,18 @@ func getProto(filename string, t *testing.T) *http_config.RBAC {
 		t.Fatalf("failed to parse YAML: %v", err)
 	}
 	return out
+}
+
+func verify(t *testing.T, got, want proto.Message) {
+	if !reflect.DeepEqual(got, want) {
+		gotYaml, err := protomarshal.ToYAML(got)
+		if err != nil {
+			t.Fatalf("failed to convert to YAML: %v", err)
+		}
+		wantYaml, err := protomarshal.ToYAML(want)
+		if err != nil {
+			t.Fatalf("failed to convert to YAML: %v", err)
+		}
+		t.Errorf("got:\n%s\nwant:\n%s\n", gotYaml, wantYaml)
+	}
 }

--- a/pilot/pkg/security/authz/builder/integration_test.go
+++ b/pilot/pkg/security/authz/builder/integration_test.go
@@ -131,7 +131,7 @@ func TestBuildHTTPFilter(t *testing.T) {
 			if b == nil {
 				t.Fatalf("failed to create builder")
 			}
-			got := b.generator.Generate(false)
+			_, got := b.generator.Generate(false)
 
 			if !reflect.DeepEqual(got, tc.want) {
 				gotYaml, err := protomarshal.ToYAML(got)

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/action-allow-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/action-allow-out.yaml
@@ -1,0 +1,19 @@
+rules:
+  policies:
+    ns[foo]-policy[httpbin-allow]-rule[0]:
+      permissions:
+      - andRules:
+          rules:
+          - any: true
+      principals:
+      - andIds:
+          ids:
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      exact: allow

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/action-deny-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/action-deny-out.yaml
@@ -1,0 +1,20 @@
+rules:
+  action: DENY
+  policies:
+    ns[foo]-policy[httpbin-deny]-rule[0]:
+      permissions:
+      - andRules:
+          rules:
+          - any: true
+      principals:
+      - andIds:
+          ids:
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      exact: deny

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/action-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/action-in.yaml
@@ -1,0 +1,23 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-deny
+  namespace: foo
+spec:
+  action: DENY
+  rules:
+  - from:
+    - source:
+        principals: ["deny"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-allow
+  namespace: foo
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        principals: ["allow"]

--- a/pilot/pkg/security/authz/policy/helper.go
+++ b/pilot/pkg/security/authz/policy/helper.go
@@ -20,16 +20,16 @@ import (
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
-	envoy_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
+	envoyRbacPb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
 	"github.com/hashicorp/go-multierror"
 
-	istio_rbac "istio.io/api/rbac/v1alpha1"
-	authpb "istio.io/api/security/v1beta1"
+	istioRbacPb "istio.io/api/rbac/v1alpha1"
+	istioSecurityPb "istio.io/api/security/v1beta1"
 
 	"istio.io/istio/galley/pkg/config/schema/collections"
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
-	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
+	authzModel "istio.io/istio/pilot/pkg/security/authz/model"
 	"istio.io/istio/pkg/config/host"
 )
 
@@ -39,7 +39,7 @@ type mockTest interface {
 	Helper()
 }
 
-func NewServiceMetadata(hostname string, labels map[string]string, t mockTest) *authz_model.ServiceMetadata {
+func NewServiceMetadata(hostname string, labels map[string]string, t mockTest) *authzModel.ServiceMetadata {
 	t.Helper()
 	splits := strings.Split(hostname, ".")
 	if len(splits) < 2 {
@@ -65,7 +65,7 @@ func NewServiceMetadata(hostname string, labels map[string]string, t mockTest) *
 		},
 	}
 
-	serviceMetadata, err := authz_model.NewServiceMetadata(name, namespace, serviceInstance)
+	serviceMetadata, err := authzModel.NewServiceMetadata(name, namespace, serviceInstance)
 	if err != nil {
 		t.Fatalf("failed to initialize service instance: %s", err)
 	}
@@ -99,8 +99,8 @@ func SimpleClusterRbacConfig() *model.Config {
 			Name:      "default",
 			Namespace: "default",
 		},
-		Spec: &istio_rbac.RbacConfig{
-			Mode: istio_rbac.RbacConfig_ON,
+		Spec: &istioRbacPb.RbacConfig{
+			Mode: istioRbacPb.RbacConfig_ON,
 		},
 	}
 	return cfg
@@ -111,8 +111,8 @@ func RoleTag(name string) string {
 }
 
 func SimpleRole(name string, namespace string, service string) *model.Config {
-	spec := &istio_rbac.ServiceRole{
-		Rules: []*istio_rbac.AccessRule{
+	spec := &istioRbacPb.ServiceRole{
+		Rules: []*istioRbacPb.AccessRule{
 			{
 				Methods: []string{RoleTag(name)},
 			},
@@ -146,13 +146,13 @@ func SimpleBinding(name, namespace, role string) *model.Config {
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: &istio_rbac.ServiceRoleBinding{
-			Subjects: []*istio_rbac.Subject{
+		Spec: &istioRbacPb.ServiceRoleBinding{
+			Subjects: []*istioRbacPb.Subject{
 				{
 					User: BindingTag(name),
 				},
 			},
-			RoleRef: &istio_rbac.RoleRef{
+			RoleRef: &istioRbacPb.RoleRef{
 				Name: role,
 				Kind: "ServiceRole",
 			},
@@ -167,13 +167,13 @@ func SimpleBindingWithUser(name, namespace, role, user string) *model.Config {
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: &istio_rbac.ServiceRoleBinding{
-			Subjects: []*istio_rbac.Subject{
+		Spec: &istioRbacPb.ServiceRoleBinding{
+			Subjects: []*istioRbacPb.Subject{
 				{
 					User: user,
 				},
 			},
-			RoleRef: &istio_rbac.RoleRef{
+			RoleRef: &istioRbacPb.RoleRef{
 				Name: role,
 				Kind: "ServiceRole",
 			},
@@ -183,8 +183,8 @@ func SimpleBindingWithUser(name, namespace, role, user string) *model.Config {
 
 func SimplePermissiveBinding(name string, namespace string, role string) *model.Config {
 	cfg := SimpleBinding(name, namespace, role)
-	binding := cfg.Spec.(*istio_rbac.ServiceRoleBinding)
-	binding.Mode = istio_rbac.EnforcementMode_PERMISSIVE
+	binding := cfg.Spec.(*istioRbacPb.ServiceRoleBinding)
+	binding.Mode = istioRbacPb.EnforcementMode_PERMISSIVE
 	return cfg
 }
 
@@ -192,20 +192,21 @@ func AuthzPolicyTag(name string) string {
 	return fmt.Sprintf("UserFromPolicy[%s]", name)
 }
 
-func SimpleAuthorizationProto(name string) *authpb.AuthorizationPolicy {
-	return &authpb.AuthorizationPolicy{
-		Rules: []*authpb.Rule{
+func SimpleAuthorizationProto(name string, action istioSecurityPb.AuthorizationPolicy_Action) *istioSecurityPb.AuthorizationPolicy {
+	return &istioSecurityPb.AuthorizationPolicy{
+		Action: action,
+		Rules: []*istioSecurityPb.Rule{
 			{
-				From: []*authpb.Rule_From{
+				From: []*istioSecurityPb.Rule_From{
 					{
-						Source: &authpb.Source{
+						Source: &istioSecurityPb.Source{
 							Principals: []string{AuthzPolicyTag(name)},
 						},
 					},
 				},
-				To: []*authpb.Rule_To{
+				To: []*istioSecurityPb.Rule_To{
 					{
-						Operation: &authpb.Operation{
+						Operation: &istioSecurityPb.Operation{
 							Methods: []string{"GET"},
 						},
 					},
@@ -215,18 +216,29 @@ func SimpleAuthorizationProto(name string) *authpb.AuthorizationPolicy {
 	}
 }
 
-func SimpleAuthorizationPolicy(name string, namespace string) *model.Config {
+func SimpleAllowPolicy(name string, namespace string) *model.Config {
 	return &model.Config{
 		ConfigMeta: model.ConfigMeta{
 			Type:      collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().Kind(),
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: SimpleAuthorizationProto(name),
+		Spec: SimpleAuthorizationProto(name, istioSecurityPb.AuthorizationPolicy_ALLOW),
 	}
 }
 
-func Verify(got *envoy_rbac.RBAC, want map[string][]string, needToCheckPrincipals bool) error {
+func SimpleDenyPolicy(name string, namespace string) *model.Config {
+	return &model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Type:      collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().Kind(),
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: SimpleAuthorizationProto(name, istioSecurityPb.AuthorizationPolicy_DENY),
+	}
+}
+
+func Verify(got *envoyRbacPb.RBAC, want map[string][]string, needToCheckPrincipals bool, wantDeny bool) error {
 	var err error
 	if len(want) == 0 {
 		if len(got.GetPolicies()) != 0 {
@@ -234,9 +246,9 @@ func Verify(got *envoy_rbac.RBAC, want map[string][]string, needToCheckPrincipal
 				fmt.Errorf("got %d rules but want 0", len(got.Policies)))
 		}
 	} else {
-		if got.Action != envoy_rbac.RBAC_ALLOW {
+		if (wantDeny && got.Action != envoyRbacPb.RBAC_DENY) || (!wantDeny && got.Action != envoyRbacPb.RBAC_ALLOW) {
 			err = multierror.Append(err,
-				fmt.Errorf("got action %s but want %s", got.GetAction(), envoy_rbac.RBAC_ALLOW))
+				fmt.Errorf("got action %s but want opposite", got.GetAction()))
 		}
 		if len(want) != len(got.Policies) {
 			err = multierror.Append(err, fmt.Errorf("got %d rules but want %d",

--- a/pilot/pkg/security/authz/policy/policy.go
+++ b/pilot/pkg/security/authz/policy/policy.go
@@ -19,5 +19,5 @@ import (
 )
 
 type Generator interface {
-	Generate(forTCPFilter bool) *http_config.RBAC
+	Generate(forTCPFilter bool) (denyConfig *http_config.RBAC, allowConfig *http_config.RBAC)
 }

--- a/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1.go
+++ b/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1.go
@@ -51,7 +51,7 @@ func NewGenerator(
 	}
 }
 
-func (g *v1alpha1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
+func (g *v1alpha1Generator) Generate(forTCPFilter bool) (denyConfig *http_config.RBAC, allowConfig *http_config.RBAC) {
 	rbacLog.Debugf("building v1alpha1 policy")
 	enforcedConfig := &envoy_rbac.RBAC{
 		Action:   envoy_rbac.RBAC_ALLOW,
@@ -96,7 +96,7 @@ func (g *v1alpha1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 	// If RBAC Config is set to permissive mode globally, RBAC is transparent to users;
 	// when mapping to rbac filter config, there is only shadow rules (no normal rules).
 	if g.isGlobalPermissiveEnabled {
-		return &http_config.RBAC{ShadowRules: permissiveConfig}
+		return nil, &http_config.RBAC{ShadowRules: permissiveConfig}
 	}
 
 	ret := &http_config.RBAC{Rules: enforcedConfig}
@@ -105,7 +105,7 @@ func (g *v1alpha1Generator) Generate(forTCPFilter bool) *http_config.RBAC {
 	if len(permissiveConfig.Policies) > 0 {
 		ret.ShadowRules = permissiveConfig
 	}
-	return ret
+	return nil, ret
 }
 
 func (g *v1alpha1Generator) generatePolicy(trustDomainBundle trustdomain.Bundle, role *istio_rbac.ServiceRole,

--- a/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1_test.go
+++ b/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1_test.go
@@ -273,7 +273,7 @@ func TestV1alpha1Generator_Generate(t *testing.T) {
 				t.Fatal("failed to create generator")
 			}
 
-			got := g.Generate(tc.forTCPFilter)
+			_, got := g.Generate(tc.forTCPFilter)
 			gotStr := spew.Sdump(got)
 
 			if tc.isGlobalPermissiveEnabled {

--- a/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1_test.go
+++ b/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1_test.go
@@ -287,10 +287,10 @@ func TestV1alpha1Generator_Generate(t *testing.T) {
 			if len(tc.trustDomainBundle.TrustDomains) > 0 {
 				needToCheckPrincipals = true
 			}
-			if err := policy.Verify(got.GetRules(), tc.wantRules, needToCheckPrincipals); err != nil {
+			if err := policy.Verify(got.GetRules(), tc.wantRules, needToCheckPrincipals, false /* wantDeny */); err != nil {
 				t.Fatalf("%s\n%s", err, gotStr)
 			}
-			if err := policy.Verify(got.GetShadowRules(), tc.wantShadowRules, needToCheckPrincipals); err != nil {
+			if err := policy.Verify(got.GetShadowRules(), tc.wantShadowRules, needToCheckPrincipals, false /* wantDeny */); err != nil {
 				t.Fatalf("%s\n%s", err, gotStr)
 			}
 		})

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
@@ -33,9 +33,6 @@ func TestV1beta1Generator_Generate(t *testing.T) {
 		forTCPFilter bool
 	}{
 		{
-			name: "no policy",
-		},
-		{
 			name: "one policy",
 			policies: []model.AuthorizationPolicyConfig{
 				{
@@ -77,15 +74,12 @@ func TestV1beta1Generator_Generate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := NewGenerator(trustdomain.NewTrustDomainBundle("", nil), tc.policies)
+			g := NewGenerator(trustdomain.NewTrustDomainBundle("", nil), tc.policies, nil)
 			if g == nil {
 				t.Fatal("failed to create generator")
 			}
 
-			got := g.Generate(tc.forTCPFilter)
-			if got.GetRules() == nil {
-				t.Fatal("rule must not be nil")
-			}
+			_, got := g.Generate(tc.forTCPFilter)
 			if err := policy.Verify(got.GetRules(), tc.wantRules, false); err != nil {
 				t.Fatalf("%s\n%s", err, spew.Sdump(got))
 			}

--- a/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
+++ b/pilot/pkg/security/authz/policy/v1beta1/v1beta1_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
+	securityPb "istio.io/api/security/v1beta1"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/security/authz/policy"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
@@ -27,41 +29,43 @@ import (
 // TODO(pitlv2109): Add unit tests with trust domain aliases.
 func TestV1beta1Generator_Generate(t *testing.T) {
 	testCases := []struct {
-		name         string
-		policies     []model.AuthorizationPolicyConfig
-		wantRules    map[string][]string
-		forTCPFilter bool
+		name           string
+		denyPolicies   []model.AuthorizationPolicyConfig
+		wantDenyRules  map[string][]string
+		allowPolicies  []model.AuthorizationPolicyConfig
+		wantAllowRules map[string][]string
+		forTCPFilter   bool
 	}{
 		{
 			name: "one policy",
-			policies: []model.AuthorizationPolicyConfig{
+			allowPolicies: []model.AuthorizationPolicyConfig{
 				{
 					Name:                "default",
 					Namespace:           "foo",
-					AuthorizationPolicy: policy.SimpleAuthorizationProto("default"),
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default", securityPb.AuthorizationPolicy_ALLOW),
 				},
 			},
-			wantRules: map[string][]string{
+			wantAllowRules: map[string][]string{
 				"ns[foo]-policy[default]-rule[0]": {
 					policy.AuthzPolicyTag("default"),
 				},
 			},
 		},
 		{
-			name: "two policies",
-			policies: []model.AuthorizationPolicyConfig{
+			name: "allow policies",
+			allowPolicies: []model.AuthorizationPolicyConfig{
 				{
 					Name:                "default",
 					Namespace:           "foo",
-					AuthorizationPolicy: policy.SimpleAuthorizationProto("default"),
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default", securityPb.AuthorizationPolicy_ALLOW),
 				},
 				{
 					Name:                "default",
 					Namespace:           "istio-system",
-					AuthorizationPolicy: policy.SimpleAuthorizationProto("default"),
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default", securityPb.AuthorizationPolicy_ALLOW),
 				},
 			},
-			wantRules: map[string][]string{
+			wantAllowRules: map[string][]string{
 				"ns[foo]-policy[default]-rule[0]": {
 					policy.AuthzPolicyTag("default"),
 				},
@@ -70,18 +74,87 @@ func TestV1beta1Generator_Generate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "deny policies",
+			denyPolicies: []model.AuthorizationPolicyConfig{
+				{
+					Name:                "default",
+					Namespace:           "foo",
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default", securityPb.AuthorizationPolicy_DENY),
+				},
+				{
+					Name:                "default",
+					Namespace:           "istio-system",
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default", securityPb.AuthorizationPolicy_DENY),
+				},
+			},
+			wantDenyRules: map[string][]string{
+				"ns[foo]-policy[default]-rule[0]": {
+					policy.AuthzPolicyTag("default"),
+				},
+				"ns[istio-system]-policy[default]-rule[0]": {
+					policy.AuthzPolicyTag("default"),
+				},
+			},
+		},
+		{
+			name: "allow and deny policies",
+			denyPolicies: []model.AuthorizationPolicyConfig{
+				{
+					Name:                "default-deny",
+					Namespace:           "foo",
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default", securityPb.AuthorizationPolicy_DENY),
+				},
+				{
+					Name:                "default-deny",
+					Namespace:           "istio-system",
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default", securityPb.AuthorizationPolicy_DENY),
+				},
+			},
+			wantDenyRules: map[string][]string{
+				"ns[foo]-policy[default-deny]-rule[0]": {
+					policy.AuthzPolicyTag("default"),
+				},
+				"ns[istio-system]-policy[default-deny]-rule[0]": {
+					policy.AuthzPolicyTag("default"),
+				},
+			},
+			allowPolicies: []model.AuthorizationPolicyConfig{
+				{
+					Name:                "default-allow",
+					Namespace:           "foo",
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default", securityPb.AuthorizationPolicy_ALLOW),
+				},
+				{
+					Name:                "default-allow",
+					Namespace:           "istio-system",
+					AuthorizationPolicy: policy.SimpleAuthorizationProto("default", securityPb.AuthorizationPolicy_ALLOW),
+				},
+			},
+			wantAllowRules: map[string][]string{
+				"ns[foo]-policy[default-allow]-rule[0]": {
+					policy.AuthzPolicyTag("default"),
+				},
+				"ns[istio-system]-policy[default-allow]-rule[0]": {
+					policy.AuthzPolicyTag("default"),
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := NewGenerator(trustdomain.NewTrustDomainBundle("", nil), tc.policies, nil)
+			g := NewGenerator(trustdomain.NewTrustDomainBundle("", nil), tc.denyPolicies, tc.allowPolicies)
 			if g == nil {
 				t.Fatal("failed to create generator")
 			}
 
-			_, got := g.Generate(tc.forTCPFilter)
-			if err := policy.Verify(got.GetRules(), tc.wantRules, false); err != nil {
-				t.Fatalf("%s\n%s", err, spew.Sdump(got))
+			gotDeny, gotAllow := g.Generate(tc.forTCPFilter)
+			if err := policy.Verify(gotDeny.GetRules(), tc.wantDenyRules, false, true /* wantDeny */); err != nil {
+				t.Fatalf("%s\n%s", err, spew.Sdump(gotDeny))
+			}
+			if err := policy.Verify(gotAllow.GetRules(), tc.wantAllowRules, false, false /* wantDeny */); err != nil {
+				t.Fatalf("%s\n%s", err, spew.Sdump(gotAllow))
 			}
 		})
 	}

--- a/tests/integration/security/rbac_v1beta1_test.go
+++ b/tests/integration/security/rbac_v1beta1_test.go
@@ -290,3 +290,65 @@ func TestV1beta1_WorkloadSelector(t *testing.T) {
 			rbacUtil.RunRBACTest(t, cases)
 		})
 }
+
+// TestV1beta1_Deny tests the authorization policy with action "DENY".
+func TestV1beta1_Deny(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "v1beta1-deny",
+				Inject: true,
+			})
+
+			var a, b, c echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
+				With(&c, util.EchoConfig("c", ns, false, nil, g, p)).
+				BuildOrFail(t)
+
+			newTestCase := func(target echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
+				return rbacUtil.TestCase{
+					Request: connection.Checker{
+						From: a,
+						Options: echo.CallOptions{
+							Target:   target,
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Path:     path,
+						},
+					},
+					ExpectAllowed: expectAllowed,
+				}
+			}
+			cases := []rbacUtil.TestCase{
+				newTestCase(b, "/deny", false),
+				newTestCase(b, "/global-deny", false),
+				newTestCase(b, "/other", true),
+				newTestCase(b, "/allow", true),
+				newTestCase(c, "/allow/admin", false),
+				newTestCase(c, "/global-deny", false),
+				newTestCase(c, "/other", false),
+				newTestCase(c, "/allow", true),
+			}
+
+			args := map[string]string{
+				"Namespace":     ns.Name(),
+				"RootNamespace": rootNamespace,
+			}
+
+			applyPolicy := func(filename string, ns namespace.Instance) []string {
+				policy := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, filename))
+				g.ApplyConfigOrFail(t, ns, policy...)
+				return policy
+			}
+
+			policy := applyPolicy("testdata/rbac/v1beta1-deny.yaml.tmpl", ns)
+			defer g.DeleteConfigOrFail(t, ns, policy...)
+			policyNSRoot := applyPolicy("testdata/rbac/v1beta1-deny-ns-root.yaml.tmpl", rootNS{})
+			defer g.DeleteConfigOrFail(t, rootNS{}, policyNSRoot...)
+
+			rbacUtil.RunRBACTest(t, cases)
+		})
+}

--- a/tests/integration/security/testdata/rbac/v1beta1-deny-ns-root.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-deny-ns-root.yaml.tmpl
@@ -1,0 +1,14 @@
+# The following policy denies access to path /global-deny for all workloads
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-deny-ns-root
+  namespace: "{{ .RootNamespace }}"
+spec:
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: ["/global-deny"]
+---

--- a/tests/integration/security/testdata/rbac/v1beta1-deny.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-deny.yaml.tmpl
@@ -1,0 +1,53 @@
+# The following policy denies access to path /deny to workload b
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-b-deny
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "b"
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: ["/deny"]
+---
+
+# The following policy denies access to path /allow/admin to workload c
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-c-deny
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "c"
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: ["/allow/admin"]
+---
+
+# The following policy allows access to path with prefix "/allow" to workload c
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-c-allow
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "c"
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        paths: ["/allow*"]
+---


### PR DESCRIPTION
This PR adds support to the `action` (ALLOW or DENY) field in authorization policy. E2E tests and unit tests are also added.

For #19894 