### PR TITLE
Check resources for analyze suppression codes

### DIFF
--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -15,6 +15,8 @@
 package snapshotter
 
 import (
+	"istio.io/api/annotation"
+	"strings"
 	"sync"
 
 	"github.com/ryanuber/go-glob"
@@ -204,6 +206,16 @@ FilterMessages:
 			if _, ok := nsNames[m.Resource.Origin.Namespace().String()]; !ok {
 				continue FilterMessages
 			}
+		}
+
+		// Filter out any messages on resources with suppression annotations.
+		if m.Resource != nil && m.Resource.Metadata.Annotations[annotation.GalleyAnalyzeSuppress.Name] != "" {
+			for _, code := range strings.Split(m.Resource.Metadata.Annotations[annotation.GalleyAnalyzeSuppress.Name], ",") {
+				if code == "*" || m.Type.Code() == code {
+					continue FilterMessages
+				}
+			}
+
 		}
 
 		// Filter out any messages that match our suppressions.

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -15,9 +15,10 @@
 package snapshotter
 
 import (
-	"istio.io/api/annotation"
 	"strings"
 	"sync"
+
+	"istio.io/api/annotation"
 
 	"github.com/ryanuber/go-glob"
 
@@ -212,10 +213,10 @@ FilterMessages:
 		if m.Resource != nil && m.Resource.Metadata.Annotations[annotation.GalleyAnalyzeSuppress.Name] != "" {
 			for _, code := range strings.Split(m.Resource.Metadata.Annotations[annotation.GalleyAnalyzeSuppress.Name], ",") {
 				if code == "*" || m.Type.Code() == code {
+					scope.Analysis.Debugf("Suppressing code %s on resource %s due to resource annotation", m.Type.Code(), m.Resource.Origin.FriendlyName())
 					continue FilterMessages
 				}
 			}
-
 		}
 
 		// Filter out any messages that match our suppressions.


### PR DESCRIPTION
This change enforces the semantics from PR https://github.com/istio/api/pull/1227 - specifically, resources with the analyze annotation are checked against message codes and suppressed if they match.