### PR TITLE
Update README for operator

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -15,14 +15,14 @@ architecture and a code overview, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
 ## Introduction
 
-The operator uses the [IstioOperator API](https://github.com/istio/api/operator/v1alpha1/operator.proto), which has
+The operator uses the [IstioOperator API](https://github.com/istio/api/blob/master/operator/v1alpha1/operator.proto), which has
 three main components:
 
-- [MeshConfig](https://github.com/istio/api/mesh/v1alpha1/operator.proto) for runtime config consumed directly by Istio
+- [MeshConfig](https://github.com/istio/api/blob/master/mesh/v1alpha1/operator.proto) for runtime config consumed directly by Istio
 control plane components.
-- [Component configuration API](https://github.com/istio/api/operator/v1alpha1/component.proto), for managing
+- [Component configuration API](https://github.com/istio/api/blob/master/operator/v1alpha1/component.proto), for managing
 K8s settings like resources, auto scaling, pod disruption budgets and others defined in the
-[KubernetesResourceSpec](https://github.com/istio/api/blob/7791470ecc4c5e123589ff2b781f47b1bcae6ddd/operator/v1alpha1/component.proto)
+[KubernetesResourceSpec](https://github.com/istio/api/blob/master/blob/7791470ecc4c5e123589ff2b781f47b1bcae6ddd/operator/v1alpha1/component.proto)
 for Istio core and addon components.
 - The legacy
 [Helm installation API](https://istio.io/docs/reference/config/installation-options/) for backwards
@@ -50,7 +50,7 @@ See [Select a specific configuration_profile](#select-a-specific-configuration-p
 
 If you don't specify a configuration profile, Istio is installed using the `default` configuration profile. All
 profiles listed in istio.io are available by default, or `profile:` can point to a local file path to reference a custom
-profile base to use as a starting point for customization. See the [API reference](https://github.com/istio/api/operator/v1alpha1/operator.proto)
+profile base to use as a starting point for customization. See the [API reference](https://github.com/istio/api/blob/master/operator/v1alpha1/operator.proto)
 for details.
 
 ## Developer quick start
@@ -268,7 +268,7 @@ istioctl manifest diff ./out/helm-template/manifest.yaml ./out/mesh-manifest/man
 
 ### New API customization
 
-The [new platform level installation API](https://github.com/istio/api/operator/v1alpha1/operator.proto)
+The [new platform level installation API](https://github.com/istio/api/blob/master/operator/v1alpha1/operator.proto)
 defines install time parameters like feature and component enablement and namespace, and K8s settings like resources, HPA spec etc. in a structured way.
 The simplest customization is to turn features and components on and off. For example, to turn off all policy ([samples/sds-policy-off.yaml](samples/sds-policy-off.yaml)):
 
@@ -313,7 +313,7 @@ spec:
 ```
 
 The K8s settings are defined in detail in the
-[operator API](https://github.com/istio/api/operator/v1alpha1/operator.proto).
+[operator API](https://github.com/istio/api/blob/master/operator/v1alpha1/operator.proto).
 The settings are the same for all components, so a user can configure pilot K8s settings in exactly the same, consistent
 way as galley settings. Supported K8s settings currently include:
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -3,8 +3,8 @@
 
 # Istio Operator
 
-The Istio operator CLI is beta and the controller is alpha for 1.4. You can
-[contribute](CONTRIBUTING.md) by picking an
+The istio/operator repo is part of istio/istio from 1.5 onwards. 
+You can [contribute](CONTRIBUTING.md) by picking an
 [unassigned open issue](https://github.com/istio/istio/issues?q=is%3Aissue+is%3Aopen+label%3Aarea%2Fenvironments%2Foperator+no%3Aassignee),
 creating a [bug or feature request](BUGS-AND-FEATURE-REQUESTS.md),
 or just coming to the weekly [Environments Working Group](https://github.com/istio/community/blob/master/WORKING-GROUPS.md)
@@ -13,40 +13,29 @@ meeting to share your ideas.
 This document is an overview of how the operator works from a user perspective. For more details about the design and
 architecture and a code overview, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
-The operator CLI is distributed to users as part of istioctl. The `mesh` command
-in this repo is simply a wrapper to speed up development - the subcommands are the same code that is incorporated into
-istioctl. Making changes to any `mesh` subcommand will be reflected in istioctl after one of the regular syncs to
-istio/operator.
-
 ## Introduction
 
-This repo reorganizes the current [Helm installation parameters](https://istio.io/docs/reference/config/installation-options/) into two groups:
+The operator uses the [IstioOperator API](https://github.com/istio/api/operator/v1alpha1/operator.proto), which has
+three main components:
 
-- The new [platform level installation API](https://github.com/istio/api/mesh/v1alpha1/operator.proto), for managing
+- [MeshConfig](https://github.com/istio/api/mesh/v1alpha1/operator.proto) for runtime config consumed directly by Istio
+control plane components.
+- [Component configuration API](https://github.com/istio/api/operator/v1alpha1/component.proto), for managing
 K8s settings like resources, auto scaling, pod disruption budgets and others defined in the
 [KubernetesResourceSpec](https://github.com/istio/api/blob/7791470ecc4c5e123589ff2b781f47b1bcae6ddd/operator/v1alpha1/component.proto)
-- The configuration API that currently uses the
-[Helm installation parameters](https://istio.io/docs/reference/config/installation-options/) for backwards
-compatibility. This API is for managing the Istio control plane configuration settings.
+for Istio core and addon components.
+- The legacy
+[Helm installation API](https://istio.io/docs/reference/config/installation-options/) for backwards
+compatibility. 
 
-Some parameters will temporarily exist in both APIs - for example, setting K8s resources currently can be done through
-either API above. However, the Istio community recommends using the first API as it is more consistent, is validated,
+Some parameters will temporarily exist both the component configuration and legacy Helm APIs - for example, K8s
+resources. However, the Istio community recommends using the first API as it is more consistent, is validated,
 and will naturally follow the graduation process for APIs while the same parameters in the configuration API are planned
 for deprecation.
 
-This repo currently provides pre-configured Helm values sets for different scenarios as configuration
-[profiles](https://istio.io/docs/setup/kubernetes/additional-setup/config-profiles/), which act as a starting point for
-an Istio install and can be customized by creating customization overlay files or passing parameters when
-calling Helm. Similarly, the operator API uses the same profiles (expressed internally through the new API), which can be selected
-as a starting point for the installation. For comparison, the following example shows the command needed to install
-Istio using the SDS configuration profile using Helm:
-
-```bash
-helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
-    --values install/kubernetes/helm/istio/values-istio-sds-auth.yaml | kubectl apply -f -
-```
-
-In the new API, the same profile would be selected through a CustomResource (CR):
+[Profiles](https://istio.io/docs/setup/kubernetes/additional-setup/config-profiles/), are provided as a starting point for
+an Istio install and can be customized by creating customization overlay files or passing parameters through the
+--set flag. For example, to select the sds profile:
 
 ```yaml
 # sds.yaml
@@ -66,34 +55,15 @@ for details.
 
 ## Developer quick start
 
-The quick start describes how to install and use the operator `mesh` CLI command and/or controller.
-
-### Building
-
-If you're trying to do a local build that bypasses the build container, you'll need to
-to execute the following step one time.
-
-```
-GO111MODULE=on go get github.com/jteeuwen/go-bindata/go-bindata@6025e8de665b
-```
-
-#### Clone the repo
-
-```bash
-git clone https://github.com/istio/operator.git
-cd operator
-```
-
 #### CLI
 
 To build the operator CLI, simply:
 
 ```bash
-make mesh
+make istioctl
 ```
 
-This will create a binary called `mesh` either in ${GOPATH}/bin or ${GOPATH}/go/src/istio.io/istio/out/<architecture>,
-depending on your platform. Ensure this is in your PATH to run the examples below.
+Ensure the created binary is in your PATH to run the examples below.
 
 #### Controller (in cluster)
 
@@ -114,8 +84,15 @@ the file deploy/operator.yaml to point to your docker hub:
 Install the controller manifest and example IstioOperator CR:
 
 ```bash
-kubectl apply -k deploy/
-kubectl apply -f deploy/crds/istio_v1alpha1_istiooperator_cr.yaml 
+istioctl operator init
+kubectl apply -f operator/deploy/crds/istio_v1alpha1_istiooperator_cr.yaml 
+```
+
+or
+
+```bash
+kubectl apply -k operator/deploy/
+kubectl apply -f operator/deploy/crds/istio_v1alpha1_istiooperator_cr.yaml 
 ```
 
 This installs the controller into the cluster in the istio-operator namespace. The controller in turns installs
@@ -141,7 +118,7 @@ dlv debug --headless --listen=:2345 --api-version=2 -- server
 ### Relationship between the CLI and controller
 
 The CLI and controller share the same API and codebase for generating manifests from the API. You can think of the
-controller as the CLI command `mesh manifest apply` running in a loop in a pod in the cluster and using the config
+controller as the CLI command `istioctl manifest apply` running in a loop in a pod in the cluster and using the config
 from the in-cluster IstioOperator CustomResource (CR). 
 There are two major differences:
 1. The controller does not accept any dynamic user config through flags. All user interaction is through the
@@ -153,7 +130,7 @@ API rather than command line.
 
 #### Flags
 
-The `mesh` command supports the following flags:
+The `istioctl` command supports the following flags:
 
 - `logtostderr`: log to console (by default logs go to ./mesh-cli.log).
 - `dry-run`: console output only, nothing applied to cluster or written to files.
@@ -164,7 +141,7 @@ The `mesh` command supports the following flags:
 The following command generates a manifest with the compiled-in `default` profile and charts:
 
 ```bash
-mesh manifest generate
+istioctl manifest generate
 ```
 
 You can see these sources for the compiled-in profiles and charts in the repo under `data/`. These profiles and charts are also included in the Istio release tar. 
@@ -175,7 +152,7 @@ The output of the manifest is concatenated into a single file. To generate a dir
 levels representing a child dependency, use the following command:
 
 ```bash
-mesh manifest generate -o istio_manifests
+istioctl manifest generate -o istio_manifests
 ```
 
 Use depth first search to traverse the created directory hierarchy when applying your YAML files. This is needed for
@@ -188,7 +165,7 @@ The following command generates the manifests and applies them in the correct de
 dependencies to have the needed CRDs available:
 
 ```bash
-mesh manifest apply
+istioctl manifest apply
 ```
 
 #### Review the values of a configuration profile
@@ -197,23 +174,23 @@ The following commands show the values of a configuration profile:
 
 ```bash
 # show available profiles
-mesh profile list
+istioctl profile list
 
 # show the values in demo profile
-mesh profile dump demo
+istioctl profile dump demo
 
 # show the values after a customization file is applied
-mesh profile dump -f samples/policy-off.yaml
+istioctl profile dump -f samples/policy-off.yaml
 
 # show differences between the default and demo profiles
-mesh profile dump default > 1.yaml
-mesh profile dump demo > 2.yaml
-mesh profile diff 1.yaml 2.yaml
+istioctl profile dump default > 1.yaml
+istioctl profile dump demo > 2.yaml
+istioctl profile diff 1.yaml 2.yaml
 
 # show the differences in the generated manifests between the default profile and a customized install
-mesh manifest generate > 1.yaml
-mesh manifest generate -f samples/pilot-k8s.yaml > 2.yaml
-mesh manifest diff 1.yam1 2.yaml
+istioctl manifest generate > 1.yaml
+istioctl manifest generate -f samples/pilot-k8s.yaml > 2.yaml
+istioctl manifest diff 1.yam1 2.yaml
 
 ```
 
@@ -222,13 +199,13 @@ The profile dump sub-command supports a couple of useful flags:
 - `config-path`: select the root for the configuration subtree you want to see e.g. just show Pilot:
 
 ```bash
-mesh profile dump --config-path components.pilot
+istioctl profile dump --config-path components.pilot
 ```
 
 - `set`: set a value in the configuration before dumping the resulting profile e.g. show the minimal profile:
 
 ```bash
-mesh profile dump --set profile=minimal
+istioctl profile dump --set profile=minimal
 ```
 
 
@@ -247,7 +224,7 @@ spec:
 Use the Istio operator `mesh` binary to generate the manifests for the new configuration profile:
 
 ```bash
-mesh manifest generate -f samples/sds.yaml
+istioctl manifest generate -f samples/sds.yaml
 ```
 
 After running the command, the Helm charts are rendered using `data/profiles/sds.yaml`.
@@ -270,23 +247,23 @@ local file system.
 #### Migration from values.yaml
 The following command takes helm values.yaml files and output the new IstioOperatorSpec:
 ```bash
-mesh manifest migrate /usr/home/bob/go/src/istio.io/installer/istio-control/istio-discovery/values.yaml
+istioctl manifest migrate /usr/home/bob/go/src/istio.io/installer/istio-control/istio-discovery/values.yaml
 ```
 
 If a directory is specified, all files called "values.yaml" under the directory will be converted into a single combined IstioOperatorSpec:
 ```bash
-mesh manifest migrate /usr/home/bob/go/src/istio.io/installer/istio-control
+istioctl manifest migrate /usr/home/bob/go/src/istio.io/installer/istio-control
 ```
 
 If no file is specified, the IstioOperator CR in the kube config cluster is used as an input:
 ```bash
-mesh manifest migrate
+istioctl manifest migrate
 ```
 
 #### Check diffs of manifests
 The following command takes two manifests and output the differences in a readable way. It can be used to compare between the manifests generated by operator API and helm directly:
 ```bash
-mesh manifest diff ./out/helm-template/manifest.yaml ./out/mesh-manifest/manifest.yaml
+istioctl manifest diff ./out/helm-template/manifest.yaml ./out/mesh-manifest/manifest.yaml
 ```
 
 ### New API customization
@@ -305,7 +282,7 @@ spec:
       enabled: false
 ```
 
-The operator validates the configuration and automatically detects syntax errors. Helm lacks this capability. If you are
+The operator validates the configuration and automatically detects syntax errors. If you are
 using Helm values that are incompatible, the schema validation used in the operator may reject input that is valid for
 Helm. 
 Each Istio component has K8s settings, and these can be overridden from the defaults using official K8s APIs rather than
@@ -429,7 +406,7 @@ the spec.
 
 The controller shares the same API as the operator CLI, so it's possible to install any of the above examples as a CR
 in the cluster in the istio-operator namespace and the controller will react to it with the same outcome as running
-`mesh manifest apply -f <path-to-custom-resource-file>`.
+`istioctl manifest apply -f <path-to-custom-resource-file>`.
 
 ## Architecture
 


### PR DESCRIPTION
This brings README up to date. We should also consider deleting parts of this since it's mostly mirrored in istio.io docs now.