### PR TITLE
support negative match (not_ fields) in authorization policy

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/v1alpha1/all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1alpha1/all-fields-out.yaml
@@ -2,191 +2,216 @@ rules:
   policies:
     httpbin-viewer:
       permissions:
-        - andRules:
-            rules:
-              - orRules:
-                  rules:
-                    - header:
-                        exactMatch: method
-                        name: :method
-                    - header:
-                        name: :method
-                        prefixMatch: method-prefix-
-                    - header:
-                        name: :method
-                        suffixMatch: -suffix-method
-                    - header:
-                        name: :method
-                        presentMatch: true
-              - orRules:
-                  rules:
-                    - header:
-                        exactMatch: /exact
-                        name: :path
-                    - header:
-                        name: :path
-                        prefixMatch: /prefix/
-                    - header:
-                        name: :path
-                        suffixMatch: /suffix
-                    - header:
-                        name: :path
-                        presentMatch: true
-              - orRules:
-                  rules:
-                    - destinationIp:
-                        addressPrefix: 10.10.10.10
-                        prefixLen: 32
-                    - destinationIp:
-                        addressPrefix: 192.168.10.0
-                        prefixLen: 24
-              - orRules:
-                  rules:
-                    - destinationPort: 91
-                    - destinationPort: 92
-              - orRules:
-                  rules:
-                    - metadata:
-                        filter: envoy.filters.network.mysql_proxy
-                        path:
-                          - key: db.table
-                        value:
-                          stringMatch:
-                            exact: experimental
-                    - metadata:
-                        filter: envoy.filters.network.mysql_proxy
-                        path:
-                          - key: db.table
-                        value:
-                          stringMatch:
-                            prefix: experimental-prefix-
-                    - metadata:
-                        filter: envoy.filters.network.mysql_proxy
-                        path:
-                          - key: db.table
-                        value:
-                          stringMatch:
-                            suffix: -suffix-experimental
-                    - metadata:
-                        filter: envoy.filters.network.mysql_proxy
-                        path:
-                          - key: db.table
-                        value:
-                          stringMatch:
-                            regex: .*
-              - orRules:
-                  rules:
-                    - header:
-                        exactMatch: header
-                        name: X-header
-                    - header:
-                        name: X-header
-                        prefixMatch: header-prefix-
-                    - header:
-                        name: X-header
-                        suffixMatch: -suffix-header
-                    - header:
-                        name: X-header
-                        presentMatch: true
+      - andRules:
+          rules:
+          - orRules:
+              rules:
+              - header:
+                  exactMatch: method
+                  name: :method
+              - header:
+                  name: :method
+                  prefixMatch: method-prefix-
+              - header:
+                  name: :method
+                  suffixMatch: -suffix-method
+              - header:
+                  name: :method
+                  presentMatch: true
+          - orRules:
+              rules:
+              - header:
+                  exactMatch: /exact
+                  name: :path
+              - header:
+                  name: :path
+                  prefixMatch: /prefix/
+              - header:
+                  name: :path
+                  suffixMatch: /suffix
+              - header:
+                  name: :path
+                  presentMatch: true
+          - orRules:
+              rules:
+              - destinationIp:
+                  addressPrefix: 10.10.10.10
+                  prefixLen: 32
+              - destinationIp:
+                  addressPrefix: 192.168.10.0
+                  prefixLen: 24
+          - orRules:
+              rules:
+              - destinationPort: 91
+              - destinationPort: 92
+          - orRules:
+              rules:
+              - metadata:
+                  filter: envoy.filters.network.mysql_proxy
+                  path:
+                  - key: db.table
+                  value:
+                    stringMatch:
+                      exact: experimental
+              - metadata:
+                  filter: envoy.filters.network.mysql_proxy
+                  path:
+                  - key: db.table
+                  value:
+                    stringMatch:
+                      prefix: experimental-prefix-
+              - metadata:
+                  filter: envoy.filters.network.mysql_proxy
+                  path:
+                  - key: db.table
+                  value:
+                    stringMatch:
+                      suffix: -suffix-experimental
+              - metadata:
+                  filter: envoy.filters.network.mysql_proxy
+                  path:
+                  - key: db.table
+                  value:
+                    stringMatch:
+                      regex: .*
+          - orRules:
+              rules:
+              - header:
+                  exactMatch: header
+                  name: X-header
+              - header:
+                  name: X-header
+                  prefixMatch: header-prefix-
+              - header:
+                  name: X-header
+                  suffixMatch: -suffix-header
+              - header:
+                  name: X-header
+                  presentMatch: true
       principals:
-        - andIds:
-            ids:
-              - orIds:
-                  ids:
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            exact: user
+      - andIds:
+          ids:
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: request.auth.audiences
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      exact: user
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.audiences
                   value:
                     stringMatch:
                       exact: request-audiences
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: request.auth.claims
-                    - key: iss
+                  - key: request.auth.claims
+                  - key: iss
                   value:
                     listMatch:
                       oneOf:
                         stringMatch:
                           exact: request-claims
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: request.auth.presenter
+                  - key: request.auth.presenter
                   value:
                     stringMatch:
                       exact: request-presenter
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: request.auth.principal
+                  - key: request.auth.principal
                   value:
                     stringMatch:
                       exact: request-principal
+          - orIds:
+              ids:
               - sourceIp:
                   addressPrefix: 1.2.3.4
                   prefixLen: 32
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: source.principal
+                  - key: source.principal
                   value:
                     stringMatch:
                       regex: .*/ns/source-ns/.*
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: source.principal
+                  - key: source.principal
                   value:
                     stringMatch:
                       exact: source-principal
-        - andIds:
-            ids:
+      - andIds:
+          ids:
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: request.auth.audiences
+                  - key: request.auth.audiences
                   value:
                     stringMatch:
                       regex: .*
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: request.auth.claims
-                    - key: iss
+                  - key: request.auth.claims
+                  - key: iss
                   value:
                     listMatch:
                       oneOf:
                         stringMatch:
                           regex: .*
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: request.auth.presenter
+                  - key: request.auth.presenter
                   value:
                     stringMatch:
                       regex: .*
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: request.auth.principal
+                  - key: request.auth.principal
                   value:
                     stringMatch:
                       regex: .*
+          - orIds:
+              ids:
               - metadata:
                   filter: istio_authn
                   path:
-                    - key: source.principal
+                  - key: source.principal
                   value:
                     stringMatch:
                       regex: .*/ns/.*/.*
+          - orIds:
+              ids:
               - any: true
-

--- a/pilot/pkg/security/authz/builder/testdata/v1alpha1/td-aliases-source-principal-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1alpha1/td-aliases-source-principal-out.yaml
@@ -1,54 +1,58 @@
 rules:
-              policies:
-                httpbin-viewer:
-                  permissions:
-                  - andRules:
-                      rules:
-                      - orRules:
-                          rules:
-                          - header:
-                              exactMatch: GET
-                              name: :method
-                  principals:
-                  - andIds:
-                      ids:
-                      - metadata:
-                          filter: istio_authn
-                          path:
-                          - key: request.auth.claims
-                          - key: groups
-                          value:
-                            listMatch:
-                              oneOf:
-                                stringMatch:
-                                  exact: some-group
-                  - andIds:
-                      ids:
-                      - any: true
-                  - andIds:
-                      ids:
-                      - metadata:
-                          filter: istio_authn
-                          path:
-                          - key: source.principal
-                          value:
-                            stringMatch:
-                              suffix: /ns/foo/sa/all-td
-                  - andIds:
-                      ids:
-                      - orIds:
-                          ids:
-                          - metadata:
-                              filter: istio_authn
-                              path:
-                              - key: source.principal
-                              value:
-                                stringMatch:
-                                  suffix: -td/ns/foo/sa/prefix-td
-                          - metadata:
-                              filter: istio_authn
-                              path:
-                              - key: source.principal
-                              value:
-                                stringMatch:
-                                  exact: some-trustdomain/ns/foo/sa/prefix-td
+  policies:
+    httpbin-viewer:
+      permissions:
+      - andRules:
+          rules:
+          - orRules:
+              rules:
+              - header:
+                  exactMatch: GET
+                  name: :method
+      principals:
+      - andIds:
+          ids:
+          - metadata:
+              filter: istio_authn
+              path:
+              - key: request.auth.claims
+              - key: groups
+              value:
+                listMatch:
+                  oneOf:
+                    stringMatch:
+                      exact: some-group
+      - andIds:
+          ids:
+          - orIds:
+              ids:
+              - any: true
+      - andIds:
+          ids:
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      suffix: /ns/foo/sa/all-td
+      - andIds:
+          ids:
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      suffix: -td/ns/foo/sa/prefix-td
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      exact: some-trustdomain/ns/foo/sa/prefix-td

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/all-fields-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/all-fields-in.yaml
@@ -15,34 +15,54 @@ spec:
             requestPrincipals: ["requestPrincipals", "requestPrincipals-prefix-*", "*-suffix-requestPrincipals", "*"]
             namespaces: ["ns", "ns-prefix-*", "*-ns-suffix", "*"]
             ipBlocks: ["1.2.3.4", "5.6.0.0/16"]
+            notPrincipals: ["not-principal", "not-principal-prefix-*", "*-not-suffix-principal", "*"]
+            notRequestPrincipals: ["not-requestPrincipals", "not-requestPrincipals-prefix-*", "*-not-suffix-requestPrincipals", "*"]
+            notNamespaces: ["not-ns", "not-ns-prefix-*", "*-not-ns-suffix", "*"]
+            notIpBlocks: ["9.0.0.1", "9.2.0.0/16"]
       to:
         - operation:
             methods: ["method", "method-prefix-*", "*-suffix-method", "*"]
             hosts: ["exact.com", "*.suffix.com", "prefix.*", "*"]
             ports: ["80", "90"]
             paths: ["/exact", "/prefix/*", "*/suffix", "*"]
+            notMethods: ["not-method", "not-method-prefix-*", "*-not-suffix-method", "*"]
+            notHosts: ["not-exact.com", "*.not-suffix.com", "not-prefix.*", "*"]
+            notPorts: ["8000", "9000"]
+            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*"]
       when:
         - key: "request.headers[X-header]"
           values: ["header", "header-prefix-*", "*-suffix-header", "*"]
+          notValues: ["not-header", "not-header-prefix-*", "*-not-suffix-header", "*"]
         - key: "source.ip"
           values: ["10.10.10.10", "192.168.10.0/24"]
+          notValues: ["90.10.10.10", "90.168.10.0/24"]
         - key: "source.namespace"
           values: ["ns", "ns-prefix-*", "*-ns-suffix", "*"]
+          notValues: ["not-ns", "not-ns-prefix-*", "*-not-ns-suffix", "*"]
         - key: "source.principal"
           values: ["principal", "principal-prefix-*", "*-suffix-principal", "*"]
+          notValues: ["not-principal", "not-principal-prefix-*", "*-not-suffix-principal", "*"]
         - key: "request.auth.principal"
           values: ["requestPrincipals", "requestPrincipals-prefix-*", "*-suffix-requestPrincipals", "*"]
+          notValues: ["not-requestPrincipals", "not-requestPrincipals-prefix-*", "*-not-suffix-requestPrincipals", "*"]
         - key: "request.auth.audiences"
           values: ["audiences", "audiences-prefix-*", "*-suffix-audiences", "*"]
+          notValues: ["not-audiences", "not-audiences-prefix-*", "*-not-suffix-audiences", "*"]
         - key: "request.auth.presenter"
           values: ["presenter", "presenter-prefix-*", "*-suffix-presenter", "*"]
+          notValues: ["not-presenter", "not-presenter-prefix-*", "*-not-suffix-presenter", "*"]
         - key: "request.auth.claims[iss]"
           values: ["iss", "iss-prefix-*", "*-suffix-iss", "*"]
+          notValues: ["not-iss", "not-iss-prefix-*", "*-not-suffix-iss", "*"]
         - key: "destination.ip"
           values: ["10.10.10.10", "192.168.10.0/24"]
+          notValues: ["90.10.10.10", "90.168.10.0/24"]
         - key: "destination.port"
           values: ["91", "92"]
+          notValues: ["9001", "9002"]
         - key: "connection.sni"
           values: ["exact.com", "*.suffix.com", "prefix.*", "*"]
+          notValues: ["not-exact.com", "*.not-suffix.com", "not-prefix.*", "*"]
         - key: "experimental.envoy.filters.a.b[c]"
           values: ["exact", "prefix-*", "*-suffix", "*"]
+          notValues: ["not-exact", "not-prefix-*", "*-not-suffix", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/all-fields-out.yaml
@@ -2,418 +2,848 @@ rules:
   policies:
     ns[foo]-policy[httpbin-1]-rule[0]:
       permissions:
-        - andRules:
-            rules:
-              - orRules:
-                  rules:
-                    - header:
-                        exactMatch: exact.com
-                        name: :authority
-                    - header:
-                        name: :authority
-                        suffixMatch: .suffix.com
-                    - header:
-                        name: :authority
-                        prefixMatch: prefix.
-                    - header:
-                        name: :authority
-                        presentMatch: true
-              - orRules:
-                  rules:
-                    - header:
-                        exactMatch: method
-                        name: :method
-                    - header:
-                        name: :method
-                        prefixMatch: method-prefix-
-                    - header:
-                        name: :method
-                        suffixMatch: -suffix-method
-                    - header:
-                        name: :method
-                        presentMatch: true
-              - orRules:
-                  rules:
-                    - header:
-                        exactMatch: /exact
-                        name: :path
-                    - header:
-                        name: :path
-                        prefixMatch: /prefix/
-                    - header:
-                        name: :path
-                        suffixMatch: /suffix
-                    - header:
-                        name: :path
-                        presentMatch: true
-              - orRules:
-                  rules:
-                    - destinationPort: 80
-                    - destinationPort: 90
-              - orRules:
-                  rules:
-                    - destinationIp:
-                        addressPrefix: 10.10.10.10
-                        prefixLen: 32
-                    - destinationIp:
-                        addressPrefix: 192.168.10.0
-                        prefixLen: 24
-              - orRules:
-                  rules:
-                    - destinationPort: 91
-                    - destinationPort: 92
-              - orRules:
-                  rules:
-                    - requestedServerName:
-                        exact: exact.com
-                    - requestedServerName:
-                        suffix: .suffix.com
-                    - requestedServerName:
-                        prefix: prefix.
-                    - requestedServerName:
+      - andRules:
+          rules:
+          - orRules:
+              rules:
+              - header:
+                  exactMatch: exact.com
+                  name: :authority
+              - header:
+                  name: :authority
+                  suffixMatch: .suffix.com
+              - header:
+                  name: :authority
+                  prefixMatch: prefix.
+              - header:
+                  name: :authority
+                  presentMatch: true
+          - notRule:
+              orRules:
+                rules:
+                - header:
+                    exactMatch: not-exact.com
+                    name: :authority
+                - header:
+                    name: :authority
+                    suffixMatch: .not-suffix.com
+                - header:
+                    name: :authority
+                    prefixMatch: not-prefix.
+                - header:
+                    name: :authority
+                    presentMatch: true
+          - orRules:
+              rules:
+              - header:
+                  exactMatch: method
+                  name: :method
+              - header:
+                  name: :method
+                  prefixMatch: method-prefix-
+              - header:
+                  name: :method
+                  suffixMatch: -suffix-method
+              - header:
+                  name: :method
+                  presentMatch: true
+          - notRule:
+              orRules:
+                rules:
+                - header:
+                    exactMatch: not-method
+                    name: :method
+                - header:
+                    name: :method
+                    prefixMatch: not-method-prefix-
+                - header:
+                    name: :method
+                    suffixMatch: -not-suffix-method
+                - header:
+                    name: :method
+                    presentMatch: true
+          - orRules:
+              rules:
+              - header:
+                  exactMatch: /exact
+                  name: :path
+              - header:
+                  name: :path
+                  prefixMatch: /prefix/
+              - header:
+                  name: :path
+                  suffixMatch: /suffix
+              - header:
+                  name: :path
+                  presentMatch: true
+          - notRule:
+              orRules:
+                rules:
+                - header:
+                    exactMatch: /not-exact
+                    name: :path
+                - header:
+                    name: :path
+                    prefixMatch: /not-prefix/
+                - header:
+                    name: :path
+                    suffixMatch: /not-suffix
+                - header:
+                    name: :path
+                    presentMatch: true
+          - orRules:
+              rules:
+              - destinationPort: 80
+              - destinationPort: 90
+          - notRule:
+              orRules:
+                rules:
+                - destinationPort: 8000
+                - destinationPort: 9000
+          - orRules:
+              rules:
+              - destinationIp:
+                  addressPrefix: 10.10.10.10
+                  prefixLen: 32
+              - destinationIp:
+                  addressPrefix: 192.168.10.0
+                  prefixLen: 24
+          - notRule:
+              orRules:
+                rules:
+                - destinationIp:
+                    addressPrefix: 90.10.10.10
+                    prefixLen: 32
+                - destinationIp:
+                    addressPrefix: 90.168.10.0
+                    prefixLen: 24
+          - orRules:
+              rules:
+              - destinationPort: 91
+              - destinationPort: 92
+          - notRule:
+              orRules:
+                rules:
+                - destinationPort: 9001
+                - destinationPort: 9002
+          - orRules:
+              rules:
+              - requestedServerName:
+                  exact: exact.com
+              - requestedServerName:
+                  suffix: .suffix.com
+              - requestedServerName:
+                  prefix: prefix.
+              - requestedServerName:
+                  regex: .+
+          - notRule:
+              orRules:
+                rules:
+                - requestedServerName:
+                    exact: not-exact.com
+                - requestedServerName:
+                    suffix: .not-suffix.com
+                - requestedServerName:
+                    prefix: not-prefix.
+                - requestedServerName:
+                    regex: .+
+          - orRules:
+              rules:
+              - metadata:
+                  filter: envoy.filters.a.b
+                  path:
+                  - key: c
+                  value:
+                    stringMatch:
+                      exact: exact
+              - metadata:
+                  filter: envoy.filters.a.b
+                  path:
+                  - key: c
+                  value:
+                    stringMatch:
+                      prefix: prefix-
+              - metadata:
+                  filter: envoy.filters.a.b
+                  path:
+                  - key: c
+                  value:
+                    stringMatch:
+                      suffix: -suffix
+              - metadata:
+                  filter: envoy.filters.a.b
+                  path:
+                  - key: c
+                  value:
+                    stringMatch:
+                      regex: .+
+          - notRule:
+              orRules:
+                rules:
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        exact: not-exact
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        prefix: not-prefix-
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        suffix: -not-suffix
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
                         regex: .+
-              - orRules:
-                  rules:
-                    - metadata:
-                        filter: envoy.filters.a.b
-                        path:
-                          - key: c
-                        value:
-                          stringMatch:
-                            exact: exact
-                    - metadata:
-                        filter: envoy.filters.a.b
-                        path:
-                          - key: c
-                        value:
-                          stringMatch:
-                            prefix: prefix-
-                    - metadata:
-                        filter: envoy.filters.a.b
-                        path:
-                          - key: c
-                        value:
-                          stringMatch:
-                            suffix: -suffix
-                    - metadata:
-                        filter: envoy.filters.a.b
-                        path:
-                          - key: c
-                        value:
-                          stringMatch:
-                            regex: .+
       principals:
-        - andIds:
-            ids:
-              - orIds:
-                  ids:
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
+      - andIds:
+          ids:
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      exact: principal
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      prefix: principal-prefix-
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      suffix: -suffix-principal
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .+
+          - notId:
+              orIds:
+                ids:
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        exact: not-principal
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        prefix: not-principal-prefix-
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        suffix: -not-suffix-principal
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        regex: .+
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      exact: requestPrincipals
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      prefix: requestPrincipals-prefix-
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      suffix: -suffix-requestPrincipals
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      regex: .+
+          - notId:
+              orIds:
+                ids:
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.principal
+                    value:
+                      stringMatch:
+                        exact: not-requestPrincipals
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.principal
+                    value:
+                      stringMatch:
+                        prefix: not-requestPrincipals-prefix-
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.principal
+                    value:
+                      stringMatch:
+                        suffix: -not-suffix-requestPrincipals
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.principal
+                    value:
+                      stringMatch:
+                        regex: .+
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/ns/.*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/ns-prefix-.*/.*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/.*-ns-suffix/.*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/.*/.*
+          - notId:
+              orIds:
+                ids:
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        regex: .*/ns/not-ns/.*
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        regex: .*/ns/not-ns-prefix-.*/.*
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        regex: .*/ns/.*-not-ns-suffix/.*
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        regex: .*/ns/.*/.*
+          - orIds:
+              ids:
+              - sourceIp:
+                  addressPrefix: 1.2.3.4
+                  prefixLen: 32
+              - sourceIp:
+                  addressPrefix: 5.6.0.0
+                  prefixLen: 16
+          - notId:
+              orIds:
+                ids:
+                - sourceIp:
+                    addressPrefix: 9.0.0.1
+                    prefixLen: 32
+                - sourceIp:
+                    addressPrefix: 9.2.0.0
+                    prefixLen: 16
+          - orIds:
+              ids:
+              - header:
+                  exactMatch: header
+                  name: X-header
+              - header:
+                  name: X-header
+                  prefixMatch: header-prefix-
+              - header:
+                  name: X-header
+                  suffixMatch: -suffix-header
+              - header:
+                  name: X-header
+                  presentMatch: true
+          - notId:
+              orIds:
+                ids:
+                - header:
+                    exactMatch: not-header
+                    name: X-header
+                - header:
+                    name: X-header
+                    prefixMatch: not-header-prefix-
+                - header:
+                    name: X-header
+                    suffixMatch: -not-suffix-header
+                - header:
+                    name: X-header
+                    presentMatch: true
+          - orIds:
+              ids:
+              - sourceIp:
+                  addressPrefix: 10.10.10.10
+                  prefixLen: 32
+              - sourceIp:
+                  addressPrefix: 192.168.10.0
+                  prefixLen: 24
+          - notId:
+              orIds:
+                ids:
+                - sourceIp:
+                    addressPrefix: 90.10.10.10
+                    prefixLen: 32
+                - sourceIp:
+                    addressPrefix: 90.168.10.0
+                    prefixLen: 24
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/ns/.*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/ns-prefix-.*/.*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/.*-ns-suffix/.*
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/.*/.*
+          - notId:
+              orIds:
+                ids:
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        regex: .*/ns/not-ns/.*
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        regex: .*/ns/not-ns-prefix-.*/.*
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        regex: .*/ns/.*-not-ns-suffix/.*
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        regex: .*/ns/.*/.*
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      exact: principal
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      prefix: principal-prefix-
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      suffix: -suffix-principal
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .+
+          - notId:
+              orIds:
+                ids:
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        exact: not-principal
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        prefix: not-principal-prefix-
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        suffix: -not-suffix-principal
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: source.principal
+                    value:
+                      stringMatch:
+                        regex: .+
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      exact: requestPrincipals
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      prefix: requestPrincipals-prefix-
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      suffix: -suffix-requestPrincipals
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.principal
+                  value:
+                    stringMatch:
+                      regex: .+
+          - notId:
+              orIds:
+                ids:
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.principal
+                    value:
+                      stringMatch:
+                        exact: not-requestPrincipals
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.principal
+                    value:
+                      stringMatch:
+                        prefix: not-requestPrincipals-prefix-
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.principal
+                    value:
+                      stringMatch:
+                        suffix: -not-suffix-requestPrincipals
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.principal
+                    value:
+                      stringMatch:
+                        regex: .+
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.audiences
+                  value:
+                    stringMatch:
+                      exact: audiences
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.audiences
+                  value:
+                    stringMatch:
+                      prefix: audiences-prefix-
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.audiences
+                  value:
+                    stringMatch:
+                      suffix: -suffix-audiences
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.audiences
+                  value:
+                    stringMatch:
+                      regex: .+
+          - notId:
+              orIds:
+                ids:
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.audiences
+                    value:
+                      stringMatch:
+                        exact: not-audiences
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.audiences
+                    value:
+                      stringMatch:
+                        prefix: not-audiences-prefix-
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.audiences
+                    value:
+                      stringMatch:
+                        suffix: -not-suffix-audiences
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.audiences
+                    value:
+                      stringMatch:
+                        regex: .+
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.presenter
+                  value:
+                    stringMatch:
+                      exact: presenter
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.presenter
+                  value:
+                    stringMatch:
+                      prefix: presenter-prefix-
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.presenter
+                  value:
+                    stringMatch:
+                      suffix: -suffix-presenter
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.presenter
+                  value:
+                    stringMatch:
+                      regex: .+
+          - notId:
+              orIds:
+                ids:
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.presenter
+                    value:
+                      stringMatch:
+                        exact: not-presenter
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.presenter
+                    value:
+                      stringMatch:
+                        prefix: not-presenter-prefix-
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.presenter
+                    value:
+                      stringMatch:
+                        suffix: -not-suffix-presenter
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.presenter
+                    value:
+                      stringMatch:
+                        regex: .+
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.claims
+                  - key: iss
+                  value:
+                    listMatch:
+                      oneOf:
+                        stringMatch:
+                          exact: iss
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.claims
+                  - key: iss
+                  value:
+                    listMatch:
+                      oneOf:
+                        stringMatch:
+                          prefix: iss-prefix-
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.claims
+                  - key: iss
+                  value:
+                    listMatch:
+                      oneOf:
+                        stringMatch:
+                          suffix: -suffix-iss
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: request.auth.claims
+                  - key: iss
+                  value:
+                    listMatch:
+                      oneOf:
+                        stringMatch:
+                          regex: .+
+          - notId:
+              orIds:
+                ids:
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.claims
+                    - key: iss
+                    value:
+                      listMatch:
+                        oneOf:
                           stringMatch:
-                            exact: principal
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
+                            exact: not-iss
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.claims
+                    - key: iss
+                    value:
+                      listMatch:
+                        oneOf:
                           stringMatch:
-                            prefix: principal-prefix-
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
+                            prefix: not-iss-prefix-
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.claims
+                    - key: iss
+                    value:
+                      listMatch:
+                        oneOf:
                           stringMatch:
-                            suffix: -suffix-principal
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
+                            suffix: -not-suffix-iss
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.claims
+                    - key: iss
+                    value:
+                      listMatch:
+                        oneOf:
                           stringMatch:
                             regex: .+
-              - orIds:
-                  ids:
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.principal
-                        value:
-                          stringMatch:
-                            exact: requestPrincipals
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.principal
-                        value:
-                          stringMatch:
-                            prefix: requestPrincipals-prefix-
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.principal
-                        value:
-                          stringMatch:
-                            suffix: -suffix-requestPrincipals
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.principal
-                        value:
-                          stringMatch:
-                            regex: .+
-              - orIds:
-                  ids:
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            regex: .*/ns/ns/.*
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            regex: .*/ns/ns-prefix-.*/.*
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            regex: .*/ns/.*-ns-suffix/.*
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            regex: .*/ns/.*/.*
-              - orIds:
-                  ids:
-                    - sourceIp:
-                        addressPrefix: 1.2.3.4
-                        prefixLen: 32
-                    - sourceIp:
-                        addressPrefix: 5.6.0.0
-                        prefixLen: 16
-              - orIds:
-                  ids:
-                    - header:
-                        exactMatch: header
-                        name: X-header
-                    - header:
-                        name: X-header
-                        prefixMatch: header-prefix-
-                    - header:
-                        name: X-header
-                        suffixMatch: -suffix-header
-                    - header:
-                        name: X-header
-                        presentMatch: true
-              - orIds:
-                  ids:
-                    - sourceIp:
-                        addressPrefix: 10.10.10.10
-                        prefixLen: 32
-                    - sourceIp:
-                        addressPrefix: 192.168.10.0
-                        prefixLen: 24
-              - orIds:
-                  ids:
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            regex: .*/ns/ns/.*
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            regex: .*/ns/ns-prefix-.*/.*
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            regex: .*/ns/.*-ns-suffix/.*
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            regex: .*/ns/.*/.*
-              - orIds:
-                  ids:
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            exact: principal
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            prefix: principal-prefix-
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            suffix: -suffix-principal
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: source.principal
-                        value:
-                          stringMatch:
-                            regex: .+
-              - orIds:
-                  ids:
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.principal
-                        value:
-                          stringMatch:
-                            exact: requestPrincipals
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.principal
-                        value:
-                          stringMatch:
-                            prefix: requestPrincipals-prefix-
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.principal
-                        value:
-                          stringMatch:
-                            suffix: -suffix-requestPrincipals
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.principal
-                        value:
-                          stringMatch:
-                            regex: .+
-              - orIds:
-                  ids:
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.audiences
-                        value:
-                          stringMatch:
-                            exact: audiences
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.audiences
-                        value:
-                          stringMatch:
-                            prefix: audiences-prefix-
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.audiences
-                        value:
-                          stringMatch:
-                            suffix: -suffix-audiences
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.audiences
-                        value:
-                          stringMatch:
-                            regex: .+
-              - orIds:
-                  ids:
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.presenter
-                        value:
-                          stringMatch:
-                            exact: presenter
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.presenter
-                        value:
-                          stringMatch:
-                            prefix: presenter-prefix-
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.presenter
-                        value:
-                          stringMatch:
-                            suffix: -suffix-presenter
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.presenter
-                        value:
-                          stringMatch:
-                            regex: .+
-              - orIds:
-                  ids:
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.claims
-                          - key: iss
-                        value:
-                          listMatch:
-                            oneOf:
-                              stringMatch:
-                                exact: iss
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.claims
-                          - key: iss
-                        value:
-                          listMatch:
-                            oneOf:
-                              stringMatch:
-                                prefix: iss-prefix-
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.claims
-                          - key: iss
-                        value:
-                          listMatch:
-                            oneOf:
-                              stringMatch:
-                                suffix: -suffix-iss
-                    - metadata:
-                        filter: istio_authn
-                        path:
-                          - key: request.auth.claims
-                          - key: iss
-                        value:
-                          listMatch:
-                            oneOf:
-                              stringMatch:
-                                regex: .+

--- a/pilot/pkg/security/authz/model/helper.go
+++ b/pilot/pkg/security/authz/model/helper.go
@@ -55,7 +55,9 @@ func fullPermission(tag string) Permission {
 		NotPorts:   []string{"2"},
 		Constraints: []KeyValues{
 			{
-				"constraint-" + tag: []string{"value1-" + tag, "value2-" + tag},
+				"constraint-" + tag: Values{
+					Values: []string{"value1-" + tag, "value2-" + tag},
+				},
 			},
 		},
 	}
@@ -75,7 +77,9 @@ func fullPrincipal(tag string) Principal {
 		NotIPs:        []string{"not-ips-" + tag},
 		Properties: []KeyValues{
 			{
-				"property-" + tag: []string{"value-" + tag},
+				"property-" + tag: Values{
+					Values: []string{"value-" + tag},
+				},
 			},
 		},
 	}
@@ -125,6 +129,10 @@ func newCondition(key string) *security.Condition {
 		Values: []string{
 			fmt.Sprintf("value-%s-1", key),
 			fmt.Sprintf("value-%s-2", key),
+		},
+		NotValues: []string{
+			fmt.Sprintf("not-value-%s-1", key),
+			fmt.Sprintf("not-value-%s-2", key),
 		},
 	}
 }

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -109,7 +109,12 @@ type Model struct {
 	Principals  []Principal
 }
 
-type KeyValues map[string][]string
+type Values struct {
+	Values    []string
+	NotValues []string
+}
+
+type KeyValues map[string]Values
 
 // NewModelV1alpha1 constructs a Model from a single ServiceRole and a list of ServiceRoleBinding. The ServiceRole
 // is converted to the permission and the ServiceRoleBinding is converted to the principal.
@@ -129,7 +134,7 @@ func NewModelV1alpha1(trustDomainBundle trustdomain.Bundle, role *istio_rbac.Ser
 
 		constraints := KeyValues{}
 		for _, constraint := range accessRule.Constraints {
-			constraints[constraint.Key] = constraint.Values
+			constraints[constraint.Key] = Values{Values: constraint.Values}
 		}
 		permission.Constraints = []KeyValues{constraints}
 
@@ -157,11 +162,11 @@ func NewModelV1alpha1(trustDomainBundle trustdomain.Bundle, role *istio_rbac.Ser
 
 			property := KeyValues{}
 			for k, v := range subject.Properties {
-				values := []string{v}
+				values := Values{Values: []string{v}}
 				if k == attrSrcPrincipal {
 					// TODO(pitlv2109): Refactor this by creating a method for Principal
 					// that searches and replaces all trust domains in both v1alpha1 and v1beta1.
-					values = trustDomainBundle.ReplaceTrustDomainAliases([]string{v})
+					values = Values{Values: trustDomainBundle.ReplaceTrustDomainAliases([]string{v})}
 				}
 				property[k] = values
 			}
@@ -183,12 +188,28 @@ func NewModelV1beta1(trustDomainBundle trustdomain.Bundle, rule *security.Rule) 
 	for _, when := range rule.When {
 		if isSupportedPrincipal(when.Key) {
 			values := when.Values
+			notValues := when.NotValues
 			if when.Key == attrSrcPrincipal {
-				values = trustDomainBundle.ReplaceTrustDomainAliases(when.Values)
+				if len(values) > 0 {
+					values = trustDomainBundle.ReplaceTrustDomainAliases(when.Values)
+				}
+				if len(notValues) > 0 {
+					notValues = trustDomainBundle.ReplaceTrustDomainAliases(when.NotValues)
+				}
 			}
-			conditionsForPrincipal = append(conditionsForPrincipal, KeyValues{when.Key: values})
+			conditionsForPrincipal = append(conditionsForPrincipal, KeyValues{
+				when.Key: Values{
+					Values:    values,
+					NotValues: notValues,
+				},
+			})
 		} else if isSupportedPermission(when.Key) {
-			conditionsForPermission = append(conditionsForPermission, KeyValues{when.Key: when.Values})
+			conditionsForPermission = append(conditionsForPermission, KeyValues{
+				when.Key: Values{
+					Values:    when.Values,
+					NotValues: when.NotValues,
+				},
+			})
 		} else {
 			rbacLog.Errorf("ignored unsupported condition: %v", when)
 		}
@@ -196,14 +217,25 @@ func NewModelV1beta1(trustDomainBundle trustdomain.Bundle, rule *security.Rule) 
 
 	for _, from := range rule.From {
 		if source := from.Source; source != nil {
-			names := trustDomainBundle.ReplaceTrustDomainAliases(source.Principals)
+			names := source.Principals
+			if len(names) > 0 {
+				names = trustDomainBundle.ReplaceTrustDomainAliases(names)
+			}
+			notNames := source.NotPrincipals
+			if len(notNames) > 0 {
+				notNames = trustDomainBundle.ReplaceTrustDomainAliases(notNames)
+			}
 			principal := Principal{
-				IPs:               source.IpBlocks,
-				Names:             names,
-				Namespaces:        source.Namespaces,
-				RequestPrincipals: source.RequestPrincipals,
-				Properties:        conditionsForPrincipal,
-				v1beta1:           true,
+				IPs:                  source.IpBlocks,
+				NotIPs:               source.NotIpBlocks,
+				Names:                names,
+				NotNames:             notNames,
+				Namespaces:           source.Namespaces,
+				NotNamespaces:        source.NotNamespaces,
+				RequestPrincipals:    source.RequestPrincipals,
+				NotRequestPrincipals: source.NotRequestPrincipals,
+				Properties:           conditionsForPrincipal,
+				v1beta1:              true,
 			}
 			m.Principals = append(m.Principals, principal)
 		}
@@ -226,9 +258,13 @@ func NewModelV1beta1(trustDomainBundle trustdomain.Bundle, rule *security.Rule) 
 		if operation := to.Operation; operation != nil {
 			permission := Permission{
 				Methods:     operation.Methods,
+				NotMethods:  operation.NotMethods,
 				Hosts:       operation.Hosts,
+				NotHosts:    operation.NotHosts,
 				Ports:       operation.Ports,
+				NotPorts:    operation.NotPorts,
 				Paths:       operation.Paths,
+				NotPaths:    operation.NotPaths,
 				Constraints: conditionsForPermission,
 				v1beta1:     true,
 			}

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -198,7 +198,12 @@ func TestNewModelV1beta1(t *testing.T) {
 				Permissions: []Permission{
 					{
 						Constraints: []KeyValues{
-							{"destination.ip": []string{"value-destination.ip-1", "value-destination.ip-2"}},
+							{
+								"destination.ip": Values{
+									Values:    []string{"value-destination.ip-1", "value-destination.ip-2"},
+									NotValues: []string{"not-value-destination.ip-1", "not-value-destination.ip-2"},
+								},
+							},
 						},
 						v1beta1: true,
 					},
@@ -228,7 +233,12 @@ func TestNewModelV1beta1(t *testing.T) {
 				Principals: []Principal{
 					{
 						Properties: []KeyValues{
-							{"request.headers": []string{"value-request.headers-1", "value-request.headers-2"}},
+							{
+								"request.headers": Values{
+									Values:    []string{"value-request.headers-1", "value-request.headers-2"},
+									NotValues: []string{"not-value-request.headers-1", "not-value-request.headers-2"},
+								},
+							},
 						},
 						v1beta1: true,
 					},
@@ -241,30 +251,40 @@ func TestNewModelV1beta1(t *testing.T) {
 				From: []*security.Rule_From{
 					{
 						Source: &security.Source{
-							Principals:        []string{"p1", "p2"},
-							RequestPrincipals: []string{"rp1", "rp2"},
-							IpBlocks:          []string{"1.1.1.1", "2.2.2.2"},
-							Namespaces:        []string{"ns1", "ns2"},
+							Principals:           []string{"p1", "p2"},
+							NotPrincipals:        []string{"np1", "np2"},
+							RequestPrincipals:    []string{"rp1", "rp2"},
+							NotRequestPrincipals: []string{"nrp1", "nrp2"},
+							IpBlocks:             []string{"1.1.1.1", "2.2.2.2"},
+							NotIpBlocks:          []string{"11.1.1.1", "22.2.2.2"},
+							Namespaces:           []string{"ns1", "ns2"},
+							NotNamespaces:        []string{"nns1", "nns2"},
 						},
 					},
 					{
 						Source: &security.Source{
-							Principals: []string{"p3"},
+							Principals:    []string{"p3"},
+							NotPrincipals: []string{"np3"},
 						},
 					},
 				},
 				To: []*security.Rule_To{
 					{
 						Operation: &security.Operation{
-							Hosts:   []string{"h1", "h2"},
-							Ports:   []string{"10", "20"},
-							Paths:   []string{"/p1", "/p2"},
-							Methods: []string{"m1", "m2"},
+							Hosts:      []string{"h1", "h2"},
+							NotHosts:   []string{"nh1", "nh2"},
+							Ports:      []string{"10", "20"},
+							NotPorts:   []string{"110", "220"},
+							Paths:      []string{"/p1", "/p2"},
+							NotPaths:   []string{"/np1", "/np2"},
+							Methods:    []string{"m1", "m2"},
+							NotMethods: []string{"nm1", "nm2"},
 						},
 					},
 					{
 						Operation: &security.Operation{
-							Hosts: []string{"h3"},
+							Hosts:    []string{"h3"},
+							NotHosts: []string{"nh3"},
 						},
 					},
 				},
@@ -291,60 +311,200 @@ func TestNewModelV1beta1(t *testing.T) {
 			want: Model{
 				Permissions: []Permission{
 					{
-						Hosts:   []string{"h1", "h2"},
-						Paths:   []string{"/p1", "/p2"},
-						Methods: []string{"m1", "m2"},
-						Ports:   []string{"10", "20"},
+						Hosts:      []string{"h1", "h2"},
+						NotHosts:   []string{"nh1", "nh2"},
+						Paths:      []string{"/p1", "/p2"},
+						NotPaths:   []string{"/np1", "/np2"},
+						Methods:    []string{"m1", "m2"},
+						NotMethods: []string{"nm1", "nm2"},
+						Ports:      []string{"10", "20"},
+						NotPorts:   []string{"110", "220"},
 						Constraints: []KeyValues{
-							{"destination.ip": []string{"value-destination.ip-1", "value-destination.ip-2"}},
-							{"destination.port": []string{"value-destination.port-1", "value-destination.port-2"}},
-							{"connection.sni": []string{"value-connection.sni-1", "value-connection.sni-2"}},
+							{
+								"destination.ip": Values{
+									Values:    []string{"value-destination.ip-1", "value-destination.ip-2"},
+									NotValues: []string{"not-value-destination.ip-1", "not-value-destination.ip-2"},
+								},
+							},
+							{
+								"destination.port": Values{
+									Values:    []string{"value-destination.port-1", "value-destination.port-2"},
+									NotValues: []string{"not-value-destination.port-1", "not-value-destination.port-2"},
+								},
+							},
+							{
+								"connection.sni": Values{
+									Values:    []string{"value-connection.sni-1", "value-connection.sni-2"},
+									NotValues: []string{"not-value-connection.sni-1", "not-value-connection.sni-2"},
+								},
+							},
 						},
 						v1beta1: true,
 					},
 					{
-						Hosts: []string{"h3"},
+						Hosts:    []string{"h3"},
+						NotHosts: []string{"nh3"},
 						Constraints: []KeyValues{
-							{"destination.ip": []string{"value-destination.ip-1", "value-destination.ip-2"}},
-							{"destination.port": []string{"value-destination.port-1", "value-destination.port-2"}},
-							{"connection.sni": []string{"value-connection.sni-1", "value-connection.sni-2"}},
+							{
+								"destination.ip": Values{
+									Values:    []string{"value-destination.ip-1", "value-destination.ip-2"},
+									NotValues: []string{"not-value-destination.ip-1", "not-value-destination.ip-2"},
+								},
+							},
+							{
+								"destination.port": Values{
+									Values:    []string{"value-destination.port-1", "value-destination.port-2"},
+									NotValues: []string{"not-value-destination.port-1", "not-value-destination.port-2"},
+								},
+							},
+							{
+								"connection.sni": Values{
+									Values:    []string{"value-connection.sni-1", "value-connection.sni-2"},
+									NotValues: []string{"not-value-connection.sni-1", "not-value-connection.sni-2"},
+								},
+							},
 						},
 						v1beta1: true,
 					},
 				},
 				Principals: []Principal{
 					{
-						Names:             []string{"p1", "p2"},
-						Namespaces:        []string{"ns1", "ns2"},
-						IPs:               []string{"1.1.1.1", "2.2.2.2"},
-						RequestPrincipals: []string{"rp1", "rp2"},
+						Names:                []string{"p1", "p2"},
+						NotNames:             []string{"np1", "np2"},
+						Namespaces:           []string{"ns1", "ns2"},
+						NotNamespaces:        []string{"nns1", "nns2"},
+						IPs:                  []string{"1.1.1.1", "2.2.2.2"},
+						NotIPs:               []string{"11.1.1.1", "22.2.2.2"},
+						RequestPrincipals:    []string{"rp1", "rp2"},
+						NotRequestPrincipals: []string{"nrp1", "nrp2"},
 						Properties: []KeyValues{
-							{"request.headers": []string{"value-request.headers-1", "value-request.headers-2"}},
-							{"source.ip": []string{"value-source.ip-1", "value-source.ip-2"}},
-							{"source.namespace": []string{"value-source.namespace-1", "value-source.namespace-2"}},
-							{"source.user": []string{"value-source.user-1", "value-source.user-2"}},
-							{"source.principal": []string{"value-source.principal-1", "value-source.principal-2"}},
-							{"request.auth.principal": []string{"value-request.auth.principal-1", "value-request.auth.principal-2"}},
-							{"request.auth.audiences": []string{"value-request.auth.audiences-1", "value-request.auth.audiences-2"}},
-							{"request.auth.presenter": []string{"value-request.auth.presenter-1", "value-request.auth.presenter-2"}},
-							{"request.auth.claims": []string{"value-request.auth.claims-1", "value-request.auth.claims-2"}},
-							{"request.auth.claims[groups]": []string{"value-request.auth.claims[groups]-1", "value-request.auth.claims[groups]-2"}},
+							{
+								"request.headers": Values{
+									Values:    []string{"value-request.headers-1", "value-request.headers-2"},
+									NotValues: []string{"not-value-request.headers-1", "not-value-request.headers-2"},
+								},
+							},
+							{
+								"source.ip": Values{
+									Values:    []string{"value-source.ip-1", "value-source.ip-2"},
+									NotValues: []string{"not-value-source.ip-1", "not-value-source.ip-2"},
+								},
+							},
+							{
+								"source.namespace": Values{
+									Values:    []string{"value-source.namespace-1", "value-source.namespace-2"},
+									NotValues: []string{"not-value-source.namespace-1", "not-value-source.namespace-2"},
+								},
+							},
+							{
+								"source.user": Values{
+									Values:    []string{"value-source.user-1", "value-source.user-2"},
+									NotValues: []string{"not-value-source.user-1", "not-value-source.user-2"},
+								},
+							},
+							{
+								"source.principal": Values{
+									Values:    []string{"value-source.principal-1", "value-source.principal-2"},
+									NotValues: []string{"not-value-source.principal-1", "not-value-source.principal-2"},
+								},
+							},
+							{
+								"request.auth.principal": Values{
+									Values:    []string{"value-request.auth.principal-1", "value-request.auth.principal-2"},
+									NotValues: []string{"not-value-request.auth.principal-1", "not-value-request.auth.principal-2"},
+								},
+							},
+							{
+								"request.auth.audiences": Values{
+									Values:    []string{"value-request.auth.audiences-1", "value-request.auth.audiences-2"},
+									NotValues: []string{"not-value-request.auth.audiences-1", "not-value-request.auth.audiences-2"},
+								},
+							},
+							{
+								"request.auth.presenter": Values{
+									Values:    []string{"value-request.auth.presenter-1", "value-request.auth.presenter-2"},
+									NotValues: []string{"not-value-request.auth.presenter-1", "not-value-request.auth.presenter-2"},
+								},
+							},
+							{
+								"request.auth.claims": Values{
+									Values:    []string{"value-request.auth.claims-1", "value-request.auth.claims-2"},
+									NotValues: []string{"not-value-request.auth.claims-1", "not-value-request.auth.claims-2"},
+								},
+							},
+							{
+								"request.auth.claims[groups]": Values{
+									Values:    []string{"value-request.auth.claims[groups]-1", "value-request.auth.claims[groups]-2"},
+									NotValues: []string{"not-value-request.auth.claims[groups]-1", "not-value-request.auth.claims[groups]-2"},
+								},
+							},
 						},
 						v1beta1: true,
 					},
 					{
-						Names: []string{"p3"},
+						Names:    []string{"p3"},
+						NotNames: []string{"np3"},
 						Properties: []KeyValues{
-							{"request.headers": []string{"value-request.headers-1", "value-request.headers-2"}},
-							{"source.ip": []string{"value-source.ip-1", "value-source.ip-2"}},
-							{"source.namespace": []string{"value-source.namespace-1", "value-source.namespace-2"}},
-							{"source.user": []string{"value-source.user-1", "value-source.user-2"}},
-							{"source.principal": []string{"value-source.principal-1", "value-source.principal-2"}},
-							{"request.auth.principal": []string{"value-request.auth.principal-1", "value-request.auth.principal-2"}},
-							{"request.auth.audiences": []string{"value-request.auth.audiences-1", "value-request.auth.audiences-2"}},
-							{"request.auth.presenter": []string{"value-request.auth.presenter-1", "value-request.auth.presenter-2"}},
-							{"request.auth.claims": []string{"value-request.auth.claims-1", "value-request.auth.claims-2"}},
-							{"request.auth.claims[groups]": []string{"value-request.auth.claims[groups]-1", "value-request.auth.claims[groups]-2"}},
+							{
+								"request.headers": Values{
+									Values:    []string{"value-request.headers-1", "value-request.headers-2"},
+									NotValues: []string{"not-value-request.headers-1", "not-value-request.headers-2"},
+								},
+							},
+							{
+								"source.ip": Values{
+									Values:    []string{"value-source.ip-1", "value-source.ip-2"},
+									NotValues: []string{"not-value-source.ip-1", "not-value-source.ip-2"},
+								},
+							},
+							{
+								"source.namespace": Values{
+									Values:    []string{"value-source.namespace-1", "value-source.namespace-2"},
+									NotValues: []string{"not-value-source.namespace-1", "not-value-source.namespace-2"},
+								},
+							},
+							{
+								"source.user": Values{
+									Values:    []string{"value-source.user-1", "value-source.user-2"},
+									NotValues: []string{"not-value-source.user-1", "not-value-source.user-2"},
+								},
+							},
+							{
+								"source.principal": Values{
+									Values:    []string{"value-source.principal-1", "value-source.principal-2"},
+									NotValues: []string{"not-value-source.principal-1", "not-value-source.principal-2"},
+								},
+							},
+							{
+								"request.auth.principal": Values{
+									Values:    []string{"value-request.auth.principal-1", "value-request.auth.principal-2"},
+									NotValues: []string{"not-value-request.auth.principal-1", "not-value-request.auth.principal-2"},
+								},
+							},
+							{
+								"request.auth.audiences": Values{
+									Values:    []string{"value-request.auth.audiences-1", "value-request.auth.audiences-2"},
+									NotValues: []string{"not-value-request.auth.audiences-1", "not-value-request.auth.audiences-2"},
+								},
+							},
+							{
+								"request.auth.presenter": Values{
+									Values:    []string{"value-request.auth.presenter-1", "value-request.auth.presenter-2"},
+									NotValues: []string{"not-value-request.auth.presenter-1", "not-value-request.auth.presenter-2"},
+								},
+							},
+							{
+								"request.auth.claims": Values{
+									Values:    []string{"value-request.auth.claims-1", "value-request.auth.claims-2"},
+									NotValues: []string{"not-value-request.auth.claims-1", "not-value-request.auth.claims-2"},
+								},
+							},
+							{
+								"request.auth.claims[groups]": Values{
+									Values:    []string{"value-request.auth.claims[groups]-1", "value-request.auth.claims[groups]-2"},
+									NotValues: []string{"not-value-request.auth.claims[groups]-1", "not-value-request.auth.claims[groups]-2"},
+								},
+							},
 						},
 						v1beta1: true,
 					},

--- a/pilot/pkg/security/authz/model/permission.go
+++ b/pilot/pkg/security/authz/model/permission.go
@@ -77,7 +77,7 @@ func (permission *Permission) Match(service *ServiceMetadata) bool {
 			// The constraint is not matched if any of the follow condition is true:
 			// a) the constraint is specified but not found in the ServiceMetadata;
 			// b) the constraint value is not matched to the actual value;
-			if !present || !stringMatch(constraintValue, values) {
+			if !present || !stringMatch(constraintValue, values.Values) {
 				return false
 			}
 		}
@@ -186,8 +186,14 @@ func (permission *Permission) Generate(forTCPFilter bool) (*envoy_rbac.Permissio
 			sort.Strings(keys)
 
 			for _, k := range keys {
-				permission := permission.forKeyValues(k, constraint[k])
-				pg.append(permission)
+				if len(constraint[k].Values) > 0 {
+					perm := permission.forKeyValues(k, constraint[k].Values)
+					pg.append(perm)
+				}
+				if len(constraint[k].NotValues) > 0 {
+					perm := permission.forKeyValues(k, constraint[k].NotValues)
+					pg.append(permissionNot(perm))
+				}
 			}
 		}
 	}

--- a/pilot/pkg/security/authz/model/permission_test.go
+++ b/pilot/pkg/security/authz/model/permission_test.go
@@ -47,7 +47,9 @@ func TestPermission_Match(t *testing.T) {
 				Services: []string{"review.default"},
 				Constraints: []KeyValues{
 					{
-						"destination.name": []string{"s1", "s2"},
+						"destination.name": Values{
+							Values: []string{"s1", "s2"},
+						},
 					},
 				},
 			},
@@ -63,7 +65,9 @@ func TestPermission_Match(t *testing.T) {
 				Services: []string{"product.default"},
 				Constraints: []KeyValues{
 					{
-						"destination.name": []string{"s1", "s2"},
+						"destination.name": Values{
+							Values: []string{"s1", "s2"},
+						},
 					},
 				},
 			},
@@ -81,7 +85,9 @@ func TestPermission_Match(t *testing.T) {
 				},
 				Constraints: []KeyValues{
 					{
-						"destination.labels[token]": []string{"t1", "t2"},
+						"destination.labels[token]": Values{
+							Values: []string{"t1", "t2"},
+						},
 					},
 				},
 			},
@@ -98,7 +104,9 @@ func TestPermission_Match(t *testing.T) {
 				Services: []string{"product.default"},
 				Constraints: []KeyValues{
 					{
-						"destination.user": []string{"user2"},
+						"destination.user": Values{
+							Values: []string{"user2"},
+						},
 					},
 				},
 			},
@@ -120,19 +128,29 @@ func TestPermission_Match(t *testing.T) {
 				Services: []string{"product.default"},
 				Constraints: []KeyValues{
 					{
-						"destination.name": []string{"s1", "s2"},
+						"destination.name": Values{
+							Values: []string{"s1", "s2"},
+						},
 					},
 					{
-						"destination.namespace": []string{"ns1", "ns2"},
+						"destination.namespace": Values{
+							Values: []string{"ns1", "ns2"},
+						},
 					},
 					{
-						"destination.user": []string{"sa1", "sa2"},
+						"destination.user": Values{
+							Values: []string{"sa1", "sa2"},
+						},
 					},
 					{
-						"destination.labels[token]": []string{"t1", "t2"},
+						"destination.labels[token]": Values{
+							Values: []string{"t1", "t2"},
+						},
 					},
 					{
-						"request.headers[user-agent]": []string{"x1", "x2"},
+						"request.headers[user-agent]": Values{
+							Values: []string{"x1", "x2"},
+						},
 					},
 				},
 			},
@@ -164,9 +182,21 @@ func TestPermission_ValidateForTCP(t *testing.T) {
 			},
 		},
 		{
+			name: "permission with notPath",
+			perm: &Permission{
+				NotPaths: []string{"/"},
+			},
+		},
+		{
 			name: "permission with method",
 			perm: &Permission{
 				Methods: []string{"GET"},
+			},
+		},
+		{
+			name: "permission with notMethod",
+			perm: &Permission{
+				NotMethods: []string{"GET"},
 			},
 		},
 		{
@@ -174,10 +204,14 @@ func TestPermission_ValidateForTCP(t *testing.T) {
 			perm: &Permission{
 				Constraints: []KeyValues{
 					{
-						attrDestIP: []string{"1.2.3.4"},
+						attrDestIP: Values{
+							Values: []string{"1.2.3.4"},
+						},
 					},
 					{
-						attrRequestHeader: []string{"TOKEN"},
+						attrRequestHeader: Values{
+							Values: []string{"TOKEN"},
+						},
 					},
 				},
 			},
@@ -187,10 +221,14 @@ func TestPermission_ValidateForTCP(t *testing.T) {
 			perm: &Permission{
 				Constraints: []KeyValues{
 					{
-						attrDestIP: []string{"1.2.3.4"},
+						attrDestIP: Values{
+							Values: []string{"1.2.3.4"},
+						},
 					},
 					{
-						attrDestPort: []string{"80"},
+						attrDestPort: Values{
+							Values: []string{"80"},
+						},
 					},
 				},
 			},
@@ -373,7 +411,9 @@ func TestPermission_Generate(t *testing.T) {
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						attrDestIP: []string{"1.2.3.4", "5.6.7.8"},
+						attrDestIP: Values{
+							Values: []string{"1.2.3.4", "5.6.7.8"},
+						},
 					},
 				},
 			},
@@ -394,7 +434,9 @@ func TestPermission_Generate(t *testing.T) {
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						attrDestPort: []string{"8000", "9000"},
+						attrDestPort: Values{
+							Values: []string{"8000", "9000"},
+						},
 					},
 				},
 			},
@@ -411,7 +453,9 @@ func TestPermission_Generate(t *testing.T) {
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						pathHeader: []string{"/hello", "/world"},
+						pathHeader: Values{
+							Values: []string{"/hello", "/world"},
+						},
 					},
 				},
 			},
@@ -432,7 +476,9 @@ func TestPermission_Generate(t *testing.T) {
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						methodHeader: []string{"GET", "POST"},
+						methodHeader: Values{
+							Values: []string{"GET", "POST"},
+						},
 					},
 				},
 			},
@@ -453,7 +499,9 @@ func TestPermission_Generate(t *testing.T) {
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						hostHeader: []string{"istio.io", "github.com"},
+						hostHeader: Values{
+							Values: []string{"istio.io", "github.com"},
+						},
 					},
 				},
 			},
@@ -474,8 +522,12 @@ func TestPermission_Generate(t *testing.T) {
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						fmt.Sprintf("%s[%s]", attrRequestHeader, "X-id"):  []string{"id-1", "id-2"},
-						fmt.Sprintf("%s[%s]", attrRequestHeader, "X-tag"): []string{"tag-1", "tag-2"},
+						fmt.Sprintf("%s[%s]", attrRequestHeader, "X-id"): Values{
+							Values: []string{"id-1", "id-2"},
+						},
+						fmt.Sprintf("%s[%s]", attrRequestHeader, "X-tag"): Values{
+							Values: []string{"tag-1", "tag-2"},
+						},
 					},
 				},
 			},
@@ -504,7 +556,9 @@ func TestPermission_Generate(t *testing.T) {
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						attrConnSNI: []string{"sni-1", "sni-2"},
+						attrConnSNI: Values{
+							Values: []string{"sni-1", "sni-2"},
+						},
 					},
 				},
 			},
@@ -523,7 +577,9 @@ func TestPermission_Generate(t *testing.T) {
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						"experimental.envoy.filters.a.b[c]": []string{"v1", "v2"},
+						"experimental.envoy.filters.a.b[c]": Values{
+							Values: []string{"v1", "v2"},
+						},
 					},
 				},
 			},
@@ -548,12 +604,73 @@ func TestPermission_Generate(t *testing.T) {
                       exact: v2`,
 		},
 		{
+			name: "permission with notValues",
+			permission: &Permission{
+				Constraints: []KeyValues{
+					{
+						attrDestIP: Values{
+							NotValues: []string{"1.2.3.4", "5.6.7.8"},
+						},
+					},
+				},
+			},
+			wantYAML: `
+        andRules:
+          rules:
+          - notRule:
+              orRules:
+                rules:
+                - destinationIp:
+                    addressPrefix: 1.2.3.4
+                    prefixLen: 32
+                - destinationIp:
+                    addressPrefix: 5.6.7.8
+                    prefixLen: 32`,
+		},
+		{
+			name: "permission with values and notValues",
+			permission: &Permission{
+				Constraints: []KeyValues{
+					{
+						attrDestIP: Values{
+							Values:    []string{"1.2.3.4", "5.6.7.8"},
+							NotValues: []string{"1.2.3.4", "5.6.7.8"},
+						},
+					},
+				},
+			},
+			wantYAML: `
+        andRules:
+          rules:
+          - orRules:
+              rules:
+              - destinationIp:
+                  addressPrefix: 1.2.3.4
+                  prefixLen: 32
+              - destinationIp:
+                  addressPrefix: 5.6.7.8
+                  prefixLen: 32
+          - notRule:
+              orRules:
+                rules:
+                - destinationIp:
+                    addressPrefix: 1.2.3.4
+                    prefixLen: 32
+                - destinationIp:
+                    addressPrefix: 5.6.7.8
+                    prefixLen: 32`,
+		},
+		{
 			name: "permission with unknown constraint",
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						"unknown":  []string{"v1", "v2"},
-						attrDestIP: []string{"1.2.3.4"},
+						"unknown": Values{
+							Values: []string{"v1", "v2"},
+						},
+						attrDestIP: Values{
+							Values: []string{"1.2.3.4"},
+						},
 					},
 				},
 			},
@@ -571,8 +688,12 @@ func TestPermission_Generate(t *testing.T) {
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						attrDestPort: []string{"9999999"},
-						attrDestIP:   []string{"1.2.3.4"},
+						attrDestPort: Values{
+							Values: []string{"9999999"},
+						},
+						attrDestIP: Values{
+							Values: []string{"1.2.3.4"},
+						},
 					},
 				},
 			},
@@ -590,12 +711,20 @@ func TestPermission_Generate(t *testing.T) {
 			permission: &Permission{
 				Constraints: []KeyValues{
 					{
-						attrDestIP:   []string{"1.2.3.4", "5.6.7.8"},
-						attrDestPort: []string{"8000", "9000"},
+						attrDestIP: Values{
+							Values: []string{"1.2.3.4", "5.6.7.8"},
+						},
+						attrDestPort: Values{
+							Values: []string{"8000", "9000"},
+						},
 					},
 					{
-						pathHeader:   []string{"/hello", "/world"},
-						methodHeader: []string{"GET", "POST"},
+						pathHeader: Values{
+							Values: []string{"/hello", "/world"},
+						},
+						methodHeader: Values{
+							Values: []string{"GET", "POST"},
+						},
 					},
 				},
 			},

--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -30,20 +30,21 @@ import (
 )
 
 type Principal struct {
-	Users             []string // For backward-compatible only.
-	Names             []string
-	NotNames          []string
-	Group             string // For backward-compatible only.
-	Groups            []string
-	NotGroups         []string
-	Namespaces        []string
-	NotNamespaces     []string
-	IPs               []string
-	NotIPs            []string
-	RequestPrincipals []string
-	Properties        []KeyValues
-	AllowAll          bool
-	v1beta1           bool
+	Users                []string // For backward-compatible only.
+	Names                []string
+	NotNames             []string
+	Group                string // For backward-compatible only.
+	Groups               []string
+	NotGroups            []string
+	Namespaces           []string
+	NotNamespaces        []string
+	IPs                  []string
+	NotIPs               []string
+	RequestPrincipals    []string
+	NotRequestPrincipals []string
+	Properties           []KeyValues
+	AllowAll             bool
+	v1beta1              bool
 }
 
 // ValidateForTCP checks if the principal is valid for TCP filter. A principal is not valid for TCP
@@ -56,12 +57,17 @@ func (principal *Principal) ValidateForTCP(forTCP bool) error {
 	if principal.Group != "" {
 		return fmt.Errorf("group(%v)", principal.Groups)
 	}
-
 	if len(principal.Groups) != 0 {
 		return fmt.Errorf("groups(%v)", principal.Groups)
 	}
 	if len(principal.NotGroups) != 0 {
 		return fmt.Errorf("not_groups(%v)", principal.NotGroups)
+	}
+	if len(principal.RequestPrincipals) != 0 {
+		return fmt.Errorf("request_principals(%v)", principal.RequestPrincipals)
+	}
+	if len(principal.NotRequestPrincipals) != 0 {
+		return fmt.Errorf("not_request_principals(%v)", principal.NotRequestPrincipals)
 	}
 
 	for _, p := range principal.Properties {
@@ -108,6 +114,11 @@ func (principal *Principal) Generate(forTCPFilter bool) (*envoy_rbac.Principal, 
 	if len(principal.RequestPrincipals) > 0 {
 		principal := principal.forKeyValues(attrRequestPrincipal, principal.RequestPrincipals, forTCPFilter)
 		pg.append(principal)
+	}
+
+	if len(principal.NotRequestPrincipals) > 0 {
+		principal := principal.forKeyValues(attrRequestPrincipal, principal.NotRequestPrincipals, forTCPFilter)
+		pg.append(principalNot(principal))
 	}
 
 	if principal.Group != "" {
@@ -157,13 +168,14 @@ func (principal *Principal) Generate(forTCPFilter bool) (*envoy_rbac.Principal, 
 
 		for _, k := range keys {
 			// TODO: Validate attrSrcPrincipal and principal.Names are not used at the same time.
-			newPrincipal := principal.forKeyValues(k, p[k], forTCPFilter)
-			if len(p[k]) == 1 {
-				// FIXME: Temporary hack to avoid changing unit tests during code refactor. Remove once
-				// we finish the code refactor with new unit tests.
-				newPrincipal = principal.forKeyValue(k, p[k][0], forTCPFilter)
+			if len(p[k].Values) > 0 {
+				newPrincipal := principal.forKeyValues(k, p[k].Values, forTCPFilter)
+				pg.append(newPrincipal)
 			}
-			pg.append(newPrincipal)
+			if len(p[k].NotValues) > 0 {
+				newPrincipal := principal.forKeyValues(k, p[k].NotValues, forTCPFilter)
+				pg.append(principalNot(newPrincipal))
+			}
 		}
 	}
 

--- a/pilot/pkg/security/authz/model/principal_test.go
+++ b/pilot/pkg/security/authz/model/principal_test.go
@@ -42,11 +42,25 @@ func TestPrincipal_ValidateForTCP(t *testing.T) {
 			},
 		},
 		{
+			name: "principal with requestPrincipal",
+			principal: &Principal{
+				RequestPrincipals: []string{"request-principal"},
+			},
+		},
+		{
+			name: "principal with notRequestPrincipal",
+			principal: &Principal{
+				NotRequestPrincipals: []string{"not-request-principal"},
+			},
+		},
+		{
 			name: "principal with unsupported property",
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrRequestPresenter: []string{"ns"},
+						attrRequestPresenter: Values{
+							Values: []string{"ns"},
+						},
 					},
 				},
 			},
@@ -57,10 +71,14 @@ func TestPrincipal_ValidateForTCP(t *testing.T) {
 				Users: []string{"user"},
 				Properties: []KeyValues{
 					{
-						attrSrcNamespace: []string{"ns"},
+						attrSrcNamespace: Values{
+							Values: []string{"ns"},
+						},
 					},
 					{
-						attrSrcPrincipal: []string{"p"},
+						attrSrcPrincipal: Values{
+							Values: []string{"p"},
+						},
 					},
 				},
 			},
@@ -202,6 +220,32 @@ func TestPrincipal_Generate(t *testing.T) {
                       exact: id-2`,
 		},
 		{
+			name: "principal with notRequestPrincipal",
+			principal: &Principal{
+				NotRequestPrincipals: []string{"id-1", "id-2"},
+			},
+			wantYAML: `
+        andIds:
+          ids:
+          - notId:
+              orIds:
+                ids:
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.principal
+                    value:
+                      stringMatch:
+                        exact: id-1
+                - metadata:
+                    filter: istio_authn
+                    path:
+                    - key: request.auth.principal
+                    value:
+                      stringMatch:
+                        exact: id-2`,
+		},
+		{
 			name: "principal with group",
 			principal: &Principal{
 				Group: "group-1",
@@ -277,6 +321,32 @@ func TestPrincipal_Generate(t *testing.T) {
                       regex: .*/ns/ns-2/.*`,
 		},
 		{
+			name: "principal with notNamespaces",
+			principal: &Principal{
+				NotNamespaces: []string{"ns-1", "ns-2"},
+			},
+			wantYAML: `
+         andIds:
+           ids:
+           - notId:
+               orIds:
+                 ids:
+                 - metadata:
+                     filter: istio_authn
+                     path:
+                     - key: source.principal
+                     value:
+                       stringMatch:
+                         regex: .*/ns/ns-1/.*
+                 - metadata:
+                     filter: istio_authn
+                     path:
+                     - key: source.principal
+                     value:
+                       stringMatch:
+                         regex: .*/ns/ns-2/.*`,
+		},
+		{
 			name: "principal with ips",
 			principal: &Principal{
 				IPs: []string{"1.2.3.4", "5.6.7.8"},
@@ -316,7 +386,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrSrcIP: []string{"1.2.3.4", "5.6.7.8"},
+						attrSrcIP: Values{
+							Values: []string{"1.2.3.4", "5.6.7.8"},
+						},
 					},
 				},
 			},
@@ -337,7 +409,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrSrcNamespace: []string{"ns-1", "ns-2"},
+						attrSrcNamespace: Values{
+							Values: []string{"ns-1", "ns-2"},
+						},
 					},
 				},
 			},
@@ -366,7 +440,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrSrcNamespace: []string{"ns-1", "ns-2"},
+						attrSrcNamespace: Values{
+							Values: []string{"ns-1", "ns-2"},
+						},
 					},
 				},
 			},
@@ -388,7 +464,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrSrcPrincipal: []string{"id-1", "*", allAuthenticatedUsers, allUsers},
+						attrSrcPrincipal: Values{
+							Values: []string{"id-1", "*", allAuthenticatedUsers, allUsers},
+						},
 					},
 				},
 			},
@@ -419,7 +497,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrSrcPrincipal: []string{"id-1", "*", allAuthenticatedUsers, allUsers},
+						attrSrcPrincipal: Values{
+							Values: []string{"id-1", "*", allAuthenticatedUsers, allUsers},
+						},
 					},
 				},
 				v1beta1: true,
@@ -463,7 +543,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrSrcPrincipal: []string{"id-1", "*", allAuthenticatedUsers, allUsers},
+						attrSrcPrincipal: Values{
+							Values: []string{"id-1", "*", allAuthenticatedUsers, allUsers},
+						},
 					},
 				},
 			},
@@ -487,7 +569,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrSrcPrincipal: []string{"id-1", "*", allAuthenticatedUsers, allUsers},
+						attrSrcPrincipal: Values{
+							Values: []string{"id-1", "*", allAuthenticatedUsers, allUsers},
+						},
 					},
 				},
 				v1beta1: true,
@@ -516,7 +600,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrRequestPrincipal: []string{"id-1", "id-2"},
+						attrRequestPrincipal: Values{
+							Values: []string{"id-1", "id-2"},
+						},
 					},
 				},
 			},
@@ -545,7 +631,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrRequestAudiences: []string{"aud-1", "aud-2"},
+						attrRequestAudiences: Values{
+							Values: []string{"aud-1", "aud-2"},
+						},
 					},
 				},
 			},
@@ -574,7 +662,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrRequestPresenter: []string{"pre-1", "pre-2"},
+						attrRequestPresenter: Values{
+							Values: []string{"pre-1", "pre-2"},
+						},
 					},
 				},
 			},
@@ -603,7 +693,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrSrcUser: []string{"user-1", "user-2"},
+						attrSrcUser: Values{
+							Values: []string{"user-1", "user-2"},
+						},
 					},
 				},
 			},
@@ -632,8 +724,12 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						fmt.Sprintf("%s[%s]", attrRequestHeader, "X-id"):  []string{"id-1", "id-2"},
-						fmt.Sprintf("%s[%s]", attrRequestHeader, "X-tag"): []string{"tag-1", "tag-2"},
+						fmt.Sprintf("%s[%s]", attrRequestHeader, "X-id"): Values{
+							Values: []string{"id-1", "id-2"},
+						},
+						fmt.Sprintf("%s[%s]", attrRequestHeader, "X-tag"): Values{
+							Values: []string{"tag-1", "tag-2"},
+						},
 					},
 				},
 			},
@@ -662,8 +758,12 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						fmt.Sprintf("%s[%s]", attrRequestClaims, "claim-1"): []string{"v-1", "v-2"},
-						fmt.Sprintf("%s[%s]", attrRequestClaims, "claim-2"): []string{"v-3", "v-4"},
+						fmt.Sprintf("%s[%s]", attrRequestClaims, "claim-1"): Values{
+							Values: []string{"v-1", "v-2"},
+						},
+						fmt.Sprintf("%s[%s]", attrRequestClaims, "claim-2"): Values{
+							Values: []string{"v-3", "v-4"},
+						},
 					},
 				},
 			},
@@ -720,7 +820,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						"custom": []string{"v1", "v2"},
+						"custom": Values{
+							Values: []string{"v1", "v2"},
+						},
 					},
 				},
 			},
@@ -749,7 +851,9 @@ func TestPrincipal_Generate(t *testing.T) {
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						"custom": []string{"v1", "v2"},
+						"custom": Values{
+							Values: []string{"v1", "v2"},
+						},
 					},
 				},
 			},
@@ -775,37 +879,108 @@ func TestPrincipal_Generate(t *testing.T) {
                       exact: v2`,
 		},
 		{
-			name: "principal with invalid property",
+			name: "principal with notValues",
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrSrcIP:        []string{"x.y.z"},
-						attrSrcNamespace: []string{"ns"},
+						attrSrcIP: Values{
+							NotValues: []string{"10.0.0.1", "10.0.0.2"},
+						},
 					},
 				},
 			},
 			wantYAML: `
         andIds:
           ids:
-          - metadata:
-              filter: istio_authn
-              path:
-              - key: source.principal
-              value:
-                stringMatch:
-                  regex: .*/ns/ns/.*`,
+          - notId:
+              orIds:
+                ids:
+                - sourceIp:
+                    addressPrefix: 10.0.0.1
+                    prefixLen: 32
+                - sourceIp:
+                    addressPrefix: 10.0.0.2
+                    prefixLen: 32`,
+		},
+		{
+			name: "principal with values and notValues",
+			principal: &Principal{
+				Properties: []KeyValues{
+					{
+						attrSrcIP: Values{
+							Values:    []string{"1.2.3.4", "5.6.7.8"},
+							NotValues: []string{"10.0.0.1", "10.0.0.2"},
+						},
+					},
+				},
+			},
+			wantYAML: `
+        andIds:
+          ids:
+          - orIds:
+              ids:
+              - sourceIp:
+                  addressPrefix: 1.2.3.4
+                  prefixLen: 32
+              - sourceIp:
+                  addressPrefix: 5.6.7.8
+                  prefixLen: 32
+          - notId:
+              orIds:
+                ids:
+                - sourceIp:
+                    addressPrefix: 10.0.0.1
+                    prefixLen: 32
+                - sourceIp:
+                    addressPrefix: 10.0.0.2
+                    prefixLen: 32`,
+		},
+		{
+			name: "principal with invalid property",
+			principal: &Principal{
+				Properties: []KeyValues{
+					{
+						attrSrcIP: Values{
+							Values: []string{"x.y.z"},
+						},
+						attrSrcNamespace: Values{
+							Values: []string{"ns"},
+						},
+					},
+				},
+			},
+			wantYAML: `
+        andIds:
+          ids:
+          - orIds:
+              ids:
+              - metadata:
+                  filter: istio_authn
+                  path:
+                  - key: source.principal
+                  value:
+                    stringMatch:
+                      regex: .*/ns/ns/.*`,
 		},
 		{
 			name: "principal with multiple properties",
 			principal: &Principal{
 				Properties: []KeyValues{
 					{
-						attrSrcIP:        []string{"1.2.3.4", "5.6.7.8"},
-						attrSrcNamespace: []string{"ns-1", "ns-2"},
+						attrSrcIP: Values{
+							Values: []string{"1.2.3.4", "5.6.7.8"},
+						},
+						attrSrcNamespace: Values{
+							Values: []string{"ns-1", "ns-2"},
+						},
 					},
 					{
-						attrSrcPrincipal:     []string{"id-1", "id-2"},
-						attrRequestAudiences: []string{"aud-1", "aud-2"},
+						attrSrcPrincipal: Values{
+							Values: []string{"id-1", "id-2"},
+						},
+						attrRequestAudiences: Values{
+							Values: []string{"aud-1", "aud-2"},
+						},
 					},
 				},
 			},

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3945,6 +3945,20 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "allow-rules-nil",
+			in: &security_beta.AuthorizationPolicy{
+				Action: security_beta.AuthorizationPolicy_ALLOW,
+			},
+			valid: true,
+		},
+		{
+			name: "deny-rules-nil",
+			in: &security_beta.AuthorizationPolicy{
+				Action: security_beta.AuthorizationPolicy_DENY,
+			},
+			valid: false,
+		},
+		{
 			name: "selector-empty-value",
 			in: &security_beta.AuthorizationPolicy{
 				Selector: &api.WorkloadSelector{
@@ -4122,6 +4136,38 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 						When: []*security_beta.Condition{
 							{
 								Key: "source.principal",
+							},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "condition-value-invalid",
+			in: &security_beta.AuthorizationPolicy{
+				Rules: []*security_beta.Rule{
+					{
+						When: []*security_beta.Condition{
+							{
+								Key:    "source.ip",
+								Values: []string{"a.b.c.d"},
+							},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "condition-notValue-invalid",
+			in: &security_beta.AuthorizationPolicy{
+				Rules: []*security_beta.Rule{
+					{
+						When: []*security_beta.Condition{
+							{
+								Key:       "source.ip",
+								NotValues: []string{"a.b.c.d"},
 							},
 						},
 					},


### PR DESCRIPTION
This PR adds support to the negative match (not_ fields) in authorization policy. E2E tests will be added in a follow-up PR.

For #19894