### PR TITLE
Fix finalization in operator

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -169,6 +169,13 @@ func (r *ReconcileIstioOperator) Reconcile(request reconcile.Request) (reconcile
 		iop.SetFinalizers(finalizers.List())
 		err := r.client.Update(context.TODO(), iop)
 		if err != nil {
+			if errors.IsNotFound(err) {
+				log.Infof("Could not add finalizer to %v: the object was deleted", request)
+				return reconcile.Result{}, nil
+			} else if errors.IsConflict(err) {
+				log.Infof("Could not add finalizer to %v due to conflict. Operation will be retried in next reconcile attempt", request)
+				return reconcile.Result{}, nil
+			}
 			log.Errorf("Failed to update IstioOperator with finalizer, %v", err)
 			return reconcile.Result{}, err
 		}

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -159,6 +159,13 @@ func (r *ReconcileIstioOperator) Reconcile(request reconcile.Request) (reconcile
 			finalizerError = r.client.Update(context.TODO(), iop)
 		}
 		if finalizerError != nil {
+			if errors.IsNotFound(finalizerError) {
+				log.Infof("Could not remove finalizer from %v: the object was deleted", request)
+				return reconcile.Result{}, nil
+			} else if errors.IsConflict(finalizerError) {
+				log.Infof("Could not remove finalizer from %v due to conflict. Operation will be retried in next reconcile attempt", request)
+				return reconcile.Result{}, nil
+			}
 			log.Errorf("error removing finalizer: %s", finalizerError)
 			return reconcile.Result{}, finalizerError
 		}

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -42,8 +42,8 @@ import (
 
 const (
 	finalizer = "istio-finalizer.install.istio.io"
-	// finalizerMaxRetries defines the maximum number of attempts to add finalizers.
-	finalizerMaxRetries = 10
+	// finalizerMaxRetries defines the maximum number of attempts to remove the finalizer.
+	finalizerMaxRetries = 1
 )
 
 /**


### PR DESCRIPTION
Conflict errors during the addition or removal of finalizers were treated and logged as errors. Running into a conflict is a perfectly normal event - controllers should expect this and handle it appropriately (which this controller does). Given how this is not an error, it shouldn't be logged as one.

Also, if the controller is unable to clean up properly, it should retry the cleanup instead of giving up and removing the finalizer (and leaving the owned resources in place).
