### PR TITLE
Version update to resolve security issue in multiple modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20171214222146-0e7658f8ee99
-	github.com/hashicorp/consul v1.3.0
+	github.com/hashicorp/consul v1.5.1
 	github.com/hashicorp/go-hclog v0.9.0 // indirect
 	github.com/hashicorp/go-memdb v1.0.1 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
@@ -101,7 +101,7 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/memberlist v0.1.3 // indirect
 	github.com/hashicorp/serf v0.8.1 // indirect
-	github.com/hashicorp/vault v0.10.0
+	github.com/hashicorp/vault v1.0.0
 	github.com/howeyc/fsnotify v0.9.0
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
@@ -123,7 +123,7 @@ require (
 	github.com/onsi/gomega v1.7.0
 	github.com/open-policy-agent/opa v0.8.2
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/opencontainers/runc v0.1.1 // indirect
+	github.com/opencontainers/runc v1.0.0-rc2.0.20161017145322-509ddd6f118c // indirect
 	github.com/openshift/api v3.9.1-0.20191008181517-e4fd21196097+incompatible
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/openzipkin/zipkin-go v0.1.7


### PR DESCRIPTION

github.com/opencontainers/runc v0.1.1 , github.com/hashicorp/consul v1.3.0, github.com/hashicorp/vault v0.10.0 is vulnerable so suggesting to upgrade the version to a secured one. You can check module vulnerability here : 
https://search.gocenter.io/github.com~2Fopencontainers~2Frunc/info?version=v0.1.1
https://search.gocenter.io/github.com~2Fhashicorp~2Fvault/info?version=v0.10.0
https://search.gocenter.io/github.com~2Fhashicorp~2Fconsul/info?version=v1.3.0

CVE-2018-19653
HashiCorp Consul 0.5.1 through 1.4.0 can use cleartext agent-to-agent RPC communication because the verify_outgoing setting is improperly documented. NOTE: the vendor has provided reconfiguration steps that do not require a software upgrade.

CVE-2018-19786
HashiCorp Vault before 1.0.0 writes the master key to the server log in certain unusual or misconfigured scenarios in which incorrect data comes from the autoseal mechanism without an error being reported.

CVE-2019-5736
runc through 1.0-rc6, as used in Docker before 18.09.2 and other products, allows attackers to overwrite the host runc binary (and consequently obtain host root access) by leveraging the ability to execute a command as root within one of these types of containers: (1) a new container with an attacker-controlled image, or (2) an existing container, to which the attacker previously had write access, that can be attached with docker exec. This occurs because of file-descriptor mishandling, related to /proc/self/exe.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure