### PR TITLE
Stop using deprecated CORS policy

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -65,6 +65,14 @@ const DefaultRouteName = "default"
 // Refer to https://github.com/google/re2/blob/a98fad02c421896bc75d97f49ccd245cdce7dd55/re2/re2.h#L287 for details.
 const maxRegExProgramSize = 1024
 
+var (
+	regexEngine = &matcher.RegexMatcher_GoogleRe2{GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
+		MaxProgramSize: &wrappers.UInt32Value{
+			Value: uint32(maxRegExProgramSize),
+		},
+	}}
+)
+
 // VirtualHostWrapper is a context-dependent virtual host entry with guarded routes.
 // Note: Currently we are not fully utilizing this structure. We could invoke this logic
 // once for all sidecars in the cluster to compute all RDS for inside the mesh and arrange
@@ -386,7 +394,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		out.Action = action
 	} else {
 		action := &route.RouteAction{
-			Cors:        translateCORSPolicy(in.CorsPolicy, node),
+			Cors:        translateCORSPolicy(in.CorsPolicy),
 			RetryPolicy: retry.ConvertPolicy(in.Retries),
 		}
 
@@ -659,12 +667,8 @@ func translateHeaderMatch(name string, in *networking.StringMatch, node *model.P
 		} else {
 			out.HeaderMatchSpecifier = &route.HeaderMatcher_SafeRegexMatch{
 				SafeRegexMatch: &matcher.RegexMatcher{
-					EngineType: &matcher.RegexMatcher_GoogleRe2{GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
-						MaxProgramSize: &wrappers.UInt32Value{
-							Value: uint32(maxRegExProgramSize),
-						},
-					}},
-					Regex: m.Regex,
+					EngineType: regexEngine,
+					Regex:      m.Regex,
 				},
 			}
 		}
@@ -673,15 +677,52 @@ func translateHeaderMatch(name string, in *networking.StringMatch, node *model.P
 	return out
 }
 
+func stringToExactMatch(in []string) []*matcher.StringMatcher {
+	res := make([]*matcher.StringMatcher, 0, len(in))
+	for _, s := range in {
+		res = append(res, &matcher.StringMatcher{
+			MatchPattern: &matcher.StringMatcher_Exact{Exact: s},
+		})
+	}
+	return res
+}
+
+func convertToEnvoyMatch(in []*networking.StringMatch) []*matcher.StringMatcher {
+	res := make([]*matcher.StringMatcher, 0, len(in))
+
+	for _, istioMatcher := range in {
+		switch m := istioMatcher.MatchType.(type) {
+		case *networking.StringMatch_Exact:
+			res = append(res, &matcher.StringMatcher{MatchPattern: &matcher.StringMatcher_Exact{m.Exact}})
+		case *networking.StringMatch_Prefix:
+			res = append(res, &matcher.StringMatcher{MatchPattern: &matcher.StringMatcher_Prefix{m.Prefix}})
+		case *networking.StringMatch_Regex:
+			res = append(res, &matcher.StringMatcher{MatchPattern: &matcher.StringMatcher_SafeRegex{
+				SafeRegex: &matcher.RegexMatcher{
+					EngineType: regexEngine,
+					Regex:      m.Regex,
+				},
+			},
+			})
+		}
+
+	}
+
+	return res
+}
+
 // translateCORSPolicy translates CORS policy
-func translateCORSPolicy(in *networking.CorsPolicy, _ *model.Proxy) *route.CorsPolicy {
+func translateCORSPolicy(in *networking.CorsPolicy) *route.CorsPolicy {
 	if in == nil {
 		return nil
 	}
 
 	// CORS filter is enabled by default
-	out := route.CorsPolicy{
-		AllowOrigin: in.AllowOrigin,
+	out := route.CorsPolicy{}
+	if in.AllowOrigin != nil {
+		out.AllowOriginStringMatch = stringToExactMatch(in.AllowOrigin)
+	} else {
+		out.AllowOriginStringMatch = convertToEnvoyMatch(in.AllowOrigins)
 	}
 
 	out.EnabledSpecifier = &route.CorsPolicy_FilterEnabled{

--- a/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
@@ -25,6 +25,7 @@ import (
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/ptypes/wrappers"
+
 	networking "istio.io/api/networking/v1alpha3"
 )
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
@@ -15,11 +15,17 @@
 package route
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
-	networking "istio.io/api/networking/v1alpha3"
-
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
+	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
+	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	networking "istio.io/api/networking/v1alpha3"
 )
 
 func TestIsCatchAllMatch(t *testing.T) {
@@ -395,6 +401,83 @@ func TestCatchAllMatch(t *testing.T) {
 			match := catchAllMatch(tt.http)
 			if tt.match && match == nil {
 				t.Errorf("Expected a catch all match but got nil")
+			}
+		})
+	}
+}
+
+func TestTranslateCORSPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *networking.CorsPolicy
+		want *route.CorsPolicy
+	}{
+		{
+			name: "deprecated matcher",
+			in: &networking.CorsPolicy{
+				AllowOrigin:      []string{"foo"},
+				AllowMethods:     []string{"allow-method-1", "allow-method-2"},
+				AllowHeaders:     []string{"allow-header-1", "allow-header-2"},
+				ExposeHeaders:    []string{"expose-header-1", "expose-header-2"},
+				MaxAge:           types.DurationProto(time.Minute * 2),
+				AllowCredentials: &types.BoolValue{Value: true},
+			},
+			want: &route.CorsPolicy{
+				AllowOriginStringMatch: []*envoy_type_matcher.StringMatcher{{
+					MatchPattern: &envoy_type_matcher.StringMatcher_Exact{Exact: "foo"},
+				}},
+				AllowMethods:     "allow-method-1,allow-method-2",
+				AllowHeaders:     "allow-header-1,allow-header-2",
+				ExposeHeaders:    "expose-header-1,expose-header-2",
+				MaxAge:           "120",
+				AllowCredentials: &wrappers.BoolValue{Value: true},
+				EnabledSpecifier: &route.CorsPolicy_FilterEnabled{
+					FilterEnabled: &envoy_api_v2_core.RuntimeFractionalPercent{
+						DefaultValue: &envoy_type.FractionalPercent{
+							Numerator:   100,
+							Denominator: envoy_type.FractionalPercent_HUNDRED,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "string matcher",
+			in: &networking.CorsPolicy{
+				AllowOrigins: []*networking.StringMatch{
+					{MatchType: &networking.StringMatch_Exact{Exact: "exact"}},
+					{MatchType: &networking.StringMatch_Prefix{Prefix: "prefix"}},
+					{MatchType: &networking.StringMatch_Regex{Regex: "regex"}},
+				},
+			},
+			want: &route.CorsPolicy{
+				AllowOriginStringMatch: []*envoy_type_matcher.StringMatcher{
+					{MatchPattern: &envoy_type_matcher.StringMatcher_Exact{Exact: "exact"}},
+					{MatchPattern: &envoy_type_matcher.StringMatcher_Prefix{Prefix: "prefix"}},
+					{
+						MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+							SafeRegex: &envoy_type_matcher.RegexMatcher{
+								EngineType: regexEngine,
+								Regex:      "regex",
+							},
+						},
+					},
+				},
+				EnabledSpecifier: &route.CorsPolicy_FilterEnabled{
+					FilterEnabled: &envoy_api_v2_core.RuntimeFractionalPercent{
+						DefaultValue: &envoy_type.FractionalPercent{
+							Numerator:   100,
+							Denominator: envoy_type.FractionalPercent_HUNDRED,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := translateCORSPolicy(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("translateCORSPolicy() = \n%v, want \n%v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
For https://github.com/istio/istio/issues/20219

Stop using the deprecated Envoy field, and implement the new cors policy
in virtual service we apparently added