### PR TITLE
Fix validation cert rotation

### DIFF
--- a/pkg/webhooks/validation/server/server.go
+++ b/pkg/webhooks/validation/server/server.go
@@ -264,9 +264,13 @@ func (wh *Webhook) Run(stopCh <-chan struct{}) {
 			keyCertTimerC = nil
 			wh.reloadKeyCert()
 		case <-wh.keyCertWatcher.Events(wh.keyFile):
-			keyCertTimerC = time.After(watchDebounceDelay)
+			if keyCertTimerC == nil { 
+				keyCertTimerC = time.After(watchDebounceDelay)
+			}
 		case <-wh.keyCertWatcher.Events(wh.certFile):
-			keyCertTimerC = time.After(watchDebounceDelay)
+			if keyCertTimerC == nil { 
+				keyCertTimerC = time.After(watchDebounceDelay)
+			}
 		case err := <-wh.keyCertWatcher.Errors(wh.keyFile):
 			scope.Errorf("configWatcher error: %v", err)
 		case err := <-wh.keyCertWatcher.Errors(wh.certFile):

--- a/pkg/webhooks/validation/server/server.go
+++ b/pkg/webhooks/validation/server/server.go
@@ -264,11 +264,11 @@ func (wh *Webhook) Run(stopCh <-chan struct{}) {
 			keyCertTimerC = nil
 			wh.reloadKeyCert()
 		case <-wh.keyCertWatcher.Events(wh.keyFile):
-			if keyCertTimerC == nil { 
+			if keyCertTimerC == nil {
 				keyCertTimerC = time.After(watchDebounceDelay)
 			}
 		case <-wh.keyCertWatcher.Events(wh.certFile):
-			if keyCertTimerC == nil { 
+			if keyCertTimerC == nil {
 				keyCertTimerC = time.After(watchDebounceDelay)
 			}
 		case err := <-wh.keyCertWatcher.Errors(wh.keyFile):


### PR DESCRIPTION
When kubernetes updates a secretMount, it is not always (ever? not
exactly sure why this ever works) a "modify" event. Generally its a
move, since its a symlink we are looking at. This changes the file
watching to be more liberal, which seems aligned with the rest of our
file watchers.

Fixes https://github.com/istio/istio/issues/20147