### PR TITLE
eds: fix eds test codecov flaky ness

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -68,7 +68,7 @@ func TestEds(t *testing.T) {
 	addTestClientEndpoints(server)
 
 	// Trigger a push to update the contents of the registry to push context and push to connected clients.
-	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
+	fullPush(server)
 
 	adscConn := adsConnectAndWait(t, 0x0a0a0a0a)
 	defer adscConn.Close()
@@ -267,6 +267,12 @@ func TestDeleteService(t *testing.T) {
 		t.Fatalf("Expected service key %s to be deleted in EndpointShardsByService. But is still there %v",
 			"removeservice.com", server.EnvoyXdsServer.EndpointShardsByService)
 	}
+}
+
+func fullPush(server *bootstrap.Server) {
+	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
+	// TODO: See if we can disable debounce completely for tests to avoid sleep.
+	time.Sleep(200 * time.Millisecond) // Wait till push debounce is stable.
 }
 
 func adsConnectAndWait(t *testing.T, ip int) *adsc.ADSC {
@@ -765,7 +771,8 @@ func addEdsCluster(server *bootstrap.Server, hostName string, portName string, a
 			Protocol: protocol.HTTP,
 		},
 	})
-	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
+
+	fullPush(server)
 }
 
 func updateServiceResolution(server *bootstrap.Server) {
@@ -793,7 +800,8 @@ func updateServiceResolution(server *bootstrap.Server) {
 			Protocol: protocol.HTTP,
 		},
 	})
-	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
+
+	fullPush(server)
 }
 
 func addOverlappingEndpoints(server *bootstrap.Server) {
@@ -824,7 +832,8 @@ func addOverlappingEndpoints(server *bootstrap.Server) {
 			Protocol: protocol.TCP,
 		},
 	})
-	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
+
+	fullPush(server)
 }
 
 // Verify the endpoint debug interface is installed and returns some string.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/20158. This flaky behaviour is especially happening without "-race" flag and is caused by push debounces. The debounces are grouping the pushes together making the test validations especially in `PushIncrement` and `EndpointFlipFlops` tests which specifically look for EDS updates flaky. This adds  a sleep for the debounce period whenever full push happens so that it is stable.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
