### PR TITLE
disable listener filter timeout for outbound listener if port name is defined as tls or https

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -101,8 +101,8 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 			opts.filterChainOpts = filterChainOpts
 		}
 
+		opts.trafficDirection = core.TrafficDirection_OUTBOUND
 		l := buildListener(opts)
-		l.TrafficDirection = core.TrafficDirection_OUTBOUND
 
 		mutable := &plugin.MutableObjects{
 			Listener: l,

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -101,8 +101,8 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 			opts.filterChainOpts = filterChainOpts
 		}
 
-		opts.trafficDirection = core.TrafficDirection_OUTBOUND
 		l := buildListener(opts)
+		l.TrafficDirection = core.TrafficDirection_OUTBOUND
 
 		mutable := &plugin.MutableObjects{
 			Listener: l,

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -2343,7 +2343,8 @@ func removeListenerFilterTimeout(listeners []*xdsapi.Listener) {
 		// 	2. without HTTP inspector
 		hasHttpInspector := false
 		for _, lf := range l.ListenerFilters {
-			if hasHttpInspector = hasHttpInspector || lf.Name == wellknown.HttpInspector; hasHttpInspector {
+			if lf.Name == wellknown.HttpInspector {
+				hasHttpInspector = true
 				break
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -722,8 +722,8 @@ allChainsLabel:
 	}
 
 	// call plugins
+	listenerOpts.trafficDirection = core.TrafficDirection_INBOUND
 	l := buildListener(listenerOpts)
-	l.TrafficDirection = core.TrafficDirection_INBOUND
 
 	mutable := &plugin.MutableObjects{
 		Listener:     l,
@@ -1055,11 +1055,11 @@ func (configgen *ConfigGeneratorImpl) buildHTTPProxy(node *model.Proxy,
 				},
 			},
 		}},
-		bindToPort:      true,
-		skipUserFilters: true,
+		bindToPort:       true,
+		skipUserFilters:  true,
+		trafficDirection: core.TrafficDirection_OUTBOUND,
 	}
 	l := buildListener(opts)
-	l.TrafficDirection = core.TrafficDirection_OUTBOUND
 
 	// TODO: plugins for HTTP_PROXY mode, envoyfilter needs another listener match for SIDECAR_HTTP_PROXY
 	// there is no mixer for http_proxy
@@ -1408,9 +1408,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 
 	// Lets build the new listener with the filter chains. In the end, we will
 	// merge the filter chains with any existing listener on the same port/bind point
+	listenerOpts.trafficDirection = core.TrafficDirection_OUTBOUND
 	l := buildListener(listenerOpts)
 	appendListenerFallthroughRoute(l, &listenerOpts, pluginParams.Node, currentListenerEntry)
-	l.TrafficDirection = core.TrafficDirection_OUTBOUND
 
 	mutable := &plugin.MutableObjects{
 		Listener:     l,
@@ -1630,12 +1630,12 @@ func buildSidecarInboundMgmtListeners(node *model.Proxy, push *model.PushContext
 					networkFilters: buildInboundNetworkFilters(push, node, instance),
 				}},
 				// No user filters for the management unless we introduce new listener matches
-				skipUserFilters: true,
-				proxy:           node,
-				push:            push,
+				skipUserFilters:  true,
+				proxy:            node,
+				push:             push,
+				trafficDirection: core.TrafficDirection_INBOUND,
 			}
 			l := buildListener(listenerOpts)
-			l.TrafficDirection = core.TrafficDirection_INBOUND
 			mutable := &plugin.MutableObjects{
 				Listener:     l,
 				FilterChains: []plugin.FilterChain{{}},
@@ -1701,6 +1701,7 @@ type buildListenerOpts struct {
 	bindToPort        bool
 	skipUserFilters   bool
 	needHTTPInspector bool
+	trafficDirection  core.TrafficDirection
 }
 
 func buildHTTPConnectionManager(pluginParams *plugin.InputParams, httpOpts *httpListenerOpts,
@@ -1952,13 +1953,15 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 	listener := &xdsapi.Listener{
 		// TODO: need to sanitize the opts.bind if its a UDS socket, as it could have colons, that envoy
 		// doesn't like
-		Name:            fmt.Sprintf("%s_%d", opts.bind, opts.port),
-		Address:         util.BuildAddress(opts.bind, uint32(opts.port)),
-		ListenerFilters: listenerFilters,
-		FilterChains:    filterChains,
-		DeprecatedV1:    deprecatedV1,
+		Name:             fmt.Sprintf("%s_%d", opts.bind, opts.port),
+		Address:          util.BuildAddress(opts.bind, uint32(opts.port)),
+		ListenerFilters:  listenerFilters,
+		FilterChains:     filterChains,
+		DeprecatedV1:     deprecatedV1,
+		TrafficDirection: opts.trafficDirection,
 	}
 
+	// setup listener filter timeout for sidecar only
 	if util.IsIstioVersionGE13(opts.proxy) && opts.proxy.Type != model.Router {
 		listener.ListenerFiltersTimeout = gogo.DurationToProtoDuration(opts.push.Mesh.ProtocolDetectionTimeout)
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1963,10 +1963,13 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 
 	// setup listener filter timeout for sidecar only
 	if util.IsIstioVersionGE13(opts.proxy) && opts.proxy.Type != model.Router {
-		listener.ListenerFiltersTimeout = gogo.DurationToProtoDuration(opts.push.Mesh.ProtocolDetectionTimeout)
+		// This implies the port is explicitly defined as tls-xxx or https-xxx
+		if !(needTLSInspector && !opts.needHTTPInspector && listener.TrafficDirection == core.TrafficDirection_OUTBOUND) {
+			listener.ListenerFiltersTimeout = gogo.DurationToProtoDuration(opts.push.Mesh.ProtocolDetectionTimeout)
 
-		if listener.ListenerFiltersTimeout != nil {
-			listener.ContinueOnListenerFiltersTimeout = true
+			if listener.ListenerFiltersTimeout != nil {
+				listener.ContinueOnListenerFiltersTimeout = true
+			}
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -2340,7 +2340,7 @@ func removeListenerFilterTimeout(listeners []*xdsapi.Listener) {
 	for _, l := range listeners {
 		// Remove listener filter timeout for
 		// 	1. outbound listeners AND
-		// 	2. with HTTP inspector
+		// 	2. without HTTP inspector
 		hasHttpInspector := false
 		for _, lf := range l.ListenerFilters {
 			if hasHttpInspector = hasHttpInspector || lf.Name == wellknown.HttpInspector; hasHttpInspector {

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -591,6 +591,23 @@ func TestOutboundTlsTrafficWithoutTimeout(t *testing.T) {
 				Namespace: "default",
 			},
 		},
+		{
+			CreationTime: tnow,
+			Hostname:     host.Name("test1.com"),
+			Address:      wildcardIP,
+			ClusterVIPs:  make(map[string]string),
+			Ports: model.PortList{
+				&model.Port{
+					Name:     "foo",
+					Port:     9090,
+					Protocol: "unknown",
+				},
+			},
+			Resolution: model.Passthrough,
+			Attributes: model.ServiceAttributes{
+				Namespace: "default",
+			},
+		},
 	}
 	testOutboundListenerFilterTimeoutV14(t, services...)
 }
@@ -704,13 +721,19 @@ func testOutboundListenerRouteV14(t *testing.T, services ...*model.Service) {
 func testOutboundListenerFilterTimeoutV14(t *testing.T, services ...*model.Service) {
 	p := &fakePlugin{}
 	listeners := buildOutboundListeners(p, &proxy14, nil, nil, services...)
-	if len(listeners) != 1 {
-		t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
+	if len(listeners) != 2 {
+		t.Fatalf("expected %d listeners, found %d", 2, len(listeners))
 	}
 
 	if listeners[0].ContinueOnListenerFiltersTimeout {
 		t.Fatalf("expected timeout disabled, found ContinueOnListenerFiltersTimeout %v",
 			listeners[0].ContinueOnListenerFiltersTimeout)
+	}
+
+	if !listeners[1].ContinueOnListenerFiltersTimeout || listeners[1].ListenerFiltersTimeout == nil {
+		t.Fatalf("expected timeout enabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+			listeners[1].ContinueOnListenerFiltersTimeout,
+			listeners[1].ListenerFiltersTimeout)
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -572,6 +572,29 @@ func TestOutboundListenerConfig_WithSidecar(t *testing.T) {
 	testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t, services...)
 }
 
+func TestOutboundTlsTrafficWithoutTimeout(t *testing.T) {
+	services := []*model.Service{
+		{
+			CreationTime: tnow,
+			Hostname:     host.Name("test.com"),
+			Address:      wildcardIP,
+			ClusterVIPs:  make(map[string]string),
+			Ports: model.PortList{
+				&model.Port{
+					Name:     "https",
+					Port:     8080,
+					Protocol: protocol.HTTPS,
+				},
+			},
+			Resolution: model.Passthrough,
+			Attributes: model.ServiceAttributes{
+				Namespace: "default",
+			},
+		},
+	}
+	testOutboundListenerFilterTimeoutV14(t, services...)
+}
+
 func TestGetActualWildcardAndLocalHost(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -678,6 +701,19 @@ func testOutboundListenerRouteV14(t *testing.T, services ...*model.Service) {
 	}
 }
 
+func testOutboundListenerFilterTimeoutV14(t *testing.T, services ...*model.Service) {
+	p := &fakePlugin{}
+	listeners := buildOutboundListeners(p, &proxy14, nil, nil, services...)
+	if len(listeners) != 1 {
+		t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
+	}
+
+	if listeners[0].ContinueOnListenerFiltersTimeout {
+		t.Fatalf("expected timeout disabled, found ContinueOnListenerFiltersTimeout %v",
+			listeners[0].ContinueOnListenerFiltersTimeout)
+	}
+}
+
 func testOutboundListenerConflictV14(t *testing.T, services ...*model.Service) {
 	t.Helper()
 	oldestService := getOldestService(services...)
@@ -714,6 +750,12 @@ func testOutboundListenerConflictV14(t *testing.T, services ...*model.Service) {
 			t.Fatalf("expected %d listener filter, found %d", 2, len(listeners[0].ListenerFilters))
 		}
 
+		if !listeners[0].ContinueOnListenerFiltersTimeout || listeners[0].ListenerFiltersTimeout == nil {
+			t.Fatalf("exptected timeout, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+				listeners[0].ContinueOnListenerFiltersTimeout,
+				listeners[0].ListenerFiltersTimeout)
+		}
+
 		f := listeners[0].FilterChains[2].Filters[0]
 		cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 		rds := cfg.Fields["rds"].GetStructValue().Fields["route_config_name"].GetStringValue()
@@ -739,6 +781,12 @@ func testOutboundListenerConflictV14(t *testing.T, services ...*model.Service) {
 			listeners[0].ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
 			listeners[0].ListenerFilters[1].Name != "envoy.listener.http_inspector" {
 			t.Fatalf("expected %d listener filter, found %d", 2, len(listeners[0].ListenerFilters))
+		}
+
+		if !listeners[0].ContinueOnListenerFiltersTimeout || listeners[0].ListenerFiltersTimeout == nil {
+			t.Fatalf("exptected timeout, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+				listeners[0].ContinueOnListenerFiltersTimeout,
+				listeners[0].ListenerFiltersTimeout)
 		}
 	}
 }


### PR DESCRIPTION
Disable listener filter timeout if the port name is defined as tls or https to avoid the timeout of tls inspector. 

enhance https://github.com/istio/istio/issues/19660