### PR TITLE
iptables: Add override for iptables validation timeout

### DIFF
--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -88,7 +88,7 @@ func constructConfig() *config.Config {
 		OutboundIPRangesExclude: viper.GetString(constants.ServiceExcludeCidr),
 		KubevirtInterfaces:      viper.GetString(constants.KubeVirtInterfaces),
 		IptablesProbePort:       uint16(viper.GetUint(constants.IptablesProbePort)),
-		ProbeTimeout:            viper.GetUint64(constants.ProbeTimeout),
+		ProbeTimeout:            viper.GetDuration(constants.ProbeTimeout),
 		SkipRuleApply:           viper.GetBool(constants.SkipRuleApply),
 		RunValidation:           viper.GetBool(constants.RunValidation),
 	}
@@ -265,7 +265,7 @@ func init() {
 	if err := viper.BindPFlag(constants.ProbeTimeout, rootCmd.Flags().Lookup(constants.ProbeTimeout)); err != nil {
 		handleError(err)
 	}
-	viper.SetDefault(constants.ProbeTimeout, strconv.FormatUint(constants.DefaultProbeTimeout, 10))
+	viper.SetDefault(constants.ProbeTimeout, constants.DefaultProbeTimeout)
 
 	rootCmd.Flags().Bool(constants.SkipRuleApply, false, "Skip iptables apply")
 	if err := viper.BindPFlag(constants.SkipRuleApply, rootCmd.Flags().Lookup(constants.SkipRuleApply)); err != nil {

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -261,7 +261,7 @@ func init() {
 	}
 	viper.SetDefault(constants.IptablesProbePort, strconv.Itoa(constants.DefaultIptablesProbePort))
 
-	rootCmd.Flags().String(constants.ProbeTimeout, strconv.FormatUint(constants.DefaultProbeTimeout, 10), "set timeout in nanosecond for failure detection")
+	rootCmd.Flags().Duration(constants.ProbeTimeout, constants.DefaultProbeTimeout, "failure detection timeout")
 	if err := viper.BindPFlag(constants.ProbeTimeout, rootCmd.Flags().Lookup(constants.ProbeTimeout)); err != nil {
 		handleError(err)
 	}

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -88,6 +88,7 @@ func constructConfig() *config.Config {
 		OutboundIPRangesExclude: viper.GetString(constants.ServiceExcludeCidr),
 		KubevirtInterfaces:      viper.GetString(constants.KubeVirtInterfaces),
 		IptablesProbePort:       uint16(viper.GetUint(constants.IptablesProbePort)),
+		ProbeTimeout:            viper.GetUint64(constants.ProbeTimeout),
 		SkipRuleApply:           viper.GetBool(constants.SkipRuleApply),
 		RunValidation:           viper.GetBool(constants.RunValidation),
 	}
@@ -259,6 +260,12 @@ func init() {
 		handleError(err)
 	}
 	viper.SetDefault(constants.IptablesProbePort, strconv.Itoa(constants.DefaultIptablesProbePort))
+
+	rootCmd.Flags().String(constants.ProbeTimeout, strconv.FormatUint(constants.DefaultProbeTimeout, 10), "set timeout in nanosecond for failure detection")
+	if err := viper.BindPFlag(constants.ProbeTimeout, rootCmd.Flags().Lookup(constants.ProbeTimeout)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.ProbeTimeout, strconv.FormatUint(constants.DefaultProbeTimeout, 10))
 
 	rootCmd.Flags().Bool(constants.SkipRuleApply, false, "Skip iptables apply")
 	if err := viper.BindPFlag(constants.SkipRuleApply, rootCmd.Flags().Lookup(constants.SkipRuleApply)); err != nil {

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -17,7 +17,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-
 	"istio.io/pkg/log"
 )
 
@@ -37,6 +36,7 @@ type Config struct {
 	OutboundIPRangesExclude string `json:"OUTBOUND_IPRANGES_EXCLUDE"`
 	KubevirtInterfaces      string `json:"KUBEVIRT_INTERFACES"`
 	IptablesProbePort       uint16 `json:"IPTABLES_PROBE_PORT"`
+	ProbeTimeout            uint64 `json: "PROBE_TIMEOUT"`
 	DryRun                  bool   `json:"DRY_RUN"`
 	RestoreFormat           bool   `json:"RESTORE_FORMAT"`
 	SkipRuleApply           bool   `json:"SKIP_RULE_APPLY"`

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -17,31 +17,33 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"istio.io/pkg/log"
 )
 
 // Command line options
 type Config struct {
-	ProxyPort               string `json:"PROXY_PORT"`
-	InboundCapturePort      string `json:"INBOUND_CAPTURE_PORT"`
-	ProxyUID                string `json:"PROXY_UID"`
-	ProxyGID                string `json:"PROXY_GID"`
-	InboundInterceptionMode string `json:"INBOUND_INTERCEPTION_MODE"`
-	InboundTProxyMark       string `json:"INBOUND_TPROXY_MARK"`
-	InboundTProxyRouteTable string `json:"INBOUND_TPROXY_ROUTE_TABLE"`
-	InboundPortsInclude     string `json:"INBOUND_PORTS_INCLUDE"`
-	InboundPortsExclude     string `json:"INBOUND_PORTS_EXCLUDE"`
-	OutboundPortsExclude    string `json:"OUTBOUND_PORTS_EXCLUDE"`
-	OutboundIPRangesInclude string `json:"OUTBOUND_IPRANGES_INCLUDE"`
-	OutboundIPRangesExclude string `json:"OUTBOUND_IPRANGES_EXCLUDE"`
-	KubevirtInterfaces      string `json:"KUBEVIRT_INTERFACES"`
-	IptablesProbePort       uint16 `json:"IPTABLES_PROBE_PORT"`
+	ProxyPort               string        `json:"PROXY_PORT"`
+	InboundCapturePort      string        `json:"INBOUND_CAPTURE_PORT"`
+	ProxyUID                string        `json:"PROXY_UID"`
+	ProxyGID                string        `json:"PROXY_GID"`
+	InboundInterceptionMode string        `json:"INBOUND_INTERCEPTION_MODE"`
+	InboundTProxyMark       string        `json:"INBOUND_TPROXY_MARK"`
+	InboundTProxyRouteTable string        `json:"INBOUND_TPROXY_ROUTE_TABLE"`
+	InboundPortsInclude     string        `json:"INBOUND_PORTS_INCLUDE"`
+	InboundPortsExclude     string        `json:"INBOUND_PORTS_EXCLUDE"`
+	OutboundPortsExclude    string        `json:"OUTBOUND_PORTS_EXCLUDE"`
+	OutboundIPRangesInclude string        `json:"OUTBOUND_IPRANGES_INCLUDE"`
+	OutboundIPRangesExclude string        `json:"OUTBOUND_IPRANGES_EXCLUDE"`
+	KubevirtInterfaces      string        `json:"KUBEVIRT_INTERFACES"`
+	IptablesProbePort       uint16        `json:"IPTABLES_PROBE_PORT"`
 	ProbeTimeout            time.Duration `json: "PROBE_TIMEOUT"`
-	DryRun                  bool   `json:"DRY_RUN"`
-	RestoreFormat           bool   `json:"RESTORE_FORMAT"`
-	SkipRuleApply           bool   `json:"SKIP_RULE_APPLY"`
-	RunValidation           bool   `json:"RUN_VALIDATION"`
-	EnableInboundIPv6       bool   `json:"ENABLE_INBOUND_IPV6"`
+	DryRun                  bool          `json:"DRY_RUN"`
+	RestoreFormat           bool          `json:"RESTORE_FORMAT"`
+	SkipRuleApply           bool          `json:"SKIP_RULE_APPLY"`
+	RunValidation           bool          `json:"RUN_VALIDATION"`
+	EnableInboundIPv6       bool          `json:"ENABLE_INBOUND_IPV6"`
 }
 
 func (c *Config) String() string {

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	OutboundIPRangesExclude string `json:"OUTBOUND_IPRANGES_EXCLUDE"`
 	KubevirtInterfaces      string `json:"KUBEVIRT_INTERFACES"`
 	IptablesProbePort       uint16 `json:"IPTABLES_PROBE_PORT"`
-	ProbeTimeout            uint64 `json: "PROBE_TIMEOUT"`
+	ProbeTimeout            time.Duration `json: "PROBE_TIMEOUT"`
 	DryRun                  bool   `json:"DRY_RUN"`
 	RestoreFormat           bool   `json:"RESTORE_FORMAT"`
 	SkipRuleApply           bool   `json:"SKIP_RULE_APPLY"`

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -115,7 +115,7 @@ const (
 
 const (
 	DefaultIptablesProbePort = 15002
-	DefaultProbeTimeout      = uint64(5 * time.Second)
+	DefaultProbeTimeout      = 5 * time.Second
 )
 
 const (

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -14,6 +14,8 @@
 
 package constants
 
+import "time"
+
 // iptables tables
 const (
 	MANGLE = "mangle"
@@ -81,6 +83,7 @@ const (
 	SkipRuleApply             = "skip-rule-apply"
 	RunValidation             = "run-validation"
 	IptablesProbePort         = "iptables-probe-port"
+	ProbeTimeout              = "probe-timeout"
 )
 
 const (
@@ -112,6 +115,7 @@ const (
 
 const (
 	DefaultIptablesProbePort = 15002
+	DefaultProbeTimeout      = uint64(5 * time.Second)
 )
 
 const (

--- a/tools/istio-iptables/pkg/validation/validator.go
+++ b/tools/istio-iptables/pkg/validation/validator.go
@@ -43,6 +43,7 @@ type Config struct {
 	ServerOriginalPort  uint16
 	ServerOriginalIP    net.IP
 	ServerReadyBarrier  chan ReturnCode
+	ProbeTimeout        time.Duration
 }
 type Service struct {
 	Config *Config
@@ -56,7 +57,7 @@ func (validator *Validator) Run() error {
 		validator.Config,
 	}
 	sError := make(chan error, 1)
-	sTimer := time.NewTimer(300 * time.Second)
+	sTimer := time.NewTimer(s.Config.ProbeTimeout)
 	defer sTimer.Stop()
 	go func() {
 		sError <- s.Run()
@@ -118,6 +119,7 @@ func NewValidator(config *config.Config, hostIP net.IP) *Validator {
 			ServerOriginalPort:  config.IptablesProbePort,
 			ServerOriginalIP:    serverIP,
 			ServerReadyBarrier:  make(chan ReturnCode, 1),
+			ProbeTimeout:        time.Duration(config.ProbeTimeout),
 		},
 	}
 }

--- a/tools/istio-iptables/pkg/validation/validator.go
+++ b/tools/istio-iptables/pkg/validation/validator.go
@@ -119,7 +119,7 @@ func NewValidator(config *config.Config, hostIP net.IP) *Validator {
 			ServerOriginalPort:  config.IptablesProbePort,
 			ServerOriginalIP:    serverIP,
 			ServerReadyBarrier:  make(chan ReturnCode, 1),
-			ProbeTimeout:        time.Duration(config.ProbeTimeout),
+			ProbeTimeout:        config.ProbeTimeout,
 		},
 	}
 }


### PR DESCRIPTION
and reset default value to 5 seconds

The validation usually complete in 0.2 seconds. The false positive rate at 5 seconds is almost 0.
Well, also the validation doesn't really need super fast in case of validation failure.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>