### PR TITLE
Revert permissions pre-check, re-add fixed `--timeout` for `istioctl analyze`

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -483,7 +484,7 @@ func TestAnalyzersHaveDescription(t *testing.T) {
 }
 
 func setupAnalyzerForCase(tc testCase, cr snapshotter.CollectionReporterFn) (*local.SourceAnalyzer, error) {
-	sa := local.NewSourceAnalyzer(schema.MustGet(), analysis.Combine("testCase", tc.analyzer), "", "istio-system", cr, true)
+	sa := local.NewSourceAnalyzer(schema.MustGet(), analysis.Combine("testCase", tc.analyzer), "", "istio-system", cr, true, 10*time.Second)
 
 	// If a mesh config file is specified, use it instead of the defaults
 	if tc.meshConfigFile != "" {

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -23,7 +23,6 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	authorizationapi "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -272,35 +271,6 @@ func TestResourceFiltering(t *testing.T) {
 			g.Expect(r.IsDisabled()).To(BeTrue(), fmt.Sprintf("%s should be disabled", r.Name()))
 		}
 	}
-}
-
-func TestRemoveResourcesWithoutPermission(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	usedCollection := k8smeta.K8SCoreV1Services
-	a := &testAnalyzer{
-		fn:     func(_ analysis.Context) {},
-		inputs: []collection.Name{usedCollection.Name()},
-	}
-
-	// Set up the mock so that when we query if the user has permission to list the collection, the answer is no.
-	mk := mock.NewKube()
-	mkClient, _ := mk.KubeClient()
-	mkSelfSubjectAccessReviews, _ := mkClient.AuthorizationV1().SelfSubjectAccessReviews().(*mock.SelfSubjectAccessReviewImpl)
-	mkSelfSubjectAccessReviews.DisallowResourceAttributes(&authorizationapi.ResourceAttributes{
-		Verb:     "list",
-		Group:    usedCollection.Resource().Group(),
-		Resource: usedCollection.Resource().GroupVersionKind().String(),
-	})
-
-	sa := NewSourceAnalyzer(schema.MustGet(), analysis.Combine("a", a), "", "", nil, true, timeout)
-	sa.AddRunningKubeSource(mk)
-
-	// Since this collection is used by an analyzer and service discovery is on, it would normally not be disabled...
-	// but since we fail the permissions pre-check, it should be disabled anyway.
-	actualCollection, found := sa.kubeResources.Find(usedCollection.Name().String())
-	g.Expect(found).To(BeTrue())
-	g.Expect(actualCollection.IsDisabled()).To(BeTrue(), fmt.Sprintf("%s should be disabled", actualCollection.Name()))
 }
 
 func tempFileFromString(t *testing.T, content string) *os.File {

--- a/galley/pkg/config/processing/snapshotter/statusupdater_test.go
+++ b/galley/pkg/config/processing/snapshotter/statusupdater_test.go
@@ -16,6 +16,7 @@ package snapshotter
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -25,7 +26,7 @@ import (
 func TestInMemoryStatusUpdaterWriteThenWait(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	su := &InMemoryStatusUpdater{}
+	su := &InMemoryStatusUpdater{WaitTimeout: 1 * time.Second}
 
 	msgs := diag.Messages{
 		diag.NewMessage(diag.NewMessageType(diag.Error, "test", "test"), nil),
@@ -34,28 +35,28 @@ func TestInMemoryStatusUpdaterWriteThenWait(t *testing.T) {
 	cancelCh := make(chan struct{})
 
 	su.Update(msgs)
-	g.Expect(su.WaitForReport(cancelCh)).To(BeTrue())
+	g.Expect(su.WaitForReport(cancelCh)).To(BeNil())
 	g.Expect(su.Get()).To(Equal(msgs))
 }
 
 func TestInMemoryStatusUpdaterWriteNothingThenWait(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	su := &InMemoryStatusUpdater{}
+	su := &InMemoryStatusUpdater{WaitTimeout: 1 * time.Second}
 
 	var msgs diag.Messages
 
 	cancelCh := make(chan struct{})
 
 	su.Update(msgs)
-	g.Expect(su.WaitForReport(cancelCh)).To(BeTrue())
+	g.Expect(su.WaitForReport(cancelCh)).To(BeNil())
 	g.Expect(su.Get()).To(Equal(msgs))
 }
 
 func TestInMemoryStatusUpdaterWaitThenWrite(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	su := &InMemoryStatusUpdater{}
+	su := &InMemoryStatusUpdater{WaitTimeout: 1 * time.Second}
 
 	msgs := diag.Messages{
 		diag.NewMessage(diag.NewMessageType(diag.Error, "test", "test"), nil),
@@ -64,9 +65,41 @@ func TestInMemoryStatusUpdaterWaitThenWrite(t *testing.T) {
 	cancelCh := make(chan struct{})
 
 	go func() {
-		g.Expect(su.WaitForReport(cancelCh)).To(BeTrue())
+		g.Expect(su.WaitForReport(cancelCh)).To(BeNil())
 	}()
 
 	su.Update(msgs)
 	g.Expect(su.Get()).To(Equal(msgs))
+}
+
+func TestInMemoryStatusUpdaterTimesOut(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	su := &InMemoryStatusUpdater{WaitTimeout: 0}
+
+	cancelCh := make(chan struct{})
+
+	err := su.WaitForReport(cancelCh)
+	g.Expect(err).To(Not(BeNil()))
+}
+
+func TestInMemoryStatusUpdaterCancelled(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	su := &InMemoryStatusUpdater{WaitTimeout: 1 * time.Second}
+
+	cancelCh := make(chan struct{})
+	testDone := make(chan struct{})
+
+	var err error
+	go func() {
+		err = su.WaitForReport(cancelCh)
+		close(testDone)
+	}()
+
+	close(cancelCh)
+	<-testDone
+
+	g.Expect(err).To(Not(BeNil()))
+	g.Expect(err.Error()).To(ContainSubstring("cancelled"))
 }

--- a/galley/pkg/config/source/kube/apiserver/watcher.go
+++ b/galley/pkg/config/source/kube/apiserver/watcher.go
@@ -88,11 +88,9 @@ func (w *watcher) start() {
 	// Start CRD shared informer and wait for it to exit.
 	go informer.Run(done)
 	// Send the FullSync event after the cache syncs.
-	go func() {
-		if cache.WaitForCacheSync(done, informer.HasSynced) {
-			go w.handler.Handle(event.FullSyncFor(w.schema))
-		}
-	}()
+	if cache.WaitForCacheSync(done, informer.HasSynced) {
+		go w.handler.Handle(event.FullSyncFor(w.schema))
+	}
 }
 
 func (w *watcher) stop() {

--- a/galley/pkg/config/source/kube/apiserver/watcher.go
+++ b/galley/pkg/config/source/kube/apiserver/watcher.go
@@ -88,9 +88,11 @@ func (w *watcher) start() {
 	// Start CRD shared informer and wait for it to exit.
 	go informer.Run(done)
 	// Send the FullSync event after the cache syncs.
-	if cache.WaitForCacheSync(done, informer.HasSynced) {
-		go w.handler.Handle(event.FullSyncFor(w.schema))
-	}
+	go func() {
+		if cache.WaitForCacheSync(done, informer.HasSynced) {
+			go w.handler.Handle(event.FullSyncFor(w.schema))
+		}
+	}()
 }
 
 func (w *watcher) stop() {

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/processing/snapshotter"
@@ -73,6 +74,7 @@ var (
 	meshCfgFile     string
 	allNamespaces   bool
 	suppress        []string
+	analysisTimeout time.Duration
 
 	termEnvVar = env.RegisterStringVar("TERM", "", "Specifies terminal type.  Use 'dumb' to suppress color output")
 
@@ -146,7 +148,7 @@ istioctl analyze -L
 			}
 
 			sa := local.NewSourceAnalyzer(schema.MustGet(), analyzers.AllCombined(),
-				resource.Namespace(selectedNamespace), resource.Namespace(istioNamespace), nil, true)
+				resource.Namespace(selectedNamespace), resource.Namespace(istioNamespace), nil, true, analysisTimeout)
 
 			// Check for suppressions and add them to our SourceAnalyzer
 			var suppressions []snapshotter.AnalysisSuppression
@@ -212,6 +214,7 @@ istioctl analyze -L
 
 			// Do the analysis
 			result, err := sa.Analyze(cancel)
+
 			if err != nil {
 				return err
 			}
@@ -318,6 +321,8 @@ istioctl analyze -L
 		"Suppress reporting a message code on a specific resource. Values are supplied in the form "+
 			`<code>=<resource> (e.g. '--suppress "IST0102=DestinationRule primary-dr.default"'). Can be repeated. `+
 			`You can include the wildcard character '*' to support a partial match (e.g. '--suppress "IST0102=DestinationRule *.default" ).`)
+	analysisCmd.PersistentFlags().DurationVar(&analysisTimeout, "timeout", 30*time.Second,
+		"the duration to wait before failing")
 	return analysisCmd
 }
 


### PR DESCRIPTION
#### Removing performance pre-check

We discovered that the permissions pre-check functionality added in https://github.com/istio/istio/pull/20010 came with a severe performance cost. `istioctl analyze` was taking a good 10 seconds extra to run. Each call to the `SelfSubjectAccessReview` API cost around a quarter second, likely due to k8s rate limiting. Multiply that by all of the resource types and permissions we were checking, and it adds up fast.

That kind of performance penalty isn't worth the tiny benefit, so we're removing the permissions pre-check. We can revisit this in the future if we can find a more efficient way to do it, or if we have a specific use-case that comes up. 

#### Fixing `--timeout`

https://github.com/istio/istio/pull/19890 added a high-level timeout so we could avoid error conditions where `istioctl analyze` never terminates (e.g missing permissions, if we don't have the pre-check). Unfortunately, the slight changes in the event processing code introduced so the timeout would work ended up causing a high rate of test flakes (see https://github.com/istio/istio/issues/20072) and were reverted. 

This PR re-introduces that change. It's been fixed so that instead of modifying the event processing code, we don't attempt to `Stop()` the event processing pipeline if there is an error (like a timeout). A limitation of the current event processing pipeline is that it can't `Stop()` if `Start()` is still underway, and permissions errors would block `Start()` [without any way for us to cleanly detect them](https://github.com/kubernetes/client-go/issues/732). So now, we don't attempt to Stop() if we detect an error or timeout and just return immediately.