### PR TITLE
Fix flaky test

### DIFF
--- a/security/pkg/nodeagent/cache/mock/secretcache_mock.go
+++ b/security/pkg/nodeagent/cache/mock/secretcache_mock.go
@@ -17,26 +17,34 @@ package mock
 import (
 	"context"
 	"fmt"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"math/rand"
 	"sync/atomic"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type CAClient struct {
 	signInvokeCount     uint64
 	mockCertChain1st    []string
 	mockCertChainRemain []string
+	failureRate         int
 }
 
-func NewMockCAClient(mockCertChain1st, mockCertChainRemain []string) *CAClient {
+// Create a CA client that sends CSR with a default failure rate 0.5. If failureRate
+// is non zero, e.g. [0.1, 0.9], the failure rate is changed.
+func NewMockCAClient(mockCertChain1st, mockCertChainRemain []string, failureRate float32) *CAClient {
 	cl := CAClient{
 		mockCertChain1st:    mockCertChain1st,
 		mockCertChainRemain: mockCertChainRemain,
+		failureRate:         2,
 	}
+
+	if failureRate > 0 {
+		cl.failureRate = int(1/failureRate)
+	}
+
 	atomic.StoreUint64(&cl.signInvokeCount, 0)
 	return &cl
 }
@@ -45,7 +53,7 @@ func (c *CAClient) CSRSign(ctx context.Context, csrPEM []byte, exchangedToken st
 	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
 	// Mock CSRSign failure errors to force Citadel agent to retry.
 	// 50% chance of failure.
-	if rand.Intn(2) != 0 {
+	if rand.Intn(c.failureRate) == 0 {
 		return nil, status.Error(codes.Unavailable, "CA is unavailable")
 	}
 

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -210,7 +210,6 @@ aFKltOc+RAjzDklcUPeG4Y6eMA==
 )
 
 func TestWorkloadAgentGenerateSecret(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/17568")
 	testWorkloadAgentGenerateSecret(t, false)
 }
 
@@ -219,7 +218,7 @@ func TestWorkloadAgentGenerateSecretWithPluginProvider(t *testing.T) {
 }
 
 func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
-	fakeCACli := mock.NewMockCAClient(mockCertChain1st, mockCertChainRemain)
+	fakeCACli := mock.NewMockCAClient(mockCertChain1st, mockCertChainRemain, 0.1)
 	opt := Options{
 		SecretTTL:        time.Minute,
 		RotationInterval: 300 * time.Microsecond,
@@ -321,7 +320,7 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 }
 
 func TestWorkloadAgentRefreshSecret(t *testing.T) {
-	fakeCACli := mock.NewMockCAClient(mockCertChain1st, mockCertChainRemain)
+	fakeCACli := mock.NewMockCAClient(mockCertChain1st, mockCertChainRemain, 0)
 	opt := Options{
 		SecretTTL:        200 * time.Microsecond,
 		RotationInterval: 200 * time.Microsecond,
@@ -861,7 +860,7 @@ func checkBool(t *testing.T, name string, got bool, want bool) {
 }
 
 func TestSetAlwaysValidTokenFlag(t *testing.T) {
-	fakeCACli := mock.NewMockCAClient(mockCertChain1st, mockCertChainRemain)
+	fakeCACli := mock.NewMockCAClient(mockCertChain1st, mockCertChainRemain, 0)
 	opt := Options{
 		SecretTTL:            200 * time.Microsecond,
 		RotationInterval:     200 * time.Microsecond,


### PR DESCRIPTION
Please provide a description for what this PR is for.
TestWorkloadAgentGenerateSecretWithPluginProvider and TestWorkloadAgentGenerateSecret use a mock CA client that sends CSR to generate workload key/cert. The CSR has a default failure rate 50%, which is pretty high, and that causes CA client fail to send CSR successfully with retry. Making this failure rate configurable and reducing the failure rate to deflake the tests.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

https://github.com/istio/istio/issues/19276