### PR TITLE
feat: add helm values to README.md docs

### DIFF
--- a/mixer/adapter/stackdriver/README.md
+++ b/mixer/adapter/stackdriver/README.md
@@ -18,15 +18,28 @@ The full Stackdriver adapter template can be found [here](https://github.com/ist
 
 ```yaml
 mixer:
-  stackdriver:
-    enabled: false
 
-  auth:
-    appCredentials: false
-    apiKey: ""
-    serviceAccountPath: ""
+  adapter:
 
-  tracer:
-    enabled: false
-    sampleProbability: 1
+    stackdriver:
+
+      enabled: false
+
+      auth:
+        appCredentials: false
+        apiKey: ""
+        serviceAccountPath: ""
+
+      tracer:
+        enabled: false
+        sampleProbability: 1
+
+      logging:
+        enabled: false
+
+      metrics:
+        enabled: false
+
+      contextGraph:
+        enabled: false
 ```


### PR DESCRIPTION

The documentation for the mixer stackdriver guides the user to go to helm template files to see what are the possible values. This PR adds all configurable Stackdriver values into the README.md file