### PR TITLE
Accept CA endpoint that is not on 15010 or 15012

### DIFF
--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -410,7 +410,9 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache *cache.Secre
 					log.Fatal("invalid config - port 15012 missing a root certificate")
 				}
 			} else {
-				log.Fatal("invalid config - the port is not 15010 or 15012")
+				// It is ok for CA endpoint to have a port that is not 15010 or 15012, e.g.,
+				// meshca.googleapis.com:443
+				log.Info("the port is not 15010 or 15012")
 			}
 		}
 


### PR DESCRIPTION
Please provide a description for what this PR is for: 
Accept CA endpoint that is not on 15010 or 15012. It is ok for CA endpoint to have a port that is not 15010 or 15012, e.g., meshca.googleapis.com:443.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure