### PR TITLE
Prune renamed components

### DIFF
--- a/operator/cmd/mesh/manifest-common.go
+++ b/operator/cmd/mesh/manifest-common.go
@@ -62,6 +62,12 @@ func genApplyManifests(setOverlay []string, inFilename []string, force bool, dry
 		Kubeconfig:  kubeConfigPath,
 		Context:     context,
 	}
+
+	for _, cn := range name.DeprecatedNames {
+		DeprecatedComponentManifest := fmt.Sprintf("# %s component has been deprecated.\n", cn)
+		manifests[cn] = append(manifests[cn], DeprecatedComponentManifest)
+	}
+
 	out, err := manifest.ApplyAll(manifests, version.OperatorBinaryVersion, opts)
 	if err != nil {
 		return fmt.Errorf("failed to apply manifest with kubectl client: %v", err)

--- a/operator/data/versions.yaml
+++ b/operator/data/versions.yaml
@@ -42,5 +42,5 @@
   recommendedIstioVersions: 1.4.4
 - operatorVersion: 1.5.0
   operatorVersionRange: ">=1.5.0,<1.6.0"
-  supportedIstioVersions: ">=1.5.0, <1.6"
+  supportedIstioVersions: ">=1.4.0, <1.6"
   recommendedIstioVersions: 1.5.0

--- a/operator/pkg/name/name.go
+++ b/operator/pkg/name/name.go
@@ -56,6 +56,11 @@ const (
 	// Operator components
 	IstioOperatorComponentName      ComponentName = "IstioOperator"
 	IstioOperatorCustomResourceName ComponentName = "IstioOperatorCustomResource"
+
+	// Component names used in old versions
+	InjectorComponentName       ComponentName = "Injector"
+	IngressGatewayComponentName ComponentName = "IngressGateway"
+	EgressGatewayComponentName  ComponentName = "EgressGateway"
 )
 
 var (
@@ -71,12 +76,19 @@ var (
 		NodeAgentComponentName,
 		CNIComponentName,
 	}
-	allComponentNamesMap = make(map[ComponentName]bool)
+	DeprecatedNames = []ComponentName{
+		InjectorComponentName,
+	}
+	allComponentNamesMap        = make(map[ComponentName]bool)
+	deprecatedComponentNamesMap = make(map[ComponentName]bool)
 )
 
 func init() {
 	for _, n := range AllCoreComponentNames {
 		allComponentNamesMap[n] = true
+	}
+	for _, n := range DeprecatedNames {
+		deprecatedComponentNamesMap[n] = true
 	}
 }
 
@@ -86,6 +98,11 @@ type ManifestMap map[ComponentName][]string
 // IsCoreComponent reports whether cn is a core component.
 func (cn ComponentName) IsCoreComponent() bool {
 	return allComponentNamesMap[cn]
+}
+
+// IsDeprecatedName reports whether cn is a deprecated component.
+func (cn ComponentName) IsDeprecatedName() bool {
+	return deprecatedComponentNamesMap[cn]
 }
 
 // IsGateway reports whether cn is a gateway component.

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -41340,7 +41340,7 @@ var _versionsYaml = []byte(`- operatorVersion: 1.3.0
   recommendedIstioVersions: 1.4.4
 - operatorVersion: 1.5.0
   operatorVersionRange: ">=1.5.0,<1.6.0"
-  supportedIstioVersions: ">=1.5.0, <1.6"
+  supportedIstioVersions: ">=1.4.0, <1.6"
   recommendedIstioVersions: 1.5.0
 `)
 


### PR DESCRIPTION
Prune renamed and merged-into-pilot components.
Alternatives considered.
1. Change back the name to `Inject` in operator/api, since this component is going away eventually - protobuf gen does not allow me to do it. Instead we need to reserve SIdecarInjector and add Injector back.
2. Using label flag -l 'operator.istio.io/component in (Injector, SidecarInjector)' to prune - not working with kubectl, i.e., cannot prune deploy and service.
 

So I add deprecated component manifest:

```
istioctldev manifest apply  -f ~/default.yaml 
- Applying manifest for component Base...
- Pruning objects for disabled component Injector...
✔ Finished pruning objects for disabled component Injector.
- Applying manifest for component SidecarInjector...
- Applying manifest for component Citadel...
- Applying manifest for component Galley...
- Applying manifest for component Addon...
- Applying manifest for component Policy...
- Applying manifest for component IngressGateways...
- Applying manifest for component Pilot...
- Applying manifest for component Telemetry...
✔ Finished applying manifest for component SidecarInjector.
✔ Finished applying manifest for component Citadel.
✔ Finished applying manifest for component Addon.
✔ Finished applying manifest for component Galley.
✔ Finished applying manifest for component IngressGateways.
✔ Finished applying manifest for component Policy.
✔ Finished applying manifest for component Pilot.
✔ Finished applying manifest for component Telemetry.


```