### PR TITLE
Support graceful shutdown in Citadel

### DIFF
--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -81,11 +81,17 @@ func NewSelfSignedCARootCertRotator(config *SelfSignedCARootCertRotatorConfig,
 }
 
 // Run refreshes root certs and updates config map accordingly.
-func (rotator *SelfSignedCARootCertRotator) Run(rootCertRotatorChan chan struct{}) {
+func (rotator *SelfSignedCARootCertRotator) Run(stopCh chan struct{}) {
 	if rotator.config.enableJitter {
 		rootCertRotatorLog.Infof("Jitter is enabled, wait %s before "+
 			"starting root cert rotator.", rotator.backOffTime.String())
-		time.Sleep(rotator.backOffTime)
+		select {
+		case <-time.After(rotator.backOffTime):
+			rootCertRotatorLog.Infof("Jitter complete, start rotator.")
+		case <-stopCh:
+			rootCertRotatorLog.Info("Received stop signal, so stop the root cert rotator.")
+			return
+		}
 	}
 	ticker := time.NewTicker(rotator.config.CheckInterval)
 	for {
@@ -93,7 +99,7 @@ func (rotator *SelfSignedCARootCertRotator) Run(rootCertRotatorChan chan struct{
 		case <-ticker.C:
 			rootCertRotatorLog.Info("Check and rotate root cert.")
 			rotator.checkAndRotateRootCert()
-		case _, ok := <-rootCertRotatorChan:
+		case _, ok := <-stopCh:
 			if !ok {
 				rootCertRotatorLog.Info("Received stop signal, so stop the root cert rotator.")
 				if ticker != nil {


### PR DESCRIPTION
Today, citadel will never shutdown on SIGTERM, only SIGKILL. With
default settings, this means 30s to shutdown (termination grace period =
30s by default). This also impacts tests.

The root cause of this is that we have a couple things blocking
shutdown. First, we do have some attempt at catching the SIGTERM, but it
only actually applies after ~45min of time.Sleeping(). Instead, we
should allow the stop channel to interupt that sleep.

The other problem is that when the monitoring server closes, it will
write an err on an unbuffered channel. In the normal case where things
exit graceful, there is a race between exiting because the stop channel
is closed, and actually reading from the monitoring error channel. To
get around this, we make the channel a buffered channel so we can write
asyncronously. This way if there is a real error, we will still see it,
but on shutdown we don't block.