### PR TITLE
Stopgap for Galley dashboards with istiod

### DIFF
--- a/manifests/istio-telemetry/grafana/dashboards/galley-dashboard.json
+++ b/manifests/istio-telemetry/grafana/dashboards/galley-dashboard.json
@@ -1001,14 +1001,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "galley_validation_cert_key_updates{job=\"galley\"}",
+          "expr": "galley_validation_cert_key_updates{}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Key Updates",
           "refId": "A"
         },
         {
-          "expr": "galley_validation_cert_key_update_errors{job=\"galley\"}",
+          "expr": "galley_validation_cert_key_update_errors{}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Key Update Errors: {{ error }}",
@@ -1093,14 +1093,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(galley_validation_passed{job=\"galley\"}) by (group, version, resource)",
+          "expr": "sum(galley_validation_passed{}) by (group, version, resource)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Passed: {{ group }}/{{ version }}/{{resource}}",
           "refId": "A"
         },
         {
-          "expr": "sum(galley_validation_failed{job=\"galley\"}) by (group, version, resource, reason)",
+          "expr": "sum(galley_validation_failed{}) by (group, version, resource, reason)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Failed: {{ group }}/{{ version }}/{{resource}} ({{ reason}})",
@@ -1185,7 +1185,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(galley_validation_http_error{job=\"galley\"}) by (status)",
+          "expr": "sum(galley_validation_http_error{}) by (status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ status }}",

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -17846,14 +17846,14 @@ var _chartsIstioTelemetryGrafanaDashboardsGalleyDashboardJson = []byte(`{
       "steppedLine": false,
       "targets": [
         {
-          "expr": "galley_validation_cert_key_updates{job=\"galley\"}",
+          "expr": "galley_validation_cert_key_updates{}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Key Updates",
           "refId": "A"
         },
         {
-          "expr": "galley_validation_cert_key_update_errors{job=\"galley\"}",
+          "expr": "galley_validation_cert_key_update_errors{}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Key Update Errors: {{ error }}",
@@ -17938,14 +17938,14 @@ var _chartsIstioTelemetryGrafanaDashboardsGalleyDashboardJson = []byte(`{
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(galley_validation_passed{job=\"galley\"}) by (group, version, resource)",
+          "expr": "sum(galley_validation_passed{}) by (group, version, resource)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Passed: {{ group }}/{{ version }}/{{resource}}",
           "refId": "A"
         },
         {
-          "expr": "sum(galley_validation_failed{job=\"galley\"}) by (group, version, resource, reason)",
+          "expr": "sum(galley_validation_failed{}) by (group, version, resource, reason)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Failed: {{ group }}/{{ version }}/{{resource}} ({{ reason}})",
@@ -18030,7 +18030,7 @@ var _chartsIstioTelemetryGrafanaDashboardsGalleyDashboardJson = []byte(`{
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(galley_validation_http_error{job=\"galley\"}) by (status)",
+          "expr": "sum(galley_validation_http_error{}) by (status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ status }}",


### PR DESCRIPTION
Right now on Istiod the galley dashboard is not useful because there is
no galley. In the 1.5 timeframe it may not be feasible to refactor our
dashboards to be feature oriented rather than component (if we even
desire this). In the short term, we can make all of the metrics shared
between istiod and galley not have a job= label. This will allow it to
pick up either source of the metric. We cannot do this for the other
metrics, as they are generic like CPU, etc.