### PR TITLE
Fix mixer policy tests

### DIFF
--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -257,6 +257,9 @@ func TestMain(m *testing.M) {
 		RequireEnvironment(environment.Kube).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
+values:
+  global:
+    disablePolicyChecks: false
 components:
   policy:
     enabled: true`


### PR DESCRIPTION
Regression since https://github.com/istio/istio/pull/20213

We turned on policy, but disabled checks. Didn't notice since it only
runs in postsubmit.