### PR TITLE
Pilot MCP bug fixes

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -712,7 +712,8 @@ func (s *Server) initEventHandlers() error {
 		}
 		for _, schema := range collections.Pilot.All() {
 			// This resource type was handled in external/servicediscovery.go, no need to rehandle here.
-			if schema == collections.IstioNetworkingV1Alpha3Serviceentries {
+			if schema.Resource().GroupVersionKind() == collections.IstioNetworkingV1Alpha3Serviceentries.
+				Resource().GroupVersionKind() {
 				continue
 			}
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -627,10 +627,12 @@ func (s *Server) grpcServerOptions(options *istiokeepalive.Options) []grpc.Serve
 	// Temp setting, default should be enough for most supported environments. Can be used for testing
 	// envoy with lower values.
 	maxStreams := features.MaxConcurrentStreams
+	maxRecvMsgSize := features.MaxRecvMsgSize
 
 	grpcOptions := []grpc.ServerOption{
 		grpc.UnaryInterceptor(middleware.ChainUnaryServer(interceptors...)),
 		grpc.MaxConcurrentStreams(uint32(maxStreams)),
+		grpc.MaxRecvMsgSize(maxRecvMsgSize),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time:                  options.Time,
 			Timeout:               options.Timeout,
@@ -709,6 +711,11 @@ func (s *Server) initEventHandlers() error {
 			s.EnvoyXdsServer.ConfigUpdate(pushReq)
 		}
 		for _, schema := range collections.Pilot.All() {
+			// This resource type was handled in external/servicediscovery.go, no need to rehandle here.
+			if schema == collections.IstioNetworkingV1Alpha3Serviceentries {
+				continue
+			}
+
 			s.configController.RegisterEventHandler(schema.Resource().GroupVersionKind(), configHandler)
 		}
 	}

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -52,7 +52,7 @@ var (
 	MaxRecvMsgSize = env.RegisterIntVar(
 		"ISTIO_GPRC_MAXRECVMSGSIZE",
 		4 * 1024 * 1024,
-		"Sets the max receive buffer size in bytes.",
+		"Sets the max receive buffer size of gRPC stream in bytes.",
 	).Get()
 
 	// DebugConfigs controls saving snapshots of configs for /debug/adsz.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -51,7 +51,7 @@ var (
 	// MaxRecvMsgSize The max receive buffer size of gRPC received channel of Pilot in bytes.
 	MaxRecvMsgSize = env.RegisterIntVar(
 		"ISTIO_GPRC_MAXRECVMSGSIZE",
-		4 * 1024 * 1024,
+		4*1024*1024,
 		"Sets the max receive buffer size of gRPC stream in bytes.",
 	).Get()
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -48,6 +48,13 @@ var (
 		"Limits the number of concurrent pushes allowed. On larger machines this can be increased for faster pushes",
 	).Get()
 
+	// MaxRecvMsgSize The max receive buffer size of gRPC received channel of Pilot in bytes.
+	MaxRecvMsgSize = env.RegisterIntVar(
+		"ISTIO_GPRC_MAXRECVMSGSIZE",
+		4 * 1024 * 1024,
+		"Sets the max receive buffer size in bytes.",
+	).Get()
+
 	// DebugConfigs controls saving snapshots of configs for /debug/adsz.
 	// Defaults to false, can be enabled with PILOT_DEBUG_ADSZ_CONFIG=1
 	// For larger clusters it can increase memory use and GC - useful for small tests.

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -117,6 +117,7 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 									ServiceAccount:  instance.Endpoint.ServiceAccount,
 									Network:         instance.Endpoint.Network,
 									Locality:        instance.Endpoint.Locality,
+									LbWeight:        instance.Endpoint.LbWeight,
 									Attributes: model.ServiceAttributes{
 										Name:      instance.Service.Attributes.Name,
 										Namespace: instance.Service.Attributes.Namespace,


### PR DESCRIPTION
This PR contains an enhancement and 3 bug fixes, details are described as bellows:
🛠Fixed the missing previous config in MCP dispatch event. If origin code always pass in an empty previous config in MCP Update event. However the ServiceDiscovery in external/servicediscovert.go will check the previous config when handling Update event. **If it can't find the previous config, it will print a warn message and cause the Incremental EDS update disabled. If the update size is pretty huge, the log output will be overwhelmed.**
```go
fp := true
if event == model.EventUpdate {
	// This is not needed, update should always have old populated, but just in case.
	if old.Spec != nil {
		os := convertServices(old)
		fp = servicesChanged(os, cs)
	} else {
		log.Warnf("Spec is not available in the old service entry during update, proceeding with full push %v", old)
	}
}
```

🛠 Fixed the missing LbWeight attribute assignment in Instance convert within ServiceDiscovery in external/servicediscovert.go.

🛠Fixed duplicate ServiceEntry event triggering because both the configSource and ServiceDiscovery in external/servicediscovert.go have registered handler of ServiceEntry type as the code shows below:

Registration in initEventHandlers() in bootstrap/server.go
```go
// TODO(Nino-k): remove this case once incrementalUpdate is default
if s.configController != nil {
	......
	for _, schema := range collections.Pilot.All() {
		s.configController.RegisterEventHandler(schema.Resource().GroupVersionKind(), configHandler)
	}
}
```

Registration in NewServiceDiscovery in external/servicediscovery.go
```go
if configController != nil {
	configController.RegisterEventHandler(serviceEntryKind,
		func(old, curr model.Config, event model.Event) {
			cs := convertServices(curr)
```
Because the handler registered by "initEventHandlers()" converts all updates to Full push, the EDS incremental will be disabled even with endpoint changes only.

✔ Added an Env. attribute to configure the max receive buffer of gRPC in Pilot xDS connection. This can be useful when the resources number within is system is very large. In our system, the resource count can be millions.