### PR TITLE
fix unused operator init wait option.

### DIFF
--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -81,7 +81,7 @@ func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 	cmd.PersistentFlags().StringVarP(&args.inFilename, "filename", "f", "", filenameFlagHelpStr)
 	cmd.PersistentFlags().StringVarP(&args.kubeConfigPath, "kubeconfig", "c", "", "Path to kube config")
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", "The name of the kubeconfig context to use")
-	cmd.PersistentFlags().DurationVar(&args.readinessTimeout, "readiness-timeout", 300*time.Second, "Maximum seconds to wait for all Istio resources to be ready."+
+	cmd.PersistentFlags().DurationVar(&args.readinessTimeout, "readiness-timeout", 300*time.Second, "Maximum seconds to wait for the Istio operator to be ready."+
 		" The --wait flag must be set for this flag to apply")
 	cmd.PersistentFlags().BoolVarP(&args.wait, "wait", "w", false, "Wait, if set will wait until all Pods, Services, and minimum number of Pods "+
 		"of a Deployment are in a ready state before the command exits. It will wait for a maximum duration of --readiness-timeout seconds")
@@ -134,7 +134,8 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l *Logger, apply man
 	opts := &kubectlcmd.Options{
 		DryRun:      args.dryRun,
 		Verbose:     args.verbose,
-		WaitTimeout: 1 * time.Minute,
+		Wait:        oiArgs.wait,
+		WaitTimeout: oiArgs.readinessTimeout,
 		Kubeconfig:  oiArgs.kubeConfigPath,
 		Context:     oiArgs.context,
 	}

--- a/operator/cmd/mesh/operator_test.go
+++ b/operator/cmd/mesh/operator_test.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/kr/pretty"
 
@@ -75,11 +74,7 @@ func TestOperatorInit(t *testing.T) {
 		t.Fatalf("diff: %s", diff)
 	}
 
-	wantOpts := kubectlcmd.Options{
-		WaitTimeout: time.Minute,
-		Prune:       nil,
-		ExtraArgs:   nil,
-	}
+	wantOpts := kubectlcmd.Options{}
 
 	wantParams := []applyParams{
 		{


### PR DESCRIPTION

Fix:
the `wait` option for operator `init` command is never used, while the `readinessTimeout` is hard-coded now.


[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure