### PR TITLE
Tune pilot logs for high endpoint scales

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -707,7 +707,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 	pushStart := time.Now()
 	loadAssignments := make([]*xdsapi.ClusterLoadAssignment, 0)
 	endpoints := 0
-	empty := make([]string, 0)
+	empty := 0
 
 	// All clusters that this endpoint is watching. For 1.0 - it's typically all clusters in the mesh.
 	// For 1.1+Sidecar - it's the small set of explicitly imported clusters, using the isolated DestinationRules
@@ -723,7 +723,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 		}
 
 		if len(l.Endpoints) == 0 {
-			empty = append(empty, clusterName)
+			empty++
 		}
 		loadAssignments = append(loadAssignments, l)
 	}
@@ -742,7 +742,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 		adsLog.Infof("EDS: PUSH for node:%s clusters:%d endpoints:%d empty:%v",
 			con.node.ID, len(con.Clusters), endpoints, empty)
 	} else {
-		adsLog.Infof("EDS: PUSH INC for node:%s clusters:%d endpoints:%d empty:%v",
+		adsLog.Debugf("EDS: PUSH INC for node:%s clusters:%d endpoints:%d empty:%v",
 			con.node.ID, len(con.Clusters), endpoints, empty)
 	}
 	return nil

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -848,13 +848,7 @@ func (c *Controller) updateEDS(ep *v1.Endpoints, event model.Event) {
 		}
 	}
 
-	if log.InfoEnabled() {
-		var addresses []string
-		for _, iep := range endpoints {
-			addresses = append(addresses, iep.Address)
-		}
-		log.Infof("Handle EDS endpoint %s in namespace %s -> %v", ep.Name, ep.Namespace, addresses)
-	}
+	log.Infof("Handle EDS: %d endpoints for %s in namespace %s", len(endpoints), ep.Name, ep.Namespace)
 
 	_ = c.xdsUpdater.EDSUpdate(c.clusterID, string(hostname), ep.Namespace, endpoints)
 }


### PR DESCRIPTION
Right now if you have a lot of endpoints Pilot logs are extremely
spammy. We log every IP every time a new IP is added, which for high #
of endpoints is often 1000s and very often. Then we log 1000s of lines
about EDS incremental update. I think those belong in debug to make the
logs a bit more sane.