### PR TITLE
Fix an error in a mixer test

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -201,7 +201,5 @@ echo "Copying ${ISTIO_ENVOY_NATIVE_PATH} to ${ISTIO_OUT}/envoy"
 cp -f "${ISTIO_ENVOY_NATIVE_PATH}" "${ISTIO_OUT}/envoy"
 
 # TODO(nmittler): Remove once tests no longer use the envoy binary directly.
-# circleCI expects this in the bin directory
-# Make sure the envoy binary exists. This is only used for tests, so use the debug binary.
-echo "Copying ${ISTIO_OUT}/envoy to ${ISTIO_BIN}/envoy"
-cp -f "${ISTIO_OUT}/envoy" "${ISTIO_BIN}/envoy"
+# TODO(nmittler): The envoy binary continues to be used by tests directly.
+# cp -f "${ISTIO_OUT}/envoy" "${ISTIO_BIN}/envoy"

--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -70,7 +70,7 @@ func (s *TestSetup) newEnvoy() (envoy.Instance, error) {
 		options = append(options, o...)
 	}
 	/* #nosec */
-	envoyPath := filepath.Join(env.IstioBin, "envoy")
+	envoyPath := filepath.Join(env.IstioOut, "envoy")
 	if path, exists := ev.RegisterStringVar("ENVOY_PATH", "", "Specifies the path to an Envoy binary.").Lookup(); exists {
 		envoyPath = path
 	}


### PR DESCRIPTION
Mixer expects the envoy binary in the (correct) location, however
the build container has changed the semantics of IstioBin, and as
such, using that directory is no longer suitable.

Additionally remove a redundant envoy copy.