### PR TITLE
support for cert with DNS SANs in permissive mtls mode

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"strings"
 	"sync"
 	"text/template"
@@ -49,6 +50,7 @@ import (
 	envoyDiscovery "istio.io/istio/pilot/pkg/proxy/envoy"
 	securityModel "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/pkg/bootstrap/option"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/constants"
@@ -69,15 +71,18 @@ const (
 // TODO: Move most of this to pkg.
 
 var (
-	role               = &model.Proxy{}
-	proxyIP            string
-	registryID         serviceregistry.ProviderID
-	trustDomain        string
-	pilotIdentity      string
-	mixerIdentity      string
-	statusPort         uint16
-	stsPort            int
-	tokenManagerPlugin string
+	role                        = &model.Proxy{}
+	proxyIP                     string
+	registryID                  serviceregistry.ProviderID
+	trustDomain                 string
+	pilotIdentity               string
+	mixerIdentity               string
+	statusPort                  uint16
+	stsPort                     int
+	tokenManagerPlugin          string
+	tlsServerDNSServerCertChain string
+	tlsServerDNSKey             string
+	tlsServerDNSRootCert        string
 
 	// proxy config flags (named identically)
 	configPath               string
@@ -219,6 +224,13 @@ var (
 			tlsCertsToWatch = []string{
 				tlsServerCertChain, tlsServerKey, tlsServerRootCert,
 				tlsClientCertChain, tlsClientKey, tlsClientRootCert,
+			}
+			tlsServerDNSCertPath := env.RegisterStringVar(bootstrap.IstioMetaPrefix+model.NodeMetadataTLSServerDNSCert, "", "").Get()
+			if tlsServerDNSCertPath != "" {
+				tlsServerDNSServerCertChain = path.Join(tlsServerDNSCertPath, constants.CertChainFilename)
+				tlsServerDNSKey = path.Join(tlsServerDNSCertPath, constants.KeyFilename)
+				tlsServerDNSRootCert = path.Join(tlsServerDNSCertPath, constants.RootCertFilename)
+				tlsCertsToWatch = append(tlsCertsToWatch, tlsServerDNSServerCertChain, tlsServerDNSKey, tlsServerDNSRootCert)
 			}
 
 			proxyConfig := mesh.DefaultProxyConfig()

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -316,6 +316,8 @@ type NodeMetadata struct {
 	TLSClientKey string `json:"TLS_CLIENT_KEY,omitempty"`
 	// TLSClientRootCert is the absolute path to client root cert file
 	TLSClientRootCert string `json:"TLS_CLIENT_ROOT_CERT,omitempty"`
+	// TLSServerDNSCert is the absolute path to a directory containing an additional non citadel issued X509 certificate with DNS SANs
+	TLSServerDNSCert string `json:"TLS_SERVER_DNS_CERT,omitempty"`
 
 	// SdsTokenPath specifies the path of the SDS token used by the Envoy proxy.
 	// If not set, Pilot uses the default SDS token path.
@@ -748,6 +750,9 @@ const (
 
 	// NodeMetadataTLSClientRootCert is the absolute path to client root cert file
 	NodeMetadataTLSClientRootCert = "TLS_CLIENT_ROOT_CERT"
+
+	// NodeMetadataTLSServerDNSCert specifies the absolute path to a directory containing an additional non citadel issued X509 certificate with DNS SANs
+	NodeMetadataTLSServerDNSCert = "TLS_SERVER_DNS_CERT"
 )
 
 // TrafficInterceptionMode indicates how traffic to/from the workload is captured and

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -402,7 +402,7 @@ func (a v1alpha1PolicyApplier) InboundFilterChain(sdsUdsPath string, node *model
 		setDownstreamTLSContext(tls, tlsServerRootCert, tlsServerCertChain, tlsServerKey, protovalue.BoolTrue, alpnProtocols, []string{})
 	} else {
 		tls.RequireClientCertificate = protovalue.BoolTrue
-		tls.CommonTlsContext.AlpnProtocols = util.ALPNHttp
+		tls.CommonTlsContext.AlpnProtocols = alpnProtocols
 		tls.CommonTlsContext.TlsCertificateSdsSecretConfigs = []*auth.SdsSecretConfig{
 			authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, sdsUdsPath, meta),
 		}
@@ -457,7 +457,7 @@ func (a v1alpha1PolicyApplier) InboundFilterChain(sdsUdsPath string, node *model
 			tlsServerCertChain := path.Join(certsPath, constants.CertChainFilename)
 			tlsServerKey := path.Join(certsPath, constants.KeyFilename)
 
-			setDownstreamTLSContext(dnsSANTLSContext, tlsServerRootCert, tlsServerCertChain, tlsServerKey, protovalue.BoolTrue, util.ALPNHttp, []string{})
+			setDownstreamTLSContext(dnsSANTLSContext, tlsServerRootCert, tlsServerCertChain, tlsServerKey, protovalue.BoolTrue, alpnProtocols, []string{})
 
 			dnsSANCertFilterChain := plugin.FilterChain{
 				FilterChainMatch: &ldsv2.FilterChainMatch{

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -805,6 +805,35 @@ func TestOnInboundFilterChains(t *testing.T) {
 		},
 		RequireClientCertificate: protovalue.BoolTrue,
 	}
+	dnsSANTLSContext := &auth.DownstreamTlsContext{
+		CommonTlsContext: &auth.CommonTlsContext{
+			TlsCertificates: []*auth.TlsCertificate{
+				{
+					CertificateChain: &core.DataSource{
+						Specifier: &core.DataSource_Filename{
+							Filename: "/etc/certs/custom/cert-chain.pem",
+						},
+					},
+					PrivateKey: &core.DataSource{
+						Specifier: &core.DataSource_Filename{
+							Filename: "/etc/certs/custom/key.pem",
+						},
+					},
+				},
+			},
+			ValidationContextType: &auth.CommonTlsContext_ValidationContext{
+				ValidationContext: &auth.CertificateValidationContext{
+					TrustedCa: &core.DataSource{
+						Specifier: &core.DataSource_Filename{
+							Filename: "/etc/certs/custom/root-cert.pem",
+						},
+					},
+				},
+			},
+			AlpnProtocols: []string{"h2", "http/1.1"},
+		},
+		RequireClientCertificate: protovalue.BoolTrue,
+	}
 	cases := []struct {
 		name       string
 		in         *authn.Policy
@@ -1064,6 +1093,54 @@ func TestOnInboundFilterChains(t *testing.T) {
 						RequireClientCertificate: protovalue.BoolTrue,
 					},
 				},
+			},
+		},
+		{
+			name: "Permissive mTLS using certificate with DNS SANs",
+			in: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{
+							Mtls: &authn.MutualTls{
+								Mode: authn.MutualTls_PERMISSIVE,
+							},
+						},
+					},
+				},
+			},
+			// Three filter chains, one for mtls traffic from istio clients, one for mtls traffic from non-istio clients, one for plain text traffic.
+			expected: []plugin.FilterChain{
+				{
+					TLSContext: tlsContext,
+					FilterChainMatch: &listener.FilterChainMatch{
+						TransportProtocol:    "tls",
+						ApplicationProtocols: []string{"istio"},
+					},
+					ListenerFilters: []*listener.ListenerFilter{
+						{
+							Name:       "envoy.listener.tls_inspector",
+							ConfigType: &listener.ListenerFilter_Config{&structpb.Struct{}},
+						},
+					},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{},
+				},
+				{
+					TLSContext: dnsSANTLSContext,
+					FilterChainMatch: &listener.FilterChainMatch{
+						TransportProtocol: "tls",
+					},
+					ListenerFilters: []*listener.ListenerFilter{
+						{
+							Name:       "envoy.listener.tls_inspector",
+							ConfigType: &listener.ListenerFilter_Config{&structpb.Struct{}},
+						},
+					},
+				},
+			},
+			meta: &model.NodeMetadata{
+				TLSServerDNSCert: "/etc/certs/custom",
 			},
 		},
 	}

--- a/tests/integration/security/mtls_permissive_test.go
+++ b/tests/integration/security/mtls_permissive_test.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 
-	"istio.io/istio/tests/integration/security/util"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
@@ -36,6 +34,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/native"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/tests/integration/security/util"
 )
 
 func verifyListener(listener *xdsapi.Listener, t *testing.T) error {

--- a/tests/integration/security/mtls_permissive_with_dns_cert_test.go
+++ b/tests/integration/security/mtls_permissive_with_dns_cert_test.go
@@ -1,0 +1,190 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package basic contains an example test suite for showcase purposes.
+package security
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	xdscore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/tests/integration/security/util"
+)
+
+func verifyListenerForTLSServerDNSCert(listener *xdsapi.Listener, t *testing.T) error {
+	t.Helper()
+	if listener == nil {
+		return errors.New("no such listener")
+	}
+	if len(listener.ListenerFilters) == 0 {
+		return errors.New("no listener filter")
+	}
+	// tls_inspector filter should exist
+	inspector := false
+	for _, lf := range listener.ListenerFilters {
+		if lf.Name == xdsutil.TlsInspector {
+			inspector = true
+			break
+		}
+	}
+	if !inspector {
+		return errors.New("no tls inspector")
+	}
+	// 3 filter chains are expected
+	if l := len(listener.FilterChains); l != 3 {
+		return fmt.Errorf("expect exactly 3 filter chains, actually %d", l)
+	}
+
+	// First filter chain should have filter chain with alpn matches for "istio"
+	// and "istio-http/1.0", "istio-http/1.1" and "istio-h2" as added by istio.alpn filter
+	mtlsChain := listener.FilterChains[0]
+	if !reflect.DeepEqual(mtlsChain.FilterChainMatch.GetTransportProtocol(), "tls") {
+		return errors.New("mtlsChain transport protocol is not tls")
+	}
+	if !reflect.DeepEqual(mtlsChain.FilterChainMatch.GetApplicationProtocols(), []string{"istio", "istio-http/1.0", "istio-http/1.1", "istio-h2"}) {
+		return errors.New("mtlsChain alpn is not set to istio, istio-http/1.0, istio-http/1.1 and istio-h2")
+	}
+	if mtlsChain.TransportSocket == nil {
+		return errors.New("mtlsChain transport socket is empty")
+	}
+
+	// Second default filter chain should have empty filter chain match and no tls context.
+	defaultChain := listener.FilterChains[1]
+	if l := len(defaultChain.FilterChainMatch.GetApplicationProtocols()); l != 0 {
+		return fmt.Errorf("expected empty alpn, actually %v", defaultChain.FilterChainMatch.GetApplicationProtocols())
+	}
+	if defaultChain.TlsContext != nil {
+		return errors.New("defaultChain has non empty tls context")
+	}
+
+	// Third filter chain should have filter chain match with transport protocol as "tls"
+	transportProtocolChain := listener.FilterChains[2]
+	if !reflect.DeepEqual(transportProtocolChain.FilterChainMatch.GetTransportProtocol(), "tls") {
+		return errors.New("transportProtocolChain transport protocol is not tls")
+	}
+	if transportProtocolChain.TransportSocket == nil {
+		return errors.New("transportProtocolChain transport socket is empty")
+	}
+
+	// TLS certificate and key paths should be set to the custom dir set through metadata value of TLS_SERVER_DNS_CERT
+	tlsContext := &envoy_api_v2_auth.DownstreamTlsContext{}
+	err := ptypes.UnmarshalAny(transportProtocolChain.GetTransportSocket().GetTypedConfig(), tlsContext)
+	if err == nil {
+		if !reflect.DeepEqual(tlsContext.GetCommonTlsContext().GetTlsCertificates()[0].GetCertificateChain().GetFilename(), "/etc/certs/custom/cert-chain.pem") {
+			return errors.New("tls cert file name is not /etc/certs/custom/cert-chain.pem")
+		}
+		if !reflect.DeepEqual(tlsContext.GetCommonTlsContext().GetTlsCertificates()[0].GetPrivateKey().GetFilename(), "/etc/certs/custom/key.pem") {
+			return errors.New("tls key file name is not /etc/certs/custom/key.pem")
+		}
+		if !reflect.DeepEqual(tlsContext.GetCommonTlsContext().GetValidationContext().GetTrustedCa().GetFilename(), "/etc/certs/custom/root-cert.pem") {
+			return errors.New("tls ca file name is not /etc/certs/custom/root-cert.pem")
+		}
+	} else {
+		return errors.New("unable to unmarshal tls context")
+	}
+	return nil
+}
+
+// TestTLSServerDNSCertWithAuthnPermissive checks when authentication policy is permissive,
+// and metadata value of TLS_SERVER_DNS_CERT is passed to Pilot, it generates expected
+// listener configuration with additional filter chain with match as transport_protocol: "tls"
+func TestTLSServerDNSCertWithAuthnPermissive(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+
+			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "permmtls",
+				Inject: true,
+			})
+			policy := `
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: default
+spec:
+  peers:
+    - mtls:
+        mode: PERMISSIVE
+`
+			g.ApplyConfigOrFail(t, ns, policy)
+
+			var b echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
+				BuildOrFail(t)
+
+			t.Logf("echo boot warmed")
+			nodeID := b.WorkloadsOrFail(t)[0].Sidecar().NodeID()
+
+			// Set custom dir path for TLS_SERVER_DNS_CERT
+			echoNodeMetadata := &model.NodeMetadata{
+				TLSServerDNSCert: "/etc/certs/custom",
+			}
+
+			newDiscoveryRequest := &xdsapi.DiscoveryRequest{
+				Node: &xdscore.Node{
+					Id:       nodeID,
+					Metadata: echoNodeMetadata.ToStruct(),
+				},
+				TypeUrl: string(pilot.Listener),
+			}
+
+			// Start the xDS stream containing the listeners for this node
+			p.StartDiscoveryOrFail(t, newDiscoveryRequest)
+
+			p.WatchDiscoveryOrFail(t, time.Second*60,
+				func(resp *xdsapi.DiscoveryResponse) (b bool, e error) {
+					var errs []error
+					for _, r := range resp.Resources {
+						foo := &xdsapi.Listener{}
+						err := ptypes.UnmarshalAny(r, foo)
+						if err != nil {
+							errs = append(errs, err)
+							continue
+						}
+						// Only test inbound listeners
+						if foo.GetTrafficDirection() == xdscore.TrafficDirection_OUTBOUND {
+							continue
+						}
+
+						err = verifyListenerForTLSServerDNSCert(foo, t)
+						if err != nil {
+							errs = append(errs, fmt.Errorf("listener %s has error %s. details: %s", foo.Name, err, foo.String()))
+							continue
+						}
+
+						return true, nil
+					}
+					return false, fmt.Errorf("no inbound listener passes the validation. Errors: %v", errs)
+				})
+		})
+}


### PR DESCRIPTION
This PR implements the proposal discussed in [Connecting non Istio clients in Permissive mTLS mode](https://docs.google.com/document/d/1mkVBUSY86h4mX5A9StX0T2u3xvLV3dYv0HFwYTBxyh0/edit)
It adds an additional filter chain with filter chain match set to `transport_protocol: tls` in order to allow connections from non Istio mTLS clients to be terminated at the Istio Proxy sidecar instead of being handled by the application container



@costinm @incfly Please help review

/cc @sureshvis