### PR TITLE
perf: remove expensive Sprintf calls on hot paths

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -586,7 +586,7 @@ func ParseServiceKey(s string) (hostname host.Name, ports PortList, lc labels.Co
 // BuildSubsetKey generates a unique string referencing service instances for a given service name, a subset and a port.
 // The proxy queries Pilot with this key to obtain the list of instances in a subset.
 func BuildSubsetKey(direction TrafficDirection, subsetName string, hostname host.Name, port int) string {
-	return fmt.Sprintf("%s|%d|%s|%s", direction, port, subsetName, hostname)
+	return string(direction) + "|" + strconv.Itoa(port) + "|" + subsetName + "|" + string(hostname)
 }
 
 // BuildDNSSrvSubsetKey generates a unique string referencing service instances for a given service name, a subset and a port.
@@ -594,7 +594,7 @@ func BuildSubsetKey(direction TrafficDirection, subsetName string, hostname host
 // This is used only for the SNI-DNAT router. Do not use for other purposes.
 // The DNS Srv format of the cluster is also used as the default SNI string for Istio mTLS connections
 func BuildDNSSrvSubsetKey(direction TrafficDirection, subsetName string, hostname host.Name, port int) string {
-	return fmt.Sprintf("%s_.%d_.%s_.%s", direction, port, subsetName, hostname)
+	return string(direction) + "_." + strconv.Itoa(port) + "_." + subsetName + "_." + string(hostname)
 }
 
 // IsValidSubsetKey checks if a string is valid for subset key parsing.

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -263,3 +263,9 @@ func TestGetLocality(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkBuildSubsetKey(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_ = BuildSubsetKey(TrafficDirectionInbound, "v1", "someHost", 80)
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1089,7 +1090,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 	if len(listenerOpts.bind) == 0 { // no user specified bind. Use 0.0.0.0:Port
 		listenerOpts.bind = actualWildcard
 	}
-	*listenerMapKey = fmt.Sprintf("%s:%d", listenerOpts.bind, pluginParams.Port.Port)
+	*listenerMapKey = listenerOpts.bind + ":" + strconv.Itoa(pluginParams.Port.Port)
 
 	var exists bool
 
@@ -1148,9 +1149,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 	} else {
 		if pluginParams.ListenerProtocol == plugin.ListenerProtocolAuto &&
 			util.IsProtocolSniffingEnabledForOutbound(node) && listenerOpts.bind != actualWildcard && pluginParams.Service != nil {
-			rdsName = fmt.Sprintf("%s:%d", pluginParams.Service.Hostname, pluginParams.Port.Port)
+			rdsName = pluginParams.Service.Hostname + ":" + strconv.Itoa(pluginParams.Port.Port)
 		} else {
-			rdsName = fmt.Sprintf("%d", pluginParams.Port.Port)
+			rdsName = strconv.Itoa(pluginParams.Port.Port)
 		}
 	}
 	httpOpts := &httpListenerOpts{
@@ -1953,7 +1954,7 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 	listener := &xdsapi.Listener{
 		// TODO: need to sanitize the opts.bind if its a UDS socket, as it could have colons, that envoy
 		// doesn't like
-		Name:            fmt.Sprintf("%s_%d", opts.bind, opts.port),
+		Name:            opts.bind + "_" + strconv.Itoa(opts.port),
 		Address:         util.BuildAddress(opts.bind, uint32(opts.port)),
 		ListenerFilters: listenerFilters,
 		FilterChains:    filterChains,

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1149,7 +1149,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 	} else {
 		if pluginParams.ListenerProtocol == plugin.ListenerProtocolAuto &&
 			util.IsProtocolSniffingEnabledForOutbound(node) && listenerOpts.bind != actualWildcard && pluginParams.Service != nil {
-			rdsName = pluginParams.Service.Hostname + ":" + strconv.Itoa(pluginParams.Port.Port)
+			rdsName = string(pluginParams.Service.Hostname) + ":" + strconv.Itoa(pluginParams.Port.Port)
 		} else {
 			rdsName = strconv.Itoa(pluginParams.Port.Port)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -762,7 +762,7 @@ func getRouteOperation(in *route.Route, vsName string, port int) string {
 	if ps != nil {
 		switch ps.(type) {
 		case *route.RouteMatch_Prefix:
-			path = fmt.Sprintf("%s*", m.GetPrefix())
+			path = m.GetPrefix() + "*"
 		case *route.RouteMatch_Path:
 			path = m.GetPath()
 		case *route.RouteMatch_Regex:
@@ -779,9 +779,9 @@ func getRouteOperation(in *route.Route, vsName string, port int) string {
 	if c := in.GetRoute().GetCluster(); model.IsValidSubsetKey(c) {
 		// Parse host and port from cluster name.
 		_, _, h, p := model.ParseSubsetKey(c)
-		return fmt.Sprintf("%s:%d%s", h, p, path)
+		return string(h) + ":" + strconv.Itoa(p) + path
 	}
-	return fmt.Sprintf("%s:%d%s", vsName, port, path)
+	return vsName + ":" + strconv.Itoa(port) + path
 }
 
 // BuildDefaultHTTPInboundRoute builds a default inbound route.

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -412,14 +412,15 @@ func cloneLocalityLbEndpoints(endpoints []*endpoint.LocalityLbEndpoints) []*endp
 // name.namespace of the config, the type, etc. Used by Mixer client
 // to generate attributes for policy and telemetry.
 func BuildConfigInfoMetadata(config model.ConfigMeta) *core.Metadata {
+	s := "/apis/" + config.Group + "/" + config.Version + "/namespaces/" + config.Namespace + "/" +
+		strcase.CamelCaseToKebabCase(config.Type) + "/" + config.Name
 	return &core.Metadata{
 		FilterMetadata: map[string]*pstruct.Struct{
 			IstioMetadataKey: {
 				Fields: map[string]*pstruct.Value{
 					"config": {
 						Kind: &pstruct.Value_StringValue{
-							StringValue: fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s", config.Group, config.Version, config.Namespace,
-								strcase.CamelCaseToKebabCase(config.Type), config.Name),
+							StringValue: s,
 						},
 					},
 				},

--- a/pkg/config/host/name.go
+++ b/pkg/config/host/name.go
@@ -86,5 +86,5 @@ func (n Name) SubsetOf(o Name) bool {
 }
 
 func (n Name) isWildCarded() bool {
-	return len(n) > 0 && string(n[0]) == "*"
+	return len(n) > 0 && n[0] == '*'
 }


### PR DESCRIPTION
These are called many times, so they add up pretty quick to ~3% of pilot
CPU usage. Not that much, but worth switching over to a simple
concatenation which is ~5x faster
(https://dev.to/pmalhaire/concatenate-strings-in-golang-a-quick-benchmark-4ahh)