### PR TITLE
Removes duplicate validation code in galley

### DIFF
--- a/galley/pkg/config/processor/transforms/serviceentry/converter/instance.go
+++ b/galley/pkg/config/processor/transforms/serviceentry/converter/instance.go
@@ -15,7 +15,6 @@
 package converter
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,8 +29,7 @@ import (
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/pkg/config/constants"
 	configKube "istio.io/istio/pkg/config/kube"
-	"istio.io/istio/pkg/config/labels"
-	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/validation"
 )
 
 // Instance of the converter.
@@ -280,13 +278,13 @@ func serviceHostname(fullName resource.FullName, domainSuffix string) string {
 }
 
 func convertPort(port coreV1.ServicePort) (*networking.Port, error) {
-	if err := validatePortName(port.Name); err != nil {
+	if err := validation.ValidatePortName(port.Name); err != nil {
 		return nil, err
 	}
-	if err := validateProtocol(string(port.Protocol)); err != nil {
+	if err := validation.ValidateProtocol(string(port.Protocol)); err != nil {
 		return nil, err
 	}
-	if err := validatePort(port.Port); err != nil {
+	if err := validation.ValidatePort(int(port.Port)); err != nil {
 		return nil, err
 	}
 
@@ -295,27 +293,4 @@ func convertPort(port coreV1.ServicePort) (*networking.Port, error) {
 		Number:   uint32(port.Port),
 		Protocol: string(configKube.ConvertProtocol(port.Port, port.Name, port.Protocol)),
 	}, nil
-}
-
-func validatePortName(name string) error {
-	if !labels.IsDNS1123Label(name) {
-		return fmt.Errorf("invalid port name: %q", name)
-	}
-	return nil
-}
-
-func validateProtocol(protocolStr string) error {
-	// Empty string is used for protocol sniffing.
-	if protocolStr != "" && protocol.Parse(protocolStr) == protocol.Unsupported {
-		return fmt.Errorf("unsupported protocol: %q", protocolStr)
-	}
-	return nil
-}
-
-// ValidatePort checks that the network port is in range
-func validatePort(port int32) error {
-	if 1 <= port && port <= 65535 {
-		return nil
-	}
-	return fmt.Errorf("port number %d must be in the range 1..65535", port)
 }

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -773,14 +773,14 @@ func validateSidecarEgressPortBindAndCaptureMode(port *networking.Port, bind str
 
 	// Port name is optional. Validate if exists.
 	if len(port.Name) > 0 {
-		errs = appendErrors(errs, validatePortName(port.Name))
+		errs = appendErrors(errs, ValidatePortName(port.Name))
 	}
 
 	// Handle Unix domain sockets
 	if port.Number == 0 {
 		// require bind to be a unix domain socket
 		errs = appendErrors(errs,
-			validateProtocol(port.Protocol))
+			ValidateProtocol(port.Protocol))
 
 		if !strings.HasPrefix(bind, UnixAddressPrefix) {
 			errs = appendErrors(errs, fmt.Errorf("sidecar: ports with 0 value must have a unix domain socket bind address"))
@@ -793,7 +793,7 @@ func validateSidecarEgressPortBindAndCaptureMode(port *networking.Port, bind str
 		}
 	} else {
 		errs = appendErrors(errs,
-			validateProtocol(port.Protocol),
+			ValidateProtocol(port.Protocol),
 			ValidatePort(int(port.Number)))
 
 		if len(bind) != 0 {
@@ -808,11 +808,11 @@ func validateSidecarIngressPortAndBind(port *networking.Port, bind string) (errs
 
 	// Port name is optional. Validate if exists.
 	if len(port.Name) > 0 {
-		errs = appendErrors(errs, validatePortName(port.Name))
+		errs = appendErrors(errs, ValidatePortName(port.Name))
 	}
 
 	errs = appendErrors(errs,
-		validateProtocol(port.Protocol),
+		ValidateProtocol(port.Protocol),
 		ValidatePort(int(port.Number)))
 
 	if len(bind) != 0 {
@@ -2568,7 +2568,7 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 						errs = appendErrors(errs, fmt.Errorf("endpoint port %v is not defined by the service entry", port))
 					}
 					errs = appendErrors(errs,
-						validatePortName(name),
+						ValidatePortName(name),
 						ValidatePort(int(port)))
 				}
 			}
@@ -2601,8 +2601,8 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 
 		for _, port := range serviceEntry.Ports {
 			errs = appendErrors(errs,
-				validatePortName(port.Name),
-				validateProtocol(port.Protocol),
+				ValidatePortName(port.Name),
+				ValidateProtocol(port.Protocol),
 				ValidatePort(int(port.Number)))
 		}
 
@@ -2610,14 +2610,14 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 		return
 	})
 
-func validatePortName(name string) error {
+func ValidatePortName(name string) error {
 	if !labels.IsDNS1123Label(name) {
 		return fmt.Errorf("invalid port name: %s", name)
 	}
 	return nil
 }
 
-func validateProtocol(protocolStr string) error {
+func ValidateProtocol(protocolStr string) error {
 	// Empty string is used for protocol sniffing.
 	if protocolStr != "" && protocol.Parse(protocolStr) == protocol.Unsupported {
 		return fmt.Errorf("unsupported protocol: %s", protocolStr)

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1911,7 +1911,7 @@ func TestValidatePortName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := validatePortName(tc.name); (err == nil) != tc.valid {
+			if err := ValidatePortName(tc.name); (err == nil) != tc.valid {
 				t.Fatalf("got valid=%v but wanted valid=%v: %v", err == nil, tc.valid, err)
 			}
 		})


### PR DESCRIPTION
This code moves the validation code for ports/protocol in galley's instance converter that was duplicated to a common pkg (pkg/config/validation).