### PR TITLE
Move webassembly files to /etc/istio/extensions

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -52,8 +52,8 @@ COPY envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 COPY envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 COPY envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
 
-COPY stats-filter.wasm /etc/istio/proxy/stats-filter.wasm
-COPY metadata-exchange-filter.wasm /etc/istio/proxy/metadata-exchange-filter.wasm
+COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
+COPY metadata-exchange-filter.wasm /etc/istio/extensions/metadata-exchange-filter.wasm
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]


### PR DESCRIPTION
`/etc/istio/proxy` is mounted with an empty dir: https://github.com/istio/istio/blob/1480ad07fe8fe0e91374b7db6987b349140e6311/manifests/istio-control/istio-autoinject/files/injection-template.yaml#L353