### PR TITLE
add stackdriver settings for telemetryv2

### DIFF
--- a/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
@@ -587,6 +587,14 @@ values:
     enabled: true
     v2:
       enabled: false
+      prometheus:
+        enabled: true
+      stackdriver:
+        configOverride: {}
+        enabled: false
+        logging: false
+        monitoring: false
+        topology: false
   tracing:
     enabled: false
     ingress:

--- a/operator/cmd/mesh/testdata/profile-dump/output/sds_policy_off.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/sds_policy_off.yaml
@@ -589,6 +589,14 @@ values:
     enabled: true
     v2:
       enabled: false
+      prometheus:
+        enabled: true
+      stackdriver:
+        configOverride: {}
+        enabled: false
+        logging: false
+        monitoring: false
+        topology: false
   tracing:
     enabled: false
     ingress:

--- a/operator/data/profiles/default.yaml
+++ b/operator/data/profiles/default.yaml
@@ -357,7 +357,14 @@ spec:
       enabled: true
       v2:
         enabled: false
-
+        prometheus:
+          enabled: true
+        stackdriver:
+          enabled: false
+          logging: false
+          monitoring: false
+          topology: false
+          configOverride: {}
     mixer:
       adapters:
         stdio:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -39390,7 +39390,14 @@ spec:
       enabled: true
       v2:
         enabled: false
-
+        prometheus:
+          enabled: true
+        stackdriver:
+          enabled: false
+          logging: false
+          monitoring: false
+          topology: false
+          configOverride: {}
     mixer:
       adapters:
         stdio:


### PR DESCRIPTION
Add the stackdriver config for envoyfilter back to master, and it is not related to other PRs to turn on the v2 default