### PR TITLE
install: Always add POD_NAMESPACE var, even if env is unset

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -76,13 +76,13 @@
           {{- else }}
           - --trace_zipkin_url=http://zipkin.{{ $.Release.Namespace }}:9411/api/v1/spans
           {{- end }}
-        {{- if .Values.env }}
         env:
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        {{- if .Values.env }}
         {{- range $key, $val := .Values.env }}
         - name: {{ $key }}
           value: "{{ $val }}"


### PR DESCRIPTION
In cases when no `env` variable is set, we wouldn't set `POD_NAMESPACE` in the policy deployment (for the telemetry deployment this has been fixed earlier already)

[x] Installation
