### PR TITLE
Set Host field appropriately when passing through probes

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -245,7 +245,7 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 	}
 
 	for _, h := range prober.HTTPHeaders {
-		if h.Name == "Host" {
+		if h.Name == "Host" || h.Name == ":authority" {
 			// Probe has specific host header override; honor it
 			appReq.Host = h.Value
 			break

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -244,6 +244,14 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 		appReq.Header[name] = newValues
 	}
 
+	for _, h := range prober.HTTPHeaders {
+		if h.Name == "Host" {
+			// Probe has specific host header override; honor it
+			appReq.Host = h.Value
+			break
+		}
+	}
+
 	// Send the request.
 	response, err := httpClient.Do(appReq)
 	if err != nil {


### PR DESCRIPTION
If someone sets a Host header, we shouldn't overwrite it back to
localhost. The health check might be affected by the value of that
header. We should ensure the host field is set to the provided host
header, if set on the probe