### PR TITLE
operator/pkg/validate: fix dropped test error

### DIFF
--- a/operator/pkg/validate/validate_values_test.go
+++ b/operator/pkg/validate/validate_values_test.go
@@ -225,6 +225,9 @@ func TestValidateValuesFromValuesYAMLs(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 		valuesYAML, err = util.OverlayYAML(valuesYAML, string(b))
+		if err != nil {
+			t.Fatal(err.Error())
+		}
 		valuesTree := make(map[string]interface{})
 		if err := yaml.Unmarshal([]byte(valuesYAML), &valuesTree); err != nil {
 			t.Fatal(err.Error())


### PR DESCRIPTION
This picks up a recently-introduced dropped test error in `operator/pkg/validate`.