### PR TITLE
Run istio-init with non-root UID

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -22,7 +22,7 @@ SHELL := /bin/bash -o pipefail
 VERSION ?= 1.6-dev
 
 # Base version of Istio image to use
-BASE_VERSION ?= 1.6-dev.0
+BASE_VERSION ?= 1.6-dev.1
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -17,6 +17,7 @@ RUN apt-get update && \
       iproute2 \
       iputils-ping \
       knot-dnsutils \
+      libcap2-bin \
       netcat \
       tcpdump \
       net-tools \

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -50,7 +50,6 @@ initContainers:
 {{- end }}
   securityContext:
     allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-    privileged: {{ .Values.global.proxy.privileged }}
     capabilities:
   {{- if not .Values.istio_cni.enabled }}
       add:
@@ -59,16 +58,11 @@ initContainers:
   {{- end }}
       drop:
       - ALL
+    privileged: {{ .Values.global.proxy.privileged }}
     readOnlyRootFilesystem: false
-  {{- if not .Values.istio_cni.enabled }}
-    runAsGroup: 0
-    runAsNonRoot: false
-    runAsUser: 0
-  {{- else }}
     runAsGroup: 1337
-    runAsUser: 1337
     runAsNonRoot: true
-  {{- end }}
+    runAsUser: 1337
   restartPolicy: Always
 {{  end -}}
 {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}

--- a/istioctl/cmd/testdata/uninject/cronjob-with-app.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/cronjob-with-app.yaml.injected
@@ -125,9 +125,9 @@ spec:
                 - ALL
               privileged: false
               readOnlyRootFilesystem: false
-              runAsGroup: 0
-              runAsNonRoot: false
-              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: true
+              runAsUser: 1337
           restartPolicy: OnFailure
           volumes:
           - emptyDir:

--- a/istioctl/cmd/testdata/uninject/cronjob.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/cronjob.yaml.injected
@@ -153,9 +153,9 @@ spec:
                 - ALL
               privileged: false
               readOnlyRootFilesystem: false
-              runAsGroup: 0
-              runAsNonRoot: false
-              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: true
+              runAsUser: 1337
           restartPolicy: OnFailure
           volumes:
           - emptyDir:

--- a/istioctl/cmd/testdata/uninject/daemonset.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/daemonset.yaml.injected
@@ -158,9 +158,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/istioctl/cmd/testdata/uninject/deploymentconfig-multi.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/deploymentconfig-multi.yaml.injected
@@ -177,9 +177,9 @@ items:
               - ALL
             privileged: false
             readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
         volumes:
         - emptyDir:
             medium: Memory

--- a/istioctl/cmd/testdata/uninject/deploymentconfig.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/deploymentconfig.yaml.injected
@@ -162,9 +162,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/istioctl/cmd/testdata/uninject/enable-core-dump.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/enable-core-dump.yaml.injected
@@ -163,9 +163,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       - args:
         - -c
         - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited

--- a/istioctl/cmd/testdata/uninject/job.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/job.yaml.injected
@@ -151,9 +151,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       restartPolicy: Never
       volumes:
       - emptyDir:

--- a/istioctl/cmd/testdata/uninject/list.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/list.yaml.injected
@@ -172,9 +172,9 @@ items:
               - ALL
             privileged: false
             readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
         volumes:
         - name: test
           secret:
@@ -351,13 +351,14 @@ items:
             capabilities:
               add:
               - NET_ADMIN
+              - NET_RAW
               drop:
               - ALL
             privileged: false
             readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
         volumes:
         - emptyDir:
             medium: Memory

--- a/istioctl/cmd/testdata/uninject/pod.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/pod.yaml.injected
@@ -151,9 +151,9 @@ spec:
         - ALL
       privileged: false
       readOnlyRootFilesystem: false
-      runAsGroup: 0
-      runAsNonRoot: false
-      runAsUser: 0
+      runAsGroup: 1337
+      runAsNonRoot: true
+      runAsUser: 1337
   volumes:
   - emptyDir:
       medium: Memory

--- a/istioctl/cmd/testdata/uninject/replicaset.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/replicaset.yaml.injected
@@ -159,9 +159,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/istioctl/cmd/testdata/uninject/replicationcontroller.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/replicationcontroller.yaml.injected
@@ -158,9 +158,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/istioctl/cmd/testdata/uninject/statefulset.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/statefulset.yaml.injected
@@ -167,9 +167,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - hostPath:
           path: /mnt/disks/ssd0

--- a/manifests/istio-control/istio-autoinject/files/injection-template.yaml
+++ b/manifests/istio-control/istio-autoinject/files/injection-template.yaml
@@ -51,7 +51,6 @@ template: |
   {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-      privileged: {{ .Values.global.proxy.privileged }}
       capabilities:
     {{- if not .Values.istio_cni.enabled }}
         add:
@@ -60,16 +59,11 @@ template: |
     {{- end }}
         drop:
         - ALL
+      privileged: {{ .Values.global.proxy.privileged }}
       readOnlyRootFilesystem: false
-    {{- if not .Values.istio_cni.enabled }}
-      runAsGroup: 0
-      runAsNonRoot: false
-      runAsUser: 0
-    {{- else }}
       runAsGroup: 1337
-      runAsUser: 1337
       runAsNonRoot: true
-    {{- end }}
+      runAsUser: 1337
     restartPolicy: Always
   {{ end -}}
   {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -56,7 +56,6 @@ template: |
   {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-      privileged: {{ .Values.global.proxy.privileged }}
       capabilities:
     {{- if not .Values.istio_cni.enabled }}
         add:
@@ -65,16 +64,11 @@ template: |
     {{- end }}
         drop:
         - ALL
+      privileged: {{ .Values.global.proxy.privileged }}
       readOnlyRootFilesystem: false
-    {{- if not .Values.istio_cni.enabled }}
-      runAsGroup: 0
-      runAsNonRoot: false
-      runAsUser: 0
-    {{- else }}
       runAsGroup: 1337
-      runAsUser: 1337
       runAsNonRoot: true
-    {{- end }}
+      runAsUser: 1337
     restartPolicy: Always
   {{ end -}}
   {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -8873,7 +8873,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -8882,16 +8881,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}
@@ -10787,7 +10781,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -10796,16 +10789,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
@@ -7793,7 +7793,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -7802,16 +7801,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
@@ -1037,7 +1037,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -1046,16 +1045,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
@@ -1040,7 +1040,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -1049,16 +1048,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -6812,7 +6812,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -6821,16 +6820,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -7649,7 +7649,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -7658,16 +7657,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
@@ -1034,7 +1034,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -1043,16 +1042,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -7648,7 +7648,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -7657,16 +7656,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1034,7 +1034,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -1043,16 +1042,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
@@ -1040,7 +1040,6 @@ data:
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-          privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
         {{- if not .Values.istio_cni.enabled }}
             add:
@@ -1049,16 +1048,11 @@ data:
         {{- end }}
             drop:
             - ALL
+          privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: false
-        {{- if not .Values.istio_cni.enabled }}
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
-        {{- else }}
           runAsGroup: 1337
-          runAsUser: 1337
           runAsNonRoot: true
-        {{- end }}
+          runAsUser: 1337
         restartPolicy: Always
       {{ end -}}
       {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -9408,7 +9408,6 @@ var _chartsIstioControlIstioAutoinjectFilesInjectionTemplateYaml = []byte(`templ
   {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-      privileged: {{ .Values.global.proxy.privileged }}
       capabilities:
     {{- if not .Values.istio_cni.enabled }}
         add:
@@ -9417,16 +9416,11 @@ var _chartsIstioControlIstioAutoinjectFilesInjectionTemplateYaml = []byte(`templ
     {{- end }}
         drop:
         - ALL
+      privileged: {{ .Values.global.proxy.privileged }}
       readOnlyRootFilesystem: false
-    {{- if not .Values.istio_cni.enabled }}
-      runAsGroup: 0
-      runAsNonRoot: false
-      runAsUser: 0
-    {{- else }}
       runAsGroup: 1337
-      runAsUser: 1337
       runAsNonRoot: true
-    {{- end }}
+      runAsUser: 1337
     restartPolicy: Always
   {{ end -}}
   {{- if eq .Values.global.proxy.enableCoreDump true }}
@@ -11834,7 +11828,6 @@ template: |
   {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-      privileged: {{ .Values.global.proxy.privileged }}
       capabilities:
     {{- if not .Values.istio_cni.enabled }}
         add:
@@ -11843,16 +11836,11 @@ template: |
     {{- end }}
         drop:
         - ALL
+      privileged: {{ .Values.global.proxy.privileged }}
       readOnlyRootFilesystem: false
-    {{- if not .Values.istio_cni.enabled }}
-      runAsGroup: 0
-      runAsNonRoot: false
-      runAsUser: 0
-    {{- else }}
       runAsGroup: 1337
-      runAsUser: 1337
       runAsNonRoot: true
-    {{- end }}
+      runAsUser: 1337
     restartPolicy: Always
   {{ end -}}
   {{- if eq .Values.global.proxy.enableCoreDump true }}

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -15,6 +15,10 @@ RUN chown -R istio-proxy /var/lib/istio
 
 COPY istio-iptables /usr/local/bin/istio-iptables
 
+# Add CAP_NET_ADMIN and CAP_NET_RAW as Permitted capabilities
+# to the istio-iptables binary.
+RUN ["/sbin/setcap", "cap_net_admin,cap_net_raw+p", "/usr/local/bin/istio-iptables"]
+
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/cc:latest as distroless
@@ -26,6 +30,14 @@ COPY --from=default /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu
 COPY --from=default /etc/iproute2 /etc/iproute2
 
 COPY istio-iptables /usr/local/bin/istio-iptables
+
+# Add CAP_NET_ADMIN and CAP_NET_RAW as Permitted capabilities
+# to the istio-iptables binary.
+COPY --from=default /sbin/setcap /sbin/
+COPY --from=default /lib/x86_64-linux-gnu/libcap.so.2 /lib/x86_64-linux-gnu/libcap.so.2.25 /lib/
+COPY --from=default /bin/rm /bin/
+RUN ["/sbin/setcap", "cap_net_admin,cap_net_raw+p", "/usr/local/bin/istio-iptables"]
+RUN ["/bin/rm", "-f", "/sbin/setcap", "/lib/x86_64-linux-gnu/libcap.so.2", "/lib/x86_64-linux-gnu/libcap.so.2.25", "/bin/rm"]
 
 # Copy Envoy bootstrap templates used by pilot-agent
 COPY --chown=nonroot:nonroot envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -231,9 +231,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -226,9 +226,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -222,9 +222,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -205,9 +205,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -223,9 +223,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -204,9 +204,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -207,9 +207,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -222,9 +222,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -204,9 +204,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -216,9 +216,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       serviceAccountName: non-default
       volumes:
       - emptyDir:

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/cronjob-with-app.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob-with-app.yaml.injected
@@ -116,9 +116,9 @@ spec:
                 - ALL
               privileged: false
               readOnlyRootFilesystem: false
-              runAsGroup: 0
-              runAsNonRoot: false
-              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: true
+              runAsUser: 1337
           restartPolicy: OnFailure
           volumes:
           - emptyDir:

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -191,9 +191,9 @@ spec:
                 - ALL
               privileged: false
               readOnlyRootFilesystem: false
-              runAsGroup: 0
-              runAsNonRoot: false
-              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: true
+              runAsUser: 1337
           restartPolicy: OnFailure
           volumes:
           - emptyDir:

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -199,9 +199,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -214,9 +214,9 @@ items:
               - ALL
             privileged: false
             readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
         volumes:
         - emptyDir:
             medium: Memory

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -199,9 +199,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -205,9 +205,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       - args:
         - -c
         - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -217,9 +217,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -205,9 +205,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -203,9 +203,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory
@@ -431,9 +431,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -202,9 +202,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -205,9 +205,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -205,9 +205,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
@@ -136,9 +136,9 @@ spec:
             - ALL
           privileged: true
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -189,9 +189,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       restartPolicy: Never
       volumes:
       - emptyDir:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -207,9 +207,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -207,9 +207,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -218,9 +218,9 @@ items:
               - ALL
             privileged: false
             readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
         volumes:
         - emptyDir:
             medium: Memory

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -205,9 +205,9 @@ items:
               - ALL
             privileged: false
             readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
         volumes:
         - emptyDir:
             medium: Memory
@@ -432,9 +432,9 @@ items:
               - ALL
             privileged: false
             readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
         volumes:
         - emptyDir:
             medium: Memory

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -203,9 +203,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -215,9 +215,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/pod-with-app.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod-with-app.yaml.injected
@@ -118,9 +118,9 @@ spec:
         - ALL
       privileged: false
       readOnlyRootFilesystem: false
-      runAsGroup: 0
-      runAsNonRoot: false
-      runAsUser: 0
+      runAsGroup: 1337
+      runAsNonRoot: true
+      runAsUser: 1337
   volumes:
   - emptyDir:
       medium: Memory

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -184,9 +184,9 @@ spec:
         - ALL
       privileged: false
       readOnlyRootFilesystem: false
-      runAsGroup: 0
-      runAsNonRoot: false
-      runAsUser: 0
+      runAsGroup: 1337
+      runAsNonRoot: true
+      runAsUser: 1337
   volumes:
   - emptyDir:
       medium: Memory

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -196,9 +196,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -195,9 +195,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -204,9 +204,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - hostPath:
           path: /mnt/disks/ssd0

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -205,9 +205,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -197,9 +197,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -201,9 +201,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -204,9 +204,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -197,9 +197,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -189,9 +189,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -189,9 +189,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -188,9 +188,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -188,9 +188,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -193,9 +193,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -190,9 +190,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -190,9 +190,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -192,9 +192,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory
@@ -410,9 +410,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -211,9 +211,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -188,9 +188,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       restartPolicy: Never
       volumes:
       - emptyDir:

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -193,9 +193,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -192,9 +192,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory
@@ -410,9 +410,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -167,9 +167,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -186,9 +186,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -188,9 +188,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -185,9 +185,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -193,9 +193,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - hostPath:
           path: /mnt/disks/ssd0

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -191,9 +191,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -190,9 +190,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -190,9 +190,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -193,9 +193,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -197,9 +197,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/tests/scripts/testdata/golang/clean_golden.txt
+++ b/tests/scripts/testdata/golang/clean_golden.txt
@@ -32,5 +32,5 @@ ip6tables -t nat -F ISTIO_REDIRECT
 ip6tables -t nat -X ISTIO_REDIRECT
 ip6tables -t nat -F ISTIO_IN_REDIRECT
 ip6tables -t nat -X ISTIO_IN_REDIRECT
-iptables-save 
-ip6tables-save 
+iptables-save --table=mangle --table=nat
+ip6tables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang/empty_parameter_golden.txt
+++ b/tests/scripts/testdata/golang/empty_parameter_golden.txt
@@ -47,4 +47,4 @@ iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 0 -
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 0 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
-iptables-save 
+iptables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang/mode_redirect_golden.txt
+++ b/tests/scripts/testdata/golang/mode_redirect_golden.txt
@@ -52,4 +52,4 @@ iptables -t nat -I PREROUTING 1 -i eth1 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth2 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -j RETURN
-iptables-save 
+iptables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang/mode_tproxy_and_ipv6_golden.txt
+++ b/tests/scripts/testdata/golang/mode_tproxy_and_ipv6_golden.txt
@@ -83,5 +83,5 @@ ip6tables -t nat -I PREROUTING 1 -i eth1 -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -I PREROUTING 1 -i eth2 -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -j RETURN
-iptables-save 
-ip6tables-save 
+iptables-save --table=mangle --table=nat
+ip6tables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang/mode_tproxy_and_wildcard_port_golden.txt
+++ b/tests/scripts/testdata/golang/mode_tproxy_and_wildcard_port_golden.txt
@@ -62,4 +62,4 @@ iptables -t nat -I PREROUTING 1 -i eth1 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth2 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -j RETURN
-iptables-save 
+iptables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang/mode_tproxy_golden.txt
+++ b/tests/scripts/testdata/golang/mode_tproxy_golden.txt
@@ -63,4 +63,4 @@ iptables -t nat -I PREROUTING 1 -i eth1 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth2 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -j RETURN
-iptables-save 
+iptables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang/outbound_port_exclude_golden.txt
+++ b/tests/scripts/testdata/golang/outbound_port_exclude_golden.txt
@@ -54,4 +54,4 @@ iptables -t nat -I PREROUTING 1 -i eth1 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth2 -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -j RETURN
-iptables-save 
+iptables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang/wildcard_include_ip_range_golden.txt
+++ b/tests/scripts/testdata/golang/wildcard_include_ip_range_golden.txt
@@ -51,4 +51,4 @@ iptables -t nat -I PREROUTING 1 -i eth2 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth1 -j ISTIO_REDIRECT
 iptables -t nat -I PREROUTING 1 -i eth2 -j ISTIO_REDIRECT
-iptables-save 
+iptables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang_clean/clean_golden.txt
+++ b/tests/scripts/testdata/golang_clean/clean_golden.txt
@@ -32,5 +32,5 @@ ip6tables -t nat -F ISTIO_REDIRECT
 ip6tables -t nat -X ISTIO_REDIRECT
 ip6tables -t nat -F ISTIO_IN_REDIRECT
 ip6tables -t nat -X ISTIO_IN_REDIRECT
-iptables-save 
-ip6tables-save 
+iptables-save --table=mangle --table=nat
+ip6tables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang_clean/empty_parameter_golden.txt
+++ b/tests/scripts/testdata/golang_clean/empty_parameter_golden.txt
@@ -44,5 +44,5 @@ ip6tables -t filter -F INPUT
 ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
 ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
 ip6tables -t filter -A INPUT -j REJECT
-iptables-save 
-ip6tables-save 
+iptables-save --table=mangle --table=nat
+ip6tables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang_clean/mode_redirect_golden.txt
+++ b/tests/scripts/testdata/golang_clean/mode_redirect_golden.txt
@@ -53,5 +53,5 @@ ip6tables -t filter -F INPUT
 ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
 ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
 ip6tables -t filter -A INPUT -j REJECT
-iptables-save 
-ip6tables-save 
+iptables-save --table=mangle --table=nat
+ip6tables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang_clean/mode_tproxy_and_ipv6_golden.txt
+++ b/tests/scripts/testdata/golang_clean/mode_tproxy_and_ipv6_golden.txt
@@ -77,5 +77,5 @@ ip6tables -t nat -I PREROUTING 1 -i eth1 -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -I PREROUTING 1 -i eth2 -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -j RETURN
-iptables-save 
-ip6tables-save 
+iptables-save --table=mangle --table=nat
+ip6tables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang_clean/mode_tproxy_and_wildcard_port_golden.txt
+++ b/tests/scripts/testdata/golang_clean/mode_tproxy_and_wildcard_port_golden.txt
@@ -63,5 +63,5 @@ ip6tables -t filter -F INPUT
 ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
 ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
 ip6tables -t filter -A INPUT -j REJECT
-iptables-save 
-ip6tables-save 
+iptables-save --table=mangle --table=nat
+ip6tables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang_clean/mode_tproxy_golden.txt
+++ b/tests/scripts/testdata/golang_clean/mode_tproxy_golden.txt
@@ -64,5 +64,5 @@ ip6tables -t filter -F INPUT
 ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
 ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
 ip6tables -t filter -A INPUT -j REJECT
-iptables-save 
-ip6tables-save 
+iptables-save --table=mangle --table=nat
+ip6tables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang_clean/outbound_port_exclude_golden.txt
+++ b/tests/scripts/testdata/golang_clean/outbound_port_exclude_golden.txt
@@ -55,5 +55,5 @@ ip6tables -t filter -F INPUT
 ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
 ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
 ip6tables -t filter -A INPUT -j REJECT
-iptables-save 
-ip6tables-save 
+iptables-save --table=mangle --table=nat
+ip6tables-save --table=mangle --table=nat

--- a/tests/scripts/testdata/golang_clean/wildcard_include_ip_range_golden.txt
+++ b/tests/scripts/testdata/golang_clean/wildcard_include_ip_range_golden.txt
@@ -52,5 +52,5 @@ ip6tables -t filter -F INPUT
 ip6tables -t filter -A INPUT -m state --state ESTABLISHED -j ACCEPT
 ip6tables -t filter -A INPUT -i lo -d ::1 -j ACCEPT
 ip6tables -t filter -A INPUT -j REJECT
-iptables-save 
-ip6tables-save 
+iptables-save --table=mangle --table=nat
+ip6tables-save --table=mangle --table=nat

--- a/tools/istio-clean-iptables/pkg/cmd/cleanup.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup.go
@@ -56,7 +56,12 @@ func cleanup(dryRun bool) {
 	defer func() {
 		for _, cmd := range []string{constants.IPTABLESSAVE, constants.IP6TABLESSAVE} {
 			// iptables-save is best efforts
-			_ = ext.Run(cmd)
+			_ = ext.Run(
+				cmd,
+				// Limit saving to only the tables actually used in Istio. This prevents iptables-restore from trying to
+				// read /proc/net/ip_tables_names, which requires uid/gid 0.
+				"--table="+constants.MANGLE,
+				"--table="+constants.NAT)
 		}
 	}()
 

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -130,11 +130,7 @@ func (rb *IptablesBuilderImpl) constructIptablesRestoreContents(tableRulesMap ma
 }
 
 func (rb *IptablesBuilderImpl) buildRestore(rules []*Rule) string {
-	tableRulesMap := map[string][]string{
-		constants.FILTER: {},
-		constants.NAT:    {},
-		constants.MANGLE: {},
-	}
+	tableRulesMap := make(map[string][]string, 2)
 
 	chainTableLookupMap := make(map[string]struct{})
 	for _, r := range rules {

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -16,11 +16,10 @@ package constants
 
 import "time"
 
-// iptables tables
+// Subset of iptables tables that are used in Istio
 const (
 	MANGLE = "mangle"
 	NAT    = "nat"
-	FILTER = "filter"
 )
 
 // Built-in iptables chains

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -19,6 +19,14 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
+)
+
+// The capabilities required by iptables commands.
+// https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
+const (
+	capNetAdmin = 12 // CAP_NET_ADMIN
+	capNetRaw   = 13 // CAP_NET_RAW
 )
 
 // RealDependencies implementation of interface Dependencies, which is used in production
@@ -29,6 +37,12 @@ func (r *RealDependencies) execute(cmd string, redirectStdout bool, args ...stri
 	fmt.Printf("%s %s\n", cmd, strings.Join(args, " "))
 	externalCommand := exec.Command(cmd, args...)
 	externalCommand.Stdout = os.Stdout
+	externalCommand.SysProcAttr = &syscall.SysProcAttr{
+		AmbientCaps: []uintptr{
+			capNetAdmin,
+			capNetRaw,
+		},
+	}
 	//TODO Check naming and redirection logic
 	if !redirectStdout {
 		externalCommand.Stderr = os.Stderr


### PR DESCRIPTION
* Run the `istio-init` container with UID 1337 instead of UID 0.
* Pass `--table=mangle --table=nat` arguments to every `iptables` command to explicitly specify the tables to setup / clean, so it won't try to access file `/proc/net/ip_tables_names` which is accessible only to UID/GID 0.
* Set `CAP_NET_ADMIN` and `CAP_NET_RAW` as ambient capabilities in `istio-iptables` to make them inherited and effective when calling `iptables` commands, even when `istio-iptables` runs as non-root. **❗️This requires Linux kernel version ≥4.3.**
* Set `CAP_NET_ADMIN` and `CAP_NET_RAW` as permitted capabilities on the `istio-iptables` binary in the `proxyv2` Docker image. **❗️This requires a filesystem supporting extended attributes.** The benefits of running as non-root outweigh the (small) risk of encountering a platform which filesystem doesn't support extended attributes.

The `CAP_SYS_MODULE` capability is not added to the `istio-init` container. It is normally needed by `iptables` to install kernel modules if they are not compiled into the kernel or already loaded. The previous configuration (non-privileged, UID 0, no `CAP_SYS_MODULE` capability) has always prevented `istio-init` from loading modules anyway, so this is not an issue.