### PR TITLE
Check k8s version before kubectl apply

### DIFF
--- a/operator/cmd/mesh/manifest-common.go
+++ b/operator/cmd/mesh/manifest-common.go
@@ -46,11 +46,6 @@ var (
 
 func genApplyManifests(setOverlay []string, inFilename []string, force bool, dryRun bool, verbose bool,
 	kubeConfigPath string, context string, wait bool, waitTimeout time.Duration, l *Logger) error {
-	overlayFromSet, err := MakeTreeFromSetList(setOverlay, force, l)
-	if err != nil {
-		return fmt.Errorf("failed to generate tree from the set overlay, error: %v", err)
-	}
-
 	opts := &kubectlcmd.Options{
 		DryRun:      dryRun,
 		Verbose:     verbose,
@@ -58,6 +53,14 @@ func genApplyManifests(setOverlay []string, inFilename []string, force bool, dry
 		WaitTimeout: waitTimeout,
 		Kubeconfig:  kubeConfigPath,
 		Context:     context,
+	}
+	if err := manifest.CheckK8sVersion(opts); err != nil {
+		l.logAndError(err)
+	}
+
+	overlayFromSet, err := MakeTreeFromSetList(setOverlay, force, l)
+	if err != nil {
+		return fmt.Errorf("failed to generate tree from the set overlay, error: %v", err)
 	}
 
 	kubeconfig, err := manifest.InitK8SRestClient(opts.Kubeconfig, opts.Context)

--- a/operator/cmd/mesh/manifest-versions_test.go
+++ b/operator/cmd/mesh/manifest-versions_test.go
@@ -17,7 +17,6 @@ package mesh
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,7 +31,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 	type args struct {
 		versionsURI string
 		binVersion  *goversion.Version
-		l           *Logger
 	}
 
 	testDataDir = filepath.Join(repoRootDir, "cmd/mesh/testdata/manifest-versions")
@@ -45,8 +43,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 	goVer137, _ := goversion.NewVersion("1.3.7")
 	goVer1331, _ := goversion.NewVersion("1.3.3.1")
 	goVer1399, _ := goversion.NewVersion("1.3.9.9")
-
-	l := NewLogger(true, os.Stdout, os.Stderr)
 
 	b, err := ioutil.ReadFile(operatorVersionsFilePath)
 	if err != nil {
@@ -87,7 +83,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 			args: args{
 				versionsURI: operatorVersionsFilePath,
 				binVersion:  binversion.OperatorBinaryGoVersion,
-				l:           l,
 			},
 			want:    curCm,
 			wantErr: nil,
@@ -97,7 +92,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 			args: args{
 				versionsURI: nonexistentFilePath,
 				binVersion:  binversion.OperatorBinaryGoVersion,
-				l:           l,
 			},
 			want:    curCm,
 			wantErr: nil,
@@ -107,7 +101,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 			args: args{
 				versionsURI: testdataVersionsFilePath,
 				binVersion:  goVer133,
-				l:           l,
 			},
 			want:    ver133Cm,
 			wantErr: nil,
@@ -117,7 +110,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 			args: args{
 				versionsURI: testdataVersionsFilePath,
 				binVersion:  goVerNonexistent,
-				l:           l,
 			},
 			want: nil,
 			wantErr: fmt.Errorf("this operator version %s was not found in the version map",
@@ -128,7 +120,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 			args: args{
 				versionsURI: nonexistentFilePath,
 				binVersion:  goVerNonexistent,
-				l:           l,
 			},
 			want: nil,
 			wantErr: fmt.Errorf("this operator version %s was not found in the version map",
@@ -139,7 +130,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 			args: args{
 				versionsURI: testdataVersionsFilePath,
 				binVersion:  goVer1331,
-				l:           l,
 			},
 			want:    ver133Cm,
 			wantErr: nil,
@@ -149,7 +139,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 			args: args{
 				versionsURI: nonexistentFilePath,
 				binVersion:  goVer1331,
-				l:           l,
 			},
 			want:    ver133Cm,
 			wantErr: nil,
@@ -159,7 +148,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 			args: args{
 				versionsURI: testdataVersionsFilePath,
 				binVersion:  goVer1399,
-				l:           l,
 			},
 			want:    ver137Cm,
 			wantErr: nil,
@@ -169,7 +157,6 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 			args: args{
 				versionsURI: nonexistentFilePath,
 				binVersion:  goVer1399,
-				l:           l,
 			},
 			want:    ver137Cm,
 			wantErr: nil,
@@ -177,7 +164,7 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotErr := getVersionCompatibleMap(tt.args.versionsURI, tt.args.binVersion, tt.args.l)
+			got, gotErr := version.GetVersionCompatibleMap(tt.args.versionsURI, tt.args.binVersion)
 			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", tt.want) {
 				t.Errorf("got: %v, want: %v", got, tt.want)
 			}

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -145,7 +145,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *Logger) (err error) {
 	}
 
 	// Check if the upgrade currentVersion -> targetVersion is supported
-	err = checkSupportedVersions(currentVersion, targetVersion, args.versionsURI, l)
+	err = checkSupportedVersions(currentVersion, targetVersion, args.versionsURI)
 	if err != nil && !args.force {
 		return fmt.Errorf("upgrade version check failed: %v -> %v. Error: %v",
 			currentVersion, targetVersion, err)
@@ -244,13 +244,13 @@ func waitForConfirmation(skipConfirmation bool, l *Logger) {
 }
 
 // checkSupportedVersions checks if the upgrade cur -> tar is supported by the tool
-func checkSupportedVersions(cur, tar, versionsURI string, l *Logger) error {
+func checkSupportedVersions(cur, tar, versionsURI string) error {
 	tarGoVersion, err := goversion.NewVersion(tar)
 	if err != nil {
 		return fmt.Errorf("failed to parse the target version: %v", tar)
 	}
 
-	compatibleMap, err := getVersionCompatibleMap(versionsURI, tarGoVersion, l)
+	compatibleMap, err := pkgversion.GetVersionCompatibleMap(versionsURI, tarGoVersion)
 	if err != nil {
 		return err
 	}

--- a/operator/data/versions.yaml
+++ b/operator/data/versions.yaml
@@ -44,3 +44,5 @@
   operatorVersionRange: ">=1.5.0,<1.6.0"
   supportedIstioVersions: ">=1.4.0, <1.6"
   recommendedIstioVersions: 1.5.0
+  k8sClientVersionRange: ">=1.14"
+  k8sServerVersionRange: ">=1.14"

--- a/operator/pkg/kubectlcmd/client.go
+++ b/operator/pkg/kubectlcmd/client.go
@@ -108,6 +108,12 @@ func (c *Client) GetConfigMap(name string, opts *Options) (string, string, error
 	return c.kubectl([]string{"get", "cm", name}, opts)
 }
 
+// Version runs the `kubectl version` and return stdout and stderr
+func (c *Client) Version(opts *Options) (string, string, error) {
+	opts.Output = "yaml"
+	return c.kubectl([]string{"version"}, opts)
+}
+
 // kubectl runs the `kubectl` command by specifying subcommands in subcmds with opts.
 func (c *Client) kubectl(subcmds []string, opts *Options) (string, string, error) {
 	hasStdin := strings.TrimSpace(opts.Stdin) != ""

--- a/operator/pkg/manifest/installer_test.go
+++ b/operator/pkg/manifest/installer_test.go
@@ -1,0 +1,94 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"reflect"
+	"testing"
+
+	goversion "github.com/hashicorp/go-version"
+)
+
+func Test_parseKubectlVersion(t *testing.T) {
+	ver1170, _ := goversion.NewVersion("v1.17.0")
+	ver1157, _ := goversion.NewVersion("v1.15.7")
+	tests := []struct {
+		name          string
+		kubectlStdout string
+		wantClientVer *goversion.Version
+		wantServerVer *goversion.Version
+		wantErr       bool
+	}{
+		{
+			name: "client version and server version",
+			kubectlStdout: `
+clientVersion:
+  buildDate: "2019-12-07T21:20:10Z"
+  compiler: gc
+  gitCommit: 70132b0f130acc0bed193d9ba59dd186f0e634cf
+  gitTreeState: clean
+  gitVersion: v1.17.0
+  goVersion: go1.13.4
+  major: "1"
+  minor: "17"
+  platform: linux/amd64
+serverVersion:
+  buildDate: "2019-12-13T12:37:28Z"
+  compiler: gc
+  gitCommit: 96c91b15a936b36701e8704844bc356862440a21
+  gitTreeState: clean
+  gitVersion: v1.15.7
+  goVersion: go1.12.12b4
+  major: "1"
+  minor: 15+
+  platform: linux/amd64`,
+			wantErr:       false,
+			wantClientVer: ver1170,
+			wantServerVer: ver1157,
+		},
+		{
+			name: "client version and server version",
+			kubectlStdout: `
+clientVersion:
+  buildDate: "2019-12-07T21:20:10Z"
+  compiler: gc
+  gitCommit: 70132b0f130acc0bed193d9ba59dd186f0e634cf
+  gitTreeState: clean
+  gitVersion: v1.17.0
+  goVersion: go1.13.4
+  major: "1"
+  minor: "17"
+  platform: linux/amd64`,
+			wantErr:       false,
+			wantClientVer: ver1170,
+			wantServerVer: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotClientVer, gotServerVer, err := parseKubectlVersion(tt.kubectlStdout)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseKubectlVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotClientVer, tt.wantClientVer) {
+				t.Errorf("Version() got ClientVer = %v, want ClientVer %v", gotClientVer, tt.wantClientVer)
+			}
+			if !reflect.DeepEqual(gotServerVer, tt.wantServerVer) {
+				t.Errorf("Version() got ServerVer = %v, want ServerVer %v", gotServerVer, tt.wantServerVer)
+			}
+		})
+	}
+}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -41443,6 +41443,8 @@ var _versionsYaml = []byte(`- operatorVersion: 1.3.0
   operatorVersionRange: ">=1.5.0,<1.6.0"
   supportedIstioVersions: ">=1.4.0, <1.6"
   recommendedIstioVersions: 1.5.0
+  k8sClientVersionRange: ">=1.14"
+  k8sServerVersionRange: ">=1.14"
 `)
 
 func versionsYamlBytes() ([]byte, error) {


### PR DESCRIPTION
istioctl checks K8s version (server, kubectl) before applying changes into clusters

Resolve: https://github.com/istio/istio/issues/20390