### PR TITLE
Determine default values for operator based on environment

### DIFF
--- a/operator/cmd/mesh/manifest-common.go
+++ b/operator/cmd/mesh/manifest-common.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"k8s.io/client-go/rest"
 
 	"istio.io/api/operator/v1alpha1"
 	"istio.io/istio/operator/pkg/component/controlplane"
@@ -50,10 +51,6 @@ func genApplyManifests(setOverlay []string, inFilename []string, force bool, dry
 		return fmt.Errorf("failed to generate tree from the set overlay, error: %v", err)
 	}
 
-	manifests, iops, err := GenManifests(inFilename, overlayFromSet, force, l)
-	if err != nil {
-		return fmt.Errorf("failed to generate manifest: %v", err)
-	}
 	opts := &kubectlcmd.Options{
 		DryRun:      dryRun,
 		Verbose:     verbose,
@@ -61,6 +58,16 @@ func genApplyManifests(setOverlay []string, inFilename []string, force bool, dry
 		WaitTimeout: waitTimeout,
 		Kubeconfig:  kubeConfigPath,
 		Context:     context,
+	}
+
+	kubeconfig, err := manifest.InitK8SRestClient(opts.Kubeconfig, opts.Context)
+	if err != nil {
+		return err
+	}
+
+	manifests, iops, err := GenManifests(inFilename, overlayFromSet, force, kubeconfig, l)
+	if err != nil {
+		return fmt.Errorf("failed to generate manifest: %v", err)
 	}
 
 	for _, cn := range name.DeprecatedNames {
@@ -112,8 +119,8 @@ func genApplyManifests(setOverlay []string, inFilename []string, force bool, dry
 }
 
 // GenManifests generate manifest from input file and setOverLay
-func GenManifests(inFilename []string, setOverlayYAML string, force bool, l *Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, error) {
-	mergedYAML, err := genProfile(false, inFilename, "", setOverlayYAML, "", force, l)
+func GenManifests(inFilename []string, setOverlayYAML string, force bool, kubeConfig *rest.Config, l *Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, error) {
+	mergedYAML, err := genProfile(false, inFilename, "", setOverlayYAML, "", force, kubeConfig, l)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -74,7 +74,10 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, l *Logger) e
 	if err != nil {
 		return err
 	}
-	manifests, _, err := GenManifests(mgArgs.inFilename, overlayFromSet, mgArgs.force, l)
+
+	// For generate, we may not have access to the kube cluster, so don't rely on kubeconfig
+	// TODO: support optional kubeconfig reading
+	manifests, _, err := GenManifests(mgArgs.inFilename, overlayFromSet, mgArgs.force, nil, l)
 	if err != nil {
 		return err
 	}

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -209,7 +209,7 @@ func TestLDFlags(t *testing.T) {
 	version.DockerInfo.Hub = "testHub"
 	version.DockerInfo.Tag = "testTag"
 	l := NewLogger(true, os.Stdout, os.Stderr)
-	_, iops, err := genIOPS(nil, "default", "", "", true, l)
+	_, iops, err := genIOPS(nil, "default", "", "", true, nil, l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/operator/cmd/mesh/operator-remove.go
+++ b/operator/cmd/mesh/operator-remove.go
@@ -88,7 +88,7 @@ func operatorRemove(args *rootArgs, orArgs *operatorRemoveArgs, l *Logger, delet
 		Context:     orArgs.context,
 	}
 
-	if err := manifest.InitK8SRestClient(opts.Kubeconfig, opts.Context); err != nil {
+	if _, err := manifest.InitK8SRestClient(opts.Kubeconfig, opts.Context); err != nil {
 		l.logAndFatal(err)
 	}
 

--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -35,7 +35,6 @@ import (
 	pkgversion "istio.io/pkg/version"
 )
 
-
 var scope = log.RegisterScope("installer", "installer", 0)
 
 // getIOPS creates an IstioOperatorSpec from the following sources, overlaid sequentially:

--- a/operator/cmd/mesh/profile-dump.go
+++ b/operator/cmd/mesh/profile-dump.go
@@ -66,7 +66,9 @@ func profileDump(args []string, rootArgs *rootArgs, pdArgs *profileDumpArgs, l *
 	if len(args) == 1 {
 		profile = args[0]
 	}
-	y, err := genProfile(pdArgs.helmValues, pdArgs.inFilename, profile, "", pdArgs.configPath, true, l)
+	// For profile dump, we may not have access to the kube cluster, so don't rely on kubeconfig
+	// TODO: support optional kubeconfig reading
+	y, err := genProfile(pdArgs.helmValues, pdArgs.inFilename, profile, "", pdArgs.configPath, true, nil, l)
 	if err != nil {
 		return err
 	}

--- a/operator/pkg/manifest/installer.go
+++ b/operator/pkg/manifest/installer.go
@@ -206,7 +206,7 @@ func ApplyAll(manifests name.ManifestMap, version pkgversion.Version, opts *kube
 		scope.Infof("- %s", c)
 	}
 	scope.Infof("Component dependencies tree: \n%s", installTreeString())
-	if err := InitK8SRestClient(opts.Kubeconfig, opts.Context); err != nil {
+	if _, err := InitK8SRestClient(opts.Kubeconfig, opts.Context); err != nil {
 		return nil, err
 	}
 	return applyRecursive(manifests, version, opts)
@@ -376,7 +376,7 @@ func GetKubectlGetItems(stdoutGet string) ([]interface{}, error) {
 }
 
 func DeploymentExists(kubeconfig, context, namespace, name string) (bool, error) {
-	if err := InitK8SRestClient(kubeconfig, context); err != nil {
+	if _, err := InitK8SRestClient(kubeconfig, context); err != nil {
 		return false, err
 	}
 
@@ -761,18 +761,18 @@ func buildInstallTreeString(componentName name.ComponentName, prefix string, sb 
 	}
 }
 
-func InitK8SRestClient(kubeconfig, context string) error {
+func InitK8SRestClient(kubeconfig, context string) (*rest.Config, error) {
 	var err error
 	if kubeconfig == currentKubeconfig && context == currentContext && k8sRESTConfig != nil {
-		return nil
+		return k8sRESTConfig, nil
 	}
 	currentKubeconfig, currentContext = kubeconfig, context
 
 	k8sRESTConfig, err = defaultRestConfig(kubeconfig, context)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return k8sRESTConfig, nil
 }
 
 func defaultRestConfig(kubeconfig, configContext string) (*rest.Config, error) {

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -872,7 +872,7 @@ func createTestWebhookFromHelmConfigMap(t *testing.T) (*Webhook, func()) {
 // This allows us to fully simulate what will actually happen at run time.
 func loadInjectionConfigMap(t testing.TB, settings string) (template *Config, values string) {
 	t.Helper()
-	manifests, _, err := operator.GenManifests(nil, settings, false, nil)
+	manifests, _, err := operator.GenManifests(nil, settings, false, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to generate manifests: %v", err)
 	}


### PR DESCRIPTION
An adoption of https://github.com/istio/operator/pull/699/files

Partially implements istio/istio#19182

This PR adds the ability for certain values to be configured based on
the currently Kubernetes environment. This should be perfectly reliable
for apply and operator, the only problems may arise are with generate.
For now, this just skips these custom modifications. In the future, if
needed, we can add a flag for generate to read from in cluster config as
well, although its a bit suspect because we may generate with one
cluster config and apply to another.

As an initial implementation, this adds support for detecting whether or
not trustworthy jwt tokens are enabled

For https://github.com/istio/istio/issues/20178