### PR TITLE
WIP Add an option to start galley's processing pipeline in istiod

### DIFF
--- a/galley/pkg/config/processing/snapshotter/snapshot.go
+++ b/galley/pkg/config/processing/snapshotter/snapshot.go
@@ -61,6 +61,23 @@ func (s *Snapshot) Resources(col string) []*mcp.Resource {
 	return result
 }
 
+func (s *Snapshot) ResourceInstances(col string) []*resource.Instance {
+	c := s.set.Collection(collection.NewName(col))
+
+	if c == nil {
+		return nil
+	}
+
+	result := make([]*resource.Instance, 0, c.Size())
+
+	s.set.Collection(collection.NewName(col)).ForEach(func(r *resource.Instance) bool {
+		result = append(result, r.Clone()) // or pass by reference?
+		return true
+	})
+
+	return result
+}
+
 // Version implements snapshotImpl.Snapshot
 func (s *Snapshot) Version(col string) string {
 	coll := s.set.Collection(collection.NewName(col))

--- a/galley/pkg/config/schema/metadata.gen.go
+++ b/galley/pkg/config/schema/metadata.gen.go
@@ -331,6 +331,32 @@ collections:
 
 # The snapshots to generate
 snapshots:
+  # Used by Istiod when running galley's processing pipeline in-process.
+  - name: "istiod"
+    strategy: debounce
+    collections:
+      - "istio/authentication/v1alpha1/meshpolicies"
+      - "istio/authentication/v1alpha1/policies"
+      - "istio/config/v1alpha2/httpapispecs"
+      - "istio/config/v1alpha2/httpapispecbindings"
+      - "istio/mesh/v1alpha1/MeshConfig"
+      - "istio/mixer/v1/config/client/quotaspecbindings"
+      - "istio/mixer/v1/config/client/quotaspecs"
+      - "istio/networking/v1alpha3/destinationrules"
+      - "istio/networking/v1alpha3/envoyfilters"
+      - "istio/networking/v1alpha3/gateways"
+      - "istio/networking/v1alpha3/serviceentries"
+      - "istio/networking/v1alpha3/sidecars"
+      - "istio/networking/v1alpha3/virtualservices"
+      - "istio/rbac/v1alpha1/clusterrbacconfigs"
+      - "istio/rbac/v1alpha1/rbacconfigs"
+      - "istio/rbac/v1alpha1/servicerolebindings"
+      - "istio/rbac/v1alpha1/serviceroles"
+      - "istio/security/v1beta1/authorizationpolicies"
+      - "istio/security/v1beta1/requestauthentications"
+      - "k8s/core/v1/namespaces"
+      - "k8s/core/v1/services"
+
   # Used by Galley to distribute configuration.
   - name: "default"
     strategy: debounce

--- a/galley/pkg/config/schema/metadata.yaml
+++ b/galley/pkg/config/schema/metadata.yaml
@@ -276,6 +276,32 @@ collections:
 
 # The snapshots to generate
 snapshots:
+  # Used by Istiod when running galley's processing pipeline in-process.
+  - name: "istiod"
+    strategy: debounce
+    collections:
+      - "istio/authentication/v1alpha1/meshpolicies"
+      - "istio/authentication/v1alpha1/policies"
+      - "istio/config/v1alpha2/httpapispecs"
+      - "istio/config/v1alpha2/httpapispecbindings"
+      - "istio/mesh/v1alpha1/MeshConfig"
+      - "istio/mixer/v1/config/client/quotaspecbindings"
+      - "istio/mixer/v1/config/client/quotaspecs"
+      - "istio/networking/v1alpha3/destinationrules"
+      - "istio/networking/v1alpha3/envoyfilters"
+      - "istio/networking/v1alpha3/gateways"
+      - "istio/networking/v1alpha3/serviceentries"
+      - "istio/networking/v1alpha3/sidecars"
+      - "istio/networking/v1alpha3/virtualservices"
+      - "istio/rbac/v1alpha1/clusterrbacconfigs"
+      - "istio/rbac/v1alpha1/rbacconfigs"
+      - "istio/rbac/v1alpha1/servicerolebindings"
+      - "istio/rbac/v1alpha1/serviceroles"
+      - "istio/security/v1beta1/authorizationpolicies"
+      - "istio/security/v1beta1/requestauthentications"
+      - "k8s/core/v1/namespaces"
+      - "k8s/core/v1/services"
+
   # Used by Galley to distribute configuration.
   - name: "default"
     strategy: debounce

--- a/galley/pkg/config/schema/snapshots/snapshots.gen.go
+++ b/galley/pkg/config/schema/snapshots/snapshots.gen.go
@@ -8,6 +8,9 @@ var (
 	// Default describes the snapshot default
 	Default = "default"
 
+	// Istiod describes the snapshot istiod
+	Istiod = "istiod"
+
 	// LocalAnalysis describes the snapshot localAnalysis
 	LocalAnalysis = "localAnalysis"
 
@@ -19,6 +22,7 @@ var (
 func SnapshotNames() []string {
 	return []string{
 		Default,
+		Istiod,
 		LocalAnalysis,
 		SyntheticServiceEntry,
 	}

--- a/galley/pkg/server/components/processing.go
+++ b/galley/pkg/server/components/processing.go
@@ -119,7 +119,13 @@ func (p *Processing) Start() (err error) {
 		return
 	}
 
-	var distributor snapshotter.Distributor = snapshotter.NewMCPDistributor(p.mcpCache)
+	var distributor snapshotter.Distributor
+
+	if p.args.AltDistributor != nil {
+		distributor = p.args.AltDistributor
+	} else {
+		distributor = snapshotter.NewMCPDistributor(p.mcpCache)
+	}
 
 	if p.args.EnableConfigAnalysis {
 		combinedAnalyzer := analyzers.AllCombined()

--- a/galley/pkg/server/settings/args.go
+++ b/galley/pkg/server/settings/args.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/pkg/ctrlz"
 	"istio.io/pkg/probe"
 
+	"istio.io/istio/galley/pkg/config/processing/snapshotter"
 	"istio.io/istio/galley/pkg/config/schema/snapshots"
 	"istio.io/istio/galley/pkg/config/util/kuberesource"
 	"istio.io/istio/pkg/keepalive"
@@ -60,6 +61,8 @@ type Args struct { // nolint:maligned
 
 	// SecureGRPC is an existing GRPC server, will be used by Galley instead of creating its own
 	SecureGRPC *grpc.Server
+
+	AltDistributor snapshotter.Distributor
 
 	// KubeRestConfig has a rest config, common with other components
 	KubeRestConfig *rest.Config


### PR DESCRIPTION
This PR starts galley's config processing pipeline in Istiod. It connect's the pipeline's distributor directly to Pilot's MCP configcontroller, thus bypassing MCP and the associated extra serialize/deserialize cost. It reuses the MCP configcontroller's Apply() function to reuse the existing configcontroller code. This also preserves the debounce behavior (i.e. batching) that currently exists between Galley and Pilot. 



 