### PR TITLE
Ensure CDS is set up for all destinations of VirtualService

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -541,6 +541,41 @@ func (ps *PushContext) UpdateMetrics() {
 	}
 }
 
+func virtualServiceDestinations(v *networking.VirtualService) []*networking.Destination {
+	if v == nil {
+		return nil
+	}
+
+	var ds []*networking.Destination
+
+	for _, h := range v.Http {
+		for _, r := range h.Route {
+			if r.Destination != nil {
+				ds = append(ds, r.Destination)
+			}
+		}
+		if h.Mirror != nil {
+			ds = append(ds, h.Mirror)
+		}
+	}
+	for _, t := range v.Tcp {
+		for _, r := range t.Route {
+			if r.Destination != nil {
+				ds = append(ds, r.Destination)
+			}
+		}
+	}
+	for _, t := range v.Tls {
+		for _, r := range t.Route {
+			if r.Destination != nil {
+				ds = append(ds, r.Destination)
+			}
+		}
+	}
+
+	return ds
+}
+
 // GatewayServices returns the set of services which are referred from the proxy gateways.
 func (ps *PushContext) GatewayServices(proxy *Proxy) []*Service {
 	svcs := ps.Services(proxy)
@@ -561,25 +596,8 @@ func (ps *PushContext) GatewayServices(proxy *Proxy) []*Service {
 			return svcs
 		}
 
-		for _, h := range vs.Http {
-			for _, r := range h.Route {
-				hostsFromGateways[r.Destination.Host] = struct{}{}
-			}
-			if h.Mirror != nil {
-				hostsFromGateways[h.Mirror.Host] = struct{}{}
-			}
-		}
-
-		for _, h := range vs.Tls {
-			for _, r := range h.Route {
-				hostsFromGateways[r.Destination.Host] = struct{}{}
-			}
-		}
-
-		for _, h := range vs.Tcp {
-			for _, r := range h.Route {
-				hostsFromGateways[r.Destination.Host] = struct{}{}
-			}
+		for _, d := range virtualServiceDestinations(vs) {
+			hostsFromGateways[d.Host] = struct{}{}
 		}
 	}
 

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -217,7 +217,53 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 	// Assign namespace dependencies
 	out.namespaceDependencies = make(map[string]struct{})
 	for _, listener := range out.EgressListeners {
-		for _, s := range listener.services {
+		// Explicitly callable services are potential destinations, copy those first
+		serviceDestinations := append([]*Service(nil), listener.services...)
+
+		addDestination := func(d *networking.Destination) {
+			if d == nil {
+				return
+			}
+			// Default to this hostname in our config namespace
+			s, ok := ps.ServiceByHostnameAndNamespace[host.Name(d.Host)][configNamespace]
+			if !ok {
+				// Otherwise pick randomly
+				for _, v := range ps.ServiceByHostnameAndNamespace[host.Name(d.Host)] {
+					s, ok = v, true
+				}
+				if !ok {
+					return
+				}
+			}
+
+			serviceDestinations = append(serviceDestinations, s)
+		}
+
+		// Infer more possible destinations from virtual services
+		for _, vs := range listener.virtualServices {
+			v := vs.Spec.(*networking.VirtualService)
+
+			for _, h := range v.Http {
+				for _, r := range h.Route {
+					addDestination(r.Destination)
+				}
+				addDestination(h.Mirror)
+
+			}
+			for _, t := range v.Tcp {
+				for _, r := range t.Route {
+					addDestination(r.Destination)
+
+				}
+			}
+			for _, t := range v.Tls {
+				for _, r := range t.Route {
+					addDestination(r.Destination)
+				}
+			}
+		}
+
+		for _, s := range serviceDestinations {
 			if _, found := servicesAdded[string(s.Hostname)]; !found {
 				servicesAdded[string(s.Hostname)] = s
 				out.services = append(out.services, s)

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -269,6 +269,7 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 					byNamespace := ps.ServiceByHostnameAndNamespace[host.Name(d.Host)]
 					if len(byNamespace) == 0 {
 						// This hostname isn't found anywhere
+						log.Debugf("Could not find service hostname %s parsed from %s", d.Host, vs.Key())
 						continue
 					}
 

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"istio.io/istio/galley/pkg/config/schema/collections"
+
 	"istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 
@@ -309,6 +311,42 @@ var (
 		},
 	}
 
+	configs11 = &Config{
+		ConfigMeta: ConfigMeta{
+			Name: "sidecar-scope-with-http-proxy-match-virtual-service",
+		},
+		Spec: &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Port: &networking.Port{
+						Number:   7443,
+						Protocol: "http_proxy",
+						Name:     "grpc-tls",
+					},
+					Hosts: []string{"foo/virtualbar"},
+				},
+			},
+		},
+	}
+
+	configs12 = &Config{
+		ConfigMeta: ConfigMeta{
+			Name: "sidecar-scope-with-http-proxy-match-virtual-service-and-service",
+		},
+		Spec: &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Port: &networking.Port{
+						Number:   7443,
+						Protocol: "http_proxy",
+						Name:     "grpc-tls",
+					},
+					Hosts: []string{"foo/virtualbar", "ns2/foo.svc.cluster.local"},
+				},
+			},
+		},
+	}
+
 	services1 = []*Service{
 		{Hostname: "bar"},
 	}
@@ -488,6 +526,79 @@ var (
 			},
 		},
 	}
+
+	services12 = []*Service{
+		{
+			Hostname: "foo.svc.cluster.local",
+			Ports:    port7443,
+			Attributes: ServiceAttributes{
+				Name:      "foo",
+				Namespace: "ns1",
+			},
+		},
+		{
+			Hostname: "foo.svc.cluster.local",
+			Ports:    port8000,
+			Attributes: ServiceAttributes{
+				Name:      "foo",
+				Namespace: "ns2",
+			},
+		},
+		{
+			Hostname: "baz.svc.cluster.local",
+			Ports:    port7443,
+			Attributes: ServiceAttributes{
+				Name:      "baz",
+				Namespace: "ns3",
+			},
+		},
+	}
+
+	services13 = []*Service{
+		{
+			Hostname: "foo.svc.cluster.local",
+			Ports:    port7443,
+			Attributes: ServiceAttributes{
+				Name:      "foo",
+				Namespace: "ns1",
+			},
+		},
+		{
+			Hostname: "foo.svc.cluster.local",
+			Ports:    port8000,
+			Attributes: ServiceAttributes{
+				Name:      "foo",
+				Namespace: "mynamespace",
+			},
+		},
+		{
+			Hostname: "baz.svc.cluster.local",
+			Ports:    port7443,
+			Attributes: ServiceAttributes{
+				Name:      "baz",
+				Namespace: "ns3",
+			},
+		},
+	}
+
+	virtualServices1 = []Config{
+		{
+			ConfigMeta: ConfigMeta{Type: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Kind(),
+				Version:   collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Version(),
+				Name:      "virtualbar",
+				Namespace: "foo",
+			},
+			Spec: &networking.VirtualService{
+				Hosts: []string{"virtualbar"},
+				Http: []*networking.HTTPRoute{
+					{
+						Mirror: &networking.Destination{Host: "foo.svc.cluster.local"},
+						Route:  []*networking.HTTPRouteDestination{{Destination: &networking.Destination{Host: "baz.svc.cluster.local"}}},
+					},
+				},
+			},
+		},
+	}
 )
 
 func TestCreateSidecarScope(t *testing.T) {
@@ -495,7 +606,8 @@ func TestCreateSidecarScope(t *testing.T) {
 		name          string
 		sidecarConfig *Config
 		// list of available service for a given proxy
-		services []*Service
+		services        []*Service
+		virtualServices []Config
 		// list of services expected to be in the listener
 		excpectedServices []*Service
 	}{
@@ -504,11 +616,13 @@ func TestCreateSidecarScope(t *testing.T) {
 			nil,
 			nil,
 			nil,
+			nil,
 		},
 		{
 			"no-sidecar-config-with-service",
 			nil,
 			services1,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -520,11 +634,14 @@ func TestCreateSidecarScope(t *testing.T) {
 			configs1,
 			nil,
 			nil,
+			nil,
 		},
 		{
 			"sidecar-with-multiple-egress-with-service",
 			configs1,
 			services1,
+			nil,
+
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -535,6 +652,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"sidecar-with-multiple-egress-with-service-on-same-port",
 			configs1,
 			services3,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -548,6 +666,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"sidecar-with-multiple-egress-with-multiple-service",
 			configs1,
 			services4,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -562,11 +681,13 @@ func TestCreateSidecarScope(t *testing.T) {
 			configs2,
 			nil,
 			nil,
+			nil,
 		},
 		{
 			"sidecar-with-zero-egress-multiple-service",
 			configs2,
 			services4,
+			nil,
 			nil,
 		},
 		{
@@ -574,11 +695,13 @@ func TestCreateSidecarScope(t *testing.T) {
 			configs3,
 			nil,
 			nil,
+			nil,
 		},
 		{
 			"sidecar-with-multiple-egress-noport-with-specific-service",
 			configs3,
 			services2,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -592,6 +715,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"sidecar-with-multiple-egress-noport-with-services",
 			configs3,
 			services4,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -605,6 +729,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"sidecar-with-egress-port-match-with-services-with-and-without-port",
 			configs4,
 			services5,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -615,6 +740,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"sidecar-with-egress-port-trims-service-non-matching-ports",
 			configs5,
 			services6,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -626,6 +752,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"sidecar-with-egress-port-merges-service-ports",
 			configs6,
 			services6,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -637,6 +764,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"sidecar-with-egress-port-trims-and-merges-service-ports",
 			configs6,
 			services7,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -656,6 +784,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"two-egresslisteners-one-with-port-and-without-port",
 			configs7,
 			services8,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bookinginfo.com",
@@ -671,6 +800,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"service-port-used-while-cloning",
 			configs8,
 			services9,
+			nil,
 			[]*Service{
 				{
 					Hostname: "foo.svc.cluster.local",
@@ -682,6 +812,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"wild-card-egress-listener-match",
 			configs9,
 			services10,
+			nil,
 			[]*Service{
 				{
 					Hostname: "foo.svc.cluster.local",
@@ -705,6 +836,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"wild-card-egress-listener-match-with-two-ports",
 			configs9,
 			services11,
+			nil,
 			[]*Service{
 				{
 					Hostname: "foo.svc.cluster.local",
@@ -728,6 +860,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			"http-proxy-protocol-matches-any-port",
 			configs10,
 			services7,
+			nil,
 			[]*Service{
 				{
 					Hostname: "bar",
@@ -736,6 +869,54 @@ func TestCreateSidecarScope(t *testing.T) {
 					Hostname: "barprime"},
 				{
 					Hostname: "foo",
+				},
+			},
+		},
+		{
+			"virtual-service",
+			configs11,
+			services11,
+			virtualServices1,
+			[]*Service{
+				{
+					Hostname: "foo.svc.cluster.local",
+					Ports:    port7443,
+				},
+				{
+					Hostname: "baz.svc.cluster.local",
+					Ports:    port7443,
+				},
+			},
+		},
+		{
+			"virtual-service-prefer-required",
+			configs12,
+			services12,
+			virtualServices1,
+			[]*Service{
+				{
+					Hostname: "foo.svc.cluster.local",
+					Ports:    port8000,
+				},
+				{
+					Hostname: "baz.svc.cluster.local",
+					Ports:    port7443,
+				},
+			},
+		},
+		{
+			"virtual-service-prefer-config-namespace",
+			configs11,
+			services13,
+			virtualServices1,
+			[]*Service{
+				{
+					Hostname: "foo.svc.cluster.local",
+					Ports:    port8000,
+				},
+				{
+					Hostname: "baz.svc.cluster.local",
+					Ports:    port7443,
 				},
 			},
 		},
@@ -749,6 +930,16 @@ func TestCreateSidecarScope(t *testing.T) {
 			ps.Mesh = &meshConfig
 			if tt.services != nil {
 				ps.publicServices = append(ps.publicServices, tt.services...)
+
+				for _, s := range tt.services {
+					if _, f := ps.ServiceByHostnameAndNamespace[s.Hostname]; !f {
+						ps.ServiceByHostnameAndNamespace[s.Hostname] = map[string]*Service{}
+					}
+					ps.ServiceByHostnameAndNamespace[s.Hostname][s.Attributes.Namespace] = s
+				}
+			}
+			if tt.virtualServices != nil {
+				ps.publicVirtualServices = append(ps.publicVirtualServices, tt.virtualServices...)
 			}
 
 			sidecarConfig := tt.sidecarConfig


### PR DESCRIPTION
Currently if you have a restrictive hosts field in your Sidecar object,
you'll need to add hosts for every service that is a destination of any
VirtualService you might call. This is problematic as VirtualServices
can change and then you'll end up with routes pointing to clusters that
aren't available. We don't necessarily want these services to get
virtual hosts, as we might only want to call them through the
VirtualService, so we need to add them here in ConvertToSidecarScope. We
parse the VS objects for all possible destinations, and add them to the
list of services that we handle for CDS purposes, on top of the
services requested in the hosts field. When parsing, we default to
hostnames in the same config namespace, before allowing hostnames from
other namespaces, picking randomly. I believe that this is the same as
or close to existing behaviour for hostname disambiguation.