### PR TITLE
Disable mTLS for connections to kube-dns.kube-system

### DIFF
--- a/manifests/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
+++ b/manifests/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
@@ -33,6 +33,17 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 ---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: disable-mtls-to-kube-dns
+  namespace: kube-system
+spec:
+  host: "kube-dns.kube-system.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
 {{ end }}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule

--- a/manifests/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
+++ b/manifests/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
@@ -37,9 +37,11 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: disable-mtls-to-kube-dns
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
 spec:
-  host: "kube-dns.kube-system.svc.cluster.local"
+  host: "kube-dns.kube-system.svc.{{ .Values.global.proxy.clusterDomain }}"
   trafficPolicy:
     tls:
       mode: DISABLE

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -13681,6 +13681,17 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 ---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: disable-mtls-to-kube-dns
+  namespace: kube-system
+spec:
+  host: "kube-dns.kube-system.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
 {{ end }}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule


### PR DESCRIPTION
Fixes #19968 .  A summary of the issue is on #19968, but the TL/DR is that DNS falls back to TCP when DNS query responses are too big, and Istio tries to use mTLS to connect to kube-dns when `values.global.mtls.auto=false` and `values.global.mtls.enabled=true`.  mTLS needs to be disabled to `kube-dns.kube-system` for DNS to work properly over TCP.

I had a PR for istio/installer, but it wasn't merged in time for the move of installer stuff to this repo.