### PR TITLE
Fix BUILD_WITH_CONTAINER=1 make init on MacOS to build MacOS binary

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -212,7 +212,7 @@ init: $(ISTIO_OUT)/istio_is_init
 # lock file, but it caused the rule for that file to get run (which
 # seems to be about obtaining a new version of the 3rd party libraries).
 $(ISTIO_OUT)/istio_is_init: bin/init.sh istio.deps | $(ISTIO_OUT)
-	ISTIO_OUT=$(ISTIO_OUT) ISTIO_BIN=$(ISTIO_BIN) bin/init.sh
+	ISTIO_OUT=$(ISTIO_OUT) ISTIO_BIN=$(ISTIO_BIN) GOOS_LOCAL=$(GOOS_LOCAL) bin/init.sh
 	touch $(ISTIO_OUT)/istio_is_init
 
 # init.sh downloads envoy and webassembly plugins

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -31,21 +31,6 @@ export ISTIO_BIN=${ISTIO_BIN:-${GOPATH}/bin}
 # Set the architecture. Matches logic in the Makefile.
 export GOARCH=${GOARCH:-'amd64'}
 
-# Determine the OS. Matches logic in the Makefile.
-LOCAL_OS=${LOCAL_OS:-"$(uname)"}
-case ${LOCAL_OS} in
-  'Linux')
-    export GOOS=${GOOS:-"linux"}
-    ;;
-  'Darwin')
-    export GOOS=${GOOS:-"darwin"}
-    ;;
-  *)
-    echo "This system's OS ${LOCAL_OS} isn't recognized/supported"
-    exit 1
-    ;;
-esac
-
 # test scripts seem to like to run this script directly rather than use make
 export ISTIO_OUT=${ISTIO_OUT:-${ISTIO_BIN}}
 
@@ -183,7 +168,7 @@ if [[ ${USE_LOCAL_PROXY} == 1 ]] ; then
   fi
 
   # Point the native paths to the local envoy build.
-  if [[ "$LOCAL_OS" == "Darwin" ]]; then
+  if [[ "$GOOS_LOCAL" == "darwin" ]]; then
     ISTIO_ENVOY_MACOS_RELEASE_PATH=${ISTIO_ENVOY_LOCAL_PATH}
 
     ISTIO_ENVOY_LINUX_LOCAL_PATH=${ISTIO_ENVOY_LINUX_LOCAL_PATH:-}
@@ -214,7 +199,7 @@ fi
 # Download and extract the Envoy linux release binary.
 download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_RELEASE_URL}" "$ISTIO_ENVOY_LINUX_RELEASE_PATH"
 
-if [[ "$LOCAL_OS" == "Darwin" ]]; then
+if [[ "$GOOS_LOCAL" == "darwin" ]]; then
   # Download and extract the Envoy macOS release binary
   download_envoy_if_necessary "${ISTIO_ENVOY_MACOS_RELEASE_URL}" "$ISTIO_ENVOY_MACOS_RELEASE_PATH"
   ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_MACOS_RELEASE_PATH}


### PR DESCRIPTION
Today, if I do a `BUILD_WITH_CONTAINER=1 make init` on my make the resulting executable in the _darwin_ output direct is a linux executable:
```
make init                                                                                                                                                                 
Building with your local toolchain.
ISTIO_OUT=/Users/ericvn/work/go/src/istio.io/istio/out/darwin_amd64 ...

file out/darwin_amd64/*                                                                                                                                                         
out/darwin_amd64/envoy:         ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, not stripped
out/darwin_amd64/istio_is_init: empty
out/darwin_amd64/logs:          directory
out/darwin_amd64/release:       directory 
```

This PR fixes that:
```
...
file out/darwin_amd64/*                                                                                                                                                     
out/darwin_amd64/envoy:         Mach-O 64-bit executable x86_64
out/darwin_amd64/istio_is_init: empty
out/darwin_amd64/logs:          directory
out/darwin_amd64/release:       directory
```