### PR TITLE
Don't create linux binaries unless needed on non linux hosts

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -276,17 +276,8 @@ BINARIES:=./istioctl/cmd/istioctl \
 # List of binaries included in releases
 RELEASE_BINARIES:=pilot-discovery pilot-agent sidecar-injector mixc mixs mixgen node_agent node_agent_k8s istio_ca istioctl galley sdsclient
 
-# We always build Linux containers even if not running in a Linux. Linux binaries
-# are needed for packaging in Docker. On other GOOS_LOCAL, such as darwin, we need
-# to specially build Linux binaries. Otherwise, the default build target will build
-# Linux on Linux platforms.
-BUILD_DEPS:=
-ifneq ($(GOOS_LOCAL),"linux")
-BUILD_DEPS += build-linux
-endif
-
 .PHONY: build
-build: depend $(BUILD_DEPS)
+build: depend
 	STATIC=0 GOOS=$(GOOS_LOCAL) GOARCH=$(GOARCH_LOCAL) LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh $(ISTIO_OUT)/ $(BINARIES)
 
 # The build-linux target is responsible for building binaries used within containers.


### PR DESCRIPTION
Note that with this PR a `make build` only generates the host OS version of the binaries. If you later run `make docker` for example, the linux binaries are built.