### PR TITLE
Make operator tests default for integration tests

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -67,7 +67,7 @@ var (
 		PolicyNamespace:                DefaultSystemNamespace,
 		IngressNamespace:               DefaultSystemNamespace,
 		EgressNamespace:                DefaultSystemNamespace,
-		Operator:                       false,
+		Operator:                       true,
 		DeployIstio:                    true,
 		DeployTimeout:                  0,
 		UndeployTimeout:                0,

--- a/tests/integration/conformance/main_test.go
+++ b/tests/integration/conformance/main_test.go
@@ -38,13 +38,13 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("conformance_test", m).
 		SetupOnEnv(environment.Kube, istio.Setup(nil, func(cfg *istio.Config) {
-		cfg.ControlPlaneValues = `
+			cfg.ControlPlaneValues = `
 components:
   galley:
     enabled: true
   citadel:
     enabled: true
 `
-	})).
+		})).
 		Run()
 }

--- a/tests/integration/conformance/main_test.go
+++ b/tests/integration/conformance/main_test.go
@@ -37,6 +37,14 @@ func loadCases() ([]*conformance.Test, error) {
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite("conformance_test", m).
-		SetupOnEnv(environment.Kube, istio.Setup(nil, nil)).
+		SetupOnEnv(environment.Kube, istio.Setup(nil, func(cfg *istio.Config) {
+		cfg.ControlPlaneValues = `
+components:
+  galley:
+    enabled: true
+  citadel:
+    enabled: true
+`
+	})).
 		Run()
 }

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -80,6 +80,18 @@ test.integration.%.kube.presubmit: istioctl | $(JUNIT_REPORT)
 	${_INTEGRATION_TEST_INGRESS_FLAG} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
+test.integration.istioio.kube.presubmit: istioctl | $(JUNIT_REPORT)
+	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ./tests/integration/istioio/... ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
+	--istio.test.select -postsubmit,-flaky \
+	--istio.test.kube.operator=false
+	--istio.test.env kube \
+	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
+	--istio.test.hub=${HUB} \
+	--istio.test.tag=${TAG} \
+	--istio.test.pullpolicy=${_INTEGRATION_TEST_PULL_POLICY} \
+	${_INTEGRATION_TEST_INGRESS_FLAG} \
+	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
+
 test.integration.istioio.kube.postsubmit: test.integration.istioio.kube.presubmit
 	SNIPPETS_GCS_PATH="istio-snippets/$(shell git rev-parse HEAD)" prow/upload-istioio-snippets.sh
 

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -38,13 +38,6 @@ ifneq ($(INTEGRATION_TEST_WORKDIR),)
     _INTEGRATION_TEST_WORKDIR_FLAG = --istio.test.work_dir $(INTEGRATION_TEST_WORKDIR)
 endif
 
-# $(_INTEGRATION_TEST_INSTALL_TYPE) specifies the installation type for a test.
-# Useful to override individual targets, as right now the makefile doesn't easily allow this
-_INTEGRATION_TEST_INSTALL_TYPE =
-ifneq ($(TEST_USE_OPERATOR),)
-    _INTEGRATION_TEST_INSTALL_TYPE = --istio.test.kube.operator
-endif
-
 # $(INTEGRATION_TEST_KUBECONFIG) specifies the kube config file to be used. If not specified, then
 # ~/.kube/config is used.
 # TODO: This probably needs to be more intelligent and take environment variables into account.
@@ -62,64 +55,12 @@ test.integration.%.kube: | $(JUNIT_REPORT)
 	--istio.test.tag=${TAG} \
 	--istio.test.pullpolicy=${_INTEGRATION_TEST_PULL_POLICY} \
 	${_INTEGRATION_TEST_INGRESS_FLAG} \
-	${_INTEGRATION_TEST_INSTALL_TYPE} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 # Test targets to run with the new installer. Some targets are filtered now as they are not yet working
 NEW_INSTALLER_TARGETS = $(shell GOPATH=${GOPATH} go list ../istio/tests/integration/... | grep -v "/mixer\|telemetry/tracing\|/istioctl\|/istioio")
 
-# TODO: Exclude examples and qualification since they are very flaky.
 TEST_PACKAGES = $(shell go list ./tests/integration/... | grep -v /qualification | grep -v /examples)
-
-# Various tests have issues with the operator currently
-# When running in operator mode, skip these tests, until these issues are resolved:
-# /sds_citadel_control_plane_auth_disabled: https://github.com/istio/istio/issues/19109
-# /sds_citadel_flow: https://github.com/istio/istio/issues/19109
-# /pilot/ingress: https://github.com/istio/istio/issues/19352
-# /telemetry/metrics: https://github.com/istio/istio/issues/19352
-# /istioio: These tests are tightly coupled to installation method
-OPERATOR_TEST_PACKAGES = $(shell go list ./tests/integration/... \
-  | grep -v /qualification \
-  | grep -v /examples \
-  | grep -v /sds_citadel_control_plane_auth_disabled \
-  | grep -v /sds_citadel_flow \
-  | grep -v /pilot/ingress \
-  | grep -v /telemetry/metrics \
-  | grep -v /istioio \
-)
-
-test.integration.operator: $(JUNIT_REPORT)
-	$(GO) test -p 1 ${T} ${OPERATOR_TEST_PACKAGES} ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
-	--istio.test.select -postsubmit,-flaky \
-	--istio.test.env kube \
-	--istio.test.kube.operator \
-	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
-	--istio.test.hub=${HUB} \
-	--istio.test.tag=${TAG} \
-	--istio.test.pullpolicy=${_INTEGRATION_TEST_PULL_POLICY} \
-	${_INTEGRATION_TEST_INGRESS_FLAG} \
-	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
-
-# Runs tests using the new installer. Istio is deployed before the test and setup and cleanup are disabled.
-# For this to work, the -customsetup selector is used.
-test.integration.new.installer: istioctl | $(JUNIT_REPORT)
-	KUBECONFIG=${INTEGRATION_TEST_KUBECONFIG} ${ISTIO_OUT}/istioctl manifest apply \
-		--set hub=${HUB} \
-		--set tag=${TAG} \
-		--skip-confirmation \
-		--logtostderr \
-		--set values.global.imagePullPolicy=${_INTEGRATION_TEST_PULL_POLICY}
-	$(GO) test -p 1 ${T} ${NEW_INSTALLER_TARGETS} ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
-	--istio.test.kube.deploy=false \
-	--istio.test.select -postsubmit,-flaky,-customsetup \
-	--istio.test.kube.minikube \
-	--istio.test.env kube \
-	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
-	--istio.test.hub=${HUB} \
-	--istio.test.tag=${TAG} \
-	--istio.test.pullpolicy=${_INTEGRATION_TEST_PULL_POLICY} \
-	${_INTEGRATION_TEST_INGRESS_FLAG} \
-	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 # Generate integration test targets for local environment.
 test.integration.%.local: | $(JUNIT_REPORT)
@@ -137,7 +78,6 @@ test.integration.%.kube.presubmit: istioctl | $(JUNIT_REPORT)
 	--istio.test.tag=${TAG} \
 	--istio.test.pullpolicy=${_INTEGRATION_TEST_PULL_POLICY} \
 	${_INTEGRATION_TEST_INGRESS_FLAG} \
-	${_INTEGRATION_TEST_INSTALL_TYPE} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 test.integration.istioio.kube.postsubmit: test.integration.istioio.kube.presubmit
@@ -171,7 +111,6 @@ test.integration.kube: istioctl | $(JUNIT_REPORT)
 	--istio.test.tag=${TAG} \
 	--istio.test.pullpolicy=${_INTEGRATION_TEST_PULL_POLICY} \
 	${_INTEGRATION_TEST_INGRESS_FLAG} \
-	${_INTEGRATION_TEST_INSTALL_TYPE} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 # Presubmit integration tests targeting Kubernetes environment.
@@ -185,7 +124,6 @@ test.integration.kube.presubmit: istioctl | $(JUNIT_REPORT)
 	--istio.test.tag=${TAG} \
 	--istio.test.pullpolicy=${_INTEGRATION_TEST_PULL_POLICY} \
 	${_INTEGRATION_TEST_INGRESS_FLAG} \
-	${_INTEGRATION_TEST_INSTALL_TYPE} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 # Integration tests that detect race condition for native environment.


### PR DESCRIPTION
Per environment WG decision, we will be aggressively dropping helm support ASAP after the 1.5 branch is cut