### PR TITLE
Support distroless in test framework

### DIFF
--- a/install/kubernetes/helm/istio/test-values/values-integ.yaml
+++ b/install/kubernetes/helm/istio/test-values/values-integ.yaml
@@ -9,7 +9,6 @@ global:
         memory: 40Mi
 
     accessLogFile: "/dev/stdout"
-    enableCoreDump: true
 
   outboundTrafficPolicy:
     mode: REGISTRY_ONLY

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -13,6 +13,8 @@ USER 1337:1337
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless
 
+WORKDIR /
+
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -28,8 +28,8 @@ COPY --from=default /etc/iproute2 /etc/iproute2
 COPY istio-iptables /usr/local/bin/istio-iptables
 
 # Copy Envoy bootstrap templates used by pilot-agent
-COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+COPY --chown=nonroot:nonroot envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+COPY --chown=nonroot:nonroot gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 
 WORKDIR /
 

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -31,6 +31,8 @@ COPY istio-iptables /usr/local/bin/istio-iptables
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 
+WORKDIR /
+
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}

--- a/pkg/test/framework/components/echo/kube/sidecar.go
+++ b/pkg/test/framework/components/echo/kube/sidecar.go
@@ -35,7 +35,6 @@ import (
 
 const (
 	proxyContainerName = "istio-proxy"
-	proxyAdminPort     = 15000
 )
 
 var _ echo.Sidecar = &sidecar{}
@@ -164,7 +163,7 @@ func (s *sidecar) ListenersOrFail(t test.Failer) *envoyAdmin.Listeners {
 
 func (s *sidecar) adminRequest(path string, out proto.Message) error {
 	// Exec onto the pod and make a curl request to the admin port, writing
-	command := fmt.Sprintf("curl http://127.0.0.1:%d/%s", proxyAdminPort, path)
+	command := fmt.Sprintf("pilot-agent request GET %s", path)
 	response, err := s.accessor.Exec(s.podNamespace, s.podName, proxyContainerName, command)
 	if err != nil {
 		return fmt.Errorf("failed exec on pod %s/%s: %v. Command: %s. Output:\n%s",

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -90,4 +90,9 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
   time kind_load_images ""
 fi
 
+# If a variant is defined, update the tag accordingly
+if [[ "${VARIANT:-}" != "" ]]; then
+  export TAG="${TAG}-${VARIANT}"
+fi
+
 make "${PARAMS[*]}"

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -33,6 +33,9 @@ set -x
 source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
 
+# Temporary, for testing
+export VARIANT=distroless
+
 while (( "$#" )); do
   case "$1" in
     # Node images can be found at https://github.com/kubernetes-sigs/kind/releases

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -194,3 +194,17 @@ test.integration.race.native: | $(JUNIT_REPORT)
 	$(GO) test -race -p 1 ${T} ${TEST_PACKAGES} -timeout 120m \
 	--istio.test.env native \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
+
+# Defines a target to run a minimal reachability testing basic traffic
+.PHONY: test.integration.kube.reachability
+test.integration.kube.reachability: istioctl | $(JUNIT_REPORT)
+	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ./tests/integration/security/ ${_INTEGRATION_TEST_WORK_DIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
+	--istio.test.env kube \
+	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
+	--istio.test.hub=${HUB} \
+	--istio.test.tag=${TAG} \
+	--test.run=TestReachability \
+	--istio.test.pullpolicy=${_INTEGRATION_TEST_PULL_POLICY} \
+	${_INTEGRATION_TEST_INGRESS_FLAG} \
+	${_INTEGRATION_TEST_INSTALL_TYPE} \
+	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))


### PR DESCRIPTION
For https://github.com/istio/istio/issues/20335

This also happens to fix distroless with istiod, which was broken due to mounts in `./...` and workdir not `/`