### PR TITLE
Allow disabling of cluster roles creation in helm

### DIFF
--- a/install/kubernetes/helm/istio/example-values/values-istio-gateways.yaml
+++ b/install/kubernetes/helm/istio/example-values/values-istio-gateways.yaml
@@ -22,6 +22,13 @@ global:
       host: # example: statsd-svc.istio-system
       port: # example: 9125
 
+  # Omit creation of cluster when generate standalone gateway.
+  # Cluster role already have been creating when other components have been
+  # installed
+  rbac:
+    clusterRole:
+      create: false
+
 
 #
 # Gateways Configuration

--- a/install/kubernetes/helm/istio/example-values/values-istio-gateways.yaml
+++ b/install/kubernetes/helm/istio/example-values/values-istio-gateways.yaml
@@ -22,9 +22,9 @@ global:
       host: # example: statsd-svc.istio-system
       port: # example: 9125
 
-  # Omit creation of cluster when generate standalone gateway.
-  # Cluster role already have been creating when other components have been
-  # installed
+  # Omit creation of cluster roles when generate standalone gateway.
+  # Cluster roles have already been created alongside other components
+  # installation
   rbac:
     clusterRole:
       create: false

--- a/install/kubernetes/helm/istio/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.clusterRole.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -9,3 +10,4 @@ rules:
   - apiGroups: ["extensions", "apps"]
     resources: ["replicasets"]
     verbs: ["get", "list", "watch"]
+{{- end }}

--- a/install/kubernetes/helm/istio/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.clusterRole.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -27,3 +28,4 @@ subjects:
 - kind: ServiceAccount
   name: istio-reader
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -622,3 +622,9 @@ global:
   # webhook configurations. When this option is set as false, webhooks manage their
   # own webhook configurations.
   operatorManageWebhooks: false
+
+  # Configure whether the cluster roles and their bindings are created.
+  # This allows to create gateways, after installing other components.
+  rbac:
+    clusterRole:
+      create: true

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -624,7 +624,7 @@ global:
   operatorManageWebhooks: false
 
   # Configure whether the cluster roles and their bindings are created.
-  # This allows to create gateways, after installing other components.
+  # This allows to create gateways after installing other components.
   rbac:
     clusterRole:
       create: true


### PR DESCRIPTION
This is required if a user want to create gateways, after having
installed other istio components

I have currently a problem when I want to install separately the gateways from the other components of istio, I get an error because the ClusterRole already exists:

`Error: release istio-gateways failed: clusterroles.rbac.authorization.k8s.io "istio-reader" already exists`

Since their is no way to disable creation of cluster roles and their binding, I cannot install gateways after. This PR provides a way to disable the creation of these cluster roles.

If possible can this modification be cherry-picked on older versions of istio (1.2, 1.3 and 1.4)