### PR TITLE
Remove sdsStatus, sds profile has been removed

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller_test.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller_test.go
@@ -60,14 +60,6 @@ var (
 		string(name.EgressComponentName):    healthyVersionStatus,
 		string(name.AddonComponentName):     healthyVersionStatus,
 	}
-	sdsStatus = map[string]*v1alpha1.InstallStatus_VersionStatus{
-		string(name.IstioBaseComponentName): healthyVersionStatus,
-		string(name.PilotComponentName):     healthyVersionStatus,
-		string(name.TelemetryComponentName): healthyVersionStatus,
-		string(name.NodeAgentComponentName): healthyVersionStatus,
-		string(name.IngressComponentName):   healthyVersionStatus,
-		string(name.AddonComponentName):     healthyVersionStatus,
-	}
 )
 
 type testCase struct {


### PR DESCRIPTION
This removes some dead code that was removed with the sds profile in #20418 and accidentally re-introduced in #20417

[x] Installation