### PR TITLE
Enable istioctl manifest --log_output_level

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -73,6 +73,7 @@ func defaultLogOptions() *log.Options {
 	o.SetOutputLevel("source", log.ErrorLevel)
 	o.SetOutputLevel("analysis", log.WarnLevel)
 	o.SetOutputLevel("installer", log.WarnLevel)
+	o.SetOutputLevel("translator", log.WarnLevel)
 
 	return o
 }

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -72,9 +72,7 @@ func defaultLogOptions() *log.Options {
 	o.SetOutputLevel("processing", log.ErrorLevel)
 	o.SetOutputLevel("source", log.ErrorLevel)
 	o.SetOutputLevel("analysis", log.WarnLevel)
-	o.SetOutputLevel("kubectlcmd", log.WarnLevel)
 	o.SetOutputLevel("installer", log.WarnLevel)
-	o.SetOutputLevel("helm", log.WarnLevel)
 
 	return o
 }

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -72,6 +72,9 @@ func defaultLogOptions() *log.Options {
 	o.SetOutputLevel("processing", log.ErrorLevel)
 	o.SetOutputLevel("source", log.ErrorLevel)
 	o.SetOutputLevel("analysis", log.WarnLevel)
+	o.SetOutputLevel("kubectlcmd", log.WarnLevel)
+	o.SetOutputLevel("installer", log.WarnLevel)
+	o.SetOutputLevel("helm", log.WarnLevel)
 
 	return o
 }

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -38,8 +38,6 @@ func configLogs(logToStdErr bool) error {
 	opt := log.DefaultOptions()
 	if logToStdErr {
 		opt.OutputPaths = []string{"stderr"}
-	} else {
-		opt.SetOutputLevel(log.OverrideScopeName, log.NoneLevel)
 	}
 	return log.Configure(opt)
 }

--- a/operator/pkg/helm/fs_renderer.go
+++ b/operator/pkg/helm/fs_renderer.go
@@ -19,8 +19,6 @@ import (
 
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/proto/hapi/chart"
-
-	"istio.io/pkg/log"
 )
 
 // FileTemplateRenderer is a helm template renderer for a local filesystem.
@@ -35,7 +33,7 @@ type FileTemplateRenderer struct {
 // NewFileTemplateRenderer creates a TemplateRenderer with the given parameters and returns a pointer to it.
 // helmChartDirPath must be an absolute file path to the root of the helm charts.
 func NewFileTemplateRenderer(helmChartDirPath, componentName, namespace string) *FileTemplateRenderer {
-	log.Infof("NewFileTemplateRenderer with helmChart=%s, componentName=%s", helmChartDirPath, componentName)
+	scope.Infof("NewFileTemplateRenderer with helmChart=%s, componentName=%s", helmChartDirPath, componentName)
 	return &FileTemplateRenderer{
 		namespace:        namespace,
 		componentName:    componentName,
@@ -45,7 +43,7 @@ func NewFileTemplateRenderer(helmChartDirPath, componentName, namespace string) 
 
 // Run implements the TemplateRenderer interface.
 func (h *FileTemplateRenderer) Run() error {
-	log.Infof("Run FileTemplateRenderer with helmChart=%s, componentName=%s", h.helmChartDirPath, h.componentName)
+	scope.Infof("Run FileTemplateRenderer with helmChart=%s, componentName=%s", h.helmChartDirPath, h.componentName)
 	if err := h.loadChart(); err != nil {
 		return err
 	}

--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -44,7 +44,7 @@ const (
 )
 
 var (
-	scope = log.RegisterScope("helm", "helm", 0)
+	scope = log.RegisterScope("installer", "installer", 0)
 )
 
 // TemplateRenderer defines a helm template renderer interface.

--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -43,6 +43,10 @@ const (
 	NotesFileNameSuffix = ".txt"
 )
 
+var (
+	scope = log.RegisterScope("helm", "helm", 0)
+)
+
 // TemplateRenderer defines a helm template renderer interface.
 type TemplateRenderer interface {
 	// Run starts the renderer and should be called before using it.
@@ -74,9 +78,9 @@ func ReadProfileYAML(profile string) (string, error) {
 	var err error
 	var globalValues string
 	if profile == "" {
-		log.Infof("ReadProfileYAML for profile name: [Empty]")
+		scope.Infof("ReadProfileYAML for profile name: [Empty]")
 	} else {
-		log.Infof("ReadProfileYAML for profile name: %s", profile)
+		scope.Infof("ReadProfileYAML for profile name: %s", profile)
 	}
 
 	// Get global values from profile.
@@ -86,7 +90,7 @@ func ReadProfileYAML(profile string) (string, error) {
 			return "", err
 		}
 	case util.IsFilePath(profile):
-		log.Infof("Loading values from local filesystem at path %s", profile)
+		scope.Infof("Loading values from local filesystem at path %s", profile)
 		if globalValues, err = readFile(profile); err != nil {
 			return "", err
 		}

--- a/operator/pkg/helm/urlfetcher.go
+++ b/operator/pkg/helm/urlfetcher.go
@@ -30,7 +30,6 @@ import (
 
 	"istio.io/istio/operator/pkg/httprequest"
 	"istio.io/istio/operator/pkg/util"
-	"istio.io/pkg/log"
 )
 
 const (
@@ -126,7 +125,7 @@ func (f *URLFetcher) fetchChart(shaF string) error {
 		hash := strings.Split(string(hashAll), " ")[0]
 		h := sha256.New()
 		if _, err := io.Copy(h, file); err != nil {
-			log.Error(err.Error())
+			scope.Error(err.Error())
 		}
 		sum := h.Sum(nil)
 		actualHash := hex.EncodeToString(sum)

--- a/operator/pkg/helm/urlwatcher.go
+++ b/operator/pkg/helm/urlwatcher.go
@@ -20,8 +20,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"istio.io/pkg/log"
 )
 
 // URLPoller is used to poll files from remote url at specific internal
@@ -61,10 +59,10 @@ func (p *URLPoller) checkUpdate() (bool, error) {
 func (p *URLPoller) poll(notify chan<- struct{}) {
 	for t := range p.ticker.C {
 		// When the ticker fires
-		log.Debugf("Tick at: %s", t)
+		scope.Debugf("Tick at: %s", t)
 		updated, err := p.checkUpdate()
 		if err != nil {
-			log.Errorf("Error polling charts: %v", err)
+			scope.Errorf("Error polling charts: %v", err)
 		}
 		if updated {
 			notify <- struct{}{}
@@ -90,13 +88,13 @@ func NewPoller(installationURL string, destDir string, interval time.Duration) (
 func PollURL(installationURL string, interval time.Duration) (chan<- struct{}, error) {
 	destDir, err := ioutil.TempDir("", InstallationDirectory)
 	if err != nil {
-		log.Error("failed to create temp directory for charts")
+		scope.Error("failed to create temp directory for charts")
 		return nil, err
 	}
 
 	po, err := NewPoller(installationURL, destDir, interval)
 	if err != nil {
-		log.Fatalf("failed to create new poller for: %s", err)
+		scope.Fatalf("failed to create new poller for: %s", err)
 	}
 	updated := make(chan struct{}, 1)
 	go po.poll(updated)

--- a/operator/pkg/helm/vfs_renderer.go
+++ b/operator/pkg/helm/vfs_renderer.go
@@ -24,8 +24,6 @@ import (
 
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/vfs"
-
-	"istio.io/pkg/log"
 )
 
 const (
@@ -64,7 +62,7 @@ type VFSRenderer struct {
 // NewVFSRenderer creates a VFSRenderer with the given relative path to helm charts, component name and namespace and
 // a base values YAML string.
 func NewVFSRenderer(helmChartDirPath, componentName, namespace string) *VFSRenderer {
-	log.Debugf("NewVFSRenderer with helmChart=%s, componentName=%s, namespace=%s", helmChartDirPath, componentName, namespace)
+	scope.Debugf("NewVFSRenderer with helmChart=%s, componentName=%s, namespace=%s", helmChartDirPath, componentName, namespace)
 	return &VFSRenderer{
 		namespace:        namespace,
 		componentName:    componentName,
@@ -74,7 +72,7 @@ func NewVFSRenderer(helmChartDirPath, componentName, namespace string) *VFSRende
 
 // Run implements the TemplateRenderer interface.
 func (h *VFSRenderer) Run() error {
-	log.Debugf("Run VFSRenderer with helmChart=%s, componentName=%s, namespace=%s", h.helmChartDirPath, h.componentName, h.namespace)
+	scope.Debugf("Run VFSRenderer with helmChart=%s, componentName=%s, namespace=%s", h.helmChartDirPath, h.componentName, h.namespace)
 	if err := h.loadChart(); err != nil {
 		return err
 	}
@@ -94,7 +92,7 @@ func (h *VFSRenderer) RenderManifest(values string) (string, error) {
 // LoadValuesVFS loads the compiled in file corresponding to the given profile name.
 func LoadValuesVFS(profileName string) (string, error) {
 	path := filepath.Join(profilesRoot, BuiltinProfileToFilename(profileName))
-	log.Infof("Loading values from compiled in VFS at path %s", path)
+	scope.Infof("Loading values from compiled in VFS at path %s", path)
 	b, err := vfs.ReadFile(path)
 	return string(b), err
 }
@@ -126,7 +124,7 @@ func (h *VFSRenderer) loadChart() error {
 			Data: b,
 		}
 		bfs = append(bfs, bf)
-		log.Debugf("Chart loaded: %s", bf.Name)
+		scope.Debugf("Chart loaded: %s", bf.Name)
 	}
 
 	h.chart, err = chartutil.LoadFiles(bfs)

--- a/operator/pkg/kubectlcmd/client.go
+++ b/operator/pkg/kubectlcmd/client.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	scope = log.RegisterScope("kubectlcmd", "kubectlcmd", 0)
+	scope = log.RegisterScope("installer", "installer", 0)
 )
 
 // New creates a Client that runs kubectl available on the path with default authentication

--- a/operator/pkg/kubectlcmd/client.go
+++ b/operator/pkg/kubectlcmd/client.go
@@ -27,6 +27,10 @@ import (
 	"istio.io/pkg/log"
 )
 
+var (
+	scope = log.RegisterScope("kubectlcmd", "kubectlcmd", 0)
+)
+
 // New creates a Client that runs kubectl available on the path with default authentication
 func New() *Client {
 	return &Client{cmdSite: &console{}}
@@ -71,7 +75,7 @@ type Options struct {
 // It returns stdout, stderr from the `kubectl` command as strings, and error for errors external to kubectl.
 func (c *Client) Apply(manifest string, opts *Options) (string, string, error) {
 	if strings.TrimSpace(manifest) == "" {
-		log.Infof("Empty manifest, not running kubectl apply.")
+		scope.Infof("Empty manifest, not running kubectl apply.")
 		return "", "", nil
 	}
 	subcmds := []string{"apply"}
@@ -83,7 +87,7 @@ func (c *Client) Apply(manifest string, opts *Options) (string, string, error) {
 // It returns stdout, stderr from the `kubectl` command as strings, and error for errors external to kubectl.
 func (c *Client) Delete(manifest string, opts *Options) (string, string, error) {
 	if strings.TrimSpace(manifest) == "" {
-		log.Infof("Empty manifest, not running kubectl delete.")
+		scope.Infof("Empty manifest, not running kubectl delete.")
 		return "", "", nil
 	}
 	subcmds := []string{"delete"}
@@ -145,20 +149,20 @@ func (c *Client) kubectl(subcmds []string, opts *Options) (string, string, error
 	}
 
 	if opts.DryRun {
-		log.Infof("dry run mode: would be running this cmd:\n%s\n", cmdStr)
+		scope.Infof("dry run mode: would be running this cmd:\n%s\n", cmdStr)
 		return "", "", nil
 	}
 
-	log.Infof("running command:\n%s\n", cmdStr)
+	scope.Infof("running command:\n%s\n", cmdStr)
 	err := c.cmdSite.Run(cmd)
 	csError := util.ConsolidateLog(stderr.String())
 
 	if err != nil {
-		log.Errorf("error running kubectl: %s", err)
+		scope.Errorf("error running kubectl: %s", err)
 		return stdout.String(), csError, fmt.Errorf("error running kubectl: %s", err)
 	}
 
-	log.Infof("command succeeded: %s", cmdStr)
+	scope.Infof("command succeeded: %s", cmdStr)
 
 	return stdout.String(), csError, nil
 }

--- a/operator/pkg/manifest/installer.go
+++ b/operator/pkg/manifest/installer.go
@@ -72,6 +72,8 @@ var (
 	istioComponentLabelStr = name.OperatorAPINamespace + "/component"
 	// istioVersionLabelStr indicates the Istio version of the installation.
 	istioVersionLabelStr = name.OperatorAPINamespace + "/version"
+
+	scope = log.RegisterScope("installer", "installer", 0)
 )
 
 // ComponentApplyOutput is used to capture errors and stdout/stderr outputs for a command, per component.
@@ -199,11 +201,11 @@ func renderRecursive(manifests name.ManifestMap, installTree componentTree, outp
 
 // ApplyAll applies all given manifests using kubectl client.
 func ApplyAll(manifests name.ManifestMap, version pkgversion.Version, opts *kubectlcmd.Options) (CompositeOutput, error) {
-	log.Infof("Preparing manifests for these components:")
+	scope.Infof("Preparing manifests for these components:")
 	for c := range manifests {
-		log.Infof("- %s", c)
+		scope.Infof("- %s", c)
 	}
-	log.Infof("Component dependencies tree: \n%s", installTreeString())
+	scope.Infof("Component dependencies tree: \n%s", installTreeString())
 	if err := InitK8SRestClient(opts.Kubeconfig, opts.Context); err != nil {
 		return nil, err
 	}
@@ -221,9 +223,9 @@ func applyRecursive(manifests name.ManifestMap, version pkgversion.Version, opts
 		wg.Add(1)
 		go func() {
 			if s := dependencyWaitCh[c]; s != nil {
-				log.Infof("%s is waiting on a prerequisite...", c)
+				scope.Infof("%s is waiting on a prerequisite...", c)
 				<-s
-				log.Infof("Prerequisite for %s has completed, proceeding with install.", c)
+				scope.Infof("Prerequisite for %s has completed, proceeding with install.", c)
 			}
 			applyOut, appliedObjects := ApplyManifest(c, strings.Join(m, helm.YAMLSeparator), version.String(), *opts)
 			mu.Lock()
@@ -235,12 +237,12 @@ func applyRecursive(manifests name.ManifestMap, version pkgversion.Version, opts
 			// For example, for the validation webhook to become ready, so we should wait for it always.
 			if len(componentDependencies[c]) > 0 {
 				if err := WaitForResources(appliedObjects, opts); err != nil {
-					log.Errorf("failed to wait for resource: %v", err)
+					scope.Errorf("failed to wait for resource: %v", err)
 				}
 			}
 			// Signal all the components that depend on us.
 			for _, ch := range componentDependencies[c] {
-				log.Infof("unblocking child %s.", ch)
+				scope.Infof("unblocking child %s.", ch)
 				dependencyWaitCh[ch] <- struct{}{}
 			}
 			wg.Done()
@@ -499,11 +501,11 @@ func objectsNotInLists(objects object.K8sObjects, lists ...object.K8sObjects) ob
 
 func waitForCRDs(objects object.K8sObjects, dryRun bool) error {
 	if dryRun {
-		log.Info("Not waiting for CRDs in dry run mode.")
+		scope.Info("Not waiting for CRDs in dry run mode.")
 		return nil
 	}
 
-	log.Info("Waiting for CRDs to be applied.")
+	scope.Info("Waiting for CRDs to be applied.")
 	cs, err := apiextensionsclient.NewForConfig(k8sRESTConfig)
 	if err != nil {
 		return fmt.Errorf("k8s client error: %s", err)
@@ -525,27 +527,27 @@ func waitForCRDs(objects object.K8sObjects, dryRun bool) error {
 				switch cond.Type {
 				case apiextensionsv1beta1.Established:
 					if cond.Status == apiextensionsv1beta1.ConditionTrue {
-						log.Infof("established CRD %q", crdName)
+						scope.Infof("established CRD %q", crdName)
 						continue descriptor
 					}
 				case apiextensionsv1beta1.NamesAccepted:
 					if cond.Status == apiextensionsv1beta1.ConditionFalse {
-						log.Warnf("name conflict: %v", cond.Reason)
+						scope.Warnf("name conflict: %v", cond.Reason)
 					}
 				}
 			}
-			log.Infof("missing status condition for %q", crdName)
+			scope.Infof("missing status condition for %q", crdName)
 			return false, nil
 		}
 		return true, nil
 	})
 
 	if errPoll != nil {
-		log.Errorf("failed to verify CRD creation; %s", errPoll)
+		scope.Errorf("failed to verify CRD creation; %s", errPoll)
 		return fmt.Errorf("failed to verify CRD creation: %s", errPoll)
 	}
 
-	log.Info("Finished applying CRDs.")
+	scope.Info("Finished applying CRDs.")
 	return nil
 }
 
@@ -817,6 +819,6 @@ func BuildClientConfig(kubeconfig, context string) (*rest.Config, error) {
 
 func logAndPrint(v ...interface{}) {
 	s := fmt.Sprintf(v[0].(string), v[1:]...)
-	log.Infof(s)
+	scope.Infof(s)
 	fmt.Println(s)
 }

--- a/operator/pkg/translate/translate.go
+++ b/operator/pkg/translate/translate.go
@@ -47,7 +47,7 @@ const (
 	HelmValuesNamespaceSubpath = "namespace"
 	// TranslateConfigFolder is the folder where we store translation configurations
 	TranslateConfigFolder = "translateConfig"
-	// translateConfig is the prefix of IstioOperator's translation configuration file
+	// TranslateConfigPrefix is the prefix of IstioOperator's translation configuration file
 	TranslateConfigPrefix = "translateConfig-"
 	// ICPToIOPConfigPrefix is the prefix of IstioControPlane-to-IstioOperator translation configuration file
 	ICPToIOPConfigPrefix = "translate-ICP-IOP-"
@@ -76,7 +76,7 @@ type Translator struct {
 	ComponentMaps map[name.ComponentName]*ComponentMaps `yaml:"componentMaps"`
 }
 
-// FeatureMaps is a set of mappings for an Istio feature.
+// FeatureMap is a set of mappings for an Istio feature.
 type FeatureMap struct {
 	// Components contains list of components that belongs to the current feature.
 	Components []name.ComponentName
@@ -128,9 +128,9 @@ func (t *Translator) OverlayK8sSettings(yml string, iop *v1alpha1.IstioOperatorS
 	if err != nil {
 		return "", err
 	}
-	log.Debugf("Manifest contains the following objects:")
+	scope.Debugf("Manifest contains the following objects:")
 	for _, o := range objects {
-		log.Debugf("%s", o.HashNameKind())
+		scope.Debugf("%s", o.HashNameKind())
 	}
 	// om is a map of kind:name string to Object ptr.
 	om := objects.ToNameKindMap()
@@ -140,30 +140,30 @@ func (t *Translator) OverlayK8sSettings(yml string, iop *v1alpha1.IstioOperatorS
 			return "", err
 		}
 		inPath = strings.Replace(inPath, "gressGateways.", "gressGateways."+fmt.Sprint(index)+".", 1)
-		log.Debugf("Checking for path %s in IstioOperatorSpec", inPath)
+		scope.Debugf("Checking for path %s in IstioOperatorSpec", inPath)
 		m, found, err := tpath.GetFromStructPath(iop, inPath)
 		if err != nil {
 			return "", err
 		}
 		if !found {
-			log.Debugf("path %s not found in IstioOperatorSpec, skip mapping.", inPath)
+			scope.Debugf("path %s not found in IstioOperatorSpec, skip mapping.", inPath)
 			continue
 		}
 		if mstr, ok := m.(string); ok && mstr == "" {
-			log.Debugf("path %s is empty string, skip mapping.", inPath)
+			scope.Debugf("path %s is empty string, skip mapping.", inPath)
 			continue
 		}
 		// Zero int values are due to proto3 compiling to scalars rather than ptrs. Skip these because values of 0 are
 		// the default in destination fields and need not be set explicitly.
 		if mint, ok := util.ToIntValue(m); ok && mint == 0 {
-			log.Debugf("path %s is int 0, skip mapping.", inPath)
+			scope.Debugf("path %s is int 0, skip mapping.", inPath)
 			continue
 		}
 		outPath, err := t.renderResourceComponentPathTemplate(v.OutPath, componentName)
 		if err != nil {
 			return "", err
 		}
-		log.Debugf("path has value in IstioOperatorSpec, mapping to output path %s", outPath)
+		scope.Debugf("path has value in IstioOperatorSpec, mapping to output path %s", outPath)
 		path := util.PathFromString(outPath)
 		pe := path[0]
 		// Output path must start with [kind:name], which is used to map to the object to overlay.
@@ -175,7 +175,7 @@ func (t *Translator) OverlayK8sSettings(yml string, iop *v1alpha1.IstioOperatorS
 		oo, ok := om[pe]
 		if !ok {
 			// skip to overlay the K8s settings if the corresponding resource doesn't exist.
-			log.Infof("resource Kind:name %s doesn't exist in the output manifest, skip overlay.", pe)
+			scope.Infof("resource Kind:name %s doesn't exist in the output manifest, skip overlay.", pe)
 			continue
 		}
 
@@ -248,7 +248,7 @@ func (t *Translator) TranslateHelmValues(iop *v1alpha1.IstioOperatorSpec, compon
 	}
 
 	if devDbg {
-		log.Infof("Values translated from IstioOperator API:\n%s", apiValsStr)
+		scope.Infof("Values translated from IstioOperator API:\n%s", apiValsStr)
 	}
 
 	// Add global overlay from IstioOperatorSpec.Values/UnvalidatedValues.
@@ -261,8 +261,8 @@ func (t *Translator) TranslateHelmValues(iop *v1alpha1.IstioOperatorSpec, compon
 		return "", err
 	}
 	if devDbg {
-		log.Infof("Values from IstioOperatorSpec.Values:\n%s", util.ToYAML(globalVals))
-		log.Infof("Values from IstioOperatorSpec.UnvalidatedValues:\n%s", util.ToYAML(globalUnvalidatedVals))
+		scope.Infof("Values from IstioOperatorSpec.Values:\n%s", util.ToYAML(globalVals))
+		scope.Infof("Values from IstioOperatorSpec.UnvalidatedValues:\n%s", util.ToYAML(globalUnvalidatedVals))
 	}
 	mergedVals, err := util.OverlayTrees(apiVals, globalVals)
 	if err != nil {


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/20430 by creating three new logging scopes, `kubectlcmd`, `installer`, and `helm`, having the Operator code log using these scopes, and setting the default log level for istioctl to WARN for these scopes.