### PR TITLE
Implement extra environment variables from ProxyMetadata

### DIFF
--- a/manifests/istio-control/istio-autoinject/files/injection-template.yaml
+++ b/manifests/istio-control/istio-autoinject/files/injection-template.yaml
@@ -302,6 +302,10 @@ template: |
         value: "{{ $value }}"
     {{- end }}
     {{- end }}
+    {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+      - name: {{ $key }}
+        value: "{{ $value }}"
+    {{- end }}
     imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
     {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
     readinessProbe:

--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -318,6 +318,10 @@ template: |
         value: "{{ $value }}"
     {{- end }}
     {{- end }}
+    {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+      - name: {{ $key }}
+        value: "{{ $value }}"
+    {{- end }}
     imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
     {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
     readinessProbe:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -8842,6 +8842,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:
@@ -9967,6 +9971,10 @@ data:
           - name: {{ $key }}
             value: "{{ $value }}"
         {{- end }}
+        {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
         {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
@@ -1181,6 +1181,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
@@ -1184,6 +1184,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
@@ -6934,6 +6934,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
@@ -7767,6 +7767,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
@@ -1178,6 +1178,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
@@ -7766,6 +7766,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
@@ -1178,6 +1178,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
@@ -1184,6 +1184,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.yaml
@@ -935,6 +935,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.yaml
@@ -1178,6 +1178,10 @@ data:
             value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -9630,6 +9630,10 @@ var _chartsIstioControlIstioAutoinjectFilesInjectionTemplateYaml = []byte(`templ
         value: "{{ $value }}"
     {{- end }}
     {{- end }}
+    {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+      - name: {{ $key }}
+        value: "{{ $value }}"
+    {{- end }}
     imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `+"`"+`Always`+"`"+` }}"
     {{ if ne (annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort) `+"`"+`0`+"`"+` }}
     readinessProbe:
@@ -12086,6 +12090,10 @@ template: |
       - name: {{ $key }}
         value: "{{ $value }}"
     {{- end }}
+    {{- end }}
+    {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+      - name: {{ $key }}
+        value: "{{ $value }}"
     {{- end }}
     imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `+"`"+`Always`+"`"+` }}"
     {{ if ne (annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort) `+"`"+`0`+"`"+` }}


### PR DESCRIPTION
We recently added this field in ProxyConfig which allows you to set
extra env vars on your proxy instances, but it doesn't look like we
plumbed it into the injection template.