### PR TITLE
Analyzer for v1alpha1 Authentication Policies using JWT targeting invalid k8s Services

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -33,6 +33,7 @@ func All() []analysis.Analyzer {
 	analyzers := []analysis.Analyzer{
 		// Please keep this list sorted alphabetically by pkg.name for convenience
 		&annotations.K8sAnalyzer{},
+		&auth.JwtAnalyzer{},
 		&auth.MTLSAnalyzer{},
 		&auth.ServiceRoleBindingAnalyzer{},
 		&auth.ServiceRoleServicesAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -83,10 +83,12 @@ var testGrid = []testCase{
 		inputFiles: []string{"testdata/jwt-invalid-service-port-name.yaml"},
 		analyzer:   &auth.JwtAnalyzer{},
 		expected: []message{
-			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy test-with-ports.my-namespace"},
-			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy test-without-ports.my-namespace-2"},
-			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy test-without-ports.my-namespace-2"},
-			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy test-with-udp-port.my-namespace-not-tcp"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-specified-ports.namespace-port-missing-prefix"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-without-specified-ports.namespace-port-missing-prefix"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-without-specified-ports.namespace-port-missing-prefix"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-udp-target-port.namespace-with-non-tcp-protocol"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-invalid-named-target-port.namespace-with-invalid-named-port"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-valid-named-target-port-invalid-protocol.namespace-with-valid-named-port-invalid-protocol"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -79,6 +79,25 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name:       "jwtTargetsInvalidServicePortName",
+		inputFiles: []string{"testdata/jwt-invalid-service-port-name.yaml"},
+		analyzer:   &auth.JwtAnalyzer{},
+		expected: []message{
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy default.my-namespace"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy default.my-namespace-2"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy default.my-namespace-2"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy default.my-namespace-not-tcp"},
+		},
+	},
+	{
+		name:       "jwtTargetsValidServicePortName",
+		inputFiles: []string{"testdata/jwt-valid-service-port-name.yaml"},
+		analyzer:   &auth.JwtAnalyzer{},
+		expected:   []message{
+			// port prefixes all pass
+		},
+	},
+	{
 		name:           "mtlsAnalyzerAutoMtlsSkips",
 		inputFiles:     []string{"testdata/mtls-global-dr-no-meshpolicy.yaml"},
 		meshConfigFile: "testdata/mesh-with-automtls.yaml",

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -83,10 +83,10 @@ var testGrid = []testCase{
 		inputFiles: []string{"testdata/jwt-invalid-service-port-name.yaml"},
 		analyzer:   &auth.JwtAnalyzer{},
 		expected: []message{
-			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy default.my-namespace"},
-			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy default.my-namespace-2"},
-			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy default.my-namespace-2"},
-			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy default.my-namespace-not-tcp"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy test-with-ports.my-namespace"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy test-without-ports.my-namespace-2"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy test-without-ports.my-namespace-2"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy test-with-udp-port.my-namespace-not-tcp"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/auth/jwt.go
+++ b/galley/pkg/config/analysis/analyzers/auth/jwt.go
@@ -1,0 +1,170 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+
+	"istio.io/api/authentication/v1alpha1"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/galley/pkg/config/resource"
+	"istio.io/istio/galley/pkg/config/schema/collection"
+	"istio.io/istio/galley/pkg/config/schema/collections"
+)
+
+const (
+	portNameHttp    = "http"
+	portNameHttp2   = "http2"
+	portNameHttps   = "https"
+	portPrefixHttp  = portNameHttp + "-"
+	portPrefixHttp2 = portNameHttp2 + "-"
+	portPrefixHttps = portNameHttps + "-"
+)
+
+// JwtAnalyzer checks for misconfiguration of an Authentication policy
+// that specifies a JWT, but the specified target host's K8s Service definition
+// does not have a named port that matches <protocol>[-<suffix>].
+type JwtAnalyzer struct{}
+
+// (compile-time check that we implement the interface)
+var _ analysis.Analyzer = &JwtAnalyzer{}
+
+// Metadata implements JwtAnalyzer
+func (j *JwtAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "injection.JwtAnalyzer",
+		Description: "Checks that jwt auth policies are against valid services",
+		Inputs: collection.Names{
+			collections.IstioAuthenticationV1Alpha1Policies.Name(),
+			collections.K8SCoreV1Services.Name(),
+		},
+	}
+}
+
+func (j *JwtAnalyzer) Analyze(c analysis.Context) {
+	nsm := j.buildNamespaceServiceMap(c)
+
+	c.ForEach(collections.IstioAuthenticationV1Alpha1Policies.Name(), func(r *resource.Instance) bool {
+		j.analyzeServiceTarget(r, c, nsm)
+		return true
+	})
+}
+
+// buildNamespaceServiceMap returns a map where the index is a namespace and the boolean
+func (j *JwtAnalyzer) buildNamespaceServiceMap(ctx analysis.Context) map[string]*v1.ServiceSpec {
+	// Keep track of each fqdn -> service definition
+	fqdnServices := map[string]*v1.ServiceSpec{}
+
+	ctx.ForEach(collections.K8SCoreV1Services.Name(), func(r *resource.Instance) bool {
+		svcNs := r.Metadata.FullName.Namespace
+		svcName := r.Metadata.FullName.Name
+
+		svc := r.Message.(*v1.ServiceSpec)
+		fqdn := util.ConvertHostToFQDN(svcNs, string(svcName))
+		fqdnServices[fqdn] = svc
+
+		return true
+	})
+
+	return fqdnServices
+}
+
+func (j *JwtAnalyzer) analyzeServiceTarget(r *resource.Instance, ctx analysis.Context, nsm map[string]*v1.ServiceSpec) {
+	policy := r.Message.(*v1alpha1.Policy)
+	ns := r.Metadata.FullName.Namespace
+
+	for _, origin := range policy.Origins {
+		if origin.GetJwt() != nil {
+			for _, target := range policy.GetTargets() {
+
+				fqdn := util.ConvertHostToFQDN(ns, target.GetName())
+				if svc, has := nsm[fqdn]; has {
+					if len(target.GetPorts()) == 0 {
+						checkServicePorts(r, ctx, svc)
+						continue
+					}
+
+					// check ports defined in the authentication policy for the service
+					for _, port := range target.GetPorts() {
+						if port.GetName() == "" {
+							checkPort(r, ctx, port.GetNumber(), svc)
+						}
+
+					}
+				} // else no target service was found, but not an error
+			}
+		}
+	}
+
+}
+
+func checkPort(r *resource.Instance, ctx analysis.Context, portNum uint32, svc *v1.ServiceSpec) {
+	var svcPort *v1.ServicePort
+	for _, port := range svc.Ports {
+		if strings.ToUpper(string(port.Protocol)) != "TCP" && port.Protocol != "" {
+			continue
+		}
+		if portNum == uint32(port.Port) {
+			svcPort = &port
+			break
+		}
+	}
+	if svcPort != nil {
+		portName := strings.ToLower(svcPort.Name)
+		if !portHasSupportedPrefix(portName) {
+			ctx.Report(collections.IstioAuthenticationV1Alpha1Policies.Name(),
+				msg.NewJwtFailureDueToInvalidServicePortPrefix(
+					r,
+					int(portNum),
+					portName,
+					string(svcPort.Protocol),
+					svcPort.TargetPort.String(),
+				))
+		}
+
+	}
+}
+
+func checkServicePorts(r *resource.Instance, ctx analysis.Context, svc *v1.ServiceSpec) {
+	for _, port := range svc.Ports {
+		portName := strings.ToLower(port.Name)
+		if (strings.ToUpper(string(port.Protocol)) == "TCP" || port.Protocol == "") &&
+			portHasSupportedPrefix(portName) {
+			continue
+		} else {
+			ctx.Report(collections.IstioAuthenticationV1Alpha1Policies.Name(),
+				msg.NewJwtFailureDueToInvalidServicePortPrefix(
+					r,
+					int(port.Port),
+					portName,
+					string(port.Protocol),
+					port.TargetPort.String(),
+				))
+
+		}
+	}
+}
+
+func portHasSupportedPrefix(portName string) bool {
+	return strings.HasPrefix(portName, portPrefixHttp) ||
+		strings.HasPrefix(portName, portPrefixHttp2) ||
+		strings.HasPrefix(portName, portPrefixHttps) ||
+		portName == portNameHttp || portName == portNameHttp2 || portName == portNameHttps
+}

--- a/galley/pkg/config/analysis/analyzers/testdata/jwt-invalid-service-port-name.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/jwt-invalid-service-port-name.yaml
@@ -1,0 +1,101 @@
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: test-with-ports
+  namespace: my-namespace
+spec:
+  targets:
+    - name: my-service
+      ports:
+        - number: 8080
+        - number: 8081
+        - number: 8082
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: my-namespace
+spec:
+  selector:
+    app: my-service
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: svc-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: https-svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: http2-svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: test-without-ports
+  namespace: my-namespace-2
+spec:
+  targets:
+    - name: my-service-no-target-ports-specified
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-no-target-ports-specified
+  namespace: my-namespace-2
+spec:
+  selector:
+    app: my-service-no-target-ports-specified
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: test-with-udp-port
+  namespace: my-namespace-not-tcp
+spec:
+  targets:
+    - name: my-service-no-target-ports-specified
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-no-target-ports-specified
+  namespace: my-namespace-not-tcp
+spec:
+  selector:
+    app: my-service-no-target-ports-specified
+  ports:
+    - protocol: UDP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+---

--- a/galley/pkg/config/analysis/analyzers/testdata/jwt-invalid-service-port-name.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/jwt-invalid-service-port-name.yaml
@@ -1,11 +1,11 @@
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: test-with-ports
-  namespace: my-namespace
+  name: policy-with-specified-ports
+  namespace: namespace-port-missing-prefix
 spec:
   targets:
-    - name: my-service
+    - name: my-service-port-missing-prefix
       ports:
         - number: 8080
         - number: 8081
@@ -18,8 +18,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: my-service
-  namespace: my-namespace
+  name: my-service-port-missing-prefix
+  namespace: namespace-port-missing-prefix
 spec:
   selector:
     app: my-service
@@ -27,7 +27,7 @@ spec:
     - protocol: TCP
       port: 8080
       targetPort: 8080
-      name: svc-8080
+      name: missingprefix-8080
     - protocol: TCP
       port: 8081
       targetPort: 8081
@@ -40,8 +40,8 @@ spec:
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: test-without-ports
-  namespace: my-namespace-2
+  name: policy-without-specified-ports
+  namespace: namespace-port-missing-prefix
 spec:
   targets:
     - name: my-service-no-target-ports-specified
@@ -54,7 +54,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: my-service-no-target-ports-specified
-  namespace: my-namespace-2
+  namespace: namespace-port-missing-prefix
 spec:
   selector:
     app: my-service-no-target-ports-specified
@@ -75,8 +75,8 @@ spec:
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: test-with-udp-port
-  namespace: my-namespace-not-tcp
+  name: policy-with-udp-target-port
+  namespace: namespace-with-non-tcp-protocol
 spec:
   targets:
     - name: my-service-no-target-ports-specified
@@ -89,7 +89,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: my-service-no-target-ports-specified
-  namespace: my-namespace-not-tcp
+  namespace: namespace-with-non-tcp-protocol
 spec:
   selector:
     app: my-service-no-target-ports-specified
@@ -98,4 +98,62 @@ spec:
       port: 8080
       targetPort: 8080
       name: http-svc-8080
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-with-invalid-named-target-port
+  namespace: namespace-with-invalid-named-port
+spec:
+  targets:
+    - name: my-service-with-invalid-named-port
+      ports:
+        - name: badname
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-with-invalid-named-port
+  namespace: namespace-with-invalid-named-port
+spec:
+  selector:
+    app: my-service-with-invalid-named-port
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: badname
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-with-valid-named-target-port-invalid-protocol
+  namespace: namespace-with-valid-named-port-invalid-protocol
+spec:
+  targets:
+    - name: my-service-with-valid-named-port-invalid-protocol
+      ports:
+        - name: https
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-with-valid-named-port-invalid-protocol
+  namespace: namespace-with-valid-named-port-invalid-protocol
+spec:
+  selector:
+    app: my-service-with-valid-named-port-invalid-protocol
+  ports:
+    - protocol: UDP
+      port: 8080
+      targetPort: 8080
+      name: https
 ---

--- a/galley/pkg/config/analysis/analyzers/testdata/jwt-valid-service-port-name.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/jwt-valid-service-port-name.yaml
@@ -1,0 +1,74 @@
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: test-ports
+  namespace: my-namespace
+spec:
+  targets:
+    - name: my-service
+      ports:
+        - number: 8080
+        - number: 8081
+        - number: 8082
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: my-namespace
+spec:
+  selector:
+    app: my-service
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: https-svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: http2-svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: test-no-ports
+  namespace: my-namespace-2
+spec:
+  targets:
+    - name: my-service-no-target-ports-specified
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-no-target-ports-specified
+  namespace: my-namespace-2
+spec:
+  selector:
+    app: my-service-no-target-ports-specified
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: https-svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: http2-svc-8082
+---

--- a/galley/pkg/config/analysis/analyzers/testdata/jwt-valid-service-port-name.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/jwt-valid-service-port-name.yaml
@@ -72,3 +72,32 @@ spec:
       targetPort: 8082
       name: http2-svc-8082
 ---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-named-ports
+  namespace: namespace-named-ports
+spec:
+  targets:
+    - name: my-service-named-port
+      ports:
+        - name: http-foo
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-named-port
+  namespace: namespace-named-ports
+spec:
+  selector:
+    app: my-service-named-port
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-foo
+---

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -88,6 +88,10 @@ var (
 	// PortNameIsNotUnderNamingConvention defines a diag.MessageType for message "PortNameIsNotUnderNamingConvention".
 	// Description: Port name is not under naming convention. Protocol detection is applied to the port.
 	PortNameIsNotUnderNamingConvention = diag.NewMessageType(diag.Info, "IST0118", "Port name %s (port: %d, targetPort: %s) doesn't follow the naming convention of Istio port.")
+
+	// JwtFailureDueToInvalidServicePortPrefix defines a diag.MessageType for message "JwtFailureDueToInvalidServicePortPrefix".
+	// Description: Authentication policy with JWT targets Service with invalid port specification.
+	JwtFailureDueToInvalidServicePortPrefix = diag.NewMessageType(diag.Error, "IST0119", "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s).")
 )
 
 // All returns a list of all known message types.
@@ -113,6 +117,7 @@ func All() []*diag.MessageType {
 		DeploymentAssociatedToMultipleServices,
 		DeploymentRequiresServiceAssociated,
 		PortNameIsNotUnderNamingConvention,
+		JwtFailureDueToInvalidServicePortPrefix,
 	}
 }
 
@@ -311,6 +316,18 @@ func NewPortNameIsNotUnderNamingConvention(r *resource.Instance, portName string
 		r,
 		portName,
 		port,
+		targetPort,
+	)
+}
+
+// NewJwtFailureDueToInvalidServicePortPrefix returns a new diag.Message based on JwtFailureDueToInvalidServicePortPrefix.
+func NewJwtFailureDueToInvalidServicePortPrefix(r *resource.Instance, port int, portName string, protocol string, targetPort string) diag.Message {
+	return diag.NewMessage(
+		JwtFailureDueToInvalidServicePortPrefix,
+		r,
+		port,
+		portName,
+		protocol,
 		targetPort,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -218,3 +218,18 @@ messages:
         type: int
       - name: targetPort
         type: string
+
+  - name: "JwtFailureDueToInvalidServicePortPrefix"
+    code: IST0119
+    level: Error
+    description: "Authentication policy with JWT targets Service with invalid port specification."
+    template: "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s)."
+    args:
+      - name: port
+        type: int
+      - name: portName
+        type: string
+      - name: protocol
+        type: string
+      - name: targetPort
+        type: string


### PR DESCRIPTION
Add analyzer to ensure that a v1alpha1 Auth Policy that uses JWT authentication targets a properly configured service.

See issue https://github.com/istio/istio/issues/17535

Problem: Improperly using the authentication policy API along with a Service definition results in JWT authentication not working as expected.

For a kubernetes Service object, a specified port does not have to have a specified protocol assigned with it, as it defaults too TCP if not present. Service protocol names are not required, but for jwt authentication they are and must be prefixed with http|http2|https.

Solution: Warn the user of when there is a problem when the Authentication Policy and K8s Service object it targets are misconfigured.

Invalid test cases are as follows:
1. No service ports are targeted by the Istio Policy.
    1. 1 or more of the Service’s ports are not of type TCP protocol
    2. 1 or more of the Service’s port names are not prefixed with http|https|http2 or do not exist
2. 1 or more service ports are targeted by the istio Policy
    1. If the specified port is a number
        1. The Service Protocol is not TCP (specified or defaulted)
        2. The Service port name does not exist or is not prefixed with http|https|http2
    2. The specified port is a named port
        1. The Service Protocol is not TCP (specified or defaulted)
        2. The Service port name does not exist or is not prefixed with http|https|http2
