### PR TITLE
fix: allow prometheus.io/scheme flag in Istioctl/operator

### DIFF
--- a/manifests/istio-telemetry/prometheus/templates/configmap.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/configmap.yaml
@@ -221,13 +221,14 @@ data:
     - job_name: 'kubernetes-pods'
       kubernetes_sd_configs:
       - role: pod
-      relabel_configs:  # If first two labels are present, pod should be scraped  by the istio-secure job.
+      relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
-      - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status]
-        action: drop
-        regex: (.+)
+      # Keep target if no sidecar or if prometheus.io/scheme is explicitly set to "http", otherwise drop and scrape securely instead
+      - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_prometheus_io_scheme]
+        action: keep
+        regex: ((;.*)|(.*;http))
       - source_labels: [__meta_kubernetes_pod_annotation_istio_mtls]
         action: drop
         regex: (true)
@@ -268,6 +269,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
         action: keep
         regex: (([^;]+);([^;]*))|(([^;]*);(true))
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+        action: drop
+        regex: (http)
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
         action: replace
         target_label: __metrics_path__


### PR DESCRIPTION
In the helm install version of templates, a prometheus.io/scheme annotation is possible. At the moment this annotation does not exist in the Operator/Istioctl version.

This PR adds the annotation to the cm for prometheus in the operator version of the manifest.