### PR TITLE
Fix `BUILD_WITH_CONTAINER=1 make test` on non Linux host

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -82,10 +82,20 @@ endif
 # Typically same as GOPATH/bin, so tests work seemlessly with IDEs.
 
 export ISTIO_BIN=$(GOBIN)
-# Using same package structure as pkg/
 
 export ISTIO_OUT:=$(TARGET_OUT)
 export ISTIO_OUT_LINUX:=$(TARGET_OUT_LINUX)
+
+# Determine if one of the targets contains `test`. If it does, and we are
+# running in the container, make sure we point at the linux (container OS) binaries.
+ifeq ($(findstring test,${MAKECMDGOALS}),test)
+  ifeq ($(IN_BUILD_CONTAINER),1)
+    $(info WARNING: Found a test target and in build container so forcing variables to linux to create/get container OS binaries)
+    ISTIO_OUT := $(ISTIO_OUT_LINUX)
+    GOARCH_LOCAL := amd64
+    GOOS_LOCAL := linux
+  endif
+endif
 
 # LOCAL_OUT should include architecture where we are currently running versus the desired.
 # This is used when we need to run a build artifact.
@@ -197,7 +207,6 @@ endif
 ifeq ($(PULL_POLICY),)
   $(error "PULL_POLICY cannot be empty")
 endif
-
 
 .PHONY: default
 default: init build test

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -33,6 +33,7 @@ export GOARCH=${GOARCH:-'amd64'}
 
 # test scripts seem to like to run this script directly rather than use make
 export ISTIO_OUT=${ISTIO_OUT:-${ISTIO_BIN}}
+export ISTIO_OUT_LINUX=${ISTIO_OUT_LINUX:-${ISTIO_BIN}}
 
 # Download Envoy debug and release binaries for Linux x86_64. They will be included in the
 # docker images created by Dockerfile.proxyv2 and Dockerfile.proxytproxy.
@@ -218,3 +219,9 @@ done
 # Copy native envoy binary to ISTIO_OUT
 echo "Copying ${ISTIO_ENVOY_NATIVE_PATH} to ${ISTIO_OUT}/envoy"
 cp -f "${ISTIO_ENVOY_NATIVE_PATH}" "${ISTIO_OUT}/envoy"
+
+# Need to copy the linux binary to ISTIO_OUT_LINUX if not already done
+if [[ "$GOOS_LOCAL" != "linux" ]]; then
+   echo "Copying ${ISTIO_ENVOY_LINUX_RELEASE_PATH} to ${ISTIO_OUT_LINUX}/envoy"
+  cp -f "${ISTIO_ENVOY_LINUX_RELEASE_PATH}" "${ISTIO_OUT_LINUX}/envoy"
+fi


### PR DESCRIPTION
If on runs `BUILD_WITH_CONTAINER=1 make test` on their non linux host (Mac in my case), there will be a number of failures in mixer and xds similar to:
```
Failed to setup test: fork/exec /work/out/darwin_amd64/envoy: exec format error
```

This is because the container is running Linux and ISTIO_OUT is pointing to the output tree associated with the host OS (/out/darwin_amd64). Tests using ISTIO_OUT as a pointer to an executable fail.

This PR basically works by checking if it is running in a container, and one of the make targets contains _test_, then it sets ISTIO_OUT (and the local OS and ARCH) to be linux. Now the tests will use linux binaries and the _exec format error_ is eliminated.

Drawbacks to this are if someone might be using multiple targets and expecting some to work on the ISTIO_OUT pointing to the HOST OS's output tree.

One can still debug locally with BUILD_WITH_CONTAINER=0.