### PR TITLE
Stop using distroless as default for tests

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -33,9 +33,6 @@ set -x
 source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
 
-# Temporary, for testing
-export VARIANT=distroless
-
 while (( "$#" )); do
   case "$1" in
     # Node images can be found at https://github.com/kubernetes-sigs/kind/releases


### PR DESCRIPTION
This was meant to be to test that everything passed but I forgot to
remove it. I guess that means everything passed...