### PR TITLE
Use new manifests for pkg/kube/inject tests

### DIFF
--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -122,20 +122,6 @@ const (
 	InjectionPolicyEnabled InjectionPolicy = "enabled"
 )
 
-// Defaults values for injecting istio proxy into kubernetes
-// resources.
-const (
-	DefaultSidecarProxyUID              = uint64(1337)
-	DefaultVerbosity                    = 2
-	DefaultStatusPort                   = 15020
-	DefaultReadinessInitialDelaySeconds = 1
-	DefaultReadinessPeriodSeconds       = 2
-	DefaultReadinessFailureThreshold    = 30
-	DefaultIncludeIPRanges              = "*"
-	DefaultIncludeInboundPorts          = "*"
-	DefaultkubevirtInterfaces           = ""
-)
-
 const (
 	// ProxyContainerName is used by e2e integration tests for fetching logs
 	ProxyContainerName = "istio-proxy"
@@ -165,96 +151,6 @@ type SidecarTemplateData struct {
 	ProxyConfig    *meshconfig.ProxyConfig
 	MeshConfig     *meshconfig.MeshConfig
 	Values         map[string]interface{}
-}
-
-// Params describes configurable parameters for injecting istio proxy
-// into a kubernetes resource.
-type Params struct {
-	InitImage       string `json:"initImage"`
-	ProxyImage      string `json:"proxyImage"`
-	Version         string `json:"version"`
-	ImagePullPolicy string `json:"imagePullPolicy"`
-	Tracer          string `json:"tracer"`
-	// Comma separated list of IP ranges in CIDR form. If set, only redirect outbound traffic to Envoy for these IP
-	// ranges. All outbound traffic can be redirected with the wildcard character "*". Defaults to "*".
-	IncludeIPRanges string `json:"includeIPRanges"`
-	// Comma separated list of IP ranges in CIDR form. If set, outbound traffic will not be redirected for
-	// these IP ranges. Exclusions are only applied if configured to redirect all outbound traffic. By default,
-	// no IP ranges are excluded.
-	ExcludeIPRanges string `json:"excludeIPRanges"`
-	// Comma separated list of inbound ports for which traffic is to be redirected to Envoy. All ports can be
-	// redirected with the wildcard character "*". Defaults to "*".
-	IncludeInboundPorts string `json:"includeInboundPorts"`
-	// Comma separated list of inbound ports. If set, inbound traffic will not be redirected for those ports.
-	// Exclusions are only applied if configured to redirect all inbound traffic. By default, no ports are excluded.
-	ExcludeInboundPorts string `json:"excludeInboundPorts"`
-	// Comma separated list of outbound ports. If set, outbound traffic will not be redirected for those ports.
-	// By default, no ports are excluded.
-	ExcludeOutboundPorts string `json:"excludeOutboundPorts"`
-	// Comma separated list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound
-	// By default, no interfaces are configured.
-	KubevirtInterfaces           string                 `json:"kubevirtInterfaces"`
-	Verbosity                    int                    `json:"verbosity"`
-	SidecarProxyUID              uint64                 `json:"sidecarProxyUID"`
-	Mesh                         *meshconfig.MeshConfig `json:"-"`
-	StatusPort                   int                    `json:"statusPort"`
-	ReadinessInitialDelaySeconds uint32                 `json:"readinessInitialDelaySeconds"`
-	ReadinessPeriodSeconds       uint32                 `json:"readinessPeriodSeconds"`
-	ReadinessFailureThreshold    uint32                 `json:"readinessFailureThreshold"`
-	RewriteAppHTTPProbe          bool                   `json:"rewriteAppHTTPProbe"`
-	EnableCoreDump               bool                   `json:"enableCoreDump"`
-	DebugMode                    bool                   `json:"debugMode"`
-	Privileged                   bool                   `json:"privileged"`
-	SDSEnabled                   bool                   `json:"sdsEnabled"`
-	PodDNSSearchNamespaces       []string               `json:"podDNSSearchNamespaces"`
-	EnableCni                    bool                   `json:"enablecni"`
-}
-
-// Validate validates the parameters and returns an error if there is configuration issue.
-func (p *Params) Validate() error {
-	if err := ValidateIncludeIPRanges(p.IncludeIPRanges); err != nil {
-		return err
-	}
-	if err := ValidateExcludeIPRanges(p.ExcludeIPRanges); err != nil {
-		return err
-	}
-	if err := ValidateIncludeInboundPorts(p.IncludeInboundPorts); err != nil {
-		return err
-	}
-	return ValidateExcludeInboundPorts(p.ExcludeInboundPorts)
-}
-
-// intoHelmValues returns a map of the traversed path in helm values YAML to the param value.
-func (p *Params) intoHelmValues() map[string]string {
-	vals := map[string]string{
-		"global.proxy_init.image":                    p.InitImage,
-		"global.proxy.image":                         p.ProxyImage,
-		"global.proxy.enableCoreDump":                strconv.FormatBool(p.EnableCoreDump),
-		"global.proxy.privileged":                    strconv.FormatBool(p.Privileged),
-		"global.imagePullPolicy":                     p.ImagePullPolicy,
-		"global.proxy.statusPort":                    strconv.Itoa(p.StatusPort),
-		"global.proxy.tracer":                        p.Tracer,
-		"global.proxy.readinessInitialDelaySeconds":  strconv.Itoa(int(p.ReadinessInitialDelaySeconds)),
-		"global.proxy.readinessPeriodSeconds":        strconv.Itoa(int(p.ReadinessPeriodSeconds)),
-		"global.proxy.readinessFailureThreshold":     strconv.Itoa(int(p.ReadinessFailureThreshold)),
-		"global.sds.enabled":                         strconv.FormatBool(p.SDSEnabled),
-		"global.proxy.includeIPRanges":               p.IncludeIPRanges,
-		"global.proxy.excludeIPRanges":               p.ExcludeIPRanges,
-		"global.proxy.includeInboundPorts":           p.IncludeInboundPorts,
-		"global.proxy.excludeInboundPorts":           p.ExcludeInboundPorts,
-		"sidecarInjectorWebhook.rewriteAppHTTPProbe": strconv.FormatBool(p.RewriteAppHTTPProbe),
-		"global.podDNSSearchNamespaces":              getHelmValue(p.PodDNSSearchNamespaces),
-		"istio_cni.enabled":                          strconv.FormatBool(p.EnableCni),
-	}
-	return vals
-}
-
-func getHelmValue(namespace []string) string {
-	if len(namespace) == 0 {
-		return ""
-	}
-
-	return "{" + strings.Join(namespace, ",") + "}"
 }
 
 // Config specifies the sidecar injection configuration This includes

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -34,15 +34,6 @@ import (
 )
 
 const (
-	// This is the hub to expect in
-	// platform/kube/inject/testdata/frontend.yaml.injected and the
-	// other .injected "want" YAMLs
-	unitTestHub = "docker.io/istio"
-
-	// Tag name should be kept in sync with value in
-	// platform/kube/inject/refresh.sh
-	unitTestTag = "unittest"
-
 	statusReplacement = "sidecar.istio.io/status: '{\"version\":\"\","
 )
 
@@ -50,567 +41,277 @@ var (
 	statusPattern = regexp.MustCompile("sidecar.istio.io/status: '{\"version\":\"([0-9a-f]+)\",")
 )
 
-// InitImageName returns the fully qualified image name for the istio
-// init image given a docker hub and tag and debug flag
-// This is used for testing only
-func InitImageName(hub string, tag string) string {
-	return hub + "/proxy_init:" + tag
-}
-
-// ProxyImageName returns the fully qualified image name for the istio
-// proxy image given a docker hub and tag and whether to use debug or not.
-// This is used for testing
-func ProxyImageName(hub string, tag string) string {
-	// Allow overriding the proxy image.
-	return hub + "/proxyv2:" + tag
-}
-
-func TestImageName(t *testing.T) {
-	want := "docker.io/istio/proxy_init:latest"
-	if got := InitImageName("docker.io/istio", "latest"); got != want {
-		t.Errorf("InitImageName() failed: got %q want %q", got, want)
-	}
-	want = "docker.io/istio/proxyv2:latest"
-	if got := ProxyImageName("docker.io/istio", "latest"); got != want {
-		t.Errorf("ProxyImageName() failed: got %q want %q", got, want)
-	}
-}
-
 func TestIntoResourceFile(t *testing.T) {
 	cases := []struct {
-		in                           string
-		want                         string
-		imagePullPolicy              string
-		duration                     time.Duration
-		includeIPRanges              string
-		excludeIPRanges              string
-		includeInboundPorts          string
-		excludeInboundPorts          string
-		kubevirtInterfaces           string
-		statusPort                   int
-		readinessInitialDelaySeconds uint32
-		readinessPeriodSeconds       uint32
-		readinessFailureThreshold    uint32
-		enableAuth                   bool
-		enableCoreDump               bool
-		privileged                   bool
-		tproxy                       bool
-		podDNSSearchNamespaces       []string
-		enableCni                    bool
+		in     string
+		want   string
+		values string
+		mesh   func(m *meshapi.MeshConfig)
 	}{
 		//"testdata/hello.yaml" is tested in http_test.go (with debug)
 		{
-			in:                           "hello.yaml",
-			want:                         "hello.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello.yaml",
+			want: "hello.yaml.injected",
 		},
 		// verify cni
 		{
-			in:                           "hello.yaml",
-			want:                         "hello.yaml.cni.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
-			enableCni:                    true,
+			in:   "hello.yaml",
+			want: "hello.yaml.cni.injected",
+			values: `
+components:
+  cni:
+    enabled: true
+`,
 		},
 		//verifies that the sidecar will not be injected again for an injected yaml
 		{
-			in:                           "hello.yaml.injected",
-			want:                         "hello.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello.yaml.injected",
+			want: "hello.yaml.injected",
 		},
 		{
-			in:                           "hello-mtls-not-ready.yaml",
-			want:                         "hello-mtls-not-ready.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello-mtls-not-ready.yaml",
+			want: "hello-mtls-not-ready.yaml.injected",
 		},
 		{
-			in:                           "hello-namespace.yaml",
-			want:                         "hello-namespace.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello-namespace.yaml",
+			want: "hello-namespace.yaml.injected",
 		},
 		{
-			in:                           "hello-proxy-override.yaml",
-			want:                         "hello-proxy-override.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello-proxy-override.yaml",
+			want: "hello-proxy-override.yaml.injected",
 		},
 		{
-			in:     "hello.yaml",
-			want:   "hello-tproxy.yaml.injected",
-			tproxy: true,
+			in:   "hello.yaml",
+			want: "hello-tproxy.yaml.injected",
+			mesh: func(m *meshapi.MeshConfig) {
+				m.DefaultConfig.InterceptionMode = meshapi.ProxyConfig_TPROXY
+			},
 		},
 		{
-			in:                           "hello.yaml",
-			want:                         "hello-config-map-name.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello.yaml",
+			want: "hello-config-map-name.yaml.injected",
 		},
 		{
-			in:                           "frontend.yaml",
-			want:                         "frontend.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "frontend.yaml",
+			want: "frontend.yaml.injected",
 		},
 		{
-			in:                           "hello-service.yaml",
-			want:                         "hello-service.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello-service.yaml",
+			want: "hello-service.yaml.injected",
 		},
 		{
-			in:                           "hello-multi.yaml",
-			want:                         "hello-multi.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello-multi.yaml",
+			want: "hello-multi.yaml.injected",
 		},
 		{
-			in:                           "hello.yaml",
-			want:                         "hello-always.yaml.injected",
-			imagePullPolicy:              "Always",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello.yaml",
+			want: "hello-always.yaml.injected",
+			values: `
+values:
+  global:
+    imagePullPolicy: Always
+`,
 		},
 		{
-			in:                           "hello.yaml",
-			want:                         "hello-never.yaml.injected",
-			imagePullPolicy:              "Never",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello.yaml",
+			want: "hello-never.yaml.injected",
+			values: `
+values:
+  global:
+    imagePullPolicy: Never
+`,
 		},
 		{
-			in:                           "hello-ignore.yaml",
-			want:                         "hello-ignore.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello-ignore.yaml",
+			want: "hello-ignore.yaml.injected",
 		},
 		{
-			in:                           "multi-init.yaml",
-			want:                         "multi-init.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "multi-init.yaml",
+			want: "multi-init.yaml.injected",
 		},
 		{
-			in:                           "statefulset.yaml",
-			want:                         "statefulset.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "statefulset.yaml",
+			want: "statefulset.yaml.injected",
 		},
 		{
-			in:                           "enable-core-dump.yaml",
-			want:                         "enable-core-dump.yaml.injected",
-			enableCoreDump:               true,
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "enable-core-dump.yaml",
+			want: "enable-core-dump.yaml.injected",
+			values: `
+values:
+  global:
+    proxy:
+      enableCoreDump: true
+`,
 		},
 		{
-			in:                           "enable-core-dump-annotation.yaml",
-			want:                         "enable-core-dump-annotation.yaml.injected",
-			enableCoreDump:               false,
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "enable-core-dump-annotation.yaml",
+			want: "enable-core-dump-annotation.yaml.injected",
 		},
 		{
-			in:                           "auth.yaml",
-			want:                         "auth.yaml.injected",
-			enableAuth:                   true,
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "auth.yaml",
+			want: "auth.yaml.injected",
 		},
 		{
-			in:                           "auth.non-default-service-account.yaml",
-			want:                         "auth.non-default-service-account.yaml.injected",
-			enableAuth:                   true,
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "auth.non-default-service-account.yaml",
+			want: "auth.non-default-service-account.yaml.injected",
 		},
 		{
-			in:                           "auth.yaml",
-			want:                         "auth.cert-dir.yaml.injected",
-			enableAuth:                   true,
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "auth.yaml",
+			want: "auth.cert-dir.yaml.injected",
 		},
 		{
-			in:                           "daemonset.yaml",
-			want:                         "daemonset.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "daemonset.yaml",
+			want: "daemonset.yaml.injected",
 		},
 		{
-			in:                           "job.yaml",
-			want:                         "job.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "job.yaml",
+			want: "job.yaml.injected",
 		},
 		{
-			in:                           "replicaset.yaml",
-			want:                         "replicaset.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "replicaset.yaml",
+			want: "replicaset.yaml.injected",
 		},
 		{
-			in:                           "replicationcontroller.yaml",
-			want:                         "replicationcontroller.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "replicationcontroller.yaml",
+			want: "replicationcontroller.yaml.injected",
 		},
 		{
-			in:                           "cronjob.yaml",
-			want:                         "cronjob.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "cronjob.yaml",
+			want: "cronjob.yaml.injected",
 		},
 		{
-			in:                           "pod.yaml",
-			want:                         "pod.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "pod.yaml",
+			want: "pod.yaml.injected",
 		},
 		{
-			in:                           "hello-host-network.yaml",
-			want:                         "hello-host-network.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "hello-host-network.yaml",
+			want: "hello-host-network.yaml.injected",
 		},
 		{
-			in:                           "list.yaml",
-			want:                         "list.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "list.yaml",
+			want: "list.yaml.injected",
 		},
 		{
-			in:                           "list-frontend.yaml",
-			want:                         "list-frontend.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "list-frontend.yaml",
+			want: "list-frontend.yaml.injected",
 		},
 		{
-			in:                           "deploymentconfig.yaml",
-			want:                         "deploymentconfig.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "deploymentconfig.yaml",
+			want: "deploymentconfig.yaml.injected",
 		},
 		{
-			in:                           "deploymentconfig-multi.yaml",
-			want:                         "deploymentconfig-multi.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "deploymentconfig-multi.yaml",
+			want: "deploymentconfig-multi.yaml.injected",
 		},
 		{
-			in:                           "format-duration.yaml",
-			want:                         "format-duration.yaml.injected",
-			duration:                     42 * time.Second,
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "format-duration.yaml",
+			want: "format-duration.yaml.injected",
+			mesh: func(m *meshapi.MeshConfig) {
+				m.DefaultConfig.DrainDuration = types.DurationProto(time.Second * 42)
+				m.DefaultConfig.ParentShutdownDuration = types.DurationProto(time.Second * 42)
+				m.DefaultConfig.ConnectTimeout = types.DurationProto(time.Second * 42)
+			},
 		},
 		{
 			// Verifies that parameters are applied properly when no annotations are provided.
-			in:                  "traffic-params.yaml",
-			want:                "traffic-params.yaml.injected",
-			includeIPRanges:     "127.0.0.1/24,10.96.0.1/24",
-			excludeIPRanges:     "10.96.0.2/24,10.96.0.3/24",
-			includeInboundPorts: "1,2,3",
-			excludeInboundPorts: "4,5,6",
-			statusPort:          0,
+			in:   "traffic-params.yaml",
+			want: "traffic-params.yaml.injected",
+			values: `
+values:
+  global:
+    proxy:
+      includeIPRanges: "127.0.0.1/24,10.96.0.1/24"
+      excludeIPRanges: "10.96.0.2/24,10.96.0.3/24"
+      includeInboundPorts: "1,2,3"
+      excludeInboundPorts: "4,5,6"
+      statusPort: 0
+  `,
 		},
 		{
 			// Verifies that empty include lists are applied properly from parameters.
-			in:                           "traffic-params-empty-includes.yaml",
-			want:                         "traffic-params-empty-includes.yaml.injected",
-			includeIPRanges:              "",
-			excludeIPRanges:              "",
-			kubevirtInterfaces:           "",
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "traffic-params-empty-includes.yaml",
+			want: "traffic-params-empty-includes.yaml.injected",
 		},
 		{
 			// Verifies that annotation values are applied properly. This also tests that annotation values
 			// override params when specified.
-			in:                           "traffic-annotations.yaml",
-			want:                         "traffic-annotations.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "traffic-annotations.yaml",
+			want: "traffic-annotations.yaml.injected",
 		},
 		{
 			// Verifies that the wildcard character "*" behaves properly when used in annotations.
-			in:                           "traffic-annotations-wildcards.yaml",
-			want:                         "traffic-annotations-wildcards.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "traffic-annotations-wildcards.yaml",
+			want: "traffic-annotations-wildcards.yaml.injected",
 		},
 		{
 			// Verifies that the wildcard character "*" behaves properly when used in annotations.
-			in:                           "traffic-annotations-empty-includes.yaml",
-			want:                         "traffic-annotations-empty-includes.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "traffic-annotations-empty-includes.yaml",
+			want: "traffic-annotations-empty-includes.yaml.injected",
 		},
 		{
 			// Verifies that pods can have multiple containers
-			in:                           "multi-container.yaml",
-			want:                         "multi-container.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "multi-container.yaml",
+			want: "multi-container.yaml.injected",
 		},
 		{
 			// Verifies that the status params behave properly.
-			in:                           "status_params.yaml",
-			want:                         "status_params.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			kubevirtInterfaces:           DefaultkubevirtInterfaces,
-			statusPort:                   123,
-			readinessInitialDelaySeconds: 100,
-			readinessPeriodSeconds:       200,
-			readinessFailureThreshold:    300,
+			in:   "status_params.yaml",
+			want: "status_params.yaml.injected",
+			values: `
+values:
+  global:
+    proxy:
+      statusPort: 123
+      readinessInitialDelaySeconds: 100
+      readinessPeriodSeconds: 200
+      readinessFailureThreshold: 300
+  `,
 		},
 		{
 			// Verifies that the status annotations override the params.
-			in:                           "status_annotations.yaml",
-			want:                         "status_annotations.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "status_annotations.yaml",
+			want: "status_annotations.yaml.injected",
 		},
 		{
 			// Verifies that the kubevirtInterfaces list are applied properly from parameters..
-			in:                           "kubevirtInterfaces.yaml",
-			want:                         "kubevirtInterfaces.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			kubevirtInterfaces:           "net1",
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "kubevirtInterfaces.yaml",
+			want: "kubevirtInterfaces.yaml.injected",
+			values: `
+values:
+  global:
+    proxy:
+      statusPort: 123
+      readinessInitialDelaySeconds: 100
+      readinessPeriodSeconds: 200
+      readinessFailureThreshold: 300
+  `,
 		},
 		{
 			// Verifies that the kubevirtInterfaces list are applied properly from parameters..
-			in:                           "kubevirtInterfaces_list.yaml",
-			want:                         "kubevirtInterfaces_list.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			kubevirtInterfaces:           "net1,net2",
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			in:   "kubevirtInterfaces_list.yaml",
+			want: "kubevirtInterfaces_list.yaml.injected",
 		},
 		{
 			// Verifies that global.podDNSSearchNamespaces are applied properly
-			in:                           "hello.yaml",
-			want:                         "hello-template-in-values.yaml.injected",
-			includeIPRanges:              DefaultIncludeIPRanges,
-			includeInboundPorts:          DefaultIncludeInboundPorts,
-			kubevirtInterfaces:           "net1,net2",
-			statusPort:                   DefaultStatusPort,
-			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
-			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
-			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
-			podDNSSearchNamespaces: []string{
-				"global",
-				"{{ valueOrDefault .DeploymentMeta.Namespace \"default\" }}.global",
-			},
+			in:   "hello.yaml",
+			want: "hello-template-in-values.yaml.injected",
+			values: `
+values:
+  global:
+    podDNSSearchNamespaces:
+    - "global"
+    - "{{ valueOrDefault .DeploymentMeta.Namespace \"default\" }}.global"
+  `,
 		},
 	}
 
 	for i, c := range cases {
+		c := c
 		testName := fmt.Sprintf("[%02d] %s", i, c.want)
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			m := mesh.DefaultMeshConfig()
-			if c.duration != 0 {
-				m.DefaultConfig.DrainDuration = types.DurationProto(c.duration)
-				m.DefaultConfig.ParentShutdownDuration = types.DurationProto(c.duration)
-				m.DefaultConfig.ConnectTimeout = types.DurationProto(c.duration)
-			}
-			if c.tproxy {
-				m.DefaultConfig.InterceptionMode = meshapi.ProxyConfig_TPROXY
-			} else {
-				m.DefaultConfig.InterceptionMode = meshapi.ProxyConfig_REDIRECT
-			}
-
-			params := &Params{
-				InitImage:                    InitImageName(unitTestHub, unitTestTag),
-				ProxyImage:                   ProxyImageName(unitTestHub, unitTestTag),
-				ImagePullPolicy:              "IfNotPresent",
-				SDSEnabled:                   false,
-				Verbosity:                    DefaultVerbosity,
-				SidecarProxyUID:              DefaultSidecarProxyUID,
-				Version:                      "12345678",
-				EnableCoreDump:               c.enableCoreDump,
-				Privileged:                   c.privileged,
-				Mesh:                         &m,
-				IncludeIPRanges:              c.includeIPRanges,
-				ExcludeIPRanges:              c.excludeIPRanges,
-				IncludeInboundPorts:          c.includeInboundPorts,
-				ExcludeInboundPorts:          c.excludeInboundPorts,
-				KubevirtInterfaces:           c.kubevirtInterfaces,
-				StatusPort:                   c.statusPort,
-				ReadinessInitialDelaySeconds: c.readinessInitialDelaySeconds,
-				ReadinessPeriodSeconds:       c.readinessPeriodSeconds,
-				ReadinessFailureThreshold:    c.readinessFailureThreshold,
-				RewriteAppHTTPProbe:          false,
-				PodDNSSearchNamespaces:       c.podDNSSearchNamespaces,
-				EnableCni:                    c.enableCni,
-			}
-			if c.imagePullPolicy != "" {
-				params.ImagePullPolicy = c.imagePullPolicy
-			}
-			sidecarTemplate := loadSidecarTemplate(t)
-			valuesConfig := getValues(params, t)
+			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, c.values)
 			inputFilePath := "testdata/inject/" + c.in
 			wantFilePath := "testdata/inject/" + c.want
 			in, err := os.Open(inputFilePath)
@@ -619,7 +320,7 @@ func TestIntoResourceFile(t *testing.T) {
 			}
 			defer func() { _ = in.Close() }()
 			var got bytes.Buffer
-			if err = IntoResourceFile(sidecarTemplate, valuesConfig, &m, in, &got); err != nil {
+			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, &m, in, &got); err != nil {
 				t.Fatalf("IntoResourceFile(%v) returned an error: %v", inputFilePath, err)
 			}
 
@@ -704,20 +405,7 @@ func TestRewriteAppProbe(t *testing.T) {
 		testName := fmt.Sprintf("[%02d] %s", i, c.want)
 		t.Run(testName, func(t *testing.T) {
 			m := mesh.DefaultMeshConfig()
-			params := &Params{
-				InitImage:                    InitImageName(unitTestHub, unitTestTag),
-				ProxyImage:                   ProxyImageName(unitTestHub, unitTestTag),
-				ImagePullPolicy:              "IfNotPresent",
-				SidecarProxyUID:              DefaultSidecarProxyUID,
-				Version:                      "12345678",
-				StatusPort:                   DefaultStatusPort,
-				ReadinessInitialDelaySeconds: DefaultReadinessPeriodSeconds,
-				ReadinessPeriodSeconds:       DefaultReadinessFailureThreshold,
-				ReadinessFailureThreshold:    DefaultReadinessFailureThreshold,
-				RewriteAppHTTPProbe:          c.rewriteAppHTTPProbe,
-			}
-			sidecarTemplate := loadSidecarTemplate(t)
-			valuesConfig := getValues(params, t)
+			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, "")
 			inputFilePath := "testdata/inject/app_probe/" + c.in
 			wantFilePath := "testdata/inject/app_probe/" + c.want
 			in, err := os.Open(inputFilePath)
@@ -726,7 +414,7 @@ func TestRewriteAppProbe(t *testing.T) {
 			}
 			defer func() { _ = in.Close() }()
 			var got bytes.Buffer
-			if err = IntoResourceFile(sidecarTemplate, valuesConfig, &m, in, &got); err != nil {
+			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, &m, in, &got); err != nil {
 				t.Fatalf("IntoResourceFile(%v) returned an error: %v", inputFilePath, err)
 			}
 
@@ -744,51 +432,6 @@ func TestRewriteAppProbe(t *testing.T) {
 
 func stripVersion(yaml []byte) []byte {
 	return statusPattern.ReplaceAllLiteral(yaml, []byte(statusReplacement))
-}
-
-func TestInvalidParams(t *testing.T) {
-	cases := []struct {
-		annotation    string
-		paramModifier func(p *Params)
-	}{
-		{
-			annotation: "includeipranges",
-			paramModifier: func(p *Params) {
-				p.IncludeIPRanges = "bad"
-			},
-		},
-		{
-			annotation: "excludeipranges",
-			paramModifier: func(p *Params) {
-				p.ExcludeIPRanges = "*"
-			},
-		},
-		{
-			annotation: "includeinboundports",
-			paramModifier: func(p *Params) {
-				p.IncludeInboundPorts = "bad"
-			},
-		},
-		{
-			annotation: "excludeinboundports",
-			paramModifier: func(p *Params) {
-				p.ExcludeInboundPorts = "*"
-			},
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.annotation, func(t *testing.T) {
-			params := newTestParams()
-			c.paramModifier(params)
-
-			if err := params.Validate(); err == nil {
-				t.Fatalf("expected error")
-			} else if !strings.Contains(strings.ToLower(err.Error()), c.annotation) {
-				t.Fatalf("unexpected error: %v", err)
-			}
-		})
-	}
 }
 
 func TestInvalidAnnotations(t *testing.T) {
@@ -817,12 +460,10 @@ func TestInvalidAnnotations(t *testing.T) {
 			in:         "traffic-annotations-bad-excludeoutboundports.yaml",
 		},
 	}
-
+	m := mesh.DefaultMeshConfig()
 	for _, c := range cases {
 		t.Run(c.annotation, func(t *testing.T) {
-			params := newTestParams()
-			sidecarTemplate := loadSidecarTemplate(t)
-			valuesConfig := getValues(params, t)
+			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, "")
 			inputFilePath := "testdata/inject/" + c.in
 			in, err := os.Open(inputFilePath)
 			if err != nil {
@@ -830,7 +471,7 @@ func TestInvalidAnnotations(t *testing.T) {
 			}
 			defer func() { _ = in.Close() }()
 			var got bytes.Buffer
-			if err = IntoResourceFile(sidecarTemplate, valuesConfig, params.Mesh, in, &got); err == nil {
+			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, &m, in, &got); err == nil {
 				t.Fatalf("expected error")
 			} else if !strings.Contains(strings.ToLower(err.Error()), c.annotation) {
 				t.Fatalf("unexpected error: %v", err)
@@ -916,26 +557,5 @@ func TestSkipUDPPorts(t *testing.T) {
 				t.Fatalf("unexpect ports result for case %d: expect %v, got %v", i, expectPorts, ports)
 			}
 		}
-	}
-}
-
-func newTestParams() *Params {
-	m := mesh.DefaultMeshConfig()
-	return &Params{
-		InitImage:           InitImageName(unitTestHub, unitTestTag),
-		ProxyImage:          ProxyImageName(unitTestHub, unitTestTag),
-		ImagePullPolicy:     "IfNotPresent",
-		SDSEnabled:          false,
-		Verbosity:           DefaultVerbosity,
-		SidecarProxyUID:     DefaultSidecarProxyUID,
-		Version:             "12345678",
-		EnableCoreDump:      false,
-		Mesh:                &m,
-		DebugMode:           false,
-		IncludeIPRanges:     DefaultIncludeIPRanges,
-		ExcludeIPRanges:     "",
-		IncludeInboundPorts: DefaultIncludeInboundPorts,
-		ExcludeInboundPorts: "",
-		EnableCni:           false,
 	}
 }

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -14,11 +14,8 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
-        sidecar.istio.io/status: '{"version":"ec8689dff7f37cdfd2c61ffe1941cc189d9f3a65df1a77e3355ae529d0d12194","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: 80,90
+        sidecar.istio.io/status: '{"version":"bf820cbcf48bd658b93aae60afb49b4650d91c3f0bddb82cd82fb05262f58d68","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -73,31 +70,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-                ,{"name":"http","containerPort":90}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -110,8 +111,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+                ,{"name":"http","containerPort":90}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -134,9 +145,11 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333},"/app-health/world/livez":{"port":90}}'
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -148,8 +161,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 15020
-          initialDelaySeconds: 2
-          periodSeconds: 30
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -168,8 +181,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -185,14 +202,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -219,6 +236,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -14,11 +14,8 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"version":"ec8689dff7f37cdfd2c61ffe1941cc189d9f3a65df1a77e3355ae529d0d12194","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: 80,90
+        sidecar.istio.io/status: '{"version":"bf820cbcf48bd658b93aae60afb49b4650d91c3f0bddb82cd82fb05262f58d68","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -70,31 +67,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-                ,{"name":"http","containerPort":90}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -107,8 +108,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+                ,{"name":"http","containerPort":90}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -131,7 +142,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -143,8 +156,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 15020
-          initialDelaySeconds: 2
-          periodSeconds: 30
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -163,8 +176,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -180,14 +197,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -214,6 +231,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -14,10 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"ec8689dff7f37cdfd2c61ffe1941cc189d9f3a65df1a77e3355ae529d0d12194","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: 80,90
+        sidecar.istio.io/status: '{"version":"bf820cbcf48bd658b93aae60afb49b4650d91c3f0bddb82cd82fb05262f58d68","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -29,22 +26,19 @@ spec:
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         livenessProbe:
           httpGet:
-            path: /app-health/hello/livez
-            port: 15020
+            port: http
         name: hello
         ports:
         - containerPort: 80
           name: http
         readinessProbe:
           httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
+            port: 3333
         resources: {}
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         livenessProbe:
           httpGet:
-            path: /app-health/world/livez
-            port: 15020
+            port: http
         name: world
         ports:
         - containerPort: 90
@@ -72,31 +66,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-                ,{"name":"http","containerPort":90}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -109,8 +107,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+                ,{"name":"http","containerPort":90}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -130,9 +138,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333},"/app-health/world/livez":{"port":90}}'
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -144,8 +152,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 15020
-          initialDelaySeconds: 2
-          periodSeconds: 30
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -164,8 +172,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -181,14 +193,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -215,6 +227,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -14,10 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"ec8689dff7f37cdfd2c61ffe1941cc189d9f3a65df1a77e3355ae529d0d12194","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
+        sidecar.istio.io/status: '{"version":"bf820cbcf48bd658b93aae60afb49b4650d91c3f0bddb82cd82fb05262f58d68","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -33,8 +30,8 @@ spec:
           name: http
         readinessProbe:
           httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
+            path: /ip
+            port: 8000
         resources: {}
       - args:
         - proxy
@@ -53,30 +50,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -89,8 +91,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -110,9 +121,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/readyz":{"path":"/ip","port":8000}}'
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -124,8 +135,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 15020
-          initialDelaySeconds: 2
-          periodSeconds: 30
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -144,8 +155,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -161,14 +176,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -195,6 +210,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -14,10 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"ec8689dff7f37cdfd2c61ffe1941cc189d9f3a65df1a77e3355ae529d0d12194","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: 80,90
+        sidecar.istio.io/status: '{"version":"bf820cbcf48bd658b93aae60afb49b4650d91c3f0bddb82cd82fb05262f58d68","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -29,23 +26,20 @@ spec:
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         livenessProbe:
           httpGet:
-            path: /app-health/hello/livez
-            port: 15020
+            port: http
         name: hello
         ports:
         - containerPort: 80
           name: http
         readinessProbe:
           httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-            scheme: HTTP
+            port: 3333
+            scheme: HTTPS
         resources: {}
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         livenessProbe:
           httpGet:
-            path: /app-health/world/livez
-            port: 15020
+            port: http
         name: world
         ports:
         - containerPort: 90
@@ -73,31 +67,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-                ,{"name":"http","containerPort":90}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -110,8 +108,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+                ,{"name":"http","containerPort":90}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -131,9 +139,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333,"scheme":"HTTPS"},"/app-health/world/livez":{"port":90}}'
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -145,8 +153,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 15020
-          initialDelaySeconds: 2
-          periodSeconds: 30
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -165,8 +173,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -182,14 +194,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -216,6 +228,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -14,10 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"ec8689dff7f37cdfd2c61ffe1941cc189d9f3a65df1a77e3355ae529d0d12194","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
+        sidecar.istio.io/status: '{"version":"bf820cbcf48bd658b93aae60afb49b4650d91c3f0bddb82cd82fb05262f58d68","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -33,8 +30,7 @@ spec:
           name: http
         readinessProbe:
           httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
+            port: http
         resources: {}
       - args:
         - proxy
@@ -53,30 +49,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -89,8 +90,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -110,9 +120,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/readyz":{"port":80}}'
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -124,8 +134,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 15020
-          initialDelaySeconds: 2
-          periodSeconds: 30
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -144,8 +154,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -161,14 +175,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -195,6 +209,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -14,10 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"ec8689dff7f37cdfd2c61ffe1941cc189d9f3a65df1a77e3355ae529d0d12194","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
+        sidecar.istio.io/status: '{"version":"bf820cbcf48bd658b93aae60afb49b4650d91c3f0bddb82cd82fb05262f58d68","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -29,16 +26,14 @@ spec:
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         livenessProbe:
           httpGet:
-            path: /app-health/hello/livez
-            port: 15020
+            port: http
         name: hello
         ports:
         - containerPort: 80
           name: http
         readinessProbe:
           httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
+            port: 3333
         resources: {}
       - args:
         - proxy
@@ -57,30 +52,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -93,8 +93,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -114,9 +123,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333}}'
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -128,8 +137,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 15020
-          initialDelaySeconds: 2
-          periodSeconds: 30
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -148,8 +157,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -165,14 +178,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -199,6 +212,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -14,10 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"ec8689dff7f37cdfd2c61ffe1941cc189d9f3a65df1a77e3355ae529d0d12194","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: 80,90
+        sidecar.istio.io/status: '{"version":"bf820cbcf48bd658b93aae60afb49b4650d91c3f0bddb82cd82fb05262f58d68","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -29,22 +26,19 @@ spec:
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         livenessProbe:
           httpGet:
-            path: /app-health/hello/livez
-            port: 15020
+            port: http
         name: hello
         ports:
         - containerPort: 80
           name: http
         readinessProbe:
           httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
+            port: 3333
         resources: {}
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         livenessProbe:
           httpGet:
-            path: /app-health/world/livez
-            port: 15020
+            port: http
         name: world
         ports:
         - containerPort: 90
@@ -72,31 +66,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-                ,{"name":"http","containerPort":90}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -109,8 +107,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+                ,{"name":"http","containerPort":90}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -130,9 +138,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333},"/app-health/world/livez":{"port":90}}'
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -144,8 +152,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 15020
-          initialDelaySeconds: 2
-          periodSeconds: 30
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -164,8 +172,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -181,14 +193,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -215,6 +227,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -14,10 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"ec8689dff7f37cdfd2c61ffe1941cc189d9f3a65df1a77e3355ae529d0d12194","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
+        sidecar.istio.io/status: '{"version":"bf820cbcf48bd658b93aae60afb49b4650d91c3f0bddb82cd82fb05262f58d68","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -33,8 +30,7 @@ spec:
           name: http
         readinessProbe:
           httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
+            port: 3333
         resources: {}
       - args:
         - proxy
@@ -53,30 +49,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -89,8 +90,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -110,9 +120,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/readyz":{"port":3333}}'
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -124,8 +134,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 15020
-          initialDelaySeconds: 2
-          periodSeconds: 30
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -144,8 +154,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -161,14 +175,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -195,6 +209,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -14,10 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"ec8689dff7f37cdfd2c61ffe1941cc189d9f3a65df1a77e3355ae529d0d12194","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: 80,90
+        sidecar.istio.io/status: '{"version":"bf820cbcf48bd658b93aae60afb49b4650d91c3f0bddb82cd82fb05262f58d68","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -33,8 +30,8 @@ spec:
           name: http
         readinessProbe:
           httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
+            path: /ip
+            port: 8000
         resources: {}
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         name: world
@@ -43,8 +40,8 @@ spec:
           name: http
         readinessProbe:
           httpGet:
-            path: /app-health/world/readyz
-            port: 15020
+            path: /ipv6
+            port: 9000
         resources: {}
       - args:
         - proxy
@@ -63,31 +60,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-                ,{"name":"http","containerPort":90}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -100,8 +101,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+                ,{"name":"http","containerPort":90}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -121,9 +132,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/readyz":{"path":"/ip","port":8000},"/app-health/world/readyz":{"path":"/ipv6","port":9000}}'
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -135,8 +146,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 15020
-          initialDelaySeconds: 2
-          periodSeconds: 30
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -155,8 +166,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -172,14 +187,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -206,6 +221,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +179,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -190,6 +206,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +179,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -191,6 +207,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +179,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -190,6 +206,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -7,10 +7,7 @@ spec:
   jobTemplate:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         security.istio.io/tlsMode: istio
@@ -44,29 +41,35 @@ spec:
             - 1m0s
             - --discoveryAddress
             - istio-pilot:15010
-            - --dnsRefreshRate
-            - 300s
+            - --zipkinAddress
+            - ""
+            - --proxyLogLevel=warning
+            - --proxyComponentLogLevel=misc:error
             - --connectTimeout
             - 1s
             - --proxyAdminPort
             - "15000"
             - --controlPlaneAuthPolicy
             - NONE
+            - --dnsRefreshRate
+            - 300s
             - --statusPort
             - "15020"
+            - --trust-domain=cluster.local
+            - --controlPlaneBootstrap=false
             - --concurrency
             - "2"
             env:
+            - name: JWT_POLICY
+              value: third-party-jwt
+            - name: PILOT_CERT_PROVIDER
+              value: citadel
+            - name: CA_ADDR
+              value: istio-pilot.istio-system.svc:15012
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: ISTIO_META_POD_PORTS
-              value: |-
-                [
-                ]
-            - name: ISTIO_META_CLUSTER_ID
-              value: Kubernetes
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -79,8 +82,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
-            - name: ISTIO_AUTO_MTLS_ENABLED
-              value: "true"
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: ISTIO_META_POD_PORTS
+              value: |-
+                [
+                ]
+            - name: ISTIO_META_CLUSTER_ID
+              value: Kubernetes
             - name: ISTIO_META_POD_NAME
               valueFrom:
                 fieldRef:
@@ -97,7 +108,9 @@ spec:
               value: hellocron
             - name: ISTIO_META_OWNER
               value: kubernetes://apis/batch/v2alpha1/namespaces/default/cronjobs/hellocron
-            image: docker.io/istio/proxyv2:unittest
+            - name: ISTIO_META_MESH_ID
+              value: cluster.local
+            image: gcr.io/istio-testing/proxyv2:latest
             imagePullPolicy: IfNotPresent
             name: istio-proxy
             ports:
@@ -129,8 +142,12 @@ spec:
               runAsNonRoot: true
               runAsUser: 1337
             volumeMounts:
+            - mountPath: /etc/istio/citadel-ca-cert
+              name: citadel-ca-cert
             - mountPath: /etc/istio/proxy
               name: istio-envoy
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
             - mountPath: /etc/certs/
               name: istio-certs
               readOnly: true
@@ -153,7 +170,7 @@ spec:
             - '*'
             - -d
             - "15020"
-            image: docker.io/istio/proxy_init:unittest
+            image: gcr.io/istio-testing/proxyv2:latest
             imagePullPolicy: IfNotPresent
             name: istio-init
             resources:
@@ -181,6 +198,16 @@ spec:
           - emptyDir:
               medium: Memory
             name: istio-envoy
+          - name: istio-token
+            projected:
+              sources:
+              - serviceAccountToken:
+                  audience: istio-ca
+                  expirationSeconds: 43200
+                  path: istio-token
+          - configMap:
+              name: istio-ca-root-cert
+            name: citadel-ca-cert
           - name: istio-certs
             secret:
               optional: true

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -12,11 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -48,30 +44,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -84,8 +85,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -105,7 +115,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/daemonsets/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -137,8 +149,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -161,7 +177,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -188,6 +204,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -27,11 +27,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/interceptionMode: REDIRECT
-          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-          traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-          traffic.sidecar.istio.io/includeInboundPorts: "80"
-          traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -63,30 +59,35 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
-          - --dnsRefreshRate
-          - 300s
+          - --zipkinAddress
+          - ""
+          - --proxyLogLevel=warning
+          - --proxyComponentLogLevel=misc:error
           - --connectTimeout
           - 1s
           - --proxyAdminPort
           - "15000"
           - --controlPlaneAuthPolicy
           - NONE
+          - --dnsRefreshRate
+          - 300s
           - --statusPort
           - "15020"
+          - --trust-domain=cluster.local
+          - --controlPlaneBootstrap=false
           - --concurrency
           - "2"
           env:
+          - name: JWT_POLICY
+            value: third-party-jwt
+          - name: PILOT_CERT_PROVIDER
+            value: citadel
+          - name: CA_ADDR
+            value: istio-pilot.istio-system.svc:15012
           - name: POD_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: ISTIO_META_POD_PORTS
-            value: |-
-              [
-                  {"name":"http","containerPort":80}
-              ]
-          - name: ISTIO_META_CLUSTER_ID
-            value: Kubernetes
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
@@ -99,8 +100,17 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
-          - name: ISTIO_AUTO_MTLS_ENABLED
-            value: "true"
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: ISTIO_META_POD_PORTS
+            value: |-
+              [
+                  {"name":"http","containerPort":80}
+              ]
+          - name: ISTIO_META_CLUSTER_ID
+            value: Kubernetes
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:
@@ -120,7 +130,9 @@ items:
             value: hello
           - name: ISTIO_META_OWNER
             value: kubernetes://apis/apps.openshift.io/v1/namespaces/default/deploymentconfigs/hello
-          image: docker.io/istio/proxyv2:unittest
+          - name: ISTIO_META_MESH_ID
+            value: cluster.local
+          image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:
@@ -152,8 +164,12 @@ items:
             runAsNonRoot: true
             runAsUser: 1337
           volumeMounts:
+          - mountPath: /etc/istio/citadel-ca-cert
+            name: citadel-ca-cert
           - mountPath: /etc/istio/proxy
             name: istio-envoy
+          - mountPath: /var/run/secrets/tokens
+            name: istio-token
           - mountPath: /etc/certs/
             name: istio-certs
             readOnly: true
@@ -176,7 +192,7 @@ items:
           - '*'
           - -d
           - "15020"
-          image: docker.io/istio/proxy_init:unittest
+          image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: IfNotPresent
           name: istio-init
           resources:
@@ -203,6 +219,16 @@ items:
         - emptyDir:
             medium: Memory
           name: istio-envoy
+        - name: istio-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                audience: istio-ca
+                expirationSeconds: 43200
+                path: istio-token
+        - configMap:
+            name: istio-ca-root-cert
+          name: citadel-ca-cert
         - name: istio-certs
           secret:
             optional: true

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -12,11 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -48,30 +44,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -84,8 +85,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -105,7 +115,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps.openshift.io/v1/namespaces/default/deploymentconfigs/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -137,8 +149,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -161,7 +177,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -188,6 +204,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -15,11 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/enableCoreDump: "true"
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -51,30 +47,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -87,8 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -111,7 +121,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -138,13 +150,17 @@ spec:
             drop:
             - ALL
           privileged: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -167,7 +183,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -190,31 +206,20 @@ spec:
           runAsGroup: 0
           runAsNonRoot: false
           runAsUser: 0
-      - args:
-        - -c
-        - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
-        command:
-        - /bin/sh
-        image: ubuntu:xenial
-        imagePullPolicy: IfNotPresent
-        name: enable-core-dump
-        resources: {}
-        securityContext:
-          allowPrivilegeEscalation: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-            drop:
-            - ALL
-          privileged: true
-          readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
       volumes:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +179,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -191,7 +207,7 @@ spec:
         - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
         command:
         - /bin/sh
-        image: ubuntu:xenial
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
@@ -211,6 +227,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -45,35 +41,40 @@ spec:
         - --serviceCluster
         - hello.$(POD_NAMESPACE)
         - --drainDuration
-        - 42s
+        - 45s
         - --parentShutdownDuration
-        - 42s
+        - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 42s
+        - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +179,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -190,6 +206,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -28,10 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -67,29 +64,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -102,8 +105,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -123,7 +134,9 @@ spec:
           value: frontend
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/frontend
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -155,8 +168,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -179,7 +196,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -206,6 +223,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +179,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init
         resources:
@@ -190,6 +206,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +179,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -190,6 +206,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -15,11 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -51,30 +47,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -87,8 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -111,7 +121,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -143,8 +155,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -167,7 +183,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -194,6 +210,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +179,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -190,6 +206,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -15,11 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -52,30 +48,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -88,8 +89,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -109,7 +119,9 @@ spec:
           value: hello-v1
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello-v1
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -141,8 +153,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -165,7 +181,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -192,6 +208,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true
@@ -215,11 +241,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "81"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -252,30 +274,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":81}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -288,8 +315,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":81}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -309,7 +345,9 @@ spec:
           value: hello-v2
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello-v2
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -341,8 +379,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -365,7 +407,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -392,6 +434,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -15,11 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -51,30 +47,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -87,8 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -108,7 +118,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/test/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -140,8 +152,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -164,7 +180,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -191,6 +207,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Never
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +179,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Never
         name: istio-init
         resources:
@@ -190,6 +206,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -14,12 +14,8 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/proxyImage: docker.io/istio/proxy2_debug:unittest
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -51,30 +47,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -87,8 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +121,8 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: docker.io/istio/proxy2_debug:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -143,8 +155,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -167,7 +183,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -194,6 +210,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -167,7 +183,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -194,6 +210,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -14,9 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: TPROXY
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -48,28 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
+        - --statusPort
+        - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -82,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -95,7 +109,7 @@ spec:
         - name: SDS_ENABLED
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
-          value: TPROXY
+          value: REDIRECT
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
@@ -103,13 +117,22 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
         - containerPort: 15090
           name: http-envoy-prom
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
         resources:
           limits:
             cpu: "2"
@@ -120,18 +143,20 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
-            add:
-            - NET_ADMIN
             drop:
             - ALL
           privileged: false
           readOnlyRootFilesystem: true
           runAsGroup: 1337
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsNonRoot: true
+          runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -145,16 +170,16 @@ spec:
         - -u
         - "1337"
         - -m
-        - TPROXY
+        - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
-        - ""
-        image: docker.io/istio/proxy_init:unittest
+        - "15020"
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -181,6 +206,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-validation"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-validation"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -165,7 +181,7 @@ spec:
         - "15020"
         - --run-validation
         - --skip-rule-apply
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-validation
         resources:
@@ -189,6 +205,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +179,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -190,6 +206,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -7,10 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         security.istio.io/tlsMode: istio
@@ -42,29 +39,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -77,8 +80,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -95,7 +106,9 @@ spec:
           value: pi
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/batch/v1/namespaces/default/jobs/pi
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -127,8 +140,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -151,7 +168,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -179,6 +196,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/kubevirtInterfaces: net1
       creationTimestamp: null
       labels:
@@ -51,30 +47,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
-        - "15020"
+        - "123"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -87,8 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -111,7 +121,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -119,12 +131,12 @@ spec:
           name: http-envoy-prom
           protocol: TCP
         readinessProbe:
-          failureThreshold: 30
+          failureThreshold: 300
           httpGet:
             path: /healthz/ready
-            port: 15020
-          initialDelaySeconds: 1
-          periodSeconds: 2
+            port: 123
+          initialDelaySeconds: 100
+          periodSeconds: 200
         resources:
           limits:
             cpu: "2"
@@ -143,8 +155,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -166,10 +182,10 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "123"
         - -k
         - net1
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -196,6 +212,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/kubevirtInterfaces: net1,net2
       creationTimestamp: null
       labels:
@@ -51,30 +47,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -87,8 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -111,7 +121,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -143,8 +155,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -169,7 +185,7 @@ spec:
         - "15020"
         - -k
         - net1,net2
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -196,6 +212,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -29,10 +29,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/interceptionMode: REDIRECT
-          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-          traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-          traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -68,29 +65,35 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
-          - --dnsRefreshRate
-          - 300s
+          - --zipkinAddress
+          - ""
+          - --proxyLogLevel=warning
+          - --proxyComponentLogLevel=misc:error
           - --connectTimeout
           - 1s
           - --proxyAdminPort
           - "15000"
           - --controlPlaneAuthPolicy
           - NONE
+          - --dnsRefreshRate
+          - 300s
           - --statusPort
           - "15020"
+          - --trust-domain=cluster.local
+          - --controlPlaneBootstrap=false
           - --concurrency
           - "2"
           env:
+          - name: JWT_POLICY
+            value: third-party-jwt
+          - name: PILOT_CERT_PROVIDER
+            value: citadel
+          - name: CA_ADDR
+            value: istio-pilot.istio-system.svc:15012
           - name: POD_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: ISTIO_META_POD_PORTS
-            value: |-
-              [
-              ]
-          - name: ISTIO_META_CLUSTER_ID
-            value: Kubernetes
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
@@ -103,8 +106,16 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
-          - name: ISTIO_AUTO_MTLS_ENABLED
-            value: "true"
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: ISTIO_META_POD_PORTS
+            value: |-
+              [
+              ]
+          - name: ISTIO_META_CLUSTER_ID
+            value: Kubernetes
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:
@@ -124,7 +135,9 @@ items:
             value: frontend
           - name: ISTIO_META_OWNER
             value: kubernetes://apis/apps/v1/namespaces/default/deployments/frontend
-          image: docker.io/istio/proxyv2:unittest
+          - name: ISTIO_META_MESH_ID
+            value: cluster.local
+          image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:
@@ -156,8 +169,12 @@ items:
             runAsNonRoot: true
             runAsUser: 1337
           volumeMounts:
+          - mountPath: /etc/istio/citadel-ca-cert
+            name: citadel-ca-cert
           - mountPath: /etc/istio/proxy
             name: istio-envoy
+          - mountPath: /var/run/secrets/tokens
+            name: istio-token
           - mountPath: /etc/certs/
             name: istio-certs
             readOnly: true
@@ -180,7 +197,7 @@ items:
           - '*'
           - -d
           - "15020"
-          image: docker.io/istio/proxy_init:unittest
+          image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: IfNotPresent
           name: istio-init
           resources:
@@ -207,6 +224,16 @@ items:
         - emptyDir:
             medium: Memory
           name: istio-envoy
+        - name: istio-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                audience: istio-ca
+                expirationSeconds: 43200
+                path: istio-token
+        - configMap:
+            name: istio-ca-root-cert
+          name: citadel-ca-cert
         - name: istio-certs
           secret:
             optional: true

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -17,11 +17,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/interceptionMode: REDIRECT
-          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-          traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-          traffic.sidecar.istio.io/includeInboundPorts: "80"
-          traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -54,30 +50,35 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
-          - --dnsRefreshRate
-          - 300s
+          - --zipkinAddress
+          - ""
+          - --proxyLogLevel=warning
+          - --proxyComponentLogLevel=misc:error
           - --connectTimeout
           - 1s
           - --proxyAdminPort
           - "15000"
           - --controlPlaneAuthPolicy
           - NONE
+          - --dnsRefreshRate
+          - 300s
           - --statusPort
           - "15020"
+          - --trust-domain=cluster.local
+          - --controlPlaneBootstrap=false
           - --concurrency
           - "2"
           env:
+          - name: JWT_POLICY
+            value: third-party-jwt
+          - name: PILOT_CERT_PROVIDER
+            value: citadel
+          - name: CA_ADDR
+            value: istio-pilot.istio-system.svc:15012
           - name: POD_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: ISTIO_META_POD_PORTS
-            value: |-
-              [
-                  {"name":"http","containerPort":80}
-              ]
-          - name: ISTIO_META_CLUSTER_ID
-            value: Kubernetes
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
@@ -90,8 +91,17 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
-          - name: ISTIO_AUTO_MTLS_ENABLED
-            value: "true"
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: ISTIO_META_POD_PORTS
+            value: |-
+              [
+                  {"name":"http","containerPort":80}
+              ]
+          - name: ISTIO_META_CLUSTER_ID
+            value: Kubernetes
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:
@@ -111,7 +121,9 @@ items:
             value: hello-v1
           - name: ISTIO_META_OWNER
             value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello-v1
-          image: docker.io/istio/proxyv2:unittest
+          - name: ISTIO_META_MESH_ID
+            value: cluster.local
+          image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:
@@ -143,8 +155,12 @@ items:
             runAsNonRoot: true
             runAsUser: 1337
           volumeMounts:
+          - mountPath: /etc/istio/citadel-ca-cert
+            name: citadel-ca-cert
           - mountPath: /etc/istio/proxy
             name: istio-envoy
+          - mountPath: /var/run/secrets/tokens
+            name: istio-token
           - mountPath: /etc/certs/
             name: istio-certs
             readOnly: true
@@ -167,7 +183,7 @@ items:
           - '*'
           - -d
           - "15020"
-          image: docker.io/istio/proxy_init:unittest
+          image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: IfNotPresent
           name: istio-init
           resources:
@@ -194,6 +210,16 @@ items:
         - emptyDir:
             medium: Memory
           name: istio-envoy
+        - name: istio-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                audience: istio-ca
+                expirationSeconds: 43200
+                path: istio-token
+        - configMap:
+            name: istio-ca-root-cert
+          name: citadel-ca-cert
         - name: istio-certs
           secret:
             optional: true
@@ -216,11 +242,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/interceptionMode: REDIRECT
-          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-          traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-          traffic.sidecar.istio.io/includeInboundPorts: "81"
-          traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -253,30 +275,35 @@ items:
           - 1m0s
           - --discoveryAddress
           - istio-pilot:15010
-          - --dnsRefreshRate
-          - 300s
+          - --zipkinAddress
+          - ""
+          - --proxyLogLevel=warning
+          - --proxyComponentLogLevel=misc:error
           - --connectTimeout
           - 1s
           - --proxyAdminPort
           - "15000"
           - --controlPlaneAuthPolicy
           - NONE
+          - --dnsRefreshRate
+          - 300s
           - --statusPort
           - "15020"
+          - --trust-domain=cluster.local
+          - --controlPlaneBootstrap=false
           - --concurrency
           - "2"
           env:
+          - name: JWT_POLICY
+            value: third-party-jwt
+          - name: PILOT_CERT_PROVIDER
+            value: citadel
+          - name: CA_ADDR
+            value: istio-pilot.istio-system.svc:15012
           - name: POD_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: ISTIO_META_POD_PORTS
-            value: |-
-              [
-                  {"name":"http","containerPort":81}
-              ]
-          - name: ISTIO_META_CLUSTER_ID
-            value: Kubernetes
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
@@ -289,8 +316,17 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
-          - name: ISTIO_AUTO_MTLS_ENABLED
-            value: "true"
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: ISTIO_META_POD_PORTS
+            value: |-
+              [
+                  {"name":"http","containerPort":81}
+              ]
+          - name: ISTIO_META_CLUSTER_ID
+            value: Kubernetes
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:
@@ -310,7 +346,9 @@ items:
             value: hello-v2
           - name: ISTIO_META_OWNER
             value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello-v2
-          image: docker.io/istio/proxyv2:unittest
+          - name: ISTIO_META_MESH_ID
+            value: cluster.local
+          image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:
@@ -342,8 +380,12 @@ items:
             runAsNonRoot: true
             runAsUser: 1337
           volumeMounts:
+          - mountPath: /etc/istio/citadel-ca-cert
+            name: citadel-ca-cert
           - mountPath: /etc/istio/proxy
             name: istio-envoy
+          - mountPath: /var/run/secrets/tokens
+            name: istio-token
           - mountPath: /etc/certs/
             name: istio-certs
             readOnly: true
@@ -366,7 +408,7 @@ items:
           - '*'
           - -d
           - "15020"
-          image: docker.io/istio/proxy_init:unittest
+          image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: IfNotPresent
           name: istio-init
           resources:
@@ -393,6 +435,16 @@ items:
         - emptyDir:
             medium: Memory
           name: istio-envoy
+        - name: istio-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                audience: istio-ca
+                expirationSeconds: 43200
+                path: istio-token
+        - configMap:
+            name: istio-ca-root-cert
+          name: citadel-ca-cert
         - name: istio-certs
           secret:
             optional: true

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -12,11 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "123"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: app
@@ -52,30 +48,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"foo","containerPort":123}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -88,8 +89,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"foo","containerPort":123}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -109,7 +119,9 @@ spec:
           value: app
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/app
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -141,8 +153,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -165,7 +181,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -192,6 +208,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +117,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +151,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -177,7 +193,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -204,6 +220,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    sidecar.istio.io/interceptionMode: REDIRECT
-    sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-    traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-    traffic.sidecar.istio.io/includeInboundPorts: "80"
-    traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+    sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
   creationTimestamp: null
   labels:
     security.istio.io/tlsMode: istio
@@ -36,30 +32,35 @@ spec:
     - 1m0s
     - --discoveryAddress
     - istio-pilot:15010
-    - --dnsRefreshRate
-    - 300s
+    - --zipkinAddress
+    - ""
+    - --proxyLogLevel=warning
+    - --proxyComponentLogLevel=misc:error
     - --connectTimeout
     - 1s
     - --proxyAdminPort
     - "15000"
     - --controlPlaneAuthPolicy
     - NONE
+    - --dnsRefreshRate
+    - 300s
     - --statusPort
     - "15020"
+    - --trust-domain=cluster.local
+    - --controlPlaneBootstrap=false
     - --concurrency
     - "2"
     env:
+    - name: JWT_POLICY
+      value: third-party-jwt
+    - name: PILOT_CERT_PROVIDER
+      value: citadel
+    - name: CA_ADDR
+      value: istio-pilot.istio-system.svc:15012
     - name: POD_NAME
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
-    - name: ISTIO_META_POD_PORTS
-      value: |-
-        [
-            {"name":"http","containerPort":80}
-        ]
-    - name: ISTIO_META_CLUSTER_ID
-      value: Kubernetes
     - name: POD_NAMESPACE
       valueFrom:
         fieldRef:
@@ -72,8 +73,17 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.serviceAccountName
-    - name: ISTIO_AUTO_MTLS_ENABLED
-      value: "true"
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: ISTIO_META_POD_PORTS
+      value: |-
+        [
+            {"name":"http","containerPort":80}
+        ]
+    - name: ISTIO_META_CLUSTER_ID
+      value: Kubernetes
     - name: ISTIO_META_POD_NAME
       valueFrom:
         fieldRef:
@@ -90,7 +100,9 @@ spec:
       value: hellopod
     - name: ISTIO_META_OWNER
       value: kubernetes://apis/v1/namespaces/default/pods/hellopod
-    image: docker.io/istio/proxyv2:unittest
+    - name: ISTIO_META_MESH_ID
+      value: cluster.local
+    image: gcr.io/istio-testing/proxyv2:latest
     imagePullPolicy: IfNotPresent
     name: istio-proxy
     ports:
@@ -122,8 +134,12 @@ spec:
       runAsNonRoot: true
       runAsUser: 1337
     volumeMounts:
+    - mountPath: /etc/istio/citadel-ca-cert
+      name: citadel-ca-cert
     - mountPath: /etc/istio/proxy
       name: istio-envoy
+    - mountPath: /var/run/secrets/tokens
+      name: istio-token
     - mountPath: /etc/certs/
       name: istio-certs
       readOnly: true
@@ -146,7 +162,7 @@ spec:
     - '*'
     - -d
     - "15020"
-    image: docker.io/istio/proxy_init:unittest
+    image: gcr.io/istio-testing/proxyv2:latest
     imagePullPolicy: IfNotPresent
     name: istio-init
     resources:
@@ -173,6 +189,16 @@ spec:
   - emptyDir:
       medium: Memory
     name: istio-envoy
+  - name: istio-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          audience: istio-ca
+          expirationSeconds: 43200
+          path: istio-token
+  - configMap:
+      name: istio-ca-root-cert
+    name: citadel-ca-cert
   - name: istio-certs
     secret:
       optional: true

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -11,11 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -45,30 +41,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -81,8 +82,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -102,7 +112,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/replicasets/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -134,8 +146,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -158,7 +174,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -185,6 +201,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -10,11 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: nginx
@@ -44,30 +40,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -80,8 +81,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -101,7 +111,9 @@ spec:
           value: nginx
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/v1/namespaces/default/replicationcontrollers/nginx
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -133,8 +145,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -157,7 +173,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -184,6 +200,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -14,11 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -53,30 +49,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -89,8 +90,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -110,7 +120,9 @@ spec:
           value: hello
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/statefulsets/hello
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -142,8 +154,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -166,7 +182,7 @@ spec:
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -196,6 +212,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -16,12 +16,8 @@ spec:
         readiness.status.sidecar.istio.io/failureThreshold: "300"
         readiness.status.sidecar.istio.io/initialDelaySeconds: "100"
         readiness.status.sidecar.istio.io/periodSeconds: "200"
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         status.sidecar.istio.io/port: "123"
-        traffic.sidecar.istio.io/excludeInboundPorts: "123"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
       creationTimestamp: null
       labels:
         app: status
@@ -51,30 +47,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "123"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -87,8 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -111,7 +121,9 @@ spec:
           value: statusPort
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/statusPort
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -143,8 +155,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -167,7 +183,7 @@ spec:
         - '*'
         - -d
         - "123"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -194,6 +210,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -12,11 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "123"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: status
@@ -46,30 +42,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "123"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -82,8 +83,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -103,7 +113,9 @@ spec:
           value: statusPort
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/statusPort
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -135,8 +147,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -159,7 +175,7 @@ spec:
         - '*'
         - -d
         - "123"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -186,6 +202,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -12,9 +12,8 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6,15020
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: ""
         traffic.sidecar.istio.io/includeOutboundIPRanges: ""
@@ -47,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -83,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +120,9 @@ spec:
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/traffic
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +154,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +182,7 @@ spec:
         - ""
         - -d
         - 4,5,6,15020
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -190,6 +209,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -12,9 +12,8 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6,15020
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: '*'
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -47,30 +46,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -83,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -107,7 +120,9 @@ spec:
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/traffic
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -139,8 +154,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -163,7 +182,7 @@ spec:
         - '*'
         - -d
         - 4,5,6,15020
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -190,6 +209,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -12,9 +12,8 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6,15020
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/excludeOutboundPorts: 7,8,9
         traffic.sidecar.istio.io/includeInboundPorts: 1,2,3
@@ -48,30 +47,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -84,8 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -108,7 +121,9 @@ spec:
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/traffic
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -140,8 +155,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -166,7 +185,7 @@ spec:
         - 4,5,6,15020
         - -o
         - 7,8,9
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -193,6 +212,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -12,10 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: traffic
@@ -45,30 +42,35 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -81,8 +83,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -102,7 +113,9 @@ spec:
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/traffic
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -134,8 +147,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -151,14 +168,14 @@ spec:
         - -m
         - REDIRECT
         - -i
-        - ""
+        - '*'
         - -x
         - ""
         - -b
         - '*'
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -185,6 +202,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -12,12 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
-        traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
-        traffic.sidecar.istio.io/includeInboundPorts: "80"
-        traffic.sidecar.istio.io/includeOutboundIPRanges: 127.0.0.1/24,10.96.0.1/24
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: traffic
@@ -47,28 +42,33 @@ spec:
         - 1m0s
         - --discoveryAddress
         - istio-pilot:15010
-        - --dnsRefreshRate
-        - 300s
+        - --zipkinAddress
+        - ""
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -81,8 +81,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -102,7 +111,9 @@ spec:
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/traffic
-        image: docker.io/istio/proxyv2:unittest
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -127,8 +138,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -151,7 +166,7 @@ spec:
         - '*'
         - -d
         - 4,5,6
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
@@ -178,6 +193,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -47,30 +47,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -83,8 +86,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -97,6 +109,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -129,8 +143,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -180,6 +198,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -46,30 +46,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -82,8 +85,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -96,6 +108,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -128,8 +142,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -179,6 +197,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -46,30 +46,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -82,8 +85,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -96,6 +108,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -128,8 +142,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -179,6 +197,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -52,29 +52,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -87,8 +91,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -101,6 +113,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -133,8 +147,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -184,6 +202,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -48,30 +48,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -84,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -98,6 +110,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -130,8 +144,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -181,6 +199,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -48,30 +48,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -84,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -98,6 +110,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -130,8 +144,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -181,6 +199,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -50,30 +50,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +89,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -100,6 +112,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -132,8 +146,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -183,6 +201,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true
@@ -242,30 +270,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":81}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -278,8 +309,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":81}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -292,6 +332,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -324,8 +366,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -375,6 +421,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -68,31 +68,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-                ,{"name":"http","containerPort":90}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -105,8 +107,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+                ,{"name":"http","containerPort":90}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -119,6 +131,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -151,8 +165,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -202,6 +220,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -43,29 +43,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -78,8 +82,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -96,6 +108,8 @@ spec:
           value: pi
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/v1/namespaces/default/pods/pi
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -128,8 +142,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -180,6 +198,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -52,29 +52,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -87,8 +91,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -101,6 +113,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -133,8 +147,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -184,6 +202,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -50,30 +50,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +89,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -100,6 +112,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -132,8 +146,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -183,6 +201,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true
@@ -242,30 +270,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":81}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -278,8 +309,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":81}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -292,6 +332,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -324,8 +366,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -375,6 +421,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -44,30 +44,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -80,8 +83,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -94,6 +106,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -126,8 +140,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -177,6 +195,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -42,30 +42,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -78,8 +81,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -96,6 +108,8 @@ spec:
           value: nginx
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/v1/namespaces/default/pods/nginx
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -128,8 +142,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -179,6 +197,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -46,30 +46,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "1"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -82,8 +85,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -96,6 +108,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -125,8 +139,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -176,6 +194,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -51,30 +51,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -87,8 +90,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -101,6 +113,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -133,8 +147,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -187,6 +205,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -49,30 +49,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "123"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -85,8 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -99,6 +111,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -131,8 +145,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -182,6 +200,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -48,30 +48,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -84,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -98,6 +110,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -130,8 +144,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -181,6 +199,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -48,30 +48,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -84,8 +87,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -98,6 +110,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -130,8 +144,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -181,6 +199,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -49,30 +49,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -85,8 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -99,6 +111,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -131,8 +145,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -184,6 +202,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -50,30 +50,33 @@ spec:
         - istio-pilot:15010
         - --zipkinAddress
         - ""
-        - --dnsRefreshRate
-        - 300s
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 1s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
         - NONE
+        - --dnsRefreshRate
+        - 300s
         - --statusPort
         - "15020"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
         - --concurrency
         - "2"
         env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: citadel
+        - name: CA_ADDR
+          value: istio-pilot.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: ISTIO_META_POD_PORTS
-          value: |-
-            [
-                {"name":"http","containerPort":80}
-            ]
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -86,8 +89,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+                {"name":"http","containerPort":80}
+            ]
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -100,6 +112,8 @@ spec:
           value: "false"
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -132,8 +146,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
+        - mountPath: /etc/istio/citadel-ca-cert
+          name: citadel-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
@@ -188,6 +206,16 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: citadel-ca-cert
       - name: istio-certs
         secret:
           optional: true

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -27,14 +27,19 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/helm/pkg/strvals"
-
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+
+	"istio.io/istio/operator/pkg/name"
 
 	"istio.io/api/annotation"
+
+	operator "istio.io/istio/operator/cmd/mesh"
 
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/config/mesh"
@@ -45,20 +50,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/helm/pkg/chartutil"
-	"k8s.io/helm/pkg/engine"
-	"k8s.io/helm/pkg/proto/hapi/chart"
-	tversion "k8s.io/helm/pkg/proto/hapi/version"
-	"k8s.io/helm/pkg/timeconv"
 )
 
-const (
-	helmChartDirectory     = "../../../install/kubernetes/helm/istio"
-	helmConfigMapKey       = "istio/templates/sidecar-injector-configmap.yaml"
-	injectorConfig         = "../../../install/kubernetes/helm/istio/files/injection-template.yaml"
-	helmValuesFile         = "values.yaml"
-	yamlSeparator          = "\n---"
-	minimalSidecarTemplate = `
+const yamlSeparator = "\n---"
+
+var minimalSidecarTemplate = &Config{
+	Policy: InjectionPolicyEnabled,
+	Template: `
 initContainers:
 - name: istio-init
 containers:
@@ -67,8 +65,8 @@ volumes:
 - name: istio-envoy
 imagePullSecrets:
 - name: istio-image-pull-secrets
-`
-)
+`,
+}
 
 var (
 	rotatedKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
@@ -643,7 +641,9 @@ func TestWebhookInject(t *testing.T) {
 		if c.templateFile != "" {
 			templateFile = c.templateFile
 		}
+		c := c
 		t.Run(fmt.Sprintf("[%d] %s", i, c.inputFile), func(t *testing.T) {
+			t.Parallel()
 			wh, cleanup := createTestWebhookFromFile(filepath.Join("testdata/webhook", templateFile), t)
 			defer cleanup()
 			podYAML := util.ReadFile(input, t)
@@ -834,7 +834,7 @@ func TestHelmInject(t *testing.T) {
 	}
 }
 
-func createTestWebhook(t testing.TB, configYaml string) (*Webhook, func()) {
+func createTestWebhook(t testing.TB, config *Config, values string) (*Webhook, func()) {
 	m := mesh.DefaultMeshConfig()
 	dir, err := ioutil.TempDir("", "webhook_test")
 	if err != nil {
@@ -843,152 +843,73 @@ func createTestWebhook(t testing.TB, configYaml string) (*Webhook, func()) {
 	cleanup := func() {
 		_ = os.RemoveAll(dir)
 	}
-	config := &Config{}
-	if err := yaml.Unmarshal([]byte(configYaml), config); err != nil {
-		t.Fatalf("failed to read webhook config: %v", err)
-	}
 	return &Webhook{
 		Config:                 config,
 		sidecarTemplateVersion: "unit-test-fake-version",
 		meshConfig:             &m,
-		valuesConfig:           getValuesWithHelm(nil, t),
+		valuesConfig:           values,
 	}, cleanup
 }
 
 func createTestWebhookFromFile(templateFile string, t *testing.T) (*Webhook, func()) {
 	t.Helper()
-	sidecarTemplate := string(util.ReadFile(templateFile, t))
-	return createTestWebhook(t, sidecarTemplate)
+	injectConfig := &Config{}
+	if err := yaml.Unmarshal(util.ReadFile(templateFile, t), injectConfig); err != nil {
+		t.Fatalf("failed to unmarshal injectionConfig: %v", err)
+	}
+	return createTestWebhook(t, injectConfig, "{}")
 }
 
 func createTestWebhookFromHelmConfigMap(t *testing.T) (*Webhook, func()) {
 	t.Helper()
 	// Load the config map with Helm. This simulates what will be done at runtime, by replacing function calls and
 	// variables and generating a new configmap for use by the injection logic.
-	sidecarTemplate := loadConfigMapWithHelm(nil, t)
-	return createTestWebhook(t, sidecarTemplate)
+	sidecarTemplate, values := loadInjectionConfigMap(t, "")
+	return createTestWebhook(t, sidecarTemplate, values)
 }
 
-func loadSidecarTemplate(t testing.TB) string {
-	injectionConfig, err := ioutil.ReadFile(injectorConfig) // nolint: vetshadow
-	if err != nil {
-		t.Fatalf("failed to load sidecar template: %v", err)
-	}
-	return string(injectionConfig)
-}
-
-func getValues(params *Params, t testing.TB) string {
-	values := getHelmValues(t)
-	mergedValues := mergeParamsIntoHelmValues(params, values, t)
-	return mergedValues
-}
-
-func getValuesWithHelm(params *Params, t testing.TB) string {
-	c, err := chartutil.Load(helmChartDirectory)
-	if err != nil {
-		t.Fatal(err)
-	}
-	values := getHelmValues(t)
-	mergedValues := mergeParamsIntoHelmValues(params, values, t)
-	chartConfig := &chart.Config{Raw: mergedValues, Values: map[string]*chart.Value{}}
-
-	vals, err := chartutil.CoalesceValues(c, chartConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-	out, err := vals.YAML()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return out
-}
-
-func loadConfigMapWithHelm(params *Params, t testing.TB) string {
+// loadInjectionConfigMap will render the charts using the operator, with given yaml overrides.
+// This allows us to fully simulate what will actually happen at run time.
+func loadInjectionConfigMap(t testing.TB, settings string) (template *Config, values string) {
 	t.Helper()
-	c, err := chartutil.Load(helmChartDirectory)
+	manifests, _, err := operator.GenManifests(nil, settings, false, nil)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to generate manifests: %v", err)
 	}
+	for _, mlist := range manifests[name.PilotComponentName] {
+		for _, object := range strings.Split(mlist, yamlSeparator) {
 
-	values := getHelmValues(t)
-	mergedValues := mergeParamsIntoHelmValues(params, values, t)
+			r := bytes.NewReader([]byte(object))
+			decoder := k8syaml.NewYAMLOrJSONDecoder(r, 1024)
 
-	chartConfig := &chart.Config{Raw: mergedValues, Values: map[string]*chart.Value{}}
-	options := chartutil.ReleaseOptions{
-		Name:      "istio",
-		Time:      timeconv.Now(),
-		Namespace: "",
-	}
-
-	vals, err := chartutil.ToRenderValuesCaps(c, chartConfig, options, &chartutil.Capabilities{TillerVersion: &tversion.Version{SemVer: "2.7.2"}})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	files, err := engine.New().Render(c, vals)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, ok := files[helmConfigMapKey]
-	if !ok {
-		t.Fatalf("Unable to located configmap file %s", helmConfigMapKey)
-	}
-
-	cfgMap := corev1.ConfigMap{}
-	err = yaml.Unmarshal([]byte(f), &cfgMap)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cfg, ok := cfgMap.Data["config"]
-	if !ok {
-		t.Fatal("ConfigMap yaml missing config field")
-	}
-
-	return cfg
-}
-
-func getHelmValues(t testing.TB) string {
-	t.Helper()
-	valuesFile := filepath.Join(helmChartDirectory, helmValuesFile)
-	return string(util.ReadFile(valuesFile, t))
-}
-
-func mergeParamsIntoHelmValues(params *Params, vals string, t testing.TB) string {
-	t.Helper()
-	if params == nil {
-		return vals
-	}
-	valMap := chartutil.FromYaml(vals)
-	paramsVals := params.intoHelmValues()
-	for path, value := range paramsVals {
-		setStr := fmt.Sprintf("%s=%s", path, escapeHelmValue(value))
-		if err := strvals.ParseInto(setStr, valMap); err != nil {
-			t.Fatal(err)
+			out := &unstructured.Unstructured{}
+			err := decoder.Decode(out)
+			if err != nil {
+				t.Fatalf("error decoding object: %v", err)
+			}
+			if out.GetName() == "istio-sidecar-injector" && (out.GroupVersionKind() == schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}) {
+				data, ok := out.Object["data"].(map[string]interface{})
+				if !ok {
+					t.Fatalf("failed to convert %v", out)
+				}
+				config, ok := data["config"].(string)
+				if !ok {
+					t.Fatalf("failed to config %v", data)
+				}
+				values, ok := data["values"].(string)
+				if !ok {
+					t.Fatalf("failed to config %v", data)
+				}
+				injectConfig := &Config{}
+				if err := yaml.Unmarshal([]byte(config), injectConfig); err != nil {
+					t.Fatalf("failed to unmarshal injectionConfig: %v", err)
+				}
+				return injectConfig, values
+			}
 		}
 	}
-	return chartutil.ToYaml(valMap)
-}
-
-func escapeHelmValue(val string) string {
-	if len(val) == 0 {
-		return val
-	}
-
-	if val[0] == '{' && val[len(val)-1] == '}' {
-		val := val[1 : len(val)-1]
-		val = strings.Replace(val, "{", "\\{", -1)
-		val = strings.Replace(val, "}", "\\}", -1)
-		val = strings.Replace(val, ".", "\\.", -1)
-		val = strings.Replace(val, "=", "\\=", -1)
-
-		return "{" + val + "}"
-	}
-
-	val = strings.Replace(val, ",", "\\,", -1)
-	val = strings.Replace(val, ".", "\\.", -1)
-	val = strings.Replace(val, "=", "\\=", -1)
-	return val
+	t.Fatal("could not find injection template")
+	return nil, ""
 }
 
 func splitYamlFile(yamlFile string, t *testing.T) [][]byte {
@@ -1258,7 +1179,7 @@ func makeTestData(t testing.TB, skip bool) []byte {
 	return reviewJSON
 }
 
-func createWebhook(t testing.TB, sidecarTemplate string) (*Webhook, func()) {
+func createWebhook(t testing.TB, cfg *Config) (*Webhook, func()) {
 	t.Helper()
 	dir, err := ioutil.TempDir("", "webhook_test")
 	if err != nil {
@@ -1268,16 +1189,12 @@ func createWebhook(t testing.TB, sidecarTemplate string) (*Webhook, func()) {
 		_ = os.RemoveAll(dir)
 	}
 
-	cfg := &Config{
-		Policy:   InjectionPolicyEnabled,
-		Template: sidecarTemplate,
-	}
 	configBytes, err := yaml.Marshal(cfg)
 	if err != nil {
 		cleanup()
 		t.Fatalf("Could not marshal test injection config: %v", err)
 	}
-	valuesBytes := []byte(getValues(&Params{}, t))
+	_, values := loadInjectionConfigMap(t, "")
 	var (
 		configFile     = filepath.Join(dir, "config-file.yaml")
 		valuesFile     = filepath.Join(dir, "values-file.yaml")
@@ -1293,7 +1210,7 @@ func createWebhook(t testing.TB, sidecarTemplate string) (*Webhook, func()) {
 		t.Fatalf("WriteFile(%v) failed: %v", configFile, err)
 	}
 
-	if err := ioutil.WriteFile(valuesFile, valuesBytes, 0644); err != nil { // nolint: vetshadow
+	if err := ioutil.WriteFile(valuesFile, []byte(values), 0644); err != nil { // nolint: vetshadow
 		cleanup()
 		t.Fatalf("WriteFile(%v) failed: %v", valuesFile, err)
 	}
@@ -1546,7 +1463,9 @@ func testSideCarInjectorMetrics(t *testing.T, wh *Webhook) {
 	if err != nil {
 		t.Fatalf("failed to read body: %v", err)
 	}
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("failed to close: %v", err)
+	}
 
 	output := string(body)
 
@@ -1568,19 +1487,7 @@ func testSideCarInjectorMetrics(t *testing.T, wh *Webhook) {
 }
 
 func BenchmarkInjectServe(b *testing.B) {
-	mesh := mesh.DefaultMeshConfig()
-	params := &Params{
-		InitImage:           InitImageName(unitTestHub, unitTestTag),
-		ProxyImage:          ProxyImageName(unitTestHub, unitTestTag),
-		ImagePullPolicy:     "IfNotPresent",
-		Verbosity:           DefaultVerbosity,
-		SidecarProxyUID:     DefaultSidecarProxyUID,
-		Version:             "12345678",
-		Mesh:                &mesh,
-		IncludeIPRanges:     DefaultIncludeIPRanges,
-		IncludeInboundPorts: DefaultIncludeInboundPorts,
-	}
-	sidecarTemplate := loadConfigMapWithHelm(params, b)
+	sidecarTemplate, _ := loadInjectionConfigMap(b, "")
 	wh, cleanup := createWebhook(b, sidecarTemplate)
 	defer cleanup()
 


### PR DESCRIPTION
For https://github.com/istio/istio/issues/20441

This cleans up the injection tests which are using the helm templates, which doesn't really give us any coverage anymore. Now we use the new templates.

This PR is pretty large mostly since all the goldens are updated. other changes are just cleaning up all  the helm crap. One thing to note is we had some `Params` object that was only used for the tests, but was disguised as being used in the code (maybe it was at some point) -- this is testing only, so I did not change any behavior by removing it.

cc @rlenglet 