### PR TITLE
Fix `BUILD_WITH_CONTAINER=1 make test` on non Linux host - alternate

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -87,12 +87,19 @@ export ISTIO_BIN=$(GOBIN)
 export ISTIO_OUT:=$(TARGET_OUT)
 export ISTIO_OUT_LINUX:=$(TARGET_OUT_LINUX)
 
-# LOCAL_OUT should include architecture where we are currently running versus the desired.
-# This is used when we need to run a build artifact.
+# LOCAL_OUT should point to architecture where we are currently running versus the desired.
+# This is used when we need to run a build artifact during tests or later as part of another
+# target. If we are running in the Linux build container on non Linux hosts, we add the
+# linux binaries to the build dependencies, BUILD_DEPS, which can be added to other targets
+# that would need the Linux binaries (ex. tests).
+BUILD_DEPS:=
 ifeq ($(IN_BUILD_CONTAINER),1)
-  LOCAL_OUT := $(ISTIO_OUT_LINUX)
+  export LOCAL_OUT := $(ISTIO_OUT_LINUX)
+  ifneq ($(GOOS_LOCAL),"linux")
+    BUILD_DEPS += build-linux
+  endif
 else
-  LOCAL_OUT := $(ISTIO_OUT)
+  export LOCAL_OUT := $(ISTIO_OUT)
 endif
 
 export HELM=helm
@@ -519,9 +526,9 @@ security-racetest:
 	go test ${T} -race ./security/pkg/... ./security/cmd/...
 
 .PHONY: common-racetest
-common-racetest:
+common-racetest: ${BUILD_DEPS}
 	# Execute bash shell unit tests scripts
-	./tests/scripts/istio-iptables-test.sh
+	LOCAL_OUT=$(LOCAL_OUT) ./tests/scripts/istio-iptables-test.sh
 	go test ${T} -race ./pkg/... ./tests/common/... ./tools/istio-iptables/...
 
 #-----------------------------------------------------------------------------

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -220,7 +220,7 @@ done
 echo "Copying ${ISTIO_ENVOY_NATIVE_PATH} to ${ISTIO_OUT}/envoy"
 cp -f "${ISTIO_ENVOY_NATIVE_PATH}" "${ISTIO_OUT}/envoy"
 
-# Need to copy the linux binary to ISTIO_OUT_LINUX if not already done
+# Copy the envoy binary to ISTIO_OUT_LINUX if the local OS is not Linux
 if [[ "$GOOS_LOCAL" != "linux" ]]; then
    echo "Copying ${ISTIO_ENVOY_LINUX_RELEASE_PATH} to ${ISTIO_OUT_LINUX}/envoy"
   cp -f "${ISTIO_ENVOY_LINUX_RELEASE_PATH}" "${ISTIO_OUT_LINUX}/envoy"

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -33,6 +33,7 @@ export GOARCH=${GOARCH:-'amd64'}
 
 # test scripts seem to like to run this script directly rather than use make
 export ISTIO_OUT=${ISTIO_OUT:-${ISTIO_BIN}}
+export ISTIO_OUT_LINUX=${ISTIO_OUT_LINUX:-${ISTIO_BIN}}
 
 # Download Envoy debug and release binaries for Linux x86_64. They will be included in the
 # docker images created by Dockerfile.proxyv2 and Dockerfile.proxytproxy.
@@ -218,3 +219,9 @@ done
 # Copy native envoy binary to ISTIO_OUT
 echo "Copying ${ISTIO_ENVOY_NATIVE_PATH} to ${ISTIO_OUT}/envoy"
 cp -f "${ISTIO_ENVOY_NATIVE_PATH}" "${ISTIO_OUT}/envoy"
+
+# Need to copy the linux binary to ISTIO_OUT_LINUX if not already done
+if [[ "$GOOS_LOCAL" != "linux" ]]; then
+   echo "Copying ${ISTIO_ENVOY_LINUX_RELEASE_PATH} to ${ISTIO_OUT_LINUX}/envoy"
+  cp -f "${ISTIO_ENVOY_LINUX_RELEASE_PATH}" "${ISTIO_OUT_LINUX}/envoy"
+fi

--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -70,7 +70,9 @@ func (s *TestSetup) newEnvoy() (envoy.Instance, error) {
 		options = append(options, o...)
 	}
 	/* #nosec */
-	envoyPath := filepath.Join(env.IstioOut, "envoy")
+	// Since we are possible running in a container, the OS may be different that what we are building (we build for host OS),
+	// we need to use the local container's OS bin found in LOCAL_OUT
+	envoyPath := filepath.Join(env.LocalOut, "envoy")
 	if path, exists := ev.RegisterStringVar("ENVOY_PATH", "", "Specifies the path to an Envoy binary.").Lookup(); exists {
 		envoyPath = path
 	}

--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -48,6 +48,10 @@ var (
 	// nolint: golint, stylecheck
 	ISTIO_OUT Variable = "ISTIO_OUT"
 
+	// LOCAL_OUT environment variable
+	// nolint: golint, stylecheck
+	LOCAL_OUT Variable = "LOCAL_OUT"
+
 	// REPO_ROOT environment variable
 	// nolint: golint, stylecheck
 	REPO_ROOT Variable = "REPO_ROOT"
@@ -81,6 +85,10 @@ var (
 
 	// IstioOut is the location of the output directory ($TOP/out)
 	IstioOut = verifyFile(ISTIO_OUT, ISTIO_OUT.ValueOrDefaultFunc(getDefaultIstioOut))
+
+	// LocalOut is the location of the output directory for the OS we are running in,
+	// not necessarily the OS we are building for
+	LocalOut = verifyFile(LOCAL_OUT, LOCAL_OUT.ValueOrDefaultFunc(getDefaultIstioOut))
 
 	// TODO: Some of these values are overlapping. We should re-align them.
 

--- a/pkg/test/envoy/binary.go
+++ b/pkg/test/envoy/binary.go
@@ -60,7 +60,7 @@ func FindBinaryOrFail(t test.Failer) string {
 
 func findBinaries() ([]string, error) {
 	binPaths := make([]string, 0)
-	err := filepath.Walk(env.IstioOut, func(path string, f os.FileInfo, err error) error {
+	err := filepath.Walk(env.LocalOut, func(path string, f os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/tests/scripts/istio-iptables-test.sh
+++ b/tests/scripts/istio-iptables-test.sh
@@ -58,10 +58,10 @@ function compareWithGolden() {
 
   case "${TEST_MODE}" in
    "golang")
-    FILE_UNDER_TEST="${ISTIO_OUT}/istio-iptables --dry-run --restore-format=false"
+    FILE_UNDER_TEST="${BINARY_PATH}/istio-iptables --dry-run --restore-format=false"
    ;;
    "golang_clean")
-    FILE_UNDER_TEST="${ISTIO_OUT}/istio-clean-iptables --dry-run"
+    FILE_UNDER_TEST="${BINARY_PATH}/istio-clean-iptables --dry-run"
    ;;
   esac
 
@@ -99,6 +99,7 @@ if [[ ${#TEST_MODES[@]} -eq 0 ]] ; then
 fi
 export PATH="${SCRIPT_DIR}/stubs:${PATH}"
 
+export BINARY_PATH="${LOCAL_OUT:-$ISTIO_OUT}"
 FAILED=()
 
 for TEST_MODE in "${TEST_MODES[@]}"; do


### PR DESCRIPTION
 - Update tests to use variable pointing to local hosts output branch.
 - Make sure the Linux binaries are built/downloaded if on non-Linux host

If one runs BUILD_WITH_CONTAINER=1 make test on their non linux host (example: MacOS), there will be a number of failures in mixer and xds similar to:
```
Failed to setup test: fork/exec /work/out/darwin_amd64/envoy: exec format error
```
This is because the container is running Linux and ISTIO_OUT is pointing to the output tree associated with the host OS (example: /out/darwin_amd64). Tests using ISTIO_OUT as a pointer to an executable fail.

This PR is an alternative to https://github.com/istio/istio/pull/20462 in that updates are only being made for test cases that fail, and not across all _test_ targets.

This PR updates the failing tests (those that call out to a binary) to use an existing LOCAL_HOST variable which points to the output branch for where the makefile is running (ISTIO_OUT_LINUX when in a build container). Now the tests will use linux binaries and the exec format error is eliminated. A few other things were needed. In the case the test cases are being run in a container on a non-Linux host, the build needs to make sure the Linux binaries are built (use BUILD_DEPS).

The init.sh was also updated to make sure that the Linux version of envoy is downloaded in case it is needed by tests.

One can still debug locally with BUILD_WITH_CONTAINER=0.