### PR TITLE
Improvements to test framework debug-ability

### DIFF
--- a/pkg/test/framework/components/echo/common/config.go
+++ b/pkg/test/framework/components/echo/common/config.go
@@ -94,9 +94,10 @@ func FillInDefaults(ctx resource.Context, defaultDomain string, c *echo.Config) 
 		}
 	}
 
-	// If readiness probe is specified by a test, we wait almost forever.
+	// If readiness probe is not specified by a test, wait a long time
+	// Waiting forever would cause the test to timeout and lose logs
 	if c.ReadinessTimeout == 0 {
-		c.ReadinessTimeout = time.Second * 36000
+		c.ReadinessTimeout = time.Minute * 10
 	}
 
 	return nil

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -17,7 +17,10 @@ package namespace
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
+	"os"
+	"path"
 	"sync"
 	"time"
 
@@ -39,11 +42,44 @@ type kubeNamespace struct {
 	id   resource.ID
 	name string
 	a    *k.Accessor
+	ctx  resource.Context
+}
+
+func (n *kubeNamespace) Dump() {
+	scopes.CI.Errorf("=== Dumping Namespace %s State...", n.name)
+
+	d, err := n.ctx.CreateTmpDirectory(n.name + "-state")
+	if err != nil {
+		scopes.CI.Errorf("Unable to create directory for dumping %s contents: %v", n.name, err)
+		return
+	}
+
+	pods, err := n.a.GetPods(n.name)
+	if err != nil {
+		scopes.CI.Errorf("Unable to get pods from the namespace: %v", err)
+		return
+	}
+
+	for _, pod := range pods {
+		for _, container := range pod.Spec.Containers {
+			l, err := n.a.Logs(pod.Namespace, pod.Name, container.Name, false /* previousLog */)
+			if err != nil {
+				scopes.CI.Errorf("Unable to get logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
+				continue
+			}
+
+			fname := path.Join(d, fmt.Sprintf("%s-%s.log", pod.Name, container.Name))
+			if err = ioutil.WriteFile(fname, []byte(l), os.ModePerm); err != nil {
+				scopes.CI.Errorf("Unable to write logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
+			}
+		}
+	}
 }
 
 var _ Instance = &kubeNamespace{}
 var _ io.Closer = &kubeNamespace{}
 var _ resource.Resource = &kubeNamespace{}
+var _ resource.Dumper = &kubeNamespace{}
 
 func (n *kubeNamespace) Name() string {
 	return n.name
@@ -103,7 +139,7 @@ func newKube(ctx resource.Context, nsConfig *Config) (Instance, error) {
 		return nil, err
 	}
 
-	n := &kubeNamespace{name: ns, a: env.Accessor}
+	n := &kubeNamespace{name: ns, a: env.Accessor, ctx: ctx}
 	id := ctx.TrackResource(n)
 	n.id = id
 


### PR DESCRIPTION
Currently if we fail to deploy, the timeout is 600min, which causes the
test to timeout and abruptly stop without error messages:
https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/20458/integ-pilot-k8s-tests_istio/6910

We also do not dump workload pods, now we will.