### PR TITLE
Print which namespace is being analyzed

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -44,20 +44,24 @@ import (
 	"istio.io/istio/pkg/kube"
 )
 
+// AnalyzerFoundIssuesError indicates that at least one analyzer found problems.
 type AnalyzerFoundIssuesError struct{}
+
+// FileParseError indicates a provided file was unable to be parsed.
 type FileParseError struct{}
 
 const (
-	NoIssuesString   = "\u2714 No validation issues found."
-	FoundIssueString = "Analyzers found issues."
-	FileParseString  = "Some files couldn't be parsed."
-	LogOutput        = "log"
-	JSONOutput       = "json"
-	YamlOutput       = "yaml"
+	FileParseString = "Some files couldn't be parsed."
+	LogOutput       = "log"
+	JSONOutput      = "json"
+	YamlOutput      = "yaml"
 )
 
 func (f AnalyzerFoundIssuesError) Error() string {
-	return fmt.Sprintf("%s\nSee %s for more information about causes and resolutions.", FoundIssueString, diag.DocPrefix)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Analyzers found issues when analyzing %s.\n", analyzeTargetAsString()))
+	sb.WriteString(fmt.Sprintf("See %s for more information about causes and resolutions.", diag.DocPrefix))
+	return sb.String()
 }
 
 func (f FileParseError) Error() string {
@@ -65,16 +69,17 @@ func (f FileParseError) Error() string {
 }
 
 var (
-	listAnalyzers   bool
-	useKube         bool
-	failureLevel    = messageThreshold{diag.Warning} // messages at least this level will generate an error exit code
-	outputLevel     = messageThreshold{diag.Info}    // messages at least this level will be included in the output
-	colorize        bool
-	msgOutputFormat string
-	meshCfgFile     string
-	allNamespaces   bool
-	suppress        []string
-	analysisTimeout time.Duration
+	listAnalyzers     bool
+	useKube           bool
+	failureLevel      = messageThreshold{diag.Warning} // messages at least this level will generate an error exit code
+	outputLevel       = messageThreshold{diag.Info}    // messages at least this level will be included in the output
+	colorize          bool
+	msgOutputFormat   string
+	meshCfgFile       string
+	selectedNamespace string
+	allNamespaces     bool
+	suppress          []string
+	analysisTimeout   time.Duration
 
 	termEnvVar = env.RegisterStringVar("TERM", "", "Specifies terminal type.  Use 'dumb' to suppress color output")
 
@@ -140,7 +145,7 @@ istioctl analyze -L
 
 			// We use the "namespace" arg that's provided as part of root istioctl as a flag for specifying what namespace to use
 			// for file resources that don't have one specified.
-			selectedNamespace := handlers.HandleNamespace(namespace, defaultNamespace)
+			selectedNamespace = handlers.HandleNamespace(namespace, defaultNamespace)
 
 			// If we've explicitly asked for all namespaces, blank the selectedNamespace var out
 			if allNamespaces {
@@ -221,11 +226,7 @@ istioctl analyze -L
 
 			// Maybe output details about which analyzers ran
 			if verbose {
-				if allNamespaces {
-					fmt.Fprintln(cmd.ErrOrStderr(), "Analyzed resources in all namespaces")
-				} else {
-					fmt.Fprintln(cmd.ErrOrStderr(), "Analyzed resources in namespace:", selectedNamespace)
-				}
+				fmt.Fprintf(cmd.ErrOrStderr(), "Analyzed resources in %s\n", analyzeTargetAsString())
 
 				if len(result.SkippedAnalyzers) > 0 {
 					fmt.Fprintln(cmd.ErrOrStderr(), "Skipped analyzers:")
@@ -256,14 +257,15 @@ istioctl analyze -L
 				// Print validation message output, or a line indicating that none were found
 				if len(outputMessages) == 0 {
 					if parseErrors == 0 {
-						fmt.Fprintln(cmd.ErrOrStderr(), NoIssuesString)
+						fmt.Fprintf(cmd.ErrOrStderr(), "\u2714 No validation issues found when analyzing %s.\n", analyzeTargetAsString())
 					} else {
 						fileOrFiles := "files"
 						if parseErrors == 1 {
 							fileOrFiles = "file"
 						}
 						fmt.Fprintf(cmd.ErrOrStderr(),
-							"No validation issues found (but %d %s could not be parsed)\n",
+							"No validation issues found when analyzing %s (but %d %s could not be parsed).\n",
+							analyzeTargetAsString(),
 							parseErrors,
 							fileOrFiles,
 						)
@@ -459,4 +461,11 @@ func AnalyzersAsString(analyzers []analysis.Analyzer) string {
 		}
 	}
 	return b.String()
+}
+
+func analyzeTargetAsString() string {
+	if allNamespaces {
+		return "all namespaces"
+	}
+	return fmt.Sprintf("namespace: %s", selectedNamespace)
 }

--- a/tests/integration/galley/analyze_test.go
+++ b/tests/integration/galley/analyze_test.go
@@ -220,7 +220,7 @@ func expectMessages(t *testing.T, g *GomegaWithT, outputLines []string, expected
 func expectNoMessages(t *testing.T, g *GomegaWithT, output []string) {
 	t.Helper()
 	g.Expect(output).To(HaveLen(1))
-	g.Expect(output[0]).To(ContainSubstring(cmd.NoIssuesString))
+	g.Expect(output[0]).To(ContainSubstring("No validation issues found when analyzing"))
 }
 
 func istioctlSafe(t *testing.T, i istioctl.Instance, ns string, useKube bool, extraArgs ...string) ([]string, error) {


### PR DESCRIPTION
A common mistake is to assume that istioctl analyze validates the entire cluster by default rather than the current default namespace. To make this behavior clear, the command now always indicates exactly what's being analyzed (either the entire cluster or just the provided namespace).

Example output now:

```
$ ./out/darwin_amd64/istioctl analyze 
Warn [IST0102] (Namespace default) The namespace is not enabled for Istio injection. Run 'kubectl label namespace default istio-injection=enabled' to enable it, or 'kubectl label namespace default istio-injection=disabled' to explicitly mark it as not needing injection
Error: Analyzers found issues when analyzing namespace: default.
See https://istio.io/docs/reference/config/analysis for more information about causes and resolutions.
```

```
$ ./out/darwin_amd64/istioctl analyze -n kube-system
✔ No validation issues found when analyzing namespace: kube-system.
```

```
$ ./out/darwin_amd64/istioctl analyze -A
Warn [IST0102] (Namespace default) The namespace is not enabled for Istio injection. Run 'kubectl label namespace default istio-injection=enabled' to enable it, or 'kubectl label namespace default istio-injection=disabled' to explicitly mark it as not needing injection
Error: Analyzers found issues when analyzing all namespaces.
See https://istio.io/docs/reference/config/analysis for more information about causes and resolutions.
```