### PR TITLE
Support standalone Galley for MCP

### DIFF
--- a/manifests/istio-control/istio-config/templates/deployment.yaml
+++ b/manifests/istio-control/istio-config/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           - --readinessProbePath=/tmp/healthready
           - --readinessProbeInterval=1s
           - --insecure=true
-  {{- if .Values.global.configValidation }}
+  {{- if and .Values.global.configValidation (not .Values.global.istiod.enabled) }}
           - --enable-validation=true
   {{- else }}
           - --enable-validation=false
@@ -89,7 +89,7 @@ spec:
           - --validation.tls.caCertificates=/etc/dnscerts/root-cert.pem
 {{- end }}
           volumeMounts:
-  {{- if .Values.global.configValidation }}
+  {{- if and .Values.global.configValidation (not .Values.global.istiod.enabled) }}
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -7179,7 +7179,7 @@ spec:
         - --readinessProbePath=/tmp/healthready
         - --readinessProbeInterval=1s
         - --insecure=true
-        - --enable-validation=true
+        - --enable-validation=false
         - --enable-reconcileWebhookConfiguration=false
         - --enable-server=true
         - --deployment-namespace=istio-system
@@ -7218,9 +7218,6 @@ spec:
           requests:
             cpu: 100m
         volumeMounts:
-        - mountPath: /etc/certs
-          name: istio-certs
-          readOnly: true
         - mountPath: /etc/config
           name: config
           readOnly: true

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -11276,7 +11276,7 @@ spec:
           - --readinessProbePath=/tmp/healthready
           - --readinessProbeInterval=1s
           - --insecure=true
-  {{- if .Values.global.configValidation }}
+  {{- if and .Values.global.configValidation (not .Values.global.istiod.enabled) }}
           - --enable-validation=true
   {{- else }}
           - --enable-validation=false
@@ -11307,7 +11307,7 @@ spec:
           - --validation.tls.caCertificates=/etc/dnscerts/root-cert.pem
 {{- end }}
           volumeMounts:
-  {{- if .Values.global.configValidation }}
+  {{- if and .Values.global.configValidation (not .Values.global.istiod.enabled) }}
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true

--- a/tests/integration/galley/main_test.go
+++ b/tests/integration/galley/main_test.go
@@ -36,8 +36,6 @@ func TestMain(m *testing.M) {
 components:
   galley:
     enabled: true
-  citadel:
-    enabled: true
 `
 		})).
 		SetupOnEnv(environment.Kube, func(ctx resource.Context) error {

--- a/tests/integration/pilot/mcp/main_test.go
+++ b/tests/integration/pilot/mcp/main_test.go
@@ -81,8 +81,6 @@ func setupConfig(cfg *istio.Config) {
 components:
   galley:
     enabled: true
-  citadel:
-    enabled: true
 values:
   galley:
     enableServiceDiscovery: true


### PR DESCRIPTION
Right now, to run Galley, you need certs (and therefor citadel) and it
will try to do validation which won't work out because it will fight
with istiod validation.

This change makes it so we only require certs if validation is enabled
and istiod is disabled. We also fix liveness probes in galley to support
this, and remove places where we deployed citadel just for galley.