### PR TITLE
Added wait on virtual service and removed sleep

### DIFF
--- a/tests/integration/istioio/trafficmanagement/scripts/traffic_shifting.txt
+++ b/tests/integration/istioio/trafficmanagement/scripts/traffic_shifting.txt
@@ -87,7 +87,6 @@ virtualservice.networking.istio.io/ratings created
 virtualservice.networking.istio.io/details created
 # $endsnippet
 
-sleep 10
 # Step 2: verify no rating stars visible, (reviews-v3 traffic=0%)
 verify_traffic_shift 0
 
@@ -98,6 +97,8 @@ $ kubectl apply -f @samples/bookinfo/networking/virtual-service-reviews-50-v3.ya
 # $verify
 virtualservice.networking.istio.io/reviews configured
 # $endsnippet
+istioctl experimental wait --for=distribution VirtualService reviews.default
+
 
 # Step 4: Confirm the rule was replaced
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR adds a wait on virtual host propagation for traffic shifting and removes a 10 second sleep that was originally present for generic base virtual services.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
