### PR TITLE
Add envoy gRPC web filter to gateway when grpc-web is enabled

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -361,6 +361,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 					ServerName:          EnvoyServerName,
 					HttpProtocolOptions: httpProtoOpts,
 				},
+				addGRPCWebFilter: serverProto == protocol.GRPCWeb,
 			},
 		}
 	}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -383,7 +383,7 @@ func validateServerPort(port *networking.Port) (errs error) {
 		return appendErrors(errs, fmt.Errorf("port is required"))
 	}
 	if protocol.Parse(port.Protocol) == protocol.Unsupported {
-		errs = appendErrors(errs, fmt.Errorf("invalid protocol %q, supported protocols are HTTP, HTTP2, GRPC, MONGO, REDIS, MYSQL, TCP", port.Protocol))
+		errs = appendErrors(errs, fmt.Errorf("invalid protocol %q, supported protocols are HTTP, HTTP2, GRPC, GRPC-WEB, MONGO, REDIS, MYSQL, TCP", port.Protocol))
 	}
 	if port.Number > 0 {
 		errs = appendErrors(errs, ValidatePort(int(port.Number)))


### PR DESCRIPTION
This patch adds `envoy.grpc_web` filter to gateway when Gateway's
port.protocol is `GRPC-WEB`.

Currently istio-sidecar adds `envoy.grpc_web` filter when grpc-web
prefixed port is used thanks to
https://github.com/istio/istio/pull/10064. But it always needs
side-car injection.

### Usage:

To enable envoy.grpc_web filter, users can use `GRPC-WEB` in the
Gateway.

```
    - hosts:
      - '*'
      port:
        name: http-server
        number: 80
        protocol: GRPC-WEB
```

The users needs to CORS policy in VirtualService which is is same
manner with https://github.com/istio/istio/pull/10064.

```
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: virtual-service
spec:
  hosts:
  - "*"
  gateways:
  - gateway
  http:
  - match:
    - port: 80
    route:
    - destination:
        host: some-service
        port:
          number: 9000
    corsPolicy:
      allowOrigin:
        - "*"
      allowMethods:
        - POST
        - GET
        - OPTIONS
        - PUT
        - DELETE
      allowHeaders:
        - grpc-timeout
        - content-type
        - keep-alive
        - user-agent
        - cache-control
        - content-type
        - content-transfer-encoding
        - custom-header-1
        - x-accept-content-transfer-encoding
        - x-accept-response-streaming
        - x-user-agent
        - x-grpc-web
      maxAge: 1728s
      exposeHeaders:
        - custom-header-1
        - grpc-status
        - grpc-message
      allowCredentials: true
```


[X] Networking