### PR TITLE
Setup workload SDS for egress

### DIFF
--- a/manifests/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/gateways/istio-egress/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
 {{ toYaml $gateway.podAnnotations | indent 8 }}
 {{ end }}
     spec:
+      serviceAccountName: istio-egressgateway-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
@@ -226,6 +227,13 @@ spec:
           - mountPath: /etc/istio/citadel-ca-cert
             name: citadel-ca-cert
           {{- end }}
+          {{- if .Values.global.istiod.enabled }}
+          {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+          - name: istio-token
+            mountPath: /var/run/secrets/tokens
+            readOnly: true
+          {{- end }}
+          {{- end }}
           {{ if .Values.global.sds.enabled }}
           - name: sdsudspath
             mountPath: /var/run/sds
@@ -252,6 +260,17 @@ spec:
         configMap:
           name: istio-ca-root-cert
       {{- end }}
+{{- if .Values.global.istiod.enabled }}
+{{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: istio-token
+              expirationSeconds: 43200
+              audience: {{ .Values.global.sds.token.aud }}
+{{- end }}
+{{- end }}
       {{- if .Values.global.sds.enabled }}
       - name: sdsudspath
         hostPath:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -6663,6 +6663,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      serviceAccountName: istio-egressgateway-service-account
       containers:
         - name: istio-proxy
           image: "gcr.io/istio-testing/proxyv2:latest"
@@ -6783,6 +6784,9 @@ spec:
           volumeMounts:
           - mountPath: /etc/istio/citadel-ca-cert
             name: citadel-ca-cert
+          - name: istio-token
+            mountPath: /var/run/secrets/tokens
+            readOnly: true
           
           - name: istio-certs
             mountPath: /etc/certs
@@ -6797,6 +6801,13 @@ spec:
       - name: citadel-ca-cert
         configMap:
           name: istio-ca-root-cert
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: istio-token
+              expirationSeconds: 43200
+              audience: istio-ca
       
       - name: istio-certs
         secret:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -6751,6 +6751,7 @@ spec:
 {{ toYaml $gateway.podAnnotations | indent 8 }}
 {{ end }}
     spec:
+      serviceAccountName: istio-egressgateway-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
@@ -6942,6 +6943,13 @@ spec:
           - mountPath: /etc/istio/citadel-ca-cert
             name: citadel-ca-cert
           {{- end }}
+          {{- if .Values.global.istiod.enabled }}
+          {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+          - name: istio-token
+            mountPath: /var/run/secrets/tokens
+            readOnly: true
+          {{- end }}
+          {{- end }}
           {{ if .Values.global.sds.enabled }}
           - name: sdsudspath
             mountPath: /var/run/sds
@@ -6968,6 +6976,17 @@ spec:
         configMap:
           name: istio-ca-root-cert
       {{- end }}
+{{- if .Values.global.istiod.enabled }}
+{{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: istio-token
+              expirationSeconds: 43200
+              audience: {{ .Values.global.sds.token.aud }}
+{{- end }}
+{{- end }}
       {{- if .Values.global.sds.enabled }}
       - name: sdsudspath
         hostPath:


### PR DESCRIPTION
Right now egress is in a pretty broken state because we expect
everything to be on SDS, but egress isn't. If we turn SDS on, we get
Ingress SDS which is broken for Egress. This attempts to get just
workload SDS, not Gateway sds.

For https://github.com/istio/istio/issues/20535