### PR TITLE
Capture init container logs for dumped pods

### DIFF
--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -61,7 +61,8 @@ func (n *kubeNamespace) Dump() {
 	}
 
 	for _, pod := range pods {
-		for _, container := range pod.Spec.Containers {
+		containers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
+		for _, container := range containers {
 			l, err := n.a.Logs(pod.Namespace, pod.Name, container.Name, false /* previousLog */)
 			if err != nil {
 				scopes.CI.Errorf("Unable to get logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)


### PR DESCRIPTION
This would allow us to debug failures like
https://prow.istio.io/view/gcs/istio-prow/logs/integ-pilot-k8s-tests_istio_postsubmit/1253
where the pod fails during init. We only dump on errors, so this won't
negatively impact test time or anything like that