### PR TITLE
Fix auto mTLS when pod has label `security.istio.io/tlsMode` ~= `istio`

### DIFF
--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -27,7 +27,8 @@ func NewPolicyApplier(push *model.PushContext,
 	serviceInstance *model.ServiceInstance, namespace string, labels labels.Collection) authn.PolicyApplier {
 	service := serviceInstance.Service
 	port := serviceInstance.ServicePort
-	authnPolicy, _ := push.AuthenticationPolicyForWorkload(service, port)
+	authnPolicy, _ := push.EffectiveAuthenticationPolicy(service, port, labels)
+
 	return v1beta1.NewPolicyApplier(push.AuthnBetaPolicies.GetJwtPoliciesForWorkload(
 		namespace, labels), authnPolicy)
 }


### PR DESCRIPTION
Currently, when autoMTLS == true, and mTLS is STRICT (via authN policy), cluster's socket will be created to use mTLS for EP with label `security.istio.io/tlsMode=istio`, and plaintext otherwise. The server side is supported mTLS as defined by authN policy so it works.

However, if users set the pod label `security.istio.io/tlsMode` to different value, server side setting doesn't change. As the endpoint label change, outbound traffic will go through plaintext socket, which will fail as the server side is set to mTLS per policy.

This PR overwrite the policy mTLS setting if label is presented (and auto mtls is enabled) to effectively disable mTLS if server (workload) has `security.istio.io/tlsMode` with value other than `istio`.