### PR TITLE
check workers started stat for envoy readiness

### DIFF
--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -72,8 +72,8 @@ func (p *Probe) isEnvoyReady() error {
 		return fmt.Errorf("server is not live, current state is: %v", admin.ServerInfo_State(*state).String())
 	}
 
-	if ws != 1 {
-		return fmt.Errorf("workers have not yet started, %d", ws)
+	if !ws {
+		return fmt.Errorf("workers have not yet started")
 	}
 
 	return nil

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -37,7 +37,7 @@ func (p *Probe) Check() error {
 	if err := p.checkConfigStatus(); err != nil {
 		return err
 	}
-	return p.checkServerState()
+	return p.isEnvoyReady()
 }
 
 // checkConfigStatus checks to make sure initial configs have been received from Pilot.
@@ -61,15 +61,19 @@ func (p *Probe) checkConfigStatus() error {
 	return fmt.Errorf("config not received from Pilot (is Pilot running?): %s", s.String())
 }
 
-// checkServerState checks to ensure that Envoy is in the READY state
-func (p *Probe) checkServerState() error {
-	state, err := util.GetServerState(p.LocalHostAddr, p.AdminPort)
+// isEnvoyReady checks to ensure that Envoy is in the LIVE state and workers have started.
+func (p *Probe) isEnvoyReady() error {
+	state, ws, err := util.GetReadinessStats(p.LocalHostAddr, p.AdminPort)
 	if err != nil {
 		return fmt.Errorf("failed to get server info: %v", err)
 	}
 
 	if state != nil && admin.ServerInfo_State(*state) != admin.ServerInfo_LIVE {
 		return fmt.Errorf("server is not live, current state is: %v", admin.ServerInfo_State(*state).String())
+	}
+
+	if ws != 1 {
+		return fmt.Errorf("workers have not yet started, %d", ws)
 	}
 
 	return nil

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -72,7 +72,7 @@ cluster_manager.cds.update_success: 1
 listener_manager.lds.update_success: 1
 listener_manager.workers_started: 0
 server.state: 0`,
-			"workers have not yet started, 0",
+			"workers have not yet started",
 		},
 		{
 			"full",

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	liveServerStats = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1\nserver.state: 0"
+	liveServerStats = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1\nserver.state: 0\nlistener_manager.workers_started: 1"
 	onlyServerStats = "server.state: 0"
 	initServerStats = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1\nserver.state: 2"
 	noServerStats   = ""
@@ -66,10 +66,20 @@ listener_manager.lds.update_success: 1`,
 			prefix + "cds updates: 0 successful, 1 rejected; lds updates: 1 successful, 0 rejected",
 		},
 		{
+			"workers not started",
+			`
+cluster_manager.cds.update_success: 1
+listener_manager.lds.update_success: 1
+listener_manager.workers_started: 0
+server.state: 0`,
+			"workers have not yet started, 0",
+		},
+		{
 			"full",
 			`
 cluster_manager.cds.update_success: 1
 listener_manager.lds.update_success: 1
+listener_manager.workers_started: 1
 server.state: 0`,
 			"",
 		},

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -24,12 +24,14 @@ import (
 )
 
 const (
-	statCdsRejected  = "cluster_manager.cds.update_rejected"
-	statsCdsSuccess  = "cluster_manager.cds.update_success"
-	statLdsRejected  = "listener_manager.lds.update_rejected"
-	statsLdsSuccess  = "listener_manager.lds.update_success"
-	statServerState  = "server.state"
-	updateStatsRegex = "^(cluster_manager.cds|listener_manager.lds).(update_success|update_rejected)$"
+	statCdsRejected    = "cluster_manager.cds.update_rejected"
+	statsCdsSuccess    = "cluster_manager.cds.update_success"
+	statLdsRejected    = "listener_manager.lds.update_rejected"
+	statLdsSuccess     = "listener_manager.lds.update_success"
+	statServerState    = "server.state"
+	statWorkersStarted = "listener_manager.workers_started"
+	readyStatsRegex    = "^(server.state|listener_manager.workers_started)"
+	updateStatsRegex   = "^(cluster_manager.cds|listener_manager.lds).(update_success|update_rejected)$"
 )
 
 type stat struct {
@@ -46,7 +48,8 @@ type Stats struct {
 	LDSUpdatesSuccess   uint64
 	LDSUpdatesRejection uint64
 	// Server State of Envoy.
-	ServerState uint64
+	ServerState    uint64
+	WorkersStarted uint64
 }
 
 // String representation of the Stats.
@@ -58,30 +61,35 @@ func (s *Stats) String() string {
 		s.LDSUpdatesRejection)
 }
 
-// GetServerState returns the current Envoy state by checking the "server.state" stat.
-func GetServerState(localHostAddr string, adminPort uint16) (*uint64, error) {
+// GetReadinessStats returns the current Envoy state by checking the "server.state" stat.
+func GetReadinessStats(localHostAddr string, adminPort uint16) (*uint64, uint64, error) {
 	// If the localHostAddr was not set, we use 'localhost' to void emppty host in URL.
 	if localHostAddr == "" {
 		localHostAddr = "localhost"
 	}
 
-	stats, err := doHTTPGet(fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, statServerState))
+	stats, err := doHTTPGet(fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, readyStatsRegex))
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if !strings.Contains(stats.String(), "server.state") {
-		return nil, fmt.Errorf("server.state is not yet updated: %s", stats.String())
+		return nil, 0, fmt.Errorf("server.state is not yet updated: %s", stats.String())
+	}
+
+	if !strings.Contains(stats.String(), "listener_manager.workers_started") {
+		return nil, 0, fmt.Errorf("listener_manager.workers_started is not yet updated: %s", stats.String())
 	}
 
 	s := &Stats{}
 	allStats := []*stat{
 		{name: statServerState, value: &s.ServerState},
+		{name: statWorkersStarted, value: &s.WorkersStarted},
 	}
 	if err := parseStats(stats, allStats); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return &s.ServerState, nil
+	return &s.ServerState, s.WorkersStarted, nil
 }
 
 // GetUpdateStatusStats returns the version stats for CDS and LDS.
@@ -100,7 +108,7 @@ func GetUpdateStatusStats(localHostAddr string, adminPort uint16) (*Stats, error
 	allStats := []*stat{
 		{name: statsCdsSuccess, value: &s.CDSUpdatesSuccess},
 		{name: statCdsRejected, value: &s.CDSUpdatesRejection},
-		{name: statsLdsSuccess, value: &s.LDSUpdatesSuccess},
+		{name: statLdsSuccess, value: &s.LDSUpdatesSuccess},
 		{name: statLdsRejected, value: &s.LDSUpdatesRejection},
 	}
 	if err := parseStats(stats, allStats); err != nil {


### PR DESCRIPTION
Envoy has added a `workers_started` stat that indicates all listeners are bound to sockets and hence it is fully ready to take traffic. This PR enhances the readiness probe to use that stat.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure