### PR TITLE
Add T&R as well as @sdake to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,8 @@
 *                                                                @costinm @linsun @rshriram @howardjohn
+Makefile*                                                        @sdake @istio/wg-test-and-release-maintainers
 /bin/                                                            @istio/wg-test-and-release-maintainers
+/common/                                                         @sdake @istio/wg-test-and-release-maintainers
+/common-protos/                                                  @sdake @istio/wg-test-and-release-maintainers
 /cmd/istiod/                                                     @istio/wg-environments-maintainers
 /galley/                                                         @istio/wg-config-maintainers
 /galley/pkg/config/analysis/                                     @istio/wg-config-maintainers @istio/wg-user-experience-maintainers


### PR DESCRIPTION
For:
Makefile*
common/*
common-files/*

@sdake is a very specific SME here. I am willing to accept a nomination
to T&R as well. In that event, T&R should continue to own these directories.