### PR TITLE
Fix Istiod w/ Galley w/o Citadel on k8s 1.15-

### DIFF
--- a/manifests/istio-control/istio-config/templates/deployment.yaml
+++ b/manifests/istio-control/istio-config/templates/deployment.yaml
@@ -187,7 +187,7 @@ spec:
 {{- end }}
 
       volumes:
-  {{- if or .Values.global.controlPlaneSecurityEnabled .Values.global.configValidation }}
+  {{- if or .Values.global.controlPlaneSecurityEnabled (and .Values.global.configValidation (not .Values.global.istiod.enabled)) }}
       - name: istio-certs
         secret:
           secretName: istio.istio-galley-service-account

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -7238,9 +7238,6 @@ spec:
           readOnly: true
       serviceAccountName: istio-galley-service-account
       volumes:
-      - name: istio-certs
-        secret:
-          secretName: istio.istio-galley-service-account
       - configMap:
           name: istio-galley-configuration
         name: config

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -11427,7 +11427,7 @@ spec:
 {{- end }}
 
       volumes:
-  {{- if or .Values.global.controlPlaneSecurityEnabled .Values.global.configValidation }}
+  {{- if or .Values.global.controlPlaneSecurityEnabled (and .Values.global.configValidation (not .Values.global.istiod.enabled)) }}
       - name: istio-certs
         secret:
           secretName: istio.istio-galley-service-account


### PR DESCRIPTION
If you have the situation above, we will add a volume to the deployment
for istio-certs. Because citadel isn't around, we do not have these
certs. Because we are not doing anything requiring certs, we do not
actually mount these either. It seems in Kubernetes 1.16 there was a
chnage that allows a pod with missing volumes to start up if there is no
volumeMount. However, on 1.15 and below this will block startup, as can
be seen:
https://prow.istio.io/view/gcs/istio-prow/logs/integ-k8s-115_istio_postsubmit/494