### PR TITLE
--set path=value support for extending slices

### DIFF
--- a/operator/pkg/tpath/tpath.go
+++ b/operator/pkg/tpath/tpath.go
@@ -91,7 +91,7 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 	ncNode := v.Interface()
 
 	// For list types, we need a key to identify the selected list item. This can be either a a value key of the
-	// from :matching_value in the case of a leaf list, or a matching key:value in the case of a non-leaf list.
+	// form :matching_value in the case of a leaf list, or a matching key:value in the case of a non-leaf list.
 	if lst, ok := ncNode.([]interface{}); ok {
 		scope.Debug("list type")
 		if util.IsNPathElement(pe) {

--- a/operator/pkg/tpath/tpath.go
+++ b/operator/pkg/tpath/tpath.go
@@ -52,10 +52,14 @@ type PathContext struct {
 // String implements the Stringer interface.
 func (nc *PathContext) String() string {
 	ret := "\n--------------- NodeContext ------------------\n"
-	ret += fmt.Sprintf("Parent.Node=\n%s\n", pretty.Sprint(nc.Parent.Node))
-	ret += fmt.Sprintf("KeyToChild=%v\n", nc.Parent.KeyToChild)
+	if nc.Parent != nil {
+		ret += fmt.Sprintf("Parent.Node=\n%s\n", pretty.Sprint(nc.Parent.Node))
+		ret += fmt.Sprintf("KeyToChild=%v\n", nc.Parent.KeyToChild)
+	}
+
 	ret += fmt.Sprintf("Node=\n%s\n", pretty.Sprint(nc.Node))
 	ret += "----------------------------------------------\n"
+
 	return ret
 }
 
@@ -87,9 +91,28 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 	ncNode := v.Interface()
 
 	// For list types, we need a key to identify the selected list item. This can be either a a value key of the
-	// form :matching_value in the case of a leaf list, or a matching key:value in the case of a non-leaf list.
+	// from :matching_value in the case of a leaf list, or a matching key:value in the case of a non-leaf list.
 	if lst, ok := ncNode.([]interface{}); ok {
 		scope.Debug("list type")
+		if util.IsNPathElement(pe) {
+			idx, err := util.PathN(pe)
+			if err != nil {
+				return nil, false, fmt.Errorf("path %s, index %s: %s", fullPath, pe, err)
+			}
+			var foundNode interface{}
+			if idx >= len(lst) {
+				foundNode = make(map[string]interface{})
+			} else {
+				foundNode = lst[idx]
+			}
+			nn := &PathContext{
+				Parent: nc,
+				Node:   foundNode,
+			}
+			nc.KeyToChild = idx
+			return getPathContext(nn, fullPath, remainPath[1:], createMissing)
+		}
+
 		for idx, le := range lst {
 			// non-leaf list, expect to match item by key:value.
 			if lm, ok := le.(map[interface{}]interface{}); ok {
@@ -215,6 +238,7 @@ func mergeConditional(newVal, originalVal interface{}, merge bool) (interface{},
 	if err != nil {
 		return nil, err
 	}
+
 	if util.IsMap(originalVal) {
 		// For JSON compatibility
 		out := make(map[string]interface{})
@@ -251,40 +275,96 @@ func WritePathContext(nc *PathContext, value interface{}, merge bool) error {
 			}
 		}
 	default:
-		switch {
-		case isSliceOrPtrInterface(nc.Parent.Node):
+		return setPathContext(nc, value, merge)
+	}
+
+	return nil
+}
+
+// setPathContext writes the given value to the Node in the given PathContext,
+// enlarging all PathContext lists to ensure all indexes are valid.
+func setPathContext(nc *PathContext, value interface{}, merge bool) error {
+	err := setValueContext(nc, value, merge)
+	if err != nil {
+		return err
+	}
+
+	// If the path included insertions, process them now
+	if nc.Parent.Parent == nil {
+		return nil
+	}
+	return setPathContext(nc.Parent, nc.Parent.Node, false) // note: tail recursive
+}
+
+// setValueContext writes the given value to the Node in the given PathContext.
+// If setting the value requires growing the final slice, grows it.
+func setValueContext(nc *PathContext, value interface{}, merge bool) error {
+	switch parentNode := nc.Parent.Node.(type) {
+	case *interface{}:
+		switch vParentNode := (*parentNode).(type) {
+		case []interface{}:
 			idx := nc.Parent.KeyToChild.(int)
 			if idx == -1 {
-				scope.Debug("insert")
-
-			} else {
-				scope.Debugf("update index %d\n", idx)
-				merged, err := mergeConditional(value, nc.Node, merge)
-				if err != nil {
-					return err
-				}
-				return util.UpdateSlicePtr(nc.Parent.Node, idx, merged)
+				// Treat -1 as insert-at-end of list
+				idx = len(vParentNode)
 			}
+
+			if idx >= len(vParentNode) {
+				newElements := make([]interface{}, idx-len(vParentNode)+1)
+				vParentNode = append(vParentNode, newElements...)
+				*parentNode = vParentNode
+			}
+
+			merged, err := mergeConditional(value, nc.Node, merge)
+			if err != nil {
+				return err
+			}
+
+			vParentNode[idx] = merged
+			nc.Node = merged
 		default:
-			if isMapOrInterface(nc.Parent.Node) {
-				switch {
-				case isSliceOrPtrInterface(nc.Node):
-					if err := util.AppendToSlicePtr(nc.Node, value); err != nil {
-						return err
-					}
-					return util.InsertIntoMap(nc.Parent.Node, nc.Parent.KeyToChild, nc.Node)
-				case isMapOrInterface(nc.Node):
-					merged, err := mergeConditional(value, nc.Node, merge)
+			return fmt.Errorf("don't know about vtype %T", vParentNode)
+		}
+	case map[string]interface{}:
+		key := nc.Parent.KeyToChild.(string)
+
+		if ncNode, ok := nc.Node.(*interface{}); ok {
+			switch vNcNode := (*ncNode).(type) {
+			case []interface{}:
+				switch value.(type) {
+				case map[string]interface{}:
+					// the value is a map, and the node is a slice
+					mergedValue := append(vNcNode, value)
+					parentNode[key] = mergedValue
+				case *interface{}:
+					merged, err := mergeConditional(value, vNcNode, merge)
 					if err != nil {
 						return err
 					}
-					return util.InsertIntoMap(nc.Parent.Node, nc.Parent.KeyToChild, merged)
+
+					parentNode[key] = merged
+					nc.Node = merged
 				default:
-					scope.Debug("leaf update")
-					return util.InsertIntoMap(nc.Parent.Node, nc.Parent.KeyToChild, value)
+					// the value is an basic JSON type (int, float, string, bool)
+					value = append(vNcNode, value)
+					parentNode[key] = value
+					nc.Node = value
 				}
+			default:
+				return fmt.Errorf("don't know about vnc type %T", vNcNode)
 			}
+		} else {
+			// the value is an basic JSON type (int, float, string, bool); or a map[string]interface{}
+			parentNode[key] = value
+			nc.Node = value
 		}
+	// TODO `map[interface{}]interface{}` is used by tests in operator/cmd/mesh, we should add our own tests
+	case map[interface{}]interface{}:
+		key := nc.Parent.KeyToChild.(string)
+		parentNode[key] = value
+		nc.Node = value
+	default:
+		return fmt.Errorf("don't know about type %T", parentNode)
 	}
 
 	return nil

--- a/operator/pkg/tpath/tpath_test.go
+++ b/operator/pkg/tpath/tpath_test.go
@@ -78,7 +78,7 @@ a:
 		},
 		{
 			desc:      "ModifyListEntry",
-			path:      `a.b.[name:n2].list.[v2]`,
+			path:      `a.b.[name:n2].list.[:v2]`,
 			value:     `v3`,
 			wantFound: true,
 			want: `
@@ -89,6 +89,93 @@ a:
   - list:
     - v1
     - v3
+    - v3_regex
+    name: n2
+`,
+		},
+		{
+			desc:      "ModifyNthListEntry",
+			path:      `a.b.[1].list.[:v2]`,
+			value:     `v-the-second`,
+			wantFound: true,
+			want: `
+a:
+  b:
+  - name: n1
+    value: v1
+  - list:
+    - v1
+    - v-the-second
+    - v3_regex
+    name: n2
+`,
+		},
+		{
+			desc:      "ModifyNthLeafListEntry",
+			path:      `a.b.[1].list.[2]`,
+			value:     `v-the-third`,
+			wantFound: true,
+			want: `
+a:
+  b:
+  - name: n1
+    value: v1
+  - list:
+    - v1
+    - v2
+    - v-the-third
+    name: n2
+`,
+		},
+		{
+			desc:      "ExtendNthLeafListEntry",
+			path:      `a.b.[1].list.[3]`,
+			value:     `v4`,
+			wantFound: true,
+			want: `
+a:
+  b:
+  - name: n1
+    value: v1
+  - list:
+    - v1
+    - v2
+    - v3_regex
+    - v4
+    name: n2
+`,
+		},
+		{
+			desc:      "ExtendNthListEntry",
+			path:      `a.b.[2].name`,
+			value:     `n3`,
+			wantFound: true,
+			want: `
+a:
+  b:
+  - name: n1
+    value: v1
+  - list:
+    - v1
+    - v2
+    - v3_regex
+    name: n2
+  - name: n3
+`,
+		},
+		{
+			desc:      "ModifyListEntryValueDotless",
+			path:      `a.b[name:n1].value`,
+			value:     `v2`,
+			wantFound: true,
+			want: `
+a:
+  b:
+  - name: n1
+    value: v2
+  - list:
+    - v1
+    - v2
     - v3_regex
     name: n2
 `,
@@ -109,7 +196,7 @@ a:
 		},
 		{
 			desc:      "DeleteListEntryValue",
-			path:      `a.b.[name:n2].list.[v2]`,
+			path:      `a.b.[name:n2].list.[:v2]`,
 			wantFound: true,
 			want: `
 a:
@@ -124,7 +211,7 @@ a:
 		},
 		{
 			desc:      "DeleteListEntryValueRegex",
-			path:      `a.b.[name:n2].list.[v3]`,
+			path:      `a.b.[name:n2].list.[:v3]`,
 			wantFound: true,
 			want: `
 a:
@@ -175,9 +262,9 @@ a:
 		},
 		{
 			desc:      "path not found",
-			path:      `a.c.[name:n2].list.[v3]`,
+			path:      `a.c.[name:n2].list.[:v3]`,
 			wantFound: false,
-			wantErr:   `path not found at element c in path a.c.[name:n2].list.[v3]`,
+			wantErr:   `path not found at element c in path a.c.[name:n2].list.[:v3]`,
 		},
 		{
 			desc:      "error key",
@@ -194,10 +281,10 @@ a:
 			}
 			pc, gotFound, gotErr := GetPathContext(root, util.PathFromString(tt.path))
 			if gotErr, wantErr := errToString(gotErr), tt.wantErr; gotErr != wantErr {
-				t.Fatalf("YAMLManifestPatch(%s): gotErr:%s, wantErr:%s", tt.desc, gotErr, wantErr)
+				t.Fatalf("GetPathContext(%s): gotErr:%s, wantErr:%s", tt.desc, gotErr, wantErr)
 			}
 			if gotFound != tt.wantFound {
-				t.Fatalf("YAMLManifestPatch(%s): gotFound:%v, wantFound:%v", tt.desc, gotFound, tt.wantFound)
+				t.Fatalf("GetPathContext(%s): gotFound:%v, wantFound:%v", tt.desc, gotFound, tt.wantFound)
 			}
 			if tt.wantErr != "" || !tt.wantFound {
 				return
@@ -374,7 +461,7 @@ a:
 `,
 		},
 		{
-			desc:     "merge list",
+			desc:     "merge list 2",
 			baseYAML: testTreeYAML,
 			path:     "a.b.list1",
 			value: `
@@ -426,4 +513,107 @@ func errToString(err error) string {
 		return ""
 	}
 	return err.Error()
+}
+
+// TestSecretVolumes simulates https://github.com/istio/istio/issues/20381
+func TestSecretVolumes(t *testing.T) {
+	rootYAML := `
+values:
+   gateways:
+      istio-egressgateway:
+         secretVolumes: []
+`
+	root := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(rootYAML), &root); err != nil {
+		t.Fatal(err)
+	}
+	overrides := []struct {
+		path  string
+		value interface{}
+	}{
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[0].name",
+			value: "egressgateway-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[0].secretName",
+			value: "istio-egressgateway-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[0].mountPath",
+			value: "/etc/istio/egressgateway-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[1].name",
+			value: "egressgateway-ca-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[1].secretName",
+			value: "istio-egressgateway-ca-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[1].mountPath",
+			value: "/etc/istio/egressgateway-ca-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[2].name",
+			value: "nginx-client-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[2].secretName",
+			value: "nginx-client-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[2].mountPath",
+			value: "/etc/istio/nginx-client-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[3].name",
+			value: "nginx-ca-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[3].secretName",
+			value: "nginx-ca-certs",
+		},
+		{
+			path:  "values.gateways.istio-egressgateway.secretVolumes[3].mountPath",
+			value: "/etc/istio/nginx-ca-certs",
+		},
+	}
+
+	for _, override := range overrides {
+
+		pc, _, err := GetPathContext(root, util.PathFromString(override.path))
+		if err != nil {
+			t.Fatalf("GetPathContext(%q): %v", override.path, err)
+		}
+		err = WritePathContext(pc, override.value, false)
+		if err != nil {
+			t.Fatalf("WritePathContext(%q): %v", override.path, err)
+		}
+	}
+
+	want := `
+values:
+   gateways:
+      istio-egressgateway:
+         secretVolumes:
+         - mountPath: /etc/istio/egressgateway-certs
+           name: egressgateway-certs
+           secretName: istio-egressgateway-certs
+         - mountPath: /etc/istio/egressgateway-ca-certs
+           name: egressgateway-ca-certs
+           secretName: istio-egressgateway-ca-certs
+         - mountPath: /etc/istio/nginx-client-certs
+           name: nginx-client-certs
+           secretName: nginx-client-certs
+         - mountPath: /etc/istio/nginx-ca-certs
+           name: nginx-ca-certs
+           secretName: nginx-ca-certs
+`
+	gotYAML := util.ToYAML(root)
+	diff := util.YAMLDiff(gotYAML, want)
+	if diff != "" {
+		t.Errorf("TestSecretVolumes: diff:\n%s\n", diff)
+	}
 }

--- a/operator/pkg/tpath/tpath_test.go
+++ b/operator/pkg/tpath/tpath_test.go
@@ -146,6 +146,26 @@ a:
 `,
 		},
 		{
+			desc:      "ExtendMoreThanOneLeafListEntry",
+			path:      `a.b.[1].list.[5]`,
+			value:     `v4`,
+			wantFound: true,
+			want: `
+a:
+  b:
+  - name: n1
+    value: v1
+  - list:
+    - v1
+    - v2
+    - v3_regex
+    - null
+    - null
+    - v4
+    name: n2
+`,
+		},
+		{
 			desc:      "ExtendNthListEntry",
 			path:      `a.b.[2].name`,
 			value:     `n3`,
@@ -160,6 +180,26 @@ a:
     - v2
     - v3_regex
     name: n2
+  - name: n3
+`,
+		},
+		{
+			desc:      "ExtendMoreThanOneListEntry",
+			path:      `a.b.[4].name`,
+			value:     `n3`,
+			wantFound: true,
+			want: `
+a:
+  b:
+  - name: n1
+    value: v1
+  - list:
+    - v1
+    - v2
+    - v3_regex
+    name: n2
+  - null
+  - null
   - name: n3
 `,
 		},
@@ -210,6 +250,21 @@ a:
 `,
 		},
 		{
+			desc:      "DeleteListEntryIndex",
+			path:      `a.b.[name:n2].list.[1]`,
+			wantFound: true,
+			want: `
+a:
+  b:
+  - name: n1
+    value: v1
+  - list:
+    - v1
+    - v3_regex
+    name: n2
+`,
+		},
+		{
 			desc:      "DeleteListEntryValueRegex",
 			path:      `a.b.[name:n2].list.[:v3]`,
 			wantFound: true,
@@ -223,6 +278,18 @@ a:
     - v2
     name: n2
 `,
+		},
+		{
+			desc:      "DeleteListLeafEntryBogusIndex",
+			path:      `a.b.[name:n2].list.[-200]`,
+			wantFound: false,
+			wantErr:   `path a.b.[name:n2].list.[-200]: element [-200] not found`,
+		},
+		{
+			desc:      "DeleteListEntryBogusIndex",
+			path:      `a.b.[1000000].list.[:v2]`,
+			wantFound: false,
+			wantErr:   `path a.b.[1000000].list.[:v2]: element [1000000] not found`,
 		},
 		{
 			desc:      "AddMapEntry",
@@ -271,6 +338,12 @@ a:
 			path:      `a.b.[].list`,
 			wantFound: false,
 			wantErr:   `path a.b.[].list: [] is not a valid value path element`,
+		},
+		{
+			desc:      "invalid index",
+			path:      `a.c.[n2].list.[:v3]`,
+			wantFound: false,
+			wantErr:   `path not found at element c in path a.c.[n2].list.[:v3]`,
 		},
 	}
 	for _, tt := range tests {

--- a/operator/pkg/util/reflect.go
+++ b/operator/pkg/util/reflect.go
@@ -280,7 +280,7 @@ func AppendToSlicePtr(parentSlice interface{}, value interface{}) error {
 	} else {
 		newSlice = reflect.Append(pv.Elem(), v)
 	}
-	fmt.Printf("parentSlice has type %T, newSlice %T", parentSlice, newSlice.Interface())
+	fmt.Printf("parentSlice has type %T, newSlice %T\n", parentSlice, newSlice.Interface())
 	pv.Elem().Set(newSlice)
 	return nil
 }

--- a/operator/pkg/util/reflect.go
+++ b/operator/pkg/util/reflect.go
@@ -56,6 +56,7 @@ func IsSlice(value interface{}) bool {
 	return kindOf(value) == reflect.Slice
 }
 
+// IsStruct reports wheter value is a struct type
 func IsStruct(value interface{}) bool {
 	return kindOf(value) == reflect.Struct
 }
@@ -280,7 +281,6 @@ func AppendToSlicePtr(parentSlice interface{}, value interface{}) error {
 	} else {
 		newSlice = reflect.Append(pv.Elem(), v)
 	}
-	fmt.Printf("parentSlice has type %T, newSlice %T\n", parentSlice, newSlice.Interface())
 	pv.Elem().Set(newSlice)
 	return nil
 }

--- a/operator/pkg/util/reflect.go
+++ b/operator/pkg/util/reflect.go
@@ -56,7 +56,7 @@ func IsSlice(value interface{}) bool {
 	return kindOf(value) == reflect.Slice
 }
 
-// IsStruct reports wheter value is a struct type
+// IsStruct reports whether value is a struct type
 func IsStruct(value interface{}) bool {
 	return kindOf(value) == reflect.Struct
 }


### PR DESCRIPTION
Continues work on https://github.com/istio/istio/issues/20381

- The `.` is optional in paths; so for example `values.gateways.istio-egressgateway.secretVolumes[0].name` is legal and means the same thing as `values.gateways.istio-egressgateway.secretVolumes.[0].name`
- Slices can be numerically indexed
- The old `[val]` notation is changed to `[:val]`
- If the numeric index on a slice is larger than its length it grows

The old tests pass, although in a few changes `[v2]` was changed to `[:v2]`.
Please look at the new tests.