### PR TITLE
Deprecation analyzer when using v1alpha Policy with jwt

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -197,6 +197,7 @@ var testGrid = []testCase{
 			{msg.Deprecated, "EnvoyFilter istio-multicluster-egressgateway.istio-system"},
 			{msg.Deprecated, "EnvoyFilter istio-multicluster-egressgateway.istio-system"}, // Duplicate, because resource has two problems
 			{msg.Deprecated, "ServiceRoleBinding bind-mongodb-viewer.default"},
+			{msg.Deprecated, "Policy policy-with-jwt.deprecation-policy"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/deprecation/deprecation.go
+++ b/galley/pkg/config/analysis/analyzers/deprecation/deprecation.go
@@ -17,9 +17,9 @@ package deprecation
 import (
 	"fmt"
 
+	authn_v1alpha1 "istio.io/api/authentication/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/api/rbac/v1alpha1"
-	authn_v1alpha1 "istio.io/api/authentication/v1alpha1"
 
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"

--- a/galley/pkg/config/analysis/analyzers/deprecation/deprecation.go
+++ b/galley/pkg/config/analysis/analyzers/deprecation/deprecation.go
@@ -19,6 +19,7 @@ import (
 
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/api/rbac/v1alpha1"
+	authn_v1alpha1 "istio.io/api/authentication/v1alpha1"
 
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
@@ -43,6 +44,7 @@ func (*FieldAnalyzer) Metadata() analysis.Metadata {
 			collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
 			collections.IstioNetworkingV1Alpha3Envoyfilters.Name(),
 			collections.IstioRbacV1Alpha1Servicerolebindings.Name(),
+			collections.IstioAuthenticationV1Alpha1Policies.Name(),
 		},
 	}
 }
@@ -59,6 +61,11 @@ func (fa *FieldAnalyzer) Analyze(ctx analysis.Context) {
 	})
 	ctx.ForEach(collections.IstioRbacV1Alpha1Servicerolebindings.Name(), func(r *resource.Instance) bool {
 		fa.analyzeServiceRoleBinding(r, ctx)
+		return true
+	})
+
+	ctx.ForEach(collections.IstioAuthenticationV1Alpha1Policies.Name(), func(r *resource.Instance) bool {
+		fa.analyzePolicy(r, ctx)
 		return true
 	})
 }
@@ -102,6 +109,17 @@ func (*FieldAnalyzer) analyzeServiceRoleBinding(r *resource.Instance, ctx analys
 		if subject.Group != "" {
 			ctx.Report(collections.IstioRbacV1Alpha1Servicerolebindings.Name(),
 				msg.NewDeprecated(r, uncertainFixMessage("ServiceRoleBinding.subjects.group")))
+		}
+	}
+}
+
+func (*FieldAnalyzer) analyzePolicy(r *resource.Instance, ctx analysis.Context) {
+	policy := r.Message.(*authn_v1alpha1.Policy)
+
+	for _, origin := range policy.Origins {
+		if origin.GetJwt() != nil {
+			ctx.Report(collections.IstioAuthenticationV1Alpha1Policies.Name(),
+				msg.NewDeprecated(r, replacedMessage("Policy.origins.jwt", "RequestAuthentication.jwtrules")))
 		}
 	}
 }

--- a/galley/pkg/config/analysis/analyzers/testdata/deprecation.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/deprecation.yaml
@@ -25,3 +25,16 @@ spec:
   roleRef:
     kind: ServiceRole
     name: "mongodb-viewer"
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: Policy
+metadata:
+  name: policy-with-jwt
+  namespace: deprecation-policy
+spec:
+  targets:
+  - name: productpage
+  origins:
+  - jwt:
+      issuer: "testing@secure.istio.io"
+      jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"


### PR DESCRIPTION
With the changes to istio 1.5, users using Authentication Policies with
jwt should begin to migrate to the v1beta1/RequestAuthentication and
v1beta1/AuthorizationPolicy apis.

This is the proposed solution for istio 1.5 based on the discussion found at https://github.com/istio/istio/pull/20450