### PR TITLE
Skip extremely flaky mixer tests

### DIFF
--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -253,6 +253,7 @@ func deleteConfigOrFail(t *testing.T, config string, g galley.Instance, ctx reso
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite("mixer_policy_ratelimit", m).
+		Skip("https://github.com/istio/istio/issues/15686").
 		Label(label.CustomSetup).
 		RequireEnvironment(environment.Kube).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, func(cfg *istio.Config) {


### PR DESCRIPTION
Tracked in https://github.com/istio/istio/issues/15686

These have had an extremely high flake rate for 7 months now, with no fixes (see https://testgrid.k8s.io/istio_istio_postsubmit#integ-mixer-k8s-tests_istio_postsubmit&exclude-non-failed-tests=&width=20). I think its time we actually have tests consistently passing in postsubmit :slightly_smiling_face: 