### PR TITLE
Associate filename with reader when analyzing

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -16,7 +16,6 @@ package analyzers
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -502,13 +501,13 @@ func setupAnalyzerForCase(tc testCase, cr snapshotter.CollectionReporterFn) (*lo
 	}
 
 	// Gather test files
-	var files []io.Reader
+	var files []local.ReaderSource
 	for _, f := range tc.inputFiles {
 		of, err := os.Open(f)
 		if err != nil {
 			return nil, fmt.Errorf("error opening test file: %q", f)
 		}
-		files = append(files, of)
+		files = append(files, local.ReaderSource{Name: f, Reader: of})
 	}
 
 	// Include resources from test files

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -97,6 +97,14 @@ type AnalysisResult struct {
 	ExecutedAnalyzers []string
 }
 
+// ReaderSource is a tuple of a io.Reader and filepath.
+type ReaderSource struct {
+	// Name is the name of the source (commonly the path to a file, but can be "-" for sources read from stdin or "" if completely synthetic).
+	Name string
+	// Reader is the reader instance to use.
+	Reader io.Reader
+}
+
 // NewSourceAnalyzer creates a new SourceAnalyzer with no sources. Use the Add*Source methods to add sources in ascending precedence order,
 // then execute Analyze to perform the analysis
 func NewSourceAnalyzer(m *schema.Metadata, analyzer *analysis.CombinedAnalyzer, namespace, istioNamespace resource.Namespace,
@@ -217,21 +225,21 @@ func (sa *SourceAnalyzer) SetSuppressions(suppressions []snapshotter.AnalysisSup
 }
 
 // AddReaderKubeSource adds a source based on the specified k8s yaml files to the current SourceAnalyzer
-func (sa *SourceAnalyzer) AddReaderKubeSource(readers []io.Reader) error {
+func (sa *SourceAnalyzer) AddReaderKubeSource(readers []ReaderSource) error {
 	src := inmemory.NewKubeSource(sa.kubeResources)
 	src.SetDefaultNamespace(sa.namespace)
 
 	var errs error
 
 	// If we encounter any errors reading or applying files, track them but attempt to continue
-	for i, r := range readers {
-		by, err := ioutil.ReadAll(r)
+	for _, r := range readers {
+		by, err := ioutil.ReadAll(r.Reader)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 			continue
 		}
 
-		if err = src.ApplyContent(string(i), string(by)); err != nil {
+		if err = src.ApplyContent(r.Name, string(by)); err != nil {
 			errs = multierror.Append(errs, err)
 		}
 	}
@@ -283,14 +291,14 @@ func (sa *SourceAnalyzer) AddFileKubeMeshConfig(file string) error {
 // and don't want to generate false positives because they aren't there.
 // Respect mesh config when deciding which default resources should be generated
 func (sa *SourceAnalyzer) AddDefaultResources() error {
-	var readers []io.Reader
+	var readers []ReaderSource
 
 	if sa.meshCfg.GetIngressControllerMode() != v1alpha1.MeshConfig_OFF {
 		ingressResources, err := getDefaultIstioIngressGateway(sa.istioNamespace.String(), sa.meshCfg.GetIngressService())
 		if err != nil {
 			return err
 		}
-		readers = append(readers, strings.NewReader(ingressResources))
+		readers = append(readers, ReaderSource{Reader: strings.NewReader(ingressResources)})
 	}
 
 	if len(readers) == 0 {

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -15,7 +15,6 @@ package local
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -188,7 +187,7 @@ func TestAddReaderKubeSource(t *testing.T) {
 	tmpfile := tempFileFromString(t, data.YamlN1I1V1)
 	defer os.Remove(tmpfile.Name())
 
-	err := sa.AddReaderKubeSource([]io.Reader{tmpfile})
+	err := sa.AddReaderKubeSource([]ReaderSource{{Reader: tmpfile}})
 	g.Expect(err).To(BeNil())
 	g.Expect(*sa.meshCfg).To(Equal(*meshcfg.Default())) // Base default meshcfg
 	g.Expect(sa.sources).To(HaveLen(1))
@@ -212,7 +211,7 @@ func TestAddReaderKubeSourceSkipsBadEntries(t *testing.T) {
 	tmpfile := tempFileFromString(t, kubeyaml.JoinString(data.YamlN1I1V1, "bogus resource entry\n"))
 	defer func() { _ = os.Remove(tmpfile.Name()) }()
 
-	err := sa.AddReaderKubeSource([]io.Reader{tmpfile})
+	err := sa.AddReaderKubeSource([]ReaderSource{{Reader: tmpfile}})
 	g.Expect(err).To(Not(BeNil()))
 	g.Expect(sa.sources).To(HaveLen(1))
 }

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"runtime"
 	"sort"
@@ -326,11 +325,12 @@ istioctl analyze -L
 	return analysisCmd
 }
 
-func gatherFiles(args []string) ([]io.Reader, error) {
-	var readers []io.Reader
-	var r *os.File
+func gatherFiles(args []string) ([]local.ReaderSource, error) {
+	var readers []local.ReaderSource
 	var err error
 	for _, f := range args {
+		var r *os.File
+
 		if f == "-" {
 			if isatty.IsTerminal(os.Stdin.Fd()) {
 				fmt.Fprint(os.Stderr, "Reading from stdin:\n")
@@ -343,7 +343,7 @@ func gatherFiles(args []string) ([]io.Reader, error) {
 			}
 			runtime.SetFinalizer(r, func(x *os.File) { x.Close() })
 		}
-		readers = append(readers, r)
+		readers = append(readers, local.ReaderSource{Name: f, Reader: r})
 	}
 	return readers, nil
 }

--- a/tests/integration/galley/analyze_test.go
+++ b/tests/integration/galley/analyze_test.go
@@ -33,6 +33,7 @@ import (
 const (
 	serviceRoleBindingFile = "testdata/servicerolebinding.yaml"
 	serviceRoleFile        = "testdata/servicerole.yaml"
+	invalidFile            = "testdata/invalid.yaml"
 )
 
 var analyzerFoundIssuesError = cmd.AnalyzerFoundIssuesError{}
@@ -81,6 +82,28 @@ func TestFileOnly(t *testing.T) {
 			output, err = istioctlSafe(t, istioCtl, ns.Name(), false, serviceRoleBindingFile, serviceRoleFile)
 			expectNoMessages(t, g, output)
 			g.Expect(err).To(BeNil())
+		})
+}
+
+func TestFileParseError(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(ctx framework.TestContext) {
+			g := NewGomegaWithT(t)
+
+			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "istioctl-analyze",
+				Inject: true,
+			})
+
+			istioCtl := istioctl.NewOrFail(t, ctx, istioctl.Config{})
+
+			// Parse error as the yaml file itself is not valid yaml.
+			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, invalidFile)
+			g.Expect(output[0]).To(ContainSubstring("Error(s) adding files"))
+			g.Expect(output[1]).To(ContainSubstring(fmt.Sprintf("errors parsing content \"%s\"", invalidFile)))
+
+			g.Expect(err).To(MatchError(cmd.FileParseError{}))
 		})
 }
 

--- a/tests/integration/galley/testdata/invalid.yaml
+++ b/tests/integration/galley/testdata/invalid.yaml
@@ -1,0 +1,1 @@
+this causes a parse error, it's not yaml!


### PR DESCRIPTION
At some point, `local.SourceAnalyzer` was rewritten to support arbitrary readers instead of files. During this rewrite the filename was no longer associated with readers, so when an error occurred you wouldn't actually see what file had the error (this is most noticeable when using xargs to provide a list of files):

```
$ # kubernetes-manifests.yaml has an error in it, but the filename isn't shown.
$ ~/go/src/istio.io/istio/out/darwin_amd64/istioctl analyze --use-kube=false cluster/workloads/hipstershop/kubernetes-manifests.yaml
Error(s) adding files: 1 error occurred:
        * errors parsing content "\x00": 1 error occurred:
        * error processing [0]: failed interpreting jsonChunk: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }



No validation issues found (but 1 file could not be parsed)
Error: Some files couldn't be parsed.
```

This change associates a filename with each reader, or "-" if read from stdin, or "" if there is no good name to associate (e.g. a synthetic resource).

The output now looks like:

```
$ ~/go/src/istio.io/istio/out/darwin_amd64/istioctl analyze --use-kube=false cluster/workloads/hipstershop/kubernetes-manifests.yaml
Error(s) adding files: 1 error occurred:
        * errors parsing content "cluster/workloads/hipstershop/kubernetes-manifests.yaml": 1 error occurred:
        * error processing cluster/workloads/hipstershop/kubernetes-manifests.yaml[0]: failed interpreting jsonChunk: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }



No validation issues found (but 1 file could not be parsed)
Error: Some files couldn't be parsed.
```