### PR TITLE
Add release builder overrides present in release-builder

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -50,6 +50,7 @@ version: ${VERSION}
 docker: ${DOCKER_HUB}
 directory: ${WORK_DIR}
 dependencies:
+${DEPENDENCIES:-$(cat <<EOD
   istio:
     localpath: ${ROOT}
   cni:
@@ -80,6 +81,9 @@ dependencies:
   tools:
     git: https://github.com/istio/tools
     branch: master
+EOD
+)}
+${PROXY_OVERRIDE:-}
 EOF
 )
 


### PR DESCRIPTION
This script mirrors the release builder one to test the release and
trigger dev-builds, but right now it doesn't support the same overrides,
making private builds less flexible