### PR TITLE
Add analyzer error message when Policies using JWT are not configured properly

### DIFF
--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -88,6 +88,10 @@ var (
 	// PortNameIsNotUnderNamingConvention defines a diag.MessageType for message "PortNameIsNotUnderNamingConvention".
 	// Description: Port name is not under naming convention. Protocol detection is applied to the port.
 	PortNameIsNotUnderNamingConvention = diag.NewMessageType(diag.Info, "IST0118", "Port name %s (port: %d, targetPort: %s) doesn't follow the naming convention of Istio port.")
+
+	// JwtFailureDueToInvalidServicePortPrefix defines a diag.MessageType for message "JwtFailureDueToInvalidServicePortPrefix".
+	// Description: Authentication policy with JWT targets Service with invalid port specification.
+	JwtFailureDueToInvalidServicePortPrefix = diag.NewMessageType(diag.Warning, "IST0119", "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s).")
 )
 
 // All returns a list of all known message types.
@@ -113,6 +117,7 @@ func All() []*diag.MessageType {
 		DeploymentAssociatedToMultipleServices,
 		DeploymentRequiresServiceAssociated,
 		PortNameIsNotUnderNamingConvention,
+		JwtFailureDueToInvalidServicePortPrefix,
 	}
 }
 
@@ -311,6 +316,18 @@ func NewPortNameIsNotUnderNamingConvention(r *resource.Instance, portName string
 		r,
 		portName,
 		port,
+		targetPort,
+	)
+}
+
+// NewJwtFailureDueToInvalidServicePortPrefix returns a new diag.Message based on JwtFailureDueToInvalidServicePortPrefix.
+func NewJwtFailureDueToInvalidServicePortPrefix(r *resource.Instance, port int, portName string, protocol string, targetPort string) diag.Message {
+	return diag.NewMessage(
+		JwtFailureDueToInvalidServicePortPrefix,
+		r,
+		port,
+		portName,
+		protocol,
 		targetPort,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -218,3 +218,18 @@ messages:
         type: int
       - name: targetPort
         type: string
+
+  - name: "JwtFailureDueToInvalidServicePortPrefix"
+    code: IST0119
+    level: Warning
+    description: "Authentication policy with JWT targets Service with invalid port specification."
+    template: "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s)."
+    args:
+      - name: port
+        type: int
+      - name: portName
+        type: string
+      - name: protocol
+        type: string
+      - name: targetPort
+        type: string


### PR DESCRIPTION
When a v1alpha1 Authentication Policy using JWT has a misconfigured K8s Service we wish for the analyzer to inform the user that they have misconfigured JWT authentication. The work to implement the analyzer using this message will be done in a separate PR.

This is to address issue https://github.com/istio/istio/issues/17535.

For the discussion about this analyzer see
https://github.com/istio/istio/pull/20450
https://github.com/istio/istio/pull/20645