### PR TITLE
Add analyzer error message when Policies using JWT are not configured properly (release 1.4)

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -31,6 +31,7 @@ func All() []analysis.Analyzer {
 	analyzers := []analysis.Analyzer{
 		// Please keep this list sorted alphabetically by pkg.name for convenience
 		&annotations.K8sAnalyzer{},
+		&auth.JwtAnalyzer{},
 		&auth.ServiceRoleBindingAnalyzer{},
 		&auth.ServiceRoleServicesAnalyzer{},
 		&deprecation.FieldAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -67,19 +67,19 @@ var testGrid = []testCase{
 			{msg.MisplacedAnnotation, "Deployment fortio-deploy"},
 		},
 	},
-	// {
-	// 	name:       "jwtTargetsInvalidServicePortName",
-	// 	inputFiles: []string{"testdata/jwt-invalid-service-port-name.yaml"},
-	// 	analyzer:   &auth.JwtAnalyzer{},
-	// 	expected: []message{
-	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-specified-ports.namespace-port-missing-prefix"},
-	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-without-specified-ports.namespace-port-missing-prefix"},
-	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-without-specified-ports.namespace-port-missing-prefix"},
-	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-udp-target-port.namespace-with-non-tcp-protocol"},
-	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-invalid-named-target-port.namespace-with-invalid-named-port"},
-	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-valid-named-target-port-invalid-protocol.namespace-with-valid-named-port-invalid-protocol"},
-	// 	},
-	// },
+	{
+		name:       "jwtTargetsInvalidServicePortName",
+		inputFiles: []string{"testdata/jwt-invalid-service-port-name.yaml"},
+		analyzer:   &auth.JwtAnalyzer{},
+		expected: []message{
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-specified-ports.namespace-port-missing-prefix"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-without-specified-ports.namespace-port-missing-prefix"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-without-specified-ports.namespace-port-missing-prefix"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-udp-target-port.namespace-with-non-tcp-protocol"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-invalid-named-target-port.namespace-with-invalid-named-port"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-valid-named-target-port-invalid-protocol.namespace-with-valid-named-port-invalid-protocol"},
+		},
+	},
 	{
 		name:       "jwtTargetsValidServicePortName",
 		inputFiles: []string{"testdata/jwt-valid-service-port-name.yaml"},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -67,6 +67,27 @@ var testGrid = []testCase{
 			{msg.MisplacedAnnotation, "Deployment fortio-deploy"},
 		},
 	},
+	// {
+	// 	name:       "jwtTargetsInvalidServicePortName",
+	// 	inputFiles: []string{"testdata/jwt-invalid-service-port-name.yaml"},
+	// 	analyzer:   &auth.JwtAnalyzer{},
+	// 	expected: []message{
+	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-specified-ports.namespace-port-missing-prefix"},
+	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-without-specified-ports.namespace-port-missing-prefix"},
+	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-without-specified-ports.namespace-port-missing-prefix"},
+	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-udp-target-port.namespace-with-non-tcp-protocol"},
+	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-invalid-named-target-port.namespace-with-invalid-named-port"},
+	// 		{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-valid-named-target-port-invalid-protocol.namespace-with-valid-named-port-invalid-protocol"},
+	// 	},
+	// },
+	{
+		name:       "jwtTargetsValidServicePortName",
+		inputFiles: []string{"testdata/jwt-valid-service-port-name.yaml"},
+		analyzer:   &auth.JwtAnalyzer{},
+		expected:   []message{
+			// port prefixes all pass
+		},
+	},
 	{
 		name:       "serviceRoleBindings",
 		inputFiles: []string{"testdata/servicerolebindings.yaml"},

--- a/galley/pkg/config/analysis/analyzers/auth/jwt.go
+++ b/galley/pkg/config/analysis/analyzers/auth/jwt.go
@@ -1,0 +1,196 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"regexp"
+
+	v1 "k8s.io/api/core/v1"
+
+	"istio.io/api/authentication/v1alpha1"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/galley/pkg/config/meta/metadata"
+	"istio.io/istio/galley/pkg/config/meta/schema/collection"
+	"istio.io/istio/galley/pkg/config/resource"
+)
+
+var (
+	jwtSupportedPortName = regexp.MustCompile("^http(2|s)?(-.*)?$")
+)
+
+// JwtAnalyzer checks for misconfiguration of an Authentication policy
+// that specifies a JWT, but the specified target host's K8s Service definition
+// does not have a named port that matches <protocol>[-<suffix>].
+type JwtAnalyzer struct{}
+
+// (compile-time check that we implement the interface)
+var _ analysis.Analyzer = &JwtAnalyzer{}
+
+// Metadata implements JwtAnalyzer
+func (j *JwtAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name: "auth.JwtAnalyzer",
+		Inputs: collection.Names{
+			metadata.IstioAuthenticationV1Alpha1Policies,
+			metadata.K8SCoreV1Services,
+		},
+	}
+}
+
+func (j *JwtAnalyzer) Analyze(ctx analysis.Context) {
+	nsm := j.buildNamespaceServiceMap(ctx)
+
+	ctx.ForEach(metadata.IstioAuthenticationV1Alpha1Policies, func(r *resource.Entry) bool {
+		j.analyzeServiceTarget(r, ctx, nsm)
+		return true
+	})
+}
+
+// buildNamespaceServiceMap returns a map where the index is a namespace and the boolean
+func (j *JwtAnalyzer) buildNamespaceServiceMap(ctx analysis.Context) map[string]*v1.ServiceSpec {
+	// Keep track of each fqdn -> service definition
+	fqdnServices := map[string]*v1.ServiceSpec{}
+
+	ctx.ForEach(metadata.K8SCoreV1Services, func(r *resource.Entry) bool {
+		svcNs, svcName := r.Metadata.Name.InterpretAsNamespaceAndName()
+
+		svc := r.Item.(*v1.ServiceSpec)
+		fqdn := util.ConvertHostToFQDN(svcNs, svcName)
+		fqdnServices[fqdn] = svc
+
+		return true
+	})
+
+	return fqdnServices
+}
+
+func (j *JwtAnalyzer) analyzeServiceTarget(r *resource.Entry, ctx analysis.Context, nsm map[string]*v1.ServiceSpec) {
+	policy := r.Item.(*v1alpha1.Policy)
+	ns, _ := r.Metadata.Name.InterpretAsNamespaceAndName()
+
+	for _, origin := range policy.Origins {
+		if origin.GetJwt() == nil {
+			continue
+		}
+
+		for _, target := range policy.GetTargets() {
+			fqdn := util.ConvertHostToFQDN(ns, target.GetName())
+			svc, ok := nsm[fqdn]
+			if !ok {
+				// service was not found, but this is not considered an error
+				continue
+			}
+
+			if len(target.GetPorts()) == 0 {
+				checkServicePorts(r, ctx, svc)
+				continue
+			}
+
+			// check ports defined in the authentication policy for the service
+			for _, port := range target.GetPorts() {
+				if port.GetName() == "" {
+					checkPortNumber(r, ctx, port.GetNumber(), svc)
+				} else {
+					checkPortName(r, ctx, port.GetName(), svc)
+				}
+			}
+		}
+	}
+}
+
+func checkPortName(r *resource.Entry, ctx analysis.Context, portName string, svc *v1.ServiceSpec) {
+	var svcPort *v1.ServicePort
+	for _, port := range svc.Ports {
+		if portName != port.Name {
+			continue
+		}
+
+		if !isTCPProtocol(port.Protocol) {
+			ctx.Report(metadata.IstioAuthenticationV1Alpha1Policies,
+				msg.NewJwtFailureDueToInvalidServicePortPrefix(
+					r,
+					int(port.Port),
+					port.Name,
+					string(port.Protocol),
+					port.TargetPort.String(),
+				))
+			return
+		}
+
+		svcPort = &port
+		break
+	}
+	checkPort(r, ctx, svcPort)
+}
+
+func checkPortNumber(r *resource.Entry, ctx analysis.Context, portNum uint32, svc *v1.ServiceSpec) {
+	var svcPort *v1.ServicePort
+	for _, port := range svc.Ports {
+		if !isTCPProtocol(port.Protocol) {
+			continue
+		}
+		if portNum == uint32(port.Port) {
+			svcPort = &port
+			break
+		}
+	}
+	checkPort(r, ctx, svcPort)
+}
+
+func checkPort(r *resource.Entry, ctx analysis.Context, svcPort *v1.ServicePort) {
+	if svcPort == nil {
+		return
+	}
+
+	svcPortName := svcPort.Name
+	if !isJwtSupportedPortName(svcPortName) {
+		ctx.Report(metadata.IstioAuthenticationV1Alpha1Policies,
+			msg.NewJwtFailureDueToInvalidServicePortPrefix(
+				r,
+				int(svcPort.Port),
+				svcPortName,
+				string(svcPort.Protocol),
+				svcPort.TargetPort.String(),
+			))
+	}
+}
+
+func checkServicePorts(r *resource.Entry, ctx analysis.Context, svc *v1.ServiceSpec) {
+	for _, port := range svc.Ports {
+		if isTCPProtocol(port.Protocol) && isJwtSupportedPortName(port.Name) {
+			continue
+		} else {
+			ctx.Report(metadata.IstioAuthenticationV1Alpha1Policies,
+				msg.NewJwtFailureDueToInvalidServicePortPrefix(
+					r,
+					int(port.Port),
+					port.Name,
+					string(port.Protocol),
+					port.TargetPort.String(),
+				))
+		}
+	}
+}
+
+func isTCPProtocol(protocol v1.Protocol) bool {
+	return string(protocol) == "TCP" || protocol == ""
+}
+
+func isJwtSupportedPortName(portName string) bool {
+	return jwtSupportedPortName.Match([]byte(portName))
+}

--- a/galley/pkg/config/analysis/analyzers/testdata/jwt-invalid-service-port-name.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/jwt-invalid-service-port-name.yaml
@@ -1,0 +1,159 @@
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-with-specified-ports
+  namespace: namespace-port-missing-prefix
+spec:
+  targets:
+    - name: my-service-port-missing-prefix
+      ports:
+        - number: 8080
+        - number: 8081
+        - number: 8082
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-port-missing-prefix
+  namespace: namespace-port-missing-prefix
+spec:
+  selector:
+    app: my-service
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: missingprefix-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: https-svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: http2-svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-without-specified-ports
+  namespace: namespace-port-missing-prefix
+spec:
+  targets:
+    - name: my-service-no-target-ports-specified
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-no-target-ports-specified
+  namespace: namespace-port-missing-prefix
+spec:
+  selector:
+    app: my-service-no-target-ports-specified
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-with-udp-target-port
+  namespace: namespace-with-non-tcp-protocol
+spec:
+  targets:
+    - name: my-service-no-target-ports-specified
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-no-target-ports-specified
+  namespace: namespace-with-non-tcp-protocol
+spec:
+  selector:
+    app: my-service-no-target-ports-specified
+  ports:
+    - protocol: UDP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-with-invalid-named-target-port
+  namespace: namespace-with-invalid-named-port
+spec:
+  targets:
+    - name: my-service-with-invalid-named-port
+      ports:
+        - name: badname
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-with-invalid-named-port
+  namespace: namespace-with-invalid-named-port
+spec:
+  selector:
+    app: my-service-with-invalid-named-port
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: badname
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-with-valid-named-target-port-invalid-protocol
+  namespace: namespace-with-valid-named-port-invalid-protocol
+spec:
+  targets:
+    - name: my-service-with-valid-named-port-invalid-protocol
+      ports:
+        - name: https
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-with-valid-named-port-invalid-protocol
+  namespace: namespace-with-valid-named-port-invalid-protocol
+spec:
+  selector:
+    app: my-service-with-valid-named-port-invalid-protocol
+  ports:
+    - protocol: UDP
+      port: 8080
+      targetPort: 8080
+      name: https
+---

--- a/galley/pkg/config/analysis/analyzers/testdata/jwt-valid-service-port-name.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/jwt-valid-service-port-name.yaml
@@ -1,0 +1,103 @@
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: test-ports
+  namespace: my-namespace
+spec:
+  targets:
+    - name: my-service
+      ports:
+        - number: 8080
+        - number: 8081
+        - number: 8082
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: my-namespace
+spec:
+  selector:
+    app: my-service
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: https-svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: http2-svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: test-no-ports
+  namespace: my-namespace-2
+spec:
+  targets:
+    - name: my-service-no-target-ports-specified
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-no-target-ports-specified
+  namespace: my-namespace-2
+spec:
+  selector:
+    app: my-service-no-target-ports-specified
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: https-svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: http2-svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-named-ports
+  namespace: namespace-named-ports
+spec:
+  targets:
+    - name: my-service-named-port
+      ports:
+        - name: http-foo
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-named-port
+  namespace: namespace-named-ports
+spec:
+  selector:
+    app: my-service-named-port
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-foo
+---

--- a/galley/pkg/config/analysis/analyzers/util/hosts.go
+++ b/galley/pkg/config/analysis/analyzers/util/hosts.go
@@ -67,3 +67,14 @@ func convertHostToFQDN(namespace, host string) string {
 	}
 	return fqdn
 }
+
+// ConvertHostToFQDN returns the given host as a FQDN, if it isn't already.
+func ConvertHostToFQDN(namespace, host string) string {
+	fqdn := host
+	// Convert to FQDN only if host is not a wildcard or a FQDN
+	if !strings.HasPrefix(host, "*") &&
+		!strings.Contains(host, ".") {
+		fqdn = host + "." + namespace + "." + DefaultKubernetesDomain
+	}
+	return fqdn
+}

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -64,6 +64,10 @@ var (
 	// VirtualServiceDestinationPortSelectorRequired defines a diag.MessageType for message "VirtualServiceDestinationPortSelectorRequired".
 	// Description: A VirtualService routes to a service with more than one port exposed, but does not specify which to use.
 	VirtualServiceDestinationPortSelectorRequired = diag.NewMessageType(diag.Error, "IST0112", "This VirtualService routes to a service %q that exposes multiple ports %v. Specifying a port in the destination is required to disambiguate.")
+
+	// JwtFailureDueToInvalidServicePortPrefix defines a diag.MessageType for message "JwtFailureDueToInvalidServicePortPrefix".
+	// Description: Authentication policy with JWT targets Service with invalid port specification.
+	JwtFailureDueToInvalidServicePortPrefix = diag.NewMessageType(diag.Error, "IST0119", "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s).")
 )
 
 // NewInternalError returns a new diag.Message based on InternalError.
@@ -200,6 +204,18 @@ func NewVirtualServiceDestinationPortSelectorRequired(entry *resource.Entry, des
 		originOrNil(entry),
 		destHost,
 		destPorts,
+	)
+}
+
+// NewJwtFailureDueToInvalidServicePortPrefix returns a new diag.Message based on JwtFailureDueToInvalidServicePortPrefix.
+func NewJwtFailureDueToInvalidServicePortPrefix(entry *resource.Entry, port int, portName string, protocol string, targetPort string) diag.Message {
+	return diag.NewMessage(
+		JwtFailureDueToInvalidServicePortPrefix,
+		originOrNil(entry),
+		port,
+		portName,
+		protocol,
+		targetPort,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -148,3 +148,18 @@ messages:
         type: string
       - name: destPorts
         type: "[]int"
+
+  - name: "JwtFailureDueToInvalidServicePortPrefix"
+    code: IST0119
+    level: Error
+    description: "Authentication policy with JWT targets Service with invalid port specification."
+    template: "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s)."
+    args:
+      - name: port
+        type: int
+      - name: portName
+        type: string
+      - name: protocol
+        type: string
+      - name: targetPort
+        type: string

--- a/galley/pkg/config/meta/metadata/metadata.gen.go
+++ b/galley/pkg/config/meta/metadata/metadata.gen.go
@@ -614,6 +614,7 @@ snapshots:
   - name: "localAnalysis"
     strategy: immediate
     collections:
+      - "istio/authentication/v1alpha1/policies"
       - "istio/rbac/v1alpha1/servicerolebindings"
       - "istio/rbac/v1alpha1/serviceroles"
       - "istio/mesh/v1alpha1/MeshConfig"

--- a/galley/pkg/config/meta/metadata/metadata.yaml
+++ b/galley/pkg/config/meta/metadata/metadata.yaml
@@ -568,6 +568,7 @@ snapshots:
   - name: "localAnalysis"
     strategy: immediate
     collections:
+      - "istio/authentication/v1alpha1/policies"
       - "istio/rbac/v1alpha1/servicerolebindings"
       - "istio/rbac/v1alpha1/serviceroles"
       - "istio/mesh/v1alpha1/MeshConfig"


### PR DESCRIPTION
When a v1alpha1 Authentication Policy using JWT has a misconfigured K8s Service we wish for the analyzer to inform the user of this misconfiguration. The work to implement the analyzer using this message will be done in a separate PR.

See https://github.com/istio/istio/pull/20671 for the change in release 1.5 and master. Due to the generated file based on the messages.yaml file, these PRs are different.

For the discussion about this analyzer see
https://github.com/istio/istio/pull/20450
https://github.com/istio/istio/pull/20645