### PR TITLE
authz: add e2e tests for negative match and wildcard

### DIFF
--- a/tests/integration/security/testdata/rbac/v1beta1-negative-match.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-negative-match.yaml.tmpl
@@ -1,0 +1,132 @@
+# The following policy denies access to path with prefix "/prefix" except "/prefix/whitelist" to workload b
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-b-deny
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "b"
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: ["/prefix*"]
+        notPaths: ["/prefix/whitelist"]
+---
+
+# The following policy denies access from other namespaces
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-c-same-namespace
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "c"
+  action: DENY
+  rules:
+  - from:
+    - source:
+        notNamespaces: ["{{ .Namespace }}"]
+---
+
+# The following policy denies access to workload d if it's not mTLS, in other words,
+# it allows only mTLS traffic to access workload d
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-d-mtls-traffic
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "d"
+  action: DENY
+  rules:
+  - from:
+    - source:
+        notPrincipals: ["*"]
+---
+
+# The following policy enables mTLS with PERMISSIVE mode for workload b, c and d
+
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: "permissive"
+  namespace: "{{ .Namespace }}"
+spec:
+  targets:
+  - name: b
+  - name: c
+  - name: d
+  peers:
+  - mtls:
+      mode: PERMISSIVE
+---
+
+# The following destination rule enables mTLS in the namespace
+
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "mtls"
+  namespace: "{{ .Namespace }}"
+spec:
+  host: "*.{{ .Namespace }}.svc.cluster.local"
+  exportTo: ["."]
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+
+# The following destination rule enables mTLS from namespace 2 to workload b
+
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "dr-b"
+  namespace: "{{ .Namespace2 }}"
+spec:
+  host: "b.{{ .Namespace }}.svc.cluster.local"
+  exportTo: ["."]
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+
+# The following destination rule enables mTLS from namespace 2 to workload c
+
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "dr-c"
+  namespace: "{{ .Namespace2 }}"
+spec:
+  host: "c.{{ .Namespace }}.svc.cluster.local"
+  exportTo: ["."]
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+
+# The following destination rule disables mTLS from namespace 2 to workload d
+
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "dr-d"
+  namespace: "{{ .Namespace2 }}"
+spec:
+  host: "d.{{ .Namespace }}.svc.cluster.local"
+  exportTo: ["."]
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---

--- a/tests/integration/security/testdata/rbac/v1beta1-negative-match.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-negative-match.yaml.tmpl
@@ -54,18 +54,14 @@ spec:
         notPrincipals: ["*"]
 ---
 
-# The following policy enables mTLS with PERMISSIVE mode for workload b, c and d
+# The following policy enables mTLS with PERMISSIVE mode for all workloads in the namespace
 
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: "permissive"
+  name: "default"
   namespace: "{{ .Namespace }}"
 spec:
-  targets:
-  - name: b
-  - name: c
-  - name: d
   peers:
   - mtls:
       mode: PERMISSIVE


### PR DESCRIPTION
For https://github.com/istio/istio/issues/19894

This PR adds e2e tests for the negative match (`not_` fields) and the wildcard in authz policy including the following test cases:
- overlap cases when `paths` and `not_paths` are used together
- deny traffic from other namespaces, in other words, only allow same namespace traffic
- deny plain text traffic, in other words, only allow mTLS traffic