### PR TITLE
Add release builder overrides present in release-builder (#20655)

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -53,6 +53,7 @@ version: ${VERSION}
 docker: ${DOCKER_HUB}
 directory: ${WORK_DIR}
 dependencies:
+${DEPENDENCIES:-$(cat <<EOD
   istio:
     localpath: ${ROOT}
   cni:
@@ -83,6 +84,9 @@ dependencies:
   tools:
     git: https://github.com/istio/tools
     branch: release-1.4
+EOD
+)}
+${PROXY_OVERRIDE:-}
 EOF
 )
 

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -16,6 +16,8 @@
 
 WD=$(dirname "$0")
 WD=$(cd "$WD"; pwd)
+# This is a shellcheck false positive
+# shellcheck disable=SC2034
 ROOT=$(dirname "$WD")
 
 set -eux


### PR DESCRIPTION
This script mirrors the release builder one to test the release and
trigger dev-builds, but right now it doesn't support the same overrides,
making private builds less flexible

(cherry picked from commit 37f5e318961d7fa59ccceea2ced2ae633083b60c)