### PR TITLE
Don't use -oyaml for `kubectl delete`

### DIFF
--- a/operator/pkg/manifest/installer.go
+++ b/operator/pkg/manifest/installer.go
@@ -329,6 +329,7 @@ func ApplyManifest(componentName name.ComponentName, manifestStr, version string
 			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 		delOpts := opts
+		delOpts.Output = ""
 		delOpts.ExtraArgs = []string{"--selector", componentLabel}
 		stdoutDel, stderrDel, err := kubectl.Delete(stdoutGet, &delOpts)
 		stdout += "\n" + stdoutDel


### PR DESCRIPTION
I have no clue how this worked before, but when we run the kubectl
delete command it fails because -oyaml is not valid. I am pretty sure we
don't need the output from delete, so should be fine to remove it?