### PR TITLE
Fixing istio-validation init container injection ordering.

### DIFF
--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
@@ -1,0 +1,72 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/initContainers/-",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/0",
+    "value": {
+      "name": "istio-validation",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/-",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "istio-envoy",
+      "emptyDir": {
+        "medium": "Memory"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\",\"istio-validation\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels",
+    "value": {
+      "security.istio.io/tlsMode": "istio"
+    }
+  }
+]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.yaml
@@ -1,0 +1,12 @@
+metadata:
+  name: something
+spec:
+  initContainers:
+  - name: c0
+  - name: injected0
+  containers:
+  - name: c1
+  - name: injected1
+  volumes:
+  - name: v0
+  - name: injected2

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder_template.yaml
@@ -1,0 +1,26 @@
+policy: enabled
+alwaysInjectSelector: []
+neverInjectSelector: []
+injectedAnnotations:
+template: |-
+  initContainers:
+  - name: istio-init
+    image: example.com/init:latest
+  - name: istio-validation
+    image: example.com/init:latest
+  containers:
+  - name: istio-proxy
+    image: example.com/proxy:latest
+  imagePullSecrets:
+  - name: istio-image-pull-secrets
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - name: istio-certs
+    secret:
+      {{ if eq .Spec.ServiceAccountName "" -}}
+      secretName: istio.default
+      {{ else -}}
+      secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+      {{ end -}}

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -399,6 +399,8 @@ func addContainer(target, added []corev1.Container, basePath string) (patch []rf
 		if first {
 			first = false
 			value = []corev1.Container{add}
+		} else if add.Name == "istio-validation" {
+			path += "/0"
 		} else {
 			path += "/-"
 		}

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -632,6 +632,11 @@ func TestWebhookInject(t *testing.T) {
 			inputFile: "TestWebhookInject_mtls_not_ready.yaml",
 			wantFile:  "TestWebhookInject_mtls_not_ready.patch",
 		},
+		{
+			inputFile:    "TestWebhookInject_validationOrder.yaml",
+			wantFile:     "TestWebhookInject_validationOrder.patch",
+			templateFile: "TestWebhookInject_validationOrder_template.yaml",
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
The istio-validation container must run before other init containers,
so that we verify that the environment is configured before they start.

Added a special case for that container and some tests to validate
the behavior.