### PR TITLE
feat(canonical service): add initial support for labeling workloads

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -146,6 +146,9 @@ const (
 
 	// IstioMutualTLSModeLabel implies that the endpoint is ready to receive Istio mTLS connections.
 	IstioMutualTLSModeLabel = "istio"
+
+	// IstioCanonicalServiceLabelName is the name of label for the Istio Canonical Service for a workload instance.
+	IstioCanonicalServiceLabelName = "service.istio.io/canonical-name"
 )
 
 // Port represents a network port where a service is listening for

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -16,7 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
-        sidecar.istio.io/status: '{"version":"08dbe54376cfc7af6adee736e19a99a0a6a1b91feda34d0c4f1915c7a3afdf89","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -16,7 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"version":"08dbe54376cfc7af6adee736e19a99a0a6a1b91feda34d0c4f1915c7a3afdf89","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"08dbe54376cfc7af6adee736e19a99a0a6a1b91feda34d0c4f1915c7a3afdf89","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"08dbe54376cfc7af6adee736e19a99a0a6a1b91feda34d0c4f1915c7a3afdf89","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"08dbe54376cfc7af6adee736e19a99a0a6a1b91feda34d0c4f1915c7a3afdf89","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"08dbe54376cfc7af6adee736e19a99a0a6a1b91feda34d0c4f1915c7a3afdf89","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"08dbe54376cfc7af6adee736e19a99a0a6a1b91feda34d0c4f1915c7a3afdf89","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"08dbe54376cfc7af6adee736e19a99a0a6a1b91feda34d0c4f1915c7a3afdf89","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"08dbe54376cfc7af6adee736e19a99a0a6a1b91feda34d0c4f1915c7a3afdf89","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"08dbe54376cfc7af6adee736e19a99a0a6a1b91feda34d0c4f1915c7a3afdf89","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
@@ -59,5 +59,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
@@ -75,6 +75,11 @@
     }
   },
   {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
+  },
+  {
     "op": "replace",
     "path": "/spec/containers/0/readinessProbe/httpGet",
     "value": {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
@@ -79,6 +79,11 @@
     }
   },
   {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
+  },
+  {
     "op": "replace",
     "path": "/spec/containers/1/readinessProbe/httpGet",
     "value": {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
@@ -57,5 +57,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
@@ -77,6 +77,11 @@
     }
   },
   {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
+  },
+  {
     "op": "replace",
     "path": "/spec/containers/1/readinessProbe/httpGet",
     "value": {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
@@ -79,6 +79,11 @@
     }
   },
   {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
+  },
+  {
     "op": "replace",
     "path": "/spec/containers/1/readinessProbe/httpGet",
     "value": {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
@@ -69,5 +69,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": "something"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
@@ -52,5 +52,10 @@
     "value": {
       "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
@@ -59,5 +59,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
@@ -61,5 +61,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
@@ -61,5 +61,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
@@ -63,5 +63,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
@@ -59,5 +59,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
@@ -59,5 +59,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
@@ -61,5 +61,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
@@ -63,5 +63,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
@@ -63,5 +63,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
@@ -61,5 +61,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
@@ -61,5 +61,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
@@ -63,5 +63,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
@@ -65,5 +65,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
@@ -59,5 +59,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
@@ -61,5 +61,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": ""
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
@@ -69,5 +69,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": "replace"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
@@ -73,5 +73,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": "replace-backwards-compat"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
@@ -68,5 +68,10 @@
     "value": {
       "security.istio.io/tlsMode": "istio"
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": "something"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -18,6 +18,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -17,6 +17,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: hello
+spec:
+  replicas: 7
+  template:
+    metadata:
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+        service.istio.io/canonical-name: test-service-name
+    spec:
+      containers:
+        - name: hello
+          image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+          ports:
+            - name: http
+              containerPort: 80
+  triggers:
+    - type: "ConfigChange"
+    - type: "ImageChange"
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - "helloworld"
+        from:
+          kind: "ImageStreamTag"
+          name: "hello-go-gke:1.0"
+  strategy:
+    type: "Rolling"
+  paused: false
+  revisionHistoryLimit: 2
+  minReadySeconds: 0

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -1,16 +1,14 @@
-apiVersion: apps/v1
-kind: StatefulSet
+apiVersion: v1
+kind: DeploymentConfig
 metadata:
   creationTimestamp: null
   name: hello
 spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: hello
-      tier: backend
-      track: stable
-  strategy: {}
+  replicas: 7
+  revisionHistoryLimit: 2
+  selector: null
+  strategy:
+    type: Rolling
   template:
     metadata:
       annotations:
@@ -19,7 +17,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
-        service.istio.io/canonical-name: hello
+        service.istio.io/canonical-name: test-service-name
         tier: backend
         track: stable
     spec:
@@ -30,9 +28,6 @@ spec:
         - containerPort: 80
           name: http
         resources: {}
-        volumeMounts:
-        - mountPath: /var/lib/data
-          name: data
       - args:
         - proxy
         - sidecar
@@ -115,7 +110,7 @@ spec:
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
         - containerPort: 15090
@@ -175,7 +170,7 @@ spec:
         - -d
         - "15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: istio-init
         resources:
           limits:
@@ -194,13 +189,10 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 1337
-          runAsNonRoot: true
-          runAsUser: 1337
+          runAsGroup: 0
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: data
       - emptyDir:
           medium: Memory
         name: istio-envoy

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -110,7 +110,7 @@ spec:
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         image: gcr.io/istio-release/proxyv2:master-latest-daily
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: istio-proxy
         ports:
         - containerPort: 15090
@@ -170,7 +170,7 @@ spec:
         - -d
         - "15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: istio-init
         resources:
           limits:
@@ -189,9 +189,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -17,6 +17,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -19,6 +19,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: frontend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -19,6 +19,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -19,6 +19,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: disabled
+        service.istio.io/canonical-name: hello
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -20,6 +20,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: backend
         track: stable
         version: v1
@@ -238,6 +239,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: backend
         track: stable
         version: v2

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -19,6 +19,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -13,6 +13,7 @@ spec:
       creationTimestamp: null
       labels:
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: pi
       name: pi
     spec:
       containers:

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -19,6 +19,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: frontend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -20,6 +20,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: backend
         track: stable
         version: v1
@@ -238,6 +239,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         tier: backend
         track: stable
         version: v2

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -17,6 +17,7 @@ spec:
       labels:
         app: hello
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
     spec:
       containers:
       - image: fake.docker.io/google-samples/hello-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -15,6 +15,7 @@ spec:
       labels:
         app: nginx
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: nginx
       name: nginx
     spec:
       containers:

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -19,6 +19,7 @@ spec:
       labels:
         app: resource
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: resource
     spec:
       containers:
       - image: fake.docker.io/google-samples/traffic-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -22,6 +22,7 @@ spec:
       labels:
         app: status
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: status
     spec:
       containers:
       - image: fake.docker.io/google-samples/traffic-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -21,6 +21,7 @@ spec:
       labels:
         app: traffic
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: traffic
     spec:
       containers:
       - image: fake.docker.io/google-samples/traffic-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -21,6 +21,7 @@ spec:
       labels:
         app: traffic
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: traffic
     spec:
       containers:
       - image: fake.docker.io/google-samples/traffic-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -22,6 +22,7 @@ spec:
       labels:
         app: traffic
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: traffic
     spec:
       containers:
       - image: fake.docker.io/google-samples/traffic-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -21,6 +21,7 @@ spec:
       labels:
         app: user-volume
         security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: user-volume
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -547,7 +547,9 @@ func updateAnnotation(target map[string]string, added map[string]string) (patch 
 	return patch
 }
 
-func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, annotations map[string]string, sic *SidecarInjectionSpec, workloadName string) ([]byte, error) {
+func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, annotations map[string]string, sic *SidecarInjectionSpec,
+	workloadName string) ([]byte, error) {
+
 	var patch []rfc6902PatchOperation
 
 	// Remove any containers previously injected by kube-inject using

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -482,7 +482,15 @@ func escapeJSONPointerValue(in string) string {
 // adds labels to the target spec, will not overwrite label's value if it already exists
 func addLabels(target map[string]string, added map[string]string) []rfc6902PatchOperation {
 	patches := []rfc6902PatchOperation{}
-	for key, value := range added {
+
+	var addedKeys []string
+	for key := range added {
+		addedKeys = append(addedKeys, key)
+	}
+	sort.Strings(addedKeys)
+
+	for _, key := range addedKeys {
+		value := added[key]
 		patch := rfc6902PatchOperation{
 			Op:    "add",
 			Path:  "/metadata/labels/" + escapeJSONPointerValue(key),
@@ -539,7 +547,7 @@ func updateAnnotation(target map[string]string, added map[string]string) (patch 
 	return patch
 }
 
-func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, annotations map[string]string, sic *SidecarInjectionSpec) ([]byte, error) {
+func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, annotations map[string]string, sic *SidecarInjectionSpec, workloadName string) ([]byte, error) {
 	var patch []rfc6902PatchOperation
 
 	// Remove any containers previously injected by kube-inject using
@@ -581,13 +589,33 @@ func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, annotation
 
 	patch = append(patch, updateAnnotation(pod.Annotations, annotations)...)
 
-	patch = append(patch, addLabels(pod.Labels, map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel})...)
+	canonicalSvc := extractCanonicalSerivceLabel(pod.Labels, workloadName)
+	patch = append(patch, addLabels(pod.Labels, map[string]string{
+		model.TLSModeLabelName:               model.IstioMutualTLSModeLabel,
+		model.IstioCanonicalServiceLabelName: canonicalSvc})...)
 
 	if rewrite {
 		patch = append(patch, createProbeRewritePatch(pod.Annotations, &pod.Spec, sic)...)
 	}
 
 	return json.Marshal(patch)
+}
+
+func extractCanonicalSerivceLabel(podLabels map[string]string, workloadName string) string {
+
+	if svc, ok := podLabels[model.IstioCanonicalServiceLabelName]; ok {
+		return svc
+	}
+
+	if svc, ok := podLabels["app.kubernetes.io/name"]; ok {
+		return svc
+	}
+
+	if svc, ok := podLabels["app"]; ok {
+		return svc
+	}
+
+	return workloadName
 }
 
 // Retain deprecated hardcoded container and volumes names to aid in
@@ -729,7 +757,7 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 		annotations[k] = v
 	}
 
-	patchBytes, err := createPatch(&pod, injectionStatus(&pod), annotations, spec)
+	patchBytes, err := createPatch(&pod, injectionStatus(&pod), annotations, spec, deployMeta.Name)
 	if err != nil {
 		handleError(fmt.Sprintf("AdmissionResponse: err=%v spec=%v\n", err, spec))
 		return toAdmissionResponse(err)

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -733,6 +733,10 @@ func TestHelmInject(t *testing.T) {
 			wantFile:  "deploymentconfig.yaml.injected",
 		},
 		{
+			inputFile: "deploymentconfig-with-canonical-service-label.yaml",
+			wantFile:  "deploymentconfig-with-canonical-service-label.yaml.injected",
+		},
+		{
 			inputFile: "deploymentconfig-multi.yaml",
 			wantFile:  "deploymentconfig-multi.yaml.injected",
 		},
@@ -1321,6 +1325,11 @@ func TestRunAndServe(t *testing.T) {
       "value": {
          "security.istio.io/tlsMode": "istio"
       }
+    },
+    {
+      "op": "add",
+      "path": "/metadata/labels/service.istio.io~1canonical-name",
+      "value": "test"
     }
 ]`)
 


### PR DESCRIPTION
This PR is the initial implementation of the work outlined in the [Istio Canonical Service proposal](https://docs.google.com/document/d/1EsKpYNW55-LqG08zdjp1tAd224T9IEG3CEnusmL-Joc/edit).

It implements _most_ of the proposed heuristic (leaving out "user-specified alternative service label names in order.").

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
