### PR TITLE
istioctl analyze loads files from a directory

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -109,10 +109,13 @@ func Analyze() *cobra.Command {
 istioctl analyze
 
 # Analyze the current live cluster, simulating the effect of applying additional yaml files
-istioctl analyze a.yaml b.yaml config/
+istioctl analyze a.yaml b.yaml my-app-config/
+
+# Analyze the current live cluster, simulating the effect of applying a directory of config recursively
+istioctl analyze --recursive my-istio-config/
 
 # Analyze yaml files without connecting to a live cluster
-istioctl analyze --use-kube=false a.yaml b.yaml config/
+istioctl analyze --use-kube=false a.yaml b.yaml my-app-config/
 
 # Analyze the current live cluster and suppress PodMissingProxy for pod mypod in namespace 'testing'.
 istioctl analyze -S "IST0103=Pod mypod.testing"
@@ -327,7 +330,7 @@ istioctl analyze -L
 	analysisCmd.PersistentFlags().DurationVar(&analysisTimeout, "timeout", 30*time.Second,
 		"the duration to wait before failing")
 	analysisCmd.PersistentFlags().BoolVarP(&recursive, "recursive", "R", false,
-		"If true, recurse into directories when a directory is provided as an argument")
+		"Process directory arguments recursively. Useful when you want to analyze related manifests organized within the same directory.")
 	return analysisCmd
 }
 

--- a/tests/integration/galley/testdata/some-dir/missing-gateway.yaml
+++ b/tests/integration/galley/testdata/some-dir/missing-gateway.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: missing-gateway
+spec:
+  hosts:
+  - "foobar"
+# We didn't specify http, tcp or tls - this will cause a schema validation error

--- a/tests/integration/galley/testdata/some-dir/nested-dir/bad-annotation-service.yaml
+++ b/tests/integration/galley/testdata/some-dir/nested-dir/bad-annotation-service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: some-service
+  annotations:
+    # This annotation doesn't exist!
+    foobar.istio.io/dontExist: "nothing-here"


### PR DESCRIPTION
Previously istioctl analyze would only load files; now you can load a directory as well, which matches the experience of kubectl's -f argument.