### PR TITLE
authz: add e2e tests for ingress gateway and host match

### DIFF
--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -15,8 +15,6 @@
 package security
 
 import (
-	"fmt"
-	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -716,33 +714,10 @@ func TestIngressRequestAuthentication(t *testing.T) {
 			for _, c := range ingTestCases {
 				t.Run(c.Name, func(t *testing.T) {
 					retry.UntilSuccessOrFail(t, func() error {
-						return checkIngress(ingr, c.Host, c.Path, c.Token, c.ExpectResponseCode)
+						return authn.CheckIngress(ingr, c.Host, c.Path, c.Token, c.ExpectResponseCode)
 					},
 						retry.Delay(250*time.Millisecond), retry.Timeout(30*time.Second))
 				})
 			}
 		})
-}
-
-func checkIngress(ingr ingress.Instance, host string, path string, token string, expectResponseCode int) error {
-	endpointAddress := ingr.HTTPAddress()
-	opts := ingress.CallOptions{
-		Host:     host,
-		Path:     path,
-		CallType: ingress.PlainText,
-		Address:  endpointAddress,
-	}
-	if len(token) != 0 {
-		opts.Headers = http.Header{
-			"Authorization": []string{
-				fmt.Sprintf("Bearer %s", token),
-			},
-		}
-	}
-	response, err := ingr.Call(opts)
-
-	if response.Code != expectResponseCode {
-		return fmt.Errorf("got response code %d, err %s", response.Code, err)
-	}
-	return nil
 }

--- a/tests/integration/security/rbac_v1beta1_test.go
+++ b/tests/integration/security/rbac_v1beta1_test.go
@@ -16,17 +16,21 @@ package security
 
 import (
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/ingress"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/tests/common/jwt"
 	"istio.io/istio/tests/integration/security/util"
+	"istio.io/istio/tests/integration/security/util/authn"
 	"istio.io/istio/tests/integration/security/util/connection"
 	rbacUtil "istio.io/istio/tests/integration/security/util/rbac_util"
 )
@@ -437,5 +441,90 @@ func TestV1beta1_NegativeMatch(t *testing.T) {
 			}
 
 			rbacUtil.RunRBACTest(t, cases)
+		})
+}
+
+// TestV1beta1_IngressGateway tests the authorization policy on ingress gateway.
+func TestV1beta1_IngressGateway(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "v1beta1-ingress-gateway",
+				Inject: true,
+			})
+			args := map[string]string{
+				"Namespace":     ns.Name(),
+				"RootNamespace": rootNamespace,
+			}
+
+			applyPolicy := func(filename string) []string {
+				policy := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, filename))
+				g.ApplyConfigOrFail(t, nil, policy...)
+				return policy
+			}
+			policies := applyPolicy("testdata/rbac/v1beta1-ingress-gateway.yaml.tmpl")
+			defer g.DeleteConfigOrFail(t, nil, policies...)
+
+			var b echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
+				BuildOrFail(t)
+
+			var ingr ingress.Instance
+			var err error
+			if ingr, err = ingress.New(ctx, ingress.Config{
+				Istio: ist,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			cases := []struct {
+				Name     string
+				Host     string
+				Path     string
+				WantCode int
+			}{
+				{
+					Name:     "allow www.company.com",
+					Host:     "www.company.com",
+					Path:     "/",
+					WantCode: 200,
+				},
+				{
+					Name:     "deny www.company.com/private",
+					Host:     "www.company.com",
+					Path:     "/private",
+					WantCode: 403,
+				},
+				{
+					Name:     "allow www.company.com/public",
+					Host:     "www.company.com",
+					Path:     "/public",
+					WantCode: 200,
+				},
+				{
+					Name:     "deny internal.company.com",
+					Host:     "internal.company.com",
+					Path:     "/",
+					WantCode: 403,
+				},
+				{
+					Name:     "deny internal.company.com/private",
+					Host:     "internal.company.com",
+					Path:     "/private",
+					WantCode: 403,
+				},
+			}
+
+			for _, tc := range cases {
+				t.Run(tc.Name, func(t *testing.T) {
+					retry.UntilSuccessOrFail(t, func() error {
+						return authn.CheckIngress(ingr, tc.Host, tc.Path, "", tc.WantCode)
+					},
+						retry.Delay(250*time.Millisecond), retry.Timeout(30*time.Second))
+				},
+				)
+			}
 		})
 }

--- a/tests/integration/security/testdata/rbac/v1beta1-ingress-gateway.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-ingress-gateway.yaml.tmpl
@@ -1,0 +1,57 @@
+# The following policy denies access to "internal.company.com" and path "/private"
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-policy
+  namespace: "{{ .RootNamespace }}"
+spec:
+  action: DENY
+  selector:
+    matchLabels:
+      app: istio-ingressgateway
+  rules:
+    - to:
+        - operation:
+            hosts: ["internal.company.com"]
+        - operation:
+            paths: ["/private"]
+---
+
+# The following gateway allows request to "*.company.com"
+
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: test-ingress
+  namespace: {{ .Namespace }}
+spec:
+  selector:
+    istio: ingressgateway # use istio default ingress gateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*.company.com"
+---
+
+# The following virtual service routes requests to workload b
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: test-vs
+  namespace: {{ .Namespace }}
+spec:
+  hosts:
+  - "*.company.com"
+  gateways:
+  - test-ingress
+  http:
+  - route:
+    - destination:
+        host: b
+        port:
+          number: 80


### PR DESCRIPTION
This PR adds e2e tests for authorization policy on ingress gateway and covers the following cases:
- the `host` and `path` field
- the DENY action
- two different sources in the `from` field

For #20139 