### PR TITLE
operator: fix applied manifest counting

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller_test.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller_test.go
@@ -83,6 +83,11 @@ func TestIOPController_SwitchProfile(t *testing.T) {
 			initialProfile: "default",
 			targetProfile:  "demo",
 		},
+		{
+			description:    "apply same profile twice",
+			initialProfile: "default",
+			targetProfile:  "default",
+		},
 	}
 	for _, c := range cases {
 		helmreconciler.FlushObjectCaches()


### PR DESCRIPTION
https://github.com/istio/istio/pull/20344 introduced a bug where we don't report status correctly when a component has not changed between two runs of `manifest apply`. This adds a test and fixes the problem.

Note that this doesn't solve the issue that the health logic desperately needs work, but it will at least get rid of the regression for now.

[x] Installation