### PR TITLE
Add optional clusterIP value to istiocoredns helm chart

### DIFF
--- a/manifests/istiocoredns/Chart.yaml
+++ b/manifests/istiocoredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Istio CoreDNS provides DNS resolution for services in multicluster setups.
 name: istiocoredns
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.1
 tillerVersion: ">=2.7.2"

--- a/manifests/istiocoredns/templates/service.yaml
+++ b/manifests/istiocoredns/templates/service.yaml
@@ -16,3 +16,6 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
+  {{- if .Values.clusterIP }}
+  clusterIP: "{{ .Values.clusterIP }}"
+  {{- end }}

--- a/manifests/istiocoredns/values.yaml
+++ b/manifests/istiocoredns/values.yaml
@@ -16,6 +16,9 @@ istiocoredns:
   tolerations: []
   podAnnotations: {}
   resources: {}
+  ## A fixed clusterIP for istiocoredns svc. Gets assigned an IP automatically if not provided.
+  ## (Optional)
+  clusterIP: ""
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are
   # already running on the node rather than based on labels on nodes.


### PR DESCRIPTION
Adds the ability to optionally specify your own clusterIP for istiocoredns when installing via helm. 

I install istio using helm and terraform to fully automate the installation from code. I'm using istio multicluster with replicated control planes. 

As part of the guide [here](https://istio.io/docs/setup/install/multicluster/gateways/#setup-dns), I need to stub coredns for routing `.global` to istiocoredns. In this scenario, I'd like to be able to install istio and stub coredns in one terraform run.

If relying on a generated clusterIP for istiocoredns, it means I don't know what it is until after istio has been installed.

Being able to set my own clusterIP solves this and means I can install istio and stub coredns in one terraform run. 

[X] Installation