### PR TITLE
Fix an array pointer overflown problem in Operator

### DIFF
--- a/operator/pkg/apis/istio/fixup_structs/main.go
+++ b/operator/pkg/apis/istio/fixup_structs/main.go
@@ -124,7 +124,7 @@ func main() {
 				anonymous[st] = true
 				subs[st] = strings.ReplaceAll(subs[st], "_ ", "")
 			}
-			for !strings.HasPrefix(lines[i], "var xxx_messageInfo_") {
+			for i < len(lines)-2 && !strings.HasPrefix(lines[i], "var xxx_messageInfo_") {
 				i++
 			}
 			tmp = append(tmp, lines[i+1])


### PR DESCRIPTION
Please provide a description for what this PR is for: fix an array pointer overflown problem in Operator that can cause the program crash.


[X ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure