### PR TITLE
authz: add e2e tests for workloads with TCP ports

### DIFF
--- a/tests/integration/security/rbac_v1beta1_test.go
+++ b/tests/integration/security/rbac_v1beta1_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -526,5 +527,129 @@ func TestV1beta1_IngressGateway(t *testing.T) {
 				},
 				)
 			}
+		})
+}
+
+// TestV1beta1_TCP tests the authorization policy on workloads using the raw TCP protocol.
+func TestV1beta1_TCP(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "v1beta1-tcp-1",
+				Inject: true,
+			})
+			ns2 := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "v1beta1-tcp-2",
+				Inject: true,
+			})
+			policy := tmpl.EvaluateAllOrFail(t, map[string]string{
+				"Namespace":  ns.Name(),
+				"Namespace2": ns2.Name(),
+			}, file.AsStringOrFail(t, "testdata/rbac/v1beta1-tcp.yaml.tmpl"))
+			g.ApplyConfigOrFail(t, nil, policy...)
+			defer g.DeleteConfigOrFail(t, nil, policy...)
+
+			var a, b, c, d, x echo.Instance
+			ports := []echo.Port{
+				{
+					Name:         "http-8090",
+					Protocol:     protocol.HTTP,
+					InstancePort: 8090,
+				},
+				{
+					Name:         "http-8091",
+					Protocol:     protocol.HTTP,
+					InstancePort: 8091,
+				},
+				{
+					Name:         "tcp",
+					Protocol:     protocol.TCP,
+					InstancePort: 8092,
+				},
+			}
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&x, util.EchoConfig("x", ns2, false, nil, g, p)).
+				With(&a, echo.Config{
+					Namespace:      ns,
+					Galley:         g,
+					Pilot:          p,
+					Service:        "a",
+					Ports:          ports,
+					ServiceAccount: true,
+				}).
+				With(&b, echo.Config{
+					Namespace:      ns,
+					Galley:         g,
+					Pilot:          p,
+					Service:        "b",
+					Ports:          ports,
+					ServiceAccount: true,
+				}).
+				With(&c, echo.Config{
+					Namespace:      ns,
+					Galley:         g,
+					Pilot:          p,
+					Service:        "c",
+					Ports:          ports,
+					ServiceAccount: true,
+				}).
+				With(&d, echo.Config{
+					Namespace:      ns,
+					Galley:         g,
+					Pilot:          p,
+					Service:        "d",
+					Ports:          ports,
+					ServiceAccount: true,
+				}).
+				BuildOrFail(t)
+
+			newTestCase := func(from, target echo.Instance, port string, expectAllowed bool) rbacUtil.TestCase {
+				return rbacUtil.TestCase{
+					Request: connection.Checker{
+						From: from,
+						Options: echo.CallOptions{
+							Target:   target,
+							PortName: port,
+							Scheme:   scheme.HTTP,
+							Path:     "/data",
+						},
+					},
+					ExpectAllowed: expectAllowed,
+				}
+			}
+
+			cases := []rbacUtil.TestCase{
+				// The policy on workload b denies request with path "/data" to port 8090:
+				// - request to port http-8090 should be denied because both path and port are matched.
+				// - request to port http-8091 should be allowed because the port is not matched.
+				// - request to port tcp should be denied because a default deny-all policy should
+				//   be generated when HTTP field (i.e. path) is used on TCP port.
+				newTestCase(a, b, "http-8090", false),
+				newTestCase(a, b, "http-8091", true),
+				newTestCase(a, b, "tcp", false),
+
+				// The policy on workload c denies request to port 8090:
+				// - request to port http-8090 should be denied because the port is matched.
+				// - request to http port 8091 should be allowed because the port is not matched.
+				// - request to tcp port 8092 should be allowed because the port is not matched.
+				newTestCase(a, c, "http-8090", false),
+				newTestCase(a, c, "http-8091", true),
+				newTestCase(a, c, "tcp", true),
+
+				// The policy on workload d denies request from service account a and workloads in namespace 2:
+				// - request from a to d should be denied because it has service account a.
+				// - request from b to d should be allowed.
+				// - request from c to d should be allowed.
+				// - request from x to a should be allowed because there is no policy on a.
+				// - request from x to d should be denied because it's in namespace 2.
+				newTestCase(a, d, "tcp", false),
+				newTestCase(b, d, "tcp", true),
+				newTestCase(c, d, "tcp", true),
+				newTestCase(x, a, "tcp", true),
+				newTestCase(x, d, "tcp", false),
+			}
+
+			rbacUtil.RunRBACTest(t, cases)
 		})
 }

--- a/tests/integration/security/testdata/rbac/v1beta1-tcp.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-tcp.yaml.tmpl
@@ -1,0 +1,56 @@
+# The following policy denies request with path "/data" to port 8090 for workload b
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-b-deny
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "b"
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: ["/data"]
+        ports: ["8090"]
+---
+
+# The following policy denies request to port 8090 for workload c
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-c-deny
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "c"
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        ports: ["8090"]
+---
+
+# The following policy denies request from service account a and namespace 2 for workload d
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-d-deny
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "d"
+  action: DENY
+  rules:
+  - from:
+    - source:
+        principals: ["cluster.local/ns/{{ .Namespace }}/sa/a"]
+    - source:
+        namespaces: ["{{ .Namespace2 }}"]
+---


### PR DESCRIPTION
For #20139 

This PR adds e2e tests for authorization policy on workloads with TCP ports, it covers the following cases:
  - policy with HTTP fields will be translated to a default deny-all policy if it's used on TCP ports
  - `ports` field used used on both HTTP and TCP ports
  - `principals` and `namespaces` used on TCP ports (different code path from the HTTP ports)
  - two different sources in one `from`