### PR TITLE
Use lint-go target

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -335,7 +335,7 @@ lint-go-split:
 lint-helm-global:
 	find manifests -name 'Chart.yaml' -print0 | ${XARGS} -L 1 dirname | xargs -r helm lint --strict -f manifests/global.yaml
 
-lint: lint-python lint-copyright-banner lint-scripts lint-go-split lint-dockerfiles lint-markdown lint-yaml lint-licenses lint-helm-global
+lint: lint-python lint-copyright-banner lint-scripts lint-go lint-dockerfiles lint-markdown lint-yaml lint-licenses lint-helm-global
 	@bin/check_helm.sh
 	@bin/check_samples.sh
 	@bin/check_dashboards.sh


### PR DESCRIPTION
This way we don't need to maintain the list, and its 2x faster