### PR TITLE
Reserve analyzer message code IST0119 for policy with jwt message

### DIFF
--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -64,6 +64,10 @@ var (
 	// VirtualServiceDestinationPortSelectorRequired defines a diag.MessageType for message "VirtualServiceDestinationPortSelectorRequired".
 	// Description: A VirtualService routes to a service with more than one port exposed, but does not specify which to use.
 	VirtualServiceDestinationPortSelectorRequired = diag.NewMessageType(diag.Error, "IST0112", "This VirtualService routes to a service %q that exposes multiple ports %v. Specifying a port in the destination is required to disambiguate.")
+
+	// JwtFailureDueToInvalidServicePortPrefix defines a diag.MessageType for message "JwtFailureDueToInvalidServicePortPrefix".
+	// Description: Authentication policy with JWT targets Service with invalid port specification.
+	JwtFailureDueToInvalidServicePortPrefix = diag.NewMessageType(diag.Warning, "IST0119", "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s).")
 )
 
 // NewInternalError returns a new diag.Message based on InternalError.
@@ -200,6 +204,18 @@ func NewVirtualServiceDestinationPortSelectorRequired(entry *resource.Entry, des
 		originOrNil(entry),
 		destHost,
 		destPorts,
+	)
+}
+
+// NewJwtFailureDueToInvalidServicePortPrefix returns a new diag.Message based on JwtFailureDueToInvalidServicePortPrefix.
+func NewJwtFailureDueToInvalidServicePortPrefix(entry *resource.Entry, port int, portName string, protocol string, targetPort string) diag.Message {
+	return diag.NewMessage(
+		JwtFailureDueToInvalidServicePortPrefix,
+		originOrNil(entry),
+		port,
+		portName,
+		protocol,
+		targetPort,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -148,3 +148,18 @@ messages:
         type: string
       - name: destPorts
         type: "[]int"
+
+  - name: "JwtFailureDueToInvalidServicePortPrefix"
+    code: IST0119
+    level: Warning
+    description: "Authentication policy with JWT targets Service with invalid port specification."
+    template: "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s)."
+    args:
+      - name: port
+        type: int
+      - name: portName
+        type: string
+      - name: protocol
+        type: string
+      - name: targetPort
+        type: string


### PR DESCRIPTION
Cherry-pick the commit aimed for master/release-1.5 branch that will
contain the error message to be used for the release-1.4 branch.

Regenerate the messages.gen.go file based on the messsage created
(remove comments suggesting it was deprecatfor the release-1.4 branch.

This is step 2 to get this merged into release 1.4 based on the plan outlined at https://github.com/istio/istio/pull/20672#issuecomment-580508680.