### PR TITLE
Optimization CRD wait on manifest appyl

### DIFF
--- a/manifests/istio-policy/templates/config.yaml
+++ b/manifests/istio-policy/templates/config.yaml
@@ -214,7 +214,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   compiledAdapter: kubernetesenv
-  params:
+  params: {}
     # when running from mixer root, use the following config after adding a
     # symbolic link to a kubernetes config file via:
     #

--- a/operator/pkg/manifest/installer.go
+++ b/operator/pkg/manifest/installer.go
@@ -380,7 +380,7 @@ func ApplyManifest(componentName name.ComponentName, manifestStr, version string
 	if err != nil {
 		return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 	}
-	if err := waitForCRDs(crdObjects, opts.DryRun); err != nil {
+	if err := waitForCRDs(crdObjects, stdout, opts.DryRun); err != nil {
 		return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 	}
 	appliedObjects = append(appliedObjects, crdObjects...)
@@ -544,12 +544,33 @@ func objectsNotInLists(objects object.K8sObjects, lists ...object.K8sObjects) ob
 	return ret
 }
 
-func waitForCRDs(objects object.K8sObjects, dryRun bool) error {
+func canSkipCrdWait(applyOut string) bool {
+	for _, line := range strings.Split(applyOut, "\n") {
+		if line == "" {
+			continue
+		}
+		segments := strings.Split(line, " ")
+		if len(segments) == 2 {
+			changed := segments[1] != "unchanged"
+			isCrd := strings.HasPrefix(segments[0], "customresourcedefinition")
+			if changed && isCrd {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func waitForCRDs(objects object.K8sObjects, stdout string, dryRun bool) error {
 	if dryRun {
 		scope.Info("Not waiting for CRDs in dry run mode.")
 		return nil
 	}
 
+	if canSkipCrdWait(stdout) {
+		scope.Info("Skipping CRD wait")
+		return nil
+	}
 	scope.Info("Waiting for CRDs to be applied.")
 	cs, err := apiextensionsclient.NewForConfig(k8sRESTConfig)
 	if err != nil {

--- a/operator/pkg/manifest/installer.go
+++ b/operator/pkg/manifest/installer.go
@@ -568,7 +568,7 @@ func waitForCRDs(objects object.K8sObjects, stdout string, dryRun bool) error {
 	}
 
 	if canSkipCrdWait(stdout) {
-		scope.Info("Skipping CRD wait")
+		scope.Info("Skipping CRD wait, no changes detected")
 		return nil
 	}
 	scope.Info("Waiting for CRDs to be applied.")

--- a/operator/pkg/manifest/installer_test.go
+++ b/operator/pkg/manifest/installer_test.go
@@ -127,7 +127,7 @@ customresourcedefinition.apiextensions.k8s.io/attributemanifests.config.istio.io
 			false,
 		},
 	}
-	for _, tt := range cases{
+	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			got := canSkipCrdWait(tt.in)
 			if got != tt.result {

--- a/operator/pkg/manifest/installer_test.go
+++ b/operator/pkg/manifest/installer_test.go
@@ -92,3 +92,47 @@ clientVersion:
 		})
 	}
 }
+
+func TestCanSkipCRD(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		result bool
+	}{
+		{
+			"re-apply",
+			`namespace/istio-system unchanged
+
+customresourcedefinition.apiextensions.k8s.io/adapters.config.istio.io unchanged
+customresourcedefinition.apiextensions.k8s.io/attributemanifests.config.istio.io unchanged
+`,
+			true,
+		},
+		{
+			"first apply",
+			`namespace/istio-system unchanged
+
+customresourcedefinition.apiextensions.k8s.io/adapters.config.istio.io created
+customresourcedefinition.apiextensions.k8s.io/attributemanifests.config.istio.io created
+`,
+			false,
+		},
+		{
+			"re-apply",
+			`namespace/istio-system unchanged
+
+customresourcedefinition.apiextensions.k8s.io/adapters.config.istio.io configured
+customresourcedefinition.apiextensions.k8s.io/attributemanifests.config.istio.io configured
+`,
+			false,
+		},
+	}
+	for _, tt := range cases{
+		t.Run(tt.name, func(t *testing.T) {
+			got := canSkipCrdWait(tt.in)
+			if got != tt.result {
+				t.Fatalf("got %v, want %v", got, tt.result)
+			}
+		})
+	}
+}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -15957,7 +15957,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   compiledAdapter: kubernetesenv
-  params:
+  params: {}
     # when running from mixer root, use the following config after adding a
     # symbolic link to a kubernetes config file via:
     #


### PR DESCRIPTION
Right now we spend ~5s waiting for CRDs to be applied. Typically these
aren't changing. Instead, we can skip the wait if we know no changes
were made.