### PR TITLE
Install libcap2-bin into base image

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -17,6 +17,7 @@ RUN apt-get update && \
       iproute2 \
       iputils-ping \
       knot-dnsutils \
+      libcap2-bin \
       netcat \
       tcpdump \
       net-tools \


### PR DESCRIPTION
Install the `libcap2-bin` package into the base image to manage Linux capabilities.