### PR TITLE
Make leader election a top level pilot component, use it for singleton components

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -94,6 +94,9 @@ var (
 			}
 
 			cmd.WaitSignal(stop)
+			// Wait until we shut down. In theory this could block forever; in practice we will get
+			// forcibly shut down after 30s in Kubernetes.
+			discoveryServer.WaitUntilCompletion()
 			return nil
 		},
 	}

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -88,8 +88,7 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 		s.ConfigStores = append(s.ConfigStores,
 			ingress.NewController(s.kubeClient, meshConfig, args.Config.ControllerOptions))
 
-		if ingressSyncer, errSyncer := ingress.NewStatusSyncer(meshConfig, s.kubeClient,
-			args.Namespace, args.Config.ControllerOptions); errSyncer != nil {
+		if ingressSyncer, errSyncer := ingress.NewStatusSyncer(meshConfig, s.kubeClient, args.Config.ControllerOptions, s.leaderElection); errSyncer != nil {
 			log.Warnf("Disabled ingress status syncer due to %v", errSyncer)
 		} else {
 			s.addStartFunc(func(stop <-chan struct{}) error {

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -220,8 +220,10 @@ func (s *Server) RunCA(grpc *grpc.Server, ca *ca.IstioCA, opts *CAOptions, stopC
 	if err != nil {
 		log.Warnf("failed to start istiod namespace controller, error: %v", err)
 	} else {
-		nc.Run(stopCh)
-		log.Info("istiod namespace controller has started")
+		s.leaderElection.AddRunFunction(func(stop <-chan struct{}) {
+			log.Infof("Starting namespace controller")
+			nc.namespaceController.Run(stop)
+		})
 	}
 }
 

--- a/pilot/pkg/bootstrap/leaderelection.go
+++ b/pilot/pkg/bootstrap/leaderelection.go
@@ -1,0 +1,86 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"istio.io/pkg/log"
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	electionId = "istio-leader"
+)
+
+type LeaderElection struct {
+	namespace string
+	name      string
+	runFns    []func(stop <-chan struct{})
+	client    kubernetes.Interface
+}
+
+func (l *LeaderElection) Run(stop <-chan struct{}) error {
+	le, err := l.create()
+	if err != nil {
+		return fmt.Errorf("failed to create leader election: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go le.Run(ctx)
+	go func() {
+		<-stop
+		cancel()
+	}()
+	return nil
+}
+
+func (l *LeaderElection) create() (*leaderelection.LeaderElector, error) {
+	callbacks := leaderelection.LeaderCallbacks{
+		OnStartedLeading: func(ctx context.Context) {
+			for _, f := range l.runFns {
+				go f(ctx.Done())
+			}
+		},
+		OnStoppedLeading: func() {
+			log.Infof("leader election lock lost")
+
+		},
+	}
+	broadcaster := record.NewBroadcaster()
+	hostname, _ := os.Hostname()
+	recorder := broadcaster.NewRecorder(scheme.Scheme, coreV1.EventSource{
+		Component: "istio-leader-elector",
+		Host:      hostname,
+	})
+	lock := resourcelock.ConfigMapLock{
+		ConfigMapMeta: metaV1.ObjectMeta{Namespace: l.namespace, Name: electionId},
+		Client:        l.client.CoreV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity:      l.name,
+			EventRecorder: recorder,
+		},
+	}
+	ttl := 30 * time.Second
+	return leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          &lock,
+		LeaseDuration: ttl,
+		RenewDeadline: ttl / 2,
+		RetryPeriod:   ttl / 4,
+		Callbacks:     callbacks,
+	})
+}
+
+func (l *LeaderElection) AddRunFunction(f func(stop <-chan struct{})) {
+	l.runFns = append(l.runFns, f)
+}
+
+func NewLeaderElection(namespace, name string, client kubernetes.Interface) *LeaderElection {
+	return &LeaderElection{namespace: namespace, name: name, client: client}
+}

--- a/pilot/pkg/bootstrap/namespacecontroller.go
+++ b/pilot/pkg/bootstrap/namespacecontroller.go
@@ -75,13 +75,7 @@ func NewNamespaceController(ca *ca.IstioCA, core corev1.CoreV1Interface) (*Names
 			UpdateFunc: c.namespaceUpdated,
 			AddFunc:    c.namespaceAdded,
 		})
-
 	return c, nil
-}
-
-// Run starts the NamespaceController until a value is sent to stopCh.
-func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
-	go nc.namespaceController.Run(stopCh)
 }
 
 // When a namespace is created, Citadel adds its public CA certificate

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -69,6 +69,7 @@ type PilotArgs struct {
 	DiscoveryOptions         DiscoveryServiceOptions
 	InjectionOptions         InjectionOptions
 	ValidationOptions        ValidationOptions
+	PodName                  string
 	Namespace                string
 	Revision                 string
 	ServiceAccountName       string
@@ -130,6 +131,7 @@ type ValidationOptions struct {
 }
 
 var podNamespaceVar = env.RegisterStringVar("POD_NAMESPACE", "", "")
+var podNameVar = env.RegisterStringVar("POD_NAME", "", "")
 var serviceAccountVar = env.RegisterStringVar("SERVICE_ACCOUNT", "", "")
 
 var revisionVar = env.RegisterStringVar("REVISION", "", "")
@@ -139,6 +141,9 @@ func (p *PilotArgs) Default() {
 	// If the namespace isn't set, try looking it up from the environment.
 	if p.Namespace == "" {
 		p.Namespace = podNamespaceVar.Get()
+	}
+	if p.PodName == "" {
+		p.PodName = podNameVar.Get()
 	}
 	if p.ServiceAccountName == "" {
 		p.ServiceAccountName = serviceAccountVar.Get()

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"istio.io/istio/pilot/pkg/leaderelection"
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/security/pkg/pki/util"
@@ -147,7 +148,7 @@ type Server struct {
 	// nil if injection disabled
 	injectionWebhook *inject.Webhook
 
-	leaderElection *LeaderElection
+	leaderElection *leaderelection.LeaderElection
 
 	webhookCertMu sync.Mutex
 	webhookCert   *tls.Certificate
@@ -853,7 +854,7 @@ func (s *Server) initDNSListener(args *PilotArgs) error {
 
 func (s *Server) initLeaderElection(args *PilotArgs) {
 	if s.kubeClient != nil {
-		s.leaderElection = NewLeaderElection(args.Namespace, args.PodName, s.kubeClient)
+		s.leaderElection = leaderelection.NewLeaderElection(args.Namespace, args.PodName, s.kubeClient)
 	}
 }
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -279,12 +279,17 @@ func NewServer(args *PilotArgs) (*Server, error) {
 
 	if s.leaderElection != nil {
 		s.addStartFunc(func(stop <-chan struct{}) error {
+			if err := s.leaderElection.Build(); err != nil {
+				return fmt.Errorf("leader election: %v", err)
+			}
 			// We mark this as a required termination as an optimization. Without this, when we exit the lock is
 			// still held for some time (30-60s or so). If we allow time for a graceful exit, then we can immediately drop the lock.
 			s.requiredTerminations.Add(1)
-			return s.leaderElection.Run(stop, func() {
+			go func() {
+				s.leaderElection.Run(stop)
 				s.requiredTerminations.Done()
-			})
+			}()
+			return nil
 		})
 	}
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -279,9 +279,6 @@ func NewServer(args *PilotArgs) (*Server, error) {
 
 	if s.leaderElection != nil {
 		s.addStartFunc(func(stop <-chan struct{}) error {
-			if err := s.leaderElection.Build(); err != nil {
-				return fmt.Errorf("leader election: %v", err)
-			}
 			// We mark this as a required termination as an optimization. Without this, when we exit the lock is
 			// still held for some time (30-60s or so). If we allow time for a graceful exit, then we can immediately drop the lock.
 			s.requiredTerminations.Add(1)

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -112,9 +112,9 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 	}
 
 	if validationWebhookConfigName.Get() != "" {
-		s.addStartFunc(func(stop <-chan struct{}) error {
-			go whController.Start(stop)
-			return nil
+		s.leaderElection.AddRunFunction(func(stop <-chan struct{}) {
+			log.Infof("Starting validation controller")
+			whController.Start(stop)
 		})
 	}
 	return nil

--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -98,8 +98,11 @@ func NewStatusSyncer(mesh *meshconfig.MeshConfig,
 		ingressService:      mesh.IngressService,
 	}
 
-	l.AddRunFunction(st.queue.Run)
-	l.AddRunFunction(st.runUpdateStatus)
+	l.AddRunFunction(func(stop <-chan struct{}) {
+		log.Infof("Starting ingress status controller")
+		go st.queue.Run(stop)
+		go st.runUpdateStatus(stop)
+	})
 
 	return &st, nil
 }

--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -98,11 +98,13 @@ func NewStatusSyncer(mesh *meshconfig.MeshConfig,
 		ingressService:      mesh.IngressService,
 	}
 
-	l.AddRunFunction(func(stop <-chan struct{}) {
-		log.Infof("Starting ingress status controller")
-		go st.queue.Run(stop)
-		go st.runUpdateStatus(stop)
-	})
+	if l != nil {
+		l.AddRunFunction(func(stop <-chan struct{}) {
+			log.Infof("Starting ingress status controller")
+			go st.queue.Run(stop)
+			go st.runUpdateStatus(stop)
+		})
+	}
 
 	return &st, nil
 }

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -131,7 +131,7 @@ func makeStatusSyncer(t *testing.T, client kubernetes.Interface) (*StatusSyncer,
 	return NewStatusSyncer(&m, client, kubecontroller.Options{
 		WatchedNamespace: testNamespace,
 		ResyncPeriod:     resync,
-	})
+	}, nil)
 }
 
 // setAndRestoreEnv set the envs with given value, and return the old setting.

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -128,7 +128,7 @@ func makeStatusSyncer(t *testing.T, client kubernetes.Interface) (*StatusSyncer,
 	// Restore env settings
 	defer setAndRestoreEnv(t, oldEnvs)
 
-	return NewStatusSyncer(&m, client, testNamespace, kubecontroller.Options{
+	return NewStatusSyncer(&m, client, kubecontroller.Options{
 		WatchedNamespace: testNamespace,
 		ResyncPeriod:     resync,
 	})

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -1,4 +1,4 @@
-package bootstrap
+package leaderelection
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	"istio.io/pkg/log"
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -14,6 +13,8 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
+
+	"istio.io/pkg/log"
 )
 
 const (
@@ -74,6 +75,10 @@ func (l *LeaderElection) create() (*leaderelection.LeaderElector, error) {
 		RenewDeadline: ttl / 2,
 		RetryPeriod:   ttl / 4,
 		Callbacks:     callbacks,
+		// When Pilot exits, the lease will be dropped. This is more likely to lead to a case where
+		// to instances are both considered the leaders. As such, if this is intended to be use for mission-critical
+		// usages (rather than avoiding duplication of work), this may need to be re-evaluated.
+		ReleaseOnCancel: true,
 	})
 }
 

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -16,19 +16,19 @@ package leaderelection
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"istio.io/pkg/log"
+	"go.uber.org/atomic"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	"istio.io/pkg/log"
 )
 
 const (
-	electionID        = "istio-leader"
-	recorderComponent = "istio-leader-elector"
+	electionID = "istio-leader"
 )
 
 type LeaderElection struct {
@@ -36,31 +36,37 @@ type LeaderElection struct {
 	name      string
 	runFns    []func(stop <-chan struct{})
 	client    kubernetes.Interface
-	le        *leaderelection.LeaderElector
 	ttl       time.Duration
+
+	// Records which "cycle" the election is on. This is incremented each time an election is won and then lost
+	// This is mostly just for testing
+	cycle *atomic.Int32
 }
 
 // Run will start leader election, calling all runFns when we become the leader.
 func (l *LeaderElection) Run(stop <-chan struct{}) {
-	if l.le == nil {
-		panic("Build() must be called before Run()")
-	}
 	for {
+		le, err := l.create()
+		if err != nil {
+			// This should never happen; errors are only from invalid input and the input is not user modifiable
+			panic("leaderelection creation failed: " + err.Error())
+		}
+		l.cycle.Inc()
 		ctx, cancel := context.WithCancel(context.Background())
 		go func() {
 			<-stop
 			cancel()
 		}()
-		l.le.Run(ctx)
+		le.Run(ctx)
 		select {
 		case <-stop:
 			// We were told to stop explicitly. Exit now
 			return
 		default:
-			log.Errorf("Leader election lost. Trying again")
 			// Otherwise, we may have lost our lock. In practice, this is extremely rare; we need to have the lock, then lose it
 			// Typically this means something went wrong, such as API server downtime, etc
 			// If this does happen, we will start the cycle over again
+			log.Errorf("Leader election cycle %v lost. Trying again", l.cycle.Load())
 		}
 	}
 }
@@ -81,7 +87,7 @@ func (l *LeaderElection) create() (*leaderelection.LeaderElector, error) {
 		ConfigMapMeta: metaV1.ObjectMeta{Namespace: l.namespace, Name: electionID},
 		Client:        l.client.CoreV1(),
 		LockConfig: resourcelock.ResourceLockConfig{
-			Identity:      l.name,
+			Identity: l.name,
 		},
 	}
 	return leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
@@ -94,7 +100,7 @@ func (l *LeaderElection) create() (*leaderelection.LeaderElector, error) {
 		// to instances are both considered the leaders. As such, if this is intended to be use for mission-critical
 		// usages (rather than avoiding duplication of work), this may need to be re-evaluated.
 		// TODO this should be true once https://github.com/kubernetes/kubernetes/issues/87800 is fixed
-		ReleaseOnCancel: true,
+		ReleaseOnCancel: false,
 	})
 }
 
@@ -104,21 +110,13 @@ func (l *LeaderElection) AddRunFunction(f func(stop <-chan struct{})) {
 	l.runFns = append(l.runFns, f)
 }
 
-func (l *LeaderElection) Build() error {
-	le, err := l.create()
-	if err != nil {
-		return fmt.Errorf("failed to create leader election: %v", err)
-	}
-	l.le = le
-	return nil
-}
-
 func NewLeaderElection(namespace, name string, client kubernetes.Interface) *LeaderElection {
 	return &LeaderElection{
 		namespace: namespace,
 		name:      name,
 		client:    client,
 		// Default to a 30s ttl. Overridable for tests
-		ttl: time.Second * 30,
+		ttl:   time.Second * 30,
+		cycle: atomic.NewInt32(0),
 	}
 }

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -17,18 +17,13 @@ package leaderelection
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
-	coreV1 "k8s.io/api/core/v1"
+	"istio.io/pkg/log"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/client-go/tools/record"
-
-	"istio.io/pkg/log"
 )
 
 const (
@@ -82,18 +77,11 @@ func (l *LeaderElection) create() (*leaderelection.LeaderElector, error) {
 
 		},
 	}
-	broadcaster := record.NewBroadcaster()
-	hostname, _ := os.Hostname()
-	recorder := broadcaster.NewRecorder(scheme.Scheme, coreV1.EventSource{
-		Component: recorderComponent,
-		Host:      hostname,
-	})
 	lock := resourcelock.ConfigMapLock{
 		ConfigMapMeta: metaV1.ObjectMeta{Namespace: l.namespace, Name: electionID},
 		Client:        l.client.CoreV1(),
 		LockConfig: resourcelock.ResourceLockConfig{
 			Identity:      l.name,
-			EventRecorder: recorder,
 		},
 	}
 	return leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package leaderelection
 
 import (

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	electionId = "istio-leader"
+	electionID        = "istio-leader"
+	recorderComponent = "istio-leader-elector"
 )
 
 type LeaderElection struct {
@@ -79,11 +80,11 @@ func (l *LeaderElection) create() (*leaderelection.LeaderElector, error) {
 	broadcaster := record.NewBroadcaster()
 	hostname, _ := os.Hostname()
 	recorder := broadcaster.NewRecorder(scheme.Scheme, coreV1.EventSource{
-		Component: "istio-leader-elector",
+		Component: recorderComponent,
 		Host:      hostname,
 	})
 	lock := resourcelock.ConfigMapLock{
-		ConfigMapMeta: metaV1.ObjectMeta{Namespace: l.namespace, Name: electionId},
+		ConfigMapMeta: metaV1.ObjectMeta{Namespace: l.namespace, Name: electionID},
 		Client:        l.client.CoreV1(),
 		LockConfig: resourcelock.ResourceLockConfig{
 			Identity:      l.name,

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -42,6 +42,7 @@ type LeaderElection struct {
 	client    kubernetes.Interface
 }
 
+// Run will start leader election, calling all runFns when we become the leader.
 func (l *LeaderElection) Run(stop <-chan struct{}) error {
 	le, err := l.create()
 	if err != nil {
@@ -96,6 +97,8 @@ func (l *LeaderElection) create() (*leaderelection.LeaderElector, error) {
 	})
 }
 
+// AddRunFunction registers a function to run when we are the leader. These will be run asynchronously.
+// To avoid running when not a leader, functions should respect the stop channel.
 func (l *LeaderElection) AddRunFunction(f func(stop <-chan struct{})) {
 	l.runFns = append(l.runFns, f)
 }

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -31,7 +31,7 @@ import (
 func createElection(t *testing.T, name string, expectLeader bool, client kubernetes.Interface, fns ...func(stop <-chan struct{})) chan struct{} {
 	t.Helper()
 	l := NewLeaderElection("ns", name, client)
-	l.ttl = time.Second
+	//l.ttl = time.Second
 	gotLeader := make(chan struct{})
 	l.AddRunFunction(func(stop <-chan struct{}) {
 		gotLeader <- struct{}{}
@@ -94,8 +94,11 @@ func TestLeaderElectionConfigMapRemoved(t *testing.T) {
 
 func TestLeaderElectionNoPermission(t *testing.T) {
 	client := fake.NewSimpleClientset()
+	started := make(chan struct{})
 	completed := make(chan struct{})
 	stop := createElection(t, "pod1", true, client, func(stop <-chan struct{}) {
+		started <- struct{}{}
+	}, func(stop <-chan struct{}) {
 		// Send on "completed" if we haven't been told to stop within 3s
 		select {
 		case <-stop:
@@ -104,15 +107,17 @@ func TestLeaderElectionNoPermission(t *testing.T) {
 		}
 		completed <- struct{}{}
 	})
-	// Immediately drop RBAC permssions to update the configmap
+	<-started
+
+	// We would expect this to complete
+	select {
+	case <-time.After(time.Second * 5):
+	case <-completed:
+		//t.Fatalf("Unexpectedly completed function")
+	}
+	// drop RBAC permssions to update the configmap
 	client.Fake.PrependReactor("update", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("nope, out of luck")
 	})
-	// We would expect this to complete
-	select {
-	case <-time.After(time.Second * 15):
-		t.Fatalf("failed to complete function")
-	case <-completed:
-	}
 	close(stop)
 }

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leaderelection
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func createElection(t *testing.T, name string, expectLeader bool, client kubernetes.Interface) chan struct{} {
+	t.Helper()
+	l := NewLeaderElection("ns", name, client)
+	gotLeader := make(chan struct{})
+	l.AddRunFunction(func(stop <-chan struct{}) {
+		gotLeader <- struct{}{}
+	})
+	stop := make(chan struct{})
+	if err := l.Run(stop); err != nil {
+		t.Fatal(err)
+	}
+
+	if expectLeader {
+		select {
+		case <-gotLeader:
+		case <-time.After(time.Second * 15):
+			t.Fatal("failed to acquire lease")
+		}
+	} else {
+		select {
+		case <-gotLeader:
+			t.Fatal("unexpectedly acquired lease")
+		case <-time.After(time.Second * 1):
+		}
+	}
+	return stop
+}
+
+func TestLeaderElection(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	// First pod becomes the leader
+	stop := createElection(t, "pod1", true, client)
+	// A new pod is not the leader
+	stop2 := createElection(t, "pod2", false, client)
+	// The first pod exists, now the new pod becomes the leader
+	close(stop2)
+	close(stop)
+	_ = createElection(t, "pod2", true, client)
+}

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -30,7 +30,7 @@ func createElection(t *testing.T, name string, expectLeader bool, client kuberne
 		gotLeader <- struct{}{}
 	})
 	stop := make(chan struct{})
-	if err := l.Run(stop); err != nil {
+	if err := l.Run(stop, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -29,7 +29,8 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 )
 
-func createElection(t *testing.T, name string, expectLeader bool, client kubernetes.Interface, fns ...func(stop <-chan struct{})) (*LeaderElection, chan struct{}) {
+func createElection(t *testing.T, name string, expectLeader bool, client kubernetes.Interface,
+	fns ...func(stop <-chan struct{})) (*LeaderElection, chan struct{}) {
 	t.Helper()
 	l := NewLeaderElection("ns", name, client)
 	l.ttl = time.Second


### PR DESCRIPTION
This PR does a few things, which I attempted to decompose into different commits

1. Add a new leaderelection component. This is largely a copy of the ingress leader election (which in turn is directly copied from some other implementation)
2. Switch ingress status to use the new component
3. Make validation and namespace controller use the new leader election