### PR TITLE
Don't complain about unknown args, print help instead

### DIFF
--- a/istioctl/cmd/istioctl_test.go
+++ b/istioctl/cmd/istioctl_test.go
@@ -49,24 +49,16 @@ type testCase struct {
 func TestBadParse(t *testing.T) {
 	// unknown flags should be a command parse
 	rootCmd := GetRootCmd([]string{"--unknown-flag"})
+
+	// we should propagate to subcommands
+	rootCmd = GetRootCmd([]string{"x", "analyze", "--unknown-flag"})
 	fErr := rootCmd.Execute()
 
 	switch fErr.(type) {
 	case CommandParseError:
 		// do nothing
 	default:
-		t.Errorf("Expected a CommandParseError, but got %q.", fErr)
-	}
-
-	// we should propagate to subcommands
-	rootCmd = GetRootCmd([]string{"x", "analyze", "--unknown-flag"})
-	fErr = rootCmd.Execute()
-
-	switch fErr.(type) {
-	case CommandParseError:
-		// do nothing
-	default:
-		t.Errorf("Expected a CommandParseError, but got %q.", fErr)
+		t.Errorf("Expected a CommandParseError, but got %v", fErr)
 	}
 
 	// all of the subcommands
@@ -77,7 +69,7 @@ func TestBadParse(t *testing.T) {
 	case CommandParseError:
 		// do nothing
 	default:
-		t.Errorf("Expected a CommandParseError, but got %q.", fErr)
+		t.Errorf("Expected a CommandParseError, but got %v", fErr)
 	}
 }
 

--- a/istioctl/cmd/istioctl_test.go
+++ b/istioctl/cmd/istioctl_test.go
@@ -47,11 +47,8 @@ type testCase struct {
 }
 
 func TestBadParse(t *testing.T) {
-	// unknown flags should be a command parse
-	rootCmd := GetRootCmd([]string{"--unknown-flag"})
-
 	// we should propagate to subcommands
-	rootCmd = GetRootCmd([]string{"x", "analyze", "--unknown-flag"})
+	rootCmd := GetRootCmd([]string{"x", "analyze", "--unknown-flag"})
 	fErr := rootCmd.Execute()
 
 	switch fErr.(type) {

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -86,6 +86,9 @@ func GetRootCmd(args []string) *cobra.Command {
 debug and diagnose their Istio mesh.
 `,
 		PersistentPreRunE: istioPersistentPreRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 	}
 
 	rootCmd.SetArgs(args)


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/20611

If the user does `istioctl -?` print the help instead of complaining about `-?` not being valid.

This applies to the root `istioctl` command, but not subcommands.  The rationale for this is that `kubectl -?` prints the help text, people are used to typing it, so why complain that `-?` is not the proper way to request help?