### PR TITLE
pilot: gateway listeners should respect targetPort

### DIFF
--- a/manifests/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/gateways/istio-ingress/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
 {{- end }}
           ports:
             {{- range $key, $val := $gateway.ports }}
-            - containerPort: {{ $val.port }}
+            - containerPort: {{ $val.targetPort | default $val.port }}
             {{- end }}
             {{- range $key, $val := $gateway.meshExpansionPorts }}
             - containerPort: {{ $val.port }}

--- a/manifests/gateways/istio-ingress/values.yaml
+++ b/manifests/gateways/istio-ingress/values.yaml
@@ -31,9 +31,10 @@ gateways:
       targetPort: 15020
       name: status-port
     - port: 80
-      targetPort: 80
+      targetPort: 8080
       name: http2
     - port: 443
+      targetPort: 8443
       name: https
     - port: 15029
       targetPort: 15029

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -7541,8 +7541,8 @@ spec:
           image: "gcr.io/istio-testing/proxyv2:latest"
           ports:
             - containerPort: 15020
-            - containerPort: 80
-            - containerPort: 443
+            - containerPort: 8080
+            - containerPort: 8443
             - containerPort: 15029
             - containerPort: 15030
             - containerPort: 15031
@@ -7839,10 +7839,11 @@ spec:
     -
       name: http2
       port: 80
-      targetPort: 80
+      targetPort: 8080
     -
       name: https
       port: 443
+      targetPort: 8443
     -
       name: kiali
       port: 15029

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
@@ -6530,8 +6530,8 @@ spec:
         name: istio-proxy
         ports:
         - containerPort: 15020
-        - containerPort: 80
-        - containerPort: 443
+        - containerPort: 8080
+        - containerPort: 8443
         - containerPort: 15029
         - containerPort: 15030
         - containerPort: 15031
@@ -6705,10 +6705,11 @@ spec:
     -
       name: http2
       port: 80
-      targetPort: 80
+      targetPort: 8080
     -
       name: https
       port: 443
+      targetPort: 8443
     -
       name: kiali
       port: 15029

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -6386,8 +6386,8 @@ spec:
         name: istio-proxy
         ports:
         - containerPort: 15020
-        - containerPort: 80
-        - containerPort: 443
+        - containerPort: 8080
+        - containerPort: 8443
         - containerPort: 15029
         - containerPort: 15030
         - containerPort: 15031
@@ -6561,10 +6561,11 @@ spec:
     -
       name: http2
       port: 80
-      targetPort: 80
+      targetPort: 8080
     -
       name: https
       port: 443
+      targetPort: 8443
     -
       name: kiali
       port: 15029

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -6385,8 +6385,8 @@ spec:
         name: istio-proxy
         ports:
         - containerPort: 15020
-        - containerPort: 80
-        - containerPort: 443
+        - containerPort: 8080
+        - containerPort: 8443
         - containerPort: 15029
         - containerPort: 15030
         - containerPort: 15031
@@ -6560,10 +6560,11 @@ spec:
     -
       name: http2
       port: 80
-      targetPort: 80
+      targetPort: 8080
     -
       name: https
       port: 443
+      targetPort: 8443
     -
       name: kiali
       port: 15029

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
@@ -184,8 +184,8 @@ spec:
         name: istio-proxy
         ports:
         - containerPort: 15020
-        - containerPort: 80
-        - containerPort: 443
+        - containerPort: 8080
+        - containerPort: 8443
         - containerPort: 15029
         - containerPort: 15030
         - containerPort: 15031
@@ -359,10 +359,11 @@ spec:
     -
       name: http2
       port: 80
-      targetPort: 80
+      targetPort: 8080
     -
       name: https
       port: 443
+      targetPort: 8443
     -
       name: kiali
       port: 15029
@@ -475,8 +476,8 @@ spec:
           image: "gcr.io/istio-testing/proxyv2:latest"
           ports:
             - containerPort: 15020
-            - containerPort: 80
-            - containerPort: 443
+            - containerPort: 8080
+            - containerPort: 8443
             - containerPort: 15029
             - containerPort: 15030
             - containerPort: 15031
@@ -771,10 +772,11 @@ spec:
     -
       name: http2
       port: 80
-      targetPort: 80
+      targetPort: 8080
     -
       name: https
       port: 443
+      targetPort: 8443
     -
       name: kiali
       port: 15029

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.golden.yaml
@@ -607,8 +607,8 @@ spec:
         name: istio-proxy
         ports:
         - containerPort: 15020
-        - containerPort: 80
-        - containerPort: 443
+        - containerPort: 8080
+        - containerPort: 8443
         - containerPort: 15029
         - containerPort: 15030
         - containerPort: 15031
@@ -782,10 +782,11 @@ spec:
     -
       name: http2
       port: 80
-      targetPort: 80
+      targetPort: 8080
     -
       name: https
       port: 443
+      targetPort: 8443
     -
       name: kiali
       port: 15029

--- a/operator/cmd/mesh/testdata/manifest-generate/output/ingressgateway_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/ingressgateway_k8s_settings.golden.yaml
@@ -36,8 +36,8 @@ spec:
           image: "gcr.io/istio-testing/proxyv2:latest"
           ports:
             - containerPort: 15020
-            - containerPort: 80
-            - containerPort: 443
+            - containerPort: 8080
+            - containerPort: 8443
             - containerPort: 15029
             - containerPort: 15030
             - containerPort: 15031
@@ -257,9 +257,10 @@ spec:
     targetPort: 15020
   - name: http2
     port: 80
-    targetPort: 80
+    targetPort: 8080
   - name: https
     port: 443
+    targetPort: 8443
   - name: kiali
     port: 15029
     targetPort: 15029

--- a/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
@@ -233,16 +233,17 @@ values:
         targetPort: 8060
       - name: tcp-dns-tls
         port: 853
-        targetPort: 853
+        targetPort: 8853
       ports:
       - name: status-port
         port: 15020
         targetPort: 15020
       - name: http2
         port: 80
-        targetPort: 80
+        targetPort: 8080
       - name: https
         port: 443
+        targetPort: 8443
       - name: kiali
         port: 15029
         targetPort: 15029

--- a/operator/data/profiles/default.yaml
+++ b/operator/data/profiles/default.yaml
@@ -495,9 +495,10 @@ spec:
             targetPort: 15020
             name: status-port
           - port: 80
-            targetPort: 80
+            targetPort: 8080
             name: http2
           - port: 443
+            targetPort: 8443
             name: https
           - port: 15029
             targetPort: 15029
@@ -522,7 +523,7 @@ spec:
             targetPort: 8060
             name: tcp-citadel-grpc-tls
           - port: 853
-            targetPort: 853
+            targetPort: 8853
             name: tcp-dns-tls
         secretVolumes:
           - name: ingressgateway-certs

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -7854,7 +7854,7 @@ spec:
 {{- end }}
           ports:
             {{- range $key, $val := $gateway.ports }}
-            - containerPort: {{ $val.port }}
+            - containerPort: {{ $val.targetPort | default $val.port }}
             {{- end }}
             {{- range $key, $val := $gateway.meshExpansionPorts }}
             - containerPort: {{ $val.port }}
@@ -8759,9 +8759,10 @@ gateways:
       targetPort: 15020
       name: status-port
     - port: 80
-      targetPort: 80
+      targetPort: 8080
       name: http2
     - port: 443
+      targetPort: 8443
       name: https
     - port: 15029
       targetPort: 15029
@@ -38960,9 +38961,10 @@ spec:
             targetPort: 15020
             name: status-port
           - port: 80
-            targetPort: 80
+            targetPort: 8080
             name: http2
           - port: 443
+            targetPort: 8443
             name: https
           - port: 15029
             targetPort: 15029
@@ -38987,7 +38989,7 @@ spec:
             targetPort: 8060
             name: tcp-citadel-grpc-tls
           - port: 853
-            targetPort: 853
+            targetPort: 8853
             name: tcp-dns-tls
         secretVolumes:
           - name: ingressgateway-certs

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -958,7 +958,7 @@ func TestBuildGatewayListeners(t *testing.T) {
 			"targetPort overrides service port",
 			&pilot_model.Proxy{
 				ServiceInstances: []*pilot_model.ServiceInstance{
-					&pilot_model.ServiceInstance{
+					{
 						Service: &pilot_model.Service{
 							Hostname: "test",
 						},

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -16,6 +16,7 @@ package v1alpha3
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
@@ -944,6 +945,75 @@ func TestGatewayHTTPRouteConfig(t *testing.T) {
 		})
 	}
 
+}
+
+func TestBuildGatewayListeners(t *testing.T) {
+	cases := []struct {
+		name              string
+		node              *pilot_model.Proxy
+		gateway           *networking.Gateway
+		expectedListeners []string
+	}{
+		{
+			"targetPort overrides service port",
+			&pilot_model.Proxy{
+				ServiceInstances: []*pilot_model.ServiceInstance{
+					&pilot_model.ServiceInstance{
+						Service: &pilot_model.Service{
+							Hostname: "test",
+						},
+						ServicePort: &pilot_model.Port{
+							Port: 80,
+						},
+						Endpoint: &pilot_model.IstioEndpoint{
+							EndpointPort: 8080,
+						},
+					},
+				},
+			},
+			&networking.Gateway{
+				Servers: []*networking.Server{
+					{
+						Port: &networking.Port{Name: "http", Number: 80, Protocol: "HTTP"},
+					},
+				},
+			},
+			[]string{"0.0.0.0_8080"},
+		},
+		{
+			"multiple ports",
+			&pilot_model.Proxy{},
+			&networking.Gateway{
+				Servers: []*networking.Server{
+					{
+						Port: &networking.Port{Name: "http", Number: 80, Protocol: "HTTP"},
+					},
+					{
+						Port: &networking.Port{Name: "http", Number: 801, Protocol: "HTTP"},
+					},
+				},
+			},
+			[]string{"0.0.0.0_80", "0.0.0.0_801"},
+		},
+	}
+
+	for _, tt := range cases {
+		p := &fakePlugin{}
+		configgen := NewConfigGenerator([]plugin.Plugin{p})
+		env := buildEnv(t, []pilot_model.Config{{Spec: tt.gateway}}, []pilot_model.Config{})
+		proxy14Gateway.SetGatewaysForProxy(env.PushContext)
+		proxy14Gateway.ServiceInstances = tt.node.ServiceInstances
+		builder := configgen.buildGatewayListeners(&proxy14Gateway, env.PushContext, &ListenerBuilder{})
+		var listeners []string
+		for _, l := range builder.gatewayListeners {
+			listeners = append(listeners, l.Name)
+		}
+		sort.Strings(listeners)
+		sort.Strings(tt.expectedListeners)
+		if !reflect.DeepEqual(listeners, tt.expectedListeners) {
+			t.Fatalf("Expected listeners: %v, got: %v\n%v", tt.expectedListeners, listeners, proxy14Gateway.MergedGateway.Servers)
+		}
+	}
 }
 
 func buildEnv(t *testing.T, gateways []pilot_model.Config, virtualServices []pilot_model.Config) pilot_model.Environment {


### PR DESCRIPTION
This makes sure that you can define non-privileged `targetPort`s for your ingress-gateway services. It also changes the default listener ports to non-privileged ports.

[x] Networking

