### PR TITLE
Fix pilot panic in CDS when there are no gateway configs

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -584,6 +584,12 @@ func (ps *PushContext) GatewayServices(proxy *Proxy) []*Service {
 	// host set.
 	hostsFromGateways := map[string]struct{}{}
 
+	// MergedGateway will be nil when there are no configs in the
+	// system during initial installation.
+	if proxy.MergedGateway == nil {
+		return nil
+	}
+
 	for _, gw := range proxy.MergedGateway.GatewayNameForServer {
 		gateways[gw] = true
 	}


### PR DESCRIPTION
When we enable the FilterGatewayClusters flag, push.GatewayServices panics
when there are no gateway configs in the system. This PR fixes the issue.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure