### PR TITLE
Drop all capabilities from control-plane containers

### DIFF
--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -12,6 +12,7 @@ USER 1337:1337
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless
+WORKDIR /
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/manifests/istio-control/istio-config/templates/deployment.yaml
+++ b/manifests/istio-control/istio-config/templates/deployment.yaml
@@ -94,6 +94,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
   {{- if and .Values.global.configValidation (not .Values.global.istiod.enabled) }}
           - name: istio-certs

--- a/manifests/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/istio-control/istio-discovery/templates/deployment.yaml
@@ -167,6 +167,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/manifests/istio-policy/templates/deployment.yaml
+++ b/manifests/istio-policy/templates/deployment.yaml
@@ -131,6 +131,9 @@ spec:
           runAsUser: 1337
           runAsGroup: 1337
           runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
 {{- if .Values.global.useMCP }}
         - name: istio-certs

--- a/manifests/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/manifests/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -130,6 +130,9 @@ spec:
           runAsUser: 1337
           runAsGroup: 1337
           runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
 {{- if .Values.global.useMCP }}
         - name: istio-certs

--- a/manifests/security/citadel/templates/deployment.yaml
+++ b/manifests/security/citadel/templates/deployment.yaml
@@ -110,6 +110,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
 {{- if not .Values.security.selfSigned }}
           volumeMounts:
           - name: cacerts

--- a/mixer/docker/Dockerfile.mixer
+++ b/mixer/docker/Dockerfile.mixer
@@ -12,6 +12,7 @@ USER 1337:1337
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless
+WORKDIR /
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -6564,6 +6564,9 @@ spec:
           requests:
             cpu: 10m
         securityContext:
+          capabilities:
+            drop:
+            - ALL
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337
@@ -7337,6 +7340,9 @@ spec:
           requests:
             cpu: 100m
         securityContext:
+          capabilities:
+            drop:
+            - ALL
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337
@@ -8505,6 +8511,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config
@@ -10291,6 +10300,9 @@ spec:
           requests:
             cpu: 10m
         securityContext:
+          capabilities:
+            drop:
+            - ALL
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337
@@ -11773,6 +11785,9 @@ spec:
             cpu: 1000m
             memory: 1G
         securityContext:
+          capabilities:
+            drop:
+            - ALL
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
@@ -7421,6 +7421,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
@@ -671,6 +671,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
@@ -674,6 +674,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -6446,6 +6446,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -7277,6 +7277,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
@@ -671,6 +671,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -7276,6 +7276,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -671,6 +671,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
@@ -671,6 +671,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
@@ -122,6 +122,9 @@ spec:
             cpu: 500m
             memory: 2048Mi
         securityContext:
+          capabilities:
+            drop:
+            - ALL
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
@@ -99,6 +99,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_default.golden.yaml
@@ -1352,6 +1352,9 @@ spec:
             cpu: 1000m
             memory: 1G
         securityContext:
+          capabilities:
+            drop:
+            - ALL
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_k8s_settings.golden.yaml
@@ -109,6 +109,9 @@ spec:
             cpu: 888m
             memory: 999Mi
         securityContext:
+          capabilities:
+            drop:
+            - ALL
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_override_kubernetes.golden.yaml
@@ -98,6 +98,9 @@ spec:
             cpu: 1000m
             memory: 1G
         securityContext:
+          capabilities:
+            drop:
+            - ALL
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -10317,6 +10317,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
   {{- if and .Values.global.configValidation (not .Values.global.istiod.enabled) }}
           - name: istio-certs
@@ -12520,6 +12523,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config
@@ -15264,6 +15270,9 @@ spec:
           runAsUser: 1337
           runAsGroup: 1337
           runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
 {{- if .Values.global.useMCP }}
         - name: istio-certs
@@ -32982,6 +32991,9 @@ spec:
           runAsUser: 1337
           runAsGroup: 1337
           runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
 {{- if .Values.global.useMCP }}
         - name: istio-certs
@@ -37613,6 +37625,9 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
 {{- if not .Values.security.selfSigned }}
           volumeMounts:
           - name: cacerts

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -14,8 +14,6 @@ USER 1337:1337
 FROM gcr.io/distroless/static:nonroot as distroless
 WORKDIR /
 
-WORKDIR /
-
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -12,6 +12,7 @@ USER 1337:1337
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless
+WORKDIR /
 
 WORKDIR /
 

--- a/security/docker/Dockerfile.citadel
+++ b/security/docker/Dockerfile.citadel
@@ -12,6 +12,7 @@ USER 1337:1337
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless
+WORKDIR /
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/sidecar-injector/docker/Dockerfile.sidecar_injector
+++ b/sidecar-injector/docker/Dockerfile.sidecar_injector
@@ -12,6 +12,7 @@ USER 1337:1337
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/static:nonroot as distroless
+WORKDIR /
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006


### PR DESCRIPTION
As suggested by @rlenglet during discussion of #20311. These containers don't run as root
and don't need any capabilities enabled.