### PR TITLE
Make sure to update all golden files when running `make gen`

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -352,7 +352,11 @@ go-gen:
 gen-charts:
 	@operator/scripts/run_update_charts.sh
 
-gen: go-gen mirror-licenses format update-crds gen-charts operator-proto
+update-golden:
+	@UPDATE_GOLDENS=true go test ./operator/cmd/mesh/...
+	@REFRESH_GOLDENS=true go test ./pkg/kube/inject/...
+
+gen: go-gen mirror-licenses format update-crds update-golden gen-charts operator-proto
 
 gen-check: gen check-clean-repo
 

--- a/bin/update_crds.sh
+++ b/bin/update_crds.sh
@@ -45,6 +45,3 @@ fi
 rm -f "${ROOTDIR}/install/kubernetes/helm/istio-init/files/crd-all.gen.yaml" "${ROOTDIR}/manifests/base/files/crd-all.gen.yaml"
 cp "${API_TMP}/kubernetes/customresourcedefinitions.gen.yaml" "${ROOTDIR}/install/kubernetes/helm/istio-init/files/crd-all.gen.yaml"
 cp "${API_TMP}/kubernetes/customresourcedefinitions.gen.yaml" "${ROOTDIR}/manifests/base/files/crd-all.gen.yaml"
-
-# update the golden files for operator tests
-(cd "${ROOTDIR}/operator" && UPDATE_GOLDENS=true go test ./cmd/mesh/...)


### PR DESCRIPTION
We didn't update the `pkg/kube/inject` golden files on `make gen`, which is why `make gen-check` doesn't catch it when you forget to update them.