### PR TITLE
Add analyzer for v1alpha1/Policy using JWT (#20812)

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -33,6 +33,7 @@ func All() []analysis.Analyzer {
 	analyzers := []analysis.Analyzer{
 		// Please keep this list sorted alphabetically by pkg.name for convenience
 		&annotations.K8sAnalyzer{},
+		&auth.JwtAnalyzer{},
 		&auth.MTLSAnalyzer{},
 		&auth.ServiceRoleBindingAnalyzer{},
 		&auth.ServiceRoleServicesAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -79,6 +79,28 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name:       "jwtTargetsInvalidServicePortName",
+		inputFiles: []string{"testdata/jwt-invalid-service-port-name.yaml"},
+		analyzer:   &auth.JwtAnalyzer{},
+		expected: []message{
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-specified-ports.namespace-port-missing-prefix"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-without-specified-ports.namespace-port-missing-prefix"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-without-specified-ports.namespace-port-missing-prefix"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-udp-target-port.namespace-with-non-tcp-protocol"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix, "Policy policy-with-invalid-named-target-port.namespace-with-invalid-named-port"},
+			{msg.JwtFailureDueToInvalidServicePortPrefix,
+				"Policy policy-with-valid-named-target-port-invalid-protocol.namespace-with-valid-named-port-invalid-protocol"},
+		},
+	},
+	{
+		name:       "jwtTargetsValidServicePortName",
+		inputFiles: []string{"testdata/jwt-valid-service-port-name.yaml"},
+		analyzer:   &auth.JwtAnalyzer{},
+		expected:   []message{
+			// port prefixes all pass
+		},
+	},
+	{
 		name:           "mtlsAnalyzerAutoMtlsSkips",
 		inputFiles:     []string{"testdata/mtls-global-dr-no-meshpolicy.yaml"},
 		meshConfigFile: "testdata/mesh-with-automtls.yaml",

--- a/galley/pkg/config/analysis/analyzers/auth/jwt.go
+++ b/galley/pkg/config/analysis/analyzers/auth/jwt.go
@@ -1,0 +1,200 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"regexp"
+
+	v1 "k8s.io/api/core/v1"
+
+	"istio.io/api/authentication/v1alpha1"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+var (
+	jwtSupportedPortName = regexp.MustCompile("^http(2|s)?(-.*)?$")
+)
+
+// JwtAnalyzer checks for misconfiguration of an Authentication policy
+// that specifies a JWT, but the specified target host's K8s Service definition
+// does not have a named port that matches <protocol>[-<suffix>].
+type JwtAnalyzer struct{}
+
+// (compile-time check that we implement the interface)
+var _ analysis.Analyzer = &JwtAnalyzer{}
+
+// Metadata implements JwtAnalyzer
+func (j *JwtAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "injection.JwtAnalyzer",
+		Description: "Checks that jwt auth policies are against valid services",
+		Inputs: collection.Names{
+			collections.IstioAuthenticationV1Alpha1Policies.Name(),
+			collections.K8SCoreV1Services.Name(),
+		},
+	}
+}
+
+func (j *JwtAnalyzer) Analyze(c analysis.Context) {
+	nsm := j.buildNamespaceServiceMap(c)
+
+	c.ForEach(collections.IstioAuthenticationV1Alpha1Policies.Name(), func(r *resource.Instance) bool {
+		j.analyzeServiceTarget(r, c, nsm)
+		return true
+	})
+}
+
+// buildNamespaceServiceMap returns a map where the index is a namespace and the boolean
+func (j *JwtAnalyzer) buildNamespaceServiceMap(ctx analysis.Context) map[string]*v1.ServiceSpec {
+	// Keep track of each fqdn -> service definition
+	fqdnServices := map[string]*v1.ServiceSpec{}
+
+	ctx.ForEach(collections.K8SCoreV1Services.Name(), func(r *resource.Instance) bool {
+		svcNs := r.Metadata.FullName.Namespace
+		svcName := r.Metadata.FullName.Name
+
+		svc := r.Message.(*v1.ServiceSpec)
+		fqdn := util.ConvertHostToFQDN(svcNs, string(svcName))
+		fqdnServices[fqdn] = svc
+
+		return true
+	})
+
+	return fqdnServices
+}
+
+func (j *JwtAnalyzer) analyzeServiceTarget(r *resource.Instance, ctx analysis.Context, nsm map[string]*v1.ServiceSpec) {
+	policy := r.Message.(*v1alpha1.Policy)
+	ns := r.Metadata.FullName.Namespace
+
+	// nolint: staticcheck
+	for _, origin := range policy.Origins {
+		if origin.GetJwt() == nil {
+			continue
+		}
+
+		// nolint: staticcheck
+		for _, target := range policy.GetTargets() {
+			fqdn := util.ConvertHostToFQDN(ns, target.GetName())
+			svc, ok := nsm[fqdn]
+			if !ok {
+				// service was not found, but this is not considered an error
+				continue
+			}
+
+			if len(target.GetPorts()) == 0 {
+				checkServicePorts(r, ctx, svc)
+				continue
+			}
+
+			// check ports defined in the authentication policy for the service
+			for _, port := range target.GetPorts() {
+				if port.GetName() == "" {
+					checkPortNumber(r, ctx, port.GetNumber(), svc)
+				} else {
+					checkPortName(r, ctx, port.GetName(), svc)
+				}
+			}
+		}
+	}
+}
+
+func checkPortName(r *resource.Instance, ctx analysis.Context, portName string, svc *v1.ServiceSpec) {
+	var svcPort *v1.ServicePort
+	for _, port := range svc.Ports {
+		if portName != port.Name {
+			continue
+		}
+		if !isTCPProtocol(port.Protocol) {
+			ctx.Report(collections.IstioAuthenticationV1Alpha1Policies.Name(),
+				msg.NewJwtFailureDueToInvalidServicePortPrefix(
+					r,
+					int(port.Port),
+					port.Name,
+					string(port.Protocol),
+					port.TargetPort.String(),
+				))
+			return
+		}
+
+		svcPort = &port
+		break
+	}
+	checkPort(r, ctx, svcPort)
+}
+
+func checkPortNumber(r *resource.Instance, ctx analysis.Context, portNum uint32, svc *v1.ServiceSpec) {
+	var svcPort *v1.ServicePort
+	for _, port := range svc.Ports {
+		if !isTCPProtocol(port.Protocol) {
+			continue
+		}
+		if portNum == uint32(port.Port) {
+			svcPort = &port
+			break
+		}
+	}
+	checkPort(r, ctx, svcPort)
+}
+
+func checkPort(r *resource.Instance, ctx analysis.Context, svcPort *v1.ServicePort) {
+	if svcPort == nil {
+		return
+	}
+
+	svcPortName := svcPort.Name
+	if !isJwtSupportedPortName(svcPortName) {
+		ctx.Report(collections.IstioAuthenticationV1Alpha1Policies.Name(),
+			msg.NewJwtFailureDueToInvalidServicePortPrefix(
+				r,
+				int(svcPort.Port),
+				svcPortName,
+				string(svcPort.Protocol),
+				svcPort.TargetPort.String(),
+			))
+	}
+}
+
+func checkServicePorts(r *resource.Instance, ctx analysis.Context, svc *v1.ServiceSpec) {
+	for _, port := range svc.Ports {
+		if isTCPProtocol(port.Protocol) && isJwtSupportedPortName(port.Name) {
+			continue
+		} else {
+			ctx.Report(collections.IstioAuthenticationV1Alpha1Policies.Name(),
+				msg.NewJwtFailureDueToInvalidServicePortPrefix(
+					r,
+					int(port.Port),
+					port.Name,
+					string(port.Protocol),
+					port.TargetPort.String(),
+				))
+
+		}
+	}
+}
+
+func isTCPProtocol(protocol v1.Protocol) bool {
+	return string(protocol) == "TCP" || protocol == ""
+}
+
+func isJwtSupportedPortName(portName string) bool {
+	return jwtSupportedPortName.Match([]byte(portName))
+}

--- a/galley/pkg/config/analysis/analyzers/testdata/jwt-invalid-service-port-name.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/jwt-invalid-service-port-name.yaml
@@ -1,0 +1,159 @@
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-with-specified-ports
+  namespace: namespace-port-missing-prefix
+spec:
+  targets:
+    - name: my-service-port-missing-prefix
+      ports:
+        - number: 8080
+        - number: 8081
+        - number: 8082
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-port-missing-prefix
+  namespace: namespace-port-missing-prefix
+spec:
+  selector:
+    app: my-service
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: missingprefix-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: https-svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: http2-svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-without-specified-ports
+  namespace: namespace-port-missing-prefix
+spec:
+  targets:
+    - name: my-service-no-target-ports-specified
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-no-target-ports-specified
+  namespace: namespace-port-missing-prefix
+spec:
+  selector:
+    app: my-service-no-target-ports-specified
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-with-udp-target-port
+  namespace: namespace-with-non-tcp-protocol
+spec:
+  targets:
+    - name: my-service-no-target-ports-specified
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-no-target-ports-specified
+  namespace: namespace-with-non-tcp-protocol
+spec:
+  selector:
+    app: my-service-no-target-ports-specified
+  ports:
+    - protocol: UDP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-with-invalid-named-target-port
+  namespace: namespace-with-invalid-named-port
+spec:
+  targets:
+    - name: my-service-with-invalid-named-port
+      ports:
+        - name: badname
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-with-invalid-named-port
+  namespace: namespace-with-invalid-named-port
+spec:
+  selector:
+    app: my-service-with-invalid-named-port
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: badname
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-with-valid-named-target-port-invalid-protocol
+  namespace: namespace-with-valid-named-port-invalid-protocol
+spec:
+  targets:
+    - name: my-service-with-valid-named-port-invalid-protocol
+      ports:
+        - name: https
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-with-valid-named-port-invalid-protocol
+  namespace: namespace-with-valid-named-port-invalid-protocol
+spec:
+  selector:
+    app: my-service-with-valid-named-port-invalid-protocol
+  ports:
+    - protocol: UDP
+      port: 8080
+      targetPort: 8080
+      name: https
+---

--- a/galley/pkg/config/analysis/analyzers/testdata/jwt-valid-service-port-name.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/jwt-valid-service-port-name.yaml
@@ -1,0 +1,103 @@
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: test-ports
+  namespace: my-namespace
+spec:
+  targets:
+    - name: my-service
+      ports:
+        - number: 8080
+        - number: 8081
+        - number: 8082
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: my-namespace
+spec:
+  selector:
+    app: my-service
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: https-svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: http2-svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: test-no-ports
+  namespace: my-namespace-2
+spec:
+  targets:
+    - name: my-service-no-target-ports-specified
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-no-target-ports-specified
+  namespace: my-namespace-2
+spec:
+  selector:
+    app: my-service-no-target-ports-specified
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-svc-8080
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+      name: https-svc-8081
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+      name: http2-svc-8082
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: policy-named-ports
+  namespace: namespace-named-ports
+spec:
+  targets:
+    - name: my-service-named-port
+      ports:
+        - name: http-foo
+  origins:
+    - jwt:
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.4/security/tools/jwt/samples/jwks.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-named-port
+  namespace: namespace-named-ports
+spec:
+  selector:
+    app: my-service-named-port
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-foo
+---


### PR DESCRIPTION
Cherry pick of c42f2ab for PR https://github.com/istio/istio/pull/20812.

* Add analyzer for v1alpha1/Policy using JWT

It is possible that JWT authentication when used with the
v1alpha1/Policy API is misconfigured leading users to believe that their
cluster is secure when it is not. Warn the users of a misconfiguration;
the associated K8s service's port name should be prefixed with
http|http2|https.

* Fixes issue https://github.com/istio/istio/issues/17535

* The code was reviewed https://github.com/istio/istio/pull/20450
