### PR TITLE
Don't pass extra parameter to analyzer message

### DIFF
--- a/galley/pkg/config/analysis/analyzers/deployment/services.go
+++ b/galley/pkg/config/analysis/analyzers/deployment/services.go
@@ -69,7 +69,7 @@ func (s *ServiceAssociationAnalyzer) analyzeDeployment(r *resource.Instance, c a
 
 	// If there isn't any matching service, generate message: At least one service is needed.
 	if len(matchingSvcs) == 0 {
-		c.Report(collections.K8SAppsV1Deployments.Name(), msg.NewDeploymentRequiresServiceAssociated(r, d.Name))
+		c.Report(collections.K8SAppsV1Deployments.Name(), msg.NewDeploymentRequiresServiceAssociated(r))
 		return
 	}
 

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -301,11 +301,10 @@ func NewDeploymentAssociatedToMultipleServices(r *resource.Instance, deployment 
 }
 
 // NewDeploymentRequiresServiceAssociated returns a new diag.Message based on DeploymentRequiresServiceAssociated.
-func NewDeploymentRequiresServiceAssociated(r *resource.Instance, deployment string) diag.Message {
+func NewDeploymentRequiresServiceAssociated(r *resource.Instance) diag.Message {
 	return diag.NewMessage(
 		DeploymentRequiresServiceAssociated,
 		r,
-		deployment,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -202,9 +202,6 @@ messages:
     level: Warning
     description: "The resulting pods of a service mesh deployment must be associated with at least one service."
     template: "No service associated with this deployment. Service mesh deployments must be associated with a service."
-    args:
-      - name: deployment
-        type: string
 
   - name: "PortNameIsNotUnderNamingConvention"
     code: IST0118


### PR DESCRIPTION
Message DeploymentRequiresServiceAssociated was receiving an extra parameter to its Sprintf formatter, which resulted in error messages like:

Warn [IST0117] (Deployment loadgenerator.hipster) No service associated with
this deployment. Service mesh deployments must be associated with a
service.%!(EXTRA string=loadgenerator)

This change removes the extra parameter (the deployment under question is already listed as the origin).