### PR TITLE
 istioctl upgrade hook for telemetryv2

### DIFF
--- a/operator/cmd/mesh/hooks_common.go
+++ b/operator/cmd/mesh/hooks_common.go
@@ -1,0 +1,82 @@
+package mesh
+
+import (
+	"fmt"
+
+	"istio.io/istio/operator/pkg/hooks"
+	"istio.io/istio/operator/pkg/manifest"
+	pkgversion "istio.io/istio/operator/pkg/version"
+)
+
+// runPreApplyHook prepares and triggers the prerun hook for manifest apply command
+func runPreApplyHook(args *rootArgs, maArgs *manifestApplyArgs, l *Logger) error {
+	// Create a kube client from args.kubeConfigPath and  args.context
+	kubeClient, err := manifest.NewClient(maArgs.kubeConfigPath, maArgs.context)
+	if err != nil {
+		return fmt.Errorf("failed to connect Kubernetes API server, error: %v", err)
+	}
+	hparams, err := generateHookParam(kubeClient, maArgs.inFilename, maArgs.force, l)
+	if err != nil {
+		return fmt.Errorf("failed to generate param for hook: %v", err)
+	}
+	errs := hooks.RunPreManifestApplyHooks(kubeClient, hparams, args.dryRun)
+	if len(errs) != 0 && !maArgs.force {
+		return errs.ToError()
+	}
+	return nil
+}
+
+// RunPreUpgradeHooks prepares and triggers the prerun hook for upgrade command
+func RunPreUpgradeHooks(kubeClient *manifest.Client, args *rootArgs, ugArgs *upgradeArgs, l *Logger) error {
+	// Run pre-upgrade hooks
+	hparams, err := generateHookParam(kubeClient, ugArgs.inFilename, ugArgs.force, l)
+	if err != nil {
+		return fmt.Errorf("failed to generate param for hook: %v", err)
+	}
+	errs := hooks.RunPreUpgradeHooks(kubeClient, hparams, args.dryRun)
+	if len(errs) != 0 && !ugArgs.force {
+		return errs.ToError()
+	}
+	return nil
+}
+
+// RunPostUpgradeHooks prepares and triggers the postrun hook for upgrade command
+func RunPostUpgradeHooks(kubeClient *manifest.Client, args *rootArgs, maArgs *upgradeArgs, l *Logger) error {
+	hparams, err := generateHookParam(kubeClient, maArgs.inFilename, maArgs.force, l)
+	if err != nil {
+		return fmt.Errorf("failed to generate param for hook: %v", err)
+	}
+	errs := hooks.RunPostUpgradeHooks(kubeClient, hparams, args.dryRun)
+	if len(errs) != 0 && !maArgs.force {
+		return errs.ToError()
+	}
+	return nil
+}
+
+func generateHookParam(kubeClient *manifest.Client, inFilename []string, force bool, l *Logger) (*hooks.HookCommonParams, error) {
+	// Generate IOPS objects
+	_, targetIOPS, err := genIOPS(inFilename, "", "", "", force, kubeClient.Config, l)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate IOPS from file %s, error: %s", inFilename, err)
+	}
+
+	targetTag := targetIOPS.GetTag()
+	targetVersion, err := pkgversion.TagToVersionString(targetTag)
+
+	istioNamespace := targetIOPS.MeshConfig.RootNamespace
+	currentVersion, err := retrieveControlPlaneVersion(kubeClient, istioNamespace, l)
+	if err != nil && force {
+		return nil, fmt.Errorf("failed to read the current Istio version, error: %v", err)
+	}
+
+	nkMap, err := generateDefaultTelemetryManifest(l)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate default manifest for telemetry: %v", err)
+	}
+	return &hooks.HookCommonParams{
+		SourceVer:                currentVersion,
+		TargetVer:                targetVersion,
+		DefaultTelemetryManifest: nkMap,
+		SourceIOPS:               nil,
+		TargetIOPS:               nil}, nil
+}

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -16,20 +16,17 @@ package mesh
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"time"
-
-	"istio.io/istio/operator/pkg/kubectlcmd"
-	"istio.io/istio/operator/pkg/manifest"
-	"istio.io/istio/operator/pkg/name"
-	"istio.io/istio/operator/version"
 
 	"github.com/spf13/cobra"
 )
 
 type manifestApplyArgs struct {
-	// inFilenames is an array of paths to the input IstioOperator CR files.
-	inFilenames []string
+	// inFilename is an array of paths to the input IstioOperator CR files.
+	inFilename []string
 	// kubeConfigPath is the path to kube config file.
 	kubeConfigPath string
 	// context is the cluster context in the kube config
@@ -49,7 +46,7 @@ type manifestApplyArgs struct {
 }
 
 func addManifestApplyFlags(cmd *cobra.Command, args *manifestApplyArgs) {
-	cmd.PersistentFlags().StringSliceVarP(&args.inFilenames, "filename", "f", nil, filenameFlagHelpStr)
+	cmd.PersistentFlags().StringSliceVarP(&args.inFilename, "filename", "f", nil, filenameFlagHelpStr)
 	cmd.PersistentFlags().StringVarP(&args.kubeConfigPath, "kubeconfig", "c", "", "Path to kube config")
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", "The name of the kubeconfig context to use")
 	cmd.PersistentFlags().BoolVarP(&args.skipConfirmation, "skip-confirmation", "y", false, skipConfirmationFlagHelpStr)
@@ -66,101 +63,56 @@ func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs) *cobra.Comm
 		Use:   "apply",
 		Short: "Applies an Istio manifest, installing or reconfiguring Istio on a cluster.",
 		Long:  "The apply subcommand generates an Istio install manifest and applies it to a cluster.",
-		// nolint: lll
-		Example: `  # Apply a default Istio installation
-  istioctl manifest apply
-
-  # Enable security
-  istioctl manifest apply --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true
-
-  # Generate the demo profile and don't wait for confirmation
-  istioctl manifest apply --set profile=demo --skip-confirmation
-
-  # To override a setting that includes dots, escape them with a backslash (\).  Your shell may require enclosing quotes.
-  istioctl manifest apply --set "values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy=runtime/default"
-`,
+		Example: "istioctl manifest apply  # installs the default profile on the current Kubernetes cluster context\n" +
+			"istioctl manifest apply --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true\n" +
+			"istioctl manifest apply --set profile=demo\n" +
+			"istioctl manifest apply --set installPackagePath=~/istio-releases/istio-1.4.3/install/kubernetes/operator/charts",
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			l := NewLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.ErrOrStderr())
 			// Warn users if they use `manifest apply` without any config args.
-			if len(maArgs.inFilenames) == 0 && len(maArgs.set) == 0 && !rootArgs.dryRun && !maArgs.skipConfirmation {
+			if len(maArgs.inFilename) == 0 && len(maArgs.set) == 0 && !rootArgs.dryRun && !maArgs.skipConfirmation {
 				if !confirm("This will install the default Istio profile into the cluster. Proceed? (y/N)", cmd.OutOrStdout()) {
 					cmd.Print("Cancelled.\n")
 					os.Exit(1)
 				}
 			}
-			if err := configLogs(rootArgs.logToStdErr); err != nil {
-				return fmt.Errorf("could not configure logs: %s", err)
-			}
-			if err := ApplyManifests(maArgs.set, maArgs.inFilenames, maArgs.force, rootArgs.dryRun, rootArgs.verbose,
-				maArgs.kubeConfigPath, maArgs.context, maArgs.wait, maArgs.readinessTimeout, l); err != nil {
-				return fmt.Errorf("failed to generate and apply manifests, error: %v", err)
-			}
-
-			return nil
+			return manifestApply(rootArgs, maArgs, l)
 		}}
 }
 
-// ApplyManifests generates manifests from the given input files and --set flag overlays and applies them to the
-// cluster. See GenManifests for more description of the manifest generation process.
-//  force   validation warnings are written to logger but command is not aborted
-//  dryRun  all operations are done but nothing is written
-//  verbose full manifests are output
-//  wait    block until Services and Deployments are ready, or timeout after waitTimeout
-func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRun bool, verbose bool,
-	kubeConfigPath string, context string, wait bool, waitTimeout time.Duration, l *Logger) error {
-
-	ysf, err := yamlFromSetFlags(setOverlay, force, l)
+func manifestApply(args *rootArgs, maArgs *manifestApplyArgs, l *Logger) error {
+	if err := configLogs(args.logToStdErr); err != nil {
+		return fmt.Errorf("could not configure logs: %s", err)
+	}
+	manifests, iop, opts, err := genApplyManifests(maArgs.set, maArgs.inFilename, maArgs.force, args.dryRun, args.verbose,
+		maArgs.kubeConfigPath, maArgs.context, maArgs.wait, maArgs.readinessTimeout, l)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to generate manifests, error: %v", err)
+	}
+	// issue a warning instead of failing directly
+	if err = runPreApplyHook(args, maArgs, l); err != nil {
+		l.logAndPrintf("failed in running pre apply hooks: %v", err)
+	}
+	if err := ApplyManifest(manifests, iop, opts, l); err != nil {
+		return fmt.Errorf("failed to apply manifests, error: %v", err)
 	}
 
-	kubeconfig, err := manifest.InitK8SRestClient(kubeConfigPath, context)
-	if err != nil {
-		return err
-	}
-	manifests, _, err := GenManifests(inFilenames, ysf, force, kubeconfig, l)
-	if err != nil {
-		return fmt.Errorf("failed to generate manifest: %v", err)
-	}
-	opts := &kubectlcmd.Options{
-		DryRun:      dryRun,
-		Verbose:     verbose,
-		Wait:        wait,
-		WaitTimeout: waitTimeout,
-		Kubeconfig:  kubeConfigPath,
-		Context:     context,
-	}
-
-	for cn := range name.DeprecatedComponentNamesMap {
-		manifests[cn] = append(manifests[cn], fmt.Sprintf("# %s component has been deprecated.\n", cn))
-	}
-
-	out, err := manifest.ApplyAll(manifests, version.OperatorBinaryVersion, opts)
-	if err != nil {
-		return fmt.Errorf("failed to apply manifest with kubectl client: %v", err)
-	}
-	gotError := false
-
-	for cn := range manifests {
-		if out[cn].Err != nil {
-			cs := fmt.Sprintf("Component %s - manifest apply returned the following errors:", cn)
-			l.logAndPrintf("\n%s", cs)
-			l.logAndPrint("Error: ", out[cn].Err, "\n")
-			gotError = true
-		}
-
-		if !ignoreError(out[cn].Stderr) {
-			l.logAndPrint("Error detail:\n", out[cn].Stderr, "\n", out[cn].Stdout, "\n")
-			gotError = true
-		}
-	}
-
-	if gotError {
-		l.logAndPrint("\n\n✘ Errors were logged during apply operation. Please check component installation logs above.\n")
-		return fmt.Errorf("errors were logged during apply operation")
-	}
-
-	l.logAndPrint("\n\n✔ Installation complete\n")
 	return nil
+}
+
+func confirm(msg string, writer io.Writer) bool {
+	fmt.Fprintf(writer, "%s ", msg)
+
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		return false
+	}
+	response = strings.ToUpper(response)
+	if response == "Y" || response == "YES" {
+		return true
+	}
+
+	return false
 }

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -16,17 +16,20 @@ package mesh
 
 import (
 	"fmt"
-	"io"
 	"os"
-	"strings"
 	"time"
+
+	"istio.io/istio/operator/pkg/kubectlcmd"
+	"istio.io/istio/operator/pkg/manifest"
+	"istio.io/istio/operator/pkg/name"
+	"istio.io/istio/operator/version"
 
 	"github.com/spf13/cobra"
 )
 
 type manifestApplyArgs struct {
-	// inFilename is an array of paths to the input IstioOperator CR files.
-	inFilename []string
+	// inFilenames is an array of paths to the input IstioOperator CR files.
+	inFilenames []string
 	// kubeConfigPath is the path to kube config file.
 	kubeConfigPath string
 	// context is the cluster context in the kube config
@@ -46,7 +49,7 @@ type manifestApplyArgs struct {
 }
 
 func addManifestApplyFlags(cmd *cobra.Command, args *manifestApplyArgs) {
-	cmd.PersistentFlags().StringSliceVarP(&args.inFilename, "filename", "f", nil, filenameFlagHelpStr)
+	cmd.PersistentFlags().StringSliceVarP(&args.inFilenames, "filename", "f", nil, filenameFlagHelpStr)
 	cmd.PersistentFlags().StringVarP(&args.kubeConfigPath, "kubeconfig", "c", "", "Path to kube config")
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", "The name of the kubeconfig context to use")
 	cmd.PersistentFlags().BoolVarP(&args.skipConfirmation, "skip-confirmation", "y", false, skipConfirmationFlagHelpStr)
@@ -63,56 +66,110 @@ func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs) *cobra.Comm
 		Use:   "apply",
 		Short: "Applies an Istio manifest, installing or reconfiguring Istio on a cluster.",
 		Long:  "The apply subcommand generates an Istio install manifest and applies it to a cluster.",
-		Example: "istioctl manifest apply  # installs the default profile on the current Kubernetes cluster context\n" +
-			"istioctl manifest apply --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true\n" +
-			"istioctl manifest apply --set profile=demo\n" +
-			"istioctl manifest apply --set installPackagePath=~/istio-releases/istio-1.4.3/install/kubernetes/operator/charts",
+		// nolint: lll
+		Example: `  # Apply a default Istio installation
+  istioctl manifest apply
+
+  # Enable security
+  istioctl manifest apply --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true
+
+  # Generate the demo profile and don't wait for confirmation
+  istioctl manifest apply --set profile=demo --skip-confirmation
+
+  # To override a setting that includes dots, escape them with a backslash (\).  Your shell may require enclosing quotes.
+  istioctl manifest apply --set "values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy=runtime/default"
+`,
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			l := NewLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.ErrOrStderr())
 			// Warn users if they use `manifest apply` without any config args.
-			if len(maArgs.inFilename) == 0 && len(maArgs.set) == 0 && !rootArgs.dryRun && !maArgs.skipConfirmation {
+			if len(maArgs.inFilenames) == 0 && len(maArgs.set) == 0 && !rootArgs.dryRun && !maArgs.skipConfirmation {
 				if !confirm("This will install the default Istio profile into the cluster. Proceed? (y/N)", cmd.OutOrStdout()) {
 					cmd.Print("Cancelled.\n")
 					os.Exit(1)
 				}
 			}
-			return manifestApply(rootArgs, maArgs, l)
+			if err := configLogs(rootArgs.logToStdErr); err != nil {
+				return fmt.Errorf("could not configure logs: %s", err)
+			}
+			if err := ApplyManifests(maArgs.set, maArgs.inFilenames, maArgs.force, rootArgs.dryRun, rootArgs.verbose,
+				maArgs.kubeConfigPath, maArgs.context, maArgs.wait, maArgs.readinessTimeout, l); err != nil {
+				return fmt.Errorf("failed to generate and apply manifests, error: %v", err)
+			}
+
+			return nil
 		}}
 }
 
-func manifestApply(args *rootArgs, maArgs *manifestApplyArgs, l *Logger) error {
-	if err := configLogs(args.logToStdErr); err != nil {
-		return fmt.Errorf("could not configure logs: %s", err)
-	}
-	manifests, iop, opts, err := genApplyManifests(maArgs.set, maArgs.inFilename, maArgs.force, args.dryRun, args.verbose,
-		maArgs.kubeConfigPath, maArgs.context, maArgs.wait, maArgs.readinessTimeout, l)
+// ApplyManifests generates manifests from the given input files and --set flag overlays and applies them to the
+// cluster. See GenManifests for more description of the manifest generation process.
+//  force   validation warnings are written to logger but command is not aborted
+//  dryRun  all operations are done but nothing is written
+//  verbose full manifests are output
+//  wait    block until Services and Deployments are ready, or timeout after waitTimeout
+func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRun bool, verbose bool,
+	kubeConfigPath string, context string, wait bool, waitTimeout time.Duration, l *Logger) error {
+
+	ysf, err := yamlFromSetFlags(setOverlay, force, l)
 	if err != nil {
-		return fmt.Errorf("failed to generate manifests, error: %v", err)
+		return err
 	}
-	// issue a warning instead of failing directly
-	if err = runPreApplyHook(args, maArgs, l); err != nil {
+
+	kubeconfig, err := manifest.InitK8SRestClient(kubeConfigPath, context)
+	if err != nil {
+		return err
+	}
+	manifests, _, err := GenManifests(inFilenames, ysf, force, kubeconfig, l)
+	if err != nil {
+		return fmt.Errorf("failed to generate manifest: %v", err)
+	}
+	opts := &kubectlcmd.Options{
+		DryRun:      dryRun,
+		Verbose:     verbose,
+		Wait:        wait,
+		WaitTimeout: waitTimeout,
+		Kubeconfig:  kubeConfigPath,
+		Context:     context,
+	}
+
+	for cn := range name.DeprecatedComponentNamesMap {
+		manifests[cn] = append(manifests[cn], fmt.Sprintf("# %s component has been deprecated.\n", cn))
+	}
+
+	kubeClient, err := manifest.NewClientFromConfig(kubeconfig)
+	if err != nil {
+		return err
+	}
+	if err = runPreApplyHook(kubeClient, inFilenames, force, dryRun, l); err != nil {
+		// issue a warning instead of failing directly
 		l.logAndPrintf("failed in running pre apply hooks: %v", err)
 	}
-	if err := ApplyManifest(manifests, iop, opts, l); err != nil {
-		return fmt.Errorf("failed to apply manifests, error: %v", err)
-	}
 
-	return nil
-}
-
-func confirm(msg string, writer io.Writer) bool {
-	fmt.Fprintf(writer, "%s ", msg)
-
-	var response string
-	_, err := fmt.Scanln(&response)
+	out, err := manifest.ApplyAll(manifests, version.OperatorBinaryVersion, opts)
 	if err != nil {
-		return false
+		return fmt.Errorf("failed to apply manifest with kubectl client: %v", err)
 	}
-	response = strings.ToUpper(response)
-	if response == "Y" || response == "YES" {
-		return true
+	gotError := false
+
+	for cn := range manifests {
+		if out[cn].Err != nil {
+			cs := fmt.Sprintf("Component %s - manifest apply returned the following errors:", cn)
+			l.logAndPrintf("\n%s", cs)
+			l.logAndPrint("Error: ", out[cn].Err, "\n")
+			gotError = true
+		}
+
+		if !ignoreError(out[cn].Stderr) {
+			l.logAndPrint("Error detail:\n", out[cn].Stderr, "\n", out[cn].Stdout, "\n")
+			gotError = true
+		}
 	}
 
-	return false
+	if gotError {
+		l.logAndPrint("\n\n✘ Errors were logged during apply operation. Please check component installation logs above.\n")
+		return fmt.Errorf("errors were logged during apply operation")
+	}
+
+	l.logAndPrint("\n\n✔ Installation complete\n")
+	return nil
 }

--- a/operator/cmd/mesh/manifest-common.go
+++ b/operator/cmd/mesh/manifest-common.go
@@ -16,26 +16,16 @@ package mesh
 
 import (
 	"fmt"
-	"istio.io/istio/operator/pkg/object"
-	"path"
-	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/ghodss/yaml"
-	"k8s.io/client-go/rest"
 
 	"istio.io/api/operator/v1alpha1"
-	"istio.io/istio/operator/pkg/component/controlplane"
-	"istio.io/istio/operator/pkg/helm"
-	"istio.io/istio/operator/pkg/kubectlcmd"
-	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/name"
+	"istio.io/istio/operator/pkg/object"
 	"istio.io/istio/operator/pkg/tpath"
-	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/validate"
-	"istio.io/istio/operator/version"
 )
 
 var (
@@ -44,123 +34,6 @@ var (
 		"Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply",
 	}
 )
-
-func genApplyManifests(setOverlay []string, inFilename []string, force bool, dryRun bool, verbose bool,
-	kubeConfigPath string, context string, wait bool, waitTimeout time.Duration, l *Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, *kubectlcmd.Options, error) {
-	opts := &kubectlcmd.Options{
-		DryRun:      dryRun,
-		Verbose:     verbose,
-		Wait:        wait,
-		WaitTimeout: waitTimeout,
-		Kubeconfig:  kubeConfigPath,
-		Context:     context,
-	}
-	if err := manifest.CheckK8sVersion(opts); err != nil {
-		l.logAndError(err)
-	}
-
-	overlayFromSet, err := MakeTreeFromSetList(setOverlay, force, l)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to generate tree from the set overlay, error: %v", err)
-	}
-
-	kubeconfig, err := manifest.InitK8SRestClient(opts.Kubeconfig, opts.Context)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	manifests, iops, err := GenManifests(inFilename, overlayFromSet, force, kubeconfig, l)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to generate manifest: %v", err)
-	}
-
-	for _, cn := range name.DeprecatedNames {
-		DeprecatedComponentManifest := fmt.Sprintf("# %s component has been deprecated.\n", cn)
-		manifests[cn] = append(manifests[cn], DeprecatedComponentManifest)
-	}
-
-	return manifests, iops, opts, nil
-}
-
-func ApplyManifest(manifests name.ManifestMap, iops *v1alpha1.IstioOperatorSpec, opts *kubectlcmd.Options, l *Logger) error {
-	out, err := manifest.ApplyAll(manifests, version.OperatorBinaryVersion, opts)
-	if err != nil {
-		return fmt.Errorf("failed to apply manifest with kubectl client: %v", err)
-	}
-	gotError := false
-	skippedComponentMap := map[name.ComponentName]bool{}
-	for cn := range manifests {
-		enabledInSpec, err := translate.IsComponentEnabledInSpec(cn, iops)
-		if err != nil {
-			l.logAndPrintf("failed to check if %s is enabled in IstioOperatorSpec: %v", cn, err)
-		}
-		// Skip the output of a component when it is disabled
-		// and not pruned (indicated by applied manifest out[cn].Manifest).
-		if !enabledInSpec && out[cn].Err == nil && out[cn].Manifest == "" {
-			skippedComponentMap[cn] = true
-		}
-	}
-
-	for cn := range manifests {
-		if out[cn].Err != nil {
-			cs := fmt.Sprintf("Component %s - manifest apply returned the following errors:", cn)
-			l.logAndPrintf("\n%s", cs)
-			l.logAndPrint("Error: ", out[cn].Err, "\n")
-			gotError = true
-		} else if skippedComponentMap[cn] {
-			continue
-		}
-
-		if !ignoreError(out[cn].Stderr) {
-			l.logAndPrint("Error detail:\n", out[cn].Stderr, "\n", out[cn].Stdout, "\n")
-			gotError = true
-		}
-	}
-
-	if gotError {
-		l.logAndPrint("\n\n✘ Errors were logged during apply operation. Please check component installation logs above.\n")
-		return fmt.Errorf("errors were logged during apply operation")
-	}
-
-	l.logAndPrint("\n\n✔ Installation complete\n")
-	return nil
-}
-
-// GenManifests generate manifest from input file and setOverLay
-func GenManifests(inFilename []string, setOverlayYAML string, force bool,
-	kubeConfig *rest.Config, l *Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, error) {
-	mergedYAML, err := genProfile(false, inFilename, "", setOverlayYAML, "", force, kubeConfig, l)
-	if err != nil {
-		return nil, nil, err
-	}
-	mergedIOPS, err := unmarshalAndValidateIOPS(mergedYAML, force, l)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	t, err := translate.NewTranslator(version.OperatorBinaryVersion.MinorVersion)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := fetchInstallPackageFromURL(mergedIOPS); err != nil {
-		return nil, nil, err
-	}
-
-	cp, err := controlplane.NewIstioOperator(mergedIOPS, t)
-	if err != nil {
-		return nil, nil, err
-	}
-	if err := cp.Run(); err != nil {
-		return nil, nil, fmt.Errorf("failed to create Istio control plane with spec: \n%v\nerror: %s", mergedIOPS, err)
-	}
-
-	manifests, errs := cp.RenderManifest()
-	if errs != nil {
-		return manifests, mergedIOPS, errs.ToError()
-	}
-	return manifests, mergedIOPS, nil
-}
 
 func ignoreError(stderr string) bool {
 	trimmedStdErr := strings.TrimSpace(stderr)
@@ -172,36 +45,24 @@ func ignoreError(stderr string) bool {
 	return trimmedStdErr == ""
 }
 
-// fetchInstallPackageFromURL downloads installation packages from specified URL.
-func fetchInstallPackageFromURL(mergedIOPS *v1alpha1.IstioOperatorSpec) error {
-	if util.IsHTTPURL(mergedIOPS.InstallPackagePath) {
-		pkgPath, err := fetchInstallPackage(mergedIOPS.InstallPackagePath)
-		if err != nil {
-			return err
-		}
-		// TODO: replace with more robust logic to set local file path
-		mergedIOPS.InstallPackagePath = filepath.Join(pkgPath, helm.ChartsFilePath)
-	}
-	return nil
-}
-
-// fetchInstallPackage downloads installation packages from the given url.
-func fetchInstallPackage(url string) (string, error) {
-	uf, err := helm.NewURLFetcher(url, "")
+// yamlFromSetFlags takes a slice of --set flag key-value pairs and returns a YAML tree representation.
+// If force is set, validation errors cause warning messages to be written to logger rather than causing error.
+func yamlFromSetFlags(setOverlay []string, force bool, l *Logger) (string, error) {
+	out, err := makeTreeFromSetList(setOverlay)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to generate tree from the set overlay, error: %v", err)
 	}
-	if err := uf.FetchBundles().ToError(); err != nil {
-		return "", err
+	if err := validate.ValidIOPYAML(out); err != nil {
+		if !force {
+			return "", fmt.Errorf("validation errors (use --force to override): \n%s", err)
+		}
+		l.logAndErrorf("Validation errors (continuing because of --force):\n%s", err)
 	}
-	isp := path.Base(url)
-	// get rid of the suffix, installation package is untared to folder name istio-{version}, e.g. istio-1.3.0
-	idx := strings.LastIndex(isp, "-")
-	return filepath.Join(uf.DestDir(), isp[:idx]), nil
+	return out, nil
 }
 
-// MakeTreeFromSetList creates a YAML tree from a string slice containing key-value pairs in the format key=value.
-func MakeTreeFromSetList(setOverlay []string, force bool, l *Logger) (string, error) {
+// makeTreeFromSetList creates a YAML tree from a string slice containing key-value pairs in the format key=value.
+func makeTreeFromSetList(setOverlay []string) (string, error) {
 	if len(setOverlay) == 0 {
 		return "", nil
 	}
@@ -222,16 +83,9 @@ func MakeTreeFromSetList(setOverlay []string, force bool, l *Logger) (string, er
 			return "", err
 		}
 		iops := &v1alpha1.IstioOperatorSpec{}
-		if err := util.UnmarshalWithJSONPB(string(testTree), iops); err != nil {
+		if err := util.UnmarshalWithJSONPB(string(testTree), iops, false); err != nil {
 			return "", fmt.Errorf("bad path=value: %s", kv)
 		}
-		if errs := validate.CheckIstioOperatorSpec(iops, true); len(errs) != 0 {
-			if !force {
-				l.logAndError("Run the command with the --force flag if you want to ignore the validation error and proceed.")
-				return "", fmt.Errorf("bad path=value (%s): %s", kv, errs)
-			}
-		}
-
 	}
 	out, err := yaml.Marshal(tree)
 	if err != nil {
@@ -242,7 +96,7 @@ func MakeTreeFromSetList(setOverlay []string, force bool, l *Logger) (string, er
 
 func generateDefaultTelemetryManifest(l *Logger) (map[string]*object.K8sObject, error) {
 	setOverlay := []string{"components.telemetry.enabled=true"}
-	overlay, err := MakeTreeFromSetList(setOverlay, false, l)
+	overlay, err := makeTreeFromSetList(setOverlay)
 	manifestMap, _, err := GenManifests(nil, overlay, false, nil, nil)
 	if err != nil {
 		return nil, err

--- a/operator/cmd/mesh/manifest-common.go
+++ b/operator/cmd/mesh/manifest-common.go
@@ -16,14 +16,26 @@ package mesh
 
 import (
 	"fmt"
+	"istio.io/istio/operator/pkg/object"
+	"path"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ghodss/yaml"
+	"k8s.io/client-go/rest"
 
 	"istio.io/api/operator/v1alpha1"
+	"istio.io/istio/operator/pkg/component/controlplane"
+	"istio.io/istio/operator/pkg/helm"
+	"istio.io/istio/operator/pkg/kubectlcmd"
+	"istio.io/istio/operator/pkg/manifest"
+	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/tpath"
+	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/validate"
+	"istio.io/istio/operator/version"
 )
 
 var (
@@ -32,6 +44,123 @@ var (
 		"Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply",
 	}
 )
+
+func genApplyManifests(setOverlay []string, inFilename []string, force bool, dryRun bool, verbose bool,
+	kubeConfigPath string, context string, wait bool, waitTimeout time.Duration, l *Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, *kubectlcmd.Options, error) {
+	opts := &kubectlcmd.Options{
+		DryRun:      dryRun,
+		Verbose:     verbose,
+		Wait:        wait,
+		WaitTimeout: waitTimeout,
+		Kubeconfig:  kubeConfigPath,
+		Context:     context,
+	}
+	if err := manifest.CheckK8sVersion(opts); err != nil {
+		l.logAndError(err)
+	}
+
+	overlayFromSet, err := MakeTreeFromSetList(setOverlay, force, l)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate tree from the set overlay, error: %v", err)
+	}
+
+	kubeconfig, err := manifest.InitK8SRestClient(opts.Kubeconfig, opts.Context)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	manifests, iops, err := GenManifests(inFilename, overlayFromSet, force, kubeconfig, l)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate manifest: %v", err)
+	}
+
+	for _, cn := range name.DeprecatedNames {
+		DeprecatedComponentManifest := fmt.Sprintf("# %s component has been deprecated.\n", cn)
+		manifests[cn] = append(manifests[cn], DeprecatedComponentManifest)
+	}
+
+	return manifests, iops, opts, nil
+}
+
+func ApplyManifest(manifests name.ManifestMap, iops *v1alpha1.IstioOperatorSpec, opts *kubectlcmd.Options, l *Logger) error {
+	out, err := manifest.ApplyAll(manifests, version.OperatorBinaryVersion, opts)
+	if err != nil {
+		return fmt.Errorf("failed to apply manifest with kubectl client: %v", err)
+	}
+	gotError := false
+	skippedComponentMap := map[name.ComponentName]bool{}
+	for cn := range manifests {
+		enabledInSpec, err := translate.IsComponentEnabledInSpec(cn, iops)
+		if err != nil {
+			l.logAndPrintf("failed to check if %s is enabled in IstioOperatorSpec: %v", cn, err)
+		}
+		// Skip the output of a component when it is disabled
+		// and not pruned (indicated by applied manifest out[cn].Manifest).
+		if !enabledInSpec && out[cn].Err == nil && out[cn].Manifest == "" {
+			skippedComponentMap[cn] = true
+		}
+	}
+
+	for cn := range manifests {
+		if out[cn].Err != nil {
+			cs := fmt.Sprintf("Component %s - manifest apply returned the following errors:", cn)
+			l.logAndPrintf("\n%s", cs)
+			l.logAndPrint("Error: ", out[cn].Err, "\n")
+			gotError = true
+		} else if skippedComponentMap[cn] {
+			continue
+		}
+
+		if !ignoreError(out[cn].Stderr) {
+			l.logAndPrint("Error detail:\n", out[cn].Stderr, "\n", out[cn].Stdout, "\n")
+			gotError = true
+		}
+	}
+
+	if gotError {
+		l.logAndPrint("\n\n✘ Errors were logged during apply operation. Please check component installation logs above.\n")
+		return fmt.Errorf("errors were logged during apply operation")
+	}
+
+	l.logAndPrint("\n\n✔ Installation complete\n")
+	return nil
+}
+
+// GenManifests generate manifest from input file and setOverLay
+func GenManifests(inFilename []string, setOverlayYAML string, force bool,
+	kubeConfig *rest.Config, l *Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, error) {
+	mergedYAML, err := genProfile(false, inFilename, "", setOverlayYAML, "", force, kubeConfig, l)
+	if err != nil {
+		return nil, nil, err
+	}
+	mergedIOPS, err := unmarshalAndValidateIOPS(mergedYAML, force, l)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t, err := translate.NewTranslator(version.OperatorBinaryVersion.MinorVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := fetchInstallPackageFromURL(mergedIOPS); err != nil {
+		return nil, nil, err
+	}
+
+	cp, err := controlplane.NewIstioOperator(mergedIOPS, t)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cp.Run(); err != nil {
+		return nil, nil, fmt.Errorf("failed to create Istio control plane with spec: \n%v\nerror: %s", mergedIOPS, err)
+	}
+
+	manifests, errs := cp.RenderManifest()
+	if errs != nil {
+		return manifests, mergedIOPS, errs.ToError()
+	}
+	return manifests, mergedIOPS, nil
+}
 
 func ignoreError(stderr string) bool {
 	trimmedStdErr := strings.TrimSpace(stderr)
@@ -43,24 +172,36 @@ func ignoreError(stderr string) bool {
 	return trimmedStdErr == ""
 }
 
-// yamlFromSetFlags takes a slice of --set flag key-value pairs and returns a YAML tree representation.
-// If force is set, validation errors cause warning messages to be written to logger rather than causing error.
-func yamlFromSetFlags(setOverlay []string, force bool, l *Logger) (string, error) {
-	out, err := makeTreeFromSetList(setOverlay)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate tree from the set overlay, error: %v", err)
-	}
-	if err := validate.ValidIOPYAML(out); err != nil {
-		if !force {
-			return "", fmt.Errorf("validation errors (use --force to override): \n%s", err)
+// fetchInstallPackageFromURL downloads installation packages from specified URL.
+func fetchInstallPackageFromURL(mergedIOPS *v1alpha1.IstioOperatorSpec) error {
+	if util.IsHTTPURL(mergedIOPS.InstallPackagePath) {
+		pkgPath, err := fetchInstallPackage(mergedIOPS.InstallPackagePath)
+		if err != nil {
+			return err
 		}
-		l.logAndErrorf("Validation errors (continuing because of --force):\n%s", err)
+		// TODO: replace with more robust logic to set local file path
+		mergedIOPS.InstallPackagePath = filepath.Join(pkgPath, helm.ChartsFilePath)
 	}
-	return out, nil
+	return nil
 }
 
-// makeTreeFromSetList creates a YAML tree from a string slice containing key-value pairs in the format key=value.
-func makeTreeFromSetList(setOverlay []string) (string, error) {
+// fetchInstallPackage downloads installation packages from the given url.
+func fetchInstallPackage(url string) (string, error) {
+	uf, err := helm.NewURLFetcher(url, "")
+	if err != nil {
+		return "", err
+	}
+	if err := uf.FetchBundles().ToError(); err != nil {
+		return "", err
+	}
+	isp := path.Base(url)
+	// get rid of the suffix, installation package is untared to folder name istio-{version}, e.g. istio-1.3.0
+	idx := strings.LastIndex(isp, "-")
+	return filepath.Join(uf.DestDir(), isp[:idx]), nil
+}
+
+// MakeTreeFromSetList creates a YAML tree from a string slice containing key-value pairs in the format key=value.
+func MakeTreeFromSetList(setOverlay []string, force bool, l *Logger) (string, error) {
 	if len(setOverlay) == 0 {
 		return "", nil
 	}
@@ -81,13 +222,35 @@ func makeTreeFromSetList(setOverlay []string) (string, error) {
 			return "", err
 		}
 		iops := &v1alpha1.IstioOperatorSpec{}
-		if err := util.UnmarshalWithJSONPB(string(testTree), iops, false); err != nil {
+		if err := util.UnmarshalWithJSONPB(string(testTree), iops); err != nil {
 			return "", fmt.Errorf("bad path=value: %s", kv)
 		}
+		if errs := validate.CheckIstioOperatorSpec(iops, true); len(errs) != 0 {
+			if !force {
+				l.logAndError("Run the command with the --force flag if you want to ignore the validation error and proceed.")
+				return "", fmt.Errorf("bad path=value (%s): %s", kv, errs)
+			}
+		}
+
 	}
 	out, err := yaml.Marshal(tree)
 	if err != nil {
 		return "", err
 	}
-	return tpath.AddSpecRoot(string(out))
+	return string(out), nil
+}
+
+func generateDefaultTelemetryManifest(l *Logger) (map[string]*object.K8sObject, error) {
+	setOverlay := []string{"components.telemetry.enabled=true"}
+	overlay, err := MakeTreeFromSetList(setOverlay, false, l)
+	manifestMap, _, err := GenManifests(nil, overlay, false, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	k8sObjects, err := object.ParseK8sObjectsFromYAMLManifest(manifestMap[name.TelemetryComponentName][0])
+	if err != nil {
+		return nil, err
+	}
+	return k8sObjects.ToNameKindMap(), nil
 }

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -146,7 +146,9 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *Logger) (err error) {
 	if err != nil && !args.force {
 		return fmt.Errorf("failed to read the current Istio version, error: %v", err)
 	}
-	
+
+	currentVersion = "1.3.0"
+	targetVersion = "1.4.3"
 	// Check if the upgrade currentVersion -> targetVersion is supported
 	err = checkSupportedVersions(currentVersion, targetVersion, args.versionsURI)
 	if err != nil && !args.force {

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -176,24 +176,20 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *Logger) (err error) {
 
 	waitForConfirmation(args.skipConfirmation, l)
 
-	// Apply the Istio Control Plane specs reading from inFilename to the cluster
-	manifests, iop, opts, err := genApplyManifests(nil, args.inFilename, args.force, rootArgs.dryRun,
-		rootArgs.verbose, args.kubeConfigPath, args.context, args.wait, upgradeWaitSecWhenApply, l)
-	if err != nil {
-		return fmt.Errorf("failed to generate the manifests. Error: %v", err)
-	}
-
-	err = RunPreUpgradeHooks(kubeClient, rootArgs, args, l)
+	err = runPreUpgradeHooks(kubeClient, rootArgs, args, l)
 	if err != nil && !args.force {
 		return fmt.Errorf("failed in pre-upgrade hooks, error: %v", err)
 	}
 
-	if err := ApplyManifest(manifests, iop, opts, l); err != nil {
-		return fmt.Errorf("failed to apply manifests, error: %v", err)
+	// Apply the Istio Control Plane specs reading from inFilenames to the cluster
+	err = ApplyManifests(nil, args.inFilenames, args.force, rootArgs.dryRun,
+		rootArgs.verbose, args.kubeConfigPath, args.context, args.wait, upgradeWaitSecWhenApply, l)
+	if err != nil {
+		return fmt.Errorf("failed to apply the Istio Control Plane specs. Error: %v", err)
 	}
 
 	// Run post-upgrade hooks
-	err = RunPostUpgradeHooks(kubeClient, rootArgs, args, l)
+	err = runPostUpgradeHooks(kubeClient, rootArgs, args, l)
 
 	if err != nil && !args.force {
 		return fmt.Errorf("failed in post-upgrade hooks, error: %v", err)

--- a/operator/pkg/hooks/hooks_common.go
+++ b/operator/pkg/hooks/hooks_common.go
@@ -1,0 +1,210 @@
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/hashicorp/go-version"
+
+	"istio.io/api/operator/v1alpha1"
+	"istio.io/istio/operator/pkg/manifest"
+	"istio.io/istio/operator/pkg/object"
+	"istio.io/istio/operator/pkg/util"
+	"istio.io/pkg/log"
+)
+
+// hook is a callout function that may be called during an upgrade to check state or modify the cluster.
+// hooks should only be used for version-specific actions.
+type hook func(kubeClient manifest.ExecClient, params HookCommonParams) util.Errors
+type hooks []hook
+
+// hookVersionMapping is a mapping between a hashicorp/go-version formatted constraints for the source and target
+// versions and the list of hooks that should be run if the constraints match.
+type hookVersionMapping struct {
+	sourceVersionConstraint string
+	targetVersionConstraint string
+	hooks                   hooks
+}
+
+// HookCommonParams is a set of common params passed to all hooks.
+type HookCommonParams struct {
+	SourceVer                string
+	TargetVer                string
+	DefaultTelemetryManifest map[string]*object.K8sObject
+	SourceIOPS               *v1alpha1.IstioOperatorSpec
+	TargetIOPS               *v1alpha1.IstioOperatorSpec
+}
+
+var (
+	// TODO: add full list
+	CRKindNamesMap = map[string][]string{
+		"instance": {"requestsize", "requestcount, requestduration", "attributes"},
+		"rule":     {"promhttp", "kubeattrgenrulerule"},
+		"handler":  {"prometheus", "kubernetesenv"},
+	}
+
+	KindResourceMap = map[string]string{
+		"instance": "instances",
+		"rule":     "rules",
+		"handler":  "handlers",
+	}
+)
+
+const (
+	// TODO: Instead of failing the upgrade request to v2, give a helpful message and fallback to mixerv1 installation.
+	CustomMixerHelpMessage = ""
+)
+
+// runUpgradeHooks checks a list of hook version map entries and runs the hooks in each entry whose constraints match
+// the source/target versions in hc.
+func runUpgradeHooks(hml []hookVersionMapping, kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
+	var errs util.Errors
+	_, err := version.NewVersion(hc.SourceVer)
+	if err != nil {
+		return util.NewErrs(err)
+	}
+	_, err = version.NewVersion(hc.TargetVer)
+	if err != nil {
+		return util.NewErrs(err)
+	}
+
+	for _, h := range hml {
+		matches, err := checkHookListEntry(h, hc)
+		if err != nil {
+			errs = util.AppendErr(errs, err)
+			continue
+		}
+		if !matches {
+			continue
+		}
+		log.Infof("Running the following hooks which match source->target versions %s->%s: %s", hc.SourceVer, hc.TargetVer, h.hooks)
+		if dryRun {
+			log.Info("(Skipping running hooks due to dry-run being set.)")
+			continue
+		}
+		for _, hf := range h.hooks {
+			log.Infof("Running hook %s", hf)
+			errs = util.AppendErrs(errs, hf(kubeClient, *hc))
+		}
+	}
+	return errs
+}
+
+// checkHookListEntry checks a hookVersionMapping against the source/target versions in hc and returns true if it
+// matches.
+func checkHookListEntry(h hookVersionMapping, hc *HookCommonParams) (bool, error) {
+	ch, err := checkConstraint(hc.SourceVer, h.sourceVersionConstraint)
+	if err != nil {
+		return false, err
+	}
+	if !ch {
+		log.Infof("Source version %s does not satisfy source constraint %s, skip hooks", hc.SourceVer, h.sourceVersionConstraint)
+		return false, nil
+	}
+
+	ch, err = checkConstraint(hc.TargetVer, h.targetVersionConstraint)
+	if err != nil {
+		return false, err
+	}
+	if !ch {
+		log.Infof("Target version %s does not satisfy target constraint %s, skip hooks", hc.TargetVer, h.targetVersionConstraint)
+		return false, nil
+	}
+	return true, nil
+}
+
+// checkConstraint reports whether SemVer formatted string verStr matches hashicorp/go-version formatted constraints
+// in constraintStr.
+func checkConstraint(verStr, constraintStr string) (bool, error) {
+	ver, err := version.NewVersion(verStr)
+	if err != nil {
+		return false, err
+	}
+	constraint, err := version.NewConstraint(constraintStr)
+	if err != nil {
+		return false, err
+	}
+	return constraint.Check(ver), nil
+}
+
+// checkMixerTelemetry compares default mixer telemetry configs with corresponding in-cluster configs
+// consider these cases with difference:
+// 1. new in-cluster CR which does not exists in default configs
+// 2. same CR but with difference in fields
+// 3. remove CR from default configs(upgrade can proceed for this case)
+func checkMixerTelemetry(kubeClient manifest.ExecClient, params HookCommonParams) util.Errors {
+	knMapDefault, err := extractTargetKNMapFromDefault(params.DefaultTelemetryManifest)
+	if err != nil {
+		return util.NewErrs(err)
+	}
+	knMapCluster, err := extractKNMapFromCluster(kubeClient)
+	if err != nil {
+		return util.NewErrs(err)
+	}
+
+	for nk, inclusterCR := range knMapCluster {
+		defaultCR, ok := knMapDefault[nk]
+		if !ok {
+			// for case 1
+			return util.NewErrs(fmt.Errorf("there are extra non default mixer configs in cluster " + CustomMixerHelpMessage))
+		}
+		// for case 2
+		diff := util.YAMLDiff(defaultCR, inclusterCR)
+		if diff != "" {
+			return util.NewErrs(fmt.Errorf("customized config exists for %s,"+
+				" diff is: %s. \n" + CustomMixerHelpMessage, nk, diff))
+		}
+	}
+	return nil
+}
+
+func extractTargetKNMapFromDefault(nkMap map[string]*object.K8sObject) (map[string]string, error) {
+	checkMap := make(map[string]string)
+	for kind, names := range CRKindNamesMap {
+		for _, name := range names {
+			knKey := kind + ":" + name
+			msObject, ok := nkMap[knKey]
+			if !ok {
+				continue
+			}
+			item := msObject.GetObject()
+			spec, ok := item.UnstructuredContent()["spec"].(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("failed to get spec from unstructured item"+
+					" of kind: %s, name: %s", kind, name)
+			}
+			specYAML, err := yaml.Marshal(spec)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal spec of kind: %s, name: %s", kind, name)
+			}
+			checkMap[knKey] = string(specYAML)
+		}
+	}
+	return checkMap, nil
+}
+
+func extractKNMapFromCluster(kubeClient manifest.ExecClient) (map[string]string, error) {
+	knYAMLMap := make(map[string]string)
+	for kind := range CRKindNamesMap {
+		uls, err := kubeClient.GetGroupVersionResource(configAPIGroup, configAPIVersion, KindResourceMap[kind], istioNamespace, "")
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range uls.Items {
+			meta, _ := item.UnstructuredContent()["metadata"].(map[string]interface{})
+			name, _ := meta["name"].(string)
+			spec, ok := item.UnstructuredContent()["spec"].(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("failed to get spec from unstructured item"+
+					" of kind: %s, name: %s", kind, name)
+			}
+			specYAML, err := yaml.Marshal(spec)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal spec of kind: %s, name: %s", kind, name)
+			}
+			key := kind + ":" + name
+			knYAMLMap[key] = string(specYAML)
+		}
+	}
+	return knYAMLMap, nil
+}

--- a/operator/pkg/hooks/hooks_common.go
+++ b/operator/pkg/hooks/hooks_common.go
@@ -36,7 +36,7 @@ type HookCommonParams struct {
 }
 
 var (
-	// TODO: add full list
+	// TODO: [richardwxn] check only http related resources now, add TCP later.
 	CRKindNamesMap = map[string][]string{
 		"instance": {"requestsize", "requestcount, requestduration", "attributes"},
 		"rule":     {"promhttp", "kubeattrgenrulerule"},
@@ -51,13 +51,16 @@ var (
 )
 
 const (
-	// TODO: Instead of failing the upgrade request to v2, give a helpful message and fallback to mixerv1 installation.
-	CustomMixerHelpMessage = ""
+	// Instead of failing the upgrade request to v2, give a helpful message and fallback to mixerv1 installation.
+	// TODO: expose option for v2 templates so user can customize.
+	CustomizedMixerHelpMessage = "Mixer(deprecated) would be installed.\n" +
+		" Please remove the mixer customized resources first and update the v2 filters accordingly,\n" +
+		"or run with --force flag to ignore the customization and proceed with the telemetry v2 installation\n"
 )
 
-// runUpgradeHooks checks a list of hook version map entries and runs the hooks in each entry whose constraints match
+// runHooks checks a list of hook version map entries and runs the hooks in each entry whose constraints match
 // the source/target versions in hc.
-func runUpgradeHooks(hml []hookVersionMapping, kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
+func runHooks(hml []hookVersionMapping, kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
 	var errs util.Errors
 	_, err := version.NewVersion(hc.SourceVer)
 	if err != nil {
@@ -146,13 +149,13 @@ func checkMixerTelemetry(kubeClient manifest.ExecClient, params HookCommonParams
 		defaultCR, ok := knMapDefault[nk]
 		if !ok {
 			// for case 1
-			return util.NewErrs(fmt.Errorf("there are extra non default mixer configs in cluster " + CustomMixerHelpMessage))
+			return util.NewErrs(fmt.Errorf("there are extra non default mixer configs in cluster " + CustomizedMixerHelpMessage))
 		}
 		// for case 2
 		diff := util.YAMLDiff(defaultCR, inclusterCR)
 		if diff != "" {
 			return util.NewErrs(fmt.Errorf("customized config exists for %s,"+
-				" diff is: %s. \n" + CustomMixerHelpMessage, nk, diff))
+				" diff is: %s. \n" + CustomizedMixerHelpMessage, nk, diff))
 		}
 	}
 	return nil

--- a/operator/pkg/hooks/manifest_apply_hooks.go
+++ b/operator/pkg/hooks/manifest_apply_hooks.go
@@ -1,0 +1,30 @@
+package hooks
+
+import (
+	"istio.io/istio/operator/pkg/manifest"
+	"istio.io/istio/operator/pkg/util"
+)
+
+var (
+	// preManifestApplyHooks is a list of hook version constraint pairs mapping to a slide of corresponding hooks to run
+	// before manifest apply.
+	preManifestApplyHooks = []hookVersionMapping{
+		{
+			sourceVersionConstraint: ">=1.4",
+			targetVersionConstraint: ">=1.4",
+			hooks:                   []hook{checkMixerTelemetry},
+		},
+	}
+	// postManifestApplyHooks is a list of hook version constraint pairs mapping to a slide of corresponding hooks to run
+	// before manifest apply.
+	postManifestApplyHooks []hookVersionMapping
+)
+
+
+func RunPreManifestApplyHooks(kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
+	return runUpgradeHooks(preManifestApplyHooks, kubeClient, hc, dryRun)
+}
+
+func RunPostManifestApplyHooks(kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
+	return runUpgradeHooks(postManifestApplyHooks, kubeClient, hc, dryRun)
+}

--- a/operator/pkg/hooks/manifest_apply_hooks.go
+++ b/operator/pkg/hooks/manifest_apply_hooks.go
@@ -11,7 +11,7 @@ var (
 	preManifestApplyHooks = []hookVersionMapping{
 		{
 			sourceVersionConstraint: ">=1.4",
-			targetVersionConstraint: ">=1.4",
+			targetVersionConstraint: ">=1.5",
 			hooks:                   []hook{checkMixerTelemetry},
 		},
 	}
@@ -22,9 +22,9 @@ var (
 
 
 func RunPreManifestApplyHooks(kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
-	return runUpgradeHooks(preManifestApplyHooks, kubeClient, hc, dryRun)
+	return runHooks(preManifestApplyHooks, kubeClient, hc, dryRun)
 }
 
 func RunPostManifestApplyHooks(kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
-	return runUpgradeHooks(postManifestApplyHooks, kubeClient, hc, dryRun)
+	return runHooks(postManifestApplyHooks, kubeClient, hc, dryRun)
 }

--- a/operator/pkg/hooks/upgrade_hooks.go
+++ b/operator/pkg/hooks/upgrade_hooks.go
@@ -26,41 +26,14 @@ import (
 	"istio.io/api/operator/v1alpha1"
 	iop "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/manifest"
-	"istio.io/istio/operator/pkg/object"
 	"istio.io/istio/operator/pkg/util"
-	"istio.io/pkg/log"
 )
 
 const (
 	configAPIGroup   = "config.istio.io"
 	configAPIVersion = "v1alpha2"
-	instanceResource = "instances"
-	ruleResource     = "rules"
-	handlerResource  = "handlers"
 	istioNamespace   = "istio-system"
 )
-
-// hook is a callout function that may be called during an upgrade to check state or modify the cluster.
-// hooks should only be used for version-specific actions.
-type hook func(kubeClient manifest.ExecClient, params HookCommonParams) util.Errors
-type hooks []hook
-
-// hookVersionMapping is a mapping between a hashicorp/go-version formatted constraints for the source and target
-// versions and the list of hooks that should be run if the constraints match.
-type hookVersionMapping struct {
-	sourceVersionConstraint string
-	targetVersionConstraint string
-	hooks                   hooks
-}
-
-// HookCommonParams is a set of common params passed to all hooks.
-type HookCommonParams struct {
-	SourceVer                string
-	TargetVer                string
-	DefaultTelemetryManifest map[string]*object.K8sObject
-	SourceIOPS               *v1alpha1.IstioOperatorSpec
-	TargetIOPS               *v1alpha1.IstioOperatorSpec
-}
 
 var (
 	// preUpgradeHooks is a list of hook version constraint pairs mapping to a slide of corresponding hooks to run
@@ -75,19 +48,6 @@ var (
 	// postUpgradeHooks is a list of hook version constraint pairs mapping to a slide of corresponding hooks to run
 	// before upgrade.
 	postUpgradeHooks []hookVersionMapping
-
-	// TODO: add full list
-	CRKindNamesMap = map[string][]string{
-		"instance": {"requestsize", "requestcount, requestduration", "attributes"},
-		"rule":     {"promhttp", "kubeattrgenrulerule"},
-		"handler":  {"prometheus", "kubernetesenv"},
-	}
-
-	KindResourceMap = map[string]string{
-		"instance": "instances",
-		"rule":     "rules",
-		"handler":  "handlers",
-	}
 )
 
 func RunPreUpgradeHooks(kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
@@ -96,160 +56,6 @@ func RunPreUpgradeHooks(kubeClient manifest.ExecClient, hc *HookCommonParams, dr
 
 func RunPostUpgradeHooks(kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
 	return runUpgradeHooks(postUpgradeHooks, kubeClient, hc, dryRun)
-}
-
-// runUpgradeHooks checks a list of hook version map entries and runs the hooks in each entry whose constraints match
-// the source/target versions in hc.
-func runUpgradeHooks(hml []hookVersionMapping, kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
-	var errs util.Errors
-	_, err := version.NewVersion(hc.SourceVer)
-	if err != nil {
-		return util.NewErrs(err)
-	}
-	_, err = version.NewVersion(hc.TargetVer)
-	if err != nil {
-		return util.NewErrs(err)
-	}
-
-	for _, h := range hml {
-		matches, err := checkHookListEntry(h, hc)
-		if err != nil {
-			errs = util.AppendErr(errs, err)
-			continue
-		}
-		if !matches {
-			continue
-		}
-		log.Infof("Running the following hooks which match source->target versions %s->%s: %s", hc.SourceVer, hc.TargetVer, h.hooks)
-		if dryRun {
-			log.Info("(Skipping running hooks due to dry-run being set.)")
-			continue
-		}
-		for _, hf := range h.hooks {
-			log.Infof("Running hook %s", hf)
-			errs = util.AppendErrs(errs, hf(kubeClient, *hc))
-		}
-	}
-	return errs
-}
-
-// checkHookListEntry checks a hookVersionMapping against the source/target versions in hc and returns true if it
-// matches.
-func checkHookListEntry(h hookVersionMapping, hc *HookCommonParams) (bool, error) {
-	ch, err := checkConstraint(hc.SourceVer, h.sourceVersionConstraint)
-	if err != nil {
-		return false, err
-	}
-	if !ch {
-		log.Infof("Source version %s does not satisfy source constraint %s, skip hooks", hc.SourceVer, h.sourceVersionConstraint)
-		return false, nil
-	}
-
-	ch, err = checkConstraint(hc.TargetVer, h.targetVersionConstraint)
-	if err != nil {
-		return false, err
-	}
-	if !ch {
-		log.Infof("Target version %s does not satisfy target constraint %s, skip hooks", hc.TargetVer, h.targetVersionConstraint)
-		return false, nil
-	}
-	return true, nil
-}
-
-// checkConstraint reports whether SemVer formatted string verStr matches hashicorp/go-version formatted constraints
-// in constraintStr.
-func checkConstraint(verStr, constraintStr string) (bool, error) {
-	ver, err := version.NewVersion(verStr)
-	if err != nil {
-		return false, err
-	}
-	constraint, err := version.NewConstraint(constraintStr)
-	if err != nil {
-		return false, err
-	}
-	return constraint.Check(ver), nil
-}
-
-// checkMixerTelemetry compares default mixer telemetry configs with corresponding in-cluster configs
-// consider these cases with difference:
-// 1. new in-cluster CR which does not exists in default configs
-// 2. same CR but with difference in fields
-// 3. remove CR from default configs(upgrade can proceed for this case)
-func checkMixerTelemetry(kubeClient manifest.ExecClient, params HookCommonParams) util.Errors {
-	knMapDefault, err := extractTargetKNMapFromDefault(params.DefaultTelemetryManifest)
-	if err != nil {
-		return util.NewErrs(err)
-	}
-	knMapCluster, err := extractKNMapFromCluster(kubeClient)
-	if err != nil {
-		return util.NewErrs(err)
-	}
-
-	for nk, inclusterCR := range knMapCluster {
-		defaultCR, ok := knMapDefault[nk]
-		if !ok {
-			// for case 1
-			return util.NewErrs(fmt.Errorf("there are extra mixer configs in cluster"))
-		}
-		// for case 2
-		diff := util.YAMLDiff(defaultCR, inclusterCR)
-		if diff != "" {
-			return util.NewErrs(fmt.Errorf("customized config exists for %s,"+
-				" diff is: %s. please check existing mixer config first before upgrade", nk, diff))
-		}
-	}
-	return nil
-}
-
-func extractTargetKNMapFromDefault(nkMap map[string]*object.K8sObject) (map[string]string, error) {
-	checkMap := make(map[string]string)
-	for kind, names := range CRKindNamesMap {
-		for _, name := range names {
-			knKey := kind + ":" + name
-			msObject, ok := nkMap[knKey]
-			if !ok {
-				continue
-			}
-			item := msObject.GetObject()
-			spec, ok := item.UnstructuredContent()["spec"].(map[string]interface{})
-			if !ok {
-				return nil, fmt.Errorf("failed to get spec from unstructured item"+
-						" of kind: %s, name: %s", kind, name)
-			}
-			specYAML, err := yaml.Marshal(spec)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal spec of kind: %s, name: %s", kind, name)
-			}
-			checkMap[knKey] = string(specYAML)
-		}
-	}
-	return checkMap, nil
-}
-
-func extractKNMapFromCluster(kubeClient manifest.ExecClient) (map[string]string, error) {
-	knYAMLMap := make(map[string]string)
-	for kind := range CRKindNamesMap {
-		uls, err := kubeClient.GetGroupVersionResource(configAPIGroup, configAPIVersion, KindResourceMap[kind], istioNamespace, "")
-		if err != nil {
-			return nil, err
-		}
-		for _, item := range uls.Items {
-			meta, _ := item.UnstructuredContent()["metadata"].(map[string]interface{})
-			name, _ := meta["name"].(string)
-			spec, ok := item.UnstructuredContent()["spec"].(map[string]interface{})
-			if !ok {
-				return nil, fmt.Errorf("failed to get spec from unstructured item"+
-					" of kind: %s, name: %s", kind, name)
-			}
-			specYAML, err := yaml.Marshal(spec)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal spec of kind: %s, name: %s", kind, name)
-			}
-			key := kind + ":" + name
-			knYAMLMap[key] = string(specYAML)
-		}
-	}
-	return knYAMLMap, nil
 }
 
 func checkInitCrdJobs(kubeClient manifest.ExecClient, params HookCommonParams) util.Errors {

--- a/operator/pkg/hooks/upgrade_hooks.go
+++ b/operator/pkg/hooks/upgrade_hooks.go
@@ -20,11 +20,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/ghodss/yaml"
-	"github.com/hashicorp/go-version"
-
-	"istio.io/api/operator/v1alpha1"
-	iop "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/util"
 )
@@ -51,11 +46,11 @@ var (
 )
 
 func RunPreUpgradeHooks(kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
-	return runUpgradeHooks(preUpgradeHooks, kubeClient, hc, dryRun)
+	return runHooks(preUpgradeHooks, kubeClient, hc, dryRun)
 }
 
 func RunPostUpgradeHooks(kubeClient manifest.ExecClient, hc *HookCommonParams, dryRun bool) util.Errors {
-	return runUpgradeHooks(postUpgradeHooks, kubeClient, hc, dryRun)
+	return runHooks(postUpgradeHooks, kubeClient, hc, dryRun)
 }
 
 func checkInitCrdJobs(kubeClient manifest.ExecClient, params HookCommonParams) util.Errors {

--- a/operator/pkg/hooks/upgrade_hooks_test.go
+++ b/operator/pkg/hooks/upgrade_hooks_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"istio.io/api/operator/v1alpha1"
 	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/util"
 )
@@ -31,13 +30,13 @@ var (
 	err3 = fmt.Errorf("err3")
 )
 
-func h1(_ manifest.ExecClient, _, _ *v1alpha1.IstioOperatorSpec) util.Errors {
+func h1(_ manifest.ExecClient, _ HookCommonParams) util.Errors {
 	return util.NewErrs(err1)
 }
-func h2(_ manifest.ExecClient, _, _ *v1alpha1.IstioOperatorSpec) util.Errors {
+func h2(_ manifest.ExecClient, _ HookCommonParams) util.Errors {
 	return util.NewErrs(err2)
 }
-func h3(_ manifest.ExecClient, _, _ *v1alpha1.IstioOperatorSpec) util.Errors {
+func h3(_ manifest.ExecClient, _ HookCommonParams) util.Errors {
 	return util.NewErrs(err3)
 }
 

--- a/operator/pkg/manifest/client.go
+++ b/operator/pkg/manifest/client.go
@@ -74,6 +74,19 @@ func NewClient(kubeconfig, configContext string) (*Client, error) {
 	return &Client{Config: config, restClient: restClient, dynamicClient: dynamicClient}, nil
 }
 
+// NewClient is the constructor for the client wrapper
+func NewClientFromConfig(config *rest.Config) (*Client, error) {
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
+	}
+	return &Client{Config: config, restClient: restClient, dynamicClient: dynamicClient}, nil
+}
+
 // GetIstioVersions gets the version for each Istio component
 func (client *Client) GetIstioVersions(namespace string) ([]ComponentVersion, error) {
 	pods, err := client.GetPods(namespace, map[string]string{

--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -190,6 +190,11 @@ func (o *K8sObject) YAMLDebugString() string {
 	return string(y)
 }
 
+// GetObject returns the unstructured object of the K8sObject.
+func(o K8sObject) GetObject() *unstructured.Unstructured {
+	return o.object
+}
+
 // AddLabels adds labels to the K8sObject.
 // This method will override the value if there is already label with the same key.
 func (o *K8sObject) AddLabels(labels map[string]string) {


### PR DESCRIPTION
Add upgrade hook to check in-cluster mixer config with the default one before upgrading to telemetryv2. Ideally we should find out the existing istio version and then find out the mixer configs  for that version. But it doesn't make sense to keep the old versioned mixer config resources with istioctl. Also, considering that the mixer default configs doesn't change between 1.4 and 1.5, we can generate the default mixer configs from installation manifests of 1.5.

TODO:
1. only run this hook if user want to enable telemetryv2 
2. see whether this can be added to manifest apply hook
3. add tests