### PR TITLE
Meshpolicy is a clusterwide resource

### DIFF
--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -74,7 +74,7 @@ func NewK8sObject(u *unstructured.Unstructured, json, yaml []byte) *K8sObject {
 func Hash(kind, namespace, name string) string {
 	switch kind {
 	// TODO: replace strings with k8s const (istio/istio#17237).
-	case "ClusterRole", "ClusterRoleBinding":
+	case "ClusterRole", "ClusterRoleBinding", "MeshPolicy":
 		namespace = ""
 	}
 	return strings.Join([]string{kind, namespace, name}, ":")


### PR DESCRIPTION
Meshpolicy is a clusterwide resource and therefor it does not have a namespace.



[ X] Configuration Infrastructure
[ ] Docs
[ X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure