### PR TITLE
Optimize namespace controller in Pilot

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -157,7 +157,7 @@ func (s *Server) EnableCA() bool {
 // Protected by installer options: the CA will be started only if the JWT token in /var/run/secrets
 // is mounted. If it is missing - for example old versions of K8S that don't support such tokens -
 // we will not start the cert-signing server, since pods will have no way to authenticate.
-func (s *Server) RunCA(grpc *grpc.Server, ca *ca.IstioCA, opts *CAOptions, stopCh <-chan struct{}) {
+func (s *Server) RunCA(grpc *grpc.Server, ca *caserver.CertificateAuthority, opts *CAOptions, stopCh <-chan struct{}) {
 	if !s.EnableCA() {
 		return
 	}

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -157,7 +157,7 @@ func (s *Server) EnableCA() bool {
 // Protected by installer options: the CA will be started only if the JWT token in /var/run/secrets
 // is mounted. If it is missing - for example old versions of K8S that don't support such tokens -
 // we will not start the cert-signing server, since pods will have no way to authenticate.
-func (s *Server) RunCA(grpc *grpc.Server, ca *caserver.CertificateAuthority, opts *CAOptions, stopCh <-chan struct{}) {
+func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts *CAOptions, stopCh <-chan struct{}) {
 	if !s.EnableCA() {
 		return
 	}

--- a/pilot/pkg/bootstrap/namespacecontroller.go
+++ b/pilot/pkg/bootstrap/namespacecontroller.go
@@ -177,7 +177,7 @@ func (nc *NamespaceController) configMapChange(obj interface{}) error {
 	cm, ok := obj.(*v1.ConfigMap)
 
 	if ok {
-		if err := certutil.UpdateDataInConfigMap(nc.core, cm, nc.getData()); err != nil {
+		if err := certutil.UpdateDataInConfigMap(nc.core, cm.DeepCopy(), nc.getData()); err != nil {
 			return fmt.Errorf("error when inserting CA cert to configmap %v: %v", cm.Name, err)
 		}
 	}

--- a/pilot/pkg/bootstrap/namespacecontroller.go
+++ b/pilot/pkg/bootstrap/namespacecontroller.go
@@ -87,9 +87,8 @@ func NewNamespaceController(data func() map[string]string, core corev1.CoreV1Int
 				})
 			},
 			DeleteFunc: func(obj interface{}) {
-				var cm *v1.ConfigMap
-				var ok bool
-				if cm, ok = obj.(*v1.ConfigMap); !ok {
+				cm, ok := obj.(*v1.ConfigMap)
+				if !ok {
 					tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 					if !ok {
 						log.Errorf("error decoding object, invalid type")

--- a/pilot/pkg/bootstrap/namespacecontroller_test.go
+++ b/pilot/pkg/bootstrap/namespacecontroller_test.go
@@ -1,0 +1,70 @@
+package bootstrap
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/security/pkg/util"
+)
+
+func TestNamespaceController(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	testdata := map[string]string{"key": "value"}
+	nc, err := NewNamespaceController(func() map[string]string {
+		return testdata
+	}, client.CoreV1())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := make(chan struct{})
+	nc.Run(stop)
+
+	createNamespace(t, client, "foo")
+	expectConfigMap(t, client, "foo", testdata)
+
+	newData := map[string]string{"key": "value", "foo": "bar"}
+	if err := util.InsertDataToConfigMap(client.CoreV1(), metav1.ObjectMeta{Name: CACertNamespaceConfigMap, Namespace: "foo"}, newData); err != nil {
+		t.Fatal(err)
+	}
+	expectConfigMap(t, client, "foo", newData)
+
+	deleteConfigMap(t, client, "foo")
+	expectConfigMap(t, client, "foo", testdata)
+}
+
+func deleteConfigMap(t *testing.T, client *fake.Clientset, ns string) {
+	t.Helper()
+	if err := client.CoreV1().ConfigMaps(ns).Delete(CACertNamespaceConfigMap, &metav1.DeleteOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createNamespace(t *testing.T, client *fake.Clientset, ns string) {
+	t.Helper()
+	if _, err := client.CoreV1().Namespaces().Create(&v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: ns},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func expectConfigMap(t *testing.T, client *fake.Clientset, ns string, data map[string]string) {
+	t.Helper()
+	retry.UntilSuccessOrFail(t, func() error {
+		cm, err := client.CoreV1().ConfigMaps(ns).Get(CACertNamespaceConfigMap, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(cm.Data, data) {
+			return fmt.Errorf("data mismatch, expected %+v got %+v", data, cm.Data)
+		}
+		return nil
+	}, retry.Timeout(time.Second*2))
+}

--- a/pilot/pkg/bootstrap/namespacecontroller_test.go
+++ b/pilot/pkg/bootstrap/namespacecontroller_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bootstrap
 
 import (

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -30,6 +30,8 @@ import (
 	"time"
 
 	"istio.io/istio/pilot/pkg/leaderelection"
+	"k8s.io/client-go/rest"
+
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/security/pkg/pki/util"
@@ -371,7 +373,10 @@ func (s *Server) WaitUntilCompletion() {
 func (s *Server) initKubeClient(args *PilotArgs) error {
 	if hasKubeRegistry(args.Service.Registries) {
 		var err error
-		s.kubeClient, err = kubelib.CreateClientset(args.Config.KubeConfig, "")
+		s.kubeClient, err = kubelib.CreateClientset(args.Config.KubeConfig, "", func(config *rest.Config) {
+			config.QPS = 20
+			config.Burst = 40
+		})
 		if err != nil {
 			return fmt.Errorf("failed creating kube client: %v", err)
 		}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -29,8 +29,9 @@ import (
 	"sync"
 	"time"
 
-	"istio.io/istio/pilot/pkg/leaderelection"
 	"k8s.io/client-go/rest"
+
+	"istio.io/istio/pilot/pkg/leaderelection"
 
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/spiffe"

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -65,10 +65,13 @@ func BuildClientCmd(kubeconfig, context string) clientcmd.ClientConfig {
 
 // CreateClientset is a helper function that builds a kubernetes Clienset from a kubeconfig
 // filepath. See `BuildClientConfig` for kubeconfig loading rules.
-func CreateClientset(kubeconfig, context string) (*kubernetes.Clientset, error) {
+func CreateClientset(kubeconfig, context string, fns ...func(*rest.Config)) (*kubernetes.Clientset, error) {
 	c, err := BuildClientConfig(kubeconfig, context)
 	if err != nil {
 		return nil, err
+	}
+	for _, fn := range fns {
+		fn(c)
 	}
 	return kubernetes.NewForConfig(c)
 }

--- a/security/pkg/util/configutil.go
+++ b/security/pkg/util/configutil.go
@@ -16,15 +16,11 @@ package util
 
 import (
 	"fmt"
-	"time"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-
-	"istio.io/pkg/log"
 )
 
 // InsertDataToConfigMap inserts a data to a configmap in a namespace.
@@ -33,60 +29,55 @@ import (
 // value: the value of the data to insert.
 // configName: the name of the configmap.
 // dataName: the name of the data in the configmap.
-func InsertDataToConfigMap(client corev1.ConfigMapsGetter, namespace, value, configName, dataName string) error {
-	configmap, err := client.ConfigMaps(namespace).Get(configName, metav1.GetOptions{})
-	exists := true
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// Create a new ConfigMap.
-			configmap = &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      configName,
-					Namespace: namespace,
-				},
-				Data: map[string]string{},
-			}
-			exists = false
-		} else {
-			return fmt.Errorf("error when getting configmap %v: %v", configName, err)
-		}
+func InsertDataToConfigMap(client corev1.ConfigMapsGetter, meta metav1.ObjectMeta, data map[string]string) error {
+	configmap, err := client.ConfigMaps(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("error when getting configmap %v: %v", meta.Name, err)
 	}
-	configmap.Data[dataName] = value
-	if exists {
-		if _, err = client.ConfigMaps(namespace).Update(configmap); err != nil {
-			return fmt.Errorf("error when updating configmap %v: %v", configName, err)
+	if errors.IsNotFound(err) {
+		// Create a new ConfigMap.
+		configmap = &v1.ConfigMap{
+			ObjectMeta: meta,
+			Data:       data,
+		}
+		if _, err = client.ConfigMaps(meta.Namespace).Create(configmap); err != nil {
+			return fmt.Errorf("error when creating configmap %v: %v", meta.Name, err)
 		}
 	} else {
-		if _, err = client.ConfigMaps(namespace).Create(configmap); err != nil {
-			return fmt.Errorf("error when creating configmap %v: %v", configName, err)
+		// Otherwise, update the config map if changes are required
+		err := UpdateDataInConfigMap(client, configmap, data)
+		if err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-// InsertDataToConfigMapWithRetry inserts a data to a configmap in a namespace with a
-// retry mechanism.
-// client: the k8s client interface.
-// namespace: the namespace of the configmap.
-// value: the value of the data to insert.
-// configName: the name of the configmap.
-// dataName: the name of the data in the configmap.
-// retryInterval: the retry interval.
-// timeout: the timeout for the retry.
-func InsertDataToConfigMapWithRetry(client corev1.ConfigMapsGetter, namespace, value,
-	configName, dataName string, retryInterval, timeout time.Duration) error {
-	start := time.Now()
-	for {
-		err := InsertDataToConfigMap(client, namespace, value, configName, dataName)
-		if err == nil {
-			return nil
-		}
-		log.Errorf("error when inserting data to config map %v: %v", configName, err)
-
-		if time.Since(start) > timeout {
-			log.Errorf("timeout for inserting data to config map %v", configName)
-			return err
-		}
-		time.Sleep(retryInterval)
+// insertData merges a configmap with a map, and returns true if any changes were made
+func insertData(cm *v1.ConfigMap, data map[string]string) bool {
+	needsUpdate := false
+	if cm.Data == nil {
+		cm.Data = data
+		return true
 	}
+	for k, v := range data {
+		if cm.Data[k] != v {
+			needsUpdate = true
+		}
+		cm.Data[k] = v
+	}
+	return needsUpdate
+}
+
+func UpdateDataInConfigMap(client corev1.ConfigMapsGetter, cm *v1.ConfigMap, data map[string]string) error {
+	if cm == nil {
+		return fmt.Errorf("cannot update nil configmap")
+	}
+	if needsUpdate := insertData(cm, data); !needsUpdate {
+		return nil
+	}
+	if _, err := client.ConfigMaps(cm.Namespace).Update(cm); err != nil {
+		return fmt.Errorf("error when updating configmap %v: %v", cm.Name, err)
+	}
+	return nil
 }

--- a/security/pkg/util/configutil.go
+++ b/security/pkg/util/configutil.go
@@ -55,11 +55,11 @@ func InsertDataToConfigMap(client corev1.ConfigMapsGetter, meta metav1.ObjectMet
 
 // insertData merges a configmap with a map, and returns true if any changes were made
 func insertData(cm *v1.ConfigMap, data map[string]string) bool {
-	needsUpdate := false
 	if cm.Data == nil {
 		cm.Data = data
 		return true
 	}
+	needsUpdate := false
 	for k, v := range data {
 		if cm.Data[k] != v {
 			needsUpdate = true


### PR DESCRIPTION
I went a bit overboard on this PR, we may be able to minimize the changes, as I did some future proofing for https://github.com/istio/istio/pull/20782 in this PR (changing the `data` field to a map, for example).

Basically, the goal here is to optimize the namespace controller. Right now it will blow up on any cluster with 75 namespaces, because there is a limit of 2.5 namespaces/s we can process, and we attempt to re-process every namespace every 30s (resync period). We are also doing extra writes when we don't actually need to (if nothing changed, no need to write).

This makes the following optimizations
* Bump up QPS/burst of kube client a bit
* Remove the resync period on the informer. We don't need to have one, k8s recommends we don't in most cases. FWIW galley has no resync and never has any "missed event" issues.
* Because we remove the resync period, we don't detect if a user removes the config map. Instead, add a configmap watcher as well
* Fix some issues where we try to write to namespaces that are being deleted
* Do not do a write if we detect that no changes are required.
