### PR TITLE
Add analyzer that recommends using PeerAuthentication

### DIFF
--- a/galley/pkg/config/analysis/README.md
+++ b/galley/pkg/config/analysis/README.md
@@ -28,11 +28,11 @@ func (s *GatewayAnalyzer) Metadata() analysis.Metadata {
         // Each analyzer should have a short, one line description of what they
         // do. This description is shown when --list-analyzers is called via
         // the command line.
-        Description: "Checks that VirtualService resources reference Gateways that exist"
+        Description: "Checks that VirtualService resources reference Gateways that exist",
         // Each analyzer should register the collections that it needs to use as input.
         Inputs: collection.Names{
-            collections.IstioNetworkingV1Alpha3Gateways.Name,
-            collections.IstioNetworkingV1Alpha3Virtualservices.Name,
+            collections.IstioNetworkingV1Alpha3Gateways.Name(),
+            collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
         },
     }
 }
@@ -43,7 +43,7 @@ func (s *GatewayAnalyzer) Analyze(c analysis.Context) {
     // in the current snapshot. The available collections, and how they map to k8s resources,
     // are defined in galley/pkg/config/schema/metadata.yaml
     // Available resources are listed under the "localAnalysis" snapshot in that file.
-    c.ForEach(collections.IstioNetworkingV1Alpha3Virtualservices.Name, func(r *resource.Instance) bool {
+    c.ForEach(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), func(r *resource.Instance) bool {
         s.analyzeVirtualService(r, c)
         return true
     })
@@ -68,7 +68,7 @@ func (s *GatewayAnalyzer) analyzeVirtualService(r *resource.Instance, c analysis
             msg := msg.NewReferencedResourceNotFound(r, "gateway", gwName)
 
             // Messages are reported via the passed-in context object.
-            c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name, msg)
+            c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), msg)
         }
     }
 }

--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/policy"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/schema"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/service"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/sidecar"
@@ -43,6 +44,7 @@ func All() []analysis.Analyzer {
 		&gateway.SecretAnalyzer{},
 		&injection.Analyzer{},
 		&injection.ImageAnalyzer{},
+		&policy.DeprecatedAnalyzer{},
 		&service.PortNameAnalyzer{},
 		&sidecar.DefaultSelectorAnalyzer{},
 		&sidecar.SelectorAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/policy"
+
 	. "github.com/onsi/gomega"
 
 	"istio.io/pkg/log"
@@ -395,6 +397,23 @@ var testGrid = []testCase{
 			{msg.DeploymentAssociatedToMultipleServices, "Deployment multiple-without-port.bookinfo"},
 			{msg.DeploymentRequiresServiceAssociated, "Deployment no-services.bookinfo"},
 			{msg.DeploymentRequiresServiceAssociated, "Deployment ann-enabled-ns-disabled.injection-disabled-ns"},
+		},
+	},
+	{
+		name:       "deprecatedPolicyProducesMessageWhenCRDExists",
+		inputFiles: []string{"testdata/policy-with-peerauthentication-crd.yaml"},
+		analyzer:   &policy.DeprecatedAnalyzer{},
+		expected: []message{
+			{msg.PolicyResourceIsDeprecated, "Policy namespace-level-policy.foobar"},
+			{msg.MeshPolicyResourceIsDeprecated, "MeshPolicy default"},
+		},
+	},
+	{
+		name:       "deprecatedPolicyProducesNoMessageWhenNoCRDExists",
+		inputFiles: []string{"testdata/policy-without-peerauthentication-crd.yaml"},
+		analyzer:   &policy.DeprecatedAnalyzer{},
+		expected:   []message{
+			// no messages, this test case verifies no false positives
 		},
 	},
 }

--- a/galley/pkg/config/analysis/analyzers/policy/policy.go
+++ b/galley/pkg/config/analysis/analyzers/policy/policy.go
@@ -1,0 +1,55 @@
+package policy
+
+import (
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+// DeprecatedAnalyzer checks for Policy or MeshPolicy resources in use when the
+// PeerAuthentication resource definition exists.
+type DeprecatedAnalyzer struct{}
+
+// Compile-time check that this Analyzer correctly implements the interface
+var _ analysis.Analyzer = &DeprecatedAnalyzer{}
+
+// Metadata implements Analyzer
+func (s *DeprecatedAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "policy.DeprecatedAnalyzer",
+		Description: "Checks for Policy/MeshPolicy resources being used when PeerAuthentication exists",
+		Inputs: collection.Names{
+			collections.K8SApiextensionsK8SIoV1Beta1Customresourcedefinitions.Name(),
+			collections.IstioAuthenticationV1Alpha1Meshpolicies.Name(),
+			collections.IstioAuthenticationV1Alpha1Policies.Name(),
+		},
+	}
+}
+
+// Analyze implements Analyzer
+func (s *DeprecatedAnalyzer) Analyze(c analysis.Context) {
+	var hasPeerAuthenticationsCRD bool
+	c.ForEach(collections.K8SApiextensionsK8SIoV1Beta1Customresourcedefinitions.Name(),
+		func(r *resource.Instance) bool {
+			if r.Metadata.FullName.String() == "peerauthentications.security.istio.io" {
+				hasPeerAuthenticationsCRD = true
+				return false
+			}
+			return true
+		})
+	if !hasPeerAuthenticationsCRD {
+		return
+	}
+
+	c.ForEach(collections.IstioAuthenticationV1Alpha1Policies.Name(), func(r *resource.Instance) bool {
+		c.Report(collections.IstioAuthenticationV1Alpha1Policies.Name(), msg.NewPolicyResourceIsDeprecated(r))
+		return true
+	})
+
+	c.ForEach(collections.IstioAuthenticationV1Alpha1Meshpolicies.Name(), func(r *resource.Instance) bool {
+		c.Report(collections.IstioAuthenticationV1Alpha1Meshpolicies.Name(), msg.NewMeshPolicyResourceIsDeprecated(r))
+		return true
+	})
+}

--- a/galley/pkg/config/analysis/analyzers/policy/policy.go
+++ b/galley/pkg/config/analysis/analyzers/policy/policy.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package policy
 
 import (

--- a/galley/pkg/config/analysis/analyzers/testdata/policy-with-peerauthentication-crd.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/policy-with-peerauthentication-crd.yaml
@@ -1,0 +1,24 @@
+# We have both a policy object and a mesh policy. We also have a CRD for
+# PeerAuthentication, so we should see messages telling us to migrate.
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: Policy
+metadata:
+  name: "namespace-level-policy"
+  namespace: "foobar"
+spec:
+  peers:
+    - mtls: {}
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: MeshPolicy
+metadata:
+  name: "default"
+spec:
+  peers:
+    - mtls: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: peerauthentications.security.istio.io
+spec:

--- a/galley/pkg/config/analysis/analyzers/testdata/policy-without-peerauthentication-crd.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/policy-without-peerauthentication-crd.yaml
@@ -1,0 +1,18 @@
+# We have both a policy object and a mesh policy. With no CRD defined, however,
+# we won't tell the user to upgrade.
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "namespace-level-policy"
+  namespace: "foobar"
+spec:
+  peers:
+    - mtls: {}
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "MeshPolicy"
+metadata:
+  name: "default"
+spec:
+  peers:
+    - mtls: {}

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -92,6 +92,14 @@ var (
 	// JwtFailureDueToInvalidServicePortPrefix defines a diag.MessageType for message "JwtFailureDueToInvalidServicePortPrefix".
 	// Description: Authentication policy with JWT targets Service with invalid port specification.
 	JwtFailureDueToInvalidServicePortPrefix = diag.NewMessageType(diag.Warning, "IST0119", "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s).")
+
+	// PolicyResourceIsDeprecated defines a diag.MessageType for message "PolicyResourceIsDeprecated".
+	// Description: The Policy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource.
+	PolicyResourceIsDeprecated = diag.NewMessageType(diag.Info, "IST0120", "The Policy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource.")
+
+	// MeshPolicyResourceIsDeprecated defines a diag.MessageType for message "MeshPolicyResourceIsDeprecated".
+	// Description: The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource.
+	MeshPolicyResourceIsDeprecated = diag.NewMessageType(diag.Info, "IST0121", "The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource.")
 )
 
 // All returns a list of all known message types.
@@ -118,6 +126,8 @@ func All() []*diag.MessageType {
 		DeploymentRequiresServiceAssociated,
 		PortNameIsNotUnderNamingConvention,
 		JwtFailureDueToInvalidServicePortPrefix,
+		PolicyResourceIsDeprecated,
+		MeshPolicyResourceIsDeprecated,
 	}
 }
 
@@ -328,5 +338,21 @@ func NewJwtFailureDueToInvalidServicePortPrefix(r *resource.Instance, port int, 
 		portName,
 		protocol,
 		targetPort,
+	)
+}
+
+// NewPolicyResourceIsDeprecated returns a new diag.Message based on PolicyResourceIsDeprecated.
+func NewPolicyResourceIsDeprecated(r *resource.Instance) diag.Message {
+	return diag.NewMessage(
+		PolicyResourceIsDeprecated,
+		r,
+	)
+}
+
+// NewMeshPolicyResourceIsDeprecated returns a new diag.Message based on MeshPolicyResourceIsDeprecated.
+func NewMeshPolicyResourceIsDeprecated(r *resource.Instance) diag.Message {
+	return diag.NewMessage(
+		MeshPolicyResourceIsDeprecated,
+		r,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -230,3 +230,16 @@ messages:
         type: string
       - name: targetPort
         type: string
+
+  - name: "PolicyResourceIsDeprecated"
+    code: IST0120
+    level: Info
+    description: "The Policy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource."
+    template: "The Policy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource."
+
+  - name: "MeshPolicyResourceIsDeprecated"
+    code: IST0121
+    level: Info
+    description: "The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource."
+    template: "The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource."
+

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -497,6 +497,24 @@ var (
 		}.MustBuild(),
 	}.MustBuild()
 
+	// K8SApiextensionsK8SIoV1Beta1Customresourcedefinitions describes the
+	// collection k8s/apiextensions.k8s.io/v1beta1/customresourcedefinitions
+	K8SApiextensionsK8SIoV1Beta1Customresourcedefinitions = collection.Builder{
+		Name:         "k8s/apiextensions.k8s.io/v1beta1/customresourcedefinitions",
+		VariableName: "K8SApiextensionsK8SIoV1Beta1Customresourcedefinitions",
+		Disabled:     false,
+		Resource: resource.Builder{
+			Group:         "apiextensions.k8s.io",
+			Kind:          "CustomResourceDefinition",
+			Plural:        "CustomResourceDefinitions",
+			Version:       "v1beta1",
+			Proto:         "k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition",
+			ProtoPackage:  "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+			ClusterScoped: false,
+			ValidateProto: validation.EmptyValidate,
+		}.MustBuild(),
+	}.MustBuild()
+
 	// K8SAppsV1Deployments describes the collection k8s/apps/v1/deployments
 	K8SAppsV1Deployments = collection.Builder{
 		Name:         "k8s/apps/v1/deployments",
@@ -1130,6 +1148,7 @@ var (
 		MustAdd(IstioSecurityV1Beta1Authorizationpolicies).
 		MustAdd(IstioSecurityV1Beta1Peerauthentications).
 		MustAdd(IstioSecurityV1Beta1Requestauthentications).
+		MustAdd(K8SApiextensionsK8SIoV1Beta1Customresourcedefinitions).
 		MustAdd(K8SAppsV1Deployments).
 		MustAdd(K8SAuthenticationIstioIoV1Alpha1Meshpolicies).
 		MustAdd(K8SAuthenticationIstioIoV1Alpha1Policies).
@@ -1199,6 +1218,7 @@ var (
 
 	// Kube contains only kubernetes collections.
 	Kube = collection.NewSchemasBuilder().
+		MustAdd(K8SApiextensionsK8SIoV1Beta1Customresourcedefinitions).
 		MustAdd(K8SAppsV1Deployments).
 		MustAdd(K8SAuthenticationIstioIoV1Alpha1Meshpolicies).
 		MustAdd(K8SAuthenticationIstioIoV1Alpha1Policies).

--- a/pkg/config/schema/collections/staticinit.gen.go
+++ b/pkg/config/schema/collections/staticinit.gen.go
@@ -38,4 +38,7 @@ import (
 
 	// Register protos in "k8s.io/api/extensions/v1beta1"
 	_ "k8s.io/api/extensions/v1beta1"
+
+	// Register protos in "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	_ "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -205,6 +205,10 @@ collections:
   ### K8s collections ###
 
   # Built-in K8s collections
+  - name: "k8s/apiextensions.k8s.io/v1beta1/customresourcedefinitions"
+    kind: "CustomResourceDefinition"
+    group: "apiextensions.k8s.io"
+
   - name: "k8s/apps/v1/deployments"
     kind: "Deployment"
     group: "apps"
@@ -242,6 +246,7 @@ collections:
     group: "extensions"
 
   # Istio CRD collections
+
   - name: "k8s/authentication.istio.io/v1alpha1/meshpolicies"
     kind: "MeshPolicy"
     group: "authentication.istio.io"
@@ -392,6 +397,7 @@ snapshots:
       - "istio/networking/v1alpha3/serviceentries"
       - "istio/networking/v1alpha3/sidecars"
       - "istio/networking/v1alpha3/virtualservices"
+      - "k8s/apiextensions.k8s.io/v1beta1/customresourcedefinitions"
       - "k8s/apps/v1/deployments"
       - "k8s/core/v1/namespaces"
       - "k8s/core/v1/pods"
@@ -402,6 +408,13 @@ snapshots:
 # Configuration for resource types.
 resources:
   # Kubernetes specific configuration.
+  - kind: "CustomResourceDefinition"
+    plural: "CustomResourceDefinitions"
+    group: "apiextensions.k8s.io"
+    version: "v1beta1"
+    proto: "k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition"
+    protoPackage: "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
   - kind: "Deployment"
     plural: "Deployments"
     group: "apps"
@@ -674,6 +687,7 @@ resources:
 transforms:
   - type: direct
     mapping:
+      "k8s/apiextensions.k8s.io/v1beta1/customresourcedefinitions": "k8s/apiextensions.k8s.io/v1beta1/customresourcedefinitions"
       "k8s/config.istio.io/v1alpha2/adapters": "istio/config/v1alpha2/adapters"
       "k8s/config.istio.io/v1alpha2/attributemanifests": "istio/policy/v1beta1/attributemanifests"
       "k8s/config.istio.io/v1alpha2/handlers": "istio/policy/v1beta1/handlers"

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -150,6 +150,10 @@ collections:
   ### K8s collections ###
 
   # Built-in K8s collections
+  - name: "k8s/apiextensions.k8s.io/v1beta1/customresourcedefinitions"
+    kind: "CustomResourceDefinition"
+    group: "apiextensions.k8s.io"
+
   - name: "k8s/apps/v1/deployments"
     kind: "Deployment"
     group: "apps"
@@ -187,6 +191,7 @@ collections:
     group: "extensions"
 
   # Istio CRD collections
+
   - name: "k8s/authentication.istio.io/v1alpha1/meshpolicies"
     kind: "MeshPolicy"
     group: "authentication.istio.io"
@@ -337,6 +342,7 @@ snapshots:
       - "istio/networking/v1alpha3/serviceentries"
       - "istio/networking/v1alpha3/sidecars"
       - "istio/networking/v1alpha3/virtualservices"
+      - "k8s/apiextensions.k8s.io/v1beta1/customresourcedefinitions"
       - "k8s/apps/v1/deployments"
       - "k8s/core/v1/namespaces"
       - "k8s/core/v1/pods"
@@ -347,6 +353,13 @@ snapshots:
 # Configuration for resource types.
 resources:
   # Kubernetes specific configuration.
+  - kind: "CustomResourceDefinition"
+    plural: "CustomResourceDefinitions"
+    group: "apiextensions.k8s.io"
+    version: "v1beta1"
+    proto: "k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition"
+    protoPackage: "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
   - kind: "Deployment"
     plural: "Deployments"
     group: "apps"
@@ -619,6 +632,7 @@ resources:
 transforms:
   - type: direct
     mapping:
+      "k8s/apiextensions.k8s.io/v1beta1/customresourcedefinitions": "k8s/apiextensions.k8s.io/v1beta1/customresourcedefinitions"
       "k8s/config.istio.io/v1alpha2/adapters": "istio/config/v1alpha2/adapters"
       "k8s/config.istio.io/v1alpha2/attributemanifests": "istio/policy/v1beta1/attributemanifests"
       "k8s/config.istio.io/v1alpha2/handlers": "istio/policy/v1beta1/handlers"

--- a/pkg/config/schema/snapshots/staticinit.gen.go
+++ b/pkg/config/schema/snapshots/staticinit.gen.go
@@ -38,4 +38,7 @@ import (
 
 	// Register protos in "k8s.io/api/extensions/v1beta1"
 	_ "k8s.io/api/extensions/v1beta1"
+
+	// Register protos in "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	_ "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )

--- a/pkg/config/schema/staticinit.gen.go
+++ b/pkg/config/schema/staticinit.gen.go
@@ -38,4 +38,7 @@ import (
 
 	// Register protos in "k8s.io/api/extensions/v1beta1"
 	_ "k8s.io/api/extensions/v1beta1"
+
+	// Register protos in "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	_ "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )

--- a/tests/integration/galley/validation_test.go
+++ b/tests/integration/galley/validation_test.go
@@ -147,6 +147,7 @@ var ignoredCRDs = []string{
 	"/v1/Secret",
 	"/v1/Service",
 	"/v1/ConfigMap",
+	"apiextensions.k8s.io/v1beta1/CustomResourceDefinition",
 	"apps/v1/Deployment",
 	"extensions/v1beta1/Ingress",
 }


### PR DESCRIPTION
The Policy/MeshPolicy resource is going away. This analyzer checks for their presence and suggests moving to the replacement PeerAuthentication resource. It does this by checking for the existence of the PeerAuthentication CRD.

Also added:

* Add support for CustomResourceDefinition in Galley
* Minor corrections to README.md for analyzers