### PR TITLE
Set mesh config in injection template

### DIFF
--- a/galley/testdatasets/conversion/dataset.gen.go
+++ b/galley/testdatasets/conversion/dataset.gen.go
@@ -970,13 +970,13 @@ var _datasetMeshIstioIoV1alpha1Meshconfig_expectedJson = []byte(`{
             "Body": {
                 "access_log_file": "/dev/stdout",
                 "connect_timeout": {
-                    "seconds": 1
+                    "seconds": 10
                 },
                 "default_config": {
                   "binary_path": "/usr/local/bin/envoy",
                   "config_path": "/etc/istio/proxy",
                   "connect_timeout": {
-                    "seconds": 1
+                    "seconds": 10
                   },
                   "discovery_address": "istio-pilot:15010",
                   "drain_duration": {
@@ -1009,6 +1009,7 @@ var _datasetMeshIstioIoV1alpha1Meshconfig_expectedJson = []byte(`{
                 "ingress_class": "istio",
                 "ingress_controller_mode": 2,
                 "ingress_service": "istio-ingressgateway",
+                "locality_lb_setting": {},
                 "outbound_traffic_policy": {
                     "mode": 1
                 },
@@ -1016,8 +1017,13 @@ var _datasetMeshIstioIoV1alpha1Meshconfig_expectedJson = []byte(`{
                   "nanos": 100000000
                 },
                 "proxy_listen_port": 15001,
+                "report_batch_max_entries": 100,
+                "report_batch_max_time": {
+                  "seconds": 1
+                },
                 "root_namespace": "istio-system",
-                "thrift_config": {}
+                "thrift_config": {},
+                "trust_domain": "cluster.local"
             }
         }
     ]

--- a/galley/testdatasets/conversion/dataset/mesh.istio.io/v1alpha1/meshconfig_expected.json
+++ b/galley/testdatasets/conversion/dataset/mesh.istio.io/v1alpha1/meshconfig_expected.json
@@ -8,13 +8,13 @@
             "Body": {
                 "access_log_file": "/dev/stdout",
                 "connect_timeout": {
-                    "seconds": 1
+                    "seconds": 10
                 },
                 "default_config": {
                   "binary_path": "/usr/local/bin/envoy",
                   "config_path": "/etc/istio/proxy",
                   "connect_timeout": {
-                    "seconds": 1
+                    "seconds": 10
                   },
                   "discovery_address": "istio-pilot:15010",
                   "drain_duration": {
@@ -47,6 +47,7 @@
                 "ingress_class": "istio",
                 "ingress_controller_mode": 2,
                 "ingress_service": "istio-ingressgateway",
+                "locality_lb_setting": {},
                 "outbound_traffic_policy": {
                     "mode": 1
                 },
@@ -54,8 +55,13 @@
                   "nanos": 100000000
                 },
                 "proxy_listen_port": 15001,
+                "report_batch_max_entries": 100,
+                "report_batch_max_time": {
+                  "seconds": 1
+                },
                 "root_namespace": "istio-system",
-                "thrift_config": {}
+                "thrift_config": {},
+                "trust_domain": "cluster.local"
             }
         }
     ]

--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -227,6 +227,9 @@ template: |
       valueFrom:
         fieldRef:
           fieldPath: status.hostIP
+    - name: MESH_CONFIG
+      value: |
+             {{ protoToJSON .MeshConfig }}
   {{- if eq .Values.global.proxy.tracer "datadog" }}
   {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
   {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -9056,6 +9056,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+                 {{ protoToJSON .MeshConfig }}
       {{- if eq .Values.global.proxy.tracer "datadog" }}
       {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
       {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
@@ -8045,6 +8045,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+                 {{ protoToJSON .MeshConfig }}
       {{- if eq .Values.global.proxy.tracer "datadog" }}
       {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
       {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
@@ -1057,6 +1057,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+                 {{ protoToJSON .MeshConfig }}
       {{- if eq .Values.global.proxy.tracer "datadog" }}
       {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
       {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
@@ -1056,6 +1056,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+                 {{ protoToJSON .MeshConfig }}
       {{- if eq .Values.global.proxy.tracer "datadog" }}
       {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
       {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -6906,6 +6906,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+                 {{ protoToJSON .MeshConfig }}
       {{- if eq .Values.global.proxy.tracer "datadog" }}
       {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
       {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -7838,6 +7838,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+                 {{ protoToJSON .MeshConfig }}
       {{- if eq .Values.global.proxy.tracer "datadog" }}
       {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
       {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
@@ -1054,6 +1054,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+                 {{ protoToJSON .MeshConfig }}
       {{- if eq .Values.global.proxy.tracer "datadog" }}
       {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
       {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -7838,6 +7838,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+                 {{ protoToJSON .MeshConfig }}
       {{- if eq .Values.global.proxy.tracer "datadog" }}
       {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
       {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1054,6 +1054,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+                 {{ protoToJSON .MeshConfig }}
       {{- if eq .Values.global.proxy.tracer "datadog" }}
       {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
       {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
@@ -1054,6 +1054,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+                 {{ protoToJSON .MeshConfig }}
       {{- if eq .Values.global.proxy.tracer "datadog" }}
       {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
       {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -10506,6 +10506,9 @@ template: |
       valueFrom:
         fieldRef:
           fieldPath: status.hostIP
+    - name: MESH_CONFIG
+      value: |
+             {{ protoToJSON .MeshConfig }}
   {{- if eq .Values.global.proxy.tracer "datadog" }}
   {{- if isset .ObjectMeta.Annotations `+"`"+`apm.datadoghq.com/env`+"`"+` }}
   {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `+"`"+`apm.datadoghq.com/env`+"`"+`) }}

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -191,7 +191,7 @@ func TestIngressClass(t *testing.T) {
 		{ingressMode: meshconfig.MeshConfig_STRICT, ingressClass: "nginx", shouldProcess: false},
 		{ingressMode: meshconfig.MeshConfig_OFF, ingressClass: istio, shouldProcess: false},
 		{ingressMode: meshconfig.MeshConfig_DEFAULT, ingressClass: istio, shouldProcess: true},
-		{ingressMode: meshconfig.MeshConfig_STRICT, ingressClass: istio, shouldProcess: false},
+		{ingressMode: meshconfig.MeshConfig_STRICT, ingressClass: istio, shouldProcess: true},
 		{ingressMode: meshconfig.MeshConfig_DEFAULT, ingressClass: "", shouldProcess: true},
 		{ingressMode: meshconfig.MeshConfig_STRICT, ingressClass: "", shouldProcess: false},
 		{ingressMode: -1, shouldProcess: false},

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -19,6 +19,9 @@ import (
 	"net"
 	"time"
 
+	"istio.io/api/networking/v1alpha3"
+
+	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
 
@@ -41,7 +44,7 @@ func DefaultProxyConfig() meshconfig.ProxyConfig {
 		DrainDuration:          types.DurationProto(45 * time.Second),
 		ParentShutdownDuration: types.DurationProto(60 * time.Second),
 		DiscoveryAddress:       constants.DiscoveryPlainAddress,
-		ConnectTimeout:         types.DurationProto(1 * time.Second),
+		ConnectTimeout:         types.DurationProto(10 * time.Second),
 		StatsdUdpAddress:       "",
 		EnvoyMetricsService:    &meshconfig.RemoteService{Address: ""},
 		EnvoyAccessLogService:  &meshconfig.RemoteService{Address: ""},
@@ -58,6 +61,9 @@ func DefaultProxyConfig() meshconfig.ProxyConfig {
 func DefaultMeshConfig() meshconfig.MeshConfig {
 	proxyConfig := DefaultProxyConfig()
 	return meshconfig.MeshConfig{
+		IngressClass:                      "istio",
+		ReportBatchMaxTime:                types.DurationProto(1 * time.Second),
+		ReportBatchMaxEntries:             100,
 		MixerCheckServer:                  "",
 		MixerReportServer:                 "",
 		DisablePolicyChecks:               true,
@@ -65,7 +71,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		SidecarToTelemetrySessionAffinity: false,
 		RootNamespace:                     constants.IstioSystemNamespace,
 		ProxyListenPort:                   15001,
-		ConnectTimeout:                    types.DurationProto(1 * time.Second),
+		ConnectTimeout:                    types.DurationProto(10 * time.Second),
 		IngressService:                    "istio-ingressgateway",
 		EnableTracing:                     true,
 		AccessLogFile:                     "/dev/stdout",
@@ -73,8 +79,9 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		DefaultConfig:                     &proxyConfig,
 		SdsUdsPath:                        "",
 		EnableSdsTokenMount:               false,
-		TrustDomain:                       "",
+		TrustDomain:                       "cluster.local",
 		TrustDomainAliases:                []string{},
+		Certificates:                      []*meshconfig.Certificate{},
 		DefaultServiceExportTo:            []string{"*"},
 		DefaultVirtualServiceExportTo:     []string{"*"},
 		DefaultDestinationRuleExportTo:    []string{"*"},
@@ -83,13 +90,28 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		ProtocolDetectionTimeout:          types.DurationProto(100 * time.Millisecond),
 		EnableAutoMtls:                    &types.BoolValue{Value: false},
 		ThriftConfig:                      &meshconfig.MeshConfig_ThriftConfig{},
+		LocalityLbSetting:                 &v1alpha3.LocalityLoadBalancerSetting{},
 	}
 }
 
 // ApplyMeshConfig returns a new MeshConfig decoded from the
 // input YAML with the provided defaults applied to omitted configuration values.
 func ApplyMeshConfig(yaml string, defaultConfig meshconfig.MeshConfig) (*meshconfig.MeshConfig, error) {
-	if err := gogoprotomarshal.ApplyYAML(yaml, &defaultConfig); err != nil {
+	return applyMeshConfigInternal(yaml, defaultConfig, gogoprotomarshal.ApplyYAML, gogoprotomarshal.ToYAML)
+}
+
+// ApplyMeshConfig returns a new MeshConfig decoded from the
+// input Json with the provided defaults applied to omitted configuration values.
+func ApplyMeshConfigJSON(json string, defaultConfig meshconfig.MeshConfig) (*meshconfig.MeshConfig, error) {
+	return applyMeshConfigInternal(json, defaultConfig, gogoprotomarshal.ApplyJSON, gogoprotomarshal.ToJSON)
+}
+
+// applyMeshConfigInternal applies settings in config to the provided mesh config
+// This allows json/yaml/other marshaling methods to be used
+func applyMeshConfigInternal(config string, defaultConfig meshconfig.MeshConfig,
+	unmarshal func(yml string, pb proto.Message) error, marshal func(msg proto.Message) (string, error),
+) (*meshconfig.MeshConfig, error) {
+	if err := unmarshal(config, &defaultConfig); err != nil {
 		return nil, multierror.Prefix(err, "failed to convert to proto.")
 	}
 
@@ -102,11 +124,11 @@ func ApplyMeshConfig(yaml string, defaultConfig meshconfig.MeshConfig) (*meshcon
 	// Re-apply defaults to ProxyConfig if they were defined in the
 	// original input MeshConfig.ProxyConfig.
 	if prevDefaultConfig != nil {
-		origProxyConfigYAML, err := gogoprotomarshal.ToYAML(prevDefaultConfig)
+		origProxyConfigYAML, err := marshal(prevDefaultConfig)
 		if err != nil {
 			return nil, multierror.Prefix(err, "failed to re-encode default proxy config")
 		}
-		if err := gogoprotomarshal.ApplyYAML(origProxyConfigYAML, defaultConfig.DefaultConfig); err != nil {
+		if err := unmarshal(origProxyConfigYAML, defaultConfig.DefaultConfig); err != nil {
 			return nil, multierror.Prefix(err, "failed to convert to proto.")
 		}
 	}

--- a/pkg/config/mesh/watcher_test.go
+++ b/pkg/config/mesh/watcher_test.go
@@ -59,7 +59,7 @@ func TestWatcherShouldNotifyHandlers(t *testing.T) {
 	})
 
 	// Change the file to trigger the update.
-	m.IngressClass = "istio"
+	m.IngressClass = "foo"
 	writeMessage(t, path, &m)
 
 	select {

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -16,7 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
-        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"378099da9edbbbee444a8695d2e1e79b68d63e3693c888549f6c69ec75b8efb7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -79,7 +79,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -119,6 +119,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -16,7 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"378099da9edbbbee444a8695d2e1e79b68d63e3693c888549f6c69ec75b8efb7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -76,7 +76,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -116,6 +116,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"378099da9edbbbee444a8695d2e1e79b68d63e3693c888549f6c69ec75b8efb7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -75,7 +75,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -115,6 +115,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"378099da9edbbbee444a8695d2e1e79b68d63e3693c888549f6c69ec75b8efb7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -59,7 +59,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -99,6 +99,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"378099da9edbbbee444a8695d2e1e79b68d63e3693c888549f6c69ec75b8efb7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -76,7 +76,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -116,6 +116,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"378099da9edbbbee444a8695d2e1e79b68d63e3693c888549f6c69ec75b8efb7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -58,7 +58,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -98,6 +98,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"378099da9edbbbee444a8695d2e1e79b68d63e3693c888549f6c69ec75b8efb7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -61,7 +61,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -101,6 +101,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"378099da9edbbbee444a8695d2e1e79b68d63e3693c888549f6c69ec75b8efb7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -75,7 +75,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -115,6 +115,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"378099da9edbbbee444a8695d2e1e79b68d63e3693c888549f6c69ec75b8efb7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -58,7 +58,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -98,6 +98,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"378099da9edbbbee444a8695d2e1e79b68d63e3693c888549f6c69ec75b8efb7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -69,7 +69,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -109,6 +109,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -49,7 +49,7 @@ spec:
             - --proxyLogLevel=warning
             - --proxyComponentLogLevel=misc:error
             - --connectTimeout
-            - 1s
+            - 10s
             - --proxyAdminPort
             - "15000"
             - --controlPlaneAuthPolicy
@@ -89,6 +89,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: MESH_CONFIG
+              value: |
+                {}
             - name: ISTIO_META_POD_PORTS
               value: |-
                 [

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -53,7 +53,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -93,6 +93,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -68,7 +68,7 @@ items:
           - --proxyLogLevel=warning
           - --proxyComponentLogLevel=misc:error
           - --connectTimeout
-          - 1s
+          - 10s
           - --proxyAdminPort
           - "15000"
           - --controlPlaneAuthPolicy
@@ -108,6 +108,9 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          - name: MESH_CONFIG
+            value: |
+              {}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -53,7 +53,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -93,6 +93,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -56,7 +56,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -96,6 +96,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -45,9 +45,9 @@ spec:
         - --serviceCluster
         - hello.$(POD_NAMESPACE)
         - --drainDuration
-        - 45s
+        - 23s
         - --parentShutdownDuration
-        - 1m0s
+        - 42s
         - --discoveryAddress
         - istio-pilot:15010
         - --zipkinAddress
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 42s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {"defaultConfig":{"drainDuration":"23s","parentShutdownDuration":"42s","connectTimeout":"42s"}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -72,7 +72,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -112,6 +112,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -56,7 +56,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -96,6 +96,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -57,7 +57,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -97,6 +97,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -278,7 +281,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -318,6 +321,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -56,7 +56,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -96,6 +96,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -56,7 +56,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -96,6 +96,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/interceptionMode: REDIRECT
+        sidecar.istio.io/interceptionMode: TPROXY
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {"defaultConfig":{"interceptionMode":"TPROXY"}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -111,7 +114,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
-          value: REDIRECT
+          value: TPROXY
         - name: ISTIO_METAJSON_LABELS
           value: |
             {"app":"hello","tier":"backend","track":"stable"}
@@ -145,13 +148,15 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
+            add:
+            - NET_ADMIN
             drop:
             - ALL
           privileged: false
           readOnlyRootFilesystem: true
           runAsGroup: 1337
-          runAsNonRoot: true
-          runAsUser: 1337
+          runAsNonRoot: false
+          runAsUser: 0
         volumeMounts:
         - mountPath: /etc/istio/citadel-ca-cert
           name: citadel-ca-cert
@@ -169,7 +174,7 @@ spec:
         - -u
         - "1337"
         - -m
-        - REDIRECT
+        - TPROXY
         - -i
         - '*'
         - -x

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -47,7 +47,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -87,6 +87,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -56,7 +56,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -96,6 +96,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -56,7 +56,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -96,6 +96,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -73,7 +73,7 @@ items:
           - --proxyLogLevel=warning
           - --proxyComponentLogLevel=misc:error
           - --connectTimeout
-          - 1s
+          - 10s
           - --proxyAdminPort
           - "15000"
           - --controlPlaneAuthPolicy
@@ -113,6 +113,9 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          - name: MESH_CONFIG
+            value: |
+              {}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -59,7 +59,7 @@ items:
           - --proxyLogLevel=warning
           - --proxyComponentLogLevel=misc:error
           - --connectTimeout
-          - 1s
+          - 10s
           - --proxyAdminPort
           - "15000"
           - --controlPlaneAuthPolicy
@@ -99,6 +99,9 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          - name: MESH_CONFIG
+            value: |
+              {}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [
@@ -279,7 +282,7 @@ items:
           - --proxyLogLevel=warning
           - --proxyComponentLogLevel=misc:error
           - --connectTimeout
-          - 1s
+          - 10s
           - --proxyAdminPort
           - "15000"
           - --controlPlaneAuthPolicy
@@ -319,6 +322,9 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          - name: MESH_CONFIG
+            value: |
+              {}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -57,7 +57,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -97,6 +97,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -41,7 +41,7 @@ spec:
     - --proxyLogLevel=warning
     - --proxyComponentLogLevel=misc:error
     - --connectTimeout
-    - 1s
+    - 10s
     - --proxyAdminPort
     - "15000"
     - --controlPlaneAuthPolicy
@@ -81,6 +81,9 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.hostIP
+    - name: MESH_CONFIG
+      value: |
+        {}
     - name: ISTIO_META_POD_PORTS
       value: |-
         [

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -50,7 +50,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -90,6 +90,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -49,7 +49,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -89,6 +89,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -58,7 +58,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -98,6 +98,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -56,7 +56,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -96,6 +96,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -51,7 +51,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -91,6 +91,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -52,7 +52,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -92,6 +92,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -52,7 +52,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -92,6 +92,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -53,7 +53,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -93,6 +93,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -51,7 +51,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -91,6 +91,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -52,7 +52,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -90,6 +90,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -52,7 +52,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -92,6 +92,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -51,7 +51,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -91,6 +91,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -51,7 +51,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -91,6 +91,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -51,7 +51,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -91,6 +91,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -57,7 +57,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -97,6 +97,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -53,7 +53,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -93,6 +93,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -53,7 +53,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -93,6 +93,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -268,7 +271,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -308,6 +311,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -73,7 +73,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -113,6 +113,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -48,7 +48,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -88,6 +88,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -57,7 +57,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -97,6 +97,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -268,7 +271,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -308,6 +311,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -49,7 +49,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -89,6 +89,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -47,7 +47,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -87,6 +87,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -51,7 +51,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -91,6 +91,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -56,7 +56,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -96,6 +96,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -54,7 +54,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -94,6 +94,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -53,7 +53,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -93,6 +93,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -53,7 +53,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -93,6 +93,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -54,7 +54,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -94,6 +94,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
-        - 1s
+        - 10s
         - --proxyAdminPort
         - "15000"
         - --controlPlaneAuthPolicy
@@ -95,6 +95,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: MESH_CONFIG
+          value: |
+            {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [


### PR DESCRIPTION
This is a way to avoid doing the round trip we do from mesh config ->
random flags and environment variables -> mesh config in pilot agent.
Instead, just pass the whole mesh config.

For now, the flags are in tact. I will remove them in another PR.

I have imlpemented this 3 ways. This way, mounting in a configmap in
each namespace, and adding an endpoint to pilot. I am pretty confident
this is the simplest approach