### PR TITLE
Disable prometheus by default in integration test

### DIFF
--- a/install/kubernetes/helm/istio/test-values/values-integ.yaml
+++ b/install/kubernetes/helm/istio/test-values/values-integ.yaml
@@ -14,6 +14,7 @@ global:
     mode: REGISTRY_ONLY
 
 prometheus:
+  enabled: false
   scrapeInterval: 5s
 
 gateways:

--- a/tests/integration/galley/main_test.go
+++ b/tests/integration/galley/main_test.go
@@ -33,6 +33,9 @@ func TestMain(m *testing.M) {
 		NewSuite("galley_test", m).
 		SetupOnEnv(environment.Kube, istio.Setup(nil, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
+values:
+  prometheus:
+    enabled: true
 components:
   galley:
     enabled: true

--- a/tests/integration/mixer/main_test.go
+++ b/tests/integration/mixer/main_test.go
@@ -34,6 +34,8 @@ func TestMain(m *testing.M) {
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:
+  prometheus:
+    enabled: true
   global:
     disablePolicyChecks: false
   telemetry:

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -259,6 +259,8 @@ func TestMain(m *testing.M) {
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:
+  prometheus:
+    enabled: true
   global:
     disablePolicyChecks: false
   telemetry:

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -196,6 +196,8 @@ func TestMain(m *testing.M) {
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:
+  prometheus:
+    enabled: true
   global:
     disablePolicyChecks: false
   telemetry:

--- a/tests/integration/security/sds_egress/main_test.go
+++ b/tests/integration/security/sds_egress/main_test.go
@@ -67,4 +67,5 @@ func setupConfig(cfg *istio.Config) {
 	}
 	cfg.ValuesFile = "values-istio-sds-auth.yaml"
 	cfg.Values["gateways.istio-egressgateway.enabled"] = "true"
+	cfg.Values["prometheus.enabled"] = "true"
 }

--- a/tests/integration/telemetry/stats/prometheus/stats_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/stats_filter_test.go
@@ -104,6 +104,7 @@ func setupConfig(cfg *istio.Config) {
 	cfg.Values["telemetry.v1.enabled"] = "false"
 	cfg.Values["telemetry.v2.enabled"] = "true"
 	cfg.Values["telemetry.v2.prometheus.enabled"] = "true"
+	cfg.Values["prometheus.enabled"] = "true"
 }
 
 func testSetup(ctx resource.Context) (err error) {

--- a/tests/integration/telemetry/stats/prometheus/tcp/stats_tcp_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/tcp/stats_tcp_filter_test.go
@@ -117,6 +117,7 @@ func setupConfig(cfg *istio.Config) {
 	cfg.Values["telemetry.enabled"] = "true"
 	cfg.Values["telemetry.v1.enabled"] = "false"
 	cfg.Values["telemetry.v2.enabled"] = "true"
+	cfg.Values["prometheus.enabled"] = "true"
 }
 
 func testsetup(ctx resource.Context) (err error) {


### PR DESCRIPTION
This will reduce costs of tests a little bit. Most tests don't need
prom, so we can just enable it only for those that do.