### PR TITLE
Proof of concept: Active load shedding in Pilot

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -119,6 +119,7 @@ func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controll
 
 	mux.HandleFunc("/debug", s.Debug)
 
+	s.addDebugHandler(mux, "/debug/load", "Status and debug interface for EDS", s.load)
 	s.addDebugHandler(mux, "/debug/edsz", "Status and debug interface for EDS", s.edsz)
 	s.addDebugHandler(mux, "/debug/adsz", "Status and debug interface for ADS", s.adsz)
 	s.addDebugHandler(mux, "/debug/adsz?push=true", "Initiates push of the current state to all connected endpoints", s.adsz)
@@ -775,6 +776,12 @@ func (s *DiscoveryServer) Debug(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(500)
 	}
 	w.WriteHeader(200)
+}
+
+func (s *DiscoveryServer) load(w http.ResponseWriter, request *http.Request) {
+	count := adsClientCount()
+	resp := fmt.Sprintf("%d", count)
+	_, _ = w.Write([]byte(resp))
 }
 
 // edsz implements a status and debug interface for EDS.

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -401,6 +401,7 @@
             "keepalive_time": 300
           }
         },
+        "max_requests_per_connection": 1,
         "http2_protocol_options": { }
       }
       {{ if .zipkin }}


### PR DESCRIPTION
For https://github.com/istio/istio/issues/11181

Note: this code is obviously really bad, this is just a proof of concept/RFC.

The general idea here is that all pilot instances expose their load (in terms of XDS connections). Periodically, pilots will check their "peers", which it knows about through standard service discovery, and determine load across the cluster. If it is overloaded (in this example, it has 2x the connections of another) it will drop connections (in this case, all of them).

If we were to do this for real, we would likely want to make it much slower/safer and start dropping connections one at a time over a period of time, not just dropping all connections immediately. At that point, maybe the 30min max connection age is sufficient though...