### PR TITLE
 feat(injector): add initial support for canonical service revision

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -149,6 +149,9 @@ const (
 
 	// IstioCanonicalServiceLabelName is the name of label for the Istio Canonical Service for a workload instance.
 	IstioCanonicalServiceLabelName = "service.istio.io/canonical-name"
+
+	// IstioCanonicalServiceRevisionLabelName is the name of label for the Istio Canonical Service revision for a workload instance.
+	IstioCanonicalServiceRevisionLabelName = "service.istio.io/canonical-revision"
 )
 
 // Port represents a network port where a service is listening for

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -139,6 +139,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -140,6 +140,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -142,6 +142,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -139,6 +139,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -161,6 +161,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -163,6 +163,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -139,6 +139,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -139,6 +139,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -139,6 +139,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -139,6 +139,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -139,6 +139,22 @@
       {
         "regex": "(tag\\.(.+?)\\.)",
         "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -16,7 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
-        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -16,7 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"5b05f1e94a1773ad5a05dab973b32859bc859117958edd04d2ea4d432732bb62","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"341418dbb29c335401a1b88f9f4f3fec23a7258273f9b6885f3c68ba3df227e0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-token","citadel-ca-cert","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
@@ -64,5 +64,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
@@ -80,6 +80,11 @@
     "value": ""
   },
   {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
+  },
+  {
     "op": "replace",
     "path": "/spec/containers/0/readinessProbe/httpGet",
     "value": {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
@@ -84,6 +84,11 @@
     "value": ""
   },
   {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
+  },
+  {
     "op": "replace",
     "path": "/spec/containers/1/readinessProbe/httpGet",
     "value": {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
@@ -62,5 +62,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
@@ -82,6 +82,11 @@
     "value": ""
   },
   {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
+  },
+  {
     "op": "replace",
     "path": "/spec/containers/1/readinessProbe/httpGet",
     "value": {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
@@ -84,6 +84,11 @@
     "value": ""
   },
   {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
+  },
+  {
     "op": "replace",
     "path": "/spec/containers/1/readinessProbe/httpGet",
     "value": {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
@@ -74,5 +74,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": "something"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
@@ -57,5 +57,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
@@ -64,5 +64,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
@@ -66,5 +66,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
@@ -66,5 +66,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
@@ -68,5 +68,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
@@ -64,5 +64,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
@@ -64,5 +64,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
@@ -66,5 +66,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
@@ -68,5 +68,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
@@ -68,5 +68,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
@@ -66,5 +66,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
@@ -66,5 +66,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
@@ -68,5 +68,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
@@ -70,5 +70,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
@@ -64,5 +64,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
@@ -66,5 +66,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
@@ -74,5 +74,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": "replace"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
@@ -78,5 +78,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": "replace-backwards-compat"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
@@ -73,5 +73,10 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": "something"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -19,6 +19,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: latest
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -18,6 +18,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: latest
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -18,6 +18,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: test-service-name
+        service.istio.io/canonical-revision: latest
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -18,6 +18,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: latest
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -20,6 +20,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: latest
         tier: frontend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -20,6 +20,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: latest
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -20,6 +20,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: disabled
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: latest
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -21,6 +21,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: v1
         tier: backend
         track: stable
         version: v1
@@ -240,6 +241,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: v2
         tier: backend
         track: stable
         version: v2

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -20,6 +20,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: latest
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -14,6 +14,7 @@ spec:
       labels:
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: pi
+        service.istio.io/canonical-revision: latest
       name: pi
     spec:
       containers:

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -20,6 +20,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: latest
         tier: frontend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -21,6 +21,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: v1
         tier: backend
         track: stable
         version: v1
@@ -240,6 +241,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: v2
         tier: backend
         track: stable
         version: v2

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -18,6 +18,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: latest
     spec:
       containers:
       - image: fake.docker.io/google-samples/hello-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -16,6 +16,7 @@ spec:
         app: nginx
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: nginx
+        service.istio.io/canonical-revision: latest
       name: nginx
     spec:
       containers:

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -20,6 +20,7 @@ spec:
         app: resource
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: resource
+        service.istio.io/canonical-revision: latest
     spec:
       containers:
       - image: fake.docker.io/google-samples/traffic-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -20,6 +20,7 @@ spec:
         app: hello
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
+        service.istio.io/canonical-revision: latest
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -23,6 +23,7 @@ spec:
         app: status
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: status
+        service.istio.io/canonical-revision: latest
     spec:
       containers:
       - image: fake.docker.io/google-samples/traffic-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -22,6 +22,7 @@ spec:
         app: traffic
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
+        service.istio.io/canonical-revision: latest
     spec:
       containers:
       - image: fake.docker.io/google-samples/traffic-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -22,6 +22,7 @@ spec:
         app: traffic
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
+        service.istio.io/canonical-revision: latest
     spec:
       containers:
       - image: fake.docker.io/google-samples/traffic-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -23,6 +23,7 @@ spec:
         app: traffic
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
+        service.istio.io/canonical-revision: latest
     spec:
       containers:
       - image: fake.docker.io/google-samples/traffic-go-gke:1.0

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -22,6 +22,7 @@ spec:
         app: user-volume
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: user-volume
+        service.istio.io/canonical-revision: latest
         tier: backend
         track: stable
     spec:

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1336,7 +1336,12 @@ func TestRunAndServe(t *testing.T) {
       "op": "add",
       "path": "/metadata/labels/service.istio.io~1canonical-name",
       "value": "test"
-    }
+	},
+	{
+		"op": "add",
+		"path": "/metadata/labels/service.istio.io~1canonical-revision",
+		"value": "latest"
+	}
 ]`)
 
 	cases := []struct {

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -149,6 +149,22 @@
       {
           "regex": "(tag\\.(.+?)\\.)",
           "tag_name": "tag"
+      },
+      {
+          "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_service"
+      },
+      {
+          "regex": "(destination_canonical_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_service"
+      },
+      {
+          "regex": "(source_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "source_canonical_revision"
+      },
+      {
+          "regex": "(destination_canonical_revision=\\.=(.+?);\\.;)",
+          "tag_name": "destination_canonical_revision"
       }
     ],
     "stats_matcher": {


### PR DESCRIPTION
This PR is the second in a series meant to support the approved [Istio Canonical Service proposal](https://docs.google.com/document/d/1EsKpYNW55-LqG08zdjp1tAd224T9IEG3CEnusmL-Joc/edit#).

In particular, it adds the `service.istio.io/canonical-revision` label according to the heuristic defined in the proposal (absent user-defined label support).

It also adds support for extraction of these labels to the bootstrap for v2 telemetry support.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
