### PR TITLE
Allow user to override manifest entries with dotted keys

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -154,6 +154,7 @@ The `istioctl` command supports the following flags:
 - `logtostderr`: log to console (by default logs go to ./mesh-cli.log).
 - `dry-run`: console output only, nothing applied to cluster or written to files.
 - `verbose`: display entire manifest contents and other debug info (default is false).
+- `set`: select profile or override profile defaults
 
 #### Basic default manifest
 
@@ -239,13 +240,35 @@ spec:
   profile: sds
 ```
 
-Use the Istio operator `mesh` binary to generate the manifests for the new configuration profile:
+Use `istioctl` to generate the manifests for the new configuration profile:
 
 ```bash
 istioctl manifest generate -f samples/sds.yaml
 ```
 
 After running the command, the Helm charts are rendered using `data/profiles/sds.yaml`.
+
+##### --set syntax
+
+The CLI `--set` option can be used to override settings within the profile.
+
+For example, to enable security, use `istioctl manifest generate --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true`
+
+To override a setting that includes dots, escape them with a backslash (\).  Your shell may require enclosing quotes.
+
+``` bash
+istioctl manifest generate --set "values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy=runtime/default"
+```
+
+To override a setting that is part of a list, use brackets.
+
+``` bash
+istioctl manifest generate --set values.gateways.istio-ingressgateway.enabled=false \
+--set values.gateways.istio-egressgateway.enabled=true \
+--set 'values.gateways.istio-egressgateway.secretVolumes[0].name'=egressgateway-certs \
+--set 'values.gateways.istio-egressgateway.secretVolumes[0].secretName'=istio-egressgateway-certs \
+--set 'values.gateways.istio-egressgateway.secretVolumes[0].mountPath'=/etc/istio/egressgateway-certs
+```
 
 #### Install from file path
 

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -68,10 +68,18 @@ func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs) *cobra.Comm
 		Use:   "apply",
 		Short: "Applies an Istio manifest, installing or reconfiguring Istio on a cluster.",
 		Long:  "The apply subcommand generates an Istio install manifest and applies it to a cluster.",
-		Example: "istioctl manifest apply  # installs the default profile on the current Kubernetes cluster context\n" +
-			"istioctl manifest apply --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true\n" +
-			"istioctl manifest apply --set profile=demo\n" +
-			"istioctl manifest apply --set installPackagePath=~/istio-releases/istio-1.4.3/install/kubernetes/operator/charts",
+		Example: `  # Apply a default Istio installation
+  istioctl manifest apply
+
+  # Enable security
+  istioctl manifest apply --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true
+
+  # Generate the demo profile and don't wait for confirmation
+  istioctl manifest apply --set profile=demo --skip-confirmation
+
+  # To override a setting that includes dots, escape them with a backslash (\).  Your shell may require enclosing quotes.
+  istioctl manifest apply --set "values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy=runtime/default"
+`,
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			l := NewLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.ErrOrStderr())

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -68,6 +68,7 @@ func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs) *cobra.Comm
 		Use:   "apply",
 		Short: "Applies an Istio manifest, installing or reconfiguring Istio on a cluster.",
 		Long:  "The apply subcommand generates an Istio install manifest and applies it to a cluster.",
+		// nolint: lll
 		Example: `  # Apply a default Istio installation
   istioctl manifest apply
 

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -59,6 +59,7 @@ func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs) *cobr
 		Use:   "generate",
 		Short: "Generates an Istio install manifest",
 		Long:  "The generate subcommand generates an Istio install manifest and outputs to the console by default.",
+		// nolint: lll
 		Example: `  # Generate a default Istio installation
   istioctl manifest generate
 

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -59,6 +59,18 @@ func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs) *cobr
 		Use:   "generate",
 		Short: "Generates an Istio install manifest",
 		Long:  "The generate subcommand generates an Istio install manifest and outputs to the console by default.",
+		Example: `  # Generate a default Istio installation
+  istioctl manifest generate
+
+  # Enable security
+  istioctl manifest generate --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true
+
+  # Generate the demo profile
+  istioctl manifest generate --set profile=demo
+
+  # To override a setting that includes dots, escape them with a backslash (\).  Your shell may require enclosing quotes.
+  istioctl manifest generate --set "values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy=runtime/default"
+`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				return fmt.Errorf("generate accepts no positional arguments, got %#v", args)

--- a/operator/pkg/tpath/tpath.go
+++ b/operator/pkg/tpath/tpath.go
@@ -83,6 +83,11 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 	}
 	pe := remainPath[0]
 
+	if nc.Node == nil {
+		// Otherwise we panic on bad input
+		return nil, false, fmt.Errorf("node %s is zero", pe)
+	}
+
 	v := reflect.ValueOf(nc.Node)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
@@ -175,6 +180,7 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 			nn, ok = m[pe]
 			if !ok {
 				// remainPath == 1 means the patch is creation of a new leaf.
+
 				if createMissing || len(remainPath) == 1 {
 					m[pe] = make(map[string]interface{})
 					nn = m[pe]

--- a/operator/pkg/tpath/tpath_test.go
+++ b/operator/pkg/tpath/tpath_test.go
@@ -690,3 +690,62 @@ values:
 		t.Errorf("TestSecretVolumes: diff:\n%s\n", diff)
 	}
 }
+
+// Simulates https://github.com/istio/istio/issues/19196
+func TestWriteEscapedPathContext(t *testing.T) {
+	rootYAML := `
+values:
+  sidecarInjectorWebhook:
+    injectedAnnotations: {}
+`
+	tests := []struct {
+		desc      string
+		path      string
+		value     interface{}
+		want      string
+		wantFound bool
+		wantErr   string
+	}{
+		{
+			desc:      "ModifyEscapedPathValue",
+			path:      `values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy`,
+			value:     `runtime/default`,
+			wantFound: true,
+			want: `
+values:
+  sidecarInjectorWebhook:
+    injectedAnnotations:
+      container.apparmor.security.beta.kubernetes.io/istio-proxy: runtime/default
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			root := make(map[string]interface{})
+			if err := yaml.Unmarshal([]byte(rootYAML), &root); err != nil {
+				t.Fatal(err)
+			}
+			pc, gotFound, gotErr := GetPathContext(root, util.PathFromString(tt.path))
+			if gotErr, wantErr := errToString(gotErr), tt.wantErr; gotErr != wantErr {
+				t.Fatalf("GetPathContext(%s): gotErr:%s, wantErr:%s", tt.desc, gotErr, wantErr)
+			}
+			if gotFound != tt.wantFound {
+				t.Fatalf("GetPathContext(%s): gotFound:%v, wantFound:%v", tt.desc, gotFound, tt.wantFound)
+			}
+			if tt.wantErr != "" || !tt.wantFound {
+				return
+			}
+
+			err := WritePathContext(pc, tt.value, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gotYAML := util.ToYAML(root)
+			diff := util.YAMLDiff(gotYAML, tt.want)
+			if diff != "" {
+				t.Errorf("%s: diff:\n%s\n", tt.desc, diff)
+			}
+		})
+	}
+}

--- a/operator/pkg/util/path.go
+++ b/operator/pkg/util/path.go
@@ -33,6 +33,11 @@ const (
 	MaxIndex = 65535
 	// InsertIndex is the index that means "insert" when setting values
 	InsertIndex = -1
+
+	// PathSeparatorRune is the separator between path elements, as a rune.
+	pathSeparatorRune = '.'
+	// EscapedPathSeparator is what to use when the path shouldn't separate
+	escapedPathSeparator = "\\" + PathSeparator
 )
 
 var (
@@ -48,10 +53,11 @@ func PathFromString(path string) Path {
 	path = filepath.Clean(path)
 	path = strings.TrimPrefix(path, PathSeparator)
 	path = strings.TrimSuffix(path, PathSeparator)
-	pv := strings.Split(path, PathSeparator)
+	pv := splitEscaped(path, pathSeparatorRune)
 	var r []string
 	for _, str := range pv {
 		if str != "" {
+			str = strings.ReplaceAll(str, escapedPathSeparator, PathSeparator)
 			// Is str of the form node[expr], convert to "node", "[expr]"?
 			nBracket := strings.IndexRune(str, '[')
 			if nBracket > 0 {

--- a/operator/pkg/validate/common.go
+++ b/operator/pkg/validate/common.go
@@ -293,7 +293,7 @@ func ValidIOPYAML(iopYAML string) error {
 	return ValidIOP(iop)
 }
 
-// ValidIOPYAML validates the given IstioOperator object.
+// ValidIOP validates the given IstioOperator object.
 func ValidIOP(iop *v1alpha1.IstioOperator) error {
 	errs := CheckIstioOperatorSpec(iop.Spec, false)
 	return errs.ToError()


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/19196

The syntax ***from bash*** is `istioctl manifest generate --set "values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy=runtime/default"`

The quotes are necessary because Bash will eat the `\` without them.

Although the generated output is seems correct I noticed that setting the injectedAnnotations this way causes `proto: tag has too few fields: "-"` to be written to stdout.  I believe this is not a new bug, but another example of https://github.com/kubernetes/kubernetes/issues/86739