### PR TITLE
Cherry pick: Apply peer authentication policy (#20829)

### DIFF
--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -28,6 +28,9 @@ func NewPolicyApplier(push *model.PushContext,
 	service := serviceInstance.Service
 	port := serviceInstance.ServicePort
 	authnPolicy, _ := push.AuthenticationPolicyForWorkload(service, port)
-	return v1beta1.NewPolicyApplier(push.AuthnBetaPolicies.GetJwtPoliciesForWorkload(
-		namespace, labels), authnPolicy)
+	return v1beta1.NewPolicyApplier(
+		push.AuthnBetaPolicies.GetRootNamespace(),
+		push.AuthnBetaPolicies.GetJwtPoliciesForWorkload(namespace, labels),
+		push.AuthnBetaPolicies.GetPeerAuthenticationsForWorkload(namespace, labels),
+		authnPolicy)
 }

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -25,7 +25,7 @@ import (
 // authentication policy. Each version of authentication policy will implement this interface.
 type PolicyApplier interface {
 	// InboundFilterChain returns inbound filter chain(s) to enforce the underlying authentication policy.
-	InboundFilterChain(sdsUdsPath string, meta *model.Proxy) []plugin.FilterChain
+	InboundFilterChain(sdsUdsPath string, node *model.Proxy) []plugin.FilterChain
 
 	// AuthNFilter returns the JWT HTTP filter to enforce the underlying authentication policy.
 	// It may return nil, if no JWT validation is needed.

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -1,0 +1,174 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	ldsv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/plugin"
+	"istio.io/istio/pilot/pkg/networking/util"
+	authn_model "istio.io/istio/pilot/pkg/security/model"
+	"istio.io/istio/pkg/config/constants"
+	protovalue "istio.io/istio/pkg/proto"
+	"istio.io/pkg/log"
+)
+
+// BuildInboundFilterChain returns the filter chain(s) correspoinding to the mTLS mode.
+func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, sdsUdsPath string, node *model.Proxy) []plugin.FilterChain {
+	if mTLSMode == model.MTLSDisable || mTLSMode == model.MTLSUnknown {
+		return nil
+	}
+
+	meta := node.Metadata
+	var alpnIstioMatch *ldsv2.FilterChainMatch
+	var tls *auth.DownstreamTlsContext
+	if util.IsTCPMetadataExchangeEnabled(node) {
+		alpnIstioMatch = &ldsv2.FilterChainMatch{
+			ApplicationProtocols: util.ALPNInMeshWithMxc,
+		}
+		tls = &auth.DownstreamTlsContext{
+			CommonTlsContext: &auth.CommonTlsContext{
+				// For TCP with mTLS, we advertise "istio-peer-exchange" from client and
+				// expect the same from server. This  is so that secure metadata exchange
+				// transfer can take place between sidecars for TCP with mTLS.
+				AlpnProtocols: util.ALPNDownstream,
+			},
+			RequireClientCertificate: protovalue.BoolTrue,
+		}
+	} else {
+		alpnIstioMatch = &ldsv2.FilterChainMatch{
+			ApplicationProtocols: util.ALPNInMesh,
+		}
+		tls = &auth.DownstreamTlsContext{
+			CommonTlsContext: &auth.CommonTlsContext{
+				// Note that in the PERMISSIVE mode, we match filter chain on "istio" ALPN,
+				// which is used to differentiate between service mesh and legacy traffic.
+				//
+				// Client sidecar outbound cluster's TLSContext.ALPN must include "istio".
+				//
+				// Server sidecar filter chain's FilterChainMatch.ApplicationProtocols must
+				// include "istio" for the secure traffic, but its TLSContext.ALPN must not
+				// include "istio", which would interfere with negotiation of the underlying
+				// protocol, e.g. HTTP/2.
+				AlpnProtocols: util.ALPNHttp,
+			},
+			RequireClientCertificate: protovalue.BoolTrue,
+		}
+	}
+
+	if !node.Metadata.SdsEnabled || sdsUdsPath == "" {
+		base := meta.SdsBase + constants.AuthCertsPath
+		tlsServerRootCert := model.GetOrDefault(meta.TLSServerRootCert, base+constants.RootCertFilename)
+
+		tls.CommonTlsContext.ValidationContextType = authn_model.ConstructValidationContext(tlsServerRootCert, []string{} /*subjectAltNames*/)
+
+		tlsServerCertChain := model.GetOrDefault(meta.TLSServerCertChain, base+constants.CertChainFilename)
+		tlsServerKey := model.GetOrDefault(meta.TLSServerKey, base+constants.KeyFilename)
+
+		tls.CommonTlsContext.TlsCertificates = []*auth.TlsCertificate{
+			{
+				CertificateChain: &core.DataSource{
+					Specifier: &core.DataSource_Filename{
+						Filename: tlsServerCertChain,
+					},
+				},
+				PrivateKey: &core.DataSource{
+					Specifier: &core.DataSource_Filename{
+						Filename: tlsServerKey,
+					},
+				},
+			},
+		}
+	} else {
+		tls.CommonTlsContext.TlsCertificateSdsSecretConfigs = []*auth.SdsSecretConfig{
+			authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, sdsUdsPath, meta),
+		}
+
+		tls.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
+			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+				DefaultValidationContext: &auth.CertificateValidationContext{VerifySubjectAltName: []string{} /*subjectAltNames*/},
+				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName,
+					sdsUdsPath, meta),
+			},
+		}
+	}
+	if mTLSMode == model.MTLSStrict {
+		log.Debug("Allow only istio mutual TLS traffic")
+		return []plugin.FilterChain{
+			{
+				TLSContext: tls,
+			}}
+	}
+	if mTLSMode == model.MTLSPermissive {
+		log.Debug("Allow both, ALPN istio and legacy traffic")
+		return []plugin.FilterChain{
+			{
+				FilterChainMatch: alpnIstioMatch,
+				TLSContext:       tls,
+				ListenerFilters: []*ldsv2.ListenerFilter{
+					{
+						Name:       xdsutil.TlsInspector,
+						ConfigType: &ldsv2.ListenerFilter_Config{Config: &structpb.Struct{}},
+					},
+				},
+			},
+			{
+				FilterChainMatch: &ldsv2.FilterChainMatch{},
+			},
+		}
+	}
+	return nil
+}
+
+// ConstructSDSConfig returns SDS secret config for the given SDS UDS path.
+func ConstructSDSConfig(name, sdsudspath string) *auth.SdsSecretConfig {
+	gRPCConfig := &core.GrpcService_GoogleGrpc{
+		TargetUri:  sdsudspath,
+		StatPrefix: authn_model.SDSStatPrefix,
+		ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+			CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
+				LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
+			},
+		},
+	}
+
+	gRPCConfig.CredentialsFactoryName = authn_model.FileBasedMetadataPlugName
+	gRPCConfig.CallCredentials = authn_model.ConstructgRPCCallCredentials(authn_model.K8sSATrustworthyJwtFileName, authn_model.K8sSAJwtTokenHeaderKey)
+
+	return &auth.SdsSecretConfig{
+		Name: name,
+		SdsConfig: &core.ConfigSource{
+			InitialFetchTimeout: features.InitialFetchTimeout,
+			ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+				ApiConfigSource: &core.ApiConfigSource{
+					ApiType: core.ApiConfigSource_GRPC,
+					GrpcServices: []*core.GrpcService{
+						{
+							TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+								GoogleGrpc: gRPCConfig,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -1,0 +1,322 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	"github.com/golang/protobuf/ptypes/any"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/plugin"
+	authn_model "istio.io/istio/pilot/pkg/security/model"
+	protovalue "istio.io/istio/pkg/proto"
+)
+
+func TestBuildInboundFilterChain(t *testing.T) {
+	tlsContext := &auth.DownstreamTlsContext{
+		CommonTlsContext: &auth.CommonTlsContext{
+			TlsCertificates: []*auth.TlsCertificate{
+				{
+					CertificateChain: &core.DataSource{
+						Specifier: &core.DataSource_Filename{
+							Filename: "/etc/certs/cert-chain.pem",
+						},
+					},
+					PrivateKey: &core.DataSource{
+						Specifier: &core.DataSource_Filename{
+							Filename: "/etc/certs/key.pem",
+						},
+					},
+				},
+			},
+			ValidationContextType: &auth.CommonTlsContext_ValidationContext{
+				ValidationContext: &auth.CertificateValidationContext{
+					TrustedCa: &core.DataSource{
+						Specifier: &core.DataSource_Filename{
+							Filename: "/etc/certs/root-cert.pem",
+						},
+					},
+				},
+			},
+			AlpnProtocols: []string{"istio-peer-exchange", "h2", "http/1.1"},
+		},
+		RequireClientCertificate: protovalue.BoolTrue,
+	}
+
+	type args struct {
+		mTLSMode   model.MutualTLSMode
+		sdsUdsPath string
+		node       *model.Proxy
+	}
+	tests := []struct {
+		name string
+		args args
+		want []plugin.FilterChain
+	}{
+		{
+			name: "MTLSUnknown",
+			args: args{
+				mTLSMode: model.MTLSUnknown,
+				node: &model.Proxy{
+					Metadata: &model.NodeMetadata{},
+				},
+			},
+			// No need to set up filter chain, default one is okay.
+			want: nil,
+		},
+		{
+			name: "MTLSDisable",
+			args: args{
+				mTLSMode: model.MTLSDisable,
+				node: &model.Proxy{
+					Metadata: &model.NodeMetadata{},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "MTLSStrict",
+			args: args{
+				mTLSMode: model.MTLSStrict,
+				node: &model.Proxy{
+					Metadata: &model.NodeMetadata{},
+				},
+			},
+			want: []plugin.FilterChain{
+				{
+					TLSContext: tlsContext,
+				},
+			},
+		},
+		{
+			name: "MTLSPermissive",
+			args: args{
+				mTLSMode: model.MTLSPermissive,
+				node: &model.Proxy{
+					Metadata: &model.NodeMetadata{},
+				},
+			},
+			// Two filter chains, one for mtls traffic within the mesh, one for plain text traffic.
+			want: []plugin.FilterChain{
+				{
+					TLSContext: tlsContext,
+					FilterChainMatch: &listener.FilterChainMatch{
+						ApplicationProtocols: []string{"istio-peer-exchange", "istio"},
+					},
+					ListenerFilters: []*listener.ListenerFilter{
+						{
+							Name:       "envoy.listener.tls_inspector",
+							ConfigType: &listener.ListenerFilter_Config{&structpb.Struct{}},
+						},
+					},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{},
+				},
+			},
+		},
+		{
+			name: "MTLSStrict using SDS",
+			args: args{
+				mTLSMode:   model.MTLSStrict,
+				sdsUdsPath: "/tmp/sdsuds.sock",
+				node: &model.Proxy{
+					Metadata: &model.NodeMetadata{
+						SdsEnabled: true,
+					},
+				},
+			},
+			want: []plugin.FilterChain{
+				{
+					TLSContext: &auth.DownstreamTlsContext{
+						CommonTlsContext: &auth.CommonTlsContext{
+							TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+								{
+									Name: "default",
+									SdsConfig: &core.ConfigSource{
+										InitialFetchTimeout: features.InitialFetchTimeout,
+										ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+											ApiConfigSource: &core.ApiConfigSource{
+												ApiType: core.ApiConfigSource_GRPC,
+												GrpcServices: []*core.GrpcService{
+													{
+														TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+															GoogleGrpc: &core.GrpcService_GoogleGrpc{
+																TargetUri:              "/tmp/sdsuds.sock",
+																StatPrefix:             authn_model.SDSStatPrefix,
+																CredentialsFactoryName: "envoy.grpc_credentials.file_based_metadata",
+																ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+																	CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
+																		LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
+																	},
+																},
+																CallCredentials: []*core.GrpcService_GoogleGrpc_CallCredentials{
+																	{
+																		CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_FromPlugin{
+																			FromPlugin: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin{
+																				Name: "envoy.grpc_credentials.file_based_metadata",
+																				ConfigType: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig{
+																					TypedConfig: &any.Any{
+																						TypeUrl: "type.googleapis.com/envoy.config.grpc_credential.v2alpha.FileBasedMetadataConfig",
+																						Value:   []byte("\n%\n#/var/run/secrets/tokens/istio-token\022 istio_sds_credentials_header-bin"),
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+								CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+									DefaultValidationContext: &auth.CertificateValidationContext{VerifySubjectAltName: []string{} /*subjectAltNames*/},
+									ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+										Name: "ROOTCA",
+										SdsConfig: &core.ConfigSource{
+											InitialFetchTimeout: features.InitialFetchTimeout,
+											ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+												ApiConfigSource: &core.ApiConfigSource{
+													ApiType: core.ApiConfigSource_GRPC,
+													GrpcServices: []*core.GrpcService{
+														{
+															TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+																GoogleGrpc: &core.GrpcService_GoogleGrpc{
+																	TargetUri:              "/tmp/sdsuds.sock",
+																	StatPrefix:             authn_model.SDSStatPrefix,
+																	CredentialsFactoryName: "envoy.grpc_credentials.file_based_metadata",
+																	ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+																		CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
+																			LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
+																		},
+																	},
+																	CallCredentials: []*core.GrpcService_GoogleGrpc_CallCredentials{
+																		{
+																			CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_FromPlugin{
+																				FromPlugin: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin{
+																					Name: "envoy.grpc_credentials.file_based_metadata",
+																					ConfigType: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig{
+																						TypedConfig: &any.Any{
+																							TypeUrl: "type.googleapis.com/envoy.config.grpc_credential.v2alpha.FileBasedMetadataConfig",
+																							Value:   []byte("\n%\n#/var/run/secrets/tokens/istio-token\022 istio_sds_credentials_header-bin"),
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							AlpnProtocols: []string{"istio-peer-exchange", "h2", "http/1.1"},
+						},
+						RequireClientCertificate: protovalue.BoolTrue,
+					},
+				},
+			},
+		},
+		{
+			name: "MTLSStrict using SDS without node meta",
+			args: args{
+				mTLSMode:   model.MTLSStrict,
+				sdsUdsPath: "/tmp/sdsuds.sock",
+				node: &model.Proxy{
+					Metadata: &model.NodeMetadata{},
+				},
+			},
+			want: []plugin.FilterChain{
+				{
+					TLSContext: tlsContext,
+				},
+			},
+		},
+		{
+			name: "MTLSStrict with custom cert paths from proxy node metadata",
+			args: args{
+				mTLSMode: model.MTLSStrict,
+				node: &model.Proxy{
+					Metadata: &model.NodeMetadata{
+						TLSServerCertChain: "/custom/path/to/cert-chain.pem",
+						TLSServerKey:       "/custom-key.pem",
+						TLSServerRootCert:  "/custom/path/to/root.pem",
+					},
+				},
+			},
+			// Only one filter chain with mTLS settings should be generated.
+			want: []plugin.FilterChain{
+				{
+					TLSContext: &auth.DownstreamTlsContext{
+						CommonTlsContext: &auth.CommonTlsContext{
+							TlsCertificates: []*auth.TlsCertificate{
+								{
+									CertificateChain: &core.DataSource{
+										Specifier: &core.DataSource_Filename{
+											Filename: "/custom/path/to/cert-chain.pem",
+										},
+									},
+									PrivateKey: &core.DataSource{
+										Specifier: &core.DataSource_Filename{
+											Filename: "/custom-key.pem",
+										},
+									},
+								},
+							},
+							ValidationContextType: &auth.CommonTlsContext_ValidationContext{
+								ValidationContext: &auth.CertificateValidationContext{
+									TrustedCa: &core.DataSource{
+										Specifier: &core.DataSource_Filename{
+											Filename: "/custom/path/to/root.pem",
+										},
+									},
+								},
+							},
+							AlpnProtocols: []string{"istio-peer-exchange", "h2", "http/1.1"},
+						},
+						RequireClientCertificate: protovalue.BoolTrue,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BuildInboundFilterChain(tt.args.mTLSMode, tt.args.sdsUdsPath, tt.args.node); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BuildInboundFilterChain() = %v, want %v", spew.Sdump(got), spew.Sdump(tt.want))
+				t.Logf("got:\n%v\n", got[0].TLSContext.CommonTlsContext.TlsCertificateSdsSecretConfigs[0])
+			}
+		})
+	}
+}

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -18,31 +18,25 @@ import (
 	"crypto/sha1"
 	"fmt"
 
-	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	ldsv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoy_jwt "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/jwt_authn/v2alpha"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
-	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	authn_v1alpha1 "istio.io/api/authentication/v1alpha1"
-	"istio.io/pkg/log"
-
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/security/authn"
+	authn_utils "istio.io/istio/pilot/pkg/security/authn/utils"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
-	"istio.io/istio/pkg/config/constants"
-	protovalue "istio.io/istio/pkg/proto"
 	authn_filter_policy "istio.io/istio/security/proto/authentication/v1alpha1"
 	authn_filter "istio.io/istio/security/proto/envoy/config/filter/http/authn/v2alpha1"
 	istio_jwt "istio.io/istio/security/proto/envoy/config/filter/http/jwt_auth/v2alpha1"
+	"istio.io/pkg/log"
 )
 
 const (
@@ -335,109 +329,7 @@ func (a v1alpha1PolicyApplier) InboundFilterChain(sdsUdsPath string, node *model
 	if a.policy == nil || len(a.policy.Peers) == 0 {
 		return nil
 	}
-	meta := node.Metadata
-	var alpnIstioMatch *ldsv2.FilterChainMatch
-	var tls *auth.DownstreamTlsContext
-	if util.IsTCPMetadataExchangeEnabled(node) {
-		alpnIstioMatch = &ldsv2.FilterChainMatch{
-			ApplicationProtocols: util.ALPNInMeshWithMxc,
-		}
-		tls = &auth.DownstreamTlsContext{
-			CommonTlsContext: &auth.CommonTlsContext{
-				// For TCP with mTLS, we advertise "istio-peer-exchange" from client and
-				// expect the same from server. This  is so that secure metadata exchange
-				// transfer can take place between sidecars for TCP with mTLS.
-				AlpnProtocols: util.ALPNDownstream,
-			},
-			RequireClientCertificate: protovalue.BoolTrue,
-		}
-	} else {
-		alpnIstioMatch = &ldsv2.FilterChainMatch{
-			ApplicationProtocols: util.ALPNInMesh,
-		}
-		tls = &auth.DownstreamTlsContext{
-			CommonTlsContext: &auth.CommonTlsContext{
-				// Note that in the PERMISSIVE mode, we match filter chain on "istio" ALPN,
-				// which is used to differentiate between service mesh and legacy traffic.
-				//
-				// Client sidecar outbound cluster's TLSContext.ALPN must include "istio".
-				//
-				// Server sidecar filter chain's FilterChainMatch.ApplicationProtocols must
-				// include "istio" for the secure traffic, but its TLSContext.ALPN must not
-				// include "istio", which would interfere with negotiation of the underlying
-				// protocol, e.g. HTTP/2.
-				AlpnProtocols: util.ALPNHttp,
-			},
-			RequireClientCertificate: protovalue.BoolTrue,
-		}
-	}
-
-	if !node.Metadata.SdsEnabled || sdsUdsPath == "" {
-		base := meta.SdsBase + constants.AuthCertsPath
-		tlsServerRootCert := model.GetOrDefault(meta.TLSServerRootCert, base+constants.RootCertFilename)
-
-		tls.CommonTlsContext.ValidationContextType = authn_model.ConstructValidationContext(tlsServerRootCert, []string{} /*subjectAltNames*/)
-
-		tlsServerCertChain := model.GetOrDefault(meta.TLSServerCertChain, base+constants.CertChainFilename)
-		tlsServerKey := model.GetOrDefault(meta.TLSServerKey, base+constants.KeyFilename)
-
-		tls.CommonTlsContext.TlsCertificates = []*auth.TlsCertificate{
-			{
-				CertificateChain: &core.DataSource{
-					Specifier: &core.DataSource_Filename{
-						Filename: tlsServerCertChain,
-					},
-				},
-				PrivateKey: &core.DataSource{
-					Specifier: &core.DataSource_Filename{
-						Filename: tlsServerKey,
-					},
-				},
-			},
-		}
-	} else {
-		tls.CommonTlsContext.TlsCertificateSdsSecretConfigs = []*auth.SdsSecretConfig{
-			authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, sdsUdsPath, meta),
-		}
-
-		tls.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
-			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-				DefaultValidationContext: &auth.CertificateValidationContext{VerifySubjectAltName: []string{} /*subjectAltNames*/},
-				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName,
-					sdsUdsPath, meta),
-			},
-		}
-	}
-	mtls := GetMutualTLS(a.policy)
-	if mtls == nil {
-		return nil
-	}
-	if mtls.GetMode() == authn_v1alpha1.MutualTls_STRICT {
-		log.Debug("Allow only istio mutual TLS traffic")
-		return []plugin.FilterChain{
-			{
-				TLSContext: tls,
-			}}
-	}
-	if mtls.GetMode() == authn_v1alpha1.MutualTls_PERMISSIVE {
-		log.Debug("Allow both, ALPN istio and legacy traffic")
-		return []plugin.FilterChain{
-			{
-				FilterChainMatch: alpnIstioMatch,
-				TLSContext:       tls,
-				ListenerFilters: []*ldsv2.ListenerFilter{
-					{
-						Name:       xdsutil.TlsInspector,
-						ConfigType: &ldsv2.ListenerFilter_Config{Config: &structpb.Struct{}},
-					},
-				},
-			},
-			{
-				FilterChainMatch: &ldsv2.FilterChainMatch{},
-			},
-		}
-	}
-	return nil
+	return authn_utils.BuildInboundFilterChain(GetMutualTLSMode(a.policy), sdsUdsPath, node)
 }
 
 // NewPolicyApplier returns new applier for v1alpha1 authentication policy.

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -32,22 +33,32 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/security/authn"
+	authn_utils "istio.io/istio/pilot/pkg/security/authn/utils"
 	alpha_applier "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 	authn_alpha "istio.io/istio/security/proto/authentication/v1alpha1"
 	authn_filter "istio.io/istio/security/proto/envoy/config/filter/http/authn/v2alpha1"
 	"istio.io/pkg/log"
+	istiolog "istio.io/pkg/log"
+)
+
+var (
+	authnLog = istiolog.RegisterScope("authn", "authn debugging", 0)
 )
 
 // Implemenation of authn.PolicyApplier with v1beta1 API.
 type v1beta1PolicyApplier struct {
 	jwtPolicies []*model.Config
-	// TODO: add mTLS configs.
+
+	peerPolices []*model.Config
 
 	// processedJwtRules is the consolidate JWT rules from all jwtPolicies.
 	processedJwtRules []*v1beta1.JWTRule
 
-	alphaApplier authn.PolicyApplier
+	consolidatedPeerPolicy *v1beta1.PeerAuthentication
+
+	hasAlphaMTLSPolicy bool
+	alphaApplier       authn.PolicyApplier
 }
 
 func (a *v1beta1PolicyApplier) JwtFilter(isXDSMarshalingToAnyEnabled bool) *http_conn.HttpFilter {
@@ -133,11 +144,24 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarsha
 }
 
 func (a *v1beta1PolicyApplier) InboundFilterChain(sdsUdsPath string, node *model.Proxy) []plugin.FilterChain {
-	return a.alphaApplier.InboundFilterChain(sdsUdsPath, node)
+	// If beta mTLS policy (PeerAuthentication) is not used for this workload, fallback to alpha policy.
+	if a.consolidatedPeerPolicy == nil && a.hasAlphaMTLSPolicy {
+		authnLog.Debug("InboundFilterChain: fallback to alpha policy applier")
+		return a.alphaApplier.InboundFilterChain(sdsUdsPath, node)
+	}
+	effectiveMTLSMode := model.MTLSPermissive
+	if a.consolidatedPeerPolicy != nil {
+		effectiveMTLSMode = getMutualTLSMode(a.consolidatedPeerPolicy.Mtls)
+	}
+	authnLog.Debugf("InboundFilterChain: build inbound filter change for %v in %s mode", node.ID, effectiveMTLSMode)
+	return authn_utils.BuildInboundFilterChain(effectiveMTLSMode, sdsUdsPath, node)
 }
 
 // NewPolicyApplier returns new applier for v1beta1 authentication policies.
-func NewPolicyApplier(jwtPolicies []*model.Config, policy *authn_alpha_api.Policy) authn.PolicyApplier {
+func NewPolicyApplier(rootNamespace string,
+	jwtPolicies []*model.Config,
+	peerPolicies []*model.Config,
+	policy *authn_alpha_api.Policy) authn.PolicyApplier {
 	processedJwtRules := []*v1beta1.JWTRule{}
 
 	// TODO(diemtvu) should we need to deduplicate JWT with the same issuer.
@@ -155,9 +179,12 @@ func NewPolicyApplier(jwtPolicies []*model.Config, policy *authn_alpha_api.Polic
 	})
 
 	return &v1beta1PolicyApplier{
-		jwtPolicies:       jwtPolicies,
-		processedJwtRules: processedJwtRules,
-		alphaApplier:      alpha_applier.NewPolicyApplier(policy),
+		jwtPolicies:            jwtPolicies,
+		peerPolices:            peerPolicies,
+		processedJwtRules:      processedJwtRules,
+		consolidatedPeerPolicy: composePeerAuthentication(rootNamespace, peerPolicies),
+		alphaApplier:           alpha_applier.NewPolicyApplier(policy),
+		hasAlphaMTLSPolicy:     alpha_applier.GetMutualTLS(policy) != nil,
 	}
 }
 
@@ -289,4 +316,104 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule) *envoy_jwt.JwtAuthenti
 		},
 		Providers: providers,
 	}
+}
+
+// getMutualTLSMode returns the MutualTLSMode enum corresponding peer MutualTLS settings.
+// Input cannot be nil.
+func getMutualTLSMode(mtls *v1beta1.PeerAuthentication_MutualTLS) model.MutualTLSMode {
+	switch mtls.Mode {
+	case v1beta1.PeerAuthentication_MutualTLS_DISABLE:
+		return model.MTLSDisable
+	case v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE:
+		return model.MTLSPermissive
+	case v1beta1.PeerAuthentication_MutualTLS_STRICT:
+		return model.MTLSStrict
+	default:
+		return model.MTLSUnknown
+	}
+}
+
+// composePeerAuthentication returns the effective PeerAuthentication given the list of applicable
+// configs. This list should contains at most 1 mesh-level and 1 namespace-level configs.
+// Workload-level configs should not be in root namespace (this should be guaranteed by the caller,
+// though they will be safely ignored in this function). If the input config list is empty, returns
+// nil which can be used to indicate no applicable (beta) policy exist in order to trigger fallback
+// to alpha policy. This can be simplified once we deprecate alpha policy.
+// If there is at least one applicable config, returns should be not nil, and is a combined policy
+// based on following rules:
+// - It should have the setting from the most narrow scope (i.e workload-level is  preferred over
+// namespace-level, which is preferred over mesh-level).
+// - When there are more than one policy in the same scope (i.e workload-level), the oldest one
+// win.
+// - UNSET will be replaced with the setting from the parrent. I.e UNSET port-level config will be
+// replaced with config from workload-level, UNSET in workload-level config will be replaced with
+// one in namespace-level and so on.
+func composePeerAuthentication(rootNamespace string, configs []*model.Config) *v1beta1.PeerAuthentication {
+	var meshPolicy, namespacePolicy, workloadPolicy *v1beta1.PeerAuthentication
+	// Creation time associate with the selected workloadPolicy above. Initially set to max time.
+	workloadPolicyCreationTime := time.Unix(1<<63-1, 0)
+
+	for _, cfg := range configs {
+		spec := cfg.Spec.(*v1beta1.PeerAuthentication)
+		if cfg.Namespace == rootNamespace && spec.Selector == nil {
+			meshPolicy = spec
+		} else if spec.Selector == nil {
+			namespacePolicy = spec
+		} else if cfg.Namespace != rootNamespace {
+			// Assign to the (selected) workloadPolicy, if it is not set or have a newer timestamp.
+			if workloadPolicy == nil || cfg.CreationTimestamp.Before(workloadPolicyCreationTime) {
+				workloadPolicy = spec
+				workloadPolicyCreationTime = cfg.CreationTimestamp
+			}
+		}
+	}
+
+	if meshPolicy == nil && namespacePolicy == nil && workloadPolicy == nil {
+		// Return nil so that caller can fallback to apply alpha policy. Once we deprecate alpha API,
+		// this special case can be removed.
+		return nil
+	}
+
+	// Initial outputPolicy is set to a PERMISSIVE.
+	outputPolicy := v1beta1.PeerAuthentication{
+		Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+			Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+		},
+	}
+
+	// Process in mesh, namespace, workload order to resolve inheritance (UNSET)
+
+	if meshPolicy != nil && !isMtlsModeUnset(meshPolicy.Mtls) {
+		// If mesh policy is defined, update parentPolicy to mesh policy.
+		outputPolicy.Mtls = meshPolicy.Mtls
+	}
+
+	if namespacePolicy != nil && !isMtlsModeUnset(namespacePolicy.Mtls) {
+		// If namespace policy is defined, update output policy to namespace policy. This means namespace
+		// policy overwrite mesh policy.
+		outputPolicy.Mtls = namespacePolicy.Mtls
+	}
+
+	if workloadPolicy != nil && !isMtlsModeUnset(workloadPolicy.Mtls) {
+		// If workload policy is defined, update parent policy to workload policy.
+		outputPolicy.Mtls = workloadPolicy.Mtls
+	}
+
+	if workloadPolicy != nil && workloadPolicy.PortLevelMtls != nil {
+		outputPolicy.PortLevelMtls = make(map[uint32]*v1beta1.PeerAuthentication_MutualTLS, len(workloadPolicy.PortLevelMtls))
+		for port, mtls := range workloadPolicy.PortLevelMtls {
+			if isMtlsModeUnset(mtls) {
+				// Inherit from workload level.
+				outputPolicy.PortLevelMtls[port] = outputPolicy.Mtls
+			} else {
+				outputPolicy.PortLevelMtls[port] = mtls
+			}
+		}
+	}
+
+	return &outputPolicy
+}
+
+func isMtlsModeUnset(mtls *v1beta1.PeerAuthentication_MutualTLS) bool {
+	return mtls == nil || mtls.Mode == v1beta1.PeerAuthentication_MutualTLS_UNSET
 }

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -17,6 +17,7 @@ package v1beta1
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
@@ -30,7 +31,8 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	authn_alpha_api "istio.io/api/authentication/v1alpha1"
-	v1beta1 "istio.io/api/security/v1beta1"
+	"istio.io/api/security/v1beta1"
+	type_beta "istio.io/api/type/v1beta1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pilot/pkg/networking/plugin"
@@ -608,7 +610,7 @@ func TestJwtFilter(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := NewPolicyApplier(c.in, c.alphaPolicyIn).JwtFilter(true); !reflect.DeepEqual(c.expected, got) {
+			if got := NewPolicyApplier("root-namespace", c.in, nil, c.alphaPolicyIn).JwtFilter(true); !reflect.DeepEqual(c.expected, got) {
 				t.Errorf("got:\n%s\nwanted:\n%s", spew.Sdump(got), spew.Sdump(c.expected))
 			}
 		})
@@ -1149,7 +1151,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := NewPolicyApplier(c.in, c.alphaPolicyIn).AuthNFilter(model.SidecarProxy, false)
+			got := NewPolicyApplier("root-namespace", c.in, nil, c.alphaPolicyIn).AuthNFilter(model.SidecarProxy, false)
 			if !reflect.DeepEqual(c.expected, got) {
 				gotYaml, _ := gogoprotomarshal.ToYAML(got)
 				expectedYaml, _ := gogoprotomarshal.ToYAML(c.expected)
@@ -1159,9 +1161,8 @@ func TestAuthnFilterConfig(t *testing.T) {
 	}
 }
 
-// Just one test case to ensure mTLS context is correctly setup, since we just invoke
-// alpha implementation.
 func TestOnInboundFilterChain(t *testing.T) {
+	now := time.Now()
 	tlsContext := &envoy_auth.DownstreamTlsContext{
 		CommonTlsContext: &envoy_auth.CommonTlsContext{
 			TlsCertificates: []*envoy_auth.TlsCertificate{
@@ -1192,52 +1193,722 @@ func TestOnInboundFilterChain(t *testing.T) {
 		RequireClientCertificate: protovalue.BoolTrue,
 	}
 
-	tc := struct {
-		name       string
-		in         *authn_alpha_api.Policy
-		sdsUdsPath string
-		expected   []plugin.FilterChain
-		node       *model.Proxy
+	cases := []struct {
+		name         string
+		peerPolicies []*model.Config
+		alphaPolicy  *authn_alpha_api.Policy
+		sdsUdsPath   string
+		expected     []plugin.FilterChain
 	}{
-		name: "PermissiveMTLS",
-		in: &authn_alpha_api.Policy{
-			Peers: []*authn_alpha_api.PeerAuthenticationMethod{
+		{
+			name: "No policy - behave as permissive",
+			expected: []plugin.FilterChain{
 				{
-					Params: &authn_alpha_api.PeerAuthenticationMethod_Mtls{
-						Mtls: &authn_alpha_api.MutualTls{
-							Mode: authn_alpha_api.MutualTls_PERMISSIVE,
+					TLSContext: tlsContext,
+					FilterChainMatch: &listener.FilterChainMatch{
+						ApplicationProtocols: []string{"istio-peer-exchange", "istio"},
+					},
+					ListenerFilters: []*listener.ListenerFilter{
+						{
+							Name:       "envoy.listener.tls_inspector",
+							ConfigType: &listener.ListenerFilter_Config{&structpb.Struct{}},
+						},
+					},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{},
+				},
+			},
+		},
+		{
+			name: "Single policy - disable mode",
+			peerPolicies: []*model.Config{
+				{
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
 						},
 					},
 				},
 			},
+			expected: nil,
 		},
-		node: &model.Proxy{
-			Metadata: &model.NodeMetadata{},
-		},
-		// Two filter chains, one for mtls traffic within the mesh, one for plain text traffic.
-		expected: []plugin.FilterChain{
-			{
-				TLSContext: tlsContext,
-				FilterChainMatch: &listener.FilterChainMatch{
-					ApplicationProtocols: []string{"istio-peer-exchange", "istio"},
-				},
-				ListenerFilters: []*listener.ListenerFilter{
-					{
-						Name:       "envoy.listener.tls_inspector",
-						ConfigType: &listener.ListenerFilter_Config{&structpb.Struct{}},
+		{
+			name: "Single policy - permissive mode",
+			peerPolicies: []*model.Config{
+				{
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+						},
 					},
 				},
 			},
-			{
-				FilterChainMatch: &listener.FilterChainMatch{},
+			expected: []plugin.FilterChain{
+				{
+					TLSContext: tlsContext,
+					FilterChainMatch: &listener.FilterChainMatch{
+						ApplicationProtocols: []string{"istio-peer-exchange", "istio"},
+					},
+					ListenerFilters: []*listener.ListenerFilter{
+						{
+							Name:       "envoy.listener.tls_inspector",
+							ConfigType: &listener.ListenerFilter_Config{&structpb.Struct{}},
+						},
+					},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{},
+				},
+			},
+		},
+		{
+			name: "Single policy - strict mode",
+			peerPolicies: []*model.Config{
+				{
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+			},
+			expected: []plugin.FilterChain{
+				{
+					TLSContext: tlsContext,
+				},
+			},
+		},
+		{
+			name: "Multiple policies resolved to STRICT",
+			peerPolicies: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "now",
+						Namespace:         "my-ns",
+						CreationTimestamp: now,
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "later",
+						Namespace:         "my-ns",
+						CreationTimestamp: now.Add(time.Second),
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+						},
+					},
+				},
+			},
+			expected: []plugin.FilterChain{
+				{
+					TLSContext: tlsContext,
+				},
+			},
+		},
+		{
+			name: "Multiple policies resolved to PERMISSIVE",
+			peerPolicies: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "now",
+						Namespace:         "my-ns",
+						CreationTimestamp: now,
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "earlier",
+						Namespace:         "my-ns",
+						CreationTimestamp: now.Add(time.Second * -1),
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+						},
+					},
+				},
+			},
+			expected: []plugin.FilterChain{
+				{
+					TLSContext: tlsContext,
+					FilterChainMatch: &listener.FilterChainMatch{
+						ApplicationProtocols: []string{"istio-peer-exchange", "istio"},
+					},
+					ListenerFilters: []*listener.ListenerFilter{
+						{
+							Name:       "envoy.listener.tls_inspector",
+							ConfigType: &listener.ListenerFilter_Config{&structpb.Struct{}},
+						},
+					},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{},
+				},
+			},
+		},
+		{
+			name: "Fallback to alpha API",
+			alphaPolicy: &authn_alpha_api.Policy{
+				Peers: []*authn_alpha_api.PeerAuthenticationMethod{
+					{
+						Params: &authn_alpha_api.PeerAuthenticationMethod_Mtls{
+							Mtls: &authn_alpha_api.MutualTls{
+								Mode: authn_alpha_api.MutualTls_PERMISSIVE,
+							},
+						},
+					},
+				},
+			},
+			// Two filter chains, one for mtls traffic within the mesh, one for plain text traffic.
+			expected: []plugin.FilterChain{
+				{
+					TLSContext: tlsContext,
+					FilterChainMatch: &listener.FilterChainMatch{
+						ApplicationProtocols: []string{"istio-peer-exchange", "istio"},
+					},
+					ListenerFilters: []*listener.ListenerFilter{
+						{
+							Name:       "envoy.listener.tls_inspector",
+							ConfigType: &listener.ListenerFilter_Config{&structpb.Struct{}},
+						},
+					},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{},
+				},
+			},
+		},
+		{
+			name: "Ignore alpha API",
+			peerPolicies: []*model.Config{
+				{
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+						},
+					},
+				},
+			},
+			alphaPolicy: &authn_alpha_api.Policy{
+				Peers: []*authn_alpha_api.PeerAuthenticationMethod{
+					{
+						Params: &authn_alpha_api.PeerAuthenticationMethod_Mtls{
+							Mtls: &authn_alpha_api.MutualTls{
+								Mode: authn_alpha_api.MutualTls_PERMISSIVE,
+							},
+						},
+					},
+				},
+			},
+			// Two filter chains, one for mtls traffic within the mesh, one for plain text traffic.
+			expected: nil,
+		},
+	}
+
+	testNode := &model.Proxy{
+		Metadata: &model.NodeMetadata{
+			Labels: map[string]string{
+				"app": "foo",
 			},
 		},
 	}
-	got := NewPolicyApplier(nil, tc.in).InboundFilterChain(
-		tc.sdsUdsPath,
-		tc.node,
-	)
-	if !reflect.DeepEqual(got, tc.expected) {
-		t.Errorf("[%v] unexpected filter chains, got %v, want %v", tc.name, got, tc.expected)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewPolicyApplier("root-namespace", nil, tc.peerPolicies, tc.alphaPolicy).InboundFilterChain(
+				tc.sdsUdsPath,
+				testNode,
+			)
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("[%v] unexpected filter chains, got %v, want %v", tc.name, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestComposePeerAuthentication(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name    string
+		configs []*model.Config
+		want    *v1beta1.PeerAuthentication
+	}{
+		{
+			name:    "no config",
+			configs: []*model.Config{},
+			want:    nil,
+		},
+		{
+			name: "mesh only",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "root-namespace",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+				},
+			},
+		},
+		{
+			name: "mesh vs namespace",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "root-namespace",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{},
+						},
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "my-ns",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+				},
+			},
+		},
+		{
+			name: "ignore non-empty selector in root namespace",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "root-namespace",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "workload vs namespace config",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "my-ns",
+					},
+					Spec: &v1beta1.PeerAuthentication{},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "foo",
+						Namespace: "my-ns",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+				},
+			},
+		},
+		{
+			name: "workload vs mesh config",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "my-ns",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "root-namespace",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+				},
+			},
+		},
+		{
+			name: "multiple workload policy",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "now",
+						Namespace:         "my-ns",
+						CreationTimestamp: now,
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "second ago",
+						Namespace:         "my-ns",
+						CreationTimestamp: now.Add(time.Second * -1),
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "second later",
+						Namespace:         "my-ns",
+						CreationTimestamp: now.Add(time.Second * -1),
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"stage": "prod",
+							},
+						},
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+				},
+			},
+		},
+		{
+			name: "inheritance: default mesh",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "root-namespace",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_UNSET,
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+				},
+			},
+		},
+		{
+			name: "inheritance: mesh to workload",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "root-namespace",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "foo",
+						Namespace: "my-ns",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+				},
+			},
+		},
+		{
+			name: "inheritance: namespace to workload",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "my-ns",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "foo",
+						Namespace: "my-ns",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+				},
+			},
+		},
+		{
+			name: "inheritance: mesh to namespace to workload",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "root-namespace",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "my-ns",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_UNSET,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "foo",
+						Namespace: "my-ns",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+				},
+			},
+		},
+		{
+			name: "port level",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "default",
+						Namespace: "root-namespace",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "foo",
+						Namespace: "my-ns",
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Selector: &type_beta.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+						PortLevelMtls: map[uint32]*v1beta1.PeerAuthentication_MutualTLS{
+							80: {
+								Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+							},
+							90: {
+								Mode: v1beta1.PeerAuthentication_MutualTLS_UNSET,
+							},
+							100: {},
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+				},
+				PortLevelMtls: map[uint32]*v1beta1.PeerAuthentication_MutualTLS{
+					80: {
+						Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+					},
+					90: {
+						Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+					},
+					100: {
+						Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := composePeerAuthentication("root-namespace", tt.configs); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("composePeerAuthentication() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMutualTLSMode(t *testing.T) {
+	tests := []struct {
+		name string
+		in   v1beta1.PeerAuthentication_MutualTLS
+		want model.MutualTLSMode
+	}{
+		{
+			name: "unset",
+			in: v1beta1.PeerAuthentication_MutualTLS{
+				Mode: v1beta1.PeerAuthentication_MutualTLS_UNSET,
+			},
+			want: model.MTLSUnknown,
+		},
+		{
+			name: "disable",
+			in: v1beta1.PeerAuthentication_MutualTLS{
+				Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+			},
+			want: model.MTLSDisable,
+		},
+		{
+			name: "permissive",
+			in: v1beta1.PeerAuthentication_MutualTLS{
+				Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+			},
+			want: model.MTLSPermissive,
+		},
+		{
+			name: "strict",
+			in: v1beta1.PeerAuthentication_MutualTLS{
+				Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+			},
+			want: model.MTLSStrict,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getMutualTLSMode(&tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getMutualTLSMode() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -91,6 +91,45 @@ func TestReachability(t *testing.T) {
 						return opts.PortName != "http"
 					},
 				},
+				{
+					ConfigFile:          "beta-mtls-on.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						if src == rctx.Naked && opts.Target == rctx.Naked {
+							// naked->naked should always succeed.
+							return true
+						}
+
+						// If one of the two endpoints is naked, expect failure.
+						return src != rctx.Naked && opts.Target != rctx.Naked
+					},
+				},
+				{
+					ConfigFile:          "beta-mtls-permissive.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude calls to the naked app.
+						return opts.Target != rctx.Naked
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+				},
+				{
+					ConfigFile: "beta-mtls-off.yaml",
+					Namespace:  systemNM,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+				},
 			}
 			rctx.Run(testCases)
 		})

--- a/tests/integration/security/testdata/beta-mtls-off.yaml
+++ b/tests/integration/security/testdata/beta-mtls-off.yaml
@@ -1,0 +1,21 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-off"
+spec:
+  mtls:
+    mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-off"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/tests/integration/security/testdata/beta-mtls-on.yaml
+++ b/tests/integration/security/testdata/beta-mtls-on.yaml
@@ -1,0 +1,21 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-on"
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-on"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/integration/security/testdata/beta-mtls-permissive.yaml
+++ b/tests/integration/security/testdata/beta-mtls-permissive.yaml
@@ -1,0 +1,23 @@
+# Global PeerAuthentication can be removed for this test, once we remove the (alpha) mesh policy
+# during installation.
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-permissive"
+spec:
+  mtls:
+    mode: PERMISSIVE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-permissive"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL


### PR DESCRIPTION
git cherry-pick 9053f47fc2aeb528124bbf035c62304837dd8516

* Apply beta peer authentication policy down to workload level

* Clean up

* Lint

* Check beta policy for auto mtls. This can be removed when EP metadata take into account the policy

* Use explicit peerauthentication policy for permissive, as we haven't remove old mesh policy during installation

* pilot/pkg/security/authn/v1beta1/policy_applier.go

* Move all test for beta mTLS api to the end

* Change to namespace policy

* Revert cluster.go

* Change peer authn consolidation algorithm for UNSET (inheritant mode)

* Reimplement getMostSpecificConfig (now composePeerAuthentication) which also consolidate port-level policies.

* Fix inheritance: do not inherit if it is weaker than the current mode

* Remove debug logs

* Change test policy to namespace level to make sure they are clean up properly with the existing test setup.

* Address comment

* Lint

* Simplify logic to pick the oldest

* fix typo

* Update function comment