### PR TITLE
Chery pick: Apply peer authentication policy at port level (#20925)

### DIFF
--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -37,7 +37,7 @@ func NewPlugin() plugin.Plugin {
 func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.FilterChain {
 	return factory.NewPolicyApplier(in.Push,
 		in.ServiceInstance, in.Node.Metadata.Namespace, in.Node.WorkloadLabels).InboundFilterChain(
-		in.Push.Mesh.SdsUdsPath, in.Node)
+		in.ServiceInstance.Endpoint.EndpointPort, in.Push.Mesh.SdsUdsPath, in.Node)
 }
 
 // OnOutboundListener is called whenever a new outbound listener is added to the LDS output for a given service

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -24,8 +24,9 @@ import (
 // PolicyApplier is the interface provides essential functionalities to help config Envoy (xDS) to enforce
 // authentication policy. Each version of authentication policy will implement this interface.
 type PolicyApplier interface {
-	// InboundFilterChain returns inbound filter chain(s) to enforce the underlying authentication policy.
-	InboundFilterChain(sdsUdsPath string, node *model.Proxy) []plugin.FilterChain
+	// InboundFilterChain returns inbound filter chain(s) for the given endpoint (aka workload) port to
+	// enforce the underlying authentication policy.
+	InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy) []plugin.FilterChain
 
 	// AuthNFilter returns the JWT HTTP filter to enforce the underlying authentication policy.
 	// It may return nil, if no JWT validation is needed.

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -325,7 +325,8 @@ func (a v1alpha1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarsha
 	return out
 }
 
-func (a v1alpha1PolicyApplier) InboundFilterChain(sdsUdsPath string, node *model.Proxy) []plugin.FilterChain {
+// v1alpha1 applier is already per port, so the endpointPort param is not needed.
+func (a v1alpha1PolicyApplier) InboundFilterChain(_ uint32, sdsUdsPath string, node *model.Proxy) []plugin.FilterChain {
 	if a.policy == nil || len(a.policy.Peers) == 0 {
 		return nil
 	}

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -1090,7 +1090,7 @@ func TestOnInboundFilterChains(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := NewPolicyApplier(c.in).InboundFilterChain(
+			got := NewPolicyApplier(c.in).InboundFilterChain(8080,
 				c.sdsUdsPath,
 				c.node,
 			)

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -143,17 +143,17 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarsha
 	return out
 }
 
-func (a *v1beta1PolicyApplier) InboundFilterChain(sdsUdsPath string, node *model.Proxy) []plugin.FilterChain {
+func (a *v1beta1PolicyApplier) InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy) []plugin.FilterChain {
 	// If beta mTLS policy (PeerAuthentication) is not used for this workload, fallback to alpha policy.
 	if a.consolidatedPeerPolicy == nil && a.hasAlphaMTLSPolicy {
 		authnLog.Debug("InboundFilterChain: fallback to alpha policy applier")
-		return a.alphaApplier.InboundFilterChain(sdsUdsPath, node)
+		return a.alphaApplier.InboundFilterChain(endpointPort, sdsUdsPath, node)
 	}
 	effectiveMTLSMode := model.MTLSPermissive
 	if a.consolidatedPeerPolicy != nil {
-		effectiveMTLSMode = getMutualTLSMode(a.consolidatedPeerPolicy.Mtls)
+		effectiveMTLSMode = a.getMutualTLSModeForPort(endpointPort)
 	}
-	authnLog.Debugf("InboundFilterChain: build inbound filter change for %v in %s mode", node.ID, effectiveMTLSMode)
+	authnLog.Debugf("InboundFilterChain: build inbound filter change for %v : %d in %s mode", node.ID, endpointPort, effectiveMTLSMode)
 	return authn_utils.BuildInboundFilterChain(effectiveMTLSMode, sdsUdsPath, node)
 }
 
@@ -316,6 +316,19 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule) *envoy_jwt.JwtAuthenti
 		},
 		Providers: providers,
 	}
+}
+
+func (a *v1beta1PolicyApplier) getMutualTLSModeForPort(endpointPort uint32) model.MutualTLSMode {
+	if a.consolidatedPeerPolicy == nil {
+		return model.MTLSPermissive
+	}
+	if a.consolidatedPeerPolicy.PortLevelMtls != nil {
+		if portMtls, ok := a.consolidatedPeerPolicy.PortLevelMtls[endpointPort]; ok {
+			return getMutualTLSMode(portMtls)
+		}
+	}
+
+	return getMutualTLSMode(a.consolidatedPeerPolicy.Mtls)
 }
 
 // getMutualTLSMode returns the MutualTLSMode enum corresponding peer MutualTLS settings.

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -121,8 +121,32 @@ func TestReachability(t *testing.T) {
 					},
 				},
 				{
-					ConfigFile: "beta-mtls-off.yaml",
-					Namespace:  systemNM,
+					ConfigFile:          "beta-mtls-off.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+				},
+				{
+					ConfigFile:          "beta-per-port-mtls.yaml",
+					Namespace:           rctx.Namespace,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Include all tests that target app B, which has the single-port config.
+						return opts.Target == rctx.B
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return opts.PortName != "http"
+					},
+				},
+				{
+					ConfigFile:          "mix-mtls-api.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
 						return true
 					},

--- a/tests/integration/security/testdata/beta-per-port-mtls.yaml
+++ b/tests/integration/security/testdata/beta-per-port-mtls.yaml
@@ -1,0 +1,28 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "per-port"
+  annotations:
+    test-suite: "beta-per-port-mtls"
+spec:
+  selector:
+    matchLabels:
+      app: b
+  mtls:
+    mode: DISABLE
+  portLevelMtls:
+    # 8090 is the targetPort for service http(80)
+    8090:
+      mode: STRICT
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-per-port-mtls"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/tests/integration/security/testdata/mix-mtls-api.yaml
+++ b/tests/integration/security/testdata/mix-mtls-api.yaml
@@ -1,0 +1,31 @@
+# Global Alpha API enable mTLS strict, namespace beta API disable mTLS. Alpha API should be
+# ignored, so this should behave same as beta-mtls-off.
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "mix-mtls-api"
+spec: {}
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "mix-mtls-api"
+spec:
+  mtls:
+    mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "mix-mtls-api"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"istio.io/istio/pkg/test/util/retry"
+
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -124,14 +126,21 @@ func (rc *Context) Run(testCases []TestCase) {
 		test.Run(func(ctx framework.TestContext) {
 			// Apply the policy.
 			policyYAML := file.AsStringOrFail(ctx, filepath.Join("./testdata", c.ConfigFile))
-			rc.g.ApplyConfigOrFail(ctx, c.Namespace, policyYAML)
+			retry.UntilSuccessOrFail(ctx, func() error {
+				ctx.Logf("[%s] [%v] Apply config %s", testName, time.Now(), c.ConfigFile)
+				// TODO(https://github.com/istio/istio/issues/20460) We shouldn't need a retry loop
+				return rc.g.ApplyConfig(c.Namespace, policyYAML)
+			})
 			ctx.WhenDone(func() error {
+				ctx.Logf("[%s] [%v] Delete config %s", testName, time.Now(), c.ConfigFile)
 				return rc.g.DeleteConfig(c.Namespace, policyYAML)
 			})
 
 			// Give some time for the policy propagate.
 			// TODO: query pilot or app to know instead of sleep.
+			ctx.Logf("[%s] [%v] Wait for config propagate to endpoints...", testName, time.Now())
 			time.Sleep(10 * time.Second)
+			ctx.Logf("[%s] [%v] Finish waiting. Continue testing.", testName, time.Now())
 
 			for _, src := range []echo.Instance{rc.A, rc.B, rc.Headless, rc.Naked} {
 				for _, dest := range []echo.Instance{rc.A, rc.B, rc.Headless, rc.Naked} {


### PR DESCRIPTION
 git cherry-pick b3ffe91a610359a16838d33612e0950fb8ee35f6

* Apply peer authentication policy at port level

* Lint

* Fix e2e TestReachability/beta-per-port-mtls

* Fix mix api test

* Add log to test to debug resource apply/delete

* Add require env kube for new tests