### PR TITLE
fix: Use https if scheme isn't provided in jwt issuer

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -260,6 +260,11 @@ func (r *JwksResolver) resolveJwksURIUsingOpenID(issuer string) (string, error) 
 		return uri.(string), nil
 	}
 
+	// Default to https if the provided url has no scheme
+	if !strings.Contains(issuer, "://") {
+		issuer = "https://" + issuer
+	}
+
 	// Try to get jwks_uri through OpenID Discovery.
 	body, err := r.getRemoteContentWithRetry(issuer+openIDDiscoveryCfgURLSuffix, networkFetchRetryCountOnMainFlow)
 	if err != nil {


### PR DESCRIPTION
This allows for discovery of issuers like accounts.google.com

Fixes #20978

I tested this locally using:

```
func TestResolveJwksURIUsingOpenIDWithoutScheme(t *testing.T) {
	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, []string{"/etc/ssl/certs/ca-certificates.crt"})

	in := "accounts.google.com"
	expectedCertURL := "https://www.googleapis.com/oauth2/v3/certs"
	jwksURI, err := r.resolveJwksURIUsingOpenID(in)
	if err != nil {
		t.Errorf("resolveJwksURIUsingOpenID(%+v): got error (%v)", in, err)
	} else if expectedCertURL != jwksURI {
		t.Errorf("resolveJwksURIUsingOpenID(%+v): expected (%s), got (%s)",
			in, expectedCertURL, jwksURI)
	}
}
```

This relies on external dependencies though, so didn't seem appropriate to include in the test suite

I wasn't able to work out how to use the mock server infrastructure for this - it generates random ports, so the scheme-less url would be `localhost:30505` etc - and then the scheme is detected as `localhost` rather than empty.