### PR TITLE
Fix quoting for custom env variables in gateway deployment helm template

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -296,7 +296,7 @@ spec:
           {{- if $spec.env }}
           {{- range $key, $val := $spec.env }}
           - name: {{ $key }}
-            value: {{ $val }}
+            value: "{{ $val }}"
           {{- end }}
           {{- end }}
           {{ if eq $key "istio-ingressgateway" }}


### PR DESCRIPTION
It is not possible to set a custom value for TERMINATION_DRAIN_DURATION_SECONDS in the ingress-gateway. Kubernetes expects a string value. Since it is a numeric value it should be quoted properly in the helm template. Trying to set it to `15` causes helm to fail with the error

```
Error: UPGRADE FAILED: release istio failed, and has been rolled back due to atomic being set: cannot patch "istio-ingressgateway" with kind Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found 1, error found in #10 byte of ...|,"value":15}],"image|..., bigger context ...|me":"TERMINATION_DRAIN_DURATION_SECONDS","value":15}],"image":"docker.io/istio/proxyv2:1.4.3","image|...
```