### PR TITLE
Remove WhenDone from test framework

### DIFF
--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -57,6 +57,7 @@ type TestContext interface {
 	RequireOrSkip(envName environment.Name)
 
 	// WhenDone runs the given function when the test context completes.
+	// This function may not (safely) access the test context.
 	WhenDone(fn func() error)
 
 	// Done should be called when this context is no longer needed. It triggers the asynchronous cleanup of any

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -56,9 +56,6 @@ type TestContext interface {
 	// RequireOrSkip skips the test if the environment is not as expected.
 	RequireOrSkip(envName environment.Name)
 
-	// WhenDone runs the given function when the test context completes.
-	WhenDone(fn func() error)
-
 	// Done should be called when this context is no longer needed. It triggers the asynchronous cleanup of any
 	// allocated resources.
 	Done()
@@ -214,10 +211,6 @@ func (c *testContext) NewSubTest(name string) *Test {
 		parent: c.test,
 		s:      c.test.s,
 	}
-}
-
-func (c *testContext) WhenDone(fn func() error) {
-	c.scope.addCloser(&closer{fn})
 }
 
 func (c *testContext) Done() {

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -56,6 +56,9 @@ type TestContext interface {
 	// RequireOrSkip skips the test if the environment is not as expected.
 	RequireOrSkip(envName environment.Name)
 
+	// WhenDone runs the given function when the test context completes.
+	WhenDone(fn func() error)
+
 	// Done should be called when this context is no longer needed. It triggers the asynchronous cleanup of any
 	// allocated resources.
 	Done()
@@ -211,6 +214,10 @@ func (c *testContext) NewSubTest(name string) *Test {
 		parent: c.test,
 		s:      c.test.s,
 	}
+}
+
+func (c *testContext) WhenDone(fn func() error) {
+	c.scope.addCloser(&closer{fn})
 }
 
 func (c *testContext) Done() {

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -132,7 +132,6 @@ func (rc *Context) Run(testCases []TestCase) {
 				return rc.g.ApplyConfig(c.Namespace, policyYAML)
 			})
 			ctx.WhenDone(func() error {
-				ctx.Logf("[%s] [%v] Delete config %s", testName, time.Now(), c.ConfigFile)
 				return rc.g.DeleteConfig(c.Namespace, policyYAML)
 			})
 

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -131,10 +131,10 @@ func (rc *Context) Run(testCases []TestCase) {
 				// TODO(https://github.com/istio/istio/issues/20460) We shouldn't need a retry loop
 				return rc.g.ApplyConfig(c.Namespace, policyYAML)
 			})
-			ctx.WhenDone(func() error {
+			defer func() {
 				ctx.Logf("[%s] [%v] Delete config %s", testName, time.Now(), c.ConfigFile)
-				return rc.g.DeleteConfig(c.Namespace, policyYAML)
-			})
+				_ = rc.g.DeleteConfig(c.Namespace, policyYAML)
+			}()
 
 			// Give some time for the policy propagate.
 			// TODO: query pilot or app to know instead of sleep.

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -131,10 +131,10 @@ func (rc *Context) Run(testCases []TestCase) {
 				// TODO(https://github.com/istio/istio/issues/20460) We shouldn't need a retry loop
 				return rc.g.ApplyConfig(c.Namespace, policyYAML)
 			})
-			defer func() {
+			ctx.WhenDone(func() error {
 				ctx.Logf("[%s] [%v] Delete config %s", testName, time.Now(), c.ConfigFile)
-				_ = rc.g.DeleteConfig(c.Namespace, policyYAML)
-			}()
+				return rc.g.DeleteConfig(c.Namespace, policyYAML)
+			})
 
 			// Give some time for the policy propagate.
 			// TODO: query pilot or app to know instead of sleep.


### PR DESCRIPTION
This command violates go test framework. See Line 900 of
https://golang.org/src/testing/testing.go, you cannot use the `t` after
the test is done. A defer works fine here.

Example failure: https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/20994/integ-security-local-tests_istio/7885