### PR TITLE
Allow operator tpath to include entirely new slices

### DIFF
--- a/operator/pkg/compare/compare.go
+++ b/operator/pkg/compare/compare.go
@@ -210,7 +210,13 @@ func pathToStringList(path cmp.Path) (up []string) {
 		case cmp.MapIndex:
 			up = append(up, fmt.Sprintf("%v", t.Key()))
 		case cmp.SliceIndex:
-			up = append(up, fmt.Sprintf("%v", t.String()))
+			// Create an element, but never an NPath
+			s := t.String()
+			if util.IsNPathElement(s) {
+				// Convert e.g. [0] to [#0]
+				s = fmt.Sprintf("%c%c%s", s[0], '#', s[1:])
+			}
+			up = append(up, s)
 		}
 	}
 	return

--- a/operator/pkg/compare/compare_test.go
+++ b/operator/pkg/compare/compare_test.go
@@ -293,8 +293,8 @@ metadata:
 `,
 			want: `metadata:
   labels:
-    '[1]': label2 -> label5
-    '[2]': label3 -> label6
+    '[#1]': label2 -> label5
+    '[#2]': label3 -> label6
 `,
 		},
 		{
@@ -352,10 +352,10 @@ metadata:
 `,
 			want: `metadata:
   labels:
+    '[#0]': label0 -> label4
     '[?->1]': -> label5
     '[?->2]': -> label2
     '[?->3]': -> label3
-    '[0]': label0 -> label4
     '[2->5]': label2 -> label0
 `,
 		},

--- a/operator/pkg/tpath/tpath.go
+++ b/operator/pkg/tpath/tpath.go
@@ -83,6 +83,11 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 	}
 	pe := remainPath[0]
 
+	if nc.Node == nil {
+		// Otherwise we panic on bad input
+		return nil, false, fmt.Errorf("node %s is zero", pe)
+	}
+
 	v := reflect.ValueOf(nc.Node)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
@@ -176,7 +181,14 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 			if !ok {
 				// remainPath == 1 means the patch is creation of a new leaf.
 				if createMissing || len(remainPath) == 1 {
-					m[pe] = make(map[string]interface{})
+					nextElementNPath := len(remainPath) > 1 && util.IsNPathElement(remainPath[1])
+					if nextElementNPath {
+						scope.Debug("map type, slice child")
+						m[pe] = make([]interface{}, 0)
+					} else {
+						scope.Debug("map type, map child")
+						m[pe] = make(map[string]interface{})
+					}
 					nn = m[pe]
 				} else {
 					return nil, false, fmt.Errorf("path not found at element %s in path %s", pe, fullPath)

--- a/operator/pkg/tpath/tpath_test.go
+++ b/operator/pkg/tpath/tpath_test.go
@@ -478,7 +478,35 @@ a:
           i3b:
             i1: val2
 `,
-		}}
+		},
+		// For https://github.com/istio/istio/issues/20950
+		{
+			desc: "with initial list",
+			baseYAML: `
+components:
+  ingressGateways:
+    - enabled: true
+`,
+			path:  "components.ingressGateways[0].enabled",
+			value: "false",
+			want: `
+components:
+  ingressGateways:
+    - enabled: "false"
+`,
+		},
+		{
+			desc:     "no initial list",
+			baseYAML: "",
+			path:     "components.ingressGateways[0].enabled",
+			value:    "false",
+			want: `
+components:
+  ingressGateways:
+    - enabled: "false"
+`,
+		},
+	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			root := make(map[string]interface{})


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/20950

https://github.com/istio/istio/pull/20631 allowed slices/lists to be extended, but if there weren't any slices it didn't allow the `[n]` notation to create lists.

This was a problem for istioctl, because the `--set` parameter of `manifest generate` and `manifest apply` is not given a profile to start with.  It starts with nothing, and could not process `[0]` properly.

cc @GregHanson This should complete the work you requested with https://github.com/istio/istio/issues/20381