### PR TITLE
Cherry pick: Disallow using portLevelMtls at namespace/mesh policy (#20926)

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1672,10 +1672,10 @@ var ValidateRequestAuthentication = registerValidateFunc("ValidateRequestAuthent
 		var errs error
 		emptySelector := in.Selector == nil || len(in.Selector.MatchLabels) == 0
 		if name == constants.DefaultAuthenticationPolicyName && !emptySelector {
-			errs = appendErrors(errs, fmt.Errorf("default request authentication cannot have workload selector"))
+			errs = appendErrors(errs, fmt.Errorf("mesh/namespace request authentication cannot have selector"))
 		} else if emptySelector && name != constants.DefaultAuthenticationPolicyName {
 			errs = appendErrors(errs,
-				fmt.Errorf("request authentication with empty workload selector must be named %q", constants.DefaultAuthenticationPolicyName))
+				fmt.Errorf("request authentication without selector must be named %q", constants.DefaultAuthenticationPolicyName))
 		}
 
 		errs = appendErrors(errs, validateWorkloadSelector(in.Selector))
@@ -1730,10 +1730,26 @@ var ValidatePeerAuthentication = registerValidateFunc("ValidatePeerAuthenticatio
 		var errs error
 		emptySelector := in.Selector == nil || len(in.Selector.MatchLabels) == 0
 		if name == constants.DefaultAuthenticationPolicyName && !emptySelector {
-			errs = appendErrors(errs, fmt.Errorf("default peer authentication cannot have workload selector"))
+			errs = appendErrors(errs, fmt.Errorf("mesh/namespace peer authentication cannot have selector"))
 		} else if emptySelector && name != constants.DefaultAuthenticationPolicyName {
 			errs = appendErrors(errs,
-				fmt.Errorf("peer authentication with empty workload selector must be named %q", constants.DefaultAuthenticationPolicyName))
+				fmt.Errorf("peer authentication without selector must be named %q", constants.DefaultAuthenticationPolicyName))
+		}
+
+		if emptySelector && len(in.PortLevelMtls) != 0 {
+			errs = appendErrors(errs,
+				fmt.Errorf("mesh/namespace peer authentication cannot have port level mTLS"))
+		}
+
+		if in.PortLevelMtls != nil && len(in.PortLevelMtls) == 0 {
+			errs = appendErrors(errs,
+				fmt.Errorf("port level mTLS, if defined, must have at least one element"))
+		}
+
+		for port := range in.PortLevelMtls {
+			if port == 0 {
+				errs = appendErrors(errs, fmt.Errorf("port cannot be 0"))
+			}
 		}
 
 		errs = appendErrors(errs, validateWorkloadSelector(in.Selector))

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -5845,6 +5845,43 @@ func TestValidatePeerAuthentication(t *testing.T) {
 			valid: false,
 		},
 		{
+			name:       "empty port level mtls",
+			configName: "foo",
+			in: &security_beta.PeerAuthentication{
+				Selector: &api.WorkloadSelector{
+					MatchLabels: map[string]string{
+						"app": "httpbin",
+					},
+				},
+				PortLevelMtls: map[uint32]*security_beta.PeerAuthentication_MutualTLS{},
+			},
+			valid: false,
+		},
+		{
+			name:       "empty selector with port level mtls",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.PeerAuthentication{
+				PortLevelMtls: map[uint32]*security_beta.PeerAuthentication_MutualTLS{
+					8080: {
+						Mode: security_beta.PeerAuthentication_MutualTLS_UNSET,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name:       "port 0",
+			configName: "foo",
+			in: &security_beta.PeerAuthentication{
+				PortLevelMtls: map[uint32]*security_beta.PeerAuthentication_MutualTLS{
+					0: {
+						Mode: security_beta.PeerAuthentication_MutualTLS_UNSET,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
 			name:       "unset mode",
 			configName: constants.DefaultAuthenticationPolicyName,
 			in: &security_beta.PeerAuthentication{
@@ -5856,8 +5893,13 @@ func TestValidatePeerAuthentication(t *testing.T) {
 		},
 		{
 			name:       "port level",
-			configName: constants.DefaultAuthenticationPolicyName,
+			configName: "port-level",
 			in: &security_beta.PeerAuthentication{
+				Selector: &api.WorkloadSelector{
+					MatchLabels: map[string]string{
+						"app": "httpbin",
+					},
+				},
 				PortLevelMtls: map[uint32]*security_beta.PeerAuthentication_MutualTLS{
 					8080: {
 						Mode: security_beta.PeerAuthentication_MutualTLS_UNSET,


### PR DESCRIPTION
git cherry-pick 87f676a4eaa941cdda1b554870d549d033ba0b3a

* Add more validation rules for peerauthentication to prevent using port level in namespace or mesh level.

* Typo

* Reword

* Reject if port is 0

* Lint