### PR TITLE
flush object caches after iop instance is deleted.

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller_test.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller_test.go
@@ -90,7 +90,6 @@ func TestIOPController_SwitchProfile(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		helmreconciler.FlushObjectCaches()
 		testSwitchProfile(t, c)
 	}
 }

--- a/operator/pkg/helmreconciler/pruning.go
+++ b/operator/pkg/helmreconciler/pruning.go
@@ -34,6 +34,9 @@ func (h *HelmReconciler) Prune(excluded map[string]bool, all bool) error {
 	namespacedResources, clusterResources := h.customizer.PruningDetails().GetResourceTypes()
 	targetNamespace := h.customizer.Input().GetTargetNamespace()
 	err := h.PruneUnlistedResources(append(namespacedResources, clusterResources...), excluded, all, targetNamespace)
+	if all {
+		h.FlushObjectCaches()
+	}
 	if err != nil {
 		allErrors = append(allErrors, err)
 	}

--- a/operator/pkg/helmreconciler/rendering.go
+++ b/operator/pkg/helmreconciler/rendering.go
@@ -60,7 +60,7 @@ var (
 )
 
 // FlushObjectCaches flushes all K8s object caches.
-func FlushObjectCaches() {
+func (h *HelmReconciler) FlushObjectCaches() {
 	objectCachesMu.Lock()
 	defer objectCachesMu.Unlock()
 	objectCaches = make(map[string]*ObjectCache)


### PR DESCRIPTION
resolve: https://github.com/istio/istio/issues/21019


[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure