### PR TITLE
Support caching for STS server

### DIFF
--- a/security/pkg/stsservice/mock/faketokenmanager.go
+++ b/security/pkg/stsservice/mock/faketokenmanager.go
@@ -83,8 +83,8 @@ func (tm *FakeTokenManager) GenerateToken(_ stsservice.StsRequestParameters) ([]
 	t := time.Now()
 	tm.tokens.Store(t.String(), stsservice.TokenInfo{
 		TokenType:  stsResp.TokenType,
-		IssueTime:  t.String(),
-		ExpireTime: t.Add(time.Duration(stsResp.ExpiresIn) * time.Second).String(),
+		IssueTime:  t,
+		ExpireTime: t.Add(time.Duration(stsResp.ExpiresIn) * time.Second),
 	})
 	statusJSON, _ := json.MarshalIndent(stsResp, "", " ")
 	return statusJSON, nil

--- a/security/pkg/stsservice/server/server_test.go
+++ b/security/pkg/stsservice/server/server_test.go
@@ -64,8 +64,8 @@ func TestStsService(t *testing.T) {
 	emptyStsParam := stsservice.StsResponseParameters{}
 	mockToken := &stsservice.TokenInfo{
 		TokenType:  "type",
-		IssueTime:  time.Now().String(),
-		ExpireTime: time.Now().Add(1 * time.Hour).String()}
+		IssueTime:  time.Now(),
+		ExpireTime: time.Now().Add(1 * time.Hour)}
 	testCases := map[string]struct {
 		genTokenError        error
 		dumpTokenError       error

--- a/security/pkg/stsservice/sts.go
+++ b/security/pkg/stsservice/sts.go
@@ -14,6 +14,8 @@
 
 package stsservice
 
+import "time"
+
 // StsRequestParameters stores all STS request attributes defined in
 // https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16#section-2.1
 type StsRequestParameters struct {
@@ -95,8 +97,9 @@ type TokenManager interface {
 // TokenInfo stores token information maintained at TokenManager.
 type TokenInfo struct {
 	TokenType  string `json:"token_type"`
-	IssueTime  string `json:"issue_time"`
-	ExpireTime string `json:"expire_time"`
+	IssueTime  time.Time `json:"issue_time"`
+	ExpireTime time.Time `json:"expire_time"`
+	Token      string `json:token`
 }
 
 // TokensDump stores information about all generated tokens.

--- a/security/pkg/stsservice/sts.go
+++ b/security/pkg/stsservice/sts.go
@@ -99,7 +99,7 @@ type TokenInfo struct {
 	TokenType  string    `json:"token_type"`
 	IssueTime  time.Time `json:"issue_time"`
 	ExpireTime time.Time `json:"expire_time"`
-	Token      string    `json:token`
+	Token      string    `json:"token"`
 }
 
 // TokensDump stores information about all generated tokens.

--- a/security/pkg/stsservice/sts.go
+++ b/security/pkg/stsservice/sts.go
@@ -96,10 +96,10 @@ type TokenManager interface {
 
 // TokenInfo stores token information maintained at TokenManager.
 type TokenInfo struct {
-	TokenType  string `json:"token_type"`
+	TokenType  string    `json:"token_type"`
 	IssueTime  time.Time `json:"issue_time"`
 	ExpireTime time.Time `json:"expire_time"`
-	Token      string `json:token`
+	Token      string    `json:token`
 }
 
 // TokensDump stores information about all generated tokens.

--- a/security/pkg/stsservice/test/setup.go
+++ b/security/pkg/stsservice/test/setup.go
@@ -236,7 +236,7 @@ func (e *Env) genStsReq(stsAddr string) (req *http.Request) {
 
 func setUpSTS(stsPort int, backendURL string) (*stsServer.Server, error) {
 	// Create token exchange Google plugin
-	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(tokenBackend.FakeTrustDomain, tokenBackend.FakeProjectNum, tokenBackend.FakeGKEClusterURL)
+	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(tokenBackend.FakeTrustDomain, tokenBackend.FakeProjectNum, tokenBackend.FakeGKEClusterURL, false)
 	federatedTokenTestingEndpoint := backendURL + "/v1/identitybindingtoken"
 	accessTokenTestingEndpoint := backendURL + "/v1/projects/-/serviceAccounts/service-%s@gcp-sa-meshdataplane.iam.gserviceaccount.com:generateAccessToken"
 	tokenExchangePlugin.SetEndpoints(federatedTokenTestingEndpoint, accessTokenTestingEndpoint)

--- a/security/pkg/stsservice/tokenmanager/google/mock/mockserver.go
+++ b/security/pkg/stsservice/tokenmanager/google/mock/mockserver.go
@@ -329,11 +329,9 @@ func (ms *AuthorizationServer) getAccessToken(w http.ResponseWriter, req *http.R
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	tokenLife.Format(time.RFC3339)
-	lifeJSON, _ := tokenLife.MarshalJSON()
 	resp := accessTokenResponse{
 		AccessToken: token,
-		ExpireTime:  string(lifeJSON),
+		ExpireTime:  tokenLife.Format(time.RFC3339Nano),
 	}
 
 	_ = json.NewEncoder(w).Encode(resp)

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
@@ -50,7 +50,7 @@ var (
 		"serviceAccounts/service-%s@gcp-sa-meshdataplane.iam.gserviceaccount.com:generateAccessToken"
 	// default grace period in seconds of an access token. If caching is enabled and token remaining life time is
 	// within this period, refresh access token.
-	defaultGracePeriod     = 300
+	defaultGracePeriod = 300
 )
 
 // Plugin supports token exchange with Google OAuth 2.0 authorization server.
@@ -125,7 +125,7 @@ func (p *Plugin) useCachedToken() ([]byte, bool) {
 		token := v.(stsservice.TokenInfo)
 		remainingLife := time.Until(token.ExpireTime)
 		pluginLog.Infof("find a cached access token with remaining lifetime: %s", remainingLife.String())
-		if remainingLife > time.Duration(defaultGracePeriod) * time.Second {
+		if remainingLife > time.Duration(defaultGracePeriod)*time.Second {
 			expireInSec := int64(remainingLife.Seconds())
 			if tokenSTS, err := p.generateSTSRespInner(token.Token, expireInSec); err == nil {
 				pluginLog.Infof("generated an STS response using a cached access token")

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
@@ -403,3 +403,9 @@ func (p *Plugin) SetEndpoints(fTokenEndpoint, aTokenEndpoint string) {
 	federatedTokenEndpoint = fTokenEndpoint
 	accessTokenEndpoint = aTokenEndpoint
 }
+
+// ClearCache is only used for testing purposes.
+func (p *Plugin) ClearCache() {
+	p.tokens.Delete(federatedToken)
+	p.tokens.Delete(accessToken)
+}

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
@@ -119,18 +119,19 @@ func (p *Plugin) useCachedToken() ([]byte, bool) {
 	if !p.enableCache {
 		return nil, false
 	}
-	if v, ok := p.tokens.Load(accessToken); !ok {
+	v, ok := p.tokens.Load(accessToken)
+	if !ok {
 		return nil, false
-	} else {
-		token := v.(stsservice.TokenInfo)
-		remainingLife := time.Until(token.ExpireTime)
-		pluginLog.Infof("find a cached access token with remaining lifetime: %s", remainingLife.String())
-		if remainingLife > time.Duration(defaultGracePeriod)*time.Second {
-			expireInSec := int64(remainingLife.Seconds())
-			if tokenSTS, err := p.generateSTSRespInner(token.Token, expireInSec); err == nil {
-				pluginLog.Infof("generated an STS response using a cached access token")
-				return tokenSTS, true
-			}
+	}
+
+	token := v.(stsservice.TokenInfo)
+	remainingLife := time.Until(token.ExpireTime)
+	pluginLog.Infof("find a cached access token with remaining lifetime: %s", remainingLife.String())
+	if remainingLife > time.Duration(defaultGracePeriod)*time.Second {
+		expireInSec := int64(remainingLife.Seconds())
+		if tokenSTS, err := p.generateSTSRespInner(token.Token, expireInSec); err == nil {
+			pluginLog.Infof("generated an STS response using a cached access token")
+			return tokenSTS, true
 		}
 	}
 	return nil, false

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin_test.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin_test.go
@@ -80,8 +80,8 @@ func verifyDumpStatus(t *testing.T, tCase string, dumpJSON []byte, lastStatus ma
 		t.Errorf("(Test case %s), failed to unmarshal status dump: %v", tCase, err)
 	}
 	newStatusMap := extractTokenDumpToMap(newStatus)
-	t.Logf("Dump newStatusMap:\n%v", newStatusMap)
-	t.Logf("Dump lastStatus:\n%v", lastStatus)
+	t.Logf("Dump newStatusMap:\n%+v", newStatusMap)
+	t.Logf("Dump lastStatus:\n%+v", lastStatus)
 	for _, exp := range expected {
 		if newVal, ok := newStatusMap[exp]; !ok {
 			t.Errorf("(Test case %s), failed to find expected token %s in status dump", tCase, exp)
@@ -137,7 +137,7 @@ func defaultSTSRequest() stsservice.StsRequestParameters {
 
 // setUpTest sets up token manager, authorization server.
 func setUpTest(t *testing.T) (*Plugin, *mock.AuthorizationServer, string, string) {
-	tm, _ := CreateTokenManagerPlugin(mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL)
+	tm, _ := CreateTokenManagerPlugin(mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL, false)
 	ms, err := mock.StartNewServer(t, mock.Config{Port: 0})
 	if err != nil {
 		t.Fatalf("failed to start a mock server: %v", err)

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin_test.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin_test.go
@@ -136,7 +136,7 @@ func defaultSTSRequest() stsservice.StsRequestParameters {
 }
 
 type testSetUp struct {
-	enableCache bool
+	enableCache        bool
 	enableDynamicToken bool
 }
 
@@ -239,7 +239,7 @@ func TestTokenExchangePluginWithCache(t *testing.T) {
 	if numATCalls != 3 {
 		t.Errorf("number of get access token API calls does not match, expected 3 got %d", numATCalls)
 	}
-	if thirdToken == fourthToken{
+	if thirdToken == fourthToken {
 		t.Errorf("should not return cached token")
 	}
 }

--- a/security/pkg/stsservice/tokenmanager/sts_test.go
+++ b/security/pkg/stsservice/tokenmanager/sts_test.go
@@ -42,11 +42,11 @@ var stsServerAddress string
 // token exchange plugin, a mock authorization server for token service, and
 // verifies STS flows.
 func TestStsFlow(t *testing.T) {
-	stsServer, mockBackend, clients := setUpTestComponents(t)
+	stsServer, mockBackend, clients := setUpTestComponents(t, testSetUp{})
 	defer tearDownTest(t, stsServer, mockBackend)
 
-	federatedTokenReceivedTime := time.Time{}.String()
-	accessTokenReceivedTime := time.Time{}.String()
+	federatedTokenReceivedTime := time.Time{}
+	accessTokenReceivedTime := time.Time{}
 	for i := 0; i < numClient; i++ {
 		resp, err := sendHTTPRequestWithRetry(clients[i], genStsReq(t))
 		if err != nil {
@@ -63,6 +63,41 @@ func TestStsFlow(t *testing.T) {
 	}
 }
 
+func TestStsCache(t *testing.T) {
+	stsServer, mockBackend, clients := setUpTestComponents(t, testSetUp{enableCache: true, enableDynamicToken: true})
+	defer tearDownTest(t, stsServer, mockBackend)
+
+	accessToken := ""
+	for i := 0; i < numClient; i++ {
+		resp, err := sendHTTPRequestWithRetry(clients[i], genStsReq(t))
+		if err != nil {
+			t.Fatalf("client %d: failure in sending STS request: %v", i, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("response HTTP status code does not match, get %d vs expected %d",
+				resp.StatusCode, http.StatusOK)
+		}
+		body, _ := ioutil.ReadAll(resp.Body)
+		respStsParam := &stsservice.StsResponseParameters{}
+		json.Unmarshal(body, respStsParam)
+		if i == 0 {
+			accessToken = respStsParam.AccessToken
+		}
+		if i > 0 {
+			if accessToken != respStsParam.AccessToken {
+				t.Errorf("cached token is not in use")
+			}
+		}
+		resp.Body.Close()
+	}
+	if mockBackend.NumGetFederatedTokenCalls() != 1 {
+		t.Errorf("Number of get federated token API calls does not match, expected 1 but got %d", mockBackend.NumGetFederatedTokenCalls())
+	}
+	if mockBackend.NumGetAccessTokenCalls() != 1 {
+		t.Errorf("Number of get access token API calls does not match, expected 1 but got %d", mockBackend.NumGetAccessTokenCalls())
+	}
+}
+
 func genDumpReq(t *testing.T) (req *http.Request) {
 	dumpURL := "http://" + stsServerAddress + stsServer.StsStatusPath
 	req, _ = http.NewRequest("GET", dumpURL, nil)
@@ -75,7 +110,7 @@ func genDumpReq(t *testing.T) (req *http.Request) {
 // verifyDumpResponse parses token info from dump response, and verifies that
 // issue time of federated token and access token have updated by comparing them
 // with oldFTime and oldATime, and returns new issue time of federated token and access token.
-func verifyDumpResponse(t *testing.T, resp *http.Response, oldFTime, oldATime string) (newFTime, newATime string) {
+func verifyDumpResponse(t *testing.T, resp *http.Response, oldFTime, oldATime time.Time) (newFTime, newATime time.Time) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("response HTTP status code does not match, get %d vs expected %d",
 			resp.StatusCode, http.StatusOK)
@@ -161,16 +196,22 @@ func sendHTTPRequestWithRetry(client *http.Client, req *http.Request) (resp *htt
 	return resp, err
 }
 
+type testSetUp struct {
+	enableCache bool
+	enableDynamicToken bool
+}
+
 // setUpTest sets up components for the STS flow, including a STS server, a
 // token manager, and an authorization server.
-func setUpTestComponents(t *testing.T) (*stsServer.Server, *mock.AuthorizationServer, []*http.Client) {
+func setUpTestComponents(t *testing.T, setup testSetUp) (*stsServer.Server, *mock.AuthorizationServer, []*http.Client) {
 	// Create mock authorization server
 	mockServer, err := mock.StartNewServer(t, mock.Config{Port: 0})
+	mockServer.EnableDynamicAccessToken(setup.enableDynamicToken)
 	if err != nil {
 		t.Fatalf("failed to start a mock server: %v", err)
 	}
 	// Create token exchange Google plugin
-	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL, false)
+	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL, setup.enableCache)
 	federatedTokenTestingEndpoint := mockServer.URL + "/v1/identitybindingtoken"
 	accessTokenTestingEndpoint := mockServer.URL + "/v1/projects/-/serviceAccounts/service-%s@gcp-sa-meshdataplane.iam.gserviceaccount.com:generateAccessToken"
 	tokenExchangePlugin.SetEndpoints(federatedTokenTestingEndpoint, accessTokenTestingEndpoint)

--- a/security/pkg/stsservice/tokenmanager/sts_test.go
+++ b/security/pkg/stsservice/tokenmanager/sts_test.go
@@ -170,7 +170,7 @@ func setUpTestComponents(t *testing.T) (*stsServer.Server, *mock.AuthorizationSe
 		t.Fatalf("failed to start a mock server: %v", err)
 	}
 	// Create token exchange Google plugin
-	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL)
+	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL, false)
 	federatedTokenTestingEndpoint := mockServer.URL + "/v1/identitybindingtoken"
 	accessTokenTestingEndpoint := mockServer.URL + "/v1/projects/-/serviceAccounts/service-%s@gcp-sa-meshdataplane.iam.gserviceaccount.com:generateAccessToken"
 	tokenExchangePlugin.SetEndpoints(federatedTokenTestingEndpoint, accessTokenTestingEndpoint)

--- a/security/pkg/stsservice/tokenmanager/sts_test.go
+++ b/security/pkg/stsservice/tokenmanager/sts_test.go
@@ -199,7 +199,7 @@ func sendHTTPRequestWithRetry(client *http.Client, req *http.Request) (resp *htt
 }
 
 type testSetUp struct {
-	enableCache bool
+	enableCache        bool
 	enableDynamicToken bool
 }
 

--- a/security/pkg/stsservice/tokenmanager/sts_test.go
+++ b/security/pkg/stsservice/tokenmanager/sts_test.go
@@ -63,6 +63,8 @@ func TestStsFlow(t *testing.T) {
 	}
 }
 
+// TestStsCache enables caching at token exchange plugin, which will return cached token if that token
+// is not going to expire soon.
 func TestStsCache(t *testing.T) {
 	stsServer, mockBackend, clients := setUpTestComponents(t, testSetUp{enableCache: true, enableDynamicToken: true})
 	defer tearDownTest(t, stsServer, mockBackend)

--- a/security/pkg/stsservice/tokenmanager/tokenmanager.go
+++ b/security/pkg/stsservice/tokenmanager/tokenmanager.go
@@ -82,7 +82,7 @@ func CreateTokenManager(tokenManagerType string, config Config) stsservice.Token
 		if projectInfo := getGCPProjectInfo(); len(projectInfo.Number) > 0 {
 			gkeClusterURL := fmt.Sprintf("https://container.googleapis.com/v1/projects/%s/locations/%s/clusters/%s",
 				projectInfo.id, projectInfo.clusterLocation, projectInfo.cluster)
-			if p, err := google.CreateTokenManagerPlugin(config.TrustDomain, projectInfo.Number, gkeClusterURL); err == nil {
+			if p, err := google.CreateTokenManagerPlugin(config.TrustDomain, projectInfo.Number, gkeClusterURL, true); err == nil {
 				tm.plugin = p
 			}
 		}


### PR DESCRIPTION
Please provide a description for what this PR is for.
Add fetched access token into cache. If the remaining life time is larger than grace period (default: 5 min), STS server returns cached token.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

https://github.com/istio/istio/issues/20133