### PR TITLE
Cherrypick: Istio-agent should cache root cert read from file (#20980)

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -40,6 +40,15 @@ import (
 
 var (
 	cacheLog = log.RegisterScope("cache", "cache debugging", 0)
+
+	// The well-known path for an existing certificate chain file
+	existingCertChainFile = defaultCertChainFilePath
+
+	// The well-known path for an existing key file
+	existingKeyFile = defaultKeyFilePath
+
+	// ExistingRootCertFile is the well-known path for an existing root certificate file
+	ExistingRootCertFile = defaultRootCertFilePath
 )
 
 const (
@@ -74,13 +83,13 @@ const (
 	notifyK8sSecretTimeout = 30 * time.Second
 
 	// The well-known path for an existing certificate chain file
-	existingCertChainFile = "./etc/certs/cert-chain.pem"
+	defaultCertChainFilePath = "./etc/certs/cert-chain.pem"
 
 	// The well-known path for an existing key file
-	existingKeyFile = "./etc/certs/key.pem"
+	defaultKeyFilePath = "./etc/certs/key.pem"
 
-	// ExistingRootCertFile is the well-known path for an existing root certificate file
-	ExistingRootCertFile = "./etc/certs/root-cert.pem"
+	// The well-known path for an existing root certificate file
+	defaultRootCertFilePath = "./etc/certs/root-cert.pem"
 )
 
 type k8sJwtPayload struct {
@@ -243,6 +252,8 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 				conIDresourceNamePrefix, err)
 			return nil, err
 		}
+		// TODO(JimmyCYJ): need a file watcher to detect file updates and push new secret to clients.
+		cacheLog.Infoa("GenerateSecret from file ", resourceName)
 		sc.secrets.Store(connKey, *ns)
 		return ns, nil
 	}

--- a/security/pkg/nodeagent/cache/testdata/privatekey.pem
+++ b/security/pkg/nodeagent/cache/testdata/privatekey.pem
@@ -1,0 +1,1 @@
+dummyprivatekeyfile


### PR DESCRIPTION

Please provide a description for what this PR is for: manually cherrypick https://github.com/istio/istio/pull/20980 since the "/cherrypick release-1.5" command does not work for the PR 20980 due to merging conflicts.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure