### PR TITLE
Re-generate charts before updating golden files

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -357,7 +357,7 @@ refresh-goldens:
 
 update-golden: refresh-goldens
 
-gen: go-gen mirror-licenses format update-crds gen-charts update-golden operator-proto
+gen: go-gen mirror-licenses format update-crds operator-proto gen-charts update-golden
 
 gen-check: gen check-clean-repo
 

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -357,7 +357,7 @@ refresh-goldens:
 
 update-golden: refresh-goldens
 
-gen: go-gen mirror-licenses format update-crds update-golden gen-charts operator-proto
+gen: go-gen mirror-licenses format update-crds gen-charts update-golden operator-proto
 
 gen-check: gen check-clean-repo
 


### PR DESCRIPTION
We should re-generate the VFS before updating the golden files, because the tests use the data from the VFS to update the golden files - currently, I keep having to run `make gen` twice to not run into `gen-check` failures.