### PR TITLE
SDS startup optimizations

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1169,14 +1169,12 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.TLSSetting
 			}
 		} else {
 			tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
-				authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName,
-					opts.push.Mesh.SdsUdsPath, proxy.Metadata))
+				authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, opts.push.Mesh.SdsUdsPath))
 
 			tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 				CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-					DefaultValidationContext: &auth.CertificateValidationContext{VerifySubjectAltName: tls.SubjectAltNames},
-					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName,
-						opts.push.Mesh.SdsUdsPath, proxy.Metadata),
+					DefaultValidationContext:         &auth.CertificateValidationContext{VerifySubjectAltName: tls.SubjectAltNames},
+					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName, opts.push.Mesh.SdsUdsPath),
 				},
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -461,14 +461,12 @@ func buildGatewayListenerTLSContext(
 			// configure egress with SDS
 			tls.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 				CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-					DefaultValidationContext: &auth.CertificateValidationContext{VerifySubjectAltName: server.Tls.SubjectAltNames},
-					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(
-						authn_model.SDSRootResourceName, sdsPath, metadata),
+					DefaultValidationContext:         &auth.CertificateValidationContext{VerifySubjectAltName: server.Tls.SubjectAltNames},
+					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName, sdsPath),
 				},
 			}
 			tls.CommonTlsContext.TlsCertificateSdsSecretConfigs = []*auth.SdsSecretConfig{
-				authn_model.ConstructSdsSecretConfig(
-					authn_model.SDSDefaultResourceName, sdsPath, metadata)}
+				authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, sdsPath)}
 		} else {
 			// global SDS disabled, fall back on using mounted certificates
 			caCertificates := model.GetOrDefault(metadata.TLSServerRootCert, constants.DefaultRootCert)

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -108,18 +108,8 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 										ApiType: core.ApiConfigSource_GRPC,
 										GrpcServices: []*core.GrpcService{
 											{
-												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
-													GoogleGrpc: &core.GrpcService_GoogleGrpc{
-														TargetUri:  "unix:/var/run/sds/uds_path",
-														StatPrefix: model.SDSStatPrefix,
-														ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
-															CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
-																LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
-															},
-														},
-														CallCredentials:        model.ConstructgRPCCallCredentials(model.K8sSATrustworthyJwtFileName, model.K8sSAJwtTokenHeaderKey),
-														CredentialsFactoryName: model.FileBasedMetadataPlugName,
-													},
+												TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+													EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
 												},
 											},
 										},
@@ -140,18 +130,8 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 											ApiType: core.ApiConfigSource_GRPC,
 											GrpcServices: []*core.GrpcService{
 												{
-													TargetSpecifier: &core.GrpcService_GoogleGrpc_{
-														GoogleGrpc: &core.GrpcService_GoogleGrpc{
-															TargetUri:  "unix:/var/run/sds/uds_path",
-															StatPrefix: model.SDSStatPrefix,
-															ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
-																CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
-																	LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
-																},
-															},
-															CallCredentials:        model.ConstructgRPCCallCredentials(model.K8sSATrustworthyJwtFileName, model.K8sSAJwtTokenHeaderKey),
-															CredentialsFactoryName: model.FileBasedMetadataPlugName,
-														},
+													TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+														EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
 													},
 												},
 											},

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -22,7 +22,6 @@ import (
 	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	"istio.io/istio/pilot/pkg/features"
@@ -160,32 +159,8 @@ func TestBuildInboundFilterChain(t *testing.T) {
 												ApiType: core.ApiConfigSource_GRPC,
 												GrpcServices: []*core.GrpcService{
 													{
-														TargetSpecifier: &core.GrpcService_GoogleGrpc_{
-															GoogleGrpc: &core.GrpcService_GoogleGrpc{
-																TargetUri:              "/tmp/sdsuds.sock",
-																StatPrefix:             authn_model.SDSStatPrefix,
-																CredentialsFactoryName: "envoy.grpc_credentials.file_based_metadata",
-																ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
-																	CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
-																		LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
-																	},
-																},
-																CallCredentials: []*core.GrpcService_GoogleGrpc_CallCredentials{
-																	{
-																		CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_FromPlugin{
-																			FromPlugin: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin{
-																				Name: "envoy.grpc_credentials.file_based_metadata",
-																				ConfigType: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig{
-																					TypedConfig: &any.Any{
-																						TypeUrl: "type.googleapis.com/envoy.config.grpc_credential.v2alpha.FileBasedMetadataConfig",
-																						Value:   []byte("\n%\n#/var/run/secrets/tokens/istio-token\022 istio_sds_credentials_header-bin"),
-																					},
-																				},
-																			},
-																		},
-																	},
-																},
-															},
+														TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+															EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: authn_model.SDSClusterName},
 														},
 													},
 												},
@@ -206,32 +181,8 @@ func TestBuildInboundFilterChain(t *testing.T) {
 													ApiType: core.ApiConfigSource_GRPC,
 													GrpcServices: []*core.GrpcService{
 														{
-															TargetSpecifier: &core.GrpcService_GoogleGrpc_{
-																GoogleGrpc: &core.GrpcService_GoogleGrpc{
-																	TargetUri:              "/tmp/sdsuds.sock",
-																	StatPrefix:             authn_model.SDSStatPrefix,
-																	CredentialsFactoryName: "envoy.grpc_credentials.file_based_metadata",
-																	ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
-																		CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
-																			LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
-																		},
-																	},
-																	CallCredentials: []*core.GrpcService_GoogleGrpc_CallCredentials{
-																		{
-																			CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_FromPlugin{
-																				FromPlugin: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin{
-																					Name: "envoy.grpc_credentials.file_based_metadata",
-																					ConfigType: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig{
-																						TypedConfig: &any.Any{
-																							TypeUrl: "type.googleapis.com/envoy.config.grpc_credential.v2alpha.FileBasedMetadataConfig",
-																							Value:   []byte("\n%\n#/var/run/secrets/tokens/istio-token\022 istio_sds_credentials_header-bin"),
-																						},
-																					},
-																				},
-																			},
-																		},
-																	},
-																},
+															TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+																EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: authn_model.SDSClusterName},
 															},
 														},
 													},

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier_test.go
@@ -999,12 +999,12 @@ func TestOnInboundFilterChains(t *testing.T) {
 					TLSContext: &auth.DownstreamTlsContext{
 						CommonTlsContext: &auth.CommonTlsContext{
 							TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
-								constructSDSConfig(authn_model.SDSDefaultResourceName, "/tmp/sdsuds.sock"),
+								authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, "/tmp/sdsuds.sock"),
 							},
 							ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
 								CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
 									DefaultValidationContext:         &auth.CertificateValidationContext{VerifySubjectAltName: []string{} /*subjectAltNames*/},
-									ValidationContextSdsSecretConfig: constructSDSConfig(authn_model.SDSRootResourceName, "/tmp/sdsuds.sock"),
+									ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName, "/tmp/sdsuds.sock"),
 								},
 							},
 							AlpnProtocols: []string{"istio-peer-exchange", "h2", "http/1.1"},
@@ -1098,39 +1098,5 @@ func TestOnInboundFilterChains(t *testing.T) {
 				t.Errorf("[%v] unexpected filter chains, got \n%v, want \n%v", c.name, got, c.expected)
 			}
 		})
-	}
-}
-
-func constructSDSConfig(name, sdsudspath string) *auth.SdsSecretConfig {
-	gRPCConfig := &core.GrpcService_GoogleGrpc{
-		TargetUri:  sdsudspath,
-		StatPrefix: authn_model.SDSStatPrefix,
-		ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
-			CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
-				LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
-			},
-		},
-	}
-
-	gRPCConfig.CredentialsFactoryName = authn_model.FileBasedMetadataPlugName
-	gRPCConfig.CallCredentials = authn_model.ConstructgRPCCallCredentials(authn_model.K8sSATrustworthyJwtFileName, authn_model.K8sSAJwtTokenHeaderKey)
-
-	return &auth.SdsSecretConfig{
-		Name: name,
-		SdsConfig: &core.ConfigSource{
-			InitialFetchTimeout: features.InitialFetchTimeout,
-			ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-				ApiConfigSource: &core.ApiConfigSource{
-					ApiType: core.ApiConfigSource_GRPC,
-					GrpcServices: []*core.GrpcService{
-						{
-							TargetSpecifier: &core.GrpcService_GoogleGrpc_{
-								GoogleGrpc: gRPCConfig,
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 }

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -24,13 +24,14 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 
 	"istio.io/istio/pilot/pkg/features"
-	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/jwt"
 )
 
 const (
 	// SDSStatPrefix is the human readable prefix to use when emitting statistics for the SDS service.
 	SDSStatPrefix = "sdsstat"
+
+	// SDSClusterName is the name of the cluster for SDS connections
+	SDSClusterName = "sds-grpc"
 
 	// SDSDefaultResourceName is the default name in sdsconfig, used for fetching normal key/cert.
 	SDSDefaultResourceName = "default"
@@ -104,39 +105,9 @@ func ConstructSdsSecretConfigForGatewayListener(name, sdsUdsPath string) *auth.S
 }
 
 // ConstructSdsSecretConfig constructs SDS Sececret Configuration for workload proxy.
-func ConstructSdsSecretConfig(name, sdsUdsPath string, metadata *model.NodeMetadata) *auth.SdsSecretConfig {
+func ConstructSdsSecretConfig(name, sdsUdsPath string) *auth.SdsSecretConfig {
 	if name == "" || sdsUdsPath == "" {
 		return nil
-	}
-
-	gRPCConfig := &core.GrpcService_GoogleGrpc{
-		TargetUri:  sdsUdsPath,
-		StatPrefix: SDSStatPrefix,
-		ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
-			CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
-				LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
-			},
-		},
-	}
-
-	// If metadata.SdsTokenPath is non-empty, envoy will fetch tokens from metadata.SdsTokenPath.
-	// Otherwise, if useK8sSATrustworthyJwt is set, envoy will fetch and pass k8s sa trustworthy jwt(which is available for k8s 1.12 or higher),
-	// pass it to SDS server to request key/cert.
-	gRPCConfig.CredentialsFactoryName = FileBasedMetadataPlugName
-	if sdsTokenPath := metadata.SdsTokenPath; len(sdsTokenPath) > 0 {
-		log.Debugf("SDS token path is (%v)", sdsTokenPath)
-		gRPCConfig.CallCredentials = ConstructgRPCCallCredentials(sdsTokenPath, K8sSAJwtTokenHeaderKey)
-	} else {
-		if features.JwtPolicy.Get() == jwt.JWTPolicyThirdPartyJWT {
-			log.Debug("call credentials uses third-party JWT")
-			gRPCConfig.CallCredentials = ConstructgRPCCallCredentials(K8sSATrustworthyJwtFileName, K8sSAJwtTokenHeaderKey)
-		} else if features.JwtPolicy.Get() == jwt.JWTPolicyFirstPartyJWT {
-			log.Debug("call credentials uses first-party JWT")
-			gRPCConfig.CallCredentials = ConstructgRPCCallCredentials(K8sSAJwtFileName, K8sSAJwtTokenHeaderKey)
-		} else {
-			log.Errorf("invalid JWT policy: %v", features.JwtPolicy.Get())
-			return nil
-		}
 	}
 
 	return &auth.SdsSecretConfig{
@@ -147,8 +118,8 @@ func ConstructSdsSecretConfig(name, sdsUdsPath string, metadata *model.NodeMetad
 					ApiType: core.ApiConfigSource_GRPC,
 					GrpcServices: []*core.GrpcService{
 						{
-							TargetSpecifier: &core.GrpcService_GoogleGrpc_{
-								GoogleGrpc: gRPCConfig,
+							TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+								EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: SDSClusterName},
 							},
 						},
 					},

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -278,7 +278,7 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 			return nil, err
 		}
 
-		cacheLog.Infof("GenerateSecret %v in %v", resourceName, time.Now().Sub(t))
+		cacheLog.Infof("GenerateSecret %v in %v", resourceName, time.Since(t))
 		sc.secrets.Store(connKey, *ns)
 		return ns, nil
 	}

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -296,7 +296,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// When nodeagent receives StreamSecrets request, if there is cached secret which matches
 			// request's <token, resourceName, Version>, then this request is a confirmation request.
 			// nodeagent stops sending response to envoy in this case.
-			if discReq.VersionInfo != "" && s.st.SecretExist(conID, resourceName, token, discReq.VersionInfo) {
+			if discReq.VersionInfo != "" && s.st.SecretExist("bootstrap", resourceName, token, discReq.VersionInfo) {
 				sdsServiceLog.Debugf("%s received SDS ACK from proxy %q, version info %q, "+
 					"error details %s\n", conIDresourceNamePrefix, discReq.Node.Id, discReq.VersionInfo,
 					discReq.ErrorDetail)
@@ -321,7 +321,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				continue
 			}
 
-			secret, err := s.st.GenerateSecret(ctx, conID, resourceName, token)
+			secret, err := s.st.GenerateSecret(ctx, "bootstrap", resourceName, token)
 			if err != nil {
 				sdsServiceLog.Errorf("%s Close connection. Failed to get secret for proxy %q from "+
 					"secret cache: %v", conIDresourceNamePrefix, discReq.Node.Id, err)
@@ -402,7 +402,7 @@ func (s *sdsservice) FetchSecrets(ctx context.Context, discReq *xdsapi.Discovery
 	}
 
 	connID := constructConnectionID(discReq.Node.Id)
-	secret, err := s.st.GenerateSecret(ctx, connID, resourceName, token)
+	secret, err := s.st.GenerateSecret(ctx, "bootstrap", resourceName, token)
 	if err != nil {
 		sdsServiceLog.Errorf("Failed to get secret for proxy %q from secret cache: %v", connID, err)
 		return nil, err

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -243,6 +243,20 @@
           }
         ]
       },
+      {{- if eq .sds_uds_path "unix:/etc/istio/proxy/SDS" }}
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "{{ .connect_timeout }}",
+        "lb_policy": "ROUND_ROBIN",
+        "hosts": [{
+          "pipe": {
+            "path": "/etc/istio/proxy/SDS"
+           }
+        }]
+      },
+      {{- end }}
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
@@ -266,13 +280,8 @@
                     "api_type":"GRPC",
                     "grpc_services":[
                       {
-                        "google_grpc":{
-                          "target_uri": "{{ .sds_uds_path }}",
-                          "channel_credentials":{
-                            "local_credentials":{
-                            }
-                          },
-                          "stat_prefix":"sdsstat"
+                        "envoy_grpc":{
+                          "cluster_name": "sds-grpc"
                         }
                       }
                     ]


### PR DESCRIPTION
This includes a few changes that all work together to bring the pod
startup p90 times from 20s to 4s
* If GenerateSecret is called, return cached key when possible
* Use "bootstrap" as the connection ID, allowing us to use cached key
* Create a single Cluster in the bootstrap for SDS, rather than inlining
the config. This has the added benefit of substantially reducing the
size of XDS resources. This requires a change from google_grpc to
envoy_grpc, but this is fine as we now support local JWTs.