### PR TITLE
tests: remove unnecessary sds.enabled=true flag

### DIFF
--- a/tests/integration/istioio/trafficmanagement/ingress/main_test.go
+++ b/tests/integration/istioio/trafficmanagement/ingress/main_test.go
@@ -43,6 +43,4 @@ func setupForSDS(cfg *istio.Config) {
 		return
 	}
 	cfg.Values["gateways.istio-egressgateway.enabled"] = "false"
-	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
-
 }

--- a/tests/integration/security/sds_ingress/mtls_gateway_invalid_secret/main_test.go
+++ b/tests/integration/security/sds_ingress/mtls_gateway_invalid_secret/main_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 		NewSuite("sds_ingress_multi_mtls_gateway_invalid_secret_test", m).
 		Label(label.CustomSetup).
 		Label(label.Flaky).
-		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, nil)).
 		Setup(func(ctx resource.Context) (err error) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
@@ -52,12 +52,4 @@ func TestMain(m *testing.M) {
 		}).
 		Run()
 
-}
-
-func setupConfig(cfg *istio.Config) {
-	if cfg == nil {
-		return
-	}
-	// Enable SDS key/certificate provisioning for ingress gateway.
-	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
 }

--- a/tests/integration/security/sds_ingress/multi_tls_gateway_invalid_secret/main_test.go
+++ b/tests/integration/security/sds_ingress/multi_tls_gateway_invalid_secret/main_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 		NewSuite("sds_ingress_multi_tls_gateway_invalid_secret_test", m).
 		Label(label.CustomSetup).
 		Label(label.Flaky).
-		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, nil)).
 		Setup(func(ctx resource.Context) (err error) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
@@ -52,12 +52,4 @@ func TestMain(m *testing.M) {
 		}).
 		Run()
 
-}
-
-func setupConfig(cfg *istio.Config) {
-	if cfg == nil {
-		return
-	}
-	// Enable SDS key/certificate provisioning for ingress gateway.
-	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
 }

--- a/tests/integration/security/sds_ingress/multiple_mtls_gateway/main_test.go
+++ b/tests/integration/security/sds_ingress/multiple_mtls_gateway/main_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 		NewSuite("sds_ingress_multiple_mtls_gateways_test", m).
 		Label(label.CustomSetup).
 		Label(label.Flaky).
-		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, nil)).
 		Setup(func(ctx resource.Context) (err error) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
@@ -52,12 +52,4 @@ func TestMain(m *testing.M) {
 		}).
 		Run()
 
-}
-
-func setupConfig(cfg *istio.Config) {
-	if cfg == nil {
-		return
-	}
-	// Enable SDS key/certificate provisioning for ingress gateway.
-	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
 }

--- a/tests/integration/security/sds_ingress/multiple_tls_gateway/main_test.go
+++ b/tests/integration/security/sds_ingress/multiple_tls_gateway/main_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 		NewSuite("sds_ingress_multiple_tls_gateways_test", m).
 		Label(label.CustomSetup).
 		Label(label.Flaky).
-		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, nil)).
 		Setup(func(ctx resource.Context) (err error) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
@@ -52,12 +52,4 @@ func TestMain(m *testing.M) {
 		}).
 		Run()
 
-}
-
-func setupConfig(cfg *istio.Config) {
-	if cfg == nil {
-		return
-	}
-	// Enable SDS key/certificate provisioning for ingress gateway.
-	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
 }

--- a/tests/integration/security/sds_ingress/single_mtls_gateway_compound_secret/main_test.go
+++ b/tests/integration/security/sds_ingress/single_mtls_gateway_compound_secret/main_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 		NewSuite("sds_ingress_single_mtls_gateway_compound_secret_test", m).
 		Label(label.CustomSetup).
 		Label(label.Flaky).
-		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, nil)).
 		Setup(func(ctx resource.Context) (err error) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
@@ -52,12 +52,4 @@ func TestMain(m *testing.M) {
 		}).
 		Run()
 
-}
-
-func setupConfig(cfg *istio.Config) {
-	if cfg == nil {
-		return
-	}
-	// Enable SDS key/certificate provisioning for ingress gateway.
-	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
 }

--- a/tests/integration/security/sds_ingress/single_mtls_gateway_separate_secret/main_test.go
+++ b/tests/integration/security/sds_ingress/single_mtls_gateway_separate_secret/main_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 		NewSuite("sds_ingress_single_mtls_gateway_separate_secret_test", m).
 		Label(label.CustomSetup).
 		Label(label.Flaky).
-		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, nil)).
 		Setup(func(ctx resource.Context) (err error) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
@@ -52,12 +52,4 @@ func TestMain(m *testing.M) {
 		}).
 		Run()
 
-}
-
-func setupConfig(cfg *istio.Config) {
-	if cfg == nil {
-		return
-	}
-	// Enable SDS key/certificate provisioning for ingress gateway.
-	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
 }

--- a/tests/integration/security/sds_ingress/single_tls_gateway/main_test.go
+++ b/tests/integration/security/sds_ingress/single_tls_gateway/main_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 		NewSuite("sds_ingress_single_tls_gateway_test", m).
 		Label(label.CustomSetup).
 		Label(label.Flaky).
-		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, nil)).
 		Setup(func(ctx resource.Context) (err error) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
@@ -52,12 +52,4 @@ func TestMain(m *testing.M) {
 		}).
 		Run()
 
-}
-
-func setupConfig(cfg *istio.Config) {
-	if cfg == nil {
-		return
-	}
-	// Enable SDS key/certificate provisioning for ingress gateway.
-	cfg.Values["gateways.istio-ingressgateway.sds.enabled"] = "true"
 }

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -80,7 +80,6 @@ func setupConfig(cfg *istio.Config) {
 	cfg.Values["sidecarInjectorWebhook.rewriteAppHTTPProbe"] = "true"
 	cfg.Values["global.controlPlaneSecurityEnabled"] = "false"
 	cfg.Values["global.mtls.enabled"] = "true"
-	cfg.Values["global.sds.enabled"] = "true"
 	cfg.Values["global.sds.udsPath"] = "unix:/var/run/sds/uds_path"
 	cfg.Values["global.sds.customTokenDirectory"] = "/etc/sdstoken"
 	cfg.Values["nodeagent.enabled"] = "true"


### PR DESCRIPTION
SDS is now enabled by default, so we don't need to set the flag.

[x] Test and Release

