### PR TITLE
Remove istioctl authn tls-check

### DIFF
--- a/istioctl/cmd/authn.go
+++ b/istioctl/cmd/authn.go
@@ -29,12 +29,10 @@ import (
 func tlsCheck() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tls-check <pod-name[.namespace]> [<service>]",
-		Short: "Deprecated. Check whether TLS setting are matching between authentication policy and destination rules",
+		Short: "Check whether TLS setting are matching between authentication policy and destination rules",
 		Long: `
 Check what authentication policies and destination rules pilot uses to config a proxy instance,
 and check if TLS settings are compatible between them.
-Warning: Do not use this tool if you start using beta API, aka PeerAuthentication. The tool will be remove
-in future release of Istio.
 `,
 		Example: `
 # Check settings for pod "foo-656bd7df7c-5zp4s" in namespace default:
@@ -83,6 +81,7 @@ istioctl authn tls-check foo-656bd7df7c-5zp4s.default bar
 			return tcw.PrintAll(debug)
 		},
 	}
+	cmd.Deprecated = "do not use if you start using PeerAuthentication"
 	return cmd
 }
 
@@ -90,17 +89,16 @@ istioctl authn tls-check foo-656bd7df7c-5zp4s.default bar
 func AuthN() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "authn",
-		Short: "Deprecated. Interact with (alpha) Istio authentication policies",
+		Short: "Interact with (alpha) Istio authentication policies",
 		Long: `
 A group of commands used to interact with (alpha) Istio authentication policies.
 	tls-check
-Warning: Do not use this tool if you start using beta API, aka PeerAuthentication. The tool will be remove
-in future release of Istio.
 `,
 		Example: `# Check whether TLS setting are matching between authentication policy and destination rules:
 istioctl authn tls-check`,
 	}
 
 	cmd.AddCommand(tlsCheck())
+	cmd.Deprecated = "do not use if you start using PeerAuthentication"
 	return cmd
 }

--- a/istioctl/cmd/authn.go
+++ b/istioctl/cmd/authn.go
@@ -29,10 +29,12 @@ import (
 func tlsCheck() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tls-check <pod-name[.namespace]> [<service>]",
-		Short: "Check whether TLS setting are matching between authentication policy and destination rules",
+		Short: "Deprecated. Check whether TLS setting are matching between authentication policy and destination rules",
 		Long: `
 Check what authentication policies and destination rules pilot uses to config a proxy instance,
 and check if TLS settings are compatible between them.
+Warning: Do not use this tool if you start using beta API, aka PeerAuthentication. The tool will be remove
+in future release of Istio.
 `,
 		Example: `
 # Check settings for pod "foo-656bd7df7c-5zp4s" in namespace default:
@@ -88,10 +90,12 @@ istioctl authn tls-check foo-656bd7df7c-5zp4s.default bar
 func AuthN() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "authn",
-		Short: "Interact with Istio authentication policies",
+		Short: "Deprecated. Interact with (alpha) Istio authentication policies",
 		Long: `
-A group of commands used to interact with Istio authentication policies.
-  tls-check
+A group of commands used to interact with (alpha) Istio authentication policies.
+	tls-check
+Warning: Do not use this tool if you start using beta API, aka PeerAuthentication. The tool will be remove
+in future release of Istio.
 `,
 		Example: `# Check whether TLS setting are matching between authentication policy and destination rules:
 istioctl authn tls-check`,

--- a/istioctl/cmd/authn_test.go
+++ b/istioctl/cmd/authn_test.go
@@ -37,14 +37,16 @@ func TestAuthnTlsCheck(t *testing.T) {
 		{ // case 1
 			configs: []model.Config{},
 			args:    strings.Split("authn tls-check foo-123456-7890", " "),
-			expectedOutput: `HOST:PORT                                  STATUS     SERVER        CLIENT     AUTHN POLICY     DESTINATION RULE
+			expectedOutput: `Command "tls-check" is deprecated, do not use if you start using PeerAuthentication
+HOST:PORT                                  STATUS     SERVER        CLIENT     AUTHN POLICY     DESTINATION RULE
 details.default.svc.cluster.local:8080     OK         HTTP/mTLS     mTLS       default/         details/default
 `,
 		},
 		{ // case 2
 			configs: []model.Config{},
 			args:    strings.Split("authn tls-check foo-123456-7890 bar", " "),
-			expectedOutput: `HOST:PORT     STATUS     SERVER     CLIENT     AUTHN POLICY     DESTINATION RULE
+			expectedOutput: `Command "tls-check" is deprecated, do not use if you start using PeerAuthentication
+HOST:PORT     STATUS     SERVER     CLIENT     AUTHN POLICY     DESTINATION RULE
 `,
 		},
 	}


### PR DESCRIPTION
Remove `istioctl authn tls-check` command as it's no longer work with mTLS beta API, as well as not necessary with auto-mTLS features.