### PR TITLE
report istio_mcp_message_sizes_bytes for all sent and received messages

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/dashboards/galley-dashboard.json
+++ b/install/kubernetes/helm/istio/charts/grafana/dashboards/galley-dashboard.json
@@ -1689,6 +1689,95 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 48
+      },
+      "id": 48,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(istio_mcp_message_sizes_bytes_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Response message sizes",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "5s",

--- a/pkg/mcp/sink/sink.go
+++ b/pkg/mcp/sink/sink.go
@@ -101,6 +101,8 @@ func (sink *Sink) handleResponse(resources *mcp.Resources) *mcp.RequestResources
 		defer handleResponseDoneProbe()
 	}
 
+	sink.reporter.RecordMessageSize(resources.Collection, 0, internal.ProtoSize(resources))
+
 	state, ok := sink.state[resources.Collection]
 	if !ok {
 		errDetails := status.Errorf(codes.Unimplemented, "unsupported collection %v", resources.Collection)

--- a/pkg/mcp/source/source.go
+++ b/pkg/mcp/source/source.go
@@ -343,6 +343,8 @@ func (con *connection) pushServerResponse(w *watch, resp *WatchResponse) error {
 		Incremental:       incremental,
 	}
 
+	con.reporter.RecordMessageSize(resp.Collection, con.id, internal.ProtoSize(msg))
+
 	// increment nonce
 	con.streamNonce++
 	msg.Nonce = strconv.FormatInt(con.streamNonce, 10)
@@ -400,8 +402,6 @@ func (con *connection) processClientRequest(req *mcp.RequestResources) error {
 	}
 
 	collection := req.Collection
-
-	con.reporter.RecordRequestSize(collection, con.id, internal.ProtoSize(req))
 
 	w, ok := con.watches[collection]
 	if !ok {

--- a/pkg/mcp/testing/monitoring/reporter.go
+++ b/pkg/mcp/testing/monitoring/reporter.go
@@ -72,8 +72,8 @@ func (s *InMemoryStatsContext) RecordRecvError(err error, code codes.Code) {
 	s.mutex.Unlock()
 }
 
-// RecordRequestSize records the size of a request from a connection for a specific type URL.
-func (s *InMemoryStatsContext) RecordRequestSize(typeURL string, connectionID int64, size int) {
+// RecordMessageSize records the size of a response message for a specific collection
+func (s *InMemoryStatsContext) RecordMessageSize(typeURL string, connectionID int64, size int) {
 	key := requestKey{typeURL, connectionID}
 	s.mutex.Lock()
 	s.RequestSizesBytes[key] = append(s.RequestSizesBytes[key], int64(size))


### PR DESCRIPTION
istio_mcp_message_sizes_bytes was reporting the size of request
messages only. This isn't particular interesting or useful since the
request size is essentially fixed. The response sizes, however, is
useful and required in large systems to alert when we're approaching
the max gRPC message size.

This PR changes adds reporting of istio_mcp_message_sizes_bytes to the
server and client paths.

fixes https://github.com/istio/istio/issues/21049


