### PR TITLE
Hide incorrect deserialization messages from user

### DIFF
--- a/operator/pkg/util/yaml.go
+++ b/operator/pkg/util/yaml.go
@@ -17,6 +17,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -73,7 +74,12 @@ func UnmarshalWithJSONPB(y string, out proto.Message, allowUnknownField bool) er
 	}
 
 	u := jsonpb.Unmarshaler{AllowUnknownFields: allowUnknownField}
+	_, w, _ := os.Pipe()
+	originalStderr := os.Stderr
+	// redirect stderr to prevent bogus `proto: tag has too few fields: "-"` messages
+	os.Stderr = w
 	err = u.Unmarshal(bytes.NewReader(jb), out)
+	os.Stderr = originalStderr
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/19735

Resolves it by hiding the message from the user.  It might be better to actually fix the underlying libraries, but until that happens why display an incorrect message?