### PR TITLE
Use JSON merge to update objects

### DIFF
--- a/operator/data/translateConfig/translateConfig-1.5.yaml
+++ b/operator/data/translateConfig/translateConfig-1.5.yaml
@@ -55,7 +55,7 @@ componentMaps:
     SkipReverseTranslate: true
   Pilot:
     ResourceType:         "Deployment"
-    ResourceName:         "istio-pilot"
+    ResourceName:         "istiod"
     ContainerName:        "discovery"
     HelmSubdir:           "istio-control/istio-discovery"
     ToHelmValuesTreeRoot: "pilot"

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -39324,7 +39324,7 @@ componentMaps:
     SkipReverseTranslate: true
   Pilot:
     ResourceType:         "Deployment"
-    ResourceName:         "istio-pilot"
+    ResourceName:         "istiod"
     ContainerName:        "discovery"
     HelmSubdir:           "istio-control/istio-discovery"
     ToHelmValuesTreeRoot: "pilot"


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/21047.
The problem here was that some fields that are populated by k8s end up being set to defaults rather than unset, which is interpreted as a value change in the API server. To fix this, this change reads the API server object and applies a simple JSON patch overlay for the newly generated object. This will cause the k8s set fields to be preserved. 