### PR TITLE
Ignore unknown GVKs in analyze instead of erroring

### DIFF
--- a/galley/pkg/config/source/kube/inmemory/kubesource_test.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource_test.go
@@ -199,7 +199,7 @@ func TestKubeSource_UnparseableSegment(t *testing.T) {
 	s.Start()
 	defer s.Stop()
 
-	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, "	\n", data.YamlN2I2V1))
+	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, "invalidyaml\n", data.YamlN2I2V1))
 	g.Expect(err).To(Not(BeNil()))
 
 	actual := removeEntryOrigins(s.Get(basicmeta.K8SCollection1.Name()).AllSorted())
@@ -216,8 +216,9 @@ func TestKubeSource_Unrecognized(t *testing.T) {
 	defer s.Stop()
 
 	err := s.ApplyContent("foo", kubeyaml.JoinString(data.YamlN1I1V1, data.YamlUnrecognized))
-	g.Expect(err).To(Not(BeNil()))
+	g.Expect(err).To(BeNil())
 
+	// Even though we got no error, we still only parsed one resource as the unrecognized one was ignored.
 	actual := removeEntryOrigins(s.Get(basicmeta.K8SCollection1.Name()).AllSorted())
 	g.Expect(actual).To(HaveLen(1))
 	fixtures.ExpectEqual(t, actual[0], data.EntryN1I1V1)


### PR DESCRIPTION
Running istioctl analyze against a resource in a file that's unknown causes a parse error; this change instead ignores the error and continues. This is desirable as users often want to analyze files which might contain all sorts of group/version/kind resources that galley does not know about. However, we still treat a resource with no GVK as an error.

For example, analyze without this change, when pointed at bookinfo in its file form produces:
```
$ istioctl analyze -R ../../
Error(s) adding files: 1 error occurred:
	* errors parsing content "../../workloads/bookinfo/bookinfo.yaml": 4 errors occurred:
	* error processing ../../workloads/bookinfo/bookinfo.yaml[1]: failed finding schema for group/kind: /ServiceAccount
	* error processing ../../workloads/bookinfo/bookinfo.yaml[4]: failed finding schema for group/kind: /ServiceAccount
	* error processing ../../workloads/bookinfo/bookinfo.yaml[7]: failed finding schema for group/kind: /ServiceAccount
	* error processing ../../workloads/bookinfo/bookinfo.yaml[12]: failed finding schema for group/kind: /ServiceAccount
```
Galley doesn't have ServiceAccount in its metadata, but that doesn't mean we should error.
