### PR TITLE
Auto mTLS for namespace/mesh beta peer authn policies

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -15,8 +15,10 @@
 package model
 
 import (
+	"istio.io/api/authentication/v1alpha1"
 	"istio.io/api/security/v1beta1"
 
+	config_consts "istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collections"
 )
@@ -59,6 +61,16 @@ type AuthenticationPolicies struct {
 
 	peerAuthentications map[string][]Config
 
+	// namespaceMutualTLSMode is the MutualTLSMode correspoinding to the namespace-level PeerAuthentication.
+	// All namespace-level policies, and only them, are added to this map. If the policy mTLS mode is set
+	// to UNSET, it will be resolved to the globalMutualTLSMode, if exist (i.e not UNKNOWN), or MTLSPermissive
+	// otherwise.
+	namespaceMutualTLSMode map[string]MutualTLSMode
+
+	// globalMutualTLSMode is the MutualTLSMode corresponding to the mesh-level PeerAuthentication.
+	// This value can be MTLSUnknown, if there is no mesh-level policy.
+	globalMutualTLSMode MutualTLSMode
+
 	rootNamespace string
 }
 
@@ -68,6 +80,7 @@ func initAuthenticationPolicies(env *Environment) (*AuthenticationPolicies, erro
 	policy := &AuthenticationPolicies{
 		requestAuthentications: map[string][]Config{},
 		peerAuthentications:    map[string][]Config{},
+		globalMutualTLSMode:    MTLSUnknown,
 		rootNamespace:          env.Mesh().GetRootNamespace(),
 	}
 
@@ -97,11 +110,73 @@ func (policy *AuthenticationPolicies) addRequestAuthentication(configs []Config)
 	}
 }
 
+func apiModeToMutualTLSMode(mode v1beta1.PeerAuthentication_MutualTLS_Mode) MutualTLSMode {
+	switch mode {
+	case v1beta1.PeerAuthentication_MutualTLS_DISABLE:
+		return MTLSDisable
+	case v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE:
+		return MTLSPermissive
+	case v1beta1.PeerAuthentication_MutualTLS_STRICT:
+		return MTLSStrict
+	default:
+		return MTLSUnknown
+	}
+}
+
 func (policy *AuthenticationPolicies) addPeerAuthentication(configs []Config) {
+	foundNamespaceMTLS := make(map[string]v1beta1.PeerAuthentication_MutualTLS_Mode)
+
 	for _, config := range configs {
 		policy.peerAuthentications[config.Namespace] =
 			append(policy.peerAuthentications[config.Namespace], config)
+
+		// Mesh & namespace level policy must be named as `default` (config_consts.DefaultAuthenticationPolicyName)
+		// per validation rule. Extra check for empty selector is optional.
+		if config.Name == config_consts.DefaultAuthenticationPolicyName {
+			spec := config.Spec.(*v1beta1.PeerAuthentication)
+			mode := v1beta1.PeerAuthentication_MutualTLS_UNSET
+			if spec.Mtls != nil {
+				mode = spec.Mtls.Mode
+			}
+			if config.Namespace == policy.rootNamespace {
+				// This is mesh-level policy. Resolve the UNSET mode if needed, and update the foundGlobalMTLS.
+				if mode == v1beta1.PeerAuthentication_MutualTLS_UNSET {
+					policy.globalMutualTLSMode = MTLSPermissive
+				} else {
+					policy.globalMutualTLSMode = apiModeToMutualTLSMode(mode)
+				}
+			} else {
+				// For regular namespace, just add to the intemediate map.
+				foundNamespaceMTLS[config.Namespace] = mode
+			}
+		}
 	}
+
+	// Process found namespace-level policy.
+	policy.namespaceMutualTLSMode = make(map[string]MutualTLSMode, len(foundNamespaceMTLS))
+
+	inheritedMTLSMode := policy.globalMutualTLSMode
+	if inheritedMTLSMode == MTLSUnknown {
+		// If the mesh policy is not presented, we want the resolve UNSET into MTLSPermissive.
+		inheritedMTLSMode = MTLSPermissive
+	}
+	for ns, mtlsMode := range foundNamespaceMTLS {
+		if mtlsMode == v1beta1.PeerAuthentication_MutualTLS_UNSET {
+			policy.namespaceMutualTLSMode[ns] = inheritedMTLSMode
+		} else {
+			policy.namespaceMutualTLSMode[ns] = apiModeToMutualTLSMode(mtlsMode)
+		}
+	}
+}
+
+// GetNamespaceMutualTLSMode returns the MutualTLSMode as defined by a namespace or mesh level
+// PeerAuthentication. The return value could be `MTLSUnknown` if there is no mesh nor namespace
+// PeerAuthentication policy for the given namespace.
+func (policy *AuthenticationPolicies) GetNamespaceMutualTLSMode(namespace string) MutualTLSMode {
+	if mode, ok := policy.namespaceMutualTLSMode[namespace]; ok {
+		return mode
+	}
+	return policy.globalMutualTLSMode
 }
 
 // GetJwtPoliciesForWorkload returns a list of JWT policies matching to labels.
@@ -159,4 +234,25 @@ func getConfigsForWorkload(configsByNamespace map[string][]Config,
 	}
 
 	return configs
+}
+
+func v1alpha1PolicyToMutualTLSMode(policy *v1alpha1.Policy) MutualTLSMode {
+	if policy == nil {
+		return MTLSDisable
+	}
+
+	for _, method := range policy.Peers {
+		switch method.GetParams().(type) {
+		case *v1alpha1.PeerAuthenticationMethod_Mtls:
+			if method.GetMtls() == nil ||
+				method.GetMtls().Mode == v1alpha1.MutualTls_STRICT {
+				return MTLSStrict
+			}
+			return MTLSPermissive
+		default:
+			continue
+		}
+	}
+
+	return MTLSDisable
 }

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -18,7 +18,6 @@ import (
 	"istio.io/api/authentication/v1alpha1"
 	"istio.io/api/security/v1beta1"
 
-	config_consts "istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collections"
 )
@@ -130,10 +129,9 @@ func (policy *AuthenticationPolicies) addPeerAuthentication(configs []Config) {
 		policy.peerAuthentications[config.Namespace] =
 			append(policy.peerAuthentications[config.Namespace], config)
 
-		// Mesh & namespace level policy must be named as `default` (config_consts.DefaultAuthenticationPolicyName)
-		// per validation rule. Extra check for empty selector is optional.
-		if config.Name == config_consts.DefaultAuthenticationPolicyName {
-			spec := config.Spec.(*v1beta1.PeerAuthentication)
+		// Mesh & namespace level policy are those that have empty selector.
+		spec := config.Spec.(*v1beta1.PeerAuthentication)
+		if spec.Selector == nil || len(spec.Selector.MatchLabels) == 0 {
 			mode := v1beta1.PeerAuthentication_MutualTLS_UNSET
 			if spec.Mtls != nil {
 				mode = spec.Mtls.Mode

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -62,7 +62,7 @@ type AuthenticationPolicies struct {
 
 	// namespaceMutualTLSMode is the MutualTLSMode correspoinding to the namespace-level PeerAuthentication.
 	// All namespace-level policies, and only them, are added to this map. If the policy mTLS mode is set
-	// to UNSET, it will be resolved to the globalMutualTLSMode, if exist (i.e not UNKNOWN), or MTLSPermissive
+	// to UNSET, it will be resolved to the value set by mesh policy if exist (i.e not UNKNOWN), or MTLSPermissive
 	// otherwise.
 	namespaceMutualTLSMode map[string]MutualTLSMode
 
@@ -137,7 +137,7 @@ func (policy *AuthenticationPolicies) addPeerAuthentication(configs []Config) {
 				mode = spec.Mtls.Mode
 			}
 			if config.Namespace == policy.rootNamespace {
-				// This is mesh-level policy. Resolve the UNSET mode if needed, and update the foundGlobalMTLS.
+				// This is mesh-level policy. UNSET is treated as permissive for mesh-policy.
 				if mode == v1beta1.PeerAuthentication_MutualTLS_UNSET {
 					policy.globalMutualTLSMode = MTLSPermissive
 				} else {
@@ -155,7 +155,7 @@ func (policy *AuthenticationPolicies) addPeerAuthentication(configs []Config) {
 
 	inheritedMTLSMode := policy.globalMutualTLSMode
 	if inheritedMTLSMode == MTLSUnknown {
-		// If the mesh policy is not presented, we want the resolve UNSET into MTLSPermissive.
+		// If the mesh policy is not explicitly presented, use default valude MTLSPermissive.
 		inheritedMTLSMode = MTLSPermissive
 	}
 	for ns, mtlsMode := range foundNamespaceMTLS {

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -38,14 +38,15 @@ var (
 )
 
 func TestGetPoliciesForWorkload(t *testing.T) {
-	policies := getTestAuthenticationPolicies(createTestConfigs(), t)
+	policies := getTestAuthenticationPolicies(createTestConfigs(true /* with mesh peer authn */), t)
 
 	cases := []struct {
-		name              string
-		workloadNamespace string
-		workloadLabels    labels.Collection
-		wantRequestAuthn  []*Config
-		wantPeerAuthn     []*Config
+		name                   string
+		workloadNamespace      string
+		workloadLabels         labels.Collection
+		wantRequestAuthn       []*Config
+		wantPeerAuthn          []*Config
+		wantNamespaceMutualTLS MutualTLSMode
 	}{
 		{
 			name:              "Empty workload labels in foo",
@@ -82,7 +83,11 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "foo",
 					},
-					Spec: &securityBeta.PeerAuthentication{},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
 				},
 				{
 					ConfigMeta: ConfigMeta{
@@ -92,9 +97,14 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &securityBeta.PeerAuthentication{},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_UNSET,
+						},
+					},
 				},
 			},
+			wantNamespaceMutualTLS: MTLSStrict,
 		},
 		{
 			name:              "Empty workload labels in bar",
@@ -131,9 +141,14 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &securityBeta.PeerAuthentication{},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_UNSET,
+						},
+					},
 				},
 			},
+			wantNamespaceMutualTLS: MTLSPermissive,
 		},
 		{
 			name:              "Empty workload labels in baz",
@@ -160,9 +175,14 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &securityBeta.PeerAuthentication{},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_UNSET,
+						},
+					},
 				},
 			},
+			wantNamespaceMutualTLS: MTLSPermissive,
 		},
 		{
 			name:              "Match workload labels in foo",
@@ -232,7 +252,11 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "foo",
 					},
-					Spec: &securityBeta.PeerAuthentication{},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
 				},
 				{
 					ConfigMeta: ConfigMeta{
@@ -248,6 +272,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 								"version": "v1",
 							},
 						},
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_DISABLE,
+						},
 					},
 				},
 				{
@@ -258,9 +285,14 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &securityBeta.PeerAuthentication{},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_UNSET,
+						},
+					},
 				},
 			},
+			wantNamespaceMutualTLS: MTLSStrict,
 		},
 		{
 			name:              "Match workload labels in bar",
@@ -313,9 +345,14 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &securityBeta.PeerAuthentication{},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_UNSET,
+						},
+					},
 				},
 			},
+			wantNamespaceMutualTLS: MTLSPermissive,
 		},
 		{
 			name:              "Paritial match workload labels in foo",
@@ -368,7 +405,11 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "foo",
 					},
-					Spec: &securityBeta.PeerAuthentication{},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
 				},
 				{
 					ConfigMeta: ConfigMeta{
@@ -378,9 +419,14 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 						Name:      "default",
 						Namespace: "istio-config",
 					},
-					Spec: &securityBeta.PeerAuthentication{},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_UNSET,
+						},
+					},
 				},
 			},
+			wantNamespaceMutualTLS: MTLSStrict,
 		},
 	}
 
@@ -391,6 +437,139 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			}
 			if got := policies.GetPeerAuthenticationsForWorkload(tc.workloadNamespace, tc.workloadLabels); !reflect.DeepEqual(tc.wantPeerAuthn, got) {
 				t.Fatalf("want %+v\n, but got %+v\n", printConfigs(tc.wantPeerAuthn), printConfigs(got))
+			}
+			if got := policies.GetNamespaceMutualTLSMode(tc.workloadNamespace); got != tc.wantNamespaceMutualTLS {
+				t.Fatalf("want %s\n, but got %s\n", tc.wantNamespaceMutualTLS, got)
+			}
+		})
+	}
+}
+
+func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
+	policies := getTestAuthenticationPolicies(createTestConfigs(false /* with mesh peer authn */), t)
+
+	cases := []struct {
+		name                   string
+		workloadNamespace      string
+		workloadLabels         labels.Collection
+		wantPeerAuthn          []*Config
+		wantNamespaceMutualTLS MutualTLSMode
+	}{
+		{
+			name:              "Empty workload labels in foo",
+			workloadNamespace: "foo",
+			workloadLabels:    labels.Collection{},
+			wantPeerAuthn: []*Config{
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      peerAuthenticationGvk.Kind,
+						Version:   peerAuthenticationGvk.Version,
+						Group:     peerAuthenticationGvk.Group,
+						Name:      "default",
+						Namespace: "foo",
+					},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+			},
+			wantNamespaceMutualTLS: MTLSStrict,
+		},
+		{
+			name:                   "Empty workload labels in bar",
+			workloadNamespace:      "bar",
+			workloadLabels:         labels.Collection{},
+			wantPeerAuthn:          []*Config{},
+			wantNamespaceMutualTLS: MTLSUnknown,
+		},
+		{
+			name:                   "Empty workload labels in baz",
+			workloadNamespace:      "baz",
+			workloadLabels:         labels.Collection{},
+			wantPeerAuthn:          []*Config{},
+			wantNamespaceMutualTLS: MTLSUnknown,
+		},
+		{
+			name:              "Match workload labels in foo",
+			workloadNamespace: "foo",
+			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1", "other": "labels"}},
+			wantPeerAuthn: []*Config{
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      peerAuthenticationGvk.Kind,
+						Version:   peerAuthenticationGvk.Version,
+						Group:     peerAuthenticationGvk.Group,
+						Name:      "default",
+						Namespace: "foo",
+					},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      peerAuthenticationGvk.Kind,
+						Version:   peerAuthenticationGvk.Version,
+						Group:     peerAuthenticationGvk.Group,
+						Name:      "peer-with-selector",
+						Namespace: "foo",
+					},
+					Spec: &securityBeta.PeerAuthentication{
+						Selector: &selectorpb.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"version": "v1",
+							},
+						},
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_DISABLE,
+						},
+					},
+				},
+			},
+			wantNamespaceMutualTLS: MTLSStrict,
+		},
+		{
+			name:                   "Match workload labels in bar",
+			workloadNamespace:      "bar",
+			workloadLabels:         labels.Collection{{"app": "httpbin", "version": "v1"}},
+			wantPeerAuthn:          []*Config{},
+			wantNamespaceMutualTLS: MTLSUnknown,
+		},
+		{
+			name:              "Paritial match workload labels in foo",
+			workloadNamespace: "foo",
+			workloadLabels:    labels.Collection{{"app": "httpbin"}},
+			wantPeerAuthn: []*Config{
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      peerAuthenticationGvk.Kind,
+						Version:   peerAuthenticationGvk.Version,
+						Group:     peerAuthenticationGvk.Group,
+						Name:      "default",
+						Namespace: "foo",
+					},
+					Spec: &securityBeta.PeerAuthentication{
+						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+							Mode: securityBeta.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+			},
+			wantNamespaceMutualTLS: MTLSStrict,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := policies.GetPeerAuthenticationsForWorkload(tc.workloadNamespace, tc.workloadLabels); !reflect.DeepEqual(tc.wantPeerAuthn, got) {
+				t.Fatalf("want %+v\n, but got %+v\n", printConfigs(tc.wantPeerAuthn), printConfigs(got))
+			}
+			if got := policies.GetNamespaceMutualTLSMode(tc.workloadNamespace); got != tc.wantNamespaceMutualTLS {
+				t.Fatalf("want %s, but got %s", tc.wantNamespaceMutualTLS, got)
 			}
 		})
 	}
@@ -431,7 +610,7 @@ func createTestRequestAuthenticationResource(name string, namespace string, sele
 	}
 }
 
-func createTestPeerAuthenticationResource(name string, namespace string, selector *selectorpb.WorkloadSelector) *Config {
+func createTestPeerAuthenticationResource(name string, namespace string, selector *selectorpb.WorkloadSelector, mode securityBeta.PeerAuthentication_MutualTLS_Mode) *Config {
 	return &Config{
 		ConfigMeta: ConfigMeta{
 			Type:      collections.IstioSecurityV1Beta1Peerauthentications.Resource().Kind(),
@@ -442,11 +621,14 @@ func createTestPeerAuthenticationResource(name string, namespace string, selecto
 		},
 		Spec: &securityBeta.PeerAuthentication{
 			Selector: selector,
+			Mtls: &securityBeta.PeerAuthentication_MutualTLS{
+				Mode: mode,
+			},
 		},
 	}
 }
 
-func createTestConfigs() []*Config {
+func createTestConfigs(withMeshPeerAuthn bool) []*Config {
 	configs := make([]*Config, 0)
 
 	selector := &selectorpb.WorkloadSelector{
@@ -464,19 +646,22 @@ func createTestConfigs() []*Config {
 		createTestRequestAuthenticationResource("default", "foo", nil),
 		createTestRequestAuthenticationResource("default", "bar", nil),
 		createTestRequestAuthenticationResource("with-selector", "foo", selector),
-		createTestPeerAuthenticationResource("default", rootNamespace, nil),
 		createTestPeerAuthenticationResource("global-peer-with-selector", rootNamespace, &selectorpb.WorkloadSelector{
 			MatchLabels: map[string]string{
 				"app":     "httpbin",
 				"version": "v2",
 			},
-		}),
-		createTestPeerAuthenticationResource("default", "foo", nil),
+		}, securityBeta.PeerAuthentication_MutualTLS_UNSET),
+		createTestPeerAuthenticationResource("default", "foo", nil, securityBeta.PeerAuthentication_MutualTLS_STRICT),
 		createTestPeerAuthenticationResource("peer-with-selector", "foo", &selectorpb.WorkloadSelector{
 			MatchLabels: map[string]string{
 				"version": "v1",
 			},
-		}))
+		}, securityBeta.PeerAuthentication_MutualTLS_DISABLE))
+
+	if withMeshPeerAuthn {
+		configs = append(configs, createTestPeerAuthenticationResource("default", rootNamespace, nil, securityBeta.PeerAuthentication_MutualTLS_UNSET))
+	}
 
 	return configs
 }

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -610,7 +610,8 @@ func createTestRequestAuthenticationResource(name string, namespace string, sele
 	}
 }
 
-func createTestPeerAuthenticationResource(name string, namespace string, selector *selectorpb.WorkloadSelector, mode securityBeta.PeerAuthentication_MutualTLS_Mode) *Config {
+func createTestPeerAuthenticationResource(name string, namespace string,
+	selector *selectorpb.WorkloadSelector, mode securityBeta.PeerAuthentication_MutualTLS_Mode) *Config {
 	return &Config{
 		ConfigMeta: ConfigMeta{
 			Type:      collections.IstioSecurityV1Beta1Peerauthentications.Resource().Kind(),

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1812,3 +1812,33 @@ func (ps *PushContext) NetworkGatewaysByNetwork(network string) []*Gateway {
 func (ps *PushContext) QuotaSpecByDestination(instance *ServiceInstance) []Config {
 	return filterQuotaSpecsByDestination(instance, ps.QuotaSpecBinding, ps.QuotaSpec)
 }
+
+// BestEffortInferServiceMTLSMode infers the mTLS mode for the service + port from all authentication
+// policies (both alpha and beta) in the system. The function always returns MTLSUnknown for external service.
+// The resulst is a best effort. It is because the PeerAuthentication is workload-based, this function is unable
+// to compute the correct service mTLS mode without knowing service to workload binding. For now, this
+// function uses only mesh and namespace level PeerAuthentication and ignore workload & port level policies.
+// This function is used to give a hint for auto-mTLS configuration on client side.
+func (ps *PushContext) BestEffortInferServiceMTLSMode(service *Service, port *Port) MutualTLSMode {
+	if service.MeshExternal {
+		// Only need the authentication MTLS mode when service is not external.
+		return MTLSUnknown
+	}
+
+	// First , check mTLS settings from beta policy (i.e PeerAuthentication) at namespace / mesh level.
+	// If the mode is not unknown, use it.
+	if serviceMTLSMode := ps.AuthnBetaPolicies.GetNamespaceMutualTLSMode(service.Attributes.Namespace); serviceMTLSMode != MTLSUnknown {
+		return serviceMTLSMode
+	}
+
+	// Namespace/Mesh PeerAuthentication does not exist, check alpha authN policy.
+	policy, _ := ps.AuthenticationPolicyForWorkload(service, port)
+	if policy != nil {
+		log.Infof("Found policy for %v, %v,  %#v", service, port, policy)
+		// If alpha authN policy exist, used the mode defined by the policy.
+		return v1alpha1PolicyToMutualTLSMode(policy)
+	}
+
+	// When all are failed, default to permissive.
+	return MTLSPermissive
+}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -24,6 +24,8 @@ import (
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	securityBeta "istio.io/api/security/v1beta1"
+	selectorpb "istio.io/api/type/v1beta1"
 
 	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pkg/config/constants"
@@ -646,6 +648,168 @@ func TestSidecarScope(t *testing.T) {
 		if c.sidecar != scopeToSidecar(scope) {
 			t.Errorf("case with %s should get sidecar %s but got %s", c.describe, c.sidecar, scopeToSidecar(scope))
 		}
+	}
+}
+
+func TestBestEffortInferServiceMTLSMode(t *testing.T) {
+	const testNamespace string = "test-namespace"
+	ps := NewPushContext()
+	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"})}
+	ps.Mesh = env.Mesh()
+	ps.ServiceDiscovery = env
+	authNPolicies := map[string]*authn.Policy{
+		constants.DefaultAuthenticationPolicyName: {},
+		"mtls-strict-svc": {
+			Targets: []*authn.TargetSelector{{
+				Name: "mtls-strict-svc",
+			}},
+			Peers: []*authn.PeerAuthenticationMethod{{
+				Params: &authn.PeerAuthenticationMethod_Mtls{},
+			},
+			}},
+		"mtls-strict-svc-port": {
+			Targets: []*authn.TargetSelector{{
+				Name: "mtls-strict-svc-port",
+				Ports: []*authn.PortSelector{
+					{
+						Port: &authn.PortSelector_Number{
+							Number: 80,
+						},
+					},
+				},
+			}},
+			Peers: []*authn.PeerAuthenticationMethod{{
+				Params: &authn.PeerAuthenticationMethod_Mtls{},
+			},
+			}},
+		"mtls-disable-svc": {
+			Targets: []*authn.TargetSelector{{
+				Name: "mtls-disable-svc",
+			}},
+		},
+	}
+	configStore := newFakeStore()
+	for key, value := range authNPolicies {
+		cfg := Config{
+			ConfigMeta: ConfigMeta{
+				Type:      collections.IstioAuthenticationV1Alpha1Policies.Resource().Kind(),
+				Group:     collections.IstioAuthenticationV1Alpha1Policies.Resource().Group(),
+				Version:   collections.IstioAuthenticationV1Alpha1Policies.Resource().Version(),
+				Name:      key,
+				Domain:    "cluster.local",
+				Namespace: testNamespace,
+			},
+			Spec: value,
+		}
+		if _, err := configStore.Create(cfg); err != nil {
+			t.Error(err)
+		}
+	}
+
+	// Add cluster-scoped policy
+	globalPolicy := &authn.Policy{
+		Peers: []*authn.PeerAuthenticationMethod{{
+			Params: &authn.PeerAuthenticationMethod_Mtls{
+				Mtls: &authn.MutualTls{
+					Mode: authn.MutualTls_PERMISSIVE,
+				},
+			},
+		}},
+	}
+	globalCfg := Config{
+		ConfigMeta: ConfigMeta{
+			Type:    collections.IstioAuthenticationV1Alpha1Meshpolicies.Resource().Kind(),
+			Group:   collections.IstioAuthenticationV1Alpha1Meshpolicies.Resource().Group(),
+			Version: collections.IstioAuthenticationV1Alpha1Meshpolicies.Resource().Version(),
+			Name:    constants.DefaultAuthenticationPolicyName,
+			Domain:  "cluster.local",
+		},
+		Spec: globalPolicy,
+	}
+
+	// Add beta policies
+	configStore.Create(*createTestPeerAuthenticationResource("default", "beta-namespace", nil, securityBeta.PeerAuthentication_MutualTLS_STRICT))
+	// workload level beta policy.
+	configStore.Create(*createTestPeerAuthenticationResource("workload-beta-policy", testNamespace, &selectorpb.WorkloadSelector{
+		MatchLabels: map[string]string{
+			"app":     "httpbin",
+			"version": "v1",
+		},
+	}, securityBeta.PeerAuthentication_MutualTLS_STRICT))
+
+	if _, err := configStore.Create(globalCfg); err != nil {
+		t.Error(err)
+	}
+
+	store := istioConfigStore{ConfigStore: configStore}
+	env.IstioConfigStore = &store
+	if err := ps.initAuthnPolicies(env); err != nil {
+		t.Fatalf("init authn policies failed: %v", err)
+	}
+
+	cases := []struct {
+		name             string
+		serviceName      host.Name
+		serviceNamespace string
+		servicePort      int
+		wanted           MutualTLSMode
+	}{
+		{
+			name:             "from beta policy",
+			serviceName:      "some-service",
+			serviceNamespace: "beta-namespace",
+			servicePort:      80,
+			wanted:           MTLSStrict,
+		},
+		{
+			name:             "from alpha global policy",
+			serviceName:      "some-service",
+			serviceNamespace: "new-namespace",
+			servicePort:      80,
+			wanted:           MTLSPermissive,
+		},
+		{
+			name:             "from alpha namespace policy",
+			serviceName:      "some-service",
+			serviceNamespace: testNamespace,
+			servicePort:      80,
+			wanted:           MTLSDisable,
+		},
+		{
+			name:             "from service specific alpha policy",
+			serviceName:      "mtls-strict-svc",
+			serviceNamespace: testNamespace,
+			servicePort:      80,
+			wanted:           MTLSStrict,
+		},
+		{
+			name:             "from service-port specific alpha policy",
+			serviceName:      "mtls-strict-svc-port",
+			serviceNamespace: testNamespace,
+			servicePort:      80,
+			wanted:           MTLSStrict,
+		},
+		{
+			name:             "from namespace alpha policy - miss port",
+			serviceName:      "mtls-strict-svc-port",
+			serviceNamespace: testNamespace,
+			servicePort:      90,
+			wanted:           MTLSDisable,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			service := &Service{
+				Hostname:   host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", tc.serviceName, tc.serviceNamespace)),
+				Attributes: ServiceAttributes{Namespace: tc.serviceNamespace},
+			}
+			port := &Port{
+				Port: tc.servicePort,
+			}
+			if got := ps.BestEffortInferServiceMTLSMode(service, port); got != tc.wanted {
+				t.Fatalf("want %s, but got %s", tc.wanted, got)
+			}
+		})
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -40,7 +40,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
-	authn_v1alpha1_applier "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
@@ -210,12 +209,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(proxy *model.Proxy, 
 			}
 
 			setUpstreamProtocol(proxy, defaultCluster, port, model.TrafficDirectionOutbound)
-			serviceMTLSMode := model.MTLSUnknown
-			if !service.MeshExternal {
-				// Only need the authentication MTLS mode when service is not external.
-				policy, _ := push.AuthenticationPolicyForWorkload(service, port)
-				serviceMTLSMode = authn_v1alpha1_applier.GetMutualTLSMode(policy)
-			}
+			serviceMTLSMode := push.BestEffortInferServiceMTLSMode(service, port)
 			clusters = append(clusters, defaultCluster)
 			destinationRule := castDestinationRuleOrDefault(destRule)
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -38,6 +38,8 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
 	networking "istio.io/api/networking/v1alpha3"
+	authn_beta "istio.io/api/security/v1beta1"
+	selectorpb "istio.io/api/type/v1beta1"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -227,12 +229,13 @@ func buildTestClusters(serviceHostname string, serviceResolution model.Resolutio
 		mesh,
 		destRule,
 		nil, // authnPolicy
+		nil, // peerAuthn
 	)
 }
 
 func buildTestClustersWithAuthnPolicy(serviceHostname string, serviceResolution model.Resolution, externalService bool,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication) ([]*apiv2.Cluster, error) {
 	return buildTestClustersWithProxyMetadata(
 		serviceHostname,
 		serviceResolution,
@@ -242,30 +245,31 @@ func buildTestClustersWithAuthnPolicy(serviceHostname string, serviceResolution 
 		mesh,
 		destRule,
 		authnPolicy,
+		peerAuthn,
 		&model.NodeMetadata{},
 		model.MaxIstioVersion)
 }
 
 func buildTestClustersWithIstioVersion(serviceHostname string, serviceResolution model.Resolution,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
 	return buildTestClustersWithProxyMetadata(serviceHostname, serviceResolution, false /* externalService */, nodeType, locality, mesh, destRule,
-		authnPolicy, &model.NodeMetadata{}, istioVersion)
+		authnPolicy, peerAuthn, &model.NodeMetadata{}, istioVersion)
 }
 
 func buildTestClustersWithProxyMetadata(serviceHostname string, serviceResolution model.Resolution, externalService bool,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy, meta *model.NodeMetadata, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication, meta *model.NodeMetadata, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
 	return buildTestClustersWithProxyMetadataWithIps(serviceHostname, serviceResolution, externalService,
 		nodeType, locality, mesh,
-		destRule, authnPolicy, meta, istioVersion,
+		destRule, authnPolicy, peerAuthn, meta, istioVersion,
 		// Add default sidecar proxy meta
 		[]string{"6.6.6.6", "::1"})
 }
 
 func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceResolution model.Resolution, externalService bool,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy, meta *model.NodeMetadata, istioVersion *model.IstioVersion, proxyIps []string) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication, meta *model.NodeMetadata, istioVersion *model.IstioVersion, proxyIps []string) ([]*apiv2.Cluster, error) {
 	configgen := NewConfigGenerator([]plugin.Plugin{})
 
 	serviceDiscovery := &fakes.ServiceDiscovery{}
@@ -376,6 +380,22 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 					},
 						Spec: authnPolicy,
 					}}, nil
+			}
+			if typ == collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind() && peerAuthn != nil {
+				policyName := "default"
+				if peerAuthn.Selector != nil {
+					policyName = "acme"
+				}
+				return []model.Config{
+					{ConfigMeta: model.ConfigMeta{
+						Type:      collections.IstioSecurityV1Beta1Peerauthentications.Resource().Kind(),
+						Version:   collections.IstioSecurityV1Beta1Peerauthentications.Resource().Version(),
+						Name:      policyName,
+						Namespace: TestServiceNamespace,
+					},
+						Spec: peerAuthn,
+					}}, nil
+
 			}
 			return nil, nil
 		},
@@ -562,7 +582,7 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 	}
 
 	clusters, err := buildTestClustersWithProxyMetadata("foo.example.org", model.ClientSideLB, false, model.SidecarProxy,
-		nil, testMesh, destRule, nil, envoyMetadata, model.MaxIstioVersion)
+		nil, testMesh, destRule, nil, nil, envoyMetadata, model.MaxIstioVersion)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(clusters).To(HaveLen(10))
@@ -620,6 +640,7 @@ func buildSniTestClustersWithMetadata(sniValue string, typ model.NodeType, meta 
 			},
 		},
 		nil, // authnPolicy
+		nil, // peerAuthn
 		meta,
 		model.MaxIstioVersion,
 	)
@@ -1295,6 +1316,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 			},
 		},
 		nil, // authnPolicy
+		nil, // peerAuthn,
 		&model.NodeMetadata{RouterMode: string(model.SniDnatRouter)},
 		model.MaxIstioVersion)
 
@@ -1345,6 +1367,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 			},
 		},
 		nil, // authnPolicy
+		nil, // peerAuthn
 		&model.NodeMetadata{RouterMode: string(model.SniDnatRouter)},
 		model.MaxIstioVersion)
 
@@ -1553,6 +1576,7 @@ func TestClusterDiscoveryTypeAndLbPolicyPassthroughIstioVersion12(t *testing.T) 
 			},
 		},
 		nil, // authnPolicy
+		nil, // peerAuthn
 		&model.IstioVersion{Major: 1, Minor: 2})
 
 	g.Expect(err).NotTo(HaveOccurred())
@@ -1943,6 +1967,7 @@ func TestPassthroughClustersBuildUponProxyIpVersions(t *testing.T) {
 				},
 			},
 			nil, // authnPolicy
+			nil, // peerAuthn
 			&model.NodeMetadata{},
 			model.MaxIstioVersion,
 			inAndOut.ips,
@@ -1981,7 +2006,7 @@ func TestAutoMTLSClusterPlaintextMode(t *testing.T) {
 		Peers: []*authn.PeerAuthenticationMethod{},
 	}
 
-	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy)
+	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// mTLS is disabled by authN policy so autoMTLS does not kick in. No cluster should have TLS context.
@@ -2028,7 +2053,7 @@ func TestAutoMTLSClusterStrictMode(t *testing.T) {
 
 	testMesh.EnableAutoMtls.Value = true
 
-	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy)
+	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// For port 8080, (m)TLS settings is automatically added, thus its cluster should have TLS context.
@@ -2082,7 +2107,17 @@ func TestAutoMTLSClusterStrictMode_SkipForExternal(t *testing.T) {
 		},
 	}
 
-	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, true, model.SidecarProxy, nil, testMesh, destRule, authnPolicy)
+	clusters, err := buildTestClustersWithAuthnPolicy(
+		TestServiceNHostname,
+		0,
+		true,
+		model.SidecarProxy,
+		nil,
+		testMesh,
+		destRule,
+		authnPolicy,
+		nil, // peerAuthn
+	)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Service is external, use the TLS settings specified in DR.
@@ -2131,7 +2166,11 @@ func TestAutoMTLSClusterPerPortStrictMode(t *testing.T) {
 
 	testMesh.EnableAutoMtls.Value = true
 
-	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy)
+	clusters, err := buildTestClustersWithAuthnPolicy(
+		TestServiceNHostname,
+		0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy,
+		nil, // peerAuthn
+	)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// For port 8080, (m)TLS settings is automatically added, thus its cluster should have TLS context.
@@ -2140,6 +2179,126 @@ func TestAutoMTLSClusterPerPortStrictMode(t *testing.T) {
 	g.Expect(clusters[0].TransportSocketMatches).To(HaveLen(2))
 
 	// For 9090, authn policy disable mTLS, so it should not have TLS context.
+	g.Expect(getTLSContext(t, clusters[1])).To(BeNil())
+
+	// Sanity check: make sure TLS is not accidentally added to other clusters.
+	for i := 2; i < len(clusters); i++ {
+		cluster := clusters[i]
+		g.Expect(getTLSContext(t, cluster)).To(BeNil())
+	}
+}
+
+func TestAutoMTLSClusterWithPeerAuthnStrictMode(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	destRule := &networking.DestinationRule{
+		Host: TestServiceNHostname,
+		TrafficPolicy: &networking.TrafficPolicy{
+			ConnectionPool: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					MaxRequestsPerConnection: 1,
+				},
+			},
+			PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+				{
+					Port: &networking.PortSelector{
+						Number: 9090,
+					},
+					Tls: &networking.TLSSettings{
+						Mode: networking.TLSSettings_DISABLE,
+					},
+				},
+			},
+		},
+	}
+
+	// This alpha policy will be ignored.
+	authnPolicy := &authn.Policy{
+		Peers: []*authn.PeerAuthenticationMethod{
+			{
+				Params: &authn.PeerAuthenticationMethod_Mtls{
+					Mtls: &authn.MutualTls{
+						Mode: authn.MutualTls_PERMISSIVE,
+					},
+				},
+			},
+		},
+	}
+
+	peerAuthn := &authn_beta.PeerAuthentication{
+		Mtls: &authn_beta.PeerAuthentication_MutualTLS{
+			Mode: authn_beta.PeerAuthentication_MutualTLS_STRICT,
+		},
+	}
+
+	testMesh.EnableAutoMtls.Value = true
+
+	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy, peerAuthn)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// For port 8080, (m)TLS settings is automatically added, thus its cluster should have TLS context.
+	// TlsContext is nil because we use socket match instead
+	g.Expect(getTLSContext(t, clusters[0])).To(BeNil())
+	g.Expect(clusters[0].TransportSocketMatches).To(HaveLen(2))
+
+	// For 9090, use the TLS settings are explicitly specified in DR (which disable TLS)
+	g.Expect(getTLSContext(t, clusters[1])).To(BeNil())
+
+	// Sanity check: make sure TLS is not accidentally added to other clusters.
+	for i := 2; i < len(clusters); i++ {
+		cluster := clusters[i]
+		g.Expect(getTLSContext(t, cluster)).To(BeNil())
+	}
+}
+
+func TestAutoMTLSClusterIgnoreWorkloadLevelPeerAuthn(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	destRule := &networking.DestinationRule{
+		Host: TestServiceNHostname,
+		TrafficPolicy: &networking.TrafficPolicy{
+			ConnectionPool: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					MaxRequestsPerConnection: 1,
+				},
+			},
+			PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+				{
+					Port: &networking.PortSelector{
+						Number: 9090,
+					},
+					Tls: &networking.TLSSettings{
+						Mode: networking.TLSSettings_DISABLE,
+					},
+				},
+			},
+		},
+	}
+
+	// This workload-level beta policy doesn't affect CDS (yet).
+	peerAuthn := &authn_beta.PeerAuthentication{
+		Selector: &selectorpb.WorkloadSelector{
+			MatchLabels: map[string]string{
+				"version": "v1",
+			},
+		},
+		Mtls: &authn_beta.PeerAuthentication_MutualTLS{
+			Mode: authn_beta.PeerAuthentication_MutualTLS_STRICT,
+		},
+	}
+
+	testMesh.EnableAutoMtls.Value = true
+
+	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, nil, peerAuthn)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// No policy visible, auto-mTLS should set to PERMISSIVE.
+	// For port 8080, (m)TLS settings is automatically added, thus its cluster should have TLS context.
+	// TlsContext is nil because we use socket match instead
+	g.Expect(getTLSContext(t, clusters[0])).To(BeNil())
+	g.Expect(clusters[0].TransportSocketMatches).To(HaveLen(2))
+
+	// For 9090, use the TLS settings are explicitly specified in DR (which disable TLS)
 	g.Expect(getTLSContext(t, clusters[1])).To(BeNil())
 
 	// Sanity check: make sure TLS is not accidentally added to other clusters.

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -252,14 +252,16 @@ func buildTestClustersWithAuthnPolicy(serviceHostname string, serviceResolution 
 
 func buildTestClustersWithIstioVersion(serviceHostname string, serviceResolution model.Resolution,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication,
+	istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
 	return buildTestClustersWithProxyMetadata(serviceHostname, serviceResolution, false /* externalService */, nodeType, locality, mesh, destRule,
 		authnPolicy, peerAuthn, &model.NodeMetadata{}, istioVersion)
 }
 
 func buildTestClustersWithProxyMetadata(serviceHostname string, serviceResolution model.Resolution, externalService bool,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication, meta *model.NodeMetadata, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication,
+	meta *model.NodeMetadata, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
 	return buildTestClustersWithProxyMetadataWithIps(serviceHostname, serviceResolution, externalService,
 		nodeType, locality, mesh,
 		destRule, authnPolicy, peerAuthn, meta, istioVersion,
@@ -269,7 +271,8 @@ func buildTestClustersWithProxyMetadata(serviceHostname string, serviceResolutio
 
 func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceResolution model.Resolution, externalService bool,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication, meta *model.NodeMetadata, istioVersion *model.IstioVersion, proxyIps []string) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication,
+	meta *model.NodeMetadata, istioVersion *model.IstioVersion, proxyIps []string) ([]*apiv2.Cluster, error) {
 	configgen := NewConfigGenerator([]plugin.Plugin{})
 
 	serviceDiscovery := &fakes.ServiceDiscovery{}

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -137,7 +137,7 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType) *http_conn.
 func (a *v1beta1PolicyApplier) InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy) []plugin.FilterChain {
 	// If beta mTLS policy (PeerAuthentication) is not used for this workload, fallback to alpha policy.
 	if a.consolidatedPeerPolicy == nil && a.hasAlphaMTLSPolicy {
-		authnLog.Debug("InboundFilterChain: fallback to alpha policy applier")
+		authnLog.Debugf("InboundFilterChain [%v:%d]: fallback to alpha policy applier", node.ID, endpointPort)
 		return a.alphaApplier.InboundFilterChain(endpointPort, sdsUdsPath, node)
 	}
 	effectiveMTLSMode := model.MTLSPermissive
@@ -175,7 +175,7 @@ func NewPolicyApplier(rootNamespace string,
 		processedJwtRules:      processedJwtRules,
 		consolidatedPeerPolicy: composePeerAuthentication(rootNamespace, peerPolicies),
 		alphaApplier:           alpha_applier.NewPolicyApplier(policy),
-		hasAlphaMTLSPolicy:     alpha_applier.GetMutualTLS(policy) != nil,
+		hasAlphaMTLSPolicy:     policy != nil,
 	}
 }
 

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -178,6 +178,17 @@ func TestReachability(t *testing.T) {
 						return opts.Target != rctx.B || opts.PortName == "http"
 					},
 				},
+				{
+					ConfigFile:          "alpha-mtls-automtls.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+				},
 			}
 			rctx.Run(testCases)
 		})

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -162,7 +162,8 @@ func TestReachability(t *testing.T) {
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
+						// autoMtls doesn't work for client that doesn't have proxy.
+						return src != rctx.Naked
 					},
 				},
 				{
@@ -173,6 +174,10 @@ func TestReachability(t *testing.T) {
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// autoMtls doesn't work for client that doesn't have proxy.
+						if src == rctx.Naked {
+							return false
+						}
 						// PeerAuthentication disable mTLS for workload app:b, except http port. Thus, autoMTLS
 						// will fail on all ports on b, except http port.
 						return opts.Target != rctx.B || opts.PortName == "http"
@@ -186,7 +191,8 @@ func TestReachability(t *testing.T) {
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
+						// autoMtls doesn't work for client that doesn't have proxy.
+						return src != rctx.Naked
 					},
 				},
 			}

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -165,6 +165,19 @@ func TestReachability(t *testing.T) {
 						return true
 					},
 				},
+				{
+					ConfigFile:          "beta-mtls-partial-automtls.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// PeerAuthentication disable mTLS for workload app:b, except http port. Thus, autoMTLS
+						// will fail on all ports on b, except http port.
+						return opts.Target != rctx.B || opts.PortName == "http"
+					},
+				},
 			}
 			rctx.Run(testCases)
 		})

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -154,6 +154,23 @@ func TestReachability(t *testing.T) {
 						return true
 					},
 				},
+				{
+					ConfigFile:          "beta-mtls-automtls.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						if src == rctx.Naked && opts.Target == rctx.Naked {
+							// naked->naked should always succeed.
+							return true
+						}
+
+						// If one of the two endpoints is naked, expect failure.
+						return src != rctx.Naked && opts.Target != rctx.Naked
+					},
+				},
 			}
 			rctx.Run(testCases)
 		})

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -162,8 +162,12 @@ func TestReachability(t *testing.T) {
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						// autoMtls doesn't work for client that doesn't have proxy.
-						return src != rctx.Naked
+						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+						// have proxy neither.
+						if src == rctx.Naked {
+							return opts.Target == rctx.Naked
+						}
+						return true
 					},
 				},
 				{
@@ -174,9 +178,10 @@ func TestReachability(t *testing.T) {
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						// autoMtls doesn't work for client that doesn't have proxy.
+						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+						// have proxy neither.
 						if src == rctx.Naked {
-							return false
+							return opts.Target == rctx.Naked
 						}
 						// PeerAuthentication disable mTLS for workload app:b, except http port. Thus, autoMTLS
 						// will fail on all ports on b, except http port.
@@ -191,8 +196,12 @@ func TestReachability(t *testing.T) {
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						// autoMtls doesn't work for client that doesn't have proxy.
-						return src != rctx.Naked
+						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+						// have proxy neither.
+						if src == rctx.Naked {
+							return opts.Target == rctx.Naked
+						}
+						return true
 					},
 				},
 			}

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -162,13 +162,7 @@ func TestReachability(t *testing.T) {
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						if src == rctx.Naked && opts.Target == rctx.Naked {
-							// naked->naked should always succeed.
-							return true
-						}
-
-						// If one of the two endpoints is naked, expect failure.
-						return src != rctx.Naked && opts.Target != rctx.Naked
+						return true
 					},
 				},
 			}

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -156,7 +156,7 @@ func TestReachability(t *testing.T) {
 				},
 				{
 					ConfigFile:          "beta-mtls-automtls.yaml",
-					Namespace:           systemNM,
+					Namespace:           rctx.Namespace,
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
 						return true
@@ -172,16 +172,17 @@ func TestReachability(t *testing.T) {
 				},
 				{
 					ConfigFile:          "beta-mtls-partial-automtls.yaml",
-					Namespace:           systemNM,
+					Namespace:           rctx.Namespace,
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
-						// have proxy neither.
+						// have proxy or have mTLS disabled
 						if src == rctx.Naked {
-							return opts.Target == rctx.Naked
+							return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
+
 						}
 						// PeerAuthentication disable mTLS for workload app:b, except http port. Thus, autoMTLS
 						// will fail on all ports on b, except http port.
@@ -190,7 +191,7 @@ func TestReachability(t *testing.T) {
 				},
 				{
 					ConfigFile:          "alpha-mtls-automtls.yaml",
-					Namespace:           systemNM,
+					Namespace:           rctx.Namespace,
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
 						return true

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -198,9 +198,9 @@ func TestReachability(t *testing.T) {
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
-						// have proxy neither.
+						// have proxy or have mTLS disabled.
 						if src == rctx.Naked {
-							return opts.Target == rctx.Naked
+							return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
 						}
 						return true
 					},

--- a/tests/integration/security/testdata/alpha-mtls-automtls.yaml
+++ b/tests/integration/security/testdata/alpha-mtls-automtls.yaml
@@ -3,6 +3,8 @@ apiVersion: authentication.istio.io/v1alpha1
 kind: MeshPolicy
 metadata:
   name: "default"
+  annotations:
+    test-suite: "alpha-mtls-automtls"
 spec:
   peers:
   - mtls: {}
@@ -11,6 +13,8 @@ apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
   name: "b-mtls-off"
+  annotations:
+    test-suite: "alpha-mtls-automtls"
 spec:
   targets:
   - name: "b"
@@ -19,6 +23,8 @@ apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
   name: "b-80-mtls-on"
+  annotations:
+    test-suite: "alpha-mtls-automtls"
 spec:
   targets:
   - name: "b"

--- a/tests/integration/security/testdata/alpha-mtls-automtls.yaml
+++ b/tests/integration/security/testdata/alpha-mtls-automtls.yaml
@@ -1,0 +1,29 @@
+# Verify auto mTLS (still) works with alpha policy.
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: "default"
+spec:
+  peers:
+  - mtls: {}
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: "b-mtl-off"
+spec:
+  targets:
+  - name: "b"
+  peers: {}
+---
+  apiVersion: authentication.istio.io/v1alpha1
+  kind: Policy
+  metadata:
+    name: "b-80-mtl-on"
+  spec:
+    targets:
+    - name: "b"
+      ports:
+      - name: http
+    peers:
+    - mtls: {}

--- a/tests/integration/security/testdata/alpha-mtls-automtls.yaml
+++ b/tests/integration/security/testdata/alpha-mtls-automtls.yaml
@@ -10,20 +10,19 @@ spec:
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: "b-mtl-off"
+  name: "b-mtls-off"
 spec:
   targets:
   - name: "b"
-  peers: {}
 ---
-  apiVersion: authentication.istio.io/v1alpha1
-  kind: Policy
-  metadata:
-    name: "b-80-mtl-on"
-  spec:
-    targets:
-    - name: "b"
-      ports:
-      - name: http
-    peers:
-    - mtls: {}
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: "b-80-mtls-on"
+spec:
+  targets:
+  - name: "b"
+    ports:
+    - name: http
+  peers:
+  - mtls: {}

--- a/tests/integration/security/testdata/beta-mtls-automtls.yaml
+++ b/tests/integration/security/testdata/beta-mtls-automtls.yaml
@@ -1,0 +1,19 @@
+# Alpha API disable, making test more hermetic.
+# No DR is added for this test. enableAutoMtls is expected on by default.
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-automtls"
+spec: {}
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-automtls"
+spec:
+  mtls:
+    mode: STRICT

--- a/tests/integration/security/testdata/beta-mtls-partial-automtls.yaml
+++ b/tests/integration/security/testdata/beta-mtls-partial-automtls.yaml
@@ -6,7 +6,7 @@ kind: MeshPolicy
 metadata:
   name: "default"
   annotations:
-    test-suite: "beta-mtls-automtls"
+    test-suite: "beta-mtls-partial-automtls"
 spec: {}
 ---
 apiVersion: "security.istio.io/v1beta1"
@@ -14,24 +14,24 @@ kind: "PeerAuthentication"
 metadata:
   name: "default"
   annotations:
-    test-suite: "beta-mtls-automtls"
+    test-suite: "beta-mtls-partial-automtls"
 spec:
   mtls:
     mode: STRICT
 ---
-  apiVersion: "security.istio.io/v1beta1"
-  kind: "PeerAuthentication"
-  metadata:
-    name: "per-port"
-    annotations:
-      test-suite: "beta-per-port-mtls"
-  spec:
-    selector:
-      matchLabels:
-        app: b
-    mtls:
-      mode: DISABLE
-    portLevelMtls:
-      # 8090 is the targetPort for service http(80)
-      8090:
-        mode: STRICT
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "per-port"
+  annotations:
+    test-suite: "beta-mtls-partial-automtls"
+spec:
+  selector:
+    matchLabels:
+      app: b
+  mtls:
+    mode: DISABLE
+  portLevelMtls:
+    # 8090 is the targetPort for service http(80)
+    8090:
+      mode: STRICT

--- a/tests/integration/security/testdata/beta-mtls-partial-automtls.yaml
+++ b/tests/integration/security/testdata/beta-mtls-partial-automtls.yaml
@@ -1,0 +1,37 @@
+# Alpha API disable, making test more hermetic.
+# No DR is added for this test. enableAutoMtls is expected on by default.
+# Workload-level PeerAuthentication will expectedly cause trouble to connect to the corresponding service
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-automtls"
+spec: {}
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-automtls"
+spec:
+  mtls:
+    mode: STRICT
+---
+  apiVersion: "security.istio.io/v1beta1"
+  kind: "PeerAuthentication"
+  metadata:
+    name: "per-port"
+    annotations:
+      test-suite: "beta-per-port-mtls"
+  spec:
+    selector:
+      matchLabels:
+        app: b
+    mtls:
+      mode: DISABLE
+    portLevelMtls:
+      # 8090 is the targetPort for service http(80)
+      8090:
+        mode: STRICT


### PR DESCRIPTION
This PR takes namespace and mesh `PeerAuthentication` into the consideration for configuring cluster socket.

This is an imperfect solution to make auto mTLS work with the new mTLS beta API, as it doesn't work correctly if workload-level or port-level policy is used.

Issue: https://github.com/istio/istio/issues/20746