### PR TITLE
Remove stack driver from Prometheus proxy

### DIFF
--- a/manifests/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/deployment.yaml
@@ -187,18 +187,6 @@ spec:
             - name: ISTIO_META_MESH_ID
               value: "{{ .Values.global.trustDomain }}"
               {{- end }}
-              {{- if eq .Values.global.proxy.tracer "stackdriver" }}
-            - name: STACKDRIVER_TRACING_ENABLED
-              value: "true"
-            - name: STACKDRIVER_TRACING_DEBUG
-              value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetDebug }}"
-            - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ANNOTATIONS
-              value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfAnnotations }}"
-            - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ATTRIBUTES
-              value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfAttributes }}"
-            - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_MESSAGE_EVENTS
-              value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfMessageEvents }}"
-                  {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Always" }}
           readinessProbe:
             failureThreshold: 30

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -34353,18 +34353,6 @@ spec:
             - name: ISTIO_META_MESH_ID
               value: "{{ .Values.global.trustDomain }}"
               {{- end }}
-              {{- if eq .Values.global.proxy.tracer "stackdriver" }}
-            - name: STACKDRIVER_TRACING_ENABLED
-              value: "true"
-            - name: STACKDRIVER_TRACING_DEBUG
-              value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetDebug }}"
-            - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ANNOTATIONS
-              value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfAnnotations }}"
-            - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ATTRIBUTES
-              value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfAttributes }}"
-            - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_MESSAGE_EVENTS
-              value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfMessageEvents }}"
-                  {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Always" }}
           readinessProbe:
             failureThreshold: 30


### PR DESCRIPTION
Please provide a description for what this PR is for: based on the review comments in https://github.com/istio/istio/pull/21050, stack driver is removed from Prometheus proxy. This PR is to apply the same change to the master branch.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure