### PR TITLE
[release-1.5] authz: fix authz policy to use path matcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20190630181448-f1e96bc0f4c5 // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20190630181448-f1e96bc0f4c5 // indirect
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
-	github.com/envoyproxy/go-control-plane v0.9.2-0.20200122210702-14108a6abe04
+	github.com/envoyproxy/go-control-plane v0.9.4
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/fluent/fluent-logger-golang v1.3.0
 	github.com/frankban/quicktest v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/emicklei/go-restful v2.9.6+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
-github.com/envoyproxy/go-control-plane v0.9.2-0.20200122210702-14108a6abe04 h1:rd9oTs67jAAhuSq90PzQ1PkI54jpNgfpUjfwxJ5tYVs=
-github.com/envoyproxy/go-control-plane v0.9.2-0.20200122210702-14108a6abe04/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.9.4 h1:rEvIZUSZ3fx39WIi3JkQqQBitGwpELBIYWeBVh6wn+E=
+github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/pilot/pkg/security/authz/builder/testdata/v1alpha1/all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1alpha1/all-fields-out.yaml
@@ -20,18 +20,20 @@ rules:
                   presentMatch: true
           - orRules:
               rules:
-              - header:
-                  exactMatch: /exact
-                  name: :path
-              - header:
-                  name: :path
-                  prefixMatch: /prefix/
-              - header:
-                  name: :path
-                  suffixMatch: /suffix
-              - header:
-                  name: :path
-                  presentMatch: true
+              - urlPath:
+                  path:
+                    exact: /exact
+              - urlPath:
+                  path:
+                    prefix: /prefix/
+              - urlPath:
+                  path:
+                    suffix: /suffix
+              - urlPath:
+                  path:
+                    safeRegex:
+                      googleRe2: {}
+                      regex: .+
           - orRules:
               rules:
               - destinationIp:

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/all-fields-out.yaml
@@ -64,33 +64,37 @@ rules:
                     presentMatch: true
           - orRules:
               rules:
-              - header:
-                  exactMatch: /exact
-                  name: :path
-              - header:
-                  name: :path
-                  prefixMatch: /prefix/
-              - header:
-                  name: :path
-                  suffixMatch: /suffix
-              - header:
-                  name: :path
-                  presentMatch: true
+              - urlPath:
+                  path:
+                    exact: /exact
+              - urlPath:
+                  path:
+                    prefix: /prefix/
+              - urlPath:
+                  path:
+                    suffix: /suffix
+              - urlPath:
+                  path:
+                    safeRegex:
+                      googleRe2: {}
+                      regex: .+
           - notRule:
               orRules:
                 rules:
-                - header:
-                    exactMatch: /not-exact
-                    name: :path
-                - header:
-                    name: :path
-                    prefixMatch: /not-prefix/
-                - header:
-                    name: :path
-                    suffixMatch: /not-suffix
-                - header:
-                    name: :path
-                    presentMatch: true
+                - urlPath:
+                    path:
+                      exact: /not-exact
+                - urlPath:
+                    path:
+                      prefix: /not-prefix/
+                - urlPath:
+                    path:
+                      suffix: /not-suffix
+                - urlPath:
+                    path:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .+
           - orRules:
               rules:
               - destinationPort: 80

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/multiple-policies-out.yaml
@@ -22,12 +22,12 @@ rules:
           rules:
           - orRules:
               rules:
-              - header:
-                  exactMatch: /v1
-                  name: :path
-              - header:
-                  exactMatch: /v2
-                  name: :path
+              - urlPath:
+                  path:
+                    exact: /v1
+              - urlPath:
+                  path:
+                    exact: /v2
       principals:
       - andIds:
           ids:

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/not-override-v1alpha1-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/not-override-v1alpha1-out.yaml
@@ -2,16 +2,16 @@ rules:
   policies:
     httpbin:
       permissions:
-        - andRules:
-            rules:
-              - orRules:
-                  rules:
-                    - header:
-                        exactMatch: /v1alpha1
-                        name: :path
+      - andRules:
+          rules:
+          - orRules:
+              rules:
+              - urlPath:
+                  path:
+                    exact: /v1alpha1
       principals:
-        - andIds:
-            ids:
-              - orIds:
-                  ids:
-                    - any: true
+      - andIds:
+          ids:
+          - orIds:
+              ids:
+              - any: true

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/single-policy-out.yaml
@@ -22,12 +22,12 @@ rules:
                   name: :method
           - orRules:
               rules:
-              - header:
-                  exactMatch: rule[0]-to[0]-path[1]
-                  name: :path
-              - header:
-                  exactMatch: rule[0]-to[0]-path[2]
-                  name: :path
+              - urlPath:
+                  path:
+                    exact: rule[0]-to[0]-path[1]
+              - urlPath:
+                  path:
+                    exact: rule[0]-to[0]-path[2]
           - orRules:
               rules:
               - destinationPort: 9001
@@ -60,12 +60,12 @@ rules:
                   name: :method
           - orRules:
               rules:
-              - header:
-                  exactMatch: rule[0]-to[1]-path[1]
-                  name: :path
-              - header:
-                  exactMatch: rule[0]-to[1]-path[2]
-                  name: :path
+              - urlPath:
+                  path:
+                    exact: rule[0]-to[1]-path[1]
+              - urlPath:
+                  path:
+                    exact: rule[0]-to[1]-path[2]
           - orRules:
               rules:
               - destinationPort: 9011
@@ -253,12 +253,12 @@ rules:
                   name: :method
           - orRules:
               rules:
-              - header:
-                  exactMatch: rule[1]-to[0]-path[1]
-                  name: :path
-              - header:
-                  exactMatch: rule[1]-to[0]-path[2]
-                  name: :path
+              - urlPath:
+                  path:
+                    exact: rule[1]-to[0]-path[1]
+              - urlPath:
+                  path:
+                    exact: rule[1]-to[0]-path[2]
           - orRules:
               rules:
               - destinationPort: 9101
@@ -283,12 +283,12 @@ rules:
                   name: :method
           - orRules:
               rules:
-              - header:
-                  exactMatch: rule[1]-to[1]-path[1]
-                  name: :path
-              - header:
-                  exactMatch: rule[1]-to[1]-path[2]
-                  name: :path
+              - urlPath:
+                  path:
+                    exact: rule[1]-to[1]-path[1]
+              - urlPath:
+                  path:
+                    exact: rule[1]-to[1]-path[2]
           - orRules:
               rules:
               - destinationPort: 9111

--- a/pilot/pkg/security/authz/model/matcher/header.go
+++ b/pilot/pkg/security/authz/model/matcher/header.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 )
 
 // HeaderMatcher converts a key, value string pair to a corresponding HeaderMatcher.
@@ -50,6 +51,15 @@ func HeaderMatcher(k, v string) *route.HeaderMatcher {
 		Name: k,
 		HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
 			ExactMatch: v,
+		},
+	}
+}
+
+// PathMatcher creates a path matcher for a path.
+func PathMatcher(path string) *envoy_matcher.PathMatcher {
+	return &envoy_matcher.PathMatcher{
+		Rule: &envoy_matcher.PathMatcher_Path{
+			Path: StringMatcher(path, true),
 		},
 	}
 }

--- a/pilot/pkg/security/authz/model/matcher/header_test.go
+++ b/pilot/pkg/security/authz/model/matcher/header_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 )
 
 func TestHeaderMatcher(t *testing.T) {
@@ -57,5 +58,80 @@ func TestHeaderMatcher(t *testing.T) {
 		if !reflect.DeepEqual(*tc.Expect, *actual) {
 			t.Errorf("%s: expecting %v, but got %v", tc.Name, *tc.Expect, *actual)
 		}
+	}
+}
+
+func TestPathMatcher(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		V      string
+		Expect *envoy_matcher.PathMatcher
+	}{
+		{
+			Name: "exact match",
+			V:    "/productpage",
+			Expect: &envoy_matcher.PathMatcher{
+				Rule: &envoy_matcher.PathMatcher_Path{
+					Path: &envoy_matcher.StringMatcher{
+						MatchPattern: &envoy_matcher.StringMatcher_Exact{
+							Exact: "/productpage",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "prefix match",
+			V:    "/prefix*",
+			Expect: &envoy_matcher.PathMatcher{
+				Rule: &envoy_matcher.PathMatcher_Path{
+					Path: &envoy_matcher.StringMatcher{
+						MatchPattern: &envoy_matcher.StringMatcher_Prefix{
+							Prefix: "/prefix",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "suffix match",
+			V:    "*suffix",
+			Expect: &envoy_matcher.PathMatcher{
+				Rule: &envoy_matcher.PathMatcher_Path{
+					Path: &envoy_matcher.StringMatcher{
+						MatchPattern: &envoy_matcher.StringMatcher_Suffix{
+							Suffix: "suffix",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "wildcard match",
+			V:    "*",
+			Expect: &envoy_matcher.PathMatcher{
+				Rule: &envoy_matcher.PathMatcher_Path{
+					Path: &envoy_matcher.StringMatcher{
+						MatchPattern: &envoy_matcher.StringMatcher_SafeRegex{
+							SafeRegex: &envoy_matcher.RegexMatcher{
+								Regex: ".+",
+								EngineType: &envoy_matcher.RegexMatcher_GoogleRe2{
+									GoogleRe2: &envoy_matcher.RegexMatcher_GoogleRE2{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actual := PathMatcher(tc.V)
+			if !reflect.DeepEqual(*tc.Expect, *actual) {
+				t.Errorf("%s: expecting %v, but got %v", tc.Name, *tc.Expect, *actual)
+			}
+		})
 	}
 }

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -68,6 +68,7 @@ const (
 	// Envoy config attributes for ServiceRole rules.
 	methodHeader = ":method"
 	pathHeader   = ":path"
+	pathMatcher  = "path-matcher"
 	hostHeader   = ":authority"
 )
 

--- a/pilot/pkg/security/authz/model/permission_test.go
+++ b/pilot/pkg/security/authz/model/permission_test.go
@@ -354,12 +354,12 @@ func TestPermission_Generate(t *testing.T) {
           rules:
           - orRules:
               rules:
-              - header:
-                  exactMatch: /hello
-                  name: :path
-              - header:
-                  exactMatch: /world
-                  name: :path`,
+              - urlPath:
+                  path:
+                    exact: /hello
+              - urlPath:
+                  path:
+                    exact: /world`,
 		},
 		{
 			name: "permission with notPaths",
@@ -372,12 +372,12 @@ func TestPermission_Generate(t *testing.T) {
           - notRule:
               orRules:
                 rules:
-                - header:
-                    exactMatch: /hello
-                    name: :path
-                - header:
-                    exactMatch: /world
-                    name: :path`,
+                - urlPath:
+                    path:
+                      exact: /hello
+                - urlPath:
+                    path:
+                      exact: /world`,
 		},
 		{
 			name: "permission with ports",

--- a/tests/integration/security/rbac_v1beta1_test.go
+++ b/tests/integration/security/rbac_v1beta1_test.go
@@ -348,13 +348,21 @@ func TestV1beta1_Deny(t *testing.T) {
 			}
 			cases := []rbacUtil.TestCase{
 				newTestCase(b, "/deny", false),
+				newTestCase(b, "/deny?param=value", false),
 				newTestCase(b, "/global-deny", false),
+				newTestCase(b, "/global-deny?param=value", false),
 				newTestCase(b, "/other", true),
+				newTestCase(b, "/other?param=value", true),
 				newTestCase(b, "/allow", true),
+				newTestCase(b, "/allow?param=value", true),
 				newTestCase(c, "/allow/admin", false),
+				newTestCase(c, "/allow/admin?param=value", false),
 				newTestCase(c, "/global-deny", false),
+				newTestCase(c, "/global-deny?param=value", false),
 				newTestCase(c, "/other", false),
+				newTestCase(c, "/other?param=value", false),
 				newTestCase(c, "/allow", true),
+				newTestCase(c, "/allow?param=value", true),
 			}
 
 			args := map[string]string{


### PR DESCRIPTION
https://github.com/istio/istio/issues/19894

This change is committed to the release-1.5 directly because it depends on a change in Envoy that is currently only in the Envoy used in the release-1.5 branch. The Envoy used in the master branch currently doesn't have this change. 

I will update the Envoy in master branch with the needed change and cherry-pick this PR back to the master later.