### PR TITLE
Drop name restriction for peer and request authn

### DIFF
--- a/galley/testdatasets/validation/dataset.gen.go
+++ b/galley/testdatasets/validation/dataset.gen.go
@@ -1809,6 +1809,7 @@ kind: "PeerAuthentication"
 metadata:
   name: invalid-peer-authentication
 spec:
+  portLevelMtls: {}
 `)
 
 func datasetSecurityV1beta1PeerauthenticationInvalidYamlBytes() ([]byte, error) {

--- a/galley/testdatasets/validation/dataset/security-v1beta1-PeerAuthentication-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/security-v1beta1-PeerAuthentication-invalid.yaml
@@ -3,3 +3,4 @@ kind: "PeerAuthentication"
 metadata:
   name: invalid-peer-authentication
 spec:
+  portLevelMtls: {}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1668,14 +1668,6 @@ var ValidateRequestAuthentication = registerValidateFunc("ValidateRequestAuthent
 		}
 
 		var errs error
-		emptySelector := in.Selector == nil || len(in.Selector.MatchLabels) == 0
-		if name == constants.DefaultAuthenticationPolicyName && !emptySelector {
-			errs = appendErrors(errs, fmt.Errorf("mesh/namespace request authentication cannot have selector"))
-		} else if emptySelector && name != constants.DefaultAuthenticationPolicyName {
-			errs = appendErrors(errs,
-				fmt.Errorf("request authentication without selector must be named %q", constants.DefaultAuthenticationPolicyName))
-		}
-
 		errs = appendErrors(errs, validateWorkloadSelector(in.Selector))
 
 		for _, rule := range in.JwtRules {
@@ -1727,12 +1719,6 @@ var ValidatePeerAuthentication = registerValidateFunc("ValidatePeerAuthenticatio
 
 		var errs error
 		emptySelector := in.Selector == nil || len(in.Selector.MatchLabels) == 0
-		if name == constants.DefaultAuthenticationPolicyName && !emptySelector {
-			errs = appendErrors(errs, fmt.Errorf("mesh/namespace peer authentication cannot have selector"))
-		} else if emptySelector && name != constants.DefaultAuthenticationPolicyName {
-			errs = appendErrors(errs,
-				fmt.Errorf("peer authentication without selector must be named %q", constants.DefaultAuthenticationPolicyName))
-		}
 
 		if emptySelector && len(in.PortLevelMtls) != 0 {
 			errs = appendErrors(errs,

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -5641,7 +5641,7 @@ func TestValidateRequestAuthentication(t *testing.T) {
 			name:       "empty spec with non default name",
 			configName: someName,
 			in:         &security_beta.RequestAuthentication{},
-			valid:      false,
+			valid:      true,
 		},
 		{
 			name:       "default name with non empty selector",
@@ -5653,11 +5653,11 @@ func TestValidateRequestAuthentication(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			valid: true,
 		},
 		{
 			name:       "empty jwt rule",
-			configName: constants.DefaultAuthenticationPolicyName,
+			configName: "foo",
 			in: &security_beta.RequestAuthentication{
 				JwtRules: []*security_beta.JWTRule{
 					{},
@@ -5667,7 +5667,7 @@ func TestValidateRequestAuthentication(t *testing.T) {
 		},
 		{
 			name:       "empty issuer",
-			configName: constants.DefaultAuthenticationPolicyName,
+			configName: "foo",
 			in: &security_beta.RequestAuthentication{
 				JwtRules: []*security_beta.JWTRule{
 					{
@@ -5679,7 +5679,7 @@ func TestValidateRequestAuthentication(t *testing.T) {
 		},
 		{
 			name:       "bad JwksUri - no protocol",
-			configName: constants.DefaultAuthenticationPolicyName,
+			configName: "foo",
 			in: &security_beta.RequestAuthentication{
 				JwtRules: []*security_beta.JWTRule{
 					{
@@ -5692,7 +5692,7 @@ func TestValidateRequestAuthentication(t *testing.T) {
 		},
 		{
 			name:       "bad JwksUri - invalid port",
-			configName: constants.DefaultAuthenticationPolicyName,
+			configName: "foo",
 			in: &security_beta.RequestAuthentication{
 				JwtRules: []*security_beta.JWTRule{
 					{
@@ -5704,8 +5704,8 @@ func TestValidateRequestAuthentication(t *testing.T) {
 			valid: false,
 		},
 		{
-			name:       "bad selector - empy value",
-			configName: constants.DefaultAuthenticationPolicyName,
+			name:       "empy value",
+			configName: "foo",
 			in: &security_beta.RequestAuthentication{
 				Selector: &api.WorkloadSelector{
 					MatchLabels: map[string]string{
@@ -5720,11 +5720,11 @@ func TestValidateRequestAuthentication(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			valid: true,
 		},
 		{
 			name:       "bad selector - empy key",
-			configName: constants.DefaultAuthenticationPolicyName,
+			configName: "foo",
 			in: &security_beta.RequestAuthentication{
 				Selector: &api.WorkloadSelector{
 					MatchLabels: map[string]string{
@@ -5829,7 +5829,7 @@ func TestValidatePeerAuthentication(t *testing.T) {
 			name:       "empty spec with non default name",
 			configName: someName,
 			in:         &security_beta.PeerAuthentication{},
-			valid:      false,
+			valid:      true,
 		},
 		{
 			name:       "default name with non empty selector",
@@ -5841,7 +5841,7 @@ func TestValidatePeerAuthentication(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			valid: true,
 		},
 		{
 			name:       "empty port level mtls",


### PR DESCRIPTION
Remove restriction that namespace and mesh level policy must be named `default`.