### PR TITLE
Expose container port for monitoring in pilot (cfr.galley)

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: grafana

--- a/install/kubernetes/helm/istio/charts/kiali/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: kiali

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -81,6 +81,7 @@ spec:
 {{- if not .Values.sidecar }}
           - containerPort: 15011
 {{- end }}
+          - containerPort: {{ .Values.global.monitoringPort }}
           readinessProbe:
             httpGet:
               path: /ready

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: prometheus

--- a/install/kubernetes/helm/istio/charts/tracing/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "tracing.fullname" . }}


### PR DESCRIPTION
This PR exposes the `monitoringPort` attribute from `values.yaml` in the `pilot` container.