### PR TITLE
Use apiVersion without deprecation warnings for Ingress resources

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: grafana

--- a/install/kubernetes/helm/istio/charts/kiali/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: kiali

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: prometheus

--- a/install/kubernetes/helm/istio/charts/tracing/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "tracing.fullname" . }}


### PR DESCRIPTION
This change will remove deprecation warnings for the `Ingress` resources in the helm chart.