### PR TITLE
Revert "tests: stop using ValuesFile, use ControlPlaneValues"

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -16,14 +16,20 @@ package istio
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/mitchellh/go-homedir"
 
 	yaml2 "gopkg.in/yaml.v2"
 
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/core/image"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/file"
 
 	kubeCore "k8s.io/api/core/v1"
 )
@@ -31,6 +37,11 @@ import (
 const (
 	// DefaultSystemNamespace default value for SystemNamespace
 	DefaultSystemNamespace = "istio-system"
+
+	// E2EValuesFile for default settings for Istio Helm deployment.
+	// This modifies a few values to help tests, like prometheus scrape interval
+	// In general, specific settings should be added to tests, not here
+	E2EValuesFile = "test-values/values-integ.yaml"
 
 	// DefaultDeployTimeout for Istio
 	DefaultDeployTimeout = time.Second * 300
@@ -59,6 +70,8 @@ var (
 		DeployIstio:                    true,
 		DeployTimeout:                  0,
 		UndeployTimeout:                0,
+		ChartDir:                       env.IstioChartDir,
+		ValuesFile:                     E2EValuesFile,
 		CustomSidecarInjectorNamespace: "",
 	}
 )
@@ -92,6 +105,12 @@ type Config struct {
 	// UndeployTimeout the timeout for undeploying Istio.
 	UndeployTimeout time.Duration
 
+	// The top-level Helm chart dir.
+	ChartDir string
+
+	// The Helm values file to be used.
+	ValuesFile string
+
 	// Override values specifically for the ICP crd
 	// This is mostly required for cases where --set cannot be used
 	// If specified, Values will be ignored
@@ -119,21 +138,22 @@ func (c *Config) IsMtlsEnabled() bool {
 		return true
 	}
 
+	data, err := file.AsString(filepath.Join(c.ChartDir, c.ValuesFile))
+	if err != nil {
+		return true
+	}
 	m := make(map[interface{}]interface{})
-	err := yaml2.Unmarshal([]byte(c.ControlPlaneValues), &m)
+	err = yaml2.Unmarshal([]byte(data), &m)
 	if err != nil {
 		return false
 	}
-	if m["values"] != nil {
-		switch values := m["values"].(type) {
+	if m["global"] != nil {
+		switch globalVal := m["global"].(type) {
 		case map[interface{}]interface{}:
-			switch globalVal := values["global"].(type) {
+			switch mtlsVal := globalVal["mtls"].(type) {
 			case map[interface{}]interface{}:
-				switch mtlsVal := globalVal["mtls"].(type) {
-				case map[interface{}]interface{}:
-					if !mtlsVal["enabled"].(bool) && !mtlsVal["auto"].(bool) {
-						return false
-					}
+				if !mtlsVal["enabled"].(bool) && !mtlsVal["auto"].(bool) {
+					return false
 				}
 			}
 		}
@@ -142,11 +162,18 @@ func (c *Config) IsMtlsEnabled() bool {
 	return true
 }
 
-// IstioOperator generates a string representing an IstioOperator manifest from a Config object
 func (c *Config) IstioOperator() string {
 	data := ""
 	if c.ControlPlaneValues != "" {
 		data = Indent(c.ControlPlaneValues, "  ")
+	} else if c.ValuesFile != "" {
+		valfile, err := file.AsString(filepath.Join(c.ChartDir, c.ValuesFile))
+		if err != nil {
+			return ""
+		}
+		data = fmt.Sprintf(`
+  values:
+%s`, Indent(valfile, "    "))
 	}
 
 	s, err := image.SettingsFromCommandLine()
@@ -164,7 +191,7 @@ spec:
 `, s.Hub, s.Tag, data)
 }
 
-// Indent indents a block of text with an indent string
+// indents a block of text with an indent string
 func Indent(text, indent string) string {
 	if text[len(text)-1:] == "\n" {
 		result := ""
@@ -184,6 +211,14 @@ func Indent(text, indent string) string {
 func DefaultConfig(ctx resource.Context) (Config, error) {
 	// Make a local copy.
 	s := *settingsFromCommandline
+
+	if err := normalizeFile(&s.ChartDir); err != nil {
+		return Config{}, err
+	}
+
+	if err := checkFileExists(filepath.Join(s.ChartDir, s.ValuesFile)); err != nil {
+		return Config{}, err
+	}
 
 	deps, err := image.SettingsFromCommandLine()
 	if err != nil {
@@ -212,6 +247,24 @@ func DefaultConfigOrFail(t test.Failer, ctx resource.Context) Config {
 		t.Fatalf("Get istio config: %v", err)
 	}
 	return cfg
+}
+
+func normalizeFile(path *string) error {
+	// If the path uses the homedir ~, expand the path.
+	var err error
+	*path, err = homedir.Expand(*path)
+	if err != nil {
+		return err
+	}
+
+	return checkFileExists(*path)
+}
+
+func checkFileExists(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func newHelmValues(ctx resource.Context, s *image.Settings) (map[string]string, error) {
@@ -279,6 +332,8 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("DeployTimeout:                  %s\n", c.DeployTimeout.String())
 	result += fmt.Sprintf("UndeployTimeout:                %s\n", c.UndeployTimeout.String())
 	result += fmt.Sprintf("Values:                         %v\n", c.Values)
+	result += fmt.Sprintf("ChartDir:                       %s\n", c.ChartDir)
+	result += fmt.Sprintf("ValuesFile:                     %s\n", c.ValuesFile)
 	result += fmt.Sprintf("SkipWaitForValidationWebhook:   %v\n", c.SkipWaitForValidationWebhook)
 	result += fmt.Sprintf("CustomSidecarInjectorNamespace: %s\n", c.CustomSidecarInjectorNamespace)
 

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -40,6 +40,10 @@ func init() {
 		"Timeout applied to deploying Istio into the target Kubernetes environment. Only applies if DeployIstio=true.")
 	flag.DurationVar(&settingsFromCommandline.UndeployTimeout, "istio.test.kube.undeployTimeout", 0,
 		"Timeout applied to undeploying Istio from the target Kubernetes environment. Only applies if DeployIstio=true.")
+	flag.StringVar(&settingsFromCommandline.ChartDir, "istio.test.kube.helm.chartDir", settingsFromCommandline.ChartDir,
+		"Helm chart dir for Istio. Only valid when deploying Istio.")
+	flag.StringVar(&settingsFromCommandline.ValuesFile, "istio.test.kube.helm.valuesFile", settingsFromCommandline.ValuesFile,
+		"Helm values file. This can be an absolute path or relative to chartDir. Only valid when deploying Istio.")
 	flag.StringVar(&helmValues, "istio.test.kube.helm.values", helmValues,
 		"Manual overrides for Helm values file. Only valid when deploying Istio.")
 	flag.StringVar(&settingsFromCommandline.CustomSidecarInjectorNamespace, "istio.test.kube.customSidecarInjectorNamespace",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -584,8 +584,14 @@ The test framework supports the following command-line flags:
   -istio.test.kube.systemNamespace string
         The namespace where the Istio components reside in a typical deployment. (default "istio-system")
 
+  -istio.test.kube.helm.chartDir string
+        Helm chart dir for Istio. Only valid when deploying Istio. (default "/Users/ozben/go/src/istio.io/istio/install/kubernetes/helm/istio")
+
   -istio.test.kube.helm.values string
         Manual overrides for Helm values file. Only valid when deploying Istio.
+
+  -istio.test.kube.helm.valuesFile string
+        Helm values file. This can be an absolute path or relative to chartDir. Only valid when deploying Istio. (default "test-values/values-e2e.yaml")
 
   -istio.test.kube.minikube
         Indicates that the target environment is Minikube. Used by Ingress component to obtain the right IP address. This also pertains to any environment that doesn't support a LoadBalancer type.

--- a/tests/integration/istioio/trafficmanagement/main_test.go
+++ b/tests/integration/istioio/trafficmanagement/main_test.go
@@ -29,47 +29,7 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite("trafficmanagement", m).
-		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
+		SetupOnEnv(environment.Kube, istio.Setup(&inst, nil)).
 		RequireEnvironment(environment.Kube).
 		Run()
-}
-
-func setupConfig(cfg *istio.Config) {
-	if cfg == nil {
-		return
-	}
-	// add a gateway configuration that includes a TCP port
-	cfg.ControlPlaneValues = `
-values:
-  gateways:
-    istio-ingressgateway:
-      ports:
-      - port: 15020
-        targetPort: 15020
-        name: status-port
-      - port: 80
-        targetPort: 8080
-        name: http2
-      - port: 443
-        targetPort: 8443
-        name: https
-      - port: 31400
-        targetPort: 31400
-        name: tcp
-      - port: 15029
-        targetPort: 15029
-        name: https-kiali
-      - port: 15030
-        targetPort: 15030
-        name: https-prometheus
-      - port: 15031
-        targetPort: 15031
-        name: https-grafana
-      - port: 15032
-        targetPort: 15032
-        name: https-tracing
-      - port: 15443
-        targetPort: 15443
-        name: tls
-`
 }

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -92,25 +92,8 @@ func setupConfig(cfg *istio.Config) {
 		return
 	}
 
-	cfg.ControlPlaneValues = `
-values:
-  # overrides to test the meshNetworks.
-  global:
-    meshNetworks:
-      # NOTE: DO NOT CHANGE THIS! Its hardcoded in Pilot in different areas
-      Kubernetes:
-        endpoints:
-        - fromRegistry: Kubernetes
-        gateways:
-        - port: 15443
-          address: 2.2.2.2
-        vm: {}
-
-    #This will cause ISTIO_META_NETWORK to be set on the pods and the
-    #kube controller code to match endpoints from kubernetes with the default
-    #cluster ID of "Kubernetes". Need to fix this code
-    network: "Kubernetes"
-`
+	// Helm values from install/kubernetes/helm/istio/test-values/values-istio-mesh-networks.yaml
+	cfg.ValuesFile = "test-values/values-istio-mesh-networks.yaml"
 }
 
 func TestAsymmetricMeshNetworkWithGatewayIP(t *testing.T) {

--- a/tests/integration/security/chiron/main_test.go
+++ b/tests/integration/security/chiron/main_test.go
@@ -56,15 +56,6 @@ func setupConfig(cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}
-
-	cfg.ControlPlaneValues = `
-values:
-  global:
-    certificates:
-      - dnsNames: [istio-pilot.istio-system.svc, istio-pilot.istio-system]
-      - secretName: dns.istio-galley-service-account
-        dnsNames: [istio-galley.istio-system.svc, istio-galley.istio-system]
-      - secretName: dns.istio-sidecar-injector-service-account
-        dnsNames: [istio-sidecar-injector.istio-system.svc, istio-sidecar-injector.istio-system]
-`
+	// Helm values from install/kubernetes/helm/istio/test-values/values-istio-dns-cert.yaml
+	cfg.ValuesFile = "test-values/values-istio-dns-cert.yaml"
 }

--- a/tests/integration/security/sds_citadel_control_plane_auth_disabled/main_test.go
+++ b/tests/integration/security/sds_citadel_control_plane_auth_disabled/main_test.go
@@ -61,28 +61,14 @@ func setupConfig(cfg *istio.Config) {
 		return
 	}
 
+	// Helm values from install/kubernetes/helm/istio/values-istio-sds-auth-control-plane-auth-disabled.yaml
+	cfg.ValuesFile = "values-istio-sds-auth-control-plane-auth-disabled.yaml"
 	cfg.ControlPlaneValues = `
 values:
   global:
     controlPlaneSecurityEnabled: false
 
     mtls:
-      # Default setting for service-to-service mtls. Can be set explicitly using
-      # destination rules or service annotations.
       enabled: true
-
-    sds:
-      enabled: true
-      udsPath: "unix:/var/run/sds/uds_path"
-      token:
-          aud: "istio-ca"
-
-  nodeagent:
-    enabled: true
-    image: node-agent-k8s
-    env:
-      CA_PROVIDER: "Citadel"
-      CA_ADDR: "istio-citadel:8060"
-      VALID_TOKEN: true
 `
 }

--- a/tests/integration/security/sds_citadel_flow/main_test.go
+++ b/tests/integration/security/sds_citadel_flow/main_test.go
@@ -61,25 +61,14 @@ func setupConfig(cfg *istio.Config) {
 		return
 	}
 
+	// Helm values from install/kubernetes/helm/istio/values-istio-sds-auth.yaml
+	cfg.ValuesFile = "values-istio-sds-auth.yaml"
 	cfg.ControlPlaneValues = `
 values:
   global:
     controlPlaneSecurityEnabled: true
+
     mtls:
-      # Default setting for service-to-service mtls. Can be set explicitly using
-      # destination rules or service annotations.
       enabled: true
-    sds:
-      enabled: true
-      udsPath: "unix:/var/run/sds/uds_path"
-      token:
-        aud: "istio-ca"
-  nodeagent:
-    enabled: true
-    image: node-agent-k8s
-    env:
-      CA_PROVIDER: "Citadel"
-      CA_ADDR: "istio-citadel:8060"
-      VALID_TOKEN: true
 `
 }

--- a/tests/integration/security/sds_egress/main_test.go
+++ b/tests/integration/security/sds_egress/main_test.go
@@ -65,34 +65,7 @@ func setupConfig(cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}
-	cfg.ControlPlaneValues = `
-components:
-  gateways:
-    istio-egressgateway:
-      enabled: true
-addonComponents:
-  prometheus:
-    enabled: true
-values:
-  global:
-    controlPlaneSecurityEnabled: true
-
-    mtls:
-      # Default setting for service-to-service mtls. Can be set explicitly using
-      # destination rules or service annotations.
-      enabled: true
-
-    sds:
-      enabled: true
-      udsPath: "unix:/var/run/sds/uds_path"
-      token:
-        aud: "istio-ca"
-  nodeagent:
-    enabled: true
-    image: node-agent-k8s
-    env:
-      CA_PROVIDER: "Citadel"
-      CA_ADDR: "istio-citadel:8060"
-      VALID_TOKEN: true
-`
+	cfg.ValuesFile = "values-istio-sds-auth.yaml"
+	cfg.Values["gateways.istio-egressgateway.enabled"] = "true"
+	cfg.Values["prometheus.enabled"] = "true"
 }

--- a/tests/integration/security/webhook/webhook_test.go
+++ b/tests/integration/security/webhook/webhook_test.go
@@ -46,17 +46,9 @@ func setupConfig(cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}
-	cfg.ControlPlaneValues = `
-values:
-  global:
-    operatorManageWebhooks: true
-    certificates:
-      - dnsNames: [istio-pilot.istio-system.svc, istio-pilot.istio-system]
-      - secretName: dns.istio-galley-service-account
-        dnsNames: [istio-galley.istio-system.svc, istio-galley.istio-system]
-      - secretName: dns.istio-sidecar-injector-service-account
-        dnsNames: [istio-sidecar-injector.istio-system.svc, istio-sidecar-injector.istio-system]
-`
+	// Helm values from install/kubernetes/helm/istio/test-values/values-istio-dns-cert.yaml
+	cfg.ValuesFile = "test-values/values-istio-dns-cert.yaml"
+	cfg.Values["global.operatorManageWebhooks"] = "true"
 }
 
 // TestWebhookManagement tests "istioctl experimental post-install webhook" command.


### PR DESCRIPTION
Reverts istio/istio#21065

I don't know why, but this broke security tests. The correct move here should be revert then investigate rather than leave things broken for days