### PR TITLE
[1.5] Optimize namespace controller in Pilot (#20915)

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"istio.io/istio/pkg/config/constants"
+
 	oidc "github.com/coreos/go-oidc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -150,7 +152,7 @@ func (s *Server) EnableCA() bool {
 // Protected by installer options: the CA will be started only if the JWT token in /var/run/secrets
 // is mounted. If it is missing - for example old versions of K8S that don't support such tokens -
 // we will not start the cert-signing server, since pods will have no way to authenticate.
-func (s *Server) RunCA(grpc *grpc.Server, ca *ca.IstioCA, opts *CAOptions, stopCh <-chan struct{}) {
+func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts *CAOptions, stopCh <-chan struct{}) {
 	if !s.EnableCA() {
 		return
 	}
@@ -210,13 +212,16 @@ func (s *Server) RunCA(grpc *grpc.Server, ca *ca.IstioCA, opts *CAOptions, stopC
 	}
 	log.Info("Istiod CA has started")
 
-	nc, err := NewNamespaceController(ca, s.kubeClient.CoreV1())
+	nc, err := NewNamespaceController(func() map[string]string {
+		return map[string]string{
+			constants.CACertNamespaceConfigMapDataName: string(ca.GetCAKeyCertBundle().GetRootCertPem()),
+		}
+	}, s.kubeClient.CoreV1())
 	if err != nil {
 		log.Warnf("failed to start istiod namespace controller, error: %v", err)
 	} else {
 		s.leaderElection.AddRunFunction(func(stop <-chan struct{}) {
-			log.Infof("Starting namespace controller")
-			nc.namespaceController.Run(stop)
+			nc.Run(stop)
 		})
 	}
 }

--- a/pilot/pkg/bootstrap/namespacecontroller.go
+++ b/pilot/pkg/bootstrap/namespacecontroller.go
@@ -15,22 +15,23 @@
 package bootstrap
 
 import (
+	"fmt"
 	"time"
 
-	"istio.io/istio/pkg/config/constants"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 
-	"istio.io/istio/security/pkg/pki/ca"
+	"istio.io/istio/pkg/queue"
+	"istio.io/istio/security/pkg/listwatch"
+	"istio.io/pkg/log"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"istio.io/istio/security/pkg/listwatch"
 	certutil "istio.io/istio/security/pkg/util"
-	"istio.io/pkg/log"
 )
 
 const (
@@ -39,27 +40,80 @@ const (
 	// can update its CA certificate in a ConfigMap in every namespace.
 	namespaceResyncPeriod = time.Second * 30
 	// The name of the ConfigMap in each namespace storing the root cert of non-Kube CA.
-	CACertNamespaceConfigMap      = "istio-ca-root-cert"
-	CACertNamespaceInsertInterval = time.Second
-	CACertNamespaceInsertTimeout  = time.Second * 2
+	CACertNamespaceConfigMap = "istio-ca-root-cert"
 )
 
-// NamespaceController manages the CA certificate in each namespace.
+var (
+	configMapLabel = map[string]string{"istio.io/config": "true"}
+)
+
+// NamespaceController manages reconciles a configmap in each namespace with a desired set of data.
 type NamespaceController struct {
-	ca   *ca.IstioCA
-	core corev1.CoreV1Interface
+	// getData is the function to fetch the data we will insert into the config map
+	getData func() map[string]string
+	core    corev1.CoreV1Interface
+
+	queue queue.Instance
 
 	// Controller and store for namespace objects
 	namespaceController cache.Controller
-	namespaceStore      cache.Store
+	// Controller and store for ConfigMap objects
+	configMapController cache.Controller
 }
 
-// NewNamespaceController returns a pointer to a newly constructed SecretController instance.
-func NewNamespaceController(ca *ca.IstioCA, core corev1.CoreV1Interface) (*NamespaceController, error) {
+// NewNamespaceController returns a pointer to a newly constructed NamespaceController instance.
+func NewNamespaceController(data func() map[string]string, core corev1.CoreV1Interface) (*NamespaceController, error) {
 	c := &NamespaceController{
-		ca:   ca,
-		core: core,
+		getData: data,
+		core:    core,
+		queue:   queue.NewQueue(time.Second),
 	}
+	configMapLw := listwatch.MultiNamespaceListerWatcher([]string{metav1.NamespaceAll}, func(namespace string) cache.ListerWatcher {
+		return &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				options.LabelSelector = fields.SelectorFromSet(configMapLabel).String()
+				return core.ConfigMaps(namespace).List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.LabelSelector = fields.SelectorFromSet(configMapLabel).String()
+				return core.ConfigMaps(namespace).Watch(options)
+			}}
+	})
+	_, c.configMapController =
+		cache.NewInformer(configMapLw, &v1.ConfigMap{}, 0, cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				c.queue.Push(func() error {
+					return c.configMapChange(newObj)
+				})
+			},
+			DeleteFunc: func(obj interface{}) {
+				cm, ok := obj.(*v1.ConfigMap)
+				if !ok {
+					tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+					if !ok {
+						log.Errorf("error decoding object, invalid type")
+						return
+					}
+					cm, ok = tombstone.Obj.(*v1.ConfigMap)
+					if !ok {
+						log.Errorf("error decoding object tombstone, invalid type")
+						return
+					}
+				}
+				c.queue.Push(func() error {
+					ns, err := core.Namespaces().Get(cm.Namespace, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					// If the namespace is terminating, we may get into a loop of trying to re-add the configmap back
+					// We should make sure the namespace still exists
+					if ns.Status.Phase != v1.NamespaceTerminating {
+						return c.insertDataForNamespace(cm.Namespace)
+					}
+					return nil
+				})
+			},
+		})
 
 	namespaceLW := listwatch.MultiNamespaceListerWatcher([]string{metav1.NamespaceAll}, func(namespace string) cache.ListerWatcher {
 		return &cache.ListWatch{
@@ -70,50 +124,62 @@ func NewNamespaceController(ca *ca.IstioCA, core corev1.CoreV1Interface) (*Names
 				return core.Namespaces().Watch(options)
 			}}
 	})
-	c.namespaceStore, c.namespaceController =
-		cache.NewInformer(namespaceLW, &v1.Namespace{}, namespaceResyncPeriod, cache.ResourceEventHandlerFuncs{
-			UpdateFunc: c.namespaceUpdated,
-			AddFunc:    c.namespaceAdded,
+	_, c.namespaceController =
+		cache.NewInformer(namespaceLW, &v1.Namespace{}, 0, cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(_, newObj interface{}) {
+				c.queue.Push(func() error {
+					return c.namespaceChange(newObj)
+				})
+			},
+			AddFunc: func(obj interface{}) {
+				c.queue.Push(func() error {
+					return c.namespaceChange(obj)
+				})
+			},
 		})
 	return c, nil
 }
 
-// When a namespace is created, Citadel adds its public CA certificate
-// to a well known configmap in the namespace.
-func (nc *NamespaceController) namespaceAdded(obj interface{}) {
-	ns, ok := obj.(*v1.Namespace)
-
-	if ok {
-		rootCert := nc.ca.GetCAKeyCertBundle().GetRootCertPem()
-		err := certutil.InsertDataToConfigMapWithRetry(nc.core, ns.GetName(), string(rootCert), CACertNamespaceConfigMap,
-			constants.CACertNamespaceConfigMapDataName, CACertNamespaceInsertInterval, CACertNamespaceInsertTimeout)
-		if err != nil {
-			log.Errorf("error when inserting CA cert to configmap: %v", err)
-		} else {
-			log.Debugf("inserted CA cert to configmap %v in ns %v",
-				CACertNamespaceConfigMap, ns.GetName())
-		}
-	}
+// Run starts the NamespaceController until a value is sent to stopCh.
+func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
+	go nc.namespaceController.Run(stopCh)
+	go nc.configMapController.Run(stopCh)
+	cache.WaitForCacheSync(stopCh, nc.namespaceController.HasSynced, nc.configMapController.HasSynced)
+	log.Infof("Namespace controller started")
+	go nc.queue.Run(stopCh)
 }
 
-func (nc *NamespaceController) namespaceUpdated(oldObj, newObj interface{}) {
-	ns, ok := newObj.(*v1.Namespace)
+// insertDataForNamespace will add data into the configmap for the specified namespace
+// If the configmap is not found, it will be created.
+// If you know the current contents of the configmap, using UpdateDataInConfigMap is more efficient.
+func (nc *NamespaceController) insertDataForNamespace(ns string) error {
+	meta := metav1.ObjectMeta{
+		Name:      CACertNamespaceConfigMap,
+		Namespace: ns,
+		Labels:    configMapLabel,
+	}
+	return certutil.InsertDataToConfigMap(nc.core, meta, nc.getData())
+}
+
+// On namespace change, update the config map.
+// If terminating, this will be skipped
+func (nc *NamespaceController) namespaceChange(obj interface{}) error {
+	ns, ok := obj.(*v1.Namespace)
+
+	if ok && ns.Status.Phase != v1.NamespaceTerminating {
+		return nc.insertDataForNamespace(ns.Name)
+	}
+	return nil
+}
+
+// When a config map is changed, merge the data into the configmap
+func (nc *NamespaceController) configMapChange(obj interface{}) error {
+	cm, ok := obj.(*v1.ConfigMap)
 
 	if ok {
-		rootCert := nc.ca.GetCAKeyCertBundle().GetRootCertPem()
-		// Every namespaceResyncPeriod, namespaceUpdated() will be invoked
-		// for every namespace. If a namespace does not have the Citadel CA
-		// certificate or the certificate in a ConfigMap of the namespace is not
-		// up to date, Citadel updates the certificate in the namespace.
-		// For simplifying the implementation and no overhead for reading the certificate from the ConfigMap,
-		// simply updates the ConfigMap to the current Citadel CA certificate.
-		err := certutil.InsertDataToConfigMapWithRetry(nc.core, ns.GetName(), string(rootCert), CACertNamespaceConfigMap,
-			constants.CACertNamespaceConfigMapDataName, CACertNamespaceInsertInterval, CACertNamespaceInsertTimeout)
-		if err != nil {
-			log.Errorf("error when updating CA cert in configmap: %v", err)
-		} else {
-			log.Debugf("updated CA cert in configmap %v in ns %v",
-				CACertNamespaceConfigMap, ns.GetName())
+		if err := certutil.UpdateDataInConfigMap(nc.core, cm.DeepCopy(), nc.getData()); err != nil {
+			return fmt.Errorf("error when inserting CA cert to configmap %v: %v", cm.Name, err)
 		}
 	}
+	return nil
 }

--- a/pilot/pkg/bootstrap/namespacecontroller_test.go
+++ b/pilot/pkg/bootstrap/namespacecontroller_test.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/security/pkg/util"
+)
+
+func TestNamespaceController(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	testdata := map[string]string{"key": "value"}
+	nc, err := NewNamespaceController(func() map[string]string {
+		return testdata
+	}, client.CoreV1())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := make(chan struct{})
+	nc.Run(stop)
+
+	createNamespace(t, client, "foo")
+	expectConfigMap(t, client, "foo", testdata)
+
+	newData := map[string]string{"key": "value", "foo": "bar"}
+	if err := util.InsertDataToConfigMap(client.CoreV1(), metav1.ObjectMeta{Name: CACertNamespaceConfigMap, Namespace: "foo"}, newData); err != nil {
+		t.Fatal(err)
+	}
+	expectConfigMap(t, client, "foo", newData)
+
+	deleteConfigMap(t, client, "foo")
+	expectConfigMap(t, client, "foo", testdata)
+}
+
+func deleteConfigMap(t *testing.T, client *fake.Clientset, ns string) {
+	t.Helper()
+	if err := client.CoreV1().ConfigMaps(ns).Delete(CACertNamespaceConfigMap, &metav1.DeleteOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createNamespace(t *testing.T, client *fake.Clientset, ns string) {
+	t.Helper()
+	if _, err := client.CoreV1().Namespaces().Create(&v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: ns},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func expectConfigMap(t *testing.T, client *fake.Clientset, ns string, data map[string]string) {
+	t.Helper()
+	retry.UntilSuccessOrFail(t, func() error {
+		cm, err := client.CoreV1().ConfigMaps(ns).Get(CACertNamespaceConfigMap, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(cm.Data, data) {
+			return fmt.Errorf("data mismatch, expected %+v got %+v", data, cm.Data)
+		}
+		return nil
+	}, retry.Timeout(time.Second*2))
+}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -29,7 +29,10 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/client-go/rest"
+
 	"istio.io/istio/pilot/pkg/leaderelection"
+
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/security/pkg/pki/util"
@@ -369,7 +372,10 @@ func (s *Server) WaitUntilCompletion() {
 func (s *Server) initKubeClient(args *PilotArgs) error {
 	if hasKubeRegistry(args.Service.Registries) {
 		var err error
-		s.kubeClient, err = kubelib.CreateClientset(args.Config.KubeConfig, "")
+		s.kubeClient, err = kubelib.CreateClientset(args.Config.KubeConfig, "", func(config *rest.Config) {
+			config.QPS = 20
+			config.Burst = 40
+		})
 		if err != nil {
 			return fmt.Errorf("failed creating kube client: %v", err)
 		}

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -65,10 +65,13 @@ func BuildClientCmd(kubeconfig, context string) clientcmd.ClientConfig {
 
 // CreateClientset is a helper function that builds a kubernetes Clienset from a kubeconfig
 // filepath. See `BuildClientConfig` for kubeconfig loading rules.
-func CreateClientset(kubeconfig, context string) (*kubernetes.Clientset, error) {
+func CreateClientset(kubeconfig, context string, fns ...func(*rest.Config)) (*kubernetes.Clientset, error) {
 	c, err := BuildClientConfig(kubeconfig, context)
 	if err != nil {
 		return nil, err
+	}
+	for _, fn := range fns {
+		fn(c)
 	}
 	return kubernetes.NewForConfig(c)
 }


### PR DESCRIPTION
* Optimize namespace controller

Right now the ns controller runs at a rate of 2.5 namespaces/s due to
kube client rate limiting. We also resync every 30s. This means that if
you have over 75 namespaces, you will be constantly writing config map.
Even worse, this limit is shared with the rest of istiod.

There is no real reason to resync every 30s, its just excessive. We can
just turn this off. Note - Galley has never had a resync period and I
have never heard of a "missed event" issue as a result. Kubernetes
provides the same guidance.

* fix lint

* fix test

* fix type

* clean up per comments

* improve error handling

* fix nits

* fix flake

(cherry picked from commit 7bcc71e51b87098bbd3da1523dcf6e9a94dbb5a3)