### PR TITLE
[release-1.5] Fix Passthrough integration tests in postsubmit

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/values.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/values.yaml
@@ -15,7 +15,7 @@ traceSampling: 1.0
 # if protocol sniffing is enabled for outbound
 enableProtocolSniffingForOutbound: true
 # if protocol sniffing is enabled for inbound
-enableProtocolSniffingForInbound: true
+enableProtocolSniffingForInbound: false
 # Resources for a small pilot install
 resources:
   requests:

--- a/install/kubernetes/helm/istio/test-values/values-integ.yaml
+++ b/install/kubernetes/helm/istio/test-values/values-integ.yaml
@@ -10,9 +10,6 @@ global:
 
     accessLogFile: "/dev/stdout"
 
-  outboundTrafficPolicy:
-    mode: REGISTRY_ONLY
-
 prometheus:
   scrapeInterval: 5s
 


### PR DESCRIPTION
Our helm values were different than the defaults in `manifests/`, causing the helm-installed integration tests to fail.