### PR TITLE
Add the cert authenticatior, using previously issued certificate for VMs

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -209,6 +209,10 @@ func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts
 		}
 	}
 
+	// Allow authorization with a previously issued certificate, for VMs
+	// Will return a caller with identities extracted from the SAN, should be a spifee identity.
+	caServer.Authenticators = append(caServer.Authenticators, &authenticate.ClientCertAuthenticator{})
+
 	if serverErr := caServer.Run(); serverErr != nil {
 		// stop the registry-related controllers
 		ch <- struct{}{}


### PR DESCRIPTION
This allows clients to refresh certificates with the existing VM node agent.

Separate PR should also merge this into the new istio-agent/pilot-agent, and update the 
install options. 

What happens inside:
- the CA server implements a gRPC service taking a CSR and returning a cert
- multiple authenticators are attempting to find the identity of the caller
- JWT are checked - either K8S (in-cluster only) or standard-based OIDC
- else, if the caller used client cert - we extract the SAN
- whatever the final identity is extracted, we issue a cert.