### PR TITLE
remove unneeded config in remote profile

### DIFF
--- a/operator/data/profiles/remote.yaml
+++ b/operator/data/profiles/remote.yaml
@@ -24,10 +24,6 @@ spec:
       enabled: false
 
   values:
-    pilot:
-      configSource:
-        subscribedResources:
-
     security:
       createMeshPolicy: false
 

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -38966,10 +38966,6 @@ spec:
       enabled: false
 
   values:
-    pilot:
-      configSource:
-        subscribedResources:
-
     security:
       createMeshPolicy: false
 


### PR DESCRIPTION
We can't figure out why this is needed given MCP is not enabled by default.


[ ] Configuration Infrastructure
[ ] Docs
[ x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure