### PR TITLE
Improve the istioctl manifest versions output.

### DIFF
--- a/operator/cmd/mesh/manifest-versions.go
+++ b/operator/cmd/mesh/manifest-versions.go
@@ -36,8 +36,8 @@ func addManifestVersionsFlags(cmd *cobra.Command, mvArgs *manifestVersionsArgs) 
 func manifestVersionsCmd(rootArgs *rootArgs, versionsArgs *manifestVersionsArgs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "versions",
-		Short: "List the versions of Istio recommended for use or supported for upgrade by this version of the operator binary",
-		Long:  "List the versions of Istio recommended for use or supported for upgrade by this version of the operator binary.",
+		Short: "List the versions of Istio recommended for use or supported for upgrade by this version of istioctl",
+		Long:  "List the versions of Istio recommended for use or supported for upgrade by this version of istioctl.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				cmd.Println(cmd.UsageString())
@@ -59,13 +59,12 @@ func manifestVersions(args *rootArgs, mvArgs *manifestVersionsArgs) error {
 	}
 
 	fmt.Print("\nOperator version is ", binversion.OperatorBinaryGoVersion.String(), ".\n\n")
-	fmt.Println("The following installation package versions are recommended for use with this version of the operator:")
+	fmt.Println("This version of istioctl can:")
 	for _, v := range myVersionMap.RecommendedIstioVersions {
-		fmt.Printf("  %s\n", v.String())
+		fmt.Printf("  Install Istio %s\n", v.String())
 	}
-	fmt.Println("\nThe following installation package versions are supported for upgrade by this version of the operator:")
 	for _, v := range myVersionMap.SupportedIstioVersions {
-		fmt.Printf("  %s\n", v.String())
+		fmt.Printf("  Update Istio from %s to %s\n", v.String(), myVersionMap.RecommendedIstioVersions)
 	}
 	fmt.Println()
 


### PR DESCRIPTION
See #21116 for discussion and details.

* Changes references from the 'operator' to 'istioctl'
* Updates the output from the 'manifest versions' cmd