### PR TITLE
Proof of concept: kubectl cp hot restart

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -564,6 +564,12 @@ var (
 			if nodeAgentSDSEnabled {
 				tlsCertsToWatch = []string{}
 			}
+			if err := os.Mkdir("/etc/istio/proxy/envoys", 0755); err != nil {
+				log.Warnf("failed to make directory: %v", err)
+			}
+			// Allow restart of envoy to a new version with
+			// kubectl cp envoy POD:/etc/istio/proxy/envoys/v1 -c istio-proxy
+			tlsCertsToWatch = append(tlsCertsToWatch, "/etc/istio/proxy/envoys/v1")
 
 			// Watcher is also kicking envoy start.
 			watcher := envoy.NewWatcher(tlsCertsToWatch, agent.Restart)

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -182,8 +182,15 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 	args := e.args(fname, epoch, istioBootstrapOverrideVar.Get())
 	log.Infof("Envoy command: %v", args)
 
+	binaryPath := e.Config.BinaryPath
+	if _, err := os.Stat("/etc/istio/proxy/envoys/v1"); err == nil {
+		binaryPath = "/etc/istio/proxy/envoys/v1"
+	} else {
+		log.Errorf("failed to find envoy v1: %v", err)
+	}
+	log.Infof("using %v as binary path", binaryPath)
 	/* #nosec */
-	cmd := exec.Command(e.Config.BinaryPath, args...)
+	cmd := exec.Command(binaryPath, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
This is just an idea to show this can worked if we want to do this,
 not intended to be merged at this time.

Basically the idea here is we watch some directory. When an envoy binary
appears there, we hot restart using that binary. This allows zero
downtime rollouts of security patches, etc. Probably not major upgrades,
but patch releases should work in most cases.

Not solved in this PR is any form of security.