### PR TITLE
Fix validation webhook on older k8s

### DIFF
--- a/manifests/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -14,7 +14,6 @@ webhooks:
         name: istiod
         namespace: {{ .Release.Namespace }}
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -10201,7 +10201,6 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
@@ -9195,7 +9195,6 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
@@ -2006,7 +2006,6 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
@@ -2005,7 +2005,6 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -8053,7 +8053,6 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -8985,7 +8985,6 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
@@ -2003,7 +2003,6 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -8985,7 +8985,6 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -2003,7 +2003,6 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
@@ -2002,7 +2002,6 @@ webhooks:
         name: istiod
         namespace: istio-control
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -13446,7 +13446,6 @@ webhooks:
         name: istiod
         namespace: {{ .Release.Namespace }}
         path: "/validate"
-        port: 443
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:


### PR DESCRIPTION
On older versions, the port field is not supported. It defaults to 443,
which we select anyways, so we should just remove the default.

This is a regression caused by #21164 - its not clear to me why it
worked before though. I guess when galley created the config it wasn't
validated or something maybe?